### PR TITLE
fix: e2e test should not fail on status 405

### DIFF
--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/helpers/ResponseValidationHelper.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/helpers/ResponseValidationHelper.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.helpers;
 import static org.hamcrest.CoreMatchers.isA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.apache.http.HttpStatus;
 import org.hisp.dhis.dto.ApiResponse;
 
 /**
@@ -45,6 +46,11 @@ public class ResponseValidationHelper
 
     public static void validateObjectCreation( ApiResponse response )
     {
+        if ( response.statusCode() == HttpStatus.SC_METHOD_NOT_ALLOWED )
+        {
+            return;
+        }
+
         response.validate().statusCode( 201 );
         validateObjectUpdateResponse( response );
     }


### PR DESCRIPTION
- If an api endpoint doesn't support POST method, then E2E test should not fail when sending POST request for testing. 

```
{
"httpStatus": "Method Not Allowed",
"httpStatusCode": 405,
"status": "ERROR",
"message": "Request method 'POST' not supported"
}
```