### PR TITLE
fix: map Dari to Persian Afghanistan (DHIS2-14873)

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LocaleController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LocaleController.java
@@ -88,10 +88,10 @@ public class LocaleController
     {
         List<Locale> locales = localeManager.getAvailableLocales();
         List<WebLocale> webLocales = locales
-                .stream()
-                .map( WebLocale::fromLocale )
-                .sorted(Comparator.comparing( WebLocale::getName, String.CASE_INSENSITIVE_ORDER ))
-                .collect( Collectors.toList() );
+            .stream()
+            .map( WebLocale::fromLocale )
+            .sorted( Comparator.comparing( WebLocale::getName, String.CASE_INSENSITIVE_ORDER ) )
+            .collect( Collectors.toList() );
 
         return webLocales;
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LocaleController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LocaleController.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.created;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -86,7 +87,11 @@ public class LocaleController
     public @ResponseBody List<WebLocale> getUiLocales( Model model )
     {
         List<Locale> locales = localeManager.getAvailableLocales();
-        List<WebLocale> webLocales = locales.stream().map( WebLocale::fromLocale ).collect( Collectors.toList() );
+        List<WebLocale> webLocales = locales
+                .stream()
+                .map( WebLocale::fromLocale )
+                .sorted(Comparator.comparing( WebLocale::getName, String.CASE_INSENSITIVE_ORDER ))
+                .collect( Collectors.toList() );
 
         return webLocales;
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/WebLocale.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/WebLocale.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.webapi.webdomain;
 
 import java.util.AbstractMap;
-import java.util.AbstractMap.SimpleEntry;
 import java.util.Locale;
 import java.util.Map;
 
@@ -47,8 +46,7 @@ public class WebLocale
     private String name;
 
     private static Map<String, Locale> localeMap = Map.ofEntries(
-        new AbstractMap.SimpleEntry<String, Locale>("prs", new Locale("fa","AF"))
-    );
+        new AbstractMap.SimpleEntry<String, Locale>( "prs", new Locale( "fa", "AF" ) ) );
 
     public static WebLocale fromLocale( Locale locale )
     {
@@ -56,12 +54,7 @@ public class WebLocale
 
         loc.setLocale( locale.toString() );
 
-        if (localeMap.containsKey( locale.toString() ))
-        {
-            loc.setName( localeMap.get( locale.toString() ).getDisplayName() );
-        } else {
-            loc.setName( locale.getDisplayName() );
-        }
+        loc.setName( localeMap.getOrDefault( locale.toString(), locale ).getDisplayName() );
 
         return loc;
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/WebLocale.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/WebLocale.java
@@ -27,7 +27,10 @@
  */
 package org.hisp.dhis.webapi.webdomain;
 
+import java.util.AbstractMap;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.Locale;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -43,12 +46,22 @@ public class WebLocale
 
     private String name;
 
+    private static Map<String, Locale> localeMap = Map.ofEntries(
+        new AbstractMap.SimpleEntry<String, Locale>("prs", new Locale("fa","AF"))
+    );
+
     public static WebLocale fromLocale( Locale locale )
     {
         WebLocale loc = new WebLocale();
 
         loc.setLocale( locale.toString() );
-        loc.setName( locale.getDisplayName() );
+
+        if (localeMap.containsKey( locale.toString() ))
+        {
+            loc.setName( localeMap.get( locale.toString() ).getDisplayName() );
+        } else {
+            loc.setName( locale.getDisplayName() );
+        }
 
         return loc;
     }

--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/security/login.vm
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/security/login.vm
@@ -150,8 +150,8 @@
         <span id="applicationRightFooter">$!{keyApplicationRightFooter}</span>
         <select id="localeSelect" onchange="login.localeChanged()" class="marginLeftClass">
             <option value="">[ $i18n.getString( "change_language" ) ]</option>
-            #foreach( $locale in $availableLocales )
-                <option value="${locale.language}">${locale.displayName}</option>
+            #foreach( $locale in $webLocales )
+                <option value="${locale.locale}">${locale.name}</option>
             #end
         </select>
     </div>

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/action/LoginAction.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/action/LoginAction.java
@@ -28,11 +28,13 @@
 package org.hisp.dhis.security.action;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpSession;
 
@@ -40,6 +42,7 @@ import org.apache.struts2.ServletActionContext;
 import org.hisp.dhis.i18n.ui.resourcebundle.ResourceBundleManager;
 import org.hisp.dhis.security.oidc.DhisOidcClientRegistration;
 import org.hisp.dhis.security.oidc.DhisOidcProviderRepository;
+import org.hisp.dhis.webapi.webdomain.WebLocale;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mobile.device.Device;
 import org.springframework.mobile.device.DeviceResolver;
@@ -120,11 +123,11 @@ public class LoginAction
         this.oidcFailure = oidcFailure;
     }
 
-    private List<Locale> availableLocales;
+    private List<WebLocale> webLocales;
 
-    public List<Locale> getAvailableLocales()
+    public List<WebLocale> getWebLocales()
     {
-        return availableLocales;
+        return webLocales;
     }
 
     private final Map<String, Object> oidcConfig = new HashMap<>();
@@ -156,7 +159,12 @@ public class LoginAction
             return "mobile";
         }
 
-        availableLocales = new ArrayList<>( resourceBundleManager.getAvailableLocales() );
+        List<Locale> availableLocales = new ArrayList<>( resourceBundleManager.getAvailableLocales() );
+        webLocales = availableLocales
+                .stream()
+                .map( WebLocale::fromLocale )
+                .sorted(Comparator.comparing( WebLocale::getName, String.CASE_INSENSITIVE_ORDER ))
+                .collect( Collectors.toList() );
 
         return "standard";
     }

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/action/LoginAction.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/action/LoginAction.java
@@ -161,10 +161,10 @@ public class LoginAction
 
         List<Locale> availableLocales = new ArrayList<>( resourceBundleManager.getAvailableLocales() );
         webLocales = availableLocales
-                .stream()
-                .map( WebLocale::fromLocale )
-                .sorted(Comparator.comparing( WebLocale::getName, String.CASE_INSENSITIVE_ORDER ))
-                .collect( Collectors.toList() );
+            .stream()
+            .map( WebLocale::fromLocale )
+            .sorted( Comparator.comparing( WebLocale::getName, String.CASE_INSENSITIVE_ORDER ) )
+            .collect( Collectors.toList() );
 
         return "standard";
     }


### PR DESCRIPTION
We use the code [prs](https://iso639-3.sil.org/code/prs) throughout our apps for providing translations for Dari, the variant of Persian spoken in Afghanistan. 

However, we rely on java.util.locale for generating the names of the languages returned from api/locales/ui, and `prs` is not supported. This PR maps `prs` code to language: `fa`, country: `AF` . This then provides a name for the language `Persian (Afghanistan)`. 

Note: we have discussed this internally and while we would prefer to use the term `Dari` as it is the name preferred by the Afghan government, we think that the possible alternative of `Persian (Afghanistan)` is preferable to the existing approach of just showing the unmapped code `prs`.

There are more notes on the [ticket](https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-14873), but this PR represents a more direct way of addressing the bug.

**Before**
<img width="544" alt="image" src="https://user-images.githubusercontent.com/18490902/223484151-10a3929d-6e7a-45f7-9e53-d16dcaf1c21e.png">


**After**
<img width="452" alt="image" src="https://user-images.githubusercontent.com/18490902/223483959-e494d76d-8d16-47b2-aafe-76150f4c1516.png">
(my local build is in Norwegian, hence the Norwegian language names)
