### PR TITLE
feat: support AMQP in event hooks

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventhook/targets/AmqpTarget.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventhook/targets/AmqpTarget.java
@@ -25,52 +25,34 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.eventhook;
-
-import java.io.Serializable;
+package org.hisp.dhis.eventhook.targets;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 import lombok.experimental.Accessors;
 
-import org.hisp.dhis.eventhook.targets.AmqpTarget;
-import org.hisp.dhis.eventhook.targets.ConsoleTarget;
-import org.hisp.dhis.eventhook.targets.JmsTarget;
-import org.hisp.dhis.eventhook.targets.KafkaTarget;
-import org.hisp.dhis.eventhook.targets.WebhookTarget;
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.eventhook.Target;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 /**
  * @author Morten Olav Hansen
  */
 @Getter
 @Setter
-@ToString
+@EqualsAndHashCode( callSuper = true )
 @Accessors( chain = true )
-@EqualsAndHashCode
-@JsonTypeInfo( use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type" )
-@JsonSubTypes( {
-    @JsonSubTypes.Type( value = WebhookTarget.class, name = WebhookTarget.TYPE ),
-    @JsonSubTypes.Type( value = ConsoleTarget.class, name = ConsoleTarget.TYPE ),
-    @JsonSubTypes.Type( value = JmsTarget.class, name = JmsTarget.TYPE ),
-    @JsonSubTypes.Type( value = KafkaTarget.class, name = KafkaTarget.TYPE ),
-    @JsonSubTypes.Type( value = AmqpTarget.class, name = AmqpTarget.TYPE )
-} )
-public abstract class Target
-    implements Serializable
+public class AmqpTarget extends Target
 {
-    @JsonCreator
-    protected Target( @JsonProperty( "type" ) String type )
-    {
-        this.type = type;
-    }
+    public static final String TYPE = "amqp";
 
-    @JsonProperty
-    protected final String type;
+    @JsonProperty( required = true )
+    private String clientId = "dhis2-amqp-" + CodeGenerator.generateUid();
+
+    public AmqpTarget()
+    {
+        super( TYPE );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-event-hook/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-event-hook/pom.xml
@@ -52,6 +52,10 @@
       <artifactId>spring-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.amqp</groupId>
+      <artifactId>spring-rabbit</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/dhis-2/dhis-services/dhis-service-event-hook/src/main/java/org/hisp/dhis/eventhook/EventHookListener.java
+++ b/dhis-2/dhis-services/dhis-service-event-hook/src/main/java/org/hisp/dhis/eventhook/EventHookListener.java
@@ -37,10 +37,12 @@ import javax.annotation.PostConstruct;
 
 import lombok.RequiredArgsConstructor;
 
+import org.hisp.dhis.eventhook.handlers.AmqpHandler;
 import org.hisp.dhis.eventhook.handlers.ConsoleHandler;
 import org.hisp.dhis.eventhook.handlers.JmsHandler;
 import org.hisp.dhis.eventhook.handlers.KafkaHandler;
 import org.hisp.dhis.eventhook.handlers.WebhookHandler;
+import org.hisp.dhis.eventhook.targets.AmqpTarget;
 import org.hisp.dhis.eventhook.targets.ConsoleTarget;
 import org.hisp.dhis.eventhook.targets.JmsTarget;
 import org.hisp.dhis.eventhook.targets.KafkaTarget;
@@ -150,6 +152,10 @@ public class EventHookListener
                 else if ( KafkaTarget.TYPE.equals( target.getType() ) )
                 {
                     targets.get( eh.getUid() ).add( new KafkaHandler( (KafkaTarget) target ) );
+                }
+                else if ( AmqpTarget.TYPE.equals( target.getType() ) )
+                {
+                    targets.get( eh.getUid() ).add( new AmqpHandler( (AmqpTarget) target ) );
                 }
             }
         }

--- a/dhis-2/dhis-services/dhis-service-event-hook/src/main/java/org/hisp/dhis/eventhook/handlers/AmqpHandler.java
+++ b/dhis-2/dhis-services/dhis-service-event-hook/src/main/java/org/hisp/dhis/eventhook/handlers/AmqpHandler.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.eventhook.handlers;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.hisp.dhis.eventhook.Event;
+import org.hisp.dhis.eventhook.EventHook;
+import org.hisp.dhis.eventhook.Handler;
+import org.hisp.dhis.eventhook.targets.AmqpTarget;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.RabbitConnectionFactoryBean;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+import com.rabbitmq.client.ConnectionFactory;
+
+/**
+ * @author Morten Olav Hansen
+ */
+@Slf4j
+public class AmqpHandler implements Handler
+{
+    private final AmqpTarget target;
+
+    private RabbitTemplate rabbitTemplate;
+
+    public AmqpHandler( AmqpTarget target )
+    {
+        this.target = target;
+        configure( target );
+    }
+
+    private void configure( AmqpTarget target )
+    {
+        try
+        {
+            System.err.println( "HELLO" );
+
+            RabbitConnectionFactoryBean factoryBean = new RabbitConnectionFactoryBean();
+            factoryBean.setPort( 5672 );
+            factoryBean.setHost( "127.0.0.1" );
+            factoryBean.setUsername( "guest" );
+            factoryBean.setPassword( "guest" );
+            factoryBean.setVirtualHost( "/" );
+            factoryBean.afterPropertiesSet();
+
+            ConnectionFactory connectionFactory = factoryBean.getRabbitConnectionFactory();
+
+            CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory( connectionFactory );
+            cachingConnectionFactory.setConnectionLimit( 3 );
+            cachingConnectionFactory.afterPropertiesSet();
+
+            this.rabbitTemplate = new RabbitTemplate( cachingConnectionFactory );
+            this.rabbitTemplate.setRoutingKey( "dhis2.hooks" );
+            this.rabbitTemplate.setExchange( "dhis2.hooks" );
+            this.rabbitTemplate.setMandatory( false );
+            this.rabbitTemplate.setReplyTimeout( 1_000 );
+        }
+        catch ( Exception e )
+        {
+            log.error( "Could not configure AMQP handler", e );
+        }
+    }
+
+    @Override
+    public void run( EventHook eventHook, Event event, String payload )
+    {
+        log.info( payload );
+        rabbitTemplate.convertAndSend( payload );
+    }
+}

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -89,6 +89,7 @@
     <spring-retry.version>1.3.4</spring-retry.version>
     <spring-restdocs.version>2.0.7.RELEASE</spring-restdocs.version>
     <spring-ldap.version>2.4.1</spring-ldap.version>
+    <spring-rabbit.version>2.4.10</spring-rabbit.version>
     <cache2k-api.version>1.6.0.Final</cache2k-api.version>
     <lettuce.version>6.2.3.RELEASE</lettuce.version>
 
@@ -1128,6 +1129,11 @@
         <groupId>org.springframework.ldap</groupId>
         <artifactId>spring-ldap-core</artifactId>
         <version>${spring-ldap.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.amqp</groupId>
+        <artifactId>spring-rabbit</artifactId>
+        <version>${spring-rabbit.version}</version>
       </dependency>
 
       <!-- Spring Security -->


### PR DESCRIPTION
## Summary

Implements `amqp` as `EventHook` target. Probably won't be included in 2.40 (maybe 2.40.1).

Very much WIP, no need to review or merge.