### PR TITLE
fix: update data entry struts app coordinate validator [DHIS2-14930]

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/dhis2/dhis2.validation.js
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/dhis2/dhis2.validation.js
@@ -77,7 +77,7 @@ dhis2.validation.isZeroOrPositiveInt = function(value) {
  */
 dhis2.validation.isCoordinate = function(value) {
   try {
-	var m = value.match(/^\[([+-]?\d+(?:\.\d+)?)\s*,\s*([+-]?\d+(?:\.\d+)?)\]$/);
+	var m = value.match(/^\[\s*([+-]?\d+(?:\.\d+)?)\s*,\s*([+-]?\d+(?:\.\d+)?)\s*\]$/);
    	var lng = parseFloat(m[1]);
     var lat = parseFloat(m[2]);
     return lng >= -180 && lng <= 180 && lat >= -90 && lat <= 90;

--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/dhis2/dhis2.validation.js
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/javascripts/dhis2/dhis2.validation.js
@@ -77,10 +77,10 @@ dhis2.validation.isZeroOrPositiveInt = function(value) {
  */
 dhis2.validation.isCoordinate = function(value) {
   try {
-	var m = value.match(/^([+-]?\d+(?:\.\d+)?)\s*,\s*([+-]?\d+(?:\.\d+)?)$/);
+	var m = value.match(/^\[([+-]?\d+(?:\.\d+)?)\s*,\s*([+-]?\d+(?:\.\d+)?)\]$/);
    	var lng = parseFloat(m[1]);
     var lat = parseFloat(m[2]);
-    return lng >= -180 && lng <= 180 && lat >= -180 && lat <= 90;
+    return lng >= -180 && lng <= 180 && lat >= -90 && lat <= 90;
   } 
   catch (_) {
     return false;


### PR DESCRIPTION
Aligns the client-side validator for COORDINATE value types in data entry app to match backend logic (see ticket [DHIS-14930](https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-14930))

- updates regex to require coordinates in form [longitude,latitude]. The backend appears to accept/persist values with spaces around the brackets (e.g. `[   45,50  ]`, so I have included that in the frontend regex
- fixed lower range of latitude to be -90