### PR TITLE
fix: use etag cache control instead of last-modified-by for app overrides [DHIS2-14957]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/AppOverrideFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/AppOverrideFilter.java
@@ -142,7 +142,6 @@ public class AppOverrideFilter
                 return;
             }
 
-            String filename = resource.getFilename();
             String etag = CodecUtils.md5Hex( String.valueOf( resource.lastModified() ) );
 
             if ( new ServletWebRequest( request, response ).checkNotModified( etag ) )
@@ -151,6 +150,7 @@ public class AppOverrideFilter
                 return;
             }
 
+            String filename = resource.getFilename();
             log.debug( String.format( "App filename: '%s'", filename ) );
 
             String mimeType = request.getSession().getServletContext().getMimeType( filename );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/AppOverrideFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/AppOverrideFilter.java
@@ -135,7 +135,6 @@ public class AppOverrideFilter
         {
             // Retrieve file
             Resource resource = appManager.getAppResource( app, resourcePath );
-
             if ( resource == null )
             {
                 response.sendError( HttpServletResponse.SC_NOT_FOUND );
@@ -143,7 +142,6 @@ public class AppOverrideFilter
             }
 
             String etag = CodecUtils.md5Hex( String.valueOf( resource.lastModified() ) );
-
             if ( new ServletWebRequest( request, response ).checkNotModified( etag ) )
             {
                 response.setStatus( HttpServletResponse.SC_NOT_MODIFIED );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/AppOverrideFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/AppOverrideFilter.java
@@ -143,8 +143,7 @@ public class AppOverrideFilter
             }
 
             String filename = resource.getFilename();
-            // TODO: use hash of app bundle in case two different bundles are installed with same version number
-            String etag = CodecUtils.md5Hex( filename + app.getVersion() );
+            String etag = CodecUtils.md5Hex( String.valueOf( resource.lastModified() ) );
 
             if ( new ServletWebRequest( request, response ).checkNotModified( etag ) )
             {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/AppOverrideFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/AppOverrideFilter.java
@@ -160,7 +160,7 @@ public class AppOverrideFilter
             }
 
             response.setContentLength( (int) resource.contentLength() );
-            response.setHeader( "etag", etag );
+            response.setHeader( "ETag", etag );
 
             StreamUtils.copyThenCloseInputStream( resource.getInputStream(), response.getOutputStream() );
         }


### PR DESCRIPTION
Jira issue: [DHIS2-14957](https://dhis2.atlassian.net/browse/DHIS2-14957)

This issue was causing some hard-to-diagnose issues when uninstalling bundled app overrides - the installed version had a last-modified date LATER than the bundled version (because it was installed later).  When uninstalling the override, the bundled version should have been restored.  However, a browser would still request an asset with a last-modified header LATER than the "latest" now on the server

The solution here is to use etag cache headers instead of last-modified.  The request should then use `If-None-Match` instead of `If-Modified-Since`.

~There is a potential issue with the way we're calculating the etag here, since we're naively using the version of the installed app which is not guaranteed to have identical file contents.  We could instead pre-calculate a hash for each file resource in the app or for each app bundle.~
We generate an etag header using an md5 hash of the lastModified datetime, so it should always be unique when a new version is installed (or uninstalled)

[DHIS2-14957]: https://dhis2.atlassian.net/browse/DHIS2-14957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ