### PR TITLE
fix: data value set import stric data element fallback [DHIS2-14693]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -465,7 +465,7 @@ public enum ErrorCode
     E7630( "Category option combo is required but is not specified" ),
     E7631( "Attribute option combo is required but is not specified" ),
     E7632( "Period type of period: `{0}` not valid for data element: `{1}`" ),
-    E7633( "Data element: `{0}` is not part of dataset: `{1}`" ),
+    E7633( "Data element: `{0}` is not part of dataset(s): `{1}`" ),
     E7634( "Category option combo: `{0}` must be part of category combo of data element: `{1}`" ),
     E7635( "Attribute option combo: `{0}` must be part of category combo of data sets of data element: `{1}`" ),
     E7636( "Data element: `{1}` must be assigned through data sets to organisation unit: `{0}`" ),

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportConflict.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportConflict.java
@@ -44,7 +44,6 @@ public enum DataValueSetImportConflict implements ImportConflictDescriptor
 
     DATASET_NOT_FOUND( ErrorCode.E7600, "dataSet", DataSet.class ),
     DATASET_NOT_ACCESSIBLE( ErrorCode.E7601, "dataSet", DataSet.class ),
-    DATASET_NOT_VALID( ErrorCode.E7602, "dataSet" ),
     ORG_UNIT_NOT_FOUND( ErrorCode.E7603, "orgUnit", OrganisationUnit.class, DataSet.class ),
     ATTR_OPTION_COMBO_NOT_FOUND( ErrorCode.E7604, "attributeOptionCombo", CategoryOptionCombo.class,
         DataSet.class );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportValidator.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportValidator.java
@@ -476,8 +476,13 @@ public class DataValueSetImportValidator
     private static void checkDataValueStrictDataElement( DataValueEntry dataValue, ImportContext context,
         DataSetContext dataSetContext, DataValueContext valueContext )
     {
-        if ( context.isStrictDataElements()
-            && !dataSetContext.getDataSetDataElements().contains( valueContext.getDataElement() ) )
+        if ( !context.isStrictDataElements() )
+        {
+            return;
+        }
+        List<DataSet> targets = context.getTargetDataSets( dataSetContext, valueContext );
+        if ( targets.stream()
+            .noneMatch( dataSet -> dataSet.getDataElements().contains( valueContext.getDataElement() ) ) )
         {
             context.addConflict( valueContext.getIndex(),
                 DataValueImportConflict.DATA_ELEMENT_STRICT,

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportValidator.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportValidator.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.dxf2.datavalueset;
 
+import static java.util.stream.Collectors.joining;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 
 import java.util.ArrayList;
@@ -129,7 +130,6 @@ public class DataValueSetImportValidator
         // DataSet Validations
         register( DataValueSetImportValidator::validateDataSetExists );
         register( this::validateDataSetIsAccessibleByUser );
-        register( DataValueSetImportValidator::validateDataSetExistsStrictDataElements );
         register( DataValueSetImportValidator::validateDataSetOrgUnitExists );
         register( DataValueSetImportValidator::validateDataSetAttrOptionComboExists );
 
@@ -202,15 +202,6 @@ public class DataValueSetImportValidator
         if ( dataSet != null && !aclService.canDataWrite( context.getCurrentUser(), dataSet ) )
         {
             context.error().addConflict( DataValueSetImportConflict.DATASET_NOT_ACCESSIBLE, dataValueSet.getDataSet() );
-        }
-    }
-
-    private static void validateDataSetExistsStrictDataElements( DataValueSet dataValueSet, ImportContext context,
-        DataSetContext dataSetContext )
-    {
-        if ( dataSetContext.getDataSet() == null && context.isStrictDataElements() )
-        {
-            context.error().addConflict( DataValueSetImportConflict.DATASET_NOT_VALID );
         }
     }
 
@@ -486,7 +477,7 @@ public class DataValueSetImportValidator
         {
             context.addConflict( valueContext.getIndex(),
                 DataValueImportConflict.DATA_ELEMENT_STRICT,
-                dataValue.getDataElement(), dataSetContext.getDataSet().getUid() );
+                dataValue.getDataElement(), targets.stream().map( DataSet::getUid ).collect( joining( "," ) ) );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportValidator.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportValidator.java
@@ -471,7 +471,10 @@ public class DataValueSetImportValidator
         {
             return;
         }
-        List<DataSet> targets = context.getTargetDataSets( dataSetContext, valueContext );
+        List<DataSet> targets = dataSetContext.getDataSet() != null
+            ? List.of( dataSetContext.getDataSet() )
+            : context.getValueContextDataSets().get( dataValue.getDataElement(),
+                () -> List.copyOf( valueContext.getDataElement().getDataSets() ) );
         if ( targets.stream()
             .noneMatch( dataSet -> dataSet.getDataElements().contains( valueContext.getDataElement() ) ) )
         {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/ImportContext.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/ImportContext.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.dxf2.datavalueset;
 
-import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toUnmodifiableList;
 
 import java.util.ArrayList;
@@ -324,12 +323,6 @@ public final class ImportContext
         private final CategoryOptionCombo outerAttrOptionCombo;
 
         private final CategoryOptionCombo fallbackCategoryOptionCombo;
-
-        public Set<DataElement> getDataSetDataElements()
-        {
-            return dataSet != null ? dataSet.getDataElements() : emptySet();
-        }
-
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportValidatorTest.java
@@ -157,17 +157,6 @@ class DataValueSetImportValidatorTest
     }
 
     @Test
-    void testValidateDataSetExistsStrictDataElements()
-    {
-        when( aclService.canDataRead( any(), any() ) ).thenReturn( true );
-        DataValueSet dataValueSet = new DataValueSet();
-        ImportContext context = createMinimalImportContext( null ).strictDataElements( true ).build();
-        DataSetContext dataSetContext = createMinimalDataSetContext( dataValueSet ).build();
-        assertTrue( validator.abortDataSetImport( dataValueSet, context, dataSetContext ) );
-        assertConflict( ErrorCode.E7602, "A valid dataset is required", context );
-    }
-
-    @Test
     void testValidateDataSetOrgUnitExists()
     {
         when( aclService.canDataRead( any(), any() ) ).thenReturn( true );
@@ -410,7 +399,7 @@ class DataValueSetImportValidatorTest
         DataSetContext dataSetContext = createMinimalDataSetContext( dataValueSet ).build();
         ImportContext context = createMinimalImportContext( valueContext ).strictDataElements( true ).build();
         assertTrue( validator.skipDataValue( dataValue, context, dataSetContext, valueContext ) );
-        assertConflict( ErrorCode.E7633, "Data element: `<object1>` is not part of dataset: `<object2>`", context,
+        assertConflict( ErrorCode.E7633, "Data element: `<object1>` is not part of dataset(s): `<object2>`", context,
             dataValue.getDataElement(), dataValueSet.getDataSet() );
     }
 


### PR DESCRIPTION
### Summary
Modifies the strict data elements validation.
If a dataset is specified in the import the data element of values must be linked to the dataset.
If no dataset is specified in the import the data element of values must be linked to any of the target elements.

### Manual Testing
* Navigate to System Settings App
* Click Data Import
* Check “require data elements to be part of data set”
* Navigate to Import/Export App
* Export data:
  * Select Data export
  * Check Sierra Leone
  * Add ART monthly summary dataset
  * Click export data and save the file
* Import data:
  * Select Data Import
  * Upload the file you just downloaded
  * Select Start dry run
