### PR TITLE
fix: ping endpoint to accept cors request

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PingController.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller;
 import static org.springframework.http.HttpStatus.OK;
 
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -38,6 +39,7 @@ public class PingController
 {
     @GetMapping( "/ping" )
     @ResponseStatus( OK )
+    @CrossOrigin
     public void ping()
     {
         // Do nothing


### PR DESCRIPTION
- Use `@CrossOrigin` to make api/ping endpoint accept all cors requests.
- The `Access-Control-Allow-Origin: *` will be added to the response header. 