### PR TITLE
fix: e2e test failed on valueType=MULTI_TEXT [TECH-1513]

### DIFF
--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/utils/DataGenerator.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/utils/DataGenerator.java
@@ -27,11 +27,10 @@
  */
 package org.hisp.dhis.utils;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
+import com.github.javafaker.Faker;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.actions.IdGenerator;
@@ -41,10 +40,10 @@ import org.hisp.dhis.dto.schemas.PropertyType;
 import org.hisp.dhis.dto.schemas.Schema;
 import org.hisp.dhis.dto.schemas.SchemaProperty;
 
-import com.github.javafaker.Faker;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -101,8 +100,7 @@ public class DataGenerator
             break;
 
         case CONSTANT:
-            int randomConstant = faker.number().numberBetween( 0, property.getConstants().size() - 1 );
-            jsonElement = new JsonPrimitive( property.getConstants().get( randomConstant ) );
+            jsonElement = generateConstantValue( property );
             break;
 
         case NUMBER:
@@ -199,5 +197,26 @@ public class DataGenerator
 
             return faker.lorem().characters( minLength, maxLength );
         }
+    }
+
+    /**
+     * Generates random value from the list of constants.
+     * If the list contains "MULTI_TEXT" value, it will be skipped.
+     * This is because a DataElement with valueType=MultiText must have an OptionSet, but currently we don't have a way to generate an OptionSet.
+     * TODO: add a way to generate an OptionSet
+     * @param property SchemaProperty
+     * @return JsonElement
+     */
+    private static JsonElement generateConstantValue( SchemaProperty property )
+    {
+        int randomConstant = -1;
+        JsonPrimitive element = null;
+        while( randomConstant == -1 || ( property.getName().equals( "valueType" ) && property.getConstants().get( randomConstant ).equals( "MULTI_TEXT" ) ) )
+        {
+            randomConstant = faker.number().numberBetween( 0, property.getConstants().size() - 1 );
+            element = new JsonPrimitive( property.getConstants().get( randomConstant ) );
+        }
+
+        return element;
     }
 }

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/utils/DataGenerator.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/utils/DataGenerator.java
@@ -27,10 +27,11 @@
  */
 package org.hisp.dhis.utils;
 
-import com.github.javafaker.Faker;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.actions.IdGenerator;
@@ -40,10 +41,10 @@ import org.hisp.dhis.dto.schemas.PropertyType;
 import org.hisp.dhis.dto.schemas.Schema;
 import org.hisp.dhis.dto.schemas.SchemaProperty;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
+import com.github.javafaker.Faker;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -200,10 +201,12 @@ public class DataGenerator
     }
 
     /**
-     * Generates random value from the list of constants.
-     * If the list contains "MULTI_TEXT" value, it will be skipped.
-     * This is because a DataElement with valueType=MultiText must have an OptionSet, but currently we don't have a way to generate an OptionSet.
-     * TODO: add a way to generate an OptionSet
+     * Generates random value from the list of constants. If the list contains
+     * "MULTI_TEXT" value, it will be skipped. This is because a DataElement
+     * with valueType=MultiText must have an OptionSet, but currently we don't
+     * have a way to generate an OptionSet. TODO: add a way to generate an
+     * OptionSet
+     *
      * @param property SchemaProperty
      * @return JsonElement
      */
@@ -211,7 +214,8 @@ public class DataGenerator
     {
         int randomConstant = -1;
         JsonPrimitive element = null;
-        while( randomConstant == -1 || ( property.getName().equals( "valueType" ) && property.getConstants().get( randomConstant ).equals( "MULTI_TEXT" ) ) )
+        while ( randomConstant == -1 || (property.getName().equals( "valueType" )
+            && property.getConstants().get( randomConstant ).equals( "MULTI_TEXT" )) )
         {
             randomConstant = faker.number().numberBetween( 0, property.getConstants().size() - 1 );
             element = new JsonPrimitive( property.getConstants().get( randomConstant ) );

--- a/dhis-2/dhis-e2e-test/src/main/resources/config.properties
+++ b/dhis-2/dhis-e2e-test/src/main/resources/config.properties
@@ -3,14 +3,14 @@
 instance.url=http://localhost:8080/api
 # properties for user set up on the instance.
 # user must be able to import metadata.
-user.default.username=admin
-user.default.password=district
+user.default.username=system
+user.default.password=System123
 # properties for super user set up on the instance.
 # default: user that has been set up when running tests
-user.super.username=admin
-user.super.password=district
-user.admin.username=admin
-user.admin.password=district
+user.super.username=tasuperadmin
+user.super.password=Test1212?
+user.admin.username=taadmin
+user.admin.password=Test1212?
 
 test.cleanup=false
 test.track_called_endpoints=false

--- a/dhis-2/dhis-e2e-test/src/main/resources/config.properties
+++ b/dhis-2/dhis-e2e-test/src/main/resources/config.properties
@@ -3,14 +3,14 @@
 instance.url=http://localhost:8080/api
 # properties for user set up on the instance.
 # user must be able to import metadata.
-user.default.username=system
-user.default.password=System123
+user.default.username=admin
+user.default.password=district
 # properties for super user set up on the instance.
 # default: user that has been set up when running tests
-user.super.username=tasuperadmin
-user.super.password=Test1212?
-user.admin.username=taadmin
-user.admin.password=Test1212?
+user.super.username=admin
+user.super.password=district
+user.admin.username=admin
+user.admin.password=district
 
 test.cleanup=false
 test.track_called_endpoints=false


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/TECH-1513
- ValueType is generated randomly for e2e test
-  If a DataElement is created with ValueType=MULTI_TEXT then this DataElement must have an OptionSet
- However e2e test doesn't have a way to generate OptionSet for DataElement so the test will fail.
- This PR exclude the MULTI_TEXT valueType from the generator. In the future we can include it when we add a way to generate and set OptionSet to DataElement.

```
"httpStatus": "Conflict",
"httpStatusCode": 409,
"status": "ERROR",
"message": "Data element of value type multi-text must have an option set: `null`",
 "errorCode": "E1116"
```