### PR TITLE
fix: check for null plugin type before dereferencing

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -138,8 +138,8 @@ public class DefaultAppManager
     private Boolean isDashboardPluginType( App app )
     {
         return app.hasPluginEntrypoint()
-            && (app.getPluginType().equalsIgnoreCase( AppManager.DASHBOARD_PLUGIN_TYPE )
-                || app.getPluginType() == null);
+            && (app.getPluginType() == null
+                || app.getPluginType().equalsIgnoreCase( AppManager.DASHBOARD_PLUGIN_TYPE ));
     }
 
     @Override


### PR DESCRIPTION
This was causing a 500 error in the `/api/dashboards/search` endpoint when apps had been installed - see https://play.dhis2.org/dev/api/dashboards/search?q=anc, reported [here on Slack](https://dhis2.slack.com/archives/C1XNHEY0L/p1678188839900769) by @janhenrikoverland 