### PR TITLE
fix: Force collate C for column ounamehierarchy in analytics [DHIS2-14871]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsTableColumn.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsTableColumn.java
@@ -41,6 +41,11 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode
 public class AnalyticsTableColumn
 {
+    public enum Collate
+    {
+        C
+    }
+
     /**
      * The column name.
      */
@@ -60,6 +65,11 @@ public class AnalyticsTableColumn
      * The column SQL alias.
      */
     private String alias;
+
+    /**
+     * Sets a custom collate for the column if one is defined.
+     */
+    private Collate collate;
 
     /**
      * Date of creation of the underlying data dimension.
@@ -99,6 +109,22 @@ public class AnalyticsTableColumn
         this.dataType = dataType;
         this.notNull = ColumnNotNullConstraint.NULL;
         this.alias = alias;
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param name analytics table column name.
+     * @param dataType analytics table column data type.
+     * @param alias source table column alias and name.
+     */
+    public AnalyticsTableColumn( String name, ColumnDataType dataType, String alias, Collate collate )
+    {
+        this.name = name;
+        this.dataType = dataType;
+        this.notNull = ColumnNotNullConstraint.NULL;
+        this.alias = alias;
+        this.collate = collate;
     }
 
     /**
@@ -193,6 +219,16 @@ public class AnalyticsTableColumn
     public String getAlias()
     {
         return alias;
+    }
+
+    public Collate getCollate()
+    {
+        return collate;
+    }
+
+    public boolean hasCollate()
+    {
+        return collate != null;
     }
 
     public ColumnNotNullConstraint getNotNull()

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -27,11 +27,13 @@
  */
 package org.hisp.dhis.analytics.table;
 
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.SPACE;
 import static org.hisp.dhis.analytics.ColumnDataType.CHARACTER_11;
 import static org.hisp.dhis.analytics.ColumnDataType.TEXT;
 import static org.hisp.dhis.analytics.util.AnalyticsIndexHelper.createIndexStatement;
 import static org.hisp.dhis.analytics.util.AnalyticsIndexHelper.getIndexName;
+import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.getCollate;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
 import static org.hisp.dhis.util.DateUtils.getLongDateString;
 
@@ -365,6 +367,7 @@ public abstract class AbstractJdbcTableManager
             sqlCreate.append( col.getName() )
                 .append( SPACE )
                 .append( col.getDataType().getValue() )
+                .append( col.hasCollate() ? getCollate( col.getCollate().name() ) : EMPTY )
                 .append( notNull )
                 .append( "," );
         }
@@ -598,7 +601,7 @@ public abstract class AbstractJdbcTableManager
         String columnAlias = "concat_ws(' / '," + organisationUnitService.getFilledOrganisationUnitLevels().stream()
             .map( lv -> "ous." + PREFIX_ORGUNITNAMELEVEL + lv.getLevel() )
             .collect( Collectors.joining( "," ) ) + ") as ounamehierarchy";
-        return new AnalyticsTableColumn( "ounamehierarchy", TEXT, columnAlias );
+        return new AnalyticsTableColumn( "ounamehierarchy", TEXT, columnAlias, AnalyticsTableColumn.Collate.C );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsSqlUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsSqlUtils.java
@@ -241,21 +241,21 @@ public class AnalyticsSqlUtils
     }
 
     /**
-     * This method will simply prefix the given column with the collate
-     * function. ie: columnA -> collate "columnA"
+     * This method will simply prefix the given "collate" with the collate
+     * function. ie: Posix -> collate "Posix"
      *
      * The final statement is surrounded by blank spaces to make its usage safet
      * to the caller.
      *
-     * @param column the column to be "collated".
-     * @return the collate statement, or blank if the given column is
+     * @param collate the type of collate to be used.
+     * @return the collate statement, or blank if the given "collate" is
      *         null/blank.
      */
-    public static String getCollate( String column )
+    public static String getCollate( String collate )
     {
-        if ( isNotBlank( column ) )
+        if ( isNotBlank( collate ) )
         {
-            return " collate \"" + column + "\" ";
+            return " collate \"" + collate + "\" ";
         }
 
         return EMPTY;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsSqlUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsSqlUtils.java
@@ -28,6 +28,8 @@
 package org.hisp.dhis.analytics.util;
 
 import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -118,7 +120,7 @@ public class AnalyticsSqlUtils
     {
         Assert.notNull( relation, "Relation must be specified" );
 
-        return relation.replaceAll( AnalyticsSqlUtils.QUOTE, StringUtils.EMPTY );
+        return relation.replaceAll( AnalyticsSqlUtils.QUOTE, EMPTY );
     }
 
     /**
@@ -190,7 +192,7 @@ public class AnalyticsSqlUtils
     {
         if ( StringUtils.isEmpty( str ) )
         {
-            return StringUtils.EMPTY;
+            return EMPTY;
         }
 
         int open = 0;
@@ -236,5 +238,26 @@ public class AnalyticsSqlUtils
 
         return args.isEmpty() ? defaultColumnName
             : "coalesce(" + args + ")";
+    }
+
+    /**
+     * This method will simply prefix the given column with the collate
+     * function. ie: columnA -> collate "columnA"
+     *
+     * The final statement is surrounded by blank spaces to make its usage safet
+     * to the caller.
+     *
+     * @param column the column to be "collated".
+     * @return the collate statement, or blank if the given column is
+     *         null/blank.
+     */
+    public static String getCollate( String column )
+    {
+        if ( isNotBlank( column ) )
+        {
+            return " collate \"" + column + "\" ";
+        }
+
+        return EMPTY;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsSqlUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsSqlUtilsTest.java
@@ -128,7 +128,7 @@ class AnalyticsSqlUtilsTest
     @Test
     void testGetCollate()
     {
-        assertEquals( " collate \"ColumnA\" ", AnalyticsSqlUtils.getCollate( "ColumnA" ) );
+        assertEquals( " collate \"Posix\" ", AnalyticsSqlUtils.getCollate( "Posix" ) );
         assertEquals( "", AnalyticsSqlUtils.getCollate( null ) );
         assertEquals( "", AnalyticsSqlUtils.getCollate( "" ) );
         assertEquals( "", AnalyticsSqlUtils.getCollate( " " ) );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsSqlUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsSqlUtilsTest.java
@@ -36,6 +36,8 @@ import org.hisp.dhis.common.FallbackCoordinateFieldType;
 import org.junit.jupiter.api.Test;
 
 /**
+ * Unit tests for {@link AnalyticsSqlUtils}.
+ *
  * @author Luciano Fiandesio
  */
 class AnalyticsSqlUtilsTest
@@ -94,7 +96,6 @@ class AnalyticsSqlUtilsTest
     @Test
     void testGetCoalesce_returns_defaultColumnName_when_coordinate_field_collection_is_empty()
     {
-        // given
         // when
         String sqlSnippet = AnalyticsSqlUtils.getCoalesce( new ArrayList<>(),
             FallbackCoordinateFieldType.PSI_GEOMETRY.getValue() );
@@ -104,9 +105,8 @@ class AnalyticsSqlUtilsTest
     }
 
     @Test
-    void testGetCoalesce_returns_defaultColumnName_when_coordinate_field_collection_is_null()
+    void testGetCoalesceReturnsDefaultColumnNameWhenCoordinateFieldCollectionIsNull()
     {
-        // given
         // when
         String sqlSnippet = AnalyticsSqlUtils.getCoalesce( null, FallbackCoordinateFieldType.PSI_GEOMETRY.getValue() );
 
@@ -115,14 +115,22 @@ class AnalyticsSqlUtilsTest
     }
 
     @Test
-    void testGetCoalesce_returns_coalesce_when_coordinate_field_collection_is_not_empty()
+    void testGetCoalesceReturnsCoalesceWhenCoordinateFieldCollectionIsNotEmpty()
     {
-        // given
         // when
         String sqlSnippet = AnalyticsSqlUtils.getCoalesce( List.of( "coorA", "coorB", "coorC" ),
             FallbackCoordinateFieldType.PSI_GEOMETRY.getValue() );
 
         // then
         assertEquals( "coalesce(ax.\"coorA\",ax.\"coorB\",ax.\"coorC\")", sqlSnippet );
+    }
+
+    @Test
+    void testGetCollate()
+    {
+        assertEquals( " collate \"ColumnA\" ", AnalyticsSqlUtils.getCollate( "ColumnA" ) );
+        assertEquals( "", AnalyticsSqlUtils.getCollate( null ) );
+        assertEquals( "", AnalyticsSqlUtils.getCollate( "" ) );
+        assertEquals( "", AnalyticsSqlUtils.getCollate( " " ) );
     }
 }


### PR DESCRIPTION
In the Events/Enrollments API, the sorting order is not correctly respected when we sort by the column `ounamehierarchy`.

This happens in some instances, depending on the DB column (type, value, collate, location, etc.) and seems like a "common" issue.

In our case, the column `ounamehierarchy` recently showed this problem. This PR will ensure that this particular column is always exported as collate "C" in order to fix it. This was the decision adopted after a quick discussion based on pros and cons.