### PR TITLE
fix: refactor owner check in AclService [TECH-1516]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
+++ b/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
@@ -141,7 +141,7 @@ public class DefaultAclService implements AclService
                 return checkOptionComboSharingPermission( user, object, Permission.READ );
             }
 
-            if ( !schema.isShareable() || object.getPublicAccess() == null || checkUser( user, object )
+            if ( !schema.isShareable() || object.getPublicAccess() == null
                 || checkSharingPermission( user, object, Permission.READ ) )
             {
                 return true;
@@ -305,7 +305,7 @@ public class DefaultAclService implements AclService
             return writeCommonCheck( schema, user, object, objType );
         }
         else if ( schema.isImplicitPrivateAuthority() && checkSharingAccess( user, object, objType )
-            && (checkUser( user, object ) || checkSharingPermission( user, object, Permission.WRITE )) )
+            && (checkSharingPermission( user, object, Permission.WRITE )) )
         {
             return true;
         }
@@ -346,13 +346,13 @@ public class DefaultAclService implements AclService
             }
 
             if ( checkSharingAccess( user, object, objType ) &&
-                (checkUser( user, object ) || checkSharingPermission( user, object, Permission.WRITE )) )
+                (checkSharingPermission( user, object, Permission.WRITE )) )
             {
                 return true;
             }
         }
         else if ( schema.isImplicitPrivateAuthority()
-            && (checkUser( user, object ) || checkSharingPermission( user, object, Permission.WRITE )) )
+            && (checkSharingPermission( user, object, Permission.WRITE )) )
         {
             return true;
         }
@@ -658,8 +658,7 @@ public class DefaultAclService implements AclService
         List<ErrorReport> errorReports = new ArrayList<>();
         Schema schema = schemaService.getSchema( HibernateProxyUtils.getRealClass( object ) );
 
-        if ( !schema.isImplicitPrivateAuthority() || checkUser( user, object )
-            || checkSharingPermission( user, object, Permission.WRITE ) )
+        if ( !schema.isImplicitPrivateAuthority() || checkSharingPermission( user, object, Permission.WRITE ) )
         {
             return errorReports;
         }
@@ -757,6 +756,11 @@ public class DefaultAclService implements AclService
             return true;
         }
 
+        if ( checkUser( user, object ) )
+        {
+            return true;
+        }
+
         if ( sharing.getUserGroups() != null && !CollectionUtils.isEmpty( user.getGroups() ) )
         {
             for ( UserGroupAccess userGroupAccess : sharing.getUserGroups().values() )
@@ -829,8 +833,8 @@ public class DefaultAclService implements AclService
             return true;
         }
 
-        return checkSharingAccess( user, object, objType ) &&
-            (checkUser( user, object ) || checkSharingPermission( user, object, Permission.WRITE ));
+        return checkSharingAccess( user, object, objType )
+            && (checkSharingPermission( user, object, Permission.WRITE ));
     }
 
     private boolean hasUserGroupAccess( Set<UserGroup> userGroups, String userGroupUid )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/security/EnrollmentSecurityTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/security/EnrollmentSecurityTest.java
@@ -115,6 +115,7 @@ class EnrollmentSecurityTest extends TransactionalIntegrationTest
     protected void setUpTest()
     {
         userService = _userService;
+        User admin = createAndInjectAdminUser();
         organisationUnitA = createOrganisationUnit( 'A' );
         organisationUnitB = createOrganisationUnit( 'B' );
         manager.save( organisationUnitA );
@@ -136,6 +137,7 @@ class EnrollmentSecurityTest extends TransactionalIntegrationTest
         programA = createProgram( 'A', new HashSet<>(), organisationUnitA );
         programA.setProgramType( ProgramType.WITH_REGISTRATION );
         programA.setTrackedEntityType( trackedEntityType );
+        programA.getSharing().setOwner( admin );
         manager.save( programA );
         ProgramStageDataElement programStageDataElement = new ProgramStageDataElement();
         programStageDataElement.setDataElement( dataElementA );
@@ -143,6 +145,7 @@ class EnrollmentSecurityTest extends TransactionalIntegrationTest
         programStageDataElementService.addProgramStageDataElement( programStageDataElement );
         programStageA.getProgramStageDataElements().add( programStageDataElement );
         programStageA.setProgram( programA );
+        programStageA.getSharing().setOwner( admin );
         programStageDataElement = new ProgramStageDataElement();
         programStageDataElement.setDataElement( dataElementB );
         programStageDataElement.setProgramStage( programStageB );
@@ -205,9 +208,11 @@ class EnrollmentSecurityTest extends TransactionalIntegrationTest
         manager.updateNoAcl( programA );
         User user = createUserWithAuth( "user1" );
         injectSecurityContext( user );
-        assertThrows( IllegalQueryException.class,
-            () -> enrollmentService.addEnrollment( createEnrollment( programA.getUid(), maleA.getUid() ),
-                ImportOptions.getDefaultImportOptions() ).getStatus() );
+        ImportSummary importReport = enrollmentService.addEnrollment(
+            createEnrollment( programA.getUid(), maleA.getUid() ),
+            ImportOptions.getDefaultImportOptions() );
+        assertEquals( ImportStatus.ERROR, importReport.getStatus() );
+        assertEquals( "Program can not be null", importReport.getDescription() );
     }
 
     /**
@@ -220,12 +225,11 @@ class EnrollmentSecurityTest extends TransactionalIntegrationTest
         manager.updateNoAcl( programA );
         User user = createUserWithAuth( "user1" ).setOrganisationUnits( Sets.newHashSet( organisationUnitA ) );
         injectSecurityContext( user );
-        assertEquals( ImportStatus.ERROR,
-            enrollmentService.addEnrollment( createEnrollment( programA.getUid(), maleA.getUid() ),
-                ImportOptions.getDefaultImportOptions() ).getStatus() );
-        assertThrows( IllegalQueryException.class,
-            () -> enrollmentService.addEnrollment( createEnrollment( programA.getUid(), maleB.getUid() ),
-                ImportOptions.getDefaultImportOptions() ).getStatus() );
+        ImportSummary importReport = enrollmentService.addEnrollment(
+            createEnrollment( programA.getUid(), maleA.getUid() ),
+            ImportOptions.getDefaultImportOptions() );
+        assertEquals( ImportStatus.ERROR, importReport.getStatus() );
+        assertEquals( "Program can not be null", importReport.getDescription() );
     }
 
     /**
@@ -238,12 +242,11 @@ class EnrollmentSecurityTest extends TransactionalIntegrationTest
         manager.updateNoAcl( programA );
         User user = createUserWithAuth( "user1" ).setOrganisationUnits( Sets.newHashSet( organisationUnitA ) );
         injectSecurityContext( user );
-        assertEquals( ImportStatus.ERROR,
-            enrollmentService.addEnrollment( createEnrollment( programA.getUid(), maleA.getUid() ),
-                ImportOptions.getDefaultImportOptions() ).getStatus() );
-        assertThrows( IllegalQueryException.class,
-            () -> enrollmentService.addEnrollment( createEnrollment( programA.getUid(), maleB.getUid() ),
-                ImportOptions.getDefaultImportOptions() ).getStatus() );
+        ImportSummary importReport = enrollmentService.addEnrollment(
+            createEnrollment( programA.getUid(), maleA.getUid() ),
+            ImportOptions.getDefaultImportOptions() );
+        assertEquals( ImportStatus.ERROR, importReport.getStatus() );
+        assertEquals( "Program can not be null", importReport.getDescription() );
     }
 
     /**
@@ -256,9 +259,11 @@ class EnrollmentSecurityTest extends TransactionalIntegrationTest
         manager.update( programA );
         User user = createUserWithAuth( "user1" );
         injectSecurityContext( user );
-        assertThrows( IllegalQueryException.class,
-            () -> enrollmentService.addEnrollment( createEnrollment( programA.getUid(), maleA.getUid() ),
-                ImportOptions.getDefaultImportOptions() ).getStatus() );
+        ImportSummary importReport = enrollmentService.addEnrollment(
+            createEnrollment( programA.getUid(), maleA.getUid() ),
+            ImportOptions.getDefaultImportOptions() );
+        assertEquals( ImportStatus.ERROR, importReport.getStatus() );
+        assertEquals( "Program can not be null", importReport.getDescription() );
     }
 
     /**

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/security/EnrollmentSecurityTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/security/EnrollmentSecurityTest.java
@@ -173,7 +173,7 @@ class EnrollmentSecurityTest extends TransactionalIntegrationTest
     }
 
     /**
-     * program = DATA READ/WRITE orgUnit = Accessible status = SUCCESS
+     * program = FULL access orgUnit = Accessible status = SUCCESS
      */
     @Test
     void testUserWithDataReadWrite()

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/acl/AclServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/acl/AclServiceTest.java
@@ -1182,7 +1182,7 @@ class AclServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    public void testOwnerDataRead()
+    void testOwnerDataRead()
     {
         User userA = makeUser( "A" );
         manager.save( userA );
@@ -1195,7 +1195,7 @@ class AclServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    public void testOwnerMetadataRead()
+    void testOwnerMetadataRead()
     {
         User userA = makeUser( "A" );
         manager.save( userA );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/acl/AclServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/acl/AclServiceTest.java
@@ -1195,6 +1195,20 @@ class AclServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
+    void testOwnerDataReadFail()
+    {
+        User admin = createAndAddAdminUser( "ALL" );
+        CategoryOption categoryOption = createCategoryOption( 'A' );
+        categoryOption.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
+        categoryOption.getSharing().setOwner( admin );
+        manager.save( categoryOption );
+        User userA = makeUser( "A" );
+        manager.save( userA );
+
+        assertFalse( aclService.canDataRead( userA, categoryOption ) );
+    }
+
+    @Test
     void testOwnerMetadataRead()
     {
         User userA = makeUser( "A" );
@@ -1205,5 +1219,19 @@ class AclServiceTest extends TransactionalIntegrationTest
         manager.save( categoryOption );
 
         assertTrue( aclService.canRead( userA, categoryOption ) );
+    }
+
+    @Test
+    void testOwnerMetadataReadFail()
+    {
+        User admin = createAndAddAdminUser( "ALL" );
+        CategoryOption categoryOption = createCategoryOption( 'A' );
+        categoryOption.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
+        categoryOption.getSharing().setOwner( admin );
+        manager.save( categoryOption );
+        User userA = makeUser( "A" );
+        manager.save( userA );
+
+        assertFalse( aclService.canRead( userA, categoryOption ) );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/acl/AclServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/acl/AclServiceTest.java
@@ -1187,7 +1187,6 @@ class AclServiceTest extends TransactionalIntegrationTest
         User userA = makeUser( "A" );
         manager.save( userA );
         CategoryOption categoryOption = createCategoryOption( 'A' );
-        // set sharing with public='--------' and owner=userA /
         categoryOption.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
         categoryOption.getSharing().setOwner( userA );
         manager.save( categoryOption );
@@ -1201,7 +1200,6 @@ class AclServiceTest extends TransactionalIntegrationTest
         User userA = makeUser( "A" );
         manager.save( userA );
         CategoryOption categoryOption = createCategoryOption( 'A' );
-        // set sharing with public='--------' and owner=userA /
         categoryOption.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
         categoryOption.getSharing().setOwner( userA );
         manager.save( categoryOption );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/acl/AclServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/acl/AclServiceTest.java
@@ -1180,4 +1180,32 @@ class AclServiceTest extends TransactionalIntegrationTest
         assertEquals( true, row.next() );
         assertEquals( de.getUid(), row.getString( "uid" ) );
     }
+
+    @Test
+    public void testOwnerDataRead()
+    {
+        User userA = makeUser( "A" );
+        manager.save( userA );
+        CategoryOption categoryOption = createCategoryOption( 'A' );
+        // set sharing with public='--------' and owner=userA /
+        categoryOption.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
+        categoryOption.getSharing().setOwner( userA );
+        manager.save( categoryOption );
+
+        assertTrue( aclService.canDataRead( userA, categoryOption ) );
+    }
+
+    @Test
+    public void testOwnerMetadataRead()
+    {
+        User userA = makeUser( "A" );
+        manager.save( userA );
+        CategoryOption categoryOption = createCategoryOption( 'A' );
+        // set sharing with public='--------' and owner=userA /
+        categoryOption.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
+        categoryOption.getSharing().setOwner( userA );
+        manager.save( categoryOption );
+
+        assertTrue( aclService.canRead( userA, categoryOption ) );
+    }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/sqlview/SqlViewServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/sqlview/SqlViewServiceTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.hisp.dhis.common.Grid;
@@ -298,11 +299,16 @@ class SqlViewServiceTest extends TransactionalIntegrationTest
     @Test
     void testGetGridRequiresDataReadSharing()
     {
-        createAndInjectAdminUser( "F_SQLVIEW_PUBLIC_ADD" );
+        createAndInjectAdminUser( "ALL" );
 
         // we have the right to create the view
         SqlView sqlView = getSqlView( "select * from dataelement; delete from dataelement" );
         sqlViewService.saveSqlView( sqlView );
+
+        User userA = makeUser( "A", List.of( "F_SQLVIEW_PUBLIC_ADD" ) );
+        userService.addUser( userA );
+
+        injectSecurityContext( userA );
 
         // but we lack sharing to view the result grid
         assertIllegalQueryEx(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentSecurityImportValidationTest.java
@@ -198,7 +198,7 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest
         clearSecurityContext();
 
         setup();
-        programA.setPublicAccess( AccessStringHelper.DATA_READ_WRITE );
+        programA.setPublicAccess( AccessStringHelper.FULL );
         TrackedEntityType bPJ0FMtcnEh = trackedEntityTypeService.getTrackedEntityType( "bPJ0FMtcnEh" );
         programA.setTrackedEntityType( bPJ0FMtcnEh );
         manager.updateNoAcl( programA );
@@ -221,7 +221,8 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest
         clearSecurityContext();
 
         setup();
-        programA.setPublicAccess( AccessStringHelper.DATA_READ );
+        programA.setPublicAccess( AccessStringHelper.newInstance()
+            .enable( AccessStringHelper.Permission.DATA_READ ).enable( AccessStringHelper.Permission.READ ).build() );
         trackedEntityType.setPublicAccess( AccessStringHelper.DATA_READ );
         programA.setTrackedEntityType( trackedEntityType );
         manager.updateNoAcl( programA );
@@ -234,7 +235,7 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest
 
         ImportReport importReport = trackerImportService.importTracker( params );
 
-        assertHasOnlyErrors( importReport, ValidationCode.E1069 );
+        assertHasOnlyErrors( importReport, ValidationCode.E1091 );
     }
 
     @Test
@@ -267,7 +268,7 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest
         clearSecurityContext();
 
         setup();
-        programA.setPublicAccess( AccessStringHelper.DATA_READ_WRITE );
+        programA.setPublicAccess( AccessStringHelper.FULL );
         programA.setTrackedEntityType( trackedEntityType );
         manager.update( programA );
         manager.flush();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentSecurityImportValidationTest.java
@@ -54,6 +54,7 @@ import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.report.ImportReport;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -78,6 +79,9 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest
 
     @Autowired
     private TrackedEntityTypeService trackedEntityTypeService;
+
+    @Autowired
+    private UserService _userService;
 
     private org.hisp.dhis.trackedentity.TrackedEntityInstance maleA;
 
@@ -105,6 +109,8 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest
 
     private void setup()
     {
+        userService = _userService;
+        injectAdminUser();
         organisationUnitA = createOrganisationUnit( 'A' );
         organisationUnitB = createOrganisationUnit( 'B' );
         manager.save( organisationUnitA );
@@ -228,7 +234,7 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest
 
         ImportReport importReport = trackerImportService.importTracker( params );
 
-        assertHasOnlyErrors( importReport, ValidationCode.E1091 );
+        assertHasOnlyErrors( importReport, ValidationCode.E1069 );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentSecurityImportValidationTest.java
@@ -270,7 +270,7 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest
         setup();
         programA.setPublicAccess( AccessStringHelper.FULL );
         programA.setTrackedEntityType( trackedEntityType );
-        manager.update( programA );
+        manager.updateNoAcl( programA );
         manager.flush();
         User user = createUserWithAuth( "user1" ).setOrganisationUnits( Sets.newHashSet( organisationUnitA ) );
         injectSecurityContext( user );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentSecurityImportValidationTest.java
@@ -223,7 +223,7 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest
         setup();
         programA.setPublicAccess( AccessStringHelper.newInstance()
             .enable( AccessStringHelper.Permission.DATA_READ ).enable( AccessStringHelper.Permission.READ ).build() );
-        trackedEntityType.setPublicAccess( AccessStringHelper.DATA_READ );
+        trackedEntityType.setPublicAccess( AccessStringHelper.FULL );
         programA.setTrackedEntityType( trackedEntityType );
         manager.updateNoAcl( programA );
         User user = createUserWithAuth( "user1" ).setOrganisationUnits( Sets.newHashSet( organisationUnitA ) );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
@@ -64,6 +64,7 @@ import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.report.ImportReport;
 import org.hisp.dhis.tracker.report.TrackerTypeReport;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -79,15 +80,18 @@ class EventImportValidationTest extends TrackerTest
     private ProgramStageInstanceService programStageServiceInstance;
 
     @Autowired
-    protected TrackerImportService trackerImportService;
+    private TrackerImportService trackerImportService;
+
+    @Autowired
+    private UserService _userService;
 
     @Override
     protected void initTest()
         throws IOException
     {
+        userService = _userService;
         setUpMetadata( "tracker/tracker_basic_metadata.json" );
         injectAdminUser();
-
         assertNoErrors( trackerImportService.importTracker( fromJson(
             "tracker/validations/enrollments_te_te-data.json" ) ) );
         assertNoErrors( trackerImportService
@@ -169,8 +173,7 @@ class EventImportValidationTest extends TrackerTest
 
         ImportReport importReport = trackerImportService.importTracker( trackerImportParams );
 
-        assertHasOnlyErrors( importReport, ValidationCode.E1099, ValidationCode.E1104,
-            ValidationCode.E1096, ValidationCode.E1095 );
+        assertHasOnlyErrors( importReport, ValidationCode.E1099, ValidationCode.E1104 );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EventSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EventSecurityImportValidationTest.java
@@ -65,6 +65,7 @@ import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.report.ImportReport;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -104,6 +105,9 @@ class EventSecurityImportValidationTest extends TrackerTest
     @Autowired
     private OrganisationUnitService organisationUnitService;
 
+    @Autowired
+    private UserService _userService;
+
     private org.hisp.dhis.trackedentity.TrackedEntityInstance maleA;
 
     private org.hisp.dhis.trackedentity.TrackedEntityInstance maleB;
@@ -132,6 +136,7 @@ class EventSecurityImportValidationTest extends TrackerTest
     protected void initTest()
         throws IOException
     {
+        userService = _userService;
         setUpMetadata( "tracker/tracker_basic_metadata.json" );
         injectAdminUser();
         assertNoErrors( trackerImportService.importTracker( fromJson(
@@ -232,10 +237,10 @@ class EventSecurityImportValidationTest extends TrackerTest
         trackerBundleParams.setUser( user );
         user.addOrganisationUnit( organisationUnitA );
         manager.update( user );
-
+        trackerBundleParams.setUser( user );
         ImportReport importReport = trackerImportService.importTracker( trackerBundleParams );
 
-        assertHasOnlyErrors( importReport, ValidationCode.E1095, ValidationCode.E1096 );
+        assertHasOnlyErrors( importReport, ValidationCode.E1095 );
     }
 
     @Test


### PR DESCRIPTION
### Issue:
- In AclService, the method [canDataRead()](https://github.com/dhis2/dhis2-core/blob/321453fc7ce9d90b948fd236b835052225ee8a8d/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java#L182-L182) doesn't include user owner access check.

- Currently we call those method separately in other methods in `AclService`
`checkUser( user, object) || checkSharingPermission(user, object, Permission.READ )`
This could make developers sometime forget to call `checkUser` as they might think method `checkSharingPermission` already check for owner access permission.

### Fix
- Put `checkUser` into `checkSharingPermission` to avoid future mistakes.

### Test
- Update various integration tests. Those tests check for `DATA_WRITE` sharing validation but the test objects are created with `owner=null` so the only the `METADATA_READ` actually works. 
- Add few more test to `AclServiceTest` for owner check.