### PR TITLE
fix: Assign null when option for data element is invalid [DHIS2-14190]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/executor/RuleActionExecutor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/executor/RuleActionExecutor.java
@@ -66,12 +66,17 @@ public interface RuleActionExecutor<T>
      */
     static boolean isEqual( String value1, String value2, ValueType valueType )
     {
+        if ( Objects.equals( value1, value2 ) )
+        {
+            return true;
+        }
+
         if ( valueType.isNumeric() )
         {
             return NumberUtils.isParsable( value1 ) && NumberUtils.isParsable( value2 ) &&
                 MathUtils.isEqual( Double.parseDouble( value1 ), Double.parseDouble( value2 ) );
         }
-        return Objects.equals( value1, value2 );
+        return false;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/executor/event/AssignDataValueExecutor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/executor/event/AssignDataValueExecutor.java
@@ -85,6 +85,7 @@ public class AssignDataValueExecutor implements RuleActionExecutor<Event>
             .findAny()
             .orElse( null );
 
+        // Hopefully we will be able to remove this special case once rule engine will support optionSets
         if ( dataElement.isOptionSetValue() && !dataElement.getOptionSet().getOptionValues().contains( value ) )
         {
             return assignInvalidOptionDataElement( payloadDataValue, canOverwrite, event );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/executor/event/AssignDataValueExecutor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/executor/event/AssignDataValueExecutor.java
@@ -80,31 +80,49 @@ public class AssignDataValueExecutor implements RuleActionExecutor<Event>
 
         DataElement dataElement = bundle.getPreheat().getDataElement( dataElementUid );
 
-        Optional<DataValue> payloadDataValue = dataValues.stream()
+        DataValue payloadDataValue = dataValues.stream()
             .filter( dv -> dv.getDataElement().isEqualTo( dataElement ) )
-            .findAny();
+            .findAny()
+            .orElse( null );
 
-        if ( payloadDataValue.isEmpty() ||
-            Boolean.TRUE.equals( canOverwrite ) ||
-            isEqual( value, payloadDataValue.get().getValue(), dataElement.getValueType() ) )
+        if ( dataElement.isOptionSetValue() && !dataElement.getOptionSet().getOptionValues().contains( value ) )
         {
-            addOrOverwriteDataValue( event, bundle );
+            return assignInvalidOptionDataElement( payloadDataValue, canOverwrite, event );
+        }
+
+        if ( payloadDataValue == null ||
+            Boolean.TRUE.equals( canOverwrite ) ||
+            isEqual( value, payloadDataValue.getValue(), dataElement.getValueType() ) )
+        {
+            addOrOverwriteDataValue( event, bundle, dataElement, payloadDataValue );
             return Optional.of( warning( ruleUid, ValidationCode.E1308, dataElementUid, event.getEvent() ) );
         }
         return Optional.of( error( ruleUid, ValidationCode.E1307, dataElementUid, value ) );
     }
 
-    private void addOrOverwriteDataValue( Event event, TrackerBundle bundle )
+    private Optional<ProgramRuleIssue> assignInvalidOptionDataElement( DataValue payloadDataValue, Boolean canOverwrite,
+        Event event )
     {
-        DataElement dataElement = bundle.getPreheat().getDataElement( dataElementUid );
-
-        Optional<DataValue> dataValue = event.getDataValues().stream()
-            .filter( dv -> dv.getDataElement().isEqualTo( dataElement ) )
-            .findAny();
-
-        if ( dataValue.isPresent() )
+        if ( payloadDataValue == null || payloadDataValue.getValue() == null )
         {
-            dataValue.get().setValue( value );
+            return Optional.of( warning( ruleUid, ValidationCode.E1308, dataElementUid, event.getEvent() ) );
+        }
+
+        if ( Boolean.TRUE.equals( canOverwrite ) )
+        {
+            payloadDataValue.setValue( null );
+            return Optional.of( warning( ruleUid, ValidationCode.E1308, dataElementUid, event.getEvent() ) );
+        }
+
+        return Optional.of( error( ruleUid, ValidationCode.E1307, dataElementUid, "" ) );
+    }
+
+    private void addOrOverwriteDataValue( Event event, TrackerBundle bundle, DataElement dataElement,
+        DataValue payloadDataValue )
+    {
+        if ( payloadDataValue != null )
+        {
+            payloadDataValue.setValue( value );
         }
         else
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/executor/event/AssignDataValueExecutorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/executor/event/AssignDataValueExecutorTest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.tracker.programrule.executor.event;
 
 import static org.hisp.dhis.tracker.programrule.IssueType.ERROR;
 import static org.hisp.dhis.tracker.programrule.IssueType.WARNING;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
@@ -38,8 +39,11 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.hisp.dhis.DhisConvenienceTest;
+import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
+import org.hisp.dhis.option.Option;
+import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.program.ValidationStrategy;
@@ -76,9 +80,15 @@ class AssignDataValueExecutorTest extends DhisConvenienceTest
 
     private final static String ANOTHER_DATA_ELEMENT_ID = "AnotherDataElementId";
 
+    private final static String OPTION_SET_DATA_ELEMENT_ID = "OptionSetDataElementId";
+
     private final static String DATAELEMENT_OLD_VALUE = "10.0";
 
     private final static String DATAELEMENT_NEW_VALUE = "24.0";
+
+    private final static String VALID_OPTION_VALUE = "10";
+
+    private final static String INVALID_OPTION_VALUE = "0";
 
     private static ProgramStage firstProgramStage;
 
@@ -87,6 +97,8 @@ class AssignDataValueExecutorTest extends DhisConvenienceTest
     private static DataElement dataElementA;
 
     private static DataElement dataElementB;
+
+    private static DataElement optionSetDataElement;
 
     private TrackerBundle bundle;
 
@@ -113,16 +125,87 @@ class AssignDataValueExecutorTest extends DhisConvenienceTest
         dataElementB.setUid( ANOTHER_DATA_ELEMENT_ID );
         ProgramStageDataElement programStageDataElementB = createProgramStageDataElement( secondProgramStage,
             dataElementB, 0 );
-        secondProgramStage.setProgramStageDataElements( Set.of( programStageDataElementB ) );
+        optionSetDataElement = createDataElement( 'P' );
+        optionSetDataElement.setUid( OPTION_SET_DATA_ELEMENT_ID );
+        OptionSet optionSet = new OptionSet();
+        Option option = new Option( "10", "10" );
+        optionSet.setOptions( List.of( option ) );
+        optionSet.setValueType( ValueType.NUMBER );
+        optionSetDataElement.setOptionSet( optionSet );
+        ProgramStageDataElement programStageDataElementOptionSet = createProgramStageDataElement( secondProgramStage,
+            optionSetDataElement, 0 );
+        secondProgramStage
+            .setProgramStageDataElements( Set.of( programStageDataElementB, programStageDataElementOptionSet ) );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( firstProgramStage ) ) )
             .thenReturn( firstProgramStage );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( secondProgramStage ) ) )
             .thenReturn( secondProgramStage );
         when( preheat.getDataElement( DATA_ELEMENT_ID ) ).thenReturn( dataElementA );
+        when( preheat.getDataElement( OPTION_SET_DATA_ELEMENT_ID ) ).thenReturn( optionSetDataElement );
+
         bundle = TrackerBundle.builder().build();
         bundle.setPreheat( preheat );
         when( systemSettingManager.getBooleanSetting( SettingKey.RULE_ENGINE_ASSIGN_OVERWRITE ) )
             .thenReturn( Boolean.FALSE );
+    }
+
+    @Test
+    void shouldFailWhenAssignedValueIsInvalidOptionAndDataValueIsValidOption()
+    {
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
+        Event eventWithOptionDataValue = getEventWithOptionSetDataValueWithValidValue();
+        List<Event> events = List.of( eventWithOptionDataValue );
+        bundle.setEvents( events );
+
+        AssignDataValueExecutor executor = new AssignDataValueExecutor( systemSettingManager,
+            "", INVALID_OPTION_VALUE, OPTION_SET_DATA_ELEMENT_ID, eventWithOptionDataValue.getDataValues() );
+
+        Optional<ProgramRuleIssue> warning = executor.executeRuleAction( bundle, eventWithOptionDataValue );
+
+        Optional<DataValue> dataValue = findDataValueByUid( bundle, EVENT_ID, OPTION_SET_DATA_ELEMENT_ID );
+
+        assertDataValueWasNotAssignedAndErrorIsPresent( VALID_OPTION_VALUE, dataValue, warning );
+    }
+
+    @Test
+    void shouldAssignDataValueWhenAssignedValueIsInvalidOptionAndDataValueIsEmpty()
+    {
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
+        Event eventWithOptionDataValue = getEventWithDataValueNOTSet();
+        List<Event> events = List.of( eventWithOptionDataValue );
+        bundle.setEvents( events );
+
+        AssignDataValueExecutor executor = new AssignDataValueExecutor( systemSettingManager,
+            "", INVALID_OPTION_VALUE, OPTION_SET_DATA_ELEMENT_ID, eventWithOptionDataValue.getDataValues() );
+
+        Optional<ProgramRuleIssue> warning = executor.executeRuleAction( bundle, eventWithOptionDataValue );
+
+        Optional<DataValue> dataValue = findDataValueByUid( bundle, SECOND_EVENT_ID, OPTION_SET_DATA_ELEMENT_ID );
+
+        assertAll(
+            () -> assertTrue( dataValue.isEmpty() ),
+            () -> assertTrue( warning.isPresent() ),
+            () -> assertEquals( WARNING, warning.get().getIssueType() ) );
+    }
+
+    @Test
+    void shouldAssignNullDataValueWhenAssignedValueIsInvalidOptionAndOverwriteIsTrue()
+    {
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
+        when( systemSettingManager.getBooleanSetting( SettingKey.RULE_ENGINE_ASSIGN_OVERWRITE ) )
+            .thenReturn( Boolean.TRUE );
+        Event eventWithOptionDataValue = getEventWithOptionSetDataValueWithValidValue();
+        List<Event> events = List.of( eventWithOptionDataValue );
+        bundle.setEvents( events );
+
+        AssignDataValueExecutor executor = new AssignDataValueExecutor( systemSettingManager,
+            "", INVALID_OPTION_VALUE, OPTION_SET_DATA_ELEMENT_ID, eventWithOptionDataValue.getDataValues() );
+
+        Optional<ProgramRuleIssue> warning = executor.executeRuleAction( bundle, eventWithOptionDataValue );
+
+        Optional<DataValue> dataValue = findDataValueByUid( bundle, EVENT_ID, OPTION_SET_DATA_ELEMENT_ID );
+
+        assertDataValueWasAssignedAndWarningIsPresent( null, dataValue, warning );
     }
 
     @Test
@@ -282,6 +365,15 @@ class AssignDataValueExecutorTest extends DhisConvenienceTest
             .build();
     }
 
+    private Event getEventWithOptionSetDataValueWithValidValue()
+    {
+        return Event.builder()
+            .event( EVENT_ID )
+            .status( EventStatus.ACTIVE )
+            .dataValues( getOptionSetDataValues() )
+            .build();
+    }
+
     private Event getEventWithDataValueNOTSet()
     {
         return Event.builder()
@@ -313,6 +405,15 @@ class AssignDataValueExecutorTest extends DhisConvenienceTest
         DataValue dataValue = DataValue.builder()
             .dataElement( MetadataIdentifier.ofUid( DATA_ELEMENT_ID ) )
             .value( DATAELEMENT_NEW_VALUE )
+            .build();
+        return Set.of( dataValue );
+    }
+
+    private Set<DataValue> getOptionSetDataValues()
+    {
+        DataValue dataValue = DataValue.builder()
+            .dataElement( MetadataIdentifier.ofUid( OPTION_SET_DATA_ELEMENT_ID ) )
+            .value( VALID_OPTION_VALUE )
             .build();
         return Set.of( dataValue );
     }


### PR DESCRIPTION
This PR fixes [DHIS2-14190](https://dhis2.atlassian.net/browse/DHIS2-14190) assigning null to a data element that is an `OptionSet` when rule-engine is trying to assign an invalid option to it. 
Rule-engine doesn't have the concept of `OptionSet` so in it will never try to assign a null value, instead it will try to assign the default value based on the `valueType` of the `OptionSet`.

`AssignDataValueExecutor` needs to check if a data element is an `OptionSet` and if the value that it is trying to assign is not a valid option (it means that is not part of the options of the `OptionSet`), it needs to assign null instead.

[DHIS2-14190]: https://dhis2.atlassian.net/browse/DHIS2-14190