### PR TITLE
fix: fetch nested fields of trackedEntity and events in /tracker/relationships DHIS2-14407

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/relationship/AbstractRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/relationship/AbstractRelationshipService.java
@@ -534,7 +534,7 @@ public abstract class AbstractRelationshipService
             else
             {
                 tei = trackedEntityInstanceService
-                    .getTrackedEntityInstance( dao.getTrackedEntityInstance(), TrackedEntityInstanceParams.FALSE );
+                    .getTrackedEntityInstance( dao.getTrackedEntityInstance(), TrackedEntityInstanceParams.TRUE );
             }
 
             relationshipItem.setTrackedEntityInstance( tei );
@@ -552,8 +552,7 @@ public abstract class AbstractRelationshipService
             }
             else
             {
-                enrollment = enrollmentService.getEnrollment( dao.getProgramInstance(),
-                    EnrollmentParams.FALSE );
+                enrollment = enrollmentService.getEnrollment( dao.getProgramInstance(), EnrollmentParams.TRUE );
             }
 
             relationshipItem.setEnrollment( enrollment );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonDataValue.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonDataValue.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker;
+
+import org.hisp.dhis.jsontree.JsonObject;
+
+/**
+ * Representation of
+ * {@link org.hisp.dhis.webapi.controller.tracker.view.DataValue}.
+ */
+public interface JsonDataValue extends JsonObject
+{
+    default String getDataElement()
+    {
+        return getString( "dataElement" ).string();
+    }
+
+    default String getValue()
+    {
+        return getString( "value" ).string();
+    }
+}

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonRelationshipItem.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonRelationshipItem.java
@@ -73,6 +73,11 @@ public interface JsonRelationshipItem extends JsonObject
             return get( "attributes" ).asList( JsonAttribute.class );
         }
 
+        default JsonList<JsonEnrollment> getEnrollments()
+        {
+            return get( "enrollments" ).asList( JsonEnrollment.class );
+        }
+
         default JsonList<JsonProgramOwner> getProgramOwners()
         {
             return get( "programOwners" ).asList( JsonProgramOwner.class );
@@ -101,6 +106,16 @@ public interface JsonRelationshipItem extends JsonObject
             return getString( "orgUnit" ).string();
         }
 
+        default JsonList<JsonEvent> getEvents()
+        {
+            return get( "events" ).asList( JsonEvent.class );
+        }
+
+        default JsonList<JsonAttribute> getAttributes()
+        {
+            return get( "attributes" ).asList( JsonAttribute.class );
+        }
+
         default JsonList<JsonNote> getNotes()
         {
             return get( "notes" ).asList( JsonNote.class );
@@ -127,6 +142,16 @@ public interface JsonRelationshipItem extends JsonObject
         default String getEnrollment()
         {
             return getString( "enrollment" ).string();
+        }
+
+        default JsonUser getAssignedUser()
+        {
+            return get( "assignedUser" ).as( JsonUser.class );
+        }
+
+        default JsonList<JsonDataValue> getDataValues()
+        {
+            return get( "dataValues" ).asList( JsonDataValue.class );
         }
 
         default JsonList<JsonNote> getNotes()

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonUser.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonUser.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker;
+
+import org.hisp.dhis.jsontree.JsonObject;
+
+/**
+ * Representation of {@link org.hisp.dhis.webapi.controller.tracker.view.User}.
+ */
+public interface JsonUser extends JsonObject
+{
+    default String getUid()
+    {
+        return getString( "uid" ).string();
+    }
+
+    default String getUsername()
+    {
+        return getString( "username" ).string();
+    }
+
+    default String getFirstName()
+    {
+        return getString( "firstName" ).string();
+    }
+
+    default String getSurname()
+    {
+        return getString( "surname" ).string();
+    }
+
+    default String getDisplayName()
+    {
+        return getString( "displayName" ).string();
+    }
+}

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportControllerTest.java
@@ -43,6 +43,8 @@ import java.util.Set;
 
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -58,6 +60,7 @@ import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.security.acl.AccessStringHelper;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.trackedentity.TrackedEntityProgramOwner;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeAttribute;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
@@ -67,8 +70,12 @@ import org.hisp.dhis.user.sharing.UserAccess;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.webapi.controller.tracker.JsonAttribute;
+import org.hisp.dhis.webapi.controller.tracker.JsonDataValue;
 import org.hisp.dhis.webapi.controller.tracker.JsonNote;
+import org.hisp.dhis.webapi.controller.tracker.JsonProgramOwner;
 import org.hisp.dhis.webapi.controller.tracker.JsonRelationship;
+import org.hisp.dhis.webapi.controller.tracker.JsonRelationshipItem;
+import org.hisp.dhis.webapi.controller.tracker.JsonUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -95,10 +102,13 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
 
     private TrackedEntityAttribute tea;
 
+    private DataElement dataElement;
+
     @BeforeEach
     void setUp()
     {
-        owner = makeUser( "owner" );
+        owner = makeUser( "o" );
+        manager.save( owner, false );
 
         orgUnit = createOrganisationUnit( 'A' );
         orgUnit.getSharing().setOwner( owner );
@@ -140,6 +150,9 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
 
         trackedEntityType.setTrackedEntityTypeAttributes( List.of( trackedEntityTypeAttribute ) );
         manager.save( trackedEntityType );
+
+        dataElement = createDataElement( 'A' );
+        manager.save( dataElement, false );
     }
 
     @Test
@@ -253,6 +266,42 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
     }
 
     @Test
+    void getRelationshipsByEventWithAssignedUser()
+    {
+        TrackedEntityInstance to = trackedEntityInstance();
+        ProgramStageInstance from = programStageInstance( programInstance( to ) );
+        from.setAssignedUser( owner );
+        relationship( from, to );
+
+        JsonList<JsonRelationship> relationships = GET(
+            "/tracker/relationships?event={uid}&fields=from[event[assignedUser]]",
+            from.getUid() )
+                .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
+
+        JsonUser user = relationships.get( 0 ).getFrom().getEvent().getAssignedUser();
+        assertEquals( owner.getUid(), user.getUid() );
+        assertEquals( owner.getUsername(), user.getUsername() );
+    }
+
+    @Test
+    void getRelationshipsByEventWithDataValues()
+    {
+        TrackedEntityInstance to = trackedEntityInstance();
+        ProgramStageInstance from = programStageInstance( programInstance( to ) );
+        from.setEventDataValues( Set.of( new EventDataValue( dataElement.getUid(), "12" ) ) );
+        relationship( from, to );
+
+        JsonList<JsonRelationship> relationships = GET(
+            "/tracker/relationships?event={uid}&fields=from[event[dataValues[dataElement,value]]]",
+            from.getUid() )
+                .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
+
+        JsonDataValue dataValue = relationships.get( 0 ).getFrom().getEvent().getDataValues().get( 0 );
+        assertEquals( dataElement.getUid(), dataValue.getDataElement() );
+        assertEquals( "12", dataValue.getValue() );
+    }
+
+    @Test
     void getRelationshipsByEventWithNotes()
     {
         TrackedEntityInstance to = trackedEntityInstance();
@@ -312,6 +361,42 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
     }
 
     @Test
+    void getRelationshipsByEnrollmentWithEvents()
+    {
+        ProgramInstance from = programInstance( trackedEntityInstance() );
+        ProgramStageInstance to = programStageInstance( from );
+        relationship( from, to );
+
+        JsonList<JsonRelationship> relationships = GET(
+            "/tracker/relationships?enrollment={uid}&fields=from[enrollment[events[enrollment,event]]]", from.getUid() )
+                .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
+
+        JsonRelationshipItem.JsonEvent event = relationships.get( 0 ).getFrom().getEnrollment().getEvents().get( 0 );
+        assertEquals( from.getUid(), event.getEnrollment() );
+        assertEquals( to.getUid(), event.getEvent() );
+    }
+
+    @Test
+    void getRelationshipsByEnrollmentWithAttributes()
+    {
+        TrackedEntityInstance to = trackedEntityInstance();
+        to.setTrackedEntityAttributeValues( Set.of( attributeValue( tea, to, "12" ) ) );
+        program.setProgramAttributes( List.of( createProgramTrackedEntityAttribute( program, tea ) ) );
+
+        ProgramInstance from = programInstance( to );
+        relationship( from, to );
+
+        JsonList<JsonRelationship> relationships = GET(
+            "/tracker/relationships?enrollment={uid}&fields=from[enrollment[attributes[attribute,value]]]",
+            from.getUid() )
+                .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
+
+        JsonAttribute attribute = relationships.get( 0 ).getFrom().getEnrollment().getAttributes().get( 0 );
+        assertEquals( tea.getUid(), attribute.getAttribute() );
+        assertEquals( "12", attribute.getValue() );
+    }
+
+    @Test
     void getRelationshipsByEnrollmentWithNotes()
     {
         TrackedEntityInstance to = trackedEntityInstance();
@@ -339,7 +424,7 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
     }
 
     @Test
-    void getRelationshipsByTrackedEntityRelationshipEnrollmentToTrackedEntity()
+    void getRelationshipsByTrackedEntity()
     {
         TrackedEntityInstance to = trackedEntityInstance();
         ProgramInstance from = programInstance( to );
@@ -371,6 +456,24 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
     }
 
     @Test
+    void getRelationshipsByTrackedEntityWithEnrollments()
+    {
+        TrackedEntityInstance to = trackedEntityInstance();
+        ProgramInstance from = programInstance( to );
+        relationship( from, to );
+
+        JsonList<JsonRelationship> relationships = GET(
+            "/tracker/relationships?trackedEntity={tei}&fields=to[trackedEntity[enrollments[enrollment,trackedEntity]]",
+            to.getUid() )
+                .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
+
+        JsonRelationshipItem.JsonEnrollment enrollment = relationships.get( 0 ).getTo().getTrackedEntity()
+            .getEnrollments().get( 0 );
+        assertEquals( from.getUid(), enrollment.getEnrollment() );
+        assertEquals( to.getUid(), enrollment.getTrackedEntity() );
+    }
+
+    @Test
     void getRelationshipsByTrackedEntityWithAttributes()
     {
         TrackedEntityInstance to = trackedEntityInstance( orgUnit );
@@ -386,6 +489,26 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
         JsonAttribute attribute = relationships.get( 0 ).getTo().getTrackedEntity().getAttributes().get( 0 );
         assertEquals( tea.getUid(), attribute.getAttribute() );
         assertEquals( "12", attribute.getValue() );
+    }
+
+    @Test
+    void getRelationshipsByTrackedEntityWithProgramOwners()
+    {
+        TrackedEntityInstance to = trackedEntityInstance( orgUnit );
+        ProgramInstance from = programInstance( to );
+        to.setProgramOwners( Set.of( new TrackedEntityProgramOwner( to, from.getProgram(), orgUnit ) ) );
+        relationship( from, to );
+
+        JsonList<JsonRelationship> relationships = GET(
+            "/tracker/relationships?trackedEntity={tei}&fields=to[trackedEntity[programOwners]",
+            to.getUid() )
+                .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
+
+        JsonProgramOwner jsonProgramOwner = relationships.get( 0 ).getTo().getTrackedEntity().getProgramOwners()
+            .get( 0 );
+        assertEquals( orgUnit.getUid(), jsonProgramOwner.getOrgUnit() );
+        assertEquals( to.getUid(), jsonProgramOwner.getTrackedEntity() );
+        assertEquals( from.getProgram().getUid(), jsonProgramOwner.getProgram() );
     }
 
     @Test
@@ -541,7 +664,9 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
         programInstance.setEnrollmentDate( new Date() );
         programInstance.setIncidentDate( new Date() );
         programInstance.setStatus( ProgramStatus.COMPLETED );
-        manager.save( programInstance );
+        manager.save( programInstance, false );
+        tei.setProgramInstances( Set.of( programInstance ) );
+        manager.save( tei, false );
         return programInstance;
     }
 
@@ -549,7 +674,9 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
     {
         ProgramStageInstance programStageInstance = new ProgramStageInstance( programInstance, programStage, orgUnit );
         programStageInstance.setAutoFields();
-        manager.save( programStageInstance );
+        manager.save( programStageInstance, false );
+        programInstance.setProgramStageInstances( Set.of( programStageInstance ) );
+        manager.save( programInstance, false );
         return programStageInstance;
     }
 
@@ -638,6 +765,34 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
 
         RelationshipType type = relationshipTypeAccessible(
             RelationshipEntity.PROGRAM_STAGE_INSTANCE, RelationshipEntity.TRACKED_ENTITY_INSTANCE );
+        r.setRelationshipType( type );
+        r.setKey( type.getUid() );
+        r.setInvertedKey( type.getUid() );
+
+        r.setAutoFields();
+        r.getSharing().setOwner( owner );
+        manager.save( r, false );
+        return r;
+    }
+
+    private Relationship relationship( ProgramInstance from, ProgramStageInstance to )
+    {
+        Relationship r = new Relationship();
+
+        RelationshipItem fromItem = new RelationshipItem();
+        fromItem.setProgramInstance( from );
+        from.getRelationshipItems().add( fromItem );
+        r.setFrom( fromItem );
+        fromItem.setRelationship( r );
+
+        RelationshipItem toItem = new RelationshipItem();
+        toItem.setProgramStageInstance( to );
+        to.getRelationshipItems().add( toItem );
+        r.setTo( toItem );
+        toItem.setRelationship( r );
+
+        RelationshipType type = relationshipTypeAccessible(
+            RelationshipEntity.PROGRAM_INSTANCE, RelationshipEntity.PROGRAM_STAGE_INSTANCE );
         r.setRelationshipType( type );
         r.setKey( type.getUid() );
         r.setInvertedKey( type.getUid() );


### PR DESCRIPTION
During the refactoring in https://github.com/dhis2/dhis2-core/pull/12717 

The following changes

https://github.com/dhis2/dhis2-core/pull/12717/files#diff-eb3d3a30f539df9d64569f4c94d8a832cb89d414467d42d3761cac48f2f0e1a1R537 

https://github.com/dhis2/dhis2-core/pull/12717/files#diff-eb3d3a30f539df9d64569f4c94d8a832cb89d414467d42d3761cac48f2f0e1a1R556 

are the reason for us not returning nested fields like attributes, enrollments, ... in `/tracker/relationships`. Any field is affected for which the called service has logic to not fetch it if its set to false in the given params.

Reproduced using

`/tracker/relationships?enrollment={uid}&fields=from[enrollment[attributes[attribute,value]]]
`
`/tracker/relationships?trackedEntity={tei}&fields=to[trackedEntity[programOwners]`