### PR TITLE
fix: empty file from VisualizationDataController [DHIS2-14240]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
@@ -529,11 +529,12 @@ public abstract class BaseAnalyticalObject
         }
         else
         {
-            Optional<DimensionalObject> trackedEntityDimension = getTrackedEntityDimension( dimension );
+            Optional<DimensionalObject> dimensionalObject = getDimensionFromEmbeddedObjects( dimension )
+                .or( () -> getTrackedEntityDimension( dimension ) );
 
-            if ( trackedEntityDimension.isPresent() )
+            if ( dimensionalObject.isPresent() )
             {
-                return trackedEntityDimension.get();
+                return dimensionalObject.get();
             }
         }
 
@@ -755,43 +756,27 @@ public abstract class BaseAnalyticalObject
         }
         else
         {
-            // Embedded dimensions
+            Optional<DimensionalObject> dimensionalObject = getDimensionFromEmbeddedObjects( dimension )
+                .or( () -> getTrackedEntityDimension( dimension ) );
 
-            Optional<DimensionalObject> object;
-
-            if ( (object = getDimensionFromEmbeddedObjects( dimension, DimensionType.DATA_ELEMENT_GROUP_SET,
-                dataElementGroupSetDimensions )).isPresent() )
+            if ( dimensionalObject.isPresent() )
             {
-                return Optional.of( object.get() );
-            }
-
-            if ( (object = getDimensionFromEmbeddedObjects( dimension, DimensionType.ORGANISATION_UNIT_GROUP_SET,
-                organisationUnitGroupSetDimensions )).isPresent() )
-            {
-                return Optional.of( object.get() );
-            }
-
-            if ( (object = getDimensionFromEmbeddedObjects( dimension, DimensionType.CATEGORY, categoryDimensions ))
-                .isPresent() )
-            {
-                return Optional.of( object.get() );
-            }
-
-            if ( (object = getDimensionFromEmbeddedObjects( dimension, DimensionType.CATEGORY_OPTION_GROUP_SET,
-                categoryOptionGroupSetDimensions )).isPresent() )
-            {
-                return Optional.of( object.get() );
-            }
-
-            Optional<DimensionalObject> trackedEntityDimension = getTrackedEntityDimension( dimension );
-
-            if ( trackedEntityDimension.isPresent() )
-            {
-                return trackedEntityDimension;
+                return dimensionalObject;
             }
         }
 
         return Optional.empty();
+    }
+
+    private Optional<DimensionalObject> getDimensionFromEmbeddedObjects( String dimension )
+    {
+        return getDimensionFromEmbeddedObjects( dimension, DimensionType.DATA_ELEMENT_GROUP_SET,
+            dataElementGroupSetDimensions )
+                .or( () -> getDimensionFromEmbeddedObjects( dimension, DimensionType.ORGANISATION_UNIT_GROUP_SET,
+                    organisationUnitGroupSetDimensions ) )
+                .or( () -> getDimensionFromEmbeddedObjects( dimension, DimensionType.CATEGORY, categoryDimensions ) )
+                .or( () -> getDimensionFromEmbeddedObjects( dimension, DimensionType.CATEGORY_OPTION_GROUP_SET,
+                    categoryOptionGroupSetDimensions ) );
     }
 
     private Optional<DimensionalObject> getTrackedEntityDimension( String dimension )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/CombinationGenerator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/CombinationGenerator.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.common;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.collections4.CollectionUtils;
+
 /**
  * @author Lars Helge Overland
  */
@@ -149,6 +151,11 @@ public class CombinationGenerator<T>
             int index = indexes[i];
 
             List<T> object = objects.get( i );
+
+            if ( CollectionUtils.isEmpty( object ) )
+            {
+                continue;
+            }
 
             current.add( object.get( index ) );
         }


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-14240
### Issue
- With a GET request to `api/visualizations/KQFhHEk5DQ7/data.csv` the server return an empty file. Although data is shown in Data Visualization App.
- The method [getDimensionalObject()](https://github.com/dhis2/dhis2-core/blob/5a6f43ee2c5cba85a5ed9180cbf455f365381a00/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java#L457-L457) at line 457 doesn't handle the dimension of type `DATA_ELEMENT_GROUP_SET`. This leads to Visualization grid rows is empty.
- In result, the backend service failed to map the valueMap to the visualization grid and return an empty file with just table header.

### Fix
- Add additional method to handle `DATA_ELEMENT_GROUP_SET`  and other similar dimension types.

### Test
- Send a GET request to `api/visualizations/KQFhHEk5DQ7/data.csv`, server will return below file 
[DS Cases by Diagnosis last year (4).csv](https://github.com/dhis2/dhis2-core/files/10999224/DS.Cases.by.Diagnosis.last.year.4.csv)
