### PR TITLE
fix: Remove existing core apps from Dashboard search results [DHIS2-14910]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
@@ -112,6 +112,20 @@ public interface AppManager
     List<App> getDashboardPlugins( String contextPath, int max );
 
     /**
+     * Returns a list of installed apps with plugins. Includes both
+     * {@link AppType.DASHBOARD_WIDGET} app types and {@link AppType.APP} app
+     * types with a pluginLaunchPath.
+     *
+     * @param contextPath the context path of this instance.
+     * @param max the maximum number of apps to return, -1 to return all.
+     * @param skipCore if true, all core apps will be removed from the result
+     *        list.
+     *
+     * @return a list of {@link App}.
+     */
+    List<App> getDashboardPlugins( String contextPath, int max, boolean skipCore );
+
+    /**
      * Returns the installed app with a given name
      *
      * @param appName the name of the app to return.

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/appmanager/DefaultAppManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/appmanager/DefaultAppManagerTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.appmanager;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.CacheBuilder;
+import org.hisp.dhis.cache.DefaultCacheBuilderProvider;
+import org.hisp.dhis.datastore.DatastoreService;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link DefaultAppManager}.
+ *
+ * @author maikel arabori
+ */
+@ExtendWith( MockitoExtension.class )
+class DefaultAppManagerTest
+{
+    @Mock
+    private DhisConfigurationProvider dhisConfigurationProvider;
+
+    @Mock
+    private AppStorageService localAppStorageService;
+
+    @Mock
+    private AppStorageService jCloudsAppStorageService;
+
+    @Mock
+    private DatastoreService datastoreService;
+
+    @Mock
+    private Cache<App> appCache;
+
+    @Mock
+    private DefaultCacheBuilderProvider cacheBuilderProvider;
+
+    @Mock
+    private CacheBuilder cacheBuilder;
+
+    private AppManager appManager;
+
+    @BeforeEach
+    void beforeEach()
+    {
+        requiredByAllTests();
+    }
+
+    @Test
+    void testGetDashboardPlugins()
+    {
+        // Given
+        String contextPath = "anyPath";
+
+        appManager = Mockito.spy( appManager );
+        doReturn( true ).when( appManager ).isAccessible( any() );
+
+        // Then
+        stubAppsStream();
+        List<App> apps = appManager.getDashboardPlugins( contextPath, 2, false );
+        assertEquals( 2, apps.size() );
+
+        stubAppsStream();
+        apps = appManager.getDashboardPlugins( contextPath, 3, false );
+        assertEquals( 3, apps.size() );
+
+        stubAppsStream();
+        apps = appManager.getDashboardPlugins( contextPath, 5, false );
+        assertEquals( 3, apps.size() );
+
+        stubAppsStream();
+        apps = appManager.getDashboardPlugins( contextPath, 5, true );
+        assertEquals( 1, apps.size() );
+        assertEquals( "App 3", apps.get( 0 ).getName() );
+
+        stubAppsStream();
+        apps = appManager.getDashboardPlugins( contextPath, 1, true );
+        assertEquals( 1, apps.size() );
+        assertEquals( "App 3", apps.get( 0 ).getName() );
+
+        stubAppsStream();
+        apps = appManager.getDashboardPlugins( contextPath, 0, true );
+        assertEquals( 0, apps.size() );
+    }
+
+    /**
+     * Required by all tests to work.
+     */
+    private void requiredByAllTests()
+    {
+        doReturn( cacheBuilder ).when( cacheBuilderProvider ).newCacheBuilder();
+        doReturn( cacheBuilder ).when( cacheBuilder ).forRegion( "appCache" );
+        doReturn( appCache ).when( cacheBuilder ).build();
+
+        appManager = new DefaultAppManager( dhisConfigurationProvider, localAppStorageService, jCloudsAppStorageService,
+            datastoreService, cacheBuilderProvider );
+    }
+
+    /**
+     * Used multiple times before each test (if applicable). Needed because
+     * streams can be used only once.
+     */
+    private void stubAppsStream()
+    {
+        when( appCache.getAll() ).thenReturn( stubApps() );
+    }
+
+    private Stream<App> stubApps()
+    {
+        return List
+            .of(
+                stubApp( "Line Listing", false ),
+                stubApp( "Data Visualizer", true ),
+                stubApp( "App 3", false ) )
+            .stream();
+    }
+
+    private App stubApp( String name, boolean isCoreApp )
+    {
+        App app = new App();
+        app.setName( name );
+        app.setCoreApp( isCoreApp );
+        app.setAppType( AppType.DASHBOARD_WIDGET );
+
+        return app;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/dashboard/impl/DefaultDashboardService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/dashboard/impl/DefaultDashboardService.java
@@ -123,7 +123,7 @@ public class DefaultDashboardService
         Set<String> words = Sets.newHashSet( query.split( TextUtils.SPACE ) );
 
         List<App> dashboardApps = appManager.getDashboardPlugins( null,
-            getMax( DashboardItemType.APP, maxTypes, count, maxCount ) );
+            getMax( DashboardItemType.APP, maxTypes, count, maxCount ), true );
 
         DashboardSearchResult result = new DashboardSearchResult();
 
@@ -171,7 +171,7 @@ public class DefaultDashboardService
         result.setResources( objectManager.getBetweenSorted( Document.class, 0,
             getMax( DashboardItemType.RESOURCES, maxTypes, count, maxCount ) ) );
         result.setApps( appManager.getDashboardPlugins( null,
-            getMax( DashboardItemType.APP, maxTypes, count, maxCount ) ) );
+            getMax( DashboardItemType.APP, maxTypes, count, maxCount ), true ) );
 
         return result;
     }


### PR DESCRIPTION
When we edit a Dashboard, the search feature should exclude core applications for the Apps section result list and specific names based on a internal exclusion list.

Some minor refactoring was done so shared code could be better reused.