### PR TITLE
fix: Remove existing core apps from Dashboard search results [DHIS2-14910]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
@@ -86,9 +86,18 @@ public interface AppManager
      * Returns a list of all installed apps.
      *
      * @param contextPath the context path of this instance.
-     * @return list of installed apps
+     * @return list of installed apps.
      */
     List<App> getApps( String contextPath );
+
+    /**
+     * Returns a list of all installed apps.
+     *
+     * @param contextPath the context path of this instance.
+     * @param skipCore if true, core apps will be filtered out.
+     * @return list of installed apps.
+     */
+    List<App> getApps( String contextPath, boolean skipCore );
 
     /**
      * Returns a list of installed apps.
@@ -98,6 +107,16 @@ public interface AppManager
      * @return a list of apps.
      */
     List<App> getApps( AppType appType, int max );
+
+    /**
+     * Returns a list of installed apps.
+     *
+     * @param appType the app type filter.
+     * @param max the max number of apps to return.
+     * @param skipCore if true, core apps will be filtered out.
+     * @return a list of apps.
+     */
+    List<App> getApps( AppType appType, int max, boolean skipCore );
 
     App getApp( String appName );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -28,6 +28,8 @@
 package org.hisp.dhis.appmanager;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableSet;
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 
 import java.io.File;
@@ -72,7 +74,7 @@ public class DefaultAppManager
 {
     public static final String INVALID_FILTER_MSG = "Invalid filter: ";
 
-    private static final Set<String> EXCLUSION_APPS = Set.of( "Line Listing" );
+    private static final Set<String> EXCLUSION_APPS = unmodifiableSet( new HashSet<>( asList( "Line Listing" ) ) );
 
     private final DhisConfigurationProvider dhisConfigurationProvider;
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.appmanager;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 
 import java.io.File;
 import java.io.IOException;
@@ -39,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
@@ -69,6 +71,8 @@ public class DefaultAppManager
     implements AppManager
 {
     public static final String INVALID_FILTER_MSG = "Invalid filter: ";
+
+    private static final Set<String> EXCLUSION_APPS = Set.of( "Line Listing" );
 
     private final DhisConfigurationProvider dhisConfigurationProvider;
 
@@ -116,8 +120,20 @@ public class DefaultAppManager
     @Override
     public List<App> getApps( String contextPath )
     {
-        List<App> apps = appCache.getAll().filter( app -> app.getAppState() != AppStatus.DELETION_IN_PROGRESS )
-            .collect( Collectors.toList() );
+        return getApps( contextPath, false );
+    }
+
+    @Override
+    public List<App> getApps( String contextPath, boolean skipCore )
+    {
+        Predicate<App> filter = app -> app.getAppState() != AppStatus.DELETION_IN_PROGRESS;
+
+        if ( skipCore )
+        {
+            filter = filter.and( app -> !EXCLUSION_APPS.contains( trimToEmpty( app.getName() ) ) && !app.isCoreApp() );
+        }
+
+        List<App> apps = appCache.getAll().filter( filter ).collect( Collectors.toList() );
 
         apps.forEach( a -> a.init( contextPath ) );
 
@@ -128,6 +144,15 @@ public class DefaultAppManager
     public List<App> getApps( AppType appType, int max )
     {
         return getApps( null ).stream()
+            .filter( app -> appType == app.getAppType() )
+            .limit( max )
+            .collect( Collectors.toList() );
+    }
+
+    @Override
+    public List<App> getApps( AppType appType, int max, boolean skipCore )
+    {
+        return getApps( null, skipCore ).stream()
             .filter( app -> appType == app.getAppType() )
             .limit( max )
             .collect( Collectors.toList() );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/appmanager/DefaultAppManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/appmanager/DefaultAppManagerTest.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.appmanager;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
 import static org.hisp.dhis.appmanager.AppType.DASHBOARD_WIDGET;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doReturn;
@@ -146,12 +148,11 @@ class DefaultAppManagerTest
 
     private Stream<App> stubApps()
     {
-        return List
-            .of(
-                stubApp( "Line Listing", false ),
-                stubApp( "Data Visualizer", true ),
-                stubApp( "App 3", false ) )
-            .stream();
+        return unmodifiableList( asList(
+            stubApp( "Line Listing", false ),
+            stubApp( "Data Visualizer", true ),
+            stubApp( "App 3", false ) ) )
+                .stream();
     }
 
     private App stubApp( String name, boolean isCoreApp )

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/appmanager/DefaultAppManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/appmanager/DefaultAppManagerTest.java
@@ -38,8 +38,8 @@ import java.util.stream.Stream;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheBuilder;
 import org.hisp.dhis.cache.DefaultCacheBuilderProvider;
-import org.hisp.dhis.datastore.DatastoreService;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.keyjsonvalue.KeyJsonValueService;
 import org.hisp.dhis.user.CurrentUserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -69,13 +69,13 @@ class DefaultAppManagerTest
     private AppStorageService jCloudsAppStorageService;
 
     @Mock
-    private DatastoreService datastoreService;
-
-    @Mock
     private Cache<App> appCache;
 
     @Mock
     private DefaultCacheBuilderProvider cacheBuilderProvider;
+
+    @Mock
+    private KeyJsonValueService keyJsonValueService;
 
     @Mock
     private CacheBuilder cacheBuilder;
@@ -132,7 +132,7 @@ class DefaultAppManagerTest
         doReturn( appCache ).when( cacheBuilder ).build();
 
         appManager = new DefaultAppManager( dhisConfigurationProvider, currentUserService, localAppStorageService,
-            jCloudsAppStorageService, datastoreService, cacheBuilderProvider );
+            jCloudsAppStorageService, keyJsonValueService, cacheBuilderProvider );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/appmanager/DefaultAppManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/appmanager/DefaultAppManagerTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.appmanager;
+
+import static org.hisp.dhis.appmanager.AppType.DASHBOARD_WIDGET;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.CacheBuilder;
+import org.hisp.dhis.cache.DefaultCacheBuilderProvider;
+import org.hisp.dhis.datastore.DatastoreService;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.user.CurrentUserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link DefaultAppManager}.
+ *
+ * @author maikel arabori
+ */
+@ExtendWith( MockitoExtension.class )
+class DefaultAppManagerTest
+{
+    @Mock
+    private DhisConfigurationProvider dhisConfigurationProvider;
+
+    @Mock
+    private CurrentUserService currentUserService;
+
+    @Mock
+    private AppStorageService localAppStorageService;
+
+    @Mock
+    private AppStorageService jCloudsAppStorageService;
+
+    @Mock
+    private DatastoreService datastoreService;
+
+    @Mock
+    private Cache<App> appCache;
+
+    @Mock
+    private DefaultCacheBuilderProvider cacheBuilderProvider;
+
+    @Mock
+    private CacheBuilder cacheBuilder;
+
+    private AppManager appManager;
+
+    @BeforeEach
+    void beforeEach()
+    {
+        requiredByAllTests();
+    }
+
+    @Test
+    void testGetDashboardPlugins()
+    {
+        // Given
+        appManager = Mockito.spy( appManager );
+
+        // Then
+        stubAppsStream();
+        List<App> apps = appManager.getApps( DASHBOARD_WIDGET, 2, false );
+        assertEquals( 2, apps.size() );
+
+        stubAppsStream();
+        apps = appManager.getApps( DASHBOARD_WIDGET, 3, false );
+        assertEquals( 3, apps.size() );
+
+        stubAppsStream();
+        apps = appManager.getApps( DASHBOARD_WIDGET, 5, false );
+        assertEquals( 3, apps.size() );
+
+        stubAppsStream();
+        apps = appManager.getApps( DASHBOARD_WIDGET, 5, true );
+        assertEquals( 1, apps.size() );
+        assertEquals( "App 3", apps.get( 0 ).getName() );
+
+        stubAppsStream();
+        apps = appManager.getApps( DASHBOARD_WIDGET, 1, true );
+        assertEquals( 1, apps.size() );
+        assertEquals( "App 3", apps.get( 0 ).getName() );
+
+        stubAppsStream();
+        apps = appManager.getApps( DASHBOARD_WIDGET, 0, true );
+        assertEquals( 0, apps.size() );
+    }
+
+    /**
+     * Required by all tests to work.
+     */
+    private void requiredByAllTests()
+    {
+        doReturn( cacheBuilder ).when( cacheBuilderProvider ).newCacheBuilder();
+        doReturn( cacheBuilder ).when( cacheBuilder ).forRegion( "appCache" );
+        doReturn( appCache ).when( cacheBuilder ).build();
+
+        appManager = new DefaultAppManager( dhisConfigurationProvider, currentUserService, localAppStorageService,
+            jCloudsAppStorageService, datastoreService, cacheBuilderProvider );
+    }
+
+    /**
+     * Used multiple times before each test (if applicable). Needed because
+     * streams can be used only once.
+     */
+    private void stubAppsStream()
+    {
+        when( appCache.getAll() ).thenReturn( stubApps() );
+    }
+
+    private Stream<App> stubApps()
+    {
+        return List
+            .of(
+                stubApp( "Line Listing", false ),
+                stubApp( "Data Visualizer", true ),
+                stubApp( "App 3", false ) )
+            .stream();
+    }
+
+    private App stubApp( String name, boolean isCoreApp )
+    {
+        App app = new App();
+        app.setName( name );
+        app.setCoreApp( isCoreApp );
+        app.setAppType( DASHBOARD_WIDGET );
+
+        return app;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/dashboard/impl/DefaultDashboardService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/dashboard/impl/DefaultDashboardService.java
@@ -134,7 +134,7 @@ public class DefaultDashboardService
         Set<String> words = Sets.newHashSet( query.split( TextUtils.SPACE ) );
 
         List<App> dashboardApps = appManager.getAppsByType( AppType.DASHBOARD_WIDGET,
-            new HashSet<>( appManager.getApps( null ) ) );
+            new HashSet<>( appManager.getApps( null, true ) ) );
 
         DashboardSearchResult result = new DashboardSearchResult();
 
@@ -176,7 +176,7 @@ public class DefaultDashboardService
         result.setResources( objectManager.getBetweenSorted( Document.class, 0,
             getMax( DashboardItemType.RESOURCES, maxTypes, count, maxCount ) ) );
         result.setApps( appManager.getApps( AppType.DASHBOARD_WIDGET,
-            getMax( DashboardItemType.APP, maxTypes, count, maxCount ) ) );
+            getMax( DashboardItemType.APP, maxTypes, count, maxCount ), true ) );
 
         return result;
     }


### PR DESCRIPTION
**_[Backport from 2.41/master]_**

When we edit a Dashboard, the search feature should exclude core applications for the Apps section result list and specific names based on an internal exclusion list.

Some minor refactoring was done, so that shared code could be better reused.