### PR TITLE
perf: Build context and call rule engine only when needed [DHIS2-14917]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEngineService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEngineService.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStageInstanceService;
+import org.hisp.dhis.programrule.ProgramRule;
 import org.hisp.dhis.rules.models.RuleEffect;
 import org.hisp.dhis.rules.models.RuleValidationResult;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -81,18 +82,25 @@ public class DefaultProgramRuleEngineService
     {
         if ( config.isDisabled( SYSTEM_PROGRAM_RULE_SERVER_EXECUTION ) )
         {
-            return Lists.newArrayList();
+            return List.of();
         }
 
         ProgramInstance programInstance = programInstanceService.getProgramInstance( enrollment );
 
         if ( programInstance == null )
         {
-            return Lists.newArrayList();
+            return List.of();
+        }
+
+        List<ProgramRule> programRules = programRuleEngine.getProgramRules( programInstance.getProgram() );
+
+        if ( programRules.isEmpty() )
+        {
+            return List.of();
         }
 
         List<RuleEffect> ruleEffects = programRuleEngine.evaluate( programInstance,
-            programInstance.getProgramStageInstances() );
+            programInstance.getProgramStageInstances(), programRules );
 
         for ( RuleEffect effect : ruleEffects )
         {
@@ -143,10 +151,28 @@ public class DefaultProgramRuleEngineService
             return Lists.newArrayList();
         }
 
-        ProgramInstance programInstance = programInstanceService.getProgramInstance( psi.getProgramInstance().getId() );
+        Program program = psi.getProgramStage().getProgram();
+        List<ProgramRule> programRules = programRuleEngine.getProgramRules( program, List.of( psi.getProgramStage() ) );
 
-        List<RuleEffect> ruleEffects = programRuleEngine.evaluate( programInstance, psi,
-            programInstance.getProgramStageInstances() );
+        if ( programRules.isEmpty() )
+        {
+            return List.of();
+        }
+
+        List<RuleEffect> ruleEffects;
+
+        if ( program.isWithoutRegistration() )
+        {
+            ruleEffects = programRuleEngine.evaluateProgramEvent( psi, program, programRules );
+        }
+        else
+        {
+            ProgramInstance programInstance = programInstanceService
+                .getProgramInstance( psi.getProgramInstance().getId() );
+
+            ruleEffects = programRuleEngine.evaluate( programInstance, psi, programInstance.getProgramStageInstances(),
+                programRules );
+        }
 
         for ( RuleEffect effect : ruleEffects )
         {

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngine.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngine.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.commons.util.DebugUtils;
 import org.hisp.dhis.constant.ConstantService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
+import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.programrule.ProgramRule;
 import org.hisp.dhis.programrule.ProgramRuleVariable;
@@ -75,45 +76,51 @@ public class ProgramRuleEngine
     @Nonnull
     private final SupplementaryDataProvider supplementaryDataProvider;
 
-    public List<RuleEffect> evaluate( ProgramInstance enrollment, Set<ProgramStageInstance> events )
+    public List<RuleEffect> evaluate( ProgramInstance enrollment, Set<ProgramStageInstance> events,
+        List<ProgramRule> rules )
     {
         return evaluateProgramRules( enrollment, null, enrollment.getProgram(), Collections.emptyList(),
-            getRuleEvents( events, null ) );
+            getRuleEvents( events, null ), rules );
     }
 
     public List<RuleEffects> evaluateEnrollmentAndEvents( ProgramInstance enrollment, Set<ProgramStageInstance> events,
         List<TrackedEntityAttributeValue> trackedEntityAttributeValues )
     {
-        return evaluateProgramRulesForMultipleTrackerObjects( enrollment, events.stream().findAny().orElse( null ),
-            enrollment.getProgram(), trackedEntityAttributeValues, getRuleEvents( events, null ) );
+        List<ProgramRule> rules = getProgramRules( enrollment.getProgram(),
+            events.stream().map( ProgramStageInstance::getProgramStage ).distinct().collect( Collectors.toList() ) );
+        return evaluateProgramRulesForMultipleTrackerObjects( enrollment, enrollment.getProgram(),
+            trackedEntityAttributeValues, getRuleEvents( events, null ), rules );
     }
 
     public List<RuleEffects> evaluateProgramEvents( Set<ProgramStageInstance> events, Program program )
     {
-        return evaluateProgramRulesForMultipleTrackerObjects( null, null, program, null,
-            getRuleEvents( events, null ) );
+        List<ProgramRule> rules = getProgramRules( program );
+        return evaluateProgramRulesForMultipleTrackerObjects( null, program, null,
+            getRuleEvents( events, null ), rules );
+    }
+
+    public List<RuleEffect> evaluateProgramEvent( ProgramStageInstance event, Program program, List<ProgramRule> rules )
+    {
+        return evaluateProgramRules( null, null, program, List.of(), getRuleEvents( Set.of( event ), null ), rules );
     }
 
     public List<RuleEffect> evaluate( ProgramInstance enrollment, ProgramStageInstance programStageInstance,
-        Set<ProgramStageInstance> events )
+        Set<ProgramStageInstance> events, List<ProgramRule> rules )
     {
         return evaluateProgramRules( enrollment, programStageInstance, enrollment.getProgram(),
-            Collections.emptyList(), getRuleEvents( events, programStageInstance ) );
+            Collections.emptyList(), getRuleEvents( events, programStageInstance ), rules );
     }
 
     private List<RuleEffect> evaluateProgramRules( ProgramInstance enrollment,
         ProgramStageInstance programStageInstance, Program program,
-        List<TrackedEntityAttributeValue> trackedEntityAttributeValues, List<RuleEvent> ruleEvents )
+        List<TrackedEntityAttributeValue> trackedEntityAttributeValues, List<RuleEvent> ruleEvents,
+        List<ProgramRule> rules )
     {
 
         try
         {
-            RuleEngine ruleEngine = getRuleEngine( programStageInstance, program, enrollment,
-                trackedEntityAttributeValues, ruleEvents );
-            if ( ruleEngine == null )
-            {
-                return Collections.emptyList();
-            }
+            RuleEngine ruleEngine = getRuleEngine( program, enrollment,
+                trackedEntityAttributeValues, ruleEvents, rules );
 
             return getRuleEngineEvaluation( ruleEngine, enrollment,
                 programStageInstance, trackedEntityAttributeValues );
@@ -126,17 +133,14 @@ public class ProgramRuleEngine
     }
 
     private List<RuleEffects> evaluateProgramRulesForMultipleTrackerObjects( ProgramInstance enrollment,
-        ProgramStageInstance programStageInstance, Program program,
-        List<TrackedEntityAttributeValue> trackedEntityAttributeValues, List<RuleEvent> ruleEvents )
+        Program program,
+        List<TrackedEntityAttributeValue> trackedEntityAttributeValues, List<RuleEvent> ruleEvents,
+        List<ProgramRule> rules )
     {
         try
         {
-            RuleEngine ruleEngine = getRuleEngine( programStageInstance, program, enrollment,
-                trackedEntityAttributeValues, ruleEvents );
-            if ( ruleEngine == null )
-            {
-                return Collections.emptyList();
-            }
+            RuleEngine ruleEngine = getRuleEngine( program, enrollment,
+                trackedEntityAttributeValues, ruleEvents, rules );
             return ruleEngine.evaluate().call();
         }
         catch ( Exception e )
@@ -146,21 +150,11 @@ public class ProgramRuleEngine
         }
     }
 
-    private RuleEngine getRuleEngine( ProgramStageInstance programStageInstance, Program program,
+    private RuleEngine getRuleEngine( Program program,
         ProgramInstance enrollment,
         List<TrackedEntityAttributeValue> trackedEntityAttributeValues,
-        List<RuleEvent> ruleEvents )
+        List<RuleEvent> ruleEvents, List<ProgramRule> programRules )
     {
-        String programStageUid = Optional.ofNullable( programStageInstance ).map( p -> p.getProgramStage().getUid() )
-            .orElse( null );
-
-        List<ProgramRule> programRules = implementableRuleService.getProgramRules( program, programStageUid );
-
-        if ( programRules.isEmpty() )
-        {
-            return null;
-        }
-
         RuleEnrollment ruleEnrollment = getRuleEnrollment( enrollment, trackedEntityAttributeValues );
 
         RuleEngine.Builder builder = getRuleEngineContext( program,
@@ -175,6 +169,25 @@ public class ProgramRuleEngine
         }
 
         return builder.build();
+    }
+
+    public List<ProgramRule> getProgramRules( Program program, List<ProgramStage> programStage )
+    {
+        if ( programStage.isEmpty() )
+        {
+            return implementableRuleService.getProgramRules( program, null );
+        }
+
+        Set<ProgramRule> programRules = programStage.stream()
+            .flatMap( ps -> implementableRuleService.getProgramRules( program, ps.getUid() ).stream() )
+            .collect( Collectors.toSet() );
+
+        return List.copyOf( programRules );
+    }
+
+    public List<ProgramRule> getProgramRules( Program program )
+    {
+        return implementableRuleService.getProgramRules( program, null );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineServiceTest.java
@@ -174,7 +174,7 @@ class ProgramRuleEngineServiceTest extends DhisConvenienceTest
 
         when( programInstanceService.getProgramInstance( anyLong() ) ).thenReturn( programInstance );
         when( programRuleEngine.evaluate( any(), any(), any() ) ).thenReturn( effects );
-        when( programRuleEngine.getProgramRules( any(), any() ) ).thenReturn( List.of( programRuleA ) );
+        when( programRuleEngine.getProgramRules( any() ) ).thenReturn( List.of( programRuleA ) );
 
         setProgramRuleActionType_SendMessage();
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineTest.java
@@ -254,9 +254,10 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
     @Test
     void testSendMessageForEnrollment()
     {
-        setUpSendMessageForEnrollment();
+        ProgramRule programRule = setUpSendMessageForEnrollment();
         ProgramInstance programInstance = programInstanceService.getProgramInstance( "UID-P1" );
-        List<RuleEffect> ruleEffects = programRuleEngine.evaluate( programInstance, Sets.newHashSet() );
+        List<RuleEffect> ruleEffects = programRuleEngine.evaluate( programInstance, Sets.newHashSet(),
+            List.of( programRule ) );
         assertEquals( 1, ruleEffects.size() );
         RuleAction ruleAction = ruleEffects.get( 0 ).ruleAction();
         assertTrue( ruleAction instanceof RuleActionSendMessage );
@@ -267,7 +268,7 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
     @Test
     void testSendMessageForEnrollmentAndEvents()
     {
-        setUpSendMessageForEnrollment();
+        ProgramRule programRule = setUpSendMessageForEnrollment();
         ProgramInstance programInstance = programInstanceService.getProgramInstance( "UID-P1" );
         List<RuleEffects> ruleEffects = programRuleEngine.evaluateEnrollmentAndEvents( programInstance,
             Sets.newHashSet(), Lists.newArrayList() );
@@ -284,9 +285,10 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
     @Test
     void testNotificationWhenUsingD2HasValueWithTEA()
     {
-        setUpNotificationForD2HasValue();
+        ProgramRule programRule = setUpNotificationForD2HasValue();
         ProgramInstance programInstance = programInstanceService.getProgramInstance( "UID-P2" );
-        List<RuleEffect> ruleEffects = programRuleEngine.evaluate( programInstance, Sets.newHashSet() );
+        List<RuleEffect> ruleEffects = programRuleEngine.evaluate( programInstance, Sets.newHashSet(),
+            List.of( programRule ) );
         assertEquals( 1, ruleEffects.size() );
         RuleAction ruleAction = ruleEffects.get( 0 ).ruleAction();
         assertTrue( ruleAction instanceof RuleActionSendMessage );
@@ -324,10 +326,10 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
     @Test
     void testSendMessageForEvent()
     {
-        setUpSendMessageForEnrollment();
+        ProgramRule programRule = setUpSendMessageForEnrollment();
         ProgramStageInstance programStageInstance = programStageInstanceService.getProgramStageInstance( "UID-PS1" );
         List<RuleEffect> ruleEffects = programRuleEngine.evaluate( programStageInstance.getProgramInstance(),
-            programStageInstance, Sets.newHashSet() );
+            programStageInstance, Sets.newHashSet(), List.of( programRule ) );
         assertEquals( 1, ruleEffects.size() );
         RuleAction ruleAction = ruleEffects.get( 0 ).ruleAction();
         assertTrue( ruleAction instanceof RuleActionSendMessage );
@@ -423,10 +425,10 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
     @Test
     void testAssignValueTypeDate()
     {
-        setUpAssignValueDate();
+        ProgramRule programRule = setUpAssignValueDate();
         ProgramStageInstance programStageInstance = programStageInstanceService.getProgramStageInstance( "UID-PS12" );
         List<RuleEffect> ruleEffects = programRuleEngine.evaluate( programStageInstance.getProgramInstance(),
-            programStageInstance, Sets.newHashSet() );
+            programStageInstance, Sets.newHashSet(), List.of( programRule ) );
         assertNotNull( ruleEffects );
         assertEquals( ruleEffects.get( 0 ).data(), "10" );
     }
@@ -448,10 +450,10 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
     @Test
     void testAssignValueTypeAge()
     {
-        setUpAssignValueAge();
+        ProgramRule programRule = setUpAssignValueAge();
         ProgramStageInstance programStageInstance = programStageInstanceService.getProgramStageInstance( "UID-PS13" );
         List<RuleEffect> ruleEffects = programRuleEngine.evaluate( programStageInstance.getProgramInstance(),
-            programStageInstance, Sets.newHashSet() );
+            programStageInstance, Sets.newHashSet(), List.of( programRule ) );
         assertNotNull( ruleEffects );
         assertEquals( ruleEffects.get( 0 ).data(), "10" );
     }
@@ -660,7 +662,7 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
 
     }
 
-    private void setUpSendMessageForEnrollment()
+    private ProgramRule setUpSendMessageForEnrollment()
     {
         ProgramNotificationTemplate pnt = new ProgramNotificationTemplate();
         pnt.setName( "Test-PNT" );
@@ -678,9 +680,10 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
         programRuleActionService.addProgramRuleAction( programRuleActionForSendMessage );
         programRuleC.setProgramRuleActions( Sets.newHashSet( programRuleActionForSendMessage ) );
         programRuleService.updateProgramRule( programRuleC );
+        return programRuleC;
     }
 
-    private void setUpNotificationForD2HasValue()
+    private ProgramRule setUpNotificationForD2HasValue()
     {
         ProgramNotificationTemplate pnt = new ProgramNotificationTemplate();
         pnt.setName( "Test-PNT" );
@@ -699,9 +702,11 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
         programRuleActionService.addProgramRuleAction( programRuleActionForSendMessage );
         programRuleE.setProgramRuleActions( Sets.newHashSet( programRuleActionForSendMessage ) );
         programRuleService.updateProgramRule( programRuleE );
+
+        return programRuleE;
     }
 
-    private void setUpScheduleMessage()
+    private ProgramRule setUpScheduleMessage()
     {
         scheduledDate = "2018-04-17";
         pnt = createNotification();
@@ -714,9 +719,11 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
         programRuleActionService.addProgramRuleAction( programRuleActionForScheduleMessage );
         programRuleS.setProgramRuleActions( Sets.newHashSet( programRuleActionForScheduleMessage ) );
         programRuleService.updateProgramRule( programRuleS );
+
+        return programRuleS;
     }
 
-    private void setUpAssignValueDate()
+    private ProgramRule setUpAssignValueDate()
     {
         ProgramNotificationTemplate pnt = createNotification();
         programNotificationTemplateStore.save( pnt );
@@ -727,9 +734,11 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
         programRuleA2.setProgramRuleActions( Sets.newHashSet( programRuleActionAssignValueDate ) );
         programRuleA2.setCondition( " d2:hasValue(#{DOB})" );
         programRuleService.updateProgramRule( programRuleA2 );
+
+        return programRuleA2;
     }
 
-    private void setUpAssignValueAge()
+    private ProgramRule setUpAssignValueAge()
     {
         ProgramNotificationTemplate pnt = createNotification();
         programNotificationTemplateStore.save( pnt );
@@ -739,6 +748,8 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
         programRuleActionService.addProgramRuleAction( programRuleActionAssignValueAge );
         programRuleA2.setProgramRuleActions( Sets.newHashSet( programRuleActionAssignValueAge ) );
         programRuleService.updateProgramRule( programRuleA2 );
+
+        return programRuleA2;
     }
 
     private ProgramNotificationTemplate createNotification()


### PR DESCRIPTION
There 2 performance fixes in this PR:
- Enrollment and sibling events are not retrieved for program event
- Rules to be run are calculated at the beginning of the flow and if there is nothing to run, the context is not built at all (this prevents a few useless calls to the DB )