### PR TITLE
fix: move login localeSelect handler

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/login.js
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/login.js
@@ -31,6 +31,11 @@ $( document ).ready( function()
     	login.changeLocale( locale );
     	$( '#localeSelect option[value="' + locale + '"]' ).attr( 'selected', 'selected' );
     }
+
+    $( '#localeSelect' ).on( 'change', function()
+    {
+        login.localeChanged();
+    } );
 } );
 
 login.localeChanged = function()

--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/security/login.vm
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/security/login.vm
@@ -148,7 +148,7 @@
     </div>
     <div id="rightFooterArea" class="innerFooterArea">
         <span id="applicationRightFooter">$!{keyApplicationRightFooter}</span>
-        <select id="localeSelect" onchange="login.localeChanged()" class="marginLeftClass">
+        <select id="localeSelect" class="marginLeftClass">
             <option value="">[ $i18n.getString( "change_language" ) ]</option>
             #foreach( $locale in $availableLocales )
                 <option value="${locale.language}">${locale.displayName}</option>


### PR DESCRIPTION
Defines localeSelect event handler in login.js to avoid issues with content security policy directive (and hence reenable translation on login page)

**Before**

<img width="1251" alt="image" src="https://user-images.githubusercontent.com/18490902/222694779-43fa280b-89d6-44e7-a6e7-e5d786bf15c2.png">

**After**
<img width="1254" alt="image" src="https://user-images.githubusercontent.com/18490902/222695037-a0ede2b4-19bd-4179-b40e-b16427155c50.png">
