### PR TITLE
feat: Include job parameters in first notifier message of a job run [DHIS2-14372]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
@@ -36,6 +36,8 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.system.notification.NotificationLevel;
 import org.hisp.dhis.system.notification.Notifier;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 /**
  * A {@link JobProgress} implementation that forwards the tracking to a
  * {@link Notifier}. It has no flow control and should be wrapped in a
@@ -72,7 +74,7 @@ public class NotifierJobProgress implements JobProgress
         {
             notifier.clear( jobId );
         }
-        notifier.notify( jobId, message );
+        notifier.notify( jobId, message + getJobParameterString() );
     }
 
     @Override
@@ -143,6 +145,23 @@ public class NotifierJobProgress implements JobProgress
         if ( isNotEmpty( error ) )
         {
             notifier.notify( jobId, NotificationLevel.ERROR, error, false );
+        }
+    }
+
+    private String getJobParameterString()
+    {
+        JobParameters params = jobId.getJobParameters();
+        if ( params == null )
+        {
+            return "";
+        }
+        try
+        {
+            return "\n" + new ObjectMapper().writeValueAsString( params );
+        }
+        catch ( Exception ex )
+        {
+            return "(failed to extract job parameter object)";
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
@@ -33,9 +33,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import lombok.RequiredArgsConstructor;
 
+import org.hisp.dhis.system.notification.NotificationDataType;
 import org.hisp.dhis.system.notification.NotificationLevel;
 import org.hisp.dhis.system.notification.Notifier;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -74,7 +76,8 @@ public class NotifierJobProgress implements JobProgress
         {
             notifier.clear( jobId );
         }
-        notifier.notify( jobId, message + getJobParameterString() );
+        notifier.notify( jobId, NotificationLevel.INFO, message, false, NotificationDataType.PARAMETERS,
+            getJobParameterData() );
     }
 
     @Override
@@ -148,20 +151,20 @@ public class NotifierJobProgress implements JobProgress
         }
     }
 
-    private String getJobParameterString()
+    private JsonNode getJobParameterData()
     {
         JobParameters params = jobId.getJobParameters();
         if ( params == null )
         {
-            return "";
+            return null;
         }
         try
         {
-            return "\n" + new ObjectMapper().writeValueAsString( params );
+            return new ObjectMapper().valueToTree( params );
         }
         catch ( Exception ex )
         {
-            return "(failed to extract job parameter object)";
+            return null;
         }
     }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/InMemoryNotifier.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/InMemoryNotifier.java
@@ -39,6 +39,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobType;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 /**
  * @author Lars Helge Overland
  */
@@ -50,11 +52,13 @@ public class InMemoryNotifier implements Notifier
     private final NotificationMap notificationMap = new NotificationMap( MAX_POOL_TYPE_SIZE );
 
     @Override
-    public Notifier notify( JobConfiguration id, @Nonnull NotificationLevel level, String message, boolean completed )
+    public Notifier notify( JobConfiguration id, @Nonnull NotificationLevel level, String message,
+        boolean completed, NotificationDataType dataType, JsonNode data )
     {
         if ( id != null && !level.isOff() )
         {
-            Notification notification = new Notification( level, id.getJobType(), new Date(), message, completed );
+            Notification notification = new Notification( level, id.getJobType(), new Date(), message, completed,
+                dataType, data );
 
             if ( id.isInMemoryJob() && !StringUtils.isEmpty( id.getUid() ) )
             {

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/Notification.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/Notification.java
@@ -31,32 +31,48 @@ import java.util.Date;
 
 import javax.annotation.Nonnull;
 
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.scheduling.JobType;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * @author Lars Helge Overland
  */
+@Setter
+@EqualsAndHashCode( onlyExplicitlyIncluded = true )
+@ToString( onlyExplicitlyIncluded = true )
 @JacksonXmlRootElement( localName = "notification", namespace = DxfNamespaces.DXF_2_0 )
 public class Notification implements Comparable<Notification>
 {
-    private String uid; // FIXME expose as "id" externally in next API version
-                       // as "uid" is internal
+    @EqualsAndHashCode.Include
+    private String uid;
 
+    @ToString.Include
     private NotificationLevel level;
 
+    @ToString.Include
     private JobType category;
 
+    @ToString.Include
     private Date time;
 
+    @ToString.Include
     private String message;
 
     private boolean completed;
+
+    private NotificationDataType dataType;
+
+    private JsonNode data;
 
     // -------------------------------------------------------------------------
     // Constructors
@@ -67,7 +83,8 @@ public class Notification implements Comparable<Notification>
         this.uid = CodeGenerator.generateUid();
     }
 
-    public Notification( NotificationLevel level, JobType category, Date time, String message, boolean completed )
+    public Notification( NotificationLevel level, JobType category, Date time, String message, boolean completed,
+        NotificationDataType dataType, JsonNode data )
     {
         this.uid = CodeGenerator.generateUid();
         this.level = level;
@@ -75,6 +92,8 @@ public class Notification implements Comparable<Notification>
         this.time = time;
         this.message = message;
         this.completed = completed;
+        this.dataType = dataType;
+        this.data = data;
     }
 
     // -------------------------------------------------------------------------
@@ -88,15 +107,9 @@ public class Notification implements Comparable<Notification>
         return level;
     }
 
-    public void setLevel( NotificationLevel level )
-    {
-        this.level = level;
-    }
-
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getId() // expose as ID also to be future proof, we should not
-                         // expose UID fields
+    public String getId()
     {
         return uid;
     }
@@ -108,21 +121,11 @@ public class Notification implements Comparable<Notification>
         return uid;
     }
 
-    public void setUid( String uid )
-    {
-        this.uid = uid;
-    }
-
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public JobType getCategory()
     {
         return category;
-    }
-
-    public void setCategory( JobType category )
-    {
-        this.category = category;
     }
 
     @JsonProperty
@@ -132,21 +135,11 @@ public class Notification implements Comparable<Notification>
         return time;
     }
 
-    public void setTime( Date time )
-    {
-        this.time = time;
-    }
-
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getMessage()
     {
         return message;
-    }
-
-    public void setMessage( String message )
-    {
-        this.message = message;
     }
 
     @JsonProperty
@@ -156,48 +149,18 @@ public class Notification implements Comparable<Notification>
         return completed;
     }
 
-    public void setCompleted( boolean completed )
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public NotificationDataType getDataType()
     {
-        this.completed = completed;
+        return dataType;
     }
 
-    // -------------------------------------------------------------------------
-    // equals, hashCode, toString
-    // -------------------------------------------------------------------------
-
-    @Override
-    public int hashCode()
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public JsonNode getData()
     {
-        return uid.hashCode();
-    }
-
-    @Override
-    public boolean equals( Object object )
-    {
-        if ( this == object )
-        {
-            return true;
-        }
-
-        if ( object == null )
-        {
-            return false;
-        }
-
-        if ( getClass() != object.getClass() )
-        {
-            return false;
-        }
-
-        final Notification other = (Notification) object;
-
-        return uid.equals( other.uid );
-    }
-
-    @Override
-    public String toString()
-    {
-        return "[Level: " + level + ", category: " + category + ", time: " + time + ", message: " + message + "]";
+        return data;
     }
 
     @Override

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/NotificationDataType.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/NotificationDataType.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.system.notification;
+
+/**
+ * A {@link Notification} can have a
+ * {@link com.fasterxml.jackson.databind.JsonNode} data object attached for
+ * additional information. The {@link NotificationDataType} indicates what data
+ * the value represents. This is purely for clarity and ease of processing the
+ * data programmatically.
+ *
+ * @author Jan Bernitt
+ */
+public enum NotificationDataType
+{
+    PARAMETERS
+}

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/Notifier.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/Notifier.java
@@ -35,6 +35,8 @@ import javax.annotation.Nonnull;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobType;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 /**
  * @author Lars Helge Overland
  * @author Jan Bernitt (pulled up default methods)
@@ -56,7 +58,13 @@ public interface Notifier
         return notify( id, NotificationLevel.INFO, message, completed );
     }
 
-    Notifier notify( JobConfiguration id, @Nonnull NotificationLevel level, String message, boolean completed );
+    default Notifier notify( JobConfiguration id, @Nonnull NotificationLevel level, String message, boolean completed )
+    {
+        return notify( id, level, message, completed, null, null );
+    }
+
+    Notifier notify( JobConfiguration id, @Nonnull NotificationLevel level, String message, boolean completed,
+        NotificationDataType dataType, JsonNode data );
 
     default Notifier update( JobConfiguration id, String message )
     {

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/RedisNotifier.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/RedisNotifier.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.scheduling.JobType;
 import org.springframework.data.redis.core.RedisTemplate;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -93,11 +94,13 @@ public class RedisNotifier implements Notifier
     // -------------------------------------------------------------------------
 
     @Override
-    public Notifier notify( JobConfiguration id, @Nonnull NotificationLevel level, String message, boolean completed )
+    public Notifier notify( JobConfiguration id, @Nonnull NotificationLevel level, String message,
+        boolean completed, NotificationDataType dataType, JsonNode data )
     {
         if ( id != null && !level.isOff() )
         {
-            Notification notification = new Notification( level, id.getJobType(), new Date(), message, completed );
+            Notification notification = new Notification( level, id.getJobType(), new Date(), message, completed,
+                dataType, data );
 
             if ( id.isInMemoryJob() && StringUtils.isEmpty( id.getUid() ) )
             {

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotificationMapTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotificationMapTest.java
@@ -110,6 +110,6 @@ class NotificationMapTest
 
     private Notification newNotification( JobConfiguration config, int no )
     {
-        return new Notification( NotificationLevel.INFO, config.getJobType(), new Date(), "" + no, false );
+        return new Notification( NotificationLevel.INFO, config.getJobType(), new Date(), "" + no, false, null, null );
     }
 }


### PR DESCRIPTION
### Summary
Adds the job parameters JSON to the first notifier message as new property `data`. 
A second new property `dataType` has the value `PARAMETERS` so that in the future other data objects can be added while still being able to tell what information is kept in `data`.

### Example

```json
{
      "uid": "t9uWDhCSO2E",
      "level": "INFO",
      "category": "ANALYTICS_TABLE",
      "time": "2023-03-07T14:13:46.421",
      "message": "Analytics table update process",
      "completed": false,
      "dataType": "PARAMETERS",
      "data": {
        "lastYears": 1,
        "skipTableTypes": [
          "ENROLLMENT",
          "EVENT",
          "OWNERSHIP",
          "COMPLETENESS",
          "DATA_VALUE",
          "COMPLETENESS_TARGET"
        ],
        "skipPrograms": [
          
        ],
        "skipResourceTables": true
      },
      "id": "t9uWDhCSO2E"
    }
```

### Manual Testing
* open data administration app
* run resource table generation (case with no parameters)
* check last in list (first in process) message of `/api/system/tasks/RESOURCE_TABLE` has a `dataType` property 
* run analytics table generation (case with parameters)
* check last in list (first in process) message of `/api/system/tasks/ANALYTICS_TABLE` has `dataType` and `data` property