### PR TITLE
test: /tracker/relationships returns nested fields TECH-1515

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAssertions.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAssertions.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.tracker.export;
+package org.hisp.dhis.webapi.controller.tracker;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -35,36 +35,37 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.hisp.dhis.jsontree.JsonArray;
+import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 
-public class TrackerControllerAssertions
+public class JsonAssertions
 {
 
-    public static JsonObject assertFirstRelationship( Relationship expected, JsonArray json )
+    public static JsonRelationship assertFirstRelationship( Relationship expected, JsonList<JsonRelationship> actual )
     {
-        return assertNthRelationship( expected, 0, json );
+        return assertNthRelationship( expected, 0, actual );
     }
 
-    public static JsonObject assertNthRelationship( Relationship expected, int n, JsonArray json )
+    public static JsonRelationship assertNthRelationship( Relationship expected, int n,
+        JsonList<JsonRelationship> actual )
     {
-        assertFalse( json.isEmpty(), "relationships should not be empty" );
-        assertTrue( json.size() >= n,
-            String.format( "element %d does not exist in %d relationships elements", n, json.size() ) );
-        JsonObject jsonRelationship = json.get( n ).as( JsonObject.class );
+        assertFalse( actual.isEmpty(), "relationships should not be empty" );
+        assertTrue( actual.size() >= n,
+            String.format( "element %d does not exist in %d relationships elements", n, actual.size() ) );
+        JsonRelationship jsonRelationship = actual.get( n );
         assertRelationship( expected, jsonRelationship );
         return jsonRelationship;
     }
 
-    public static void assertRelationship( Relationship expected, JsonObject json )
+    public static void assertRelationship( Relationship expected, JsonRelationship actual )
     {
-        assertFalse( json.isEmpty(), "relationship should not be empty" );
-        assertEquals( expected.getUid(), json.getString( "relationship" ).string(), "relationship UID" );
-        assertEquals( expected.getRelationshipType().getUid(), json.getString( "relationshipType" ).string(),
-            "relationshipType UID" );
+        assertFalse( actual.isEmpty(), "relationship should not be empty" );
+        assertEquals( expected.getUid(), actual.getRelationship(), "relationship UID" );
+        assertEquals( expected.getRelationshipType().getUid(), actual.getRelationshipType(), "relationshipType UID" );
     }
 
     public static void assertNoRelationships( JsonObject json )
@@ -74,29 +75,28 @@ public class TrackerControllerAssertions
         assertTrue( rels.isEmpty(), "instances should not contain any relationships" );
     }
 
-    public static void assertEventWithinRelationship( ProgramStageInstance expected, JsonObject json )
+    public static void assertEventWithinRelationshipItem( ProgramStageInstance expected, JsonRelationshipItem actual )
     {
-        JsonObject jsonEvent = json.getObject( "event" );
+        JsonRelationshipItem.JsonEvent jsonEvent = actual.getEvent();
         assertFalse( jsonEvent.isEmpty(), "event should not be empty" );
-        assertEquals( expected.getUid(), jsonEvent.getString( "event" ).string(), "event UID" );
+        assertEquals( expected.getUid(), jsonEvent.getEvent(), "event UID" );
 
-        assertEquals( expected.getStatus().toString(), jsonEvent.getString( "status" ).string(), "event status" );
-        assertEquals( expected.getProgramStage().getUid(), jsonEvent.getString( "programStage" ).string(),
-            "event programStage UID" );
-        assertEquals( expected.getProgramInstance().getUid(),
-            jsonEvent.getString( "enrollment" ).string(), "event programInstance UID" );
+        assertEquals( expected.getStatus().toString(), jsonEvent.getStatus(), "event status" );
+        assertEquals( expected.getProgramStage().getUid(), jsonEvent.getProgramStage(), "event programStage UID" );
+        assertEquals( expected.getProgramInstance().getUid(), jsonEvent.getEnrollment(), "event programInstance UID" );
         assertFalse( jsonEvent.has( "relationships" ), "relationships is not returned within relationship items" );
     }
 
-    public static void assertTrackedEntityWithinRelationship( TrackedEntityInstance expected, JsonObject json )
+    public static void assertTrackedEntityWithinRelationshipItem( TrackedEntityInstance expected,
+        JsonRelationshipItem actual )
     {
-        JsonObject jsonTEI = json.getObject( "trackedEntity" );
+        JsonRelationshipItem.JsonTrackedEntity jsonTEI = actual.getTrackedEntity();
         assertFalse( jsonTEI.isEmpty(), "trackedEntity should not be empty" );
-        assertEquals( expected.getUid(), jsonTEI.getString( "trackedEntity" ).string(), "trackedEntity UID" );
-        assertEquals( expected.getTrackedEntityType().getUid(), jsonTEI.getString( "trackedEntityType" ).string(),
+        assertEquals( expected.getUid(), jsonTEI.getTrackedEntity(), "trackedEntity UID" );
+        assertEquals( expected.getTrackedEntityType().getUid(), jsonTEI.getTrackedEntityType(),
             "trackedEntityType UID" );
-        assertEquals( expected.getOrganisationUnit().getUid(), jsonTEI.getString( "orgUnit" ).string(), "orgUnit UID" );
-        assertTrue( jsonTEI.getArray( "attributes" ).isEmpty(), "attributes should be empty" );
+        assertEquals( expected.getOrganisationUnit().getUid(), jsonTEI.getOrgUnit(), "orgUnit UID" );
+        assertTrue( jsonTEI.getAttributes().isEmpty(), "attributes should be empty" );
         assertFalse( jsonTEI.has( "relationships" ), "relationships is not returned within relationship items" );
     }
 
@@ -108,16 +108,14 @@ public class TrackerControllerAssertions
         assertEquals( expectedUid, j.getString( member ).string(), member + " UID" );
     }
 
-    public static void assertEnrollmentWithinRelationship( ProgramInstance expected, JsonObject json )
+    public static void assertEnrollmentWithinRelationship( ProgramInstance expected, JsonRelationshipItem actual )
     {
-        JsonObject jsonEnrollment = json.getObject( "enrollment" );
+        JsonRelationshipItem.JsonEnrollment jsonEnrollment = actual.getEnrollment();
         assertFalse( jsonEnrollment.isEmpty(), "enrollment should not be empty" );
-        assertEquals( expected.getUid(), jsonEnrollment.getString( "enrollment" ).string(), "enrollment UID" );
-        assertEquals( expected.getEntityInstance().getUid(),
-            jsonEnrollment.getString( "trackedEntity" ).string(), "trackedEntity UID" );
-        assertEquals( expected.getProgram().getUid(), jsonEnrollment.getString( "program" ).string(), "program UID" );
-        assertEquals( expected.getOrganisationUnit().getUid(), jsonEnrollment.getString( "orgUnit" ).string(),
-            "orgUnit UID" );
+        assertEquals( expected.getUid(), jsonEnrollment.getEnrollment(), "enrollment UID" );
+        assertEquals( expected.getEntityInstance().getUid(), jsonEnrollment.getTrackedEntity(), "trackedEntity UID" );
+        assertEquals( expected.getProgram().getUid(), jsonEnrollment.getProgram(), "program UID" );
+        assertEquals( expected.getOrganisationUnit().getUid(), jsonEnrollment.getOrgUnit(), "orgUnit UID" );
         assertTrue( jsonEnrollment.getArray( "events" ).isEmpty(), "events should be empty" );
         assertFalse( jsonEnrollment.has( "relationships" ), "relationships is not returned within relationship items" );
     }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAttribute.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAttribute.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker;
+
+import org.hisp.dhis.jsontree.JsonObject;
+
+/**
+ * Web API equivalent of a
+ * {@link org.hisp.dhis.webapi.controller.tracker.view.Attribute}.
+ */
+public interface JsonAttribute extends JsonObject
+{
+    default String getAttribute()
+    {
+        return getString( "attribute" ).string();
+    }
+
+    default String getValue()
+    {
+        return getString( "value" ).string();
+    }
+}

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAttribute.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAttribute.java
@@ -30,7 +30,7 @@ package org.hisp.dhis.webapi.controller.tracker;
 import org.hisp.dhis.jsontree.JsonObject;
 
 /**
- * Web API equivalent of a
+ * Representation of
  * {@link org.hisp.dhis.webapi.controller.tracker.view.Attribute}.
  */
 public interface JsonAttribute extends JsonObject

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonNote.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonNote.java
@@ -34,7 +34,6 @@ import org.hisp.dhis.jsontree.JsonObject;
  */
 public interface JsonNote extends JsonObject
 {
-
     default String getNote()
     {
         return getString( "note" ).string();

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonNote.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonNote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2023, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,33 +30,23 @@ package org.hisp.dhis.webapi.controller.tracker;
 import org.hisp.dhis.jsontree.JsonObject;
 
 /**
- * Representation of
- * {@link org.hisp.dhis.webapi.controller.tracker.view.Relationship}.
+ * Representation of {@link org.hisp.dhis.webapi.controller.tracker.view.Note}.
  */
-public interface JsonRelationship extends JsonObject
+public interface JsonNote extends JsonObject
 {
-    default String getRelationship()
+
+    default String getNote()
     {
-        return getString( "relationship" ).string();
+        return getString( "note" ).string();
     }
 
-    default String getRelationshipName()
+    default String getValue()
     {
-        return getString( "relationshipName" ).string();
+        return getString( "value" ).string();
     }
 
-    default String getRelationshipType()
+    default String getStoredBy()
     {
-        return getString( "relationshipType" ).string();
-    }
-
-    default JsonRelationshipItem getFrom()
-    {
-        return get( "from" ).as( JsonRelationshipItem.class );
-    }
-
-    default JsonRelationshipItem getTo()
-    {
-        return get( "to" ).as( JsonRelationshipItem.class );
+        return getString( "storedBy" ).string();
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonProgramOwner.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonProgramOwner.java
@@ -31,32 +31,22 @@ import org.hisp.dhis.jsontree.JsonObject;
 
 /**
  * Representation of
- * {@link org.hisp.dhis.webapi.controller.tracker.view.Relationship}.
+ * {@link org.hisp.dhis.webapi.controller.tracker.view.ProgramOwner}.
  */
-public interface JsonRelationship extends JsonObject
+public interface JsonProgramOwner extends JsonObject
 {
-    default String getRelationship()
+    default String getOrgUnit()
     {
-        return getString( "relationship" ).string();
+        return getString( "orgUnit" ).string();
     }
 
-    default String getRelationshipName()
+    default String getTrackedEntity()
     {
-        return getString( "relationshipName" ).string();
+        return getString( "trackedEntity" ).string();
     }
 
-    default String getRelationshipType()
+    default String getProgram()
     {
-        return getString( "relationshipType" ).string();
-    }
-
-    default JsonRelationshipItem getFrom()
-    {
-        return get( "from" ).as( JsonRelationshipItem.class );
-    }
-
-    default JsonRelationshipItem getTo()
-    {
-        return get( "to" ).as( JsonRelationshipItem.class );
+        return getString( "program" ).string();
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonRelationship.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonRelationship.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker;
+
+import org.hisp.dhis.jsontree.JsonObject;
+
+/**
+ * Web API equivalent of a
+ * {@link org.hisp.dhis.webapi.controller.tracker.view.Relationship}.
+ */
+public interface JsonRelationship extends JsonObject
+{
+    default String getRelationship()
+    {
+        return getString( "relationship" ).string();
+    }
+
+    default String getRelationshipName()
+    {
+        return getString( "relationshipName" ).string();
+    }
+
+    default String getRelationshipType()
+    {
+        return getString( "relationshipType" ).string();
+    }
+
+    default JsonRelationshipItem getFrom()
+    {
+        return get( "from" ).as( JsonRelationshipItem.class );
+    }
+
+    default JsonRelationshipItem getTo()
+    {
+        return get( "to" ).as( JsonRelationshipItem.class );
+    }
+}

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonRelationshipItem.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonRelationshipItem.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker;
+
+import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.jsontree.JsonObject;
+
+/**
+ * Web API equivalent of a
+ * {@link org.hisp.dhis.webapi.controller.tracker.view.RelationshipItem}.
+ */
+public interface JsonRelationshipItem extends JsonObject
+{
+    default JsonTrackedEntity getTrackedEntity()
+    {
+        return get( "trackedEntity" ).as( JsonTrackedEntity.class );
+    }
+
+    default JsonEnrollment getEnrollment()
+    {
+        return get( "enrollment" ).as( JsonEnrollment.class );
+    }
+
+    default JsonEvent getEvent()
+    {
+        return get( "event" ).as( JsonEvent.class );
+    }
+
+    interface JsonTrackedEntity extends JsonObject
+    {
+        default String getTrackedEntity()
+        {
+            return getString( "trackedEntity" ).string();
+        }
+
+        default JsonList<JsonAttribute> getAttributes()
+        {
+            return get( "attributes" ).asList( JsonAttribute.class );
+        }
+    }
+
+    interface JsonEnrollment extends JsonObject
+    {
+        default String getEnrollment()
+        {
+            return getString( "enrollment" ).string();
+        }
+    }
+
+    interface JsonEvent extends JsonObject
+    {
+        default String getEvent()
+        {
+            return getString( "event" ).string();
+        }
+    }
+}

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonRelationshipItem.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonRelationshipItem.java
@@ -31,7 +31,7 @@ import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
 
 /**
- * Web API equivalent of a
+ * Representation of
  * {@link org.hisp.dhis.webapi.controller.tracker.view.RelationshipItem}.
  */
 public interface JsonRelationshipItem extends JsonObject
@@ -62,6 +62,11 @@ public interface JsonRelationshipItem extends JsonObject
         {
             return get( "attributes" ).asList( JsonAttribute.class );
         }
+
+        default JsonList<JsonProgramOwner> getProgramOwners()
+        {
+            return get( "programOwners" ).asList( JsonProgramOwner.class );
+        }
     }
 
     interface JsonEnrollment extends JsonObject
@@ -70,6 +75,11 @@ public interface JsonRelationshipItem extends JsonObject
         {
             return getString( "enrollment" ).string();
         }
+
+        default JsonList<JsonNote> getNotes()
+        {
+            return get( "notes" ).asList( JsonNote.class );
+        }
     }
 
     interface JsonEvent extends JsonObject
@@ -77,6 +87,11 @@ public interface JsonRelationshipItem extends JsonObject
         default String getEvent()
         {
             return getString( "event" ).string();
+        }
+
+        default JsonList<JsonNote> getNotes()
+        {
+            return get( "notes" ).asList( JsonNote.class );
         }
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonRelationshipItem.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonRelationshipItem.java
@@ -58,6 +58,16 @@ public interface JsonRelationshipItem extends JsonObject
             return getString( "trackedEntity" ).string();
         }
 
+        default String getTrackedEntityType()
+        {
+            return getString( "trackedEntityType" ).string();
+        }
+
+        default String getOrgUnit()
+        {
+            return getString( "orgUnit" ).string();
+        }
+
         default JsonList<JsonAttribute> getAttributes()
         {
             return get( "attributes" ).asList( JsonAttribute.class );
@@ -76,6 +86,21 @@ public interface JsonRelationshipItem extends JsonObject
             return getString( "enrollment" ).string();
         }
 
+        default String getTrackedEntity()
+        {
+            return getString( "trackedEntity" ).string();
+        }
+
+        default String getProgram()
+        {
+            return getString( "program" ).string();
+        }
+
+        default String getOrgUnit()
+        {
+            return getString( "orgUnit" ).string();
+        }
+
         default JsonList<JsonNote> getNotes()
         {
             return get( "notes" ).asList( JsonNote.class );
@@ -87,6 +112,21 @@ public interface JsonRelationshipItem extends JsonObject
         default String getEvent()
         {
             return getString( "event" ).string();
+        }
+
+        default String getStatus()
+        {
+            return getString( "status" ).string();
+        }
+
+        default String getProgramStage()
+        {
+            return getString( "programStage" ).string();
+        }
+
+        default String getEnrollment()
+        {
+            return getString( "enrollment" ).string();
         }
 
         default JsonList<JsonNote> getNotes()

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerControllerAssertions.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerControllerAssertions.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller;
+package org.hisp.dhis.webapi.controller.tracker.export;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportControllerTest.java
@@ -27,9 +27,9 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export;
 
-import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertHasMember;
-import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertHasNoMember;
-import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertHasOnlyMembers;
+import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasMember;
+import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasNoMember;
+import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasOnlyMembers;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportControllerTest.java
@@ -25,11 +25,11 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller;
+package org.hisp.dhis.webapi.controller.tracker.export;
 
-import static org.hisp.dhis.webapi.controller.TrackerControllerAssertions.assertHasMember;
-import static org.hisp.dhis.webapi.controller.TrackerControllerAssertions.assertHasNoMember;
-import static org.hisp.dhis.webapi.controller.TrackerControllerAssertions.assertHasOnlyMembers;
+import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertHasMember;
+import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertHasNoMember;
+import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertHasOnlyMembers;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportControllerTest.java
@@ -25,12 +25,12 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller;
+package org.hisp.dhis.webapi.controller.tracker.export;
 
-import static org.hisp.dhis.webapi.controller.TrackerControllerAssertions.assertHasMember;
-import static org.hisp.dhis.webapi.controller.TrackerControllerAssertions.assertHasNoMember;
-import static org.hisp.dhis.webapi.controller.TrackerControllerAssertions.assertHasOnlyMembers;
-import static org.hisp.dhis.webapi.controller.TrackerControllerAssertions.assertRelationship;
+import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertHasMember;
+import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertHasNoMember;
+import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertHasOnlyMembers;
+import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertRelationship;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportControllerTest.java
@@ -27,10 +27,10 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export;
 
-import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertHasMember;
-import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertHasNoMember;
-import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertHasOnlyMembers;
-import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertRelationship;
+import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertFirstRelationship;
+import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasMember;
+import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasNoMember;
+import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasOnlyMembers;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -43,7 +43,7 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
-import org.hisp.dhis.jsontree.JsonArray;
+import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
@@ -63,6 +63,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.sharing.UserAccess;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.webapi.controller.tracker.JsonRelationship;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -152,16 +153,14 @@ class TrackerEventsExportControllerTest extends DhisControllerConvenienceTest
         ProgramStageInstance from = programStageInstance( programInstance( to ) );
         Relationship r = relationship( from, to );
 
-        JsonObject json = GET( "/tracker/events/{id}?fields=relationships", from.getUid() )
-            .content( HttpStatus.OK );
+        JsonList<JsonRelationship> relationships = GET( "/tracker/events/{id}?fields=relationships", from.getUid() )
+            .content( HttpStatus.OK ).getList( "relationships", JsonRelationship.class );
 
-        assertFalse( json.isEmpty() );
-        JsonArray rels = json.getArray( "relationships" );
-        assertFalse( rels.isEmpty() );
-        assertEquals( 1, rels.size() );
-        assertRelationship( r, rels.getObject( 0 ) );
-        assertEventWithinRelationship( from, rels.getObject( 0 ).getObject( "from" ) );
-        assertTrackedEntityWithinRelationship( to, rels.getObject( 0 ).getObject( "to" ) );
+        assertFalse( relationships.isEmpty() );
+        assertEquals( 1, relationships.size() );
+        JsonRelationship relationship = assertFirstRelationship( r, relationships );
+        assertEventWithinRelationship( from, relationship.getFrom() );
+        assertTrackedEntityWithinRelationship( to, relationship.getTo() );
     }
 
     @Test
@@ -172,11 +171,9 @@ class TrackerEventsExportControllerTest extends DhisControllerConvenienceTest
         relationship( relationshipTypeNotAccessible(), from, to );
         this.switchContextToUser( user );
 
-        JsonObject json = GET( "/tracker/events/{id}?fields=relationships", from.getUid() )
-            .content( HttpStatus.OK );
+        JsonList<JsonRelationship> relationships = GET( "/tracker/events/{id}?fields=relationships", from.getUid() )
+            .content( HttpStatus.OK ).getList( "relationships", JsonRelationship.class );
 
-        assertFalse( json.isEmpty() );
-        JsonArray relationships = json.getArray( "relationships" );
         assertEquals( 0, relationships.size() );
     }
 
@@ -189,11 +186,9 @@ class TrackerEventsExportControllerTest extends DhisControllerConvenienceTest
         relationship( from, to );
         this.switchContextToUser( user );
 
-        JsonObject json = GET( "/tracker/events/{id}?fields=relationships", from.getUid() )
-            .content( HttpStatus.OK );
+        JsonList<JsonRelationship> relationships = GET( "/tracker/events/{id}?fields=relationships", from.getUid() )
+            .content( HttpStatus.OK ).getList( "relationships", JsonRelationship.class );
 
-        assertFalse( json.isEmpty() );
-        JsonArray relationships = json.getArray( "relationships" );
         assertEquals( 0, relationships.size() );
     }
 
@@ -219,11 +214,9 @@ class TrackerEventsExportControllerTest extends DhisControllerConvenienceTest
         relationship( from, to );
         this.switchContextToUser( user );
 
-        JsonObject json = GET( "/tracker/events/{id}?fields=relationships", to.getUid() )
-            .content( HttpStatus.OK );
+        JsonList<JsonRelationship> relationships = GET( "/tracker/events/{id}?fields=relationships", to.getUid() )
+            .content( HttpStatus.OK ).getList( "relationships", JsonRelationship.class );
 
-        assertFalse( json.isEmpty() );
-        JsonArray relationships = json.getArray( "relationships" );
         assertEquals( 0, relationships.size() );
     }
 

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportControllerTest.java
@@ -25,16 +25,16 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller;
+package org.hisp.dhis.webapi.controller.tracker.export;
 
-import static org.hisp.dhis.webapi.controller.TrackerControllerAssertions.assertEnrollmentWithinRelationship;
-import static org.hisp.dhis.webapi.controller.TrackerControllerAssertions.assertEventWithinRelationship;
-import static org.hisp.dhis.webapi.controller.TrackerControllerAssertions.assertFirstRelationship;
-import static org.hisp.dhis.webapi.controller.TrackerControllerAssertions.assertHasOnlyMembers;
-import static org.hisp.dhis.webapi.controller.TrackerControllerAssertions.assertHasOnlyUid;
-import static org.hisp.dhis.webapi.controller.TrackerControllerAssertions.assertNoRelationships;
-import static org.hisp.dhis.webapi.controller.TrackerControllerAssertions.assertRelationship;
-import static org.hisp.dhis.webapi.controller.TrackerControllerAssertions.assertTrackedEntityWithinRelationship;
+import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertEnrollmentWithinRelationship;
+import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertEventWithinRelationship;
+import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertFirstRelationship;
+import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertHasOnlyMembers;
+import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertHasOnlyUid;
+import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertNoRelationships;
+import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertRelationship;
+import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertTrackedEntityWithinRelationship;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportControllerTest.java
@@ -25,14 +25,17 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller;
+package org.hisp.dhis.webapi.controller.tracker.export;
 
 import static org.hisp.dhis.utils.Assertions.assertContains;
-import static org.hisp.dhis.webapi.controller.TrackerControllerAssertions.assertHasMember;
-import static org.hisp.dhis.webapi.controller.TrackerControllerAssertions.assertHasNoMember;
-import static org.hisp.dhis.webapi.controller.TrackerControllerAssertions.assertHasOnlyMembers;
-import static org.hisp.dhis.webapi.controller.TrackerControllerAssertions.assertRelationship;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertHasMember;
+import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertHasNoMember;
+import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertHasOnlyMembers;
+import static org.hisp.dhis.webapi.controller.tracker.export.TrackerControllerAssertions.assertRelationship;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Date;
 import java.util.Set;

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller;
+package org.hisp.dhis.webapi.controller.tracker.imports;
 
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;


### PR DESCRIPTION
* move new tracker tests in packages matching implementation
* add more tests for nested fields `trackedEntity.attributes`, `enrollment.notes` and `event.notes` returned by `/tracker/relationships` so that refactorings in https://dhis2.atlassian.net/browse/TECH-1515 become safer.
* use the awesome views introduced by @jbee 😍 thank you!! This allows us to write readable assertions.