### PR TITLE
fix: period date range check should consider end date as full day [DHIS2-14591]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
@@ -514,9 +514,12 @@ public class DataElement extends BaseDimensionalItemObject
     public boolean isExpired( Period period, Date now )
     {
         int expiryDays = getExpiryDays();
-
-        return expiryDays != DataSet.NO_EXPIRY
-            && new DateTime( period.getEndDate() ).plusDays( expiryDays ).isBefore( new DateTime( now ) );
+        if ( expiryDays == DataSet.NO_EXPIRY )
+        {
+            return false;
+        }
+        return !Period.isDateInTimeFrame( null, new DateTime( period.getEndDate() ).plusDays( expiryDays ).toDate(),
+            now );
     }
 
     /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
@@ -31,6 +31,7 @@ import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.hisp.dhis.common.DimensionalObject.TEXTVALUE_COLUMN_NAME;
 import static org.hisp.dhis.common.DimensionalObject.VALUE_COLUMN_NAME;
 import static org.hisp.dhis.dataset.DataSet.NO_EXPIRY;
+import static org.hisp.dhis.util.DateUtils.addDays;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -65,7 +66,6 @@ import org.hisp.dhis.period.YearlyPeriodType;
 import org.hisp.dhis.schema.PropertyType;
 import org.hisp.dhis.schema.annotation.Property;
 import org.hisp.dhis.schema.annotation.PropertyRange;
-import org.joda.time.DateTime;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -518,8 +518,7 @@ public class DataElement extends BaseDimensionalItemObject
         {
             return false;
         }
-        return !Period.isDateInTimeFrame( null, new DateTime( period.getEndDate() ).plusDays( expiryDays ).toDate(),
-            now );
+        return !Period.isDateInTimeFrame( null, addDays( period.getEndDate(), expiryDays ), now );
     }
 
     /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/DataSet.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/DataSet.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.dataset;
 
+import static org.hisp.dhis.util.DateUtils.addDays;
+
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -63,7 +65,6 @@ import org.hisp.dhis.schema.annotation.PropertyRange;
 import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
-import org.joda.time.DateTime;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -550,16 +551,13 @@ public class DataSet
      */
     public boolean isLocked( User user, Period period, Date now )
     {
-        if ( user != null && user.isAuthorized( Authorities.F_EDIT_EXPIRED.getAuthority() ) )
+        if ( expiryDays == DataSet.NO_EXPIRY
+            || user != null && user.isAuthorized( Authorities.F_EDIT_EXPIRED.getAuthority() ) )
         {
             return false;
         }
-
         Date date = now != null ? now : new Date();
-
-        return expiryDays != DataSet.NO_EXPIRY
-            && !Period.isDateInTimeFrame( null, new DateTime( period.getEndDate() ).plusDays( expiryDays ).toDate(),
-                date );
+        return !Period.isDateInTimeFrame( null, addDays( period.getEndDate(), expiryDays ), date );
     }
 
     /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/Period.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/Period.java
@@ -333,7 +333,10 @@ public class Period
      */
     public boolean isFuture()
     {
-        return getEndDate().after( new Date() );
+        Date now = new Date();
+        return getEndDate().after( now )
+            // on same day it is not the future yet
+            && new DateTime( getEndDate() ).getDayOfWeek() != new DateTime( now ).getDayOfYear();
     }
 
     /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/Period.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/Period.java
@@ -327,19 +327,6 @@ public class Period
     }
 
     /**
-     * Determines whether this is a future period relative to the current time.
-     *
-     * @return true if this period ends in the future, false otherwise.
-     */
-    public boolean isFuture()
-    {
-        Date now = new Date();
-        return getEndDate().after( now )
-            // on same day it is not the future yet
-            && new DateTime( getEndDate() ).getDayOfWeek() != new DateTime( now ).getDayOfYear();
-    }
-
-    /**
      * Indicates whether this period is after the given period. Bases the
      * comparison on the end dates of the periods. If the given period is null,
      * false is returned.

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/dataelement/DataElementTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/dataelement/DataElementTest.java
@@ -31,12 +31,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Date;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.common.DataDimensionType;
 import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.dataset.DataSetElement;
 import org.hisp.dhis.period.MonthlyPeriodType;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.period.PeriodTypeEnum;
 import org.hisp.dhis.period.QuarterlyPeriodType;
 import org.junit.jupiter.api.Test;
 
@@ -145,5 +152,43 @@ class DataElementTest
         dsB.addDataSetElement( deA );
         Period lastOpen = deA.getLatestOpenFuturePeriod();
         assertTrue( lastOpen.isAfter( new MonthlyPeriodType().createPeriod() ) );
+    }
+
+    @Test
+    void testIsExpired_BeforeFirstDayOfPeriod()
+    {
+        assertIsExpired( false, period -> new Date( period.getStartDate().getTime() - 1L ) );
+    }
+
+    @Test
+    void testIsExpired_FirstDayOfPeriod()
+    {
+        assertIsExpired( false, Period::getStartDate );
+    }
+
+    @Test
+    void testIsExpired_LastDayOfPeriod()
+    {
+        assertIsExpired( false, Period::getEndDate );
+    }
+
+    @Test
+    void testIsExpired_AfterLastDayOfPeriod()
+    {
+        // expiryDays is 1 so 1 extra day after the end is still ok
+        assertIsExpired( false, period -> new Date( period.getEndDate().getTime() + TimeUnit.DAYS.toMillis( 1 ) ) );
+        // but 2 is too much
+        assertIsExpired( true, period -> new Date( period.getEndDate().getTime() + TimeUnit.DAYS.toMillis( 2 ) ) );
+    }
+
+    private static void assertIsExpired( boolean expected, Function<Period, Date> actual )
+    {
+        Date now = new Date();
+        Period thisMonth = PeriodType.getPeriodType( PeriodTypeEnum.MONTHLY ).createPeriod( now );
+        DataElement de = new DataElement();
+        DataSet ds = new DataSet();
+        ds.setExpiryDays( 1 );
+        de.setDataSetElements( Set.of( new DataSetElement( ds, de ) ) );
+        assertEquals( expected, de.isExpired( thisMonth, actual.apply( thisMonth ) ) );
     }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/dataset/DataSetTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/dataset/DataSetTest.java
@@ -30,9 +30,16 @@ package org.hisp.dhis.dataset;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.period.PeriodTypeEnum;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Sets;
@@ -105,5 +112,41 @@ class DataSetTest
         assertEquals( 1, indicatorB.getDataSets().size() );
         assertTrue( indicatorA.getDataSets().contains( dsA ) );
         assertTrue( indicatorB.getDataSets().contains( dsA ) );
+    }
+
+    @Test
+    void testIsLocked_BeforeFirstDayOfPeriod()
+    {
+        assertIsLocked( false, period -> new Date( period.getStartDate().getTime() - 1L ) );
+    }
+
+    @Test
+    void testIsLocked_FirstDayOfPeriod()
+    {
+        assertIsLocked( false, Period::getStartDate );
+    }
+
+    @Test
+    void testIsLocked_LastDayOfPeriod()
+    {
+        assertIsLocked( false, Period::getEndDate );
+    }
+
+    @Test
+    void testIsLocked_AfterLastDayOfPeriod()
+    {
+        // expiryDays is 1 so 1 extra day after the end is still ok
+        assertIsLocked( false, period -> new Date( period.getEndDate().getTime() + TimeUnit.DAYS.toMillis( 1 ) ) );
+        // but 2 is too much
+        assertIsLocked( true, period -> new Date( period.getEndDate().getTime() + TimeUnit.DAYS.toMillis( 2 ) ) );
+    }
+
+    private static void assertIsLocked( boolean expected, Function<Period, Date> actual )
+    {
+        Date now = new Date();
+        Period thisMonth = PeriodType.getPeriodType( PeriodTypeEnum.MONTHLY ).createPeriod( now );
+        DataSet ds = new DataSet();
+        ds.setExpiryDays( 1 );
+        assertEquals( expected, ds.isLocked( null, thisMonth, actual.apply( thisMonth ) ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/update/validation/ExpirationDaysCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/update/validation/ExpirationDaysCheck.java
@@ -139,7 +139,8 @@ public class ExpirationDaysCheck implements Checker
                 }
 
                 Period period = periodType.createPeriod( programStageInstance.getExecutionDate() );
-                if ( today.after( DateUtils.addDays( period.getEndDate(), program.getExpiryDays() ) ) )
+                if ( !Period.isDateInTimeFrame( null, DateUtils.addDays( period.getEndDate(), program.getExpiryDays() ),
+                    today ) )
                 {
                     return error(
                         "The program's expiry date has passed. It is not possible to make changes to this event",

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/update/validation/ExpirationDaysCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/update/validation/ExpirationDaysCheck.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.dxf2.events.importer.update.validation;
 
 import static org.hisp.dhis.dxf2.importsummary.ImportSummary.error;
 import static org.hisp.dhis.dxf2.importsummary.ImportSummary.success;
+import static org.hisp.dhis.util.DateUtils.addDays;
 
 import java.util.Date;
 
@@ -110,7 +111,7 @@ public class ExpirationDaysCheck implements Checker
                 }
 
                 if ( (new Date()).after(
-                    DateUtils.addDays( referenceDate, program.getCompleteEventsExpiryDays() ) ) )
+                    addDays( referenceDate, program.getCompleteEventsExpiryDays() ) ) )
                 {
                     return error(
                         "The event's completeness date has expired. Not possible to make changes to this event",
@@ -139,8 +140,7 @@ public class ExpirationDaysCheck implements Checker
                 }
 
                 Period period = periodType.createPeriod( programStageInstance.getExecutionDate() );
-                if ( !Period.isDateInTimeFrame( null, DateUtils.addDays( period.getEndDate(), program.getExpiryDays() ),
-                    today ) )
+                if ( !Period.isDateInTimeFrame( null, addDays( period.getEndDate(), program.getExpiryDays() ), today ) )
                 {
                     return error(
                         "The program's expiry date has passed. It is not possible to make changes to this event",


### PR DESCRIPTION
### Summary
3 more places where period end date was used to make a "moment is in period range" check.

With these checks a moment given as a timestamp is  checked to be within the range of the period (with some extra expiry days given). In such a scenarios when the end date timestamp points at the first second of the day the rest of the day is excluded and would not be considered included in the range when simply checking the mement to not be after the end. The method `Period.isDateInTimeFrame` adjusts the range check so that the full day is considered included. Therefore the 3 checks are now based on this method.

`Period.isFuture()` would have had a similar issue but it wasn't even used so it got removed.

### Automatic Testing
New test scenarios were added to check basic correctness for `DateElement.isExpired` and `DataSet.isLicked`.
`ExpirationDaysCheck` was already covered by tests.