### PR TITLE
fix: Only return LINE_LIST type in dashboard search feat [DHIS2-14908]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualizationStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualizationStore.java
@@ -100,6 +100,18 @@ public interface EventVisualizationStore extends
     List<EventVisualization> getReportsLikeName( Set<String> words, int first, int max );
 
     /**
+     * Query the EventVisualization collection and retrieve only the
+     * EventVisualizations of type Line list only, comparing the name based on
+     * the given "words".
+     *
+     * @param words the characters describing the Visualization's name.
+     * @param first the first result row.
+     * @param max the maximum result row.
+     * @return a list of EventVisualization containing only Line lists.
+     */
+    List<EventVisualization> getLineListsLikeName( Set<String> words, int first, int max );
+
+    /**
      * Counts the number of Reports (Pivot and Line list) created since the
      * given date.
      *

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventvisualization/hibernate/HibernateEventVisualizationStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventvisualization/hibernate/HibernateEventVisualizationStore.java
@@ -125,7 +125,13 @@ public class HibernateEventVisualizationStore extends
     @Override
     public List<EventVisualization> getLineLists( int first, int max )
     {
-        return getEventVisualizations( first, max, EventVisualizationSet.EVENT_LINE_LIST, false );
+        return getEventVisualizations( first, max, EventVisualizationSet.EVENT_LINE_LIST, null );
+    }
+
+    @Override
+    public List<EventVisualization> getLineListsLikeName( Set<String> words, int first, int max )
+    {
+        return getEventVisualizationsLikeName( words, first, max, EventVisualizationSet.EVENT_LINE_LIST, null );
     }
 
     private int countEventVisualizationCreated( Date startingAt, EventVisualizationSet eventVisualizationSet,
@@ -144,7 +150,7 @@ public class HibernateEventVisualizationStore extends
     }
 
     private List<EventVisualization> getEventVisualizations( int first, int max,
-        EventVisualizationSet eventVisualizationSet, boolean legacy )
+        EventVisualizationSet eventVisualizationSet, Boolean legacy )
     {
         CriteriaBuilder builder = getCriteriaBuilder();
 
@@ -158,7 +164,7 @@ public class HibernateEventVisualizationStore extends
     }
 
     private List<EventVisualization> getEventVisualizationsLikeName( Set<String> words, int first, int max,
-        EventVisualizationSet eventVisualizationSet, boolean legacy )
+        EventVisualizationSet eventVisualizationSet, Boolean legacy )
     {
         CriteriaBuilder builder = getCriteriaBuilder();
 
@@ -188,7 +194,7 @@ public class HibernateEventVisualizationStore extends
     }
 
     private void setCorrectPredicates( EventVisualizationSet eventVisualizationSet, CriteriaBuilder builder,
-        JpaQueryParameters<EventVisualization> params, boolean legacy )
+        JpaQueryParameters<EventVisualization> params, Boolean legacy )
     {
         if ( eventVisualizationSet == EventVisualizationSet.EVENT_CHART )
         {
@@ -205,6 +211,9 @@ public class HibernateEventVisualizationStore extends
             params.addPredicate( root -> builder.equal( root.get( "type" ), LINE_LIST ) );
         }
 
-        params.addPredicate( root -> builder.equal( root.get( "legacy" ), legacy ) );
+        if ( legacy != null )
+        {
+            params.addPredicate( root -> builder.equal( root.get( "legacy" ), legacy ) );
+        }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/dashboard/impl/DefaultDashboardService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/dashboard/impl/DefaultDashboardService.java
@@ -151,7 +151,7 @@ public class DefaultDashboardService
             convertFromVisualization( objectManager.getBetweenLikeName( Visualization.class, words, 0,
                 getMax( DashboardItemType.VISUALIZATION, maxTypes, count, maxCount ) ) ) );
         result.setEventVisualizations(
-            convertFromEventVisualization( objectManager.getBetweenLikeName( EventVisualization.class, words, 0,
+            convertFromEventVisualization( eventVisualizationStore.getLineListsLikeName( words, 0,
                 getMax( DashboardItemType.EVENT_VISUALIZATION, maxTypes, count, maxCount ) ) ) );
         result.setEventCharts( eventVisualizationStore.getChartsLikeName( words, 0,
             getMax( DashboardItemType.EVENT_CHART, maxTypes, count, maxCount ) ) );
@@ -491,13 +491,13 @@ public class DefaultDashboardService
         return maxTypes != null && maxTypes.contains( type ) ? dashboardsMax : dashboardsCount;
     }
 
-    private List<SimpleVisualizationView> convertFromVisualization( final List<Visualization> visualizations )
+    private List<SimpleVisualizationView> convertFromVisualization( List<Visualization> visualizations )
     {
-        final List<SimpleVisualizationView> views = new ArrayList<>();
+        List<SimpleVisualizationView> views = new ArrayList<>();
 
         if ( isNotEmpty( visualizations ) )
         {
-            for ( final Visualization visualization : visualizations )
+            for ( Visualization visualization : visualizations )
             {
                 views.add( convertFrom( visualization ) );
             }
@@ -506,18 +506,18 @@ public class DefaultDashboardService
         return views;
     }
 
-    private SimpleVisualizationView convertFrom( final Visualization visualization )
+    private SimpleVisualizationView convertFrom( Visualization visualization )
     {
-        final SimpleVisualizationView view = new SimpleVisualizationView();
+        SimpleVisualizationView view = new SimpleVisualizationView();
         BeanUtils.copyProperties( visualization, view );
 
         return view;
     }
 
     private List<SimpleEventVisualizationView> convertFromEventVisualization(
-        final List<EventVisualization> eventVisualizations )
+        List<EventVisualization> eventVisualizations )
     {
-        final List<SimpleEventVisualizationView> views = new ArrayList<>();
+        List<SimpleEventVisualizationView> views = new ArrayList<>();
 
         if ( isNotEmpty( eventVisualizations ) )
         {
@@ -530,9 +530,9 @@ public class DefaultDashboardService
         return views;
     }
 
-    private SimpleEventVisualizationView convertFrom( final EventVisualization visualization )
+    private SimpleEventVisualizationView convertFrom( EventVisualization visualization )
     {
-        final SimpleEventVisualizationView view = new SimpleEventVisualizationView();
+        SimpleEventVisualizationView view = new SimpleEventVisualizationView();
         BeanUtils.copyProperties( visualization, view );
 
         return view;

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/dashboard/DashboardServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/dashboard/DashboardServiceTest.java
@@ -226,8 +226,7 @@ class DashboardServiceTest extends DhisSpringTest
     {
         dashboardService.saveDashboard( dbA );
         dashboardService.saveDashboard( dbB );
-        DashboardItem itemA = dashboardService.addItemContent( dbA.getUid(), VISUALIZATION,
-            vzA.getUid() );
+        DashboardItem itemA = dashboardService.addItemContent( dbA.getUid(), VISUALIZATION, vzA.getUid() );
         assertNotNull( itemA );
         assertNotNull( itemA.getUid() );
     }
@@ -259,29 +258,43 @@ class DashboardServiceTest extends DhisSpringTest
             visualization.setName( randomAlphabetic( 5 ) );
             visualizationService.save( visualization );
         } );
+
         range( 1, 30 ).forEach( i -> {
             EventVisualization eventVisualization = createEventVisualization( "A", prA );
             eventVisualization.setName( randomAlphabetic( 5 ) );
             eventVisualizationService.save( eventVisualization );
         } );
+
+        // Non Line List event visualization should be ignored when we search
+        // for EVENT_VISUALIZATION:
+        EventVisualization eventVisualization = createEventVisualization( "A", prA );
+        eventVisualization.setName( randomAlphabetic( 5 ) );
+        eventVisualization.setType( COLUMN );
+        eventVisualizationService.save( eventVisualization );
+
         range( 1, 30 ).forEach( i -> eventChartService.saveEventChart( createEventChart( prA ) ) );
         range( 1, 20 ).forEach( i -> eventReportService.saveEventReport( createEventReport( prA ) ) );
 
         DashboardSearchResult result = dashboardService.search( Set.of( VISUALIZATION ) );
         assertThat( result.getVisualizationCount(), is( 25 ) );
         assertThat( result.getEventChartCount(), is( 6 ) );
+
         result = dashboardService.search( Set.of( VISUALIZATION ), 3, null );
         assertThat( result.getVisualizationCount(), is( 25 ) );
         assertThat( result.getEventChartCount(), is( 3 ) );
+
         result = dashboardService.search( Set.of( VISUALIZATION ), 3, 29 );
         assertThat( result.getVisualizationCount(), is( 29 ) );
         assertThat( result.getEventChartCount(), is( 3 ) );
+
         result = dashboardService.search( Set.of( EVENT_VISUALIZATION ), 3, 29 );
         assertThat( result.getEventVisualizationCount(), is( 29 ) );
         assertThat( result.getEventReportCount(), is( 3 ) );
+
         result = dashboardService.search( Set.of( EVENT_VISUALIZATION ), 3, 30 );
         assertThat( result.getEventVisualizationCount(), is( 30 ) );
         assertThat( result.getEventChartCount(), is( 3 ) );
+
         result = dashboardService.search( Set.of( EVENT_REPORT ), 3, 29 );
         assertThat( result.getEventVisualizationCount(), is( 3 ) );
         assertThat( result.getEventReportCount(), is( 19 ) );


### PR DESCRIPTION
**_[Backport from 2.41/master]_**

When we edit a Dashboard, the search feature should only show visualizations of type LINE_LIST for the "Line lists" section (at the dashboard API level it means the `eventVisualizations` collection).

These changes add a method that implements the required filtering and its respective invocation.
Example of response object:
```
...
"eventVisualizations": [
    {
      "name": "Inpatient: Cases 5 to 15 years this year (case)",
      "created": "2014-04-22T17:15:24.147",
      "lastUpdated": "2014-04-22T17:15:24.147",
      "translations": [],
      "externalAccess": false,
      "publicAccess": "rw------",
      "createdBy": {
        "id": "xE7jOejl9FI",
        "code": null,
        "name": "John Traore",
        "displayName": "John Traore",
        "username": "admin"
      },
      "userGroupAccesses": [],
      "userAccesses": [],
      "sharing": {
        "owner": "xE7jOejl9FI",
        "external": false,
        "users": {},
        "userGroups": {},
        "public": "rw------"
      },
      "type": "LINE_LIST",
      "displayName": "Inpatient: Cases 5 to 15 years this year (case)",
      "user": {
        "id": "xE7jOejl9FI",
        "code": null,
        "name": "John Traore",
        "displayName": "John Traore",
        "username": "admin"
      },
      "favorite": false,
      "id": "TIuOzZ0ID0V",
      "attributeValues": []
    },
...
```