### PR TITLE
fix: Missing isolation in periods query events/enrol [DHIS2-14442]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
@@ -74,7 +74,7 @@ public abstract class TimeFieldSqlRenderer
             sql.append( getAggregatedConditionForPeriods( params ) );
         }
 
-        return sql.toString();
+        return "(" + sql + ")";
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -150,7 +150,7 @@ class EnrollmentAnalyticsManagerTest extends
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
-            + " as ax where (enrollmentdate >= '2017-01-01' and enrollmentdate < '2018-01-01')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) ";
+            + " as ax where ((enrollmentdate >= '2017-01-01' and enrollmentdate < '2018-01-01'))and (ax.\"uidlevel1\" = 'ouabcdefghA' ) ";
 
         assertSql( sql.getValue(), expected );
         assertTrue( grid.hasLastDataRow() );
@@ -170,7 +170,7 @@ class EnrollmentAnalyticsManagerTest extends
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
-            + " as ax where (lastupdated >= '2017-01-01' and lastupdated < '2018-01-01')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
+            + " as ax where ((lastupdated >= '2017-01-01' and lastupdated < '2018-01-01'))and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
 
         assertSql( sql.getValue(), expected );
     }
@@ -204,7 +204,7 @@ class EnrollmentAnalyticsManagerTest extends
             subSelect = subSelect + " as \"fWIAEtYVEGk\"";
         }
         String expected = "ax.\"monthly\",ax.\"ou\"," + subSelect + "  from " + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and (ax.\"uidlevel1\" = 'ouabcdefghA' ) " + "and ps = '"
+            + " as ax where (ax.\"monthly\" in ('2000Q1') )and (ax.\"uidlevel1\" = 'ouabcdefghA' ) " + "and ps = '"
             + programStage.getUid() + "' limit 101";
 
         assertSql( sql.getValue(), expected );
@@ -225,7 +225,7 @@ class EnrollmentAnalyticsManagerTest extends
             + programStage.getUid() + "' order by executiondate desc limit 1 )";
 
         String expected = "ax.\"monthly\",ax.\"ou\"," + subSelect + "  from " + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and (ax.\"uidlevel1\" = 'ouabcdefghA' ) "
+            + " as ax where (ax.\"monthly\" in ('2000Q1') )and (ax.\"uidlevel1\" = 'ouabcdefghA' ) "
             + "and ps = '" + programStage.getUid() + "' and " + subSelect + " > '10' limit 10001";
 
         assertSql( sql.getValue(), expected );
@@ -243,7 +243,7 @@ class EnrollmentAnalyticsManagerTest extends
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and (ax.\"uidlevel1\" = 'ouabcdefghA' )"
+            + " as ax where (ax.\"monthly\" in ('2000Q1') )and (ax.\"uidlevel1\" = 'ouabcdefghA' )"
             + " and enrollmentstatus in ('ACTIVE','COMPLETED') limit 10001";
 
         assertSql( sql.getValue(), expected );
@@ -252,7 +252,6 @@ class EnrollmentAnalyticsManagerTest extends
     @Test
     void verifyWithProgramStageAndNumericDataElementAndFilter2()
     {
-
         EventQueryParams params = createRequestParamsWithFilter( programStage, ValueType.NUMBER );
 
         subject.getEnrollments( params, new ListGrid(), 10000 );
@@ -267,7 +266,7 @@ class EnrollmentAnalyticsManagerTest extends
         String expected = "ax.\"monthly\",ax.\"ou\"," + subSelect
             + " as \"fWIAEtYVEGk\"" + "  from "
             + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and (ax.\"uidlevel1\" = 'ouabcdefghA' ) "
+            + " as ax where (ax.\"monthly\" in ('2000Q1') )and (ax.\"uidlevel1\" = 'ouabcdefghA' ) "
             + "and ps = '" + programStage.getUid() + "' and " + subSelect + " > '10' limit 10001";
 
         assertSql( sql.getValue(), expected );
@@ -394,7 +393,7 @@ class EnrollmentAnalyticsManagerTest extends
             + " AND tei.uid = ax.tei )) as \""
             + programIndicatorA.getUid()
             + "\"  " + "from analytics_enrollment_" + programA.getUid()
-            + " as ax where (enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
+            + " as ax where ((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09'))and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
 
         assertSql( sql.getValue(), expected );
     }
@@ -436,7 +435,7 @@ class EnrollmentAnalyticsManagerTest extends
             "= " + relationshipTypeA.getId() + " AND pi.uid = ax.pi ))" + " as \""
             + programIndicatorA.getUid() + "\"  "
             + "from analytics_enrollment_" + programA.getUid()
-            + " as ax where (enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
+            + " as ax where ((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09'))and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
 
         assertSql( sql.getValue(), expected );
     }
@@ -508,7 +507,7 @@ class EnrollmentAnalyticsManagerTest extends
             + " AND tei.uid = ax.tei )) as \""
             + programIndicatorA.getUid()
             + "\"  " + "from analytics_enrollment_" + programA.getUid()
-            + " as ax where (enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
+            + " as ax where ((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09'))and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
 
         assertSql( sql.getValue(), expected );
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
@@ -153,7 +153,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest
             + ",lastupdated,duedate,ST_AsGeoJSON(coalesce(ax.\"psigeometry\",ax.\"pigeometry\",ax.\"teigeometry\",ax.\"ougeometry\"), 6) as geometry,"
             + "longitude,latitude,ouname,ounamehierarchy,oucode,pistatus,psistatus,ax.\"monthly\",ax.\"ou\"  from "
             + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA') limit 101";
+            + " as ax where (ax.\"monthly\" in ('2000Q1') )and ax.\"uidlevel1\" in ('ouabcdefghA') limit 101";
 
         assertThat( sql.getValue(), is( expected ) );
     }
@@ -177,7 +177,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest
             + "incidentdate,tei,pi,ST_AsGeoJSON(coalesce(ax.\"psigeometry\",ax.\"pigeometry\",ax.\"teigeometry\",ax.\"ougeometry\"), 6) as geometry,longitude,latitude,ouname,ounamehierarchy,oucode,pistatus,"
             + "psistatus,ax.\"monthly\",ax.\"ou\",\"" + dataElement.getUid() + "_name"
             + "\"  from " + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA')"
+            + " as ax where (ax.\"monthly\" in ('2000Q1') )and ax.\"uidlevel1\" in ('ouabcdefghA')"
             + " limit 101";
 
         assertThat( sql.getValue(), is( expected ) );
@@ -196,7 +196,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA') ";
+            + " as ax where (ax.\"monthly\" in ('2000Q1') )and ax.\"uidlevel1\" in ('ouabcdefghA') ";
 
         assertSql( expected, sql.getValue() );
         assertTrue( grid.hasLastDataRow() );
@@ -213,7 +213,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
+            + " as ax where (ax.\"monthly\" in ('2000Q1') )and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid() + "' limit 101";
 
         assertSql( expected, sql.getValue() );
@@ -230,7 +230,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\",ax.\"fWIAEtYVEGk\"  from " + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
+            + " as ax where (ax.\"monthly\" in ('2000Q1') )and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid() + "' limit 101";
 
         assertSql( expected, sql.getValue() );
@@ -247,7 +247,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\",ax.\"fWIAEtYVEGk\"  from " + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
+            + " as ax where (ax.\"monthly\" in ('2000Q1') )and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid()
             + "' and ax.\"fWIAEtYVEGk\" > '10' limit 101";
 
@@ -264,7 +264,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA')" +
+            + " as ax where (ax.\"monthly\" in ('2000Q1') )and ax.\"uidlevel1\" in ('ouabcdefghA')" +
             " and pistatus in ('ACTIVE','COMPLETED') and psistatus in ('SCHEDULE') limit 101";
 
         assertSql( expected, sql.getValue() );
@@ -281,7 +281,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest
 
         String expected = "ps.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
             + " as ax left join _dateperiodstructure as ps on cast(ax.\"duedate\" as date) = ps.\"dateperiod\" "
-            + "where ps.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" "
+            + "where (ps.\"monthly\" in ('2000Q1') )and ax.\"uidlevel1\" "
             + "in ('ouabcdefghA') and pistatus in ('ACTIVE','COMPLETED') limit 101";
 
         assertSql( expected, sql.getValue() );
@@ -297,7 +297,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() ) + " as ax "
-            + "where (( ax.\"lastupdated\" >= '2000-01-01' and ax.\"lastupdated\" < '2000-04-01') )and ax.\"uidlevel1\" "
+            + "where ((( ax.\"lastupdated\" >= '2000-01-01' and ax.\"lastupdated\" < '2000-04-01') ))and ax.\"uidlevel1\" "
             + "in ('ouabcdefghA') and pistatus in ('ACTIVE','COMPLETED') limit 101";
 
         assertSql( expected, sql.getValue() );
@@ -373,7 +373,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\",ax.\"fWIAEtYVEGk\"  from " + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
+            + " as ax where (ax.\"monthly\" in ('2000Q1') )and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid() + "' limit 101";
 
         assertSql( expected, sql.getValue() );
@@ -389,7 +389,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\",ax.\"fWIAEtYVEGk\"  from " + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
+            + " as ax where (ax.\"monthly\" in ('2000Q1') )and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid()
             + "' and ax.\"fWIAEtYVEGk\" > '10' limit 101";
 
@@ -417,7 +417,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest
 
         String expected = "select count(ax.\"psi\") as value,ax.\"monthly\",ax.\"ou\",ax.\"fWIAEtYVEGk\" from "
             + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
+            + " as ax where (ax.\"monthly\" in ('2000Q1') )and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid()
             + "' group by ax.\"monthly\", ax.\"ou\", ax.\"fWIAEtYVEGk\" limit 200001";
 
@@ -445,7 +445,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
         String expected = "select count(ax.\"psi\") as value,ax.\"monthly\",ax.\"ou\",ax.\"fWIAEtYVEGk\" from "
             + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
+            + " as ax where (ax.\"monthly\" in ('2000Q1') )and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid()
             + "' and ax.\"fWIAEtYVEGk\" > '10'"
             + " group by ax.\"monthly\", ax.\"ou\", ax.\"fWIAEtYVEGk\" limit 200001";

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.analytics.event.data;
 
 import static org.hisp.dhis.analytics.TimeField.INCIDENT_DATE;
 import static org.hisp.dhis.analytics.TimeField.LAST_UPDATED;
+import static org.hisp.dhis.analytics.TimeField.SCHEDULED_DATE;
+import static org.hisp.dhis.common.DimensionType.PERIOD;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -37,7 +39,6 @@ import java.util.List;
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.common.BaseDimensionalObject;
-import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.jdbc.statementbuilder.PostgreSQLStatementBuilder;
 import org.hisp.dhis.period.MonthlyPeriodType;
 import org.hisp.dhis.period.Period;
@@ -68,15 +69,14 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
     void testRenderEventTimeFieldSqlWhenNonContinuousDateRange()
     {
         EventQueryParams params = new EventQueryParams.Builder()
-            .addDimension(
-                new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peC ) ) )
+            .addDimension( new BaseDimensionalObject( PERIOD_DIM_ID, PERIOD, List.of( peA, peC ) ) )
             .build();
+
         TimeFieldSqlRenderer timeFieldSqlRenderer = new EventTimeFieldSqlRenderer( new PostgreSQLStatementBuilder() );
 
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
-        assertEquals(
-            "(ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-07-01')",
+        assertEquals( "((ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-07-01'))",
             timeFieldSqlRenderer.renderPeriodTimeFieldSql( params ) );
     }
 
@@ -84,14 +84,14 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
     void testRenderEventTimeFieldSqlWhenContinuousDateRange()
     {
         EventQueryParams params = new EventQueryParams.Builder()
-            .addDimension(
-                new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peB, peC ) ) )
+            .addDimension( new BaseDimensionalObject( PERIOD_DIM_ID, PERIOD, List.of( peA, peB, peC ) ) )
             .build();
+
         TimeFieldSqlRenderer timeFieldSqlRenderer = new EventTimeFieldSqlRenderer( new PostgreSQLStatementBuilder() );
 
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
-        assertEquals( "(ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-07-01')",
+        assertEquals( "((ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-07-01'))",
             timeFieldSqlRenderer.renderPeriodTimeFieldSql( params ) );
     }
 
@@ -99,16 +99,14 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
     void testRenderEnrollmentTimeFieldSqlWhenNonContinuousDateRange()
     {
         EventQueryParams params = new EventQueryParams.Builder()
-            .addDimension(
-                new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peC ) ) )
+            .addDimension( new BaseDimensionalObject( PERIOD_DIM_ID, PERIOD, List.of( peA, peC ) ) )
             .build();
         TimeFieldSqlRenderer timeFieldSqlRenderer = new EnrollmentTimeFieldSqlRenderer(
             new PostgreSQLStatementBuilder() );
 
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
-        assertEquals(
-            "(enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-07-01')",
+        assertEquals( "((enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-07-01'))",
             timeFieldSqlRenderer.renderPeriodTimeFieldSql( params ) );
     }
 
@@ -116,15 +114,15 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
     void testRenderEnrollmentTimeFieldSqlWhenContinuousDateRange()
     {
         EventQueryParams params = new EventQueryParams.Builder()
-            .addDimension(
-                new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peB, peC ) ) )
+            .addDimension( new BaseDimensionalObject( PERIOD_DIM_ID, PERIOD, List.of( peA, peB, peC ) ) )
             .build();
+
         TimeFieldSqlRenderer timeFieldSqlRenderer = new EnrollmentTimeFieldSqlRenderer(
             new PostgreSQLStatementBuilder() );
 
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
-        assertEquals( "(enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-07-01')",
+        assertEquals( "((enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-07-01'))",
             timeFieldSqlRenderer.renderPeriodTimeFieldSql( params ) );
     }
 
@@ -132,16 +130,16 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
     void testRenderEnrollmentTimeFieldSqlWhenContinuousDateRangeWithTimeFieldAllowed()
     {
         EventQueryParams params = new EventQueryParams.Builder()
-            .addDimension(
-                new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peB, peC ) ) )
+            .addDimension( new BaseDimensionalObject( PERIOD_DIM_ID, PERIOD, List.of( peA, peB, peC ) ) )
             .withTimeField( LAST_UPDATED.name() )
             .build();
+
         TimeFieldSqlRenderer timeFieldSqlRenderer = new EnrollmentTimeFieldSqlRenderer(
             new PostgreSQLStatementBuilder() );
 
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
-        assertEquals( "(lastupdated >= '2022-04-01' and lastupdated < '2022-07-01')",
+        assertEquals( "((lastupdated >= '2022-04-01' and lastupdated < '2022-07-01'))",
             timeFieldSqlRenderer.renderPeriodTimeFieldSql( params ) );
     }
 
@@ -149,16 +147,43 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
     void testRenderEnrollmentTimeFieldSqlWhenContinuousDateRangeWithTimeFieldNotAllowed()
     {
         EventQueryParams params = new EventQueryParams.Builder()
-            .addDimension(
-                new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peB, peC ) ) )
+            .addDimension( new BaseDimensionalObject( PERIOD_DIM_ID, PERIOD, List.of( peA, peB, peC ) ) )
             .withTimeField( INCIDENT_DATE.getField() )
             .build();
-        TimeFieldSqlRenderer timeFieldSqlRenderer = new EnrollmentTimeFieldSqlRenderer(
+
+        TimeFieldSqlRenderer timeFieldSqlRenderer = new EventTimeFieldSqlRenderer(
             new PostgreSQLStatementBuilder() );
 
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
-        assertEquals( "(enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-07-01')",
+        assertEquals( "((ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-07-01'))",
+            timeFieldSqlRenderer.renderPeriodTimeFieldSql( params ) );
+    }
+
+    @Test
+    void testRenderEnrollmentTimeFieldSqlWhenNoContinuousMonthlyPeriodWithTimeFieldAllowed()
+    {
+        Period march = new MonthlyPeriodType().createPeriod( new DateTime( 2022, 3, 1, 0, 0 ).toDate() );
+        march.setDateField( "SCHEDULED_DATE" );
+        march.setPeriodType( new MonthlyPeriodType() );
+
+        Period september = new MonthlyPeriodType().createPeriod( new DateTime( 2022, 9, 1, 0, 0 ).toDate() );
+        september.setDateField( "SCHEDULED_DATE" );
+        march.setPeriodType( new MonthlyPeriodType() );
+
+        EventQueryParams params = new EventQueryParams.Builder()
+            .addDimension( new BaseDimensionalObject( PERIOD_DIM_ID, PERIOD, List.of( march, september ) ) )
+            .withTimeField( SCHEDULED_DATE.getField() )
+            .withStartEndDatesForPeriods()
+            .build();
+
+        TimeFieldSqlRenderer timeFieldSqlRenderer = new EventTimeFieldSqlRenderer(
+            new PostgreSQLStatementBuilder() );
+
+        params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
+
+        assertEquals( "((ax.\"duedate\" >= '2022-03-01' and ax.\"duedate\" < '2022-04-01') " +
+            "or (ax.\"duedate\" >= '2022-09-01' and ax.\"duedate\" < '2022-10-01'))",
             timeFieldSqlRenderer.renderPeriodTimeFieldSql( params ) );
     }
 }


### PR DESCRIPTION
The Period query lacked some parenthesis to isolate the Period SQL conditions correctly.
This PR should fix this problem.
