### PR TITLE
fix: event pageSize is not respected with more than 1 category DHIS2-13135

### DIFF
--- a/dhis-2/build-dev.sh
+++ b/dhis-2/build-dev.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Builds DHIS2 war and Docker image for development use
 
+set -e
+
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 D2CLUSTER="${1:-}"

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -1144,7 +1144,7 @@ public class JdbcEventStore implements EventStore
             joinAttributeValueWithoutQueryParameter( fromBuilder, params.getFilterAttributes() );
         }
 
-        fromBuilder.append( getCategoryOptionComboQuery( user, params ) );
+        fromBuilder.append( getCategoryOptionComboQuery( user ) );
 
         fromBuilder.append( dataElementAndFiltersSql );
 
@@ -1819,7 +1819,7 @@ public class JdbcEventStore implements EventStore
      * to an event.</li>
      * </ul>
      */
-    private String getCategoryOptionComboQuery( User user, EventSearchParams params )
+    private String getCategoryOptionComboQuery( User user )
     {
         String joinCondition = "inner join categoryoptioncombo coc on coc.categoryoptioncomboid = psi.attributeoptioncomboid "
             +

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/feedback/Assertions.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/feedback/Assertions.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.feedback;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationReport;
+
+/**
+ * Assertions for feedback like metadata validation reports.
+ */
+public class Assertions
+{
+    public static void assertNoErrors( ObjectBundleValidationReport report )
+    {
+        assertNotNull( report );
+        List<String> errors = new ArrayList<>();
+        report.forEachErrorReport( err -> {
+            errors.add( err.toString() );
+        } );
+        assertFalse( report.hasErrorReports(), String.format( "Expected no errors, instead got: %s\n", errors ) );
+    }
+
+}

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/Assertions.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/Assertions.java
@@ -36,11 +36,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
 
-import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationReport;
 import org.hisp.dhis.tracker.report.ImportReport;
 import org.hisp.dhis.tracker.report.Status;
 import org.hisp.dhis.tracker.report.ValidationReport;
@@ -266,16 +264,6 @@ public class Assertions
     {
         assertNotNull( report );
         assertFalse( report.hasErrors(), errorMessage( "Expected no validation errors, instead got:\n", report ) );
-    }
-
-    public static void assertNoErrors( ObjectBundleValidationReport report )
-    {
-        assertNotNull( report );
-        List<String> errors = new ArrayList<>();
-        report.forEachErrorReport( err -> {
-            errors.add( err.toString() );
-        } );
-        assertFalse( report.hasErrorReports(), String.format( "Expected no errors, instead got: %s\n", errors ) );
     }
 
     private static Supplier<String> errorMessage( String errorTitle, ValidationReport report )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/Assertions.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/Assertions.java
@@ -270,7 +270,6 @@ public class Assertions
 
     public static void assertNoErrors( ObjectBundleValidationReport report )
     {
-        // TODO(ivo): refactor, is there a way to reuse the existing errorMessage()?
         assertNotNull( report );
         List<String> errors = new ArrayList<>();
         report.forEachErrorReport( err -> {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/Assertions.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/Assertions.java
@@ -36,9 +36,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
 
+import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationReport;
 import org.hisp.dhis.tracker.report.ImportReport;
 import org.hisp.dhis.tracker.report.Status;
 import org.hisp.dhis.tracker.report.ValidationReport;
@@ -243,13 +245,6 @@ public class Assertions
                 report.getErrors() ) );
     }
 
-    public static void assertNoErrors( ImportReport report )
-    {
-        assertNotNull( report );
-        assertEquals( Status.OK, report.getStatus(),
-            errorMessage( "Expected import with status OK, instead got:\n", report.getValidationReport() ) );
-    }
-
     public static void assertNoErrorsAndNoWarnings( ImportReport report )
     {
         assertNotNull( report );
@@ -260,10 +255,28 @@ public class Assertions
                 "Expected import without warnings, instead got:\n" + report.getValidationReport().getWarnings() ) );
     }
 
+    public static void assertNoErrors( ImportReport report )
+    {
+        assertNotNull( report );
+        assertEquals( Status.OK, report.getStatus(),
+            errorMessage( "Expected import with status OK, instead got:\n", report.getValidationReport() ) );
+    }
+
     public static void assertNoErrors( ValidationReport report )
     {
         assertNotNull( report );
         assertFalse( report.hasErrors(), errorMessage( "Expected no validation errors, instead got:\n", report ) );
+    }
+
+    public static void assertNoErrors( ObjectBundleValidationReport report )
+    {
+        // TODO(ivo): refactor, is there a way to reuse the existing errorMessage()?
+        assertNotNull( report );
+        List<String> errors = new ArrayList<>();
+        report.forEachErrorReport( err -> {
+            errors.add( err.toString() );
+        } );
+        assertFalse( report.hasErrorReports(), String.format( "Expected no errors, instead got: %s\n", errors ) );
     }
 
     private static Supplier<String> errorMessage( String errorTitle, ValidationReport report )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -29,9 +29,15 @@ package org.hisp.dhis.tracker;
 
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.hisp.dhis.util.DateUtils.parseDate;
+import static org.hisp.dhis.utils.Assertions.assertContains;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
+import static org.hisp.dhis.utils.Assertions.assertStartsWith;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.time.ZoneId;
@@ -44,17 +50,23 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.hisp.dhis.analytics.AggregationType;
+import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.IdSchemes;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryOperator;
+import org.hisp.dhis.common.SlimPager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dxf2.events.event.Event;
 import org.hisp.dhis.dxf2.events.event.EventSearchParams;
 import org.hisp.dhis.dxf2.events.event.EventService;
+import org.hisp.dhis.dxf2.events.event.Events;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
@@ -65,7 +77,9 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam.SortDirection;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -117,11 +131,24 @@ class EventExporterTest extends TrackerTest
         User userA = userService.getUser( "M5zQapPyTZI" );
         assertNoErrors(
             trackerImportService.importTracker( fromJson( "tracker/event_and_enrollment.json", userA.getUid() ) ) );
-        orgUnit = manager.get( OrganisationUnit.class, "h4w96yEMlzO" );
-        programStage = manager.get( ProgramStage.class, "NpsdDv6kKSO" );
+        orgUnit = get( OrganisationUnit.class, "h4w96yEMlzO" );
+        programStage = get( ProgramStage.class, "NpsdDv6kKSO" );
         program = programStage.getProgram();
-        trackedEntityInstance = manager.get( TrackedEntityInstance.class, "dUE514NMOlo" );
+        trackedEntityInstance = get( TrackedEntityInstance.class, "dUE514NMOlo" );
+
+        // to test that events are only returned if the user has read access to ALL COs of an events COC
+        CategoryOption categoryOption = get( CategoryOption.class, "yMj2MnmNI8L" );
+        categoryOption.getSharing().setOwner( "o1HMTIzBGo7" );
+        manager.update( categoryOption );
+
         manager.flush();
+    }
+
+    @BeforeEach
+    void setUp()
+    {
+        // needed as some tests are run using another user (injectSecurityContext) while most tests expect to be run by admin
+        injectAdminUser();
     }
 
     private Stream<Arguments> getEventsFunctions()
@@ -181,7 +208,7 @@ class EventExporterTest extends TrackerTest
         params.setProgramStage( programStage );
 
         params.setStartDate( getDate( 2018, 1, 1 ) );
-        params.setEndDate( getDate( 2020, 1, 1 ) );
+        params.setEndDate( getDate( 2020, 1, 29 ) );
         params.setSkipChangedBefore( getDate( 2018, 1, 1 ) );
 
         List<String> events = eventFunction.apply( params );
@@ -354,6 +381,198 @@ class EventExporterTest extends TrackerTest
         List<String> events = eventsFunction.apply( params );
 
         assertContainsOnly( List.of( "pTzf9KYMk72" ), events );
+    }
+
+    @Test
+    void shouldReturnEventsNonSuperUserIsOwnerOrHasUserAccess()
+    {
+        // given events have a COC which has a CO which the
+        // user owns yMj2MnmNI8L and has user read access to OUUdG3sdOqb
+        injectSecurityContext( userService.getUser( "o1HMTIzBGo7" ) );
+
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( get( OrganisationUnit.class, "DiszpKrYNg8" ) );
+        params.setEvents( Set.of( "lumVtWwwy0O", "cadc5eGj0j7" ) );
+
+        Events events = eventService.getEvents( params );
+
+        assertContainsOnly( List.of( "lumVtWwwy0O", "cadc5eGj0j7" ), eventUids( events ) );
+        List<Executable> executables = events.getEvents().stream()
+            .map( e -> (Executable) () -> assertEquals( 2, e.getOptionSize(),
+                String.format( "got category options %s", e.getAttributeCategoryOptions() ) ) )
+            .collect( Collectors.toList() );
+        assertAll( "all events should have the optionSize set which is the number of COs in the COC", executables );
+    }
+
+    @Test
+    void shouldReturnNoEventsGivenUserHasNoAccess()
+    {
+        // given events have a COC which has a CO (OUUdG3sdOqb/yMj2MnmNI8L) which are not publicly readable, user is not the owner and has no user access
+        injectSecurityContext( userService.getUser( "CYVgFNKCaUS" ) );
+
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( get( OrganisationUnit.class, "DiszpKrYNg8" ) );
+        params.setEvents( Set.of( "lumVtWwwy0O", "cadc5eGj0j7" ) );
+
+        List<String> events = eventsFunction.apply( params );
+
+        assertIsEmpty( events );
+    }
+
+    @Test
+    void shouldReturnPublicEventsWithMultipleCategoryOptionsGivenNonDefaultPageSize()
+    {
+        OrganisationUnit orgUnit = get( OrganisationUnit.class, "DiszpKrYNg8" );
+        Program program = get( Program.class, "iS7eutanDry" );
+
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setProgram( program );
+
+        params.addOrders( List.of( new OrderParam( "occurredAt", OrderParam.SortDirection.DESC ) ) );
+        params.setPage( 1 );
+        params.setPageSize( 3 );
+
+        Events firstPage = eventService.getEvents( params );
+
+        assertAll( "first page",
+            () -> assertSlimPager( 1, 3, false, firstPage ),
+            () -> assertEquals( List.of( "ck7DzdxqLqA", "OTmjvJDn0Fu", "kWjSezkXHVp" ), eventUids( firstPage ) ) );
+
+        params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setProgram( program );
+
+        params.addOrders( List.of( new OrderParam( "occurredAt", OrderParam.SortDirection.DESC ) ) );
+        params.setPage( 2 );
+        params.setPageSize( 3 );
+
+        Events secondPage = eventService.getEvents( params );
+
+        assertAll( "second (last) page",
+            () -> assertSlimPager( 2, 3, true, secondPage ),
+            () -> assertEquals( List.of( "lumVtWwwy0O", "QRYjLTiJTrA", "cadc5eGj0j7" ), eventUids( secondPage ) ) );
+
+        params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setProgram( program );
+
+        params.addOrders( List.of( new OrderParam( "occurredAt", OrderParam.SortDirection.DESC ) ) );
+        params.setPage( 3 );
+        params.setPageSize( 3 );
+
+        assertIsEmpty( eventsFunction.apply( params ) );
+    }
+
+    @Test
+    void shouldReturnEventsWithMultipleCategoryOptionsGivenNonDefaultPageSizeAndTotalPages()
+    {
+        OrganisationUnit orgUnit = get( OrganisationUnit.class, "DiszpKrYNg8" );
+        Program program = get( Program.class, "iS7eutanDry" );
+
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setProgram( program );
+
+        params.addOrders( List.of( new OrderParam( "occurredAt", OrderParam.SortDirection.DESC ) ) );
+        params.setPage( 1 );
+        params.setPageSize( 2 );
+        params.setTotalPages( true );
+
+        Events events = eventService.getEvents( params );
+
+        assertAll( "first page",
+            () -> assertPager( 1, 2, 6, events ),
+            () -> assertEquals( List.of( "ck7DzdxqLqA", "OTmjvJDn0Fu" ), eventUids( events ) ) );
+    }
+
+    @Test
+    void shouldReturnEventsGivenCategoryOptionCombo()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( get( OrganisationUnit.class, "DiszpKrYNg8" ) );
+        params.setCategoryOptionCombo( get( CategoryOptionCombo.class, "cr89ebDZrac" ) );
+
+        Events events = eventService.getEvents( params );
+
+        assertContainsOnly( List.of( "kWjSezkXHVp", "OTmjvJDn0Fu" ), eventUids( events ) );
+        List<Executable> executables = events.getEvents().stream()
+            .map( e -> (Executable) () -> assertAll( "category options and combo of event " + e.getUid(),
+                () -> assertEquals( "cr89ebDZrac", e.getAttributeOptionCombo() ),
+                () -> assertEquals( "xwZ2u3WyQR0;M58XdOfhiJ7", e.getAttributeCategoryOptions() ),
+                () -> assertEquals( 2, e.getOptionSize(),
+                    String.format( "got category options %s", e.getAttributeCategoryOptions() ) ) ) )
+            .collect( Collectors.toList() );
+        assertAll( "all events should have the same category option combo and options", executables );
+    }
+
+    @Test
+    void shouldFailIfCategoryOptionComboOfGivenEventDoesNotHaveAValueForGivenIdScheme()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( get( OrganisationUnit.class, "DiszpKrYNg8" ) );
+        IdSchemes idSchemes = new IdSchemes();
+        idSchemes.setCategoryOptionComboIdScheme( "ATTRIBUTE:GOLswS44mh8" );
+        params.setIdSchemes( idSchemes );
+        params.setEvents( Set.of( "kWjSezkXHVp" ) );
+
+        IllegalStateException ex = assertThrows( IllegalStateException.class, () -> eventService.getEvents( params ) );
+        assertStartsWith( "CategoryOptionCombo", ex.getMessage() );
+        assertContains( "not have a value assigned for idScheme ATTRIBUTE:GOLswS44mh8", ex.getMessage() );
+    }
+
+    @Test
+    void shouldReturnEventsGivenIdSchemeCode()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( get( OrganisationUnit.class, "DiszpKrYNg8" ) );
+        params.setCategoryOptionCombo( get( CategoryOptionCombo.class, "cr89ebDZrac" ) );
+        IdSchemes idSchemes = new IdSchemes();
+        idSchemes.setProgramIdScheme( "code" );
+        idSchemes.setProgramStageIdScheme( "code" );
+        idSchemes.setOrgUnitIdScheme( "code" );
+        idSchemes.setCategoryOptionComboIdScheme( "code" );
+        params.setIdSchemes( idSchemes );
+
+        Events events = eventService.getEvents( params );
+
+        assertContainsOnly( List.of( "kWjSezkXHVp", "OTmjvJDn0Fu" ), eventUids( events ) );
+        List<Executable> executables = events.getEvents().stream()
+            .map( e -> (Executable) () -> assertAll( "event " + e.getUid(),
+                () -> assertEquals( "multi-program", e.getProgram() ),
+                () -> assertEquals( "multi-stage", e.getProgramStage() ),
+                () -> assertEquals( "DiszpKrYNg8", e.getOrgUnit() ), // TODO(ivo): this might be a bug caused by https://github.com/dhis2/dhis2-core/pull/12518
+                () -> assertEquals( "COC_1153452", e.getAttributeOptionCombo() ),
+                () -> assertEquals( "xwZ2u3WyQR0;M58XdOfhiJ7", e.getAttributeCategoryOptions() ) ) )
+            .collect( Collectors.toList() );
+        assertAll( "all events should have the same category option combo and options", executables );
+    }
+
+    @Test
+    void shouldReturnEventsGivenIdSchemeAttribute()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( get( OrganisationUnit.class, "DiszpKrYNg8" ) );
+        params.setCategoryOptionCombo( get( CategoryOptionCombo.class, "cr89ebDZrac" ) );
+        IdSchemes idSchemes = new IdSchemes();
+        idSchemes.setProgramIdScheme( "ATTRIBUTE:j45AR9cBQKc" );
+        idSchemes.setProgramStageIdScheme( "ATTRIBUTE:j45AR9cBQKc" );
+        idSchemes.setOrgUnitIdScheme( "ATTRIBUTE:j45AR9cBQKc" );
+        idSchemes.setCategoryOptionComboIdScheme( "ATTRIBUTE:j45AR9cBQKc" );
+        params.setIdSchemes( idSchemes );
+
+        Events events = eventService.getEvents( params );
+
+        assertContainsOnly( List.of( "kWjSezkXHVp", "OTmjvJDn0Fu" ), eventUids( events ) );
+        List<Executable> executables = events.getEvents().stream()
+            .map( e -> (Executable) () -> assertAll( "event " + e.getUid(),
+                () -> assertEquals( "multi-program-attribute", e.getProgram() ),
+                () -> assertEquals( "multi-program-stage-attribute", e.getProgramStage() ),
+                () -> assertEquals( "DiszpKrYNg8", e.getOrgUnit() ), // TODO(ivo): this might be a bug caused by https://github.com/dhis2/dhis2-core/pull/12518
+                () -> assertEquals( "COC_1153452-attribute", e.getAttributeOptionCombo() ),
+                () -> assertEquals( "xwZ2u3WyQR0;M58XdOfhiJ7", e.getAttributeCategoryOptions() ) ) )
+            .collect( Collectors.toList() );
+        assertAll( "all events should have the same category option combo and options", executables );
     }
 
     @Test
@@ -792,10 +1011,9 @@ class EventExporterTest extends TrackerTest
         params.setOrgUnit( orgUnit );
         params.addOrders( List.of( new OrderParam( "occurredAt", SortDirection.DESC ) ) );
 
-        List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
-            .collect( Collectors.toList() );
+        Events events = eventService.getEvents( params );
 
-        assertEquals( List.of( "TvctPPhpD8z", "nxP7UnKhomJ" ), enrollments );
+        assertEquals( List.of( "D9PbzJY8bJM", "pTzf9KYMk72" ), eventUids( events ) );
     }
 
     @Test
@@ -805,10 +1023,9 @@ class EventExporterTest extends TrackerTest
         params.setOrgUnit( orgUnit );
         params.addOrders( List.of( new OrderParam( "occurredAt", SortDirection.ASC ) ) );
 
-        List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
-            .collect( Collectors.toList() );
+        Events events = eventService.getEvents( params );
 
-        assertEquals( List.of( "nxP7UnKhomJ", "TvctPPhpD8z" ), enrollments );
+        assertEquals( List.of( "pTzf9KYMk72", "D9PbzJY8bJM" ), eventUids( events ) );
     }
 
     @Test
@@ -962,4 +1179,36 @@ class EventExporterTest extends TrackerTest
             at.isUnique() );
     }
 
+    private <T extends IdentifiableObject> T get( Class<T> type, String uid )
+    {
+        T t = manager.get( type, uid );
+        assertNotNull( t, () -> String.format( "metadata with uid '%s' should have been created", uid ) );
+        return t;
+    }
+
+    private static List<String> eventUids( Events events )
+    {
+        return events.getEvents()
+            .stream().map( Event::getEvent ).collect( Collectors.toList() );
+    }
+
+    private static void assertSlimPager( int pageNumber, int pageSize, boolean isLast, Events events )
+    {
+        assertInstanceOf( SlimPager.class, events.getPager(), "SlimPager should be returned if totalPages=false" );
+        SlimPager pager = (SlimPager) events.getPager();
+        assertAll( "pagination details",
+            () -> assertEquals( pageNumber, pager.getPage(), "number of current page" ),
+            () -> assertEquals( pageSize, pager.getPageSize(), "page size" ),
+            () -> assertEquals( isLast, pager.isLastPage(),
+                isLast ? "should be the last page" : "should NOT be the last page" ) );
+    }
+
+    private static void assertPager( int pageNumber, int pageSize, int totalCount, Events events )
+    {
+        Pager pager = events.getPager();
+        assertAll( "pagination details",
+            () -> assertEquals( pageNumber, pager.getPage(), "number of current page" ),
+            () -> assertEquals( pageSize, pager.getPageSize(), "page size" ),
+            () -> assertEquals( totalCount, pager.getTotal(), "total page count" ) );
+    }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/TrackerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/TrackerTest.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.tracker;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 
 import java.io.IOException;
 import java.util.List;
@@ -42,7 +42,6 @@ import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleMode;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleParams;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleService;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleValidationService;
-import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationReport;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.render.RenderFormat;
 import org.hisp.dhis.render.RenderService;
@@ -83,7 +82,6 @@ public abstract class TrackerTest extends SingleSetupIntegrationTestBase
     {
         userService = _userService;
         preCreateInjectAdminUser();
-        //
         renderService = _renderService;
         initTest();
     }
@@ -101,13 +99,7 @@ public abstract class TrackerTest extends SingleSetupIntegrationTestBase
         params.setImportStrategy( ImportStrategy.CREATE );
         params.setObjects( metadata );
         ObjectBundle bundle = objectBundleService.create( params );
-        ObjectBundleValidationReport validationReport = objectBundleValidationService.validate( bundle );
-        validationReport.forEachErrorReport( errorReport -> {
-            String s = errorReport.toString();
-            log.error( s );
-        } );
-        boolean condition = validationReport.hasErrorReports();
-        assertFalse( condition );
+        assertNoErrors( objectBundleValidationService.validate( bundle ) );
         objectBundleService.commit( bundle );
         return bundle;
     }
@@ -123,13 +115,7 @@ public abstract class TrackerTest extends SingleSetupIntegrationTestBase
         params.setObjects( metadata );
         params.setUser( user );
         ObjectBundle bundle = objectBundleService.create( params );
-        ObjectBundleValidationReport validationReport = objectBundleValidationService.validate( bundle );
-        validationReport.forEachErrorReport( errorReport -> {
-            String s = errorReport.toString();
-            log.error( s );
-        } );
-        boolean condition = validationReport.hasErrorReports();
-        assertFalse( condition );
+        assertNoErrors( objectBundleValidationService.validate( bundle ) );
         objectBundleService.commit( bundle );
         return bundle;
     }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/TrackerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/TrackerTest.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.tracker;
 
-import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
+import static org.hisp.dhis.feedback.Assertions.assertNoErrors;
 
 import java.io.IOException;
 import java.util.List;

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
@@ -222,9 +222,9 @@
             "identifier": "DATAEL00001"
           },
           "value": "value00001",
-          "created": "2021-07-01T12:05:00",
+          "createdAt": "2021-07-01T12:05:00",
           "storedBy": null,
-          "lastUpdated": "2022-07-01T12:05:00",
+          "updatedAt": "2022-07-01T12:05:00",
           "providedElsewhere": false
         },
         {
@@ -233,9 +233,9 @@
             "identifier": "DATAEL00005"
           },
           "value": "option1",
-          "created": "2021-07-01T12:05:00",
+          "createdAt": "2021-07-01T12:05:00",
           "storedBy": null,
-          "lastUpdated": "2022-07-01T12:05:00",
+          "updatedAt": "2022-07-01T12:05:00",
           "providedElsewhere": false
         },
         {
@@ -244,9 +244,9 @@
             "identifier": "DATAEL00006"
           },
           "value": "88",
-          "created": "2021-07-01T12:05:00",
+          "createdAt": "2021-07-01T12:05:00",
           "storedBy": null,
-          "lastUpdated": "2022-07-01T12:05:00",
+          "updatedAt": "2022-07-01T12:05:00",
           "providedElsewhere": false
         }
       ],
@@ -269,9 +269,9 @@
         "identifier": "h4w96yEMlzO"
       },
       "relationships": [],
-      "occurredAt": "2019-01-28T00:00:00.000",
+      "occurredAt": "2020-01-28T00:00:00.000",
       "executionDate": "2019-01-28T00:00:00.000",
-      "lastUpdated": "2019-01-28T00:00:00.000",
+      "updatedAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
       "storedBy": "admin",
       "followup": false,
@@ -337,6 +337,362 @@
         }
       ],
       "notes": []
+    },
+    {
+      "event": "QRYjLTiJTrA",
+      "occurredAt": "2022-04-20T06:00:38.343",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "SeWJkpLAyLt"
+      },
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xwZ2u3WyQR0"
+        },
+        {
+          "idScheme": "UID",
+          "identifier": "i4Nbp8S2G6A"
+        }
+      ],
+      "storedBy": "admin",
+      "scheduledAt": "2022-04-22T06:00:38.343",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "iS7eutanDry"
+      },
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "qLZC0lvvxQH"
+      },
+      "programType": "WITHOUT_REGISTRATION",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "DiszpKrYNg8"
+      },
+      "status": "ACTIVE",
+      "deleted": false,
+      "lastUpdatedByUserInfo": {
+        "uid": "xE7jOejl9FI",
+        "firstName": "John",
+        "surname": "Traore",
+        "username": "admin"
+      },
+      "createdByUserInfo": {
+        "uid": "xE7jOejl9FI",
+        "firstName": "John",
+        "surname": "Traore",
+        "username": "admin"
+      },
+      "dataValues": [
+        {
+          "created": "2022-04-22T06:00:38.339",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "GieVkTxp4HH"
+          },
+          "value": "15",
+          "providedElsewhere": false,
+          "createdByUserInfo": {
+            "uid": "xE7jOejl9FI",
+            "firstName": "John",
+            "surname": "Traore",
+            "username": "admin"
+          },
+          "lastUpdatedByUserInfo": {
+            "uid": "xE7jOejl9FI",
+            "firstName": "John",
+            "surname": "Traore",
+            "username": "admin"
+          }
+        }
+      ],
+      "notes": [],
+      "relationships": []
+    },
+    {
+      "event": "kWjSezkXHVp",
+      "occurredAt": "2022-04-22T06:00:38.343",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "cr89ebDZrac"
+      },
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xwZ2u3WyQR0"
+        },
+        {
+          "idScheme": "UID",
+          "identifier": "M58XdOfhiJ7"
+        }
+      ],
+      "storedBy": "admin",
+      "scheduledAt": "2022-04-26T06:00:34.323",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "iS7eutanDry"
+      },
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "qLZC0lvvxQH"
+      },
+      "programType": "WITHOUT_REGISTRATION",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "DiszpKrYNg8"
+      },
+      "status": "ACTIVE",
+      "deleted": false,
+      "lastUpdatedByUserInfo": {
+        "uid": "xE7jOejl9FI",
+        "firstName": "John",
+        "surname": "Traore",
+        "username": "admin"
+      },
+      "createdByUserInfo": {
+        "uid": "xE7jOejl9FI",
+        "firstName": "John",
+        "surname": "Traore",
+        "username": "admin"
+      },
+      "dataValues": [
+        {
+          "created": "2022-04-22T06:00:34.319",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "GieVkTxp4HH"
+          },
+          "value": "14",
+          "providedElsewhere": false,
+          "createdByUserInfo": {
+            "uid": "xE7jOejl9FI",
+            "firstName": "John",
+            "surname": "Traore",
+            "username": "admin"
+          },
+          "lastUpdatedByUserInfo": {
+            "uid": "xE7jOejl9FI",
+            "firstName": "John",
+            "surname": "Traore",
+            "username": "admin"
+          }
+        }
+      ],
+      "notes": [],
+      "relationships": []
+    },
+    {
+      "event": "OTmjvJDn0Fu",
+      "occurredAt": "2022-04-23T06:00:38.343",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "cr89ebDZrac"
+      },
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xwZ2u3WyQR0"
+        },
+        {
+          "idScheme": "UID",
+          "identifier": "M58XdOfhiJ7"
+        }
+      ],
+      "storedBy": "admin",
+      "scheduledAt": "2022-04-22T06:00:30.562",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "iS7eutanDry"
+      },
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "qLZC0lvvxQH"
+      },
+      "programType": "WITHOUT_REGISTRATION",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "DiszpKrYNg8"
+      },
+      "status": "ACTIVE",
+      "deleted": false,
+      "lastUpdatedByUserInfo": {
+        "uid": "xE7jOejl9FI",
+        "firstName": "John",
+        "surname": "Traore",
+        "username": "admin"
+      },
+      "createdByUserInfo": {
+        "uid": "xE7jOejl9FI",
+        "firstName": "John",
+        "surname": "Traore",
+        "username": "admin"
+      },
+      "dataValues": [
+        {
+          "created": "2022-04-22T06:00:30.559",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "GieVkTxp4HH"
+          },
+          "value": "13",
+          "providedElsewhere": false,
+          "createdByUserInfo": {
+            "uid": "xE7jOejl9FI",
+            "firstName": "John",
+            "surname": "Traore",
+            "username": "admin"
+          },
+          "lastUpdatedByUserInfo": {
+            "uid": "xE7jOejl9FI",
+            "firstName": "John",
+            "surname": "Traore",
+            "username": "admin"
+          }
+        }
+      ],
+      "notes": [],
+      "relationships": []
+    },
+    {
+      "event": "ck7DzdxqLqA",
+      "occurredAt": "2022-04-24T06:00:38.343",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "tzsPhPtE94U"
+      },
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xEunk8LPzkb"
+        },
+        {
+          "idScheme": "UID",
+          "identifier": "M58XdOfhiJ7"
+        }
+      ],
+      "storedBy": "admin",
+      "scheduledAt": "2022-04-22T06:00:14.228",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "iS7eutanDry"
+      },
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "qLZC0lvvxQH"
+      },
+      "programType": "WITHOUT_REGISTRATION",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "DiszpKrYNg8"
+      },
+      "status": "ACTIVE",
+      "deleted": false,
+      "lastUpdatedByUserInfo": {
+        "uid": "xE7jOejl9FI",
+        "firstName": "John",
+        "surname": "Traore",
+        "username": "admin"
+      },
+      "createdByUserInfo": {
+        "uid": "xE7jOejl9FI",
+        "firstName": "John",
+        "surname": "Traore",
+        "username": "admin"
+      },
+      "dataValues": [
+        {
+          "created": "2022-04-22T06:00:14.224",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "GieVkTxp4HH"
+          },
+          "value": "12",
+          "providedElsewhere": false,
+          "createdByUserInfo": {
+            "uid": "xE7jOejl9FI",
+            "firstName": "John",
+            "surname": "Traore",
+            "username": "admin"
+          },
+          "lastUpdatedByUserInfo": {
+            "uid": "xE7jOejl9FI",
+            "firstName": "John",
+            "surname": "Traore",
+            "username": "admin"
+          }
+        }
+      ],
+      "notes": [],
+      "relationships": []
+    },
+    {
+      "event": "lumVtWwwy0O",
+      "occurredAt": "2022-04-21T06:00:38.343",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "AeOORUC0ISH"
+      },
+      "storedBy": "admin",
+      "scheduledAt": "2022-04-22T06:00:14.228",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "iS7eutanDry"
+      },
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "qLZC0lvvxQH"
+      },
+      "programType": "WITHOUT_REGISTRATION",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "DiszpKrYNg8"
+      },
+      "status": "ACTIVE",
+      "dataValues": [
+        {
+          "created": "2022-04-22T06:00:14.224",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "GieVkTxp4HH"
+          },
+          "value": "12"
+        }
+      ]
+    },
+    {
+      "event": "cadc5eGj0j7",
+      "occurredAt": "2022-04-20T03:00:38.343",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "V2gbpszLQJm"
+      },
+      "storedBy": "admin",
+      "scheduledAt": "2022-04-22T06:00:14.228",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "iS7eutanDry"
+      },
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "qLZC0lvvxQH"
+      },
+      "programType": "WITHOUT_REGISTRATION",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "DiszpKrYNg8"
+      },
+      "status": "ACTIVE",
+      "dataValues": [
+        {
+          "created": "2022-04-22T06:00:14.224",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "GieVkTxp4HH"
+          },
+          "value": "12"
+        }
+      ]
     }
   ],
   "relationships": [],

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/simple_metadata.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/simple_metadata.json
@@ -1,4 +1,377 @@
 {
+  "attributes": [
+    {
+      "id": "j45AR9cBQKc",
+      "name": "some attribute",
+      "sharing": {
+        "owner": "PQD6wXJ2r5j",
+        "users": {},
+        "userGroups": {},
+        "public": "rw------"
+      },
+      "valueType": "TEXT",
+      "mandatory": false,
+      "unique": true,
+      "programAttribute": true,
+      "programStageAttribute": true,
+      "trackedEntityTypeAttribute": true,
+      "trackedEntityAttributeAttribute": true,
+      "organisationUnitAttribute": true,
+      "dataElementAttribute": true,
+      "relationshipTypeAttribute": true,
+      "categoryOptionAttribute": true,
+      "categoryOptionComboAttribute": true
+    }
+  ],
+  "categoryOptions": [
+    {
+      "id": "xYerKDKCefk",
+      "name": "default",
+      "code": "default",
+      "shortName": "default"
+    },
+    {
+      "id": "xwZ2u3WyQR0",
+      "name": "Unicef",
+      "code": "Unicef",
+      "shortName": "Unicef",
+      "sharing": {
+        "owner": "M5zQapPyTZI",
+        "users": {},
+        "userGroups": {},
+        "public": "rwr-----"
+      }
+    },
+    {
+      "id": "xEunk8LPzkb",
+      "name": "World Relief",
+      "code": "World Relief",
+      "shortName": "World Relief",
+      "description": "sharing.public data 'r' needs to be set to test this sharing case",
+      "sharing": {
+        "owner": "M5zQapPyTZI",
+        "users": {},
+        "userGroups": {},
+        "public": "rwr-----"
+      }
+    },
+    {
+      "id": "i4Nbp8S2G6A",
+      "name": "Improve access to clean water",
+      "code": "Project01",
+      "shortName": "Improve access to clean water",
+      "description": "used to test sharing when owner is null",
+      "sharing": {
+        "owner": null,
+        "users": {},
+        "userGroups": {},
+        "public": "rw------"
+      }
+    },
+    {
+      "id": "OUUdG3sdOqb",
+      "name": "Provide access to primary health care",
+      "code": "Project02",
+      "shortName": "Provide access to primary health care",
+      "description": "used to test non public data access. only super user or user with data access should get access",
+      "sharing": {
+        "owner": "M5zQapPyTZI",
+        "users": {
+          "o1HMTIzBGo7": {
+            "displayName": "foofi",
+            "access": "--r-----",
+            "id": "o1HMTIzBGo7"
+          }
+        },
+        "userGroups": {},
+        "public": "rw------"
+      }
+    },
+    {
+      "id": "yMj2MnmNI8L",
+      "name": "Improve access to medicines",
+      "code": "Project03",
+      "shortName": "Improve access to medicines",
+      "description": "used to test non public data access. only super user or owner should get access",
+      "sharing": {
+        "owner": "o1HMTIzBGo7",
+        "users": {},
+        "userGroups": {},
+        "public": "--------"
+      }
+    },
+    {
+      "id": "M58XdOfhiJ7",
+      "name": "Provide access to basic education",
+      "code": "Project04",
+      "shortName": "Provide access to basic education",
+      "description": "used to test sharing when public is null",
+      "sharing": {
+        "owner": "M5zQapPyTZI",
+        "users": {},
+        "userGroups": {},
+        "public": null
+      }
+    }
+  ],
+  "categories": [
+    {
+      "id": "GLevLNI9wkl",
+      "name": "default",
+      "code": "default",
+      "shortName": "default",
+      "dataDimensionType": "DISAGGREGATION",
+      "dataDimension": false,
+      "categoryOptions": [
+        {
+          "id": "xYerKDKCefk"
+        }
+      ]
+    },
+    {
+      "id": "LFsZ8v5v7rq",
+      "name": "Implementing Partner",
+      "code": "IMPL_PARTNER",
+      "shortName": "Implementing Partner",
+      "dataDimensionType": "ATTRIBUTE",
+      "dataDimension": true,
+      "categoryOptions": [
+        {
+          "id": "xwZ2u3WyQR0"
+        },
+        {
+          "id": "xEunk8LPzkb"
+        }
+      ]
+    },
+    {
+      "id": "yY2bQYqNt0o",
+      "name": "Project",
+      "code": "PROJECT",
+      "shortName": "Project",
+      "dataDimensionType": "ATTRIBUTE",
+      "dataDimension": true,
+      "categoryOptions": [
+        {
+          "id": "i4Nbp8S2G6A"
+        },
+        {
+          "id": "OUUdG3sdOqb"
+        },
+        {
+          "id": "yMj2MnmNI8L"
+        },
+        {
+          "id": "M58XdOfhiJ7"
+        }
+      ]
+    }
+  ],
+  "categoryCombos": [
+    {
+      "id": "bjDvmb4bfuf",
+      "code": "default",
+      "name": "default",
+      "dataDimensionType": "DISAGGREGATION",
+      "sharing": {
+        "users": {},
+        "userGroups": {},
+        "public": "rw------"
+      },
+      "skipTotal": false,
+      "categories": [
+        {
+          "id": "GLevLNI9wkl"
+        }
+      ]
+    },
+    {
+      "id": "O4VaNks6tta",
+      "name": "Implementing Partner and Projects",
+      "dataDimensionType": "ATTRIBUTE",
+      "skipTotal": false,
+      "categories": [
+        {
+          "id": "LFsZ8v5v7rq"
+        },
+        {
+          "id": "yY2bQYqNt0o"
+        }
+      ]
+    }
+  ],
+  "categoryOptionCombos": [
+    {
+      "id": "HllvX50cXC0",
+      "name": "default",
+      "code": "default",
+      "ignoreApproval": false,
+      "categoryCombo": {
+        "id": "bjDvmb4bfuf"
+      },
+      "translations": [],
+      "attributeValues": [],
+      "categoryOptions": [
+        {
+          "id": "xYerKDKCefk"
+        }
+      ]
+    },
+    {
+      "id": "tzsPhPtE94U",
+      "name": "World Relief, Provide access to basic education",
+      "code": "COC_1153413",
+      "ignoreApproval": false,
+      "categoryCombo": {
+        "id": "O4VaNks6tta"
+      },
+      "categoryOptions": [
+        {
+          "id": "xEunk8LPzkb"
+        },
+        {
+          "id": "M58XdOfhiJ7"
+        }
+      ]
+    },
+    {
+      "id": "UcWQppzD1it",
+      "name": "World Relief, Improve access to medicines",
+      "code": "COC_1153405",
+      "ignoreApproval": false,
+      "categoryCombo": {
+        "id": "O4VaNks6tta"
+      },
+      "translations": [],
+      "attributeValues": [],
+      "categoryOptions": [
+        {
+          "id": "xEunk8LPzkb"
+        },
+        {
+          "id": "yMj2MnmNI8L"
+        }
+      ]
+    },
+    {
+      "id": "i3HQ1ziPjC7",
+      "name": "World Relief, Improve access to clean water",
+      "code": "COC_1153403",
+      "ignoreApproval": false,
+      "categoryCombo": {
+        "id": "O4VaNks6tta"
+      },
+      "categoryOptions": [
+        {
+          "id": "i4Nbp8S2G6A"
+        },
+        {
+          "id": "xEunk8LPzkb"
+        }
+      ]
+    },
+    {
+      "id": "AeOORUC0ISH",
+      "name": "World Relief, Provide access to primary health care",
+      "code": "COC_1153408",
+      "ignoreApproval": false,
+      "categoryCombo": {
+        "id": "O4VaNks6tta"
+      },
+      "translations": [],
+      "attributeValues": [],
+      "categoryOptions": [
+        {
+          "id": "xEunk8LPzkb"
+        },
+        {
+          "id": "OUUdG3sdOqb"
+        }
+      ]
+    },
+    {
+      "id": "cr89ebDZrac",
+      "name": "Unicef, Provide access to basic education",
+      "code": "COC_1153452",
+      "ignoreApproval": false,
+      "categoryCombo": {
+        "id": "O4VaNks6tta"
+      },
+      "categoryOptions": [
+        {
+          "id": "xwZ2u3WyQR0"
+        },
+        {
+          "id": "M58XdOfhiJ7"
+        }
+      ],
+      "attributeValues": [
+        {
+          "attribute": {
+            "id": "j45AR9cBQKc"
+          },
+          "value": "COC_1153452-attribute"
+        }
+      ]
+    },
+    {
+      "id": "V2gbpszLQJm",
+      "name": "Unicef, Improve access to medicines",
+      "code": "COC_1153434",
+      "ignoreApproval": false,
+      "categoryCombo": {
+        "id": "O4VaNks6tta"
+      },
+      "translations": [],
+      "attributeValues": [],
+      "categoryOptions": [
+        {
+          "id": "xwZ2u3WyQR0"
+        },
+        {
+          "id": "yMj2MnmNI8L"
+        }
+      ]
+    },
+    {
+      "id": "SeWJkpLAyLt",
+      "name": "Unicef, Improve access to clean water",
+      "code": "COC_1153438",
+      "ignoreApproval": false,
+      "categoryCombo": {
+        "id": "O4VaNks6tta"
+      },
+      "translations": [],
+      "attributeValues": [],
+      "categoryOptions": [
+        {
+          "id": "xwZ2u3WyQR0"
+        },
+        {
+          "id": "i4Nbp8S2G6A"
+        }
+      ]
+    },
+    {
+      "id": "B81quHGEY7H",
+      "name": "Unicef, Provide access to primary health care",
+      "code": "COC_1153446",
+      "ignoreApproval": false,
+      "categoryCombo": {
+        "id": "O4VaNks6tta"
+      },
+      "translations": [],
+      "attributeValues": [],
+      "categoryOptions": [
+        {
+          "id": "xwZ2u3WyQR0"
+        },
+        {
+          "id": "OUUdG3sdOqb"
+        }
+      ]
+    }
+  ],
   "trackedEntityTypes": [
     {
       "created": "2020-05-31T08:59:52.758",
@@ -242,6 +615,22 @@
       "userAccesses": [],
       "legendSets": [],
       "aggregationLevels": []
+    },
+    {
+      "id": "GieVkTxp4HH",
+      "code": "DE_240794",
+      "lastUpdated": "2015-03-31T11:22:51.642",
+      "created": "2015-03-31T10:27:46.069",
+      "name": "Height in cm",
+      "shortName": "Height in cm",
+      "aggregationType": "AVERAGE",
+      "domainType": "TRACKER",
+      "valueType": "NUMBER",
+      "zeroIsSignificant": false,
+      "url": "",
+      "categoryCombo": {
+        "id": "bjDvmb4bfuf"
+      }
     }
   ],
   "options": [
@@ -654,6 +1043,80 @@
       "attributeValues": [],
       "userAccesses": [],
       "programStageSections": []
+    },
+    {
+      "id": "qLZC0lvvxQH",
+      "name": "Program stage for multiple categories program",
+      "code": "multi-stage",
+      "lastUpdated": "2022-04-22T05:57:59.849",
+      "created": "2022-04-22T05:57:48.383",
+      "allowGenerateNextVisit": false,
+      "preGenerateUID": false,
+      "openAfterEnrollment": false,
+      "repeatable": false,
+      "remindCompleted": false,
+      "displayGenerateEventBox": true,
+      "generatedByEnrollmentDate": false,
+      "validationStrategy": "ON_UPDATE_AND_INSERT",
+      "autoGenerateEvent": true,
+      "hideDueDate": false,
+      "blockEntryForm": false,
+      "enableUserAssignment": false,
+      "minDaysFromStart": 0,
+      "program": {
+        "id": "iS7eutanDry"
+      },
+      "notificationTemplates": [],
+      "programStageDataElements": [
+        {
+          "lastUpdated": "2022-04-22T05:57:59.783",
+          "id": "j4bu9hXjR6n",
+          "created": "2022-04-22T05:57:48.383",
+          "displayInReports": false,
+          "skipSynchronization": false,
+          "externalAccess": false,
+          "renderOptionsAsRadio": false,
+          "skipAnalytics": false,
+          "allowFutureDate": false,
+          "sharing": {
+            "users": {},
+            "userGroups": {}
+          },
+          "compulsory": false,
+          "allowProvidedElsewhere": false,
+          "sortOrder": 1,
+          "favorite": false,
+          "access": {
+            "read": true,
+            "update": true,
+            "externalize": false,
+            "delete": true,
+            "write": true,
+            "manage": true
+          },
+          "programStage": {
+            "id": "qLZC0lvvxQH"
+          },
+          "dataElement": {
+            "id": "GieVkTxp4HH"
+          },
+          "favorites": [],
+          "translations": [],
+          "userGroupAccesses": [],
+          "attributeValues": [],
+          "userAccesses": []
+        }
+      ],
+      "translations": [],
+      "attributeValues": [
+        {
+          "attribute": {
+            "id": "j45AR9cBQKc"
+          },
+          "value": "multi-program-stage-attribute"
+        }
+      ],
+      "programStageSections": []
     }
   ],
   "users": [
@@ -753,18 +1216,123 @@
       "organisationUnits": [
         {
           "id": "h4w96yEMlzO"
+        },
+        {
+          "id": "DiszpKrYNg8"
         }
       ],
       "dataViewOrganisationUnits": []
+    },
+    {
+      "id": "o1HMTIzBGo7",
+      "created": "2020-05-31T08:57:59.048",
+      "surname": "foofi",
+      "email": "foofi@dhis2.org",
+      "firstName": "foofi",
+      "password": "Test123###...",
+      "phoneNumber": "+4740332255",
+      "name": "foofi",
+      "displayName": "foofi",
+      "externalAuth": false,
+      "externalAccess": false,
+      "disabled": false,
+      "twoFA": false,
+      "passwordLastUpdated": "2020-05-31T08:57:59.060",
+      "invitation": false,
+      "selfRegistered": false,
+      "favorite": false,
+      "username": "foofi",
+      "access": {
+        "read": true,
+        "update": true,
+        "externalize": true,
+        "delete": true,
+        "write": true,
+        "manage": true
+      },
+      "favorites": [],
+      "cogsDimensionConstraints": [],
+      "catDimensionConstraints": [],
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userRoles": [
+        {
+          "id": "UbhT3bXWUyb"
+        }
+      ],
+      "userAccesses": [],
+      "teiSearchOrganisationUnits": [],
+      "organisationUnits": [
+        {
+          "id": "DiszpKrYNg8"
+        }
+      ],
+      "dataViewOrganisationUnits": [
+        {
+          "id": "DiszpKrYNg8"
+        }
+      ]
+    },
+    {
+      "id": "CYVgFNKCaUS",
+      "created": "2020-05-31T08:57:59.048",
+      "surname": "aaaa",
+      "email": "aaaa@dhis2.org",
+      "firstName": "aaaa",
+      "password": "Test123###...",
+      "phoneNumber": "+4740332255",
+      "name": "aaaa",
+      "displayName": "aaaa",
+      "externalAuth": false,
+      "externalAccess": false,
+      "disabled": false,
+      "twoFA": false,
+      "passwordLastUpdated": "2020-05-31T08:57:59.060",
+      "invitation": false,
+      "selfRegistered": false,
+      "favorite": false,
+      "username": "aaaa",
+      "access": {
+        "read": true,
+        "update": true,
+        "externalize": true,
+        "delete": true,
+        "write": true,
+        "manage": true
+      },
+      "favorites": [],
+      "cogsDimensionConstraints": [],
+      "catDimensionConstraints": [],
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userRoles": [
+        {
+          "id": "UbhT3bXWUyb"
+        }
+      ],
+      "userAccesses": [],
+      "teiSearchOrganisationUnits": [],
+      "organisationUnits": [
+        {
+          "id": "DiszpKrYNg8"
+        }
+      ],
+      "dataViewOrganisationUnits": [
+        {
+          "id": "DiszpKrYNg8"
+        }
+      ]
     }
   ],
   "organisationUnits": [
     {
+      "id": "h4w96yEMlzO",
+      "name": "test-orgunit",
       "level": 1,
       "created": "2020-05-31T08:56:15.922",
       "lastUpdated": "2020-05-31T11:41:22.384",
-      "name": "test-orgunit",
-      "id": "h4w96yEMlzO",
       "publicAccess": "rwrw----",
       "shortName": "test-orgunit",
       "description": "test-orgunit",
@@ -780,11 +1348,11 @@
       "translations": []
     },
     {
+      "id": "uoNW0E3xXUy",
+      "name": "test-orgunit-2",
       "level": 2,
       "created": "2020-05-31T09:05:34.570",
       "lastUpdated": "2020-05-31T11:41:22.385",
-      "name": "test-orgunit-2",
-      "id": "uoNW0E3xXUy",
       "shortName": "test-program-rule",
       "path": "/h4w96yEMlzO/uoNW0E3xXUy",
       "closedDate": "2020-12-27T00:00:00.000",
@@ -800,15 +1368,43 @@
       },
       "attributeValues": [],
       "translations": []
+    },
+    {
+      "id": "DiszpKrYNg8",
+      "name": "test-orgunit-3",
+      "code": "org3",
+      "level": 1,
+      "created": "2020-05-31T08:56:15.922",
+      "lastUpdated": "2020-05-31T11:41:22.384",
+      "publicAccess": "rwrw----",
+      "shortName": "test-orgunit-3",
+      "description": "test-orgunit-3",
+      "path": "/DiszpKrYNg8",
+      "openingDate": "2020-05-31T00:00:00.000",
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "attributeValues": [
+        {
+          "attribute": {
+            "id": "j45AR9cBQKc"
+          },
+          "value": "multi-org-attribute"
+        }
+      ],
+      "translations": []
     }
   ],
   "programs": [
     {
-      "lastUpdated": "2020-05-31T11:41:22.438",
       "id": "BFcipDERJnf",
-      "created": "2020-05-31T09:02:52.718",
       "name": "test-program",
       "shortName": "test-program",
+      "lastUpdated": "2020-05-31T11:41:22.438",
+      "created": "2020-05-31T09:02:52.718",
       "publicAccess": "rwrw----",
       "completeEventsExpiryDays": 0,
       "ignoreOverdueEvents": false,
@@ -859,11 +1455,11 @@
       "userAccesses": []
     },
     {
-      "lastUpdated": "2019-01-28T11:23:20.906",
       "id": "BFcipDERJne",
-      "created": "2019-01-28T11:23:20.906",
       "name": "ProgramA",
       "shortName": "ProgramA",
+      "lastUpdated": "2019-01-28T11:23:20.906",
+      "created": "2019-01-28T11:23:20.906",
       "publicAccess": "rw------",
       "completeEventsExpiryDays": 0,
       "ignoreOverdueEvents": false,
@@ -906,6 +1502,54 @@
         }
       ],
       "userAccesses": []
+    },
+    {
+      "id": "iS7eutanDry",
+      "name": "Program with multiple categories",
+      "code": "multi-program",
+      "shortName": "Program with multiple categories",
+      "lastUpdated": "2022-04-22T05:57:59.829",
+      "created": "2022-04-22T05:57:48.409",
+      "completeEventsExpiryDays": 0,
+      "ignoreOverdueEvents": false,
+      "skipOffline": false,
+      "minAttributesRequiredToSearch": 1,
+      "displayFrontPageList": false,
+      "onlyEnrollOnce": false,
+      "programType": "WITHOUT_REGISTRATION",
+      "accessLevel": "OPEN",
+      "version": 1,
+      "maxTeiCountToReturn": 0,
+      "selectIncidentDatesInFuture": false,
+      "displayIncidentDate": true,
+      "selectEnrollmentDatesInFuture": false,
+      "expiryDays": 0,
+      "useFirstStageDuringRegistration": false,
+      "categoryCombo": {
+        "id": "O4VaNks6tta"
+      },
+      "programTrackedEntityAttributes": [],
+      "notificationTemplates": [],
+      "translations": [],
+      "organisationUnits": [
+        {
+          "id": "DiszpKrYNg8"
+        }
+      ],
+      "programSections": [],
+      "attributeValues": [
+        {
+          "attribute": {
+            "id": "j45AR9cBQKc"
+          },
+          "value": "multi-program-attribute"
+        }
+      ],
+      "programStages": [
+        {
+          "id": "qLZC0lvvxQH"
+        }
+      ]
     }
   ],
   "userRoles": [
@@ -962,6 +1606,27 @@
       ],
       "translations": [],
       "userAccesses": []
+    },
+    {
+      "id": "UbhT3bXWUyb",
+      "name": "Basic",
+      "created": "2020-04-17T14:32:31.826",
+      "lastUpdated": "2020-04-17T14:32:31.826",
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "authorities": [
+        "M_dhis-web-capture",
+        "M_dhis-web-tracker-capture"
+      ],
+      "translations": []
     }
   ],
   "trackedEntityAttributes": [


### PR DESCRIPTION
## Main Bug Description

`/tracker/events?pageSize` is not respected for events with multiple category options (COs). If an event belongs to a program with a category combo (CC) with multiple categories the category option combo (COC) will be composed of multiple category options. One category option per category 😅 

The `pageSize` query parameter translates to an SQL limit. So for this endpoint the limit should mean number of events returned.

If the program has a category combination of 2 categories the COC will be composed of 2 COs.

Right now `pageSize=2` leads to a result set with one row per event * 2 (the number of COs)

```
   psi_uid   │  co_uid
═════════════╪═════════════
 AGu4QcxKJQ1 │ yMj2MnmNI8L
 AGu4QcxKJQ1 │ B3nxOazOO2G
```

So instead of getting 2 events we get 1. If you were to look at the query and extend the limit to see the next rows it would look like

```
   psi_uid   │  co_uid
═════════════╪═════════════
 AGu4QcxKJQ1 │ yMj2MnmNI8L
 AGu4QcxKJQ1 │ B3nxOazOO2G
 AmofQP7pKPL │ yMj2MnmNI8L
 AmofQP7pKPL │ C6nZpLKjEJr
```

The root cause is that we join on `dataelementcategoryoption` without any aggregation. This leads to the number of rows = number of events * number of categories. Right now the aggregation is done in Java code https://github.com/dhis2/dhis2-core/blob/20f4fb95e269fe6276ccc4d1ca88988f20cf5d64/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java#L486-L497
At this point the limit has already had its effect and we will not get all necessary events.

### Side bug

Discovered while adding tests for the issue reported via Jira.

* order by `occurredAt` uses enrollments `occurredAt` ([pi.incidentdate](https://github.com/dhis2/dhis2-core/blob/f1df7838dce14abf75d126018706826637602946/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java#L216)) instead of events `occurredAt` (psi.executiondate). dxf2 Event.eventDate is set from [psi.executiondate](https://github.com/dhis2/dhis2-core/blob/f1df7838dce14abf75d126018706826637602946/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java#L450) and mapped to tracker [occurredAt](https://github.com/dhis2/dhis2-core/blob/f1df7838dce14abf75d126018706826637602946/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/EventMapper.java#L45) from dxf2 Event.eventDate

## Constraints

* Pagination can only be correct if the limit is applied to the final result set. Meaning all possible joins, filters and ordering needs to be applied.
* Sharing needs to be respected. A user has access to an event if they are a super user or have access to every CO in the events COC. This means we need to aggregate as COCs in CCs with more than one category would otherwise lead to number of rows = number of events * number of categories.
* The query is very dynamic and has lots of permutations. JdbcEventStore > 2300 LoC.

## Fix

* Aggregate COs using `string_agg` in SQL instead of the result set mapper in the JdbcEventStore.
* Merge it with the aggregation of the option size count which is just the count of COs.
* Merge it with the ACL check. A user has access to an event only if the user has access to all COs of the events COC. Use the ACL check we already had but instead of returning an access flag for each events CO, aggregate over all COs using `bool_and`.

### Sample query

To make it easier to see what sub-query `coc_agg` is used in the end to make the ACL check and aggregate COs into a single string like `xwZ2u3WyQR0;M58XdOfhiJ7` and get the CO count

```sql
inner join (select coc.categoryoptioncomboid  as id,
                                  string_agg(co.uid, ';')    as co_uids,
                                  count(co.categoryoptionid) as co_count
                           from categoryoptioncombo coc
                                    inner join categoryoptioncombos_categoryoptions cocco
                                               on coc.categoryoptioncomboid = cocco.categoryoptioncomboid
                                    inner join dataelementcategoryoption co
                                               on cocco.categoryoptionid = co.categoryoptionid
                           group by coc.categoryoptioncomboid
                           having bool_and(case
                                               when (co.sharing ->> 'owner' is null or co.sharing ->> 'owner' = 'o1HMTIzBGo7') or
                                                    co.sharing ->> 'public' like '__r_____' or
                                                    co.sharing ->> 'public' is null or
                                                    (jsonb_has_user_id(co.sharing, 'o1HMTIzBGo7') = true and
                                                     jsonb_check_user_access(co.sharing, 'o1HMTIzBGo7', '__r_____') =
                                                     true) then true
                                               else false end) = True) as coc_agg
                          on coc_agg.id = psi.attributeoptioncomboid
```
