### PR TITLE
fix: Createdbyuserinfo and lastupdatedbyuserinfo jsonb fields in programinstance are all blank (Old Tracker Capture)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -607,6 +607,7 @@ public abstract class AbstractEnrollmentService
         }
 
         programInstance.setCreatedByUserInfo( UserInfoSnapshot.from( importOptions.getUser() ) );
+        programInstance.setLastUpdatedByUserInfo( UserInfoSnapshot.from( importOptions.getUser() ) );
 
         programInstanceService.addProgramInstance( programInstance, importOptions.getUser() );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventStore.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import org.hisp.dhis.dxf2.events.report.EventRow;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.ProgramStageInstance;
+import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.user.User;
 
 /**
@@ -69,6 +70,8 @@ public interface EventStore
     List<EventRow> getEventRows( EventSearchParams params, List<OrganisationUnit> organisationUnits );
 
     int getEventCount( EventSearchParams params, List<OrganisationUnit> organisationUnits );
+
+    void updateEnrollmentsLastUpdatedUserInfo( List<String> enrollmentUids, UserInfoSnapshot userInfoSnapshot );
 
     /**
      * Delete list of given events to be removed. This operation also remove

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -2074,6 +2074,21 @@ public class JdbcEventStore implements EventStore
             PreparedStatement::execute );
     }
 
+    @Override
+    public void updateEnrollmentsLastUpdatedUserInfo( List<String> enrollmentUids, UserInfoSnapshot userInfoSnapshot )
+    {
+        List<List<String>> uidsPartitions = Lists.partition( Lists.newArrayList( enrollmentUids ), 20000 );
+
+        PGobject userInfoToJson = userInfoToJson( userInfoSnapshot, jsonMapper );
+
+        uidsPartitions.forEach( uids -> jdbcTemplate.execute(
+            "update programinstance set lastupdatedbyuserinfo = :lastupdatedbyuserinfo where uid IN (:uids)",
+            new MapSqlParameterSource()
+                .addValue( "lastupdatedbyuserinfo", userInfoToJson )
+                .addValue( "uids", uids ),
+            PreparedStatement::execute ) );
+    }
+
     private void bindEventParamsForInsert( PreparedStatement ps, ProgramStageInstance event )
         throws SQLException,
         JsonProcessingException

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/persistence/DefaultEventPersistenceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/persistence/DefaultEventPersistenceService.java
@@ -43,6 +43,7 @@ import org.hisp.dhis.dxf2.events.event.EventStore;
 import org.hisp.dhis.dxf2.events.importer.context.WorkContext;
 import org.hisp.dhis.dxf2.events.importer.mapper.ProgramStageInstanceMapper;
 import org.hisp.dhis.program.ProgramStageInstance;
+import org.hisp.dhis.program.UserInfoSnapshot;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -142,4 +143,12 @@ public class DefaultEventPersistenceService
 
         jdbcEventStore.updateTrackedEntityInstances( distinctTeiList, context.getImportOptions().getUser() );
     }
+
+    @Override
+    @Transactional
+    public void updateEnrollmentsLastUpdatedUserInfo( List<String> enrollmentUids, UserInfoSnapshot userInfoSnapshot )
+    {
+        jdbcEventStore.updateEnrollmentsLastUpdatedUserInfo( enrollmentUids, userInfoSnapshot );
+    }
+
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/persistence/EventPersistenceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/persistence/EventPersistenceService.java
@@ -31,6 +31,8 @@ import java.util.List;
 
 import org.hisp.dhis.dxf2.events.event.Event;
 import org.hisp.dhis.dxf2.events.importer.context.WorkContext;
+import org.hisp.dhis.program.UserInfoSnapshot;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Wrapper service for Event-related operations. This service acts as a
@@ -63,4 +65,7 @@ public interface EventPersistenceService
      * @param events a List of {@see Event}
      */
     void delete( WorkContext context, List<Event> events );
+
+    @Transactional
+    void updateEnrollmentsLastUpdatedUserInfo( List<String> enrollmentUids, UserInfoSnapshot userInfoSnapshot );
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/EnrollmentImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/EnrollmentImportTest.java
@@ -133,7 +133,10 @@ class EnrollmentImportTest extends TransactionalIntegrationTest
         assertAll( () -> assertEquals( ImportStatus.SUCCESS, importSummaries.getStatus() ),
             () -> assertEquals( UserInfoSnapshot.from( user ),
                 enrollmentService.getEnrollment( enrollmentUid, EnrollmentParams.FALSE )
-                    .getCreatedByUserInfo() ) );
+                    .getCreatedByUserInfo() ),
+            () -> assertEquals( UserInfoSnapshot.from( user ),
+                enrollmentService.getEnrollment( enrollmentUid, EnrollmentParams.FALSE )
+                    .getLastUpdatedByUserInfo() ) );
     }
 
     @Test


### PR DESCRIPTION
Set programinstance's lastUpdatedUserInfo when :

- creating enrollments

- adding or updating the Enrollment events. This is due to /events endpoint invoked even though we are on the enrollment page