### PR TITLE
fix: Pagination flag and unlimited [DHIS2-14777]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/AnalyticsPagingCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/AnalyticsPagingCriteria.java
@@ -69,14 +69,9 @@ public class AnalyticsPagingCriteria extends RequestTypeAware
      */
     public void definePageSize( int maxLimit )
     {
-        if ( isPaging() )
-        {
-            if ( getPageSize() != null && maxLimit > 0 && getPageSize() > maxLimit )
-            {
-                setPageSize( maxLimit );
-            }
-        }
-        else
+        final int unlimited = 0;
+
+        if ( (isPaging() && getPageSize() != null && maxLimit != unlimited && getPageSize() > maxLimit) || !isPaging() )
         {
             setPageSize( maxLimit );
         }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/AnalyticsPagingCriteriaTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/AnalyticsPagingCriteriaTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link AnalyticsPagingCriteria}.
+ *
+ * @author maikel arabori
+ */
+class AnalyticsPagingCriteriaTest
+{
+    @Test
+    void testDefinePageSizeWithLimitWhenPagingIsFalse()
+    {
+        // Given
+        int maxLimit = 50000;
+        AnalyticsPagingCriteria analyticsPagingCriteria = new AnalyticsPagingCriteria();
+        analyticsPagingCriteria.setPageSize( 50 );
+        analyticsPagingCriteria.setPaging( false );
+
+        // When
+        analyticsPagingCriteria.definePageSize( maxLimit );
+
+        // Then
+        assertEquals( maxLimit, analyticsPagingCriteria.getPageSize() );
+    }
+
+    @Test
+    void testDefinePageSizeWithLimitWhenPagingIsTrue()
+    {
+        // Given
+        int maxLimit = 50000;
+        AnalyticsPagingCriteria analyticsPagingCriteria = new AnalyticsPagingCriteria();
+        analyticsPagingCriteria.setPageSize( 50 );
+        analyticsPagingCriteria.setPaging( true );
+
+        // When
+        analyticsPagingCriteria.definePageSize( maxLimit );
+
+        // Then
+        assertEquals( 50, analyticsPagingCriteria.getPageSize() );
+    }
+
+    @Test
+    void testDefinePageSizeWithLimitGreaterThanMaxAllowedWhenPagingIsFalse()
+    {
+        // Given
+        int maxLimit = 50000;
+        AnalyticsPagingCriteria analyticsPagingCriteria = new AnalyticsPagingCriteria();
+        analyticsPagingCriteria.setPageSize( 60000 );
+        analyticsPagingCriteria.setPaging( false );
+
+        // When
+        analyticsPagingCriteria.definePageSize( maxLimit );
+
+        // Then
+        assertEquals( maxLimit, analyticsPagingCriteria.getPageSize() );
+    }
+
+    @Test
+    void testDefinePageSizeWithLimitGreaterThanMaxAllowedWhenPagingIsTrue()
+    {
+        // Given
+        int maxLimit = 50000;
+        AnalyticsPagingCriteria analyticsPagingCriteria = new AnalyticsPagingCriteria();
+        analyticsPagingCriteria.setPageSize( 60000 );
+        analyticsPagingCriteria.setPaging( true );
+
+        // When
+        analyticsPagingCriteria.definePageSize( maxLimit );
+
+        // Then
+        assertEquals( maxLimit, analyticsPagingCriteria.getPageSize() );
+    }
+
+    @Test
+    void testDefinePageSizeUnlimitedWhenPagingIsFalse()
+    {
+        // Given
+        int unlimited = 0;
+        AnalyticsPagingCriteria analyticsPagingCriteria = new AnalyticsPagingCriteria();
+        analyticsPagingCriteria.setPageSize( 50 );
+        analyticsPagingCriteria.setPaging( false );
+
+        // When
+        analyticsPagingCriteria.definePageSize( unlimited );
+
+        // Then
+        assertEquals( unlimited, analyticsPagingCriteria.getPageSize() );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -123,7 +123,7 @@ public class JdbcEnrollmentAnalyticsManager
         }
         else
         {
-            withExceptionHandling( () -> getEnrollments( params, grid, sql ) );
+            withExceptionHandling( () -> getEnrollments( params, grid, sql, maxLimit == 0 ) );
         }
     }
 
@@ -134,8 +134,9 @@ public class JdbcEnrollmentAnalyticsManager
      * @param params the {@link EventQueryParams}.
      * @param grid the {@link Grid}.
      * @param sql the SQL statement used to retrieve events.
+     * @param unlimitedPaging if true, will ignore any paging limit.
      */
-    private void getEnrollments( EventQueryParams params, Grid grid, String sql )
+    private void getEnrollments( EventQueryParams params, Grid grid, String sql, boolean unlimitedPaging )
     {
         log.debug( String.format( "Analytics enrollment query SQL: %s", sql ) );
 
@@ -147,7 +148,7 @@ public class JdbcEnrollmentAnalyticsManager
 
         while ( rowSet.next() )
         {
-            if ( ++rowsRed > params.getPageSizeWithDefault() && !params.isTotalPages() )
+            if ( ++rowsRed > params.getPageSizeWithDefault() && !params.isTotalPages() && !unlimitedPaging )
             {
                 grid.setLastDataRow( false );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -137,7 +137,7 @@ public class JdbcEventAnalyticsManager
         }
         else
         {
-            withExceptionHandling( () -> getEvents( params, grid, sql ) );
+            withExceptionHandling( () -> getEvents( params, grid, sql, maxLimit == 0 ) );
         }
 
         return grid;
@@ -150,8 +150,9 @@ public class JdbcEventAnalyticsManager
      * @param params the {@link EventQueryParams}.
      * @param grid the {@link Grid}.
      * @param sql the SQL statement used to retrieve events.
+     * @param unlimitedPaging if true, will ignore any paging limit.
      */
-    private void getEvents( EventQueryParams params, Grid grid, String sql )
+    private void getEvents( EventQueryParams params, Grid grid, String sql, boolean unlimitedPaging )
     {
         log.debug( "Analytics event query SQL: '{}'", sql );
 
@@ -163,7 +164,7 @@ public class JdbcEventAnalyticsManager
 
         while ( rowSet.next() )
         {
-            if ( ++rowsRed > params.getPageSizeWithDefault() && !params.isTotalPages() )
+            if ( ++rowsRed > params.getPageSizeWithDefault() && !params.isTotalPages() && !unlimitedPaging )
             {
                 grid.setLastDataRow( false );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -43,6 +43,7 @@ import static org.hisp.dhis.common.DimensionalObject.OPTION_SEP;
 import static org.hisp.dhis.common.QueryOperator.EQ;
 import static org.hisp.dhis.common.QueryOperator.IN;
 import static org.hisp.dhis.common.QueryOperator.NEQ;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -58,6 +59,7 @@ import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.data.programindicator.DefaultProgramIndicatorSubqueryBuilder;
 import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.RepeatableStageParams;
@@ -138,14 +140,18 @@ class EnrollmentAnalyticsManagerTest extends
         EventQueryParams params = new EventQueryParams.Builder( createRequestParams() )
             .withStartDate( getDate( 2017, 1, 1 ) ).withEndDate( getDate( 2017, 12, 31 ) ).build();
 
-        subject.getEnrollments( params, new ListGrid(), 10000 );
+        Grid grid = new ListGrid();
+        int unlimited = 0;
+
+        subject.getEnrollments( params, grid, unlimited );
 
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
-            + " as ax where (enrollmentdate >= '2017-01-01' and enrollmentdate < '2018-01-01')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
-        assertSql( sql.getValue(), expected );
+            + " as ax where (enrollmentdate >= '2017-01-01' and enrollmentdate < '2018-01-01')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) ";
 
+        assertTrue( grid.hasLastDataRow() );
+        assertSql( sql.getValue(), expected );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
@@ -47,6 +47,7 @@ import static org.hisp.dhis.common.DimensionalObjectUtils.getList;
 import static org.hisp.dhis.common.QueryOperator.EQ;
 import static org.hisp.dhis.common.QueryOperator.IN;
 import static org.hisp.dhis.common.QueryOperator.NEQ;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -187,17 +188,20 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest
     @Test
     void verifyGetEventSqlWithProgram()
     {
+        Grid grid = createGrid();
+        int unlimited = 0;
+
         mockEmptyRowSet();
 
-        subject.getEvents( createRequestParams(), createGrid(), 100 );
+        subject.getEvents( createRequestParams(), grid, unlimited );
 
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA')"
-            + " limit 101";
+            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA') ";
 
         assertSql( expected, sql.getValue() );
+        assertTrue( grid.hasLastDataRow() );
     }
 
     @Test


### PR DESCRIPTION
**_[Backport from 2.40]_**

This PR fixes the pagination when analytics unlimited is enabled.
It needs to be taken into consideration when the Grid is being created.
The changes will improve the logic on top of a recent code we introduced for handling the `lastPage` flag in analytics events/enrollments.