### PR TITLE
fix: Createdbyuserinfo and lastupdatedbyuserinfo jsonb fields in programinstance are all blank (Old Tracker Capture) [2.37]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -577,6 +577,7 @@ public abstract class AbstractEnrollmentService
         }
 
         programInstance.setCreatedByUserInfo( UserInfoSnapshot.from( importOptions.getUser() ) );
+        programInstance.setLastUpdatedByUserInfo( UserInfoSnapshot.from( importOptions.getUser() ) );
 
         programInstanceService.addProgramInstance( programInstance, importOptions.getUser() );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/EnrollmentImportTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/EnrollmentImportTest.java
@@ -132,6 +132,9 @@ public class EnrollmentImportTest extends TransactionalIntegrationTest
         assertEquals( UserInfoSnapshot.from( user ),
             enrollmentService.getEnrollment( enrollmentUid )
                 .getCreatedByUserInfo() );
+        assertEquals( UserInfoSnapshot.from( user ),
+            enrollmentService.getEnrollment( enrollmentUid )
+                .getLastUpdatedByUserInfo() );
     }
 
     @Test


### PR DESCRIPTION
see https://github.com/dhis2/dhis2-core/pull/13236