### PR TITLE
fix: Three ownership analytics bugs [DHIS2-13373]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryPlanner.java
@@ -267,8 +267,8 @@ public class DefaultEventQueryPlanner
     {
         List<EventQueryParams> queries = new ArrayList<>();
 
-        if ( (params.isFirstOrLastPeriodAggregationType() || params.useIndividualQuery()) &&
-            !params.getPeriods().isEmpty() )
+        if ( (params.isFirstOrLastPeriodAggregationType() || params.getOrgUnitField().getType().isOwnership() ||
+            params.useIndividualQuery()) && !params.getPeriods().isEmpty() )
         {
             for ( DimensionalItemObject period : params.getPeriods() )
             {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/OrgUnitTableJoinerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/OrgUnitTableJoinerTest.java
@@ -130,13 +130,13 @@ class OrgUnitTableJoinerTest
             .build();
 
         assertEquals( "left join analytics_ownership_prabcdefgha as own on ax.\"tei\" = own.\"teiuid\" " +
-            "and cast(ax.\"daily\" as date) between own.\"startdate\" and own.\"enddate\" " +
+            "and '2023-01-01' between own.\"startdate\" and own.\"enddate\" " +
             "left join _orgunitstructure as ous on ax.\"enrollmentou\" = ous.\"organisationunituid\" " +
             "left join _organisationunitgroupsetstructure as ougs on ous.\"organisationunitid\" = ougs.\"organisationunitid\" ",
             joinOrgUnitTables( params, EVENT ) );
 
         assertEquals( "left join analytics_ownership_prabcdefgha as own on ax.\"tei\" = own.\"teiuid\" " +
-            "and cast(ax.\"daily\" as date) between own.\"startdate\" and own.\"enddate\" ",
+            "and '2023-01-01' between own.\"startdate\" and own.\"enddate\" ",
             joinOrgUnitTables( params, ENROLLMENT ) );
     }
 
@@ -151,16 +151,14 @@ class OrgUnitTableJoinerTest
             .addDimension( ouGroupSetA )
             .build();
 
-        assertEquals( "left join _periodstructure periodstruct on ax.\"monthly\" = periodstruct.\"iso\" " +
-            "left join analytics_ownership_prabcdefgha as own on ax.\"tei\" = own.\"teiuid\" " +
-            "and periodstruct.\"startdate\" between own.\"startdate\" and own.\"enddate\" " +
+        assertEquals( "left join analytics_ownership_prabcdefgha as own on ax.\"tei\" = own.\"teiuid\" " +
+            "and '2022-01-01' between own.\"startdate\" and own.\"enddate\" " +
             "left join _orgunitstructure as ous on ax.\"enrollmentou\" = ous.\"organisationunituid\" " +
             "left join _organisationunitgroupsetstructure as ougs on ous.\"organisationunitid\" = ougs.\"organisationunitid\" ",
             joinOrgUnitTables( params, EVENT ) );
 
-        assertEquals( "left join _periodstructure periodstruct on ax.\"monthly\" = periodstruct.\"iso\" " +
-            "left join analytics_ownership_prabcdefgha as own on ax.\"tei\" = own.\"teiuid\" " +
-            "and periodstruct.\"startdate\" between own.\"startdate\" and own.\"enddate\" ",
+        assertEquals( "left join analytics_ownership_prabcdefgha as own on ax.\"tei\" = own.\"teiuid\" " +
+            "and '2022-01-01' between own.\"startdate\" and own.\"enddate\" ",
             joinOrgUnitTables( params, ENROLLMENT ) );
     }
 
@@ -199,13 +197,13 @@ class OrgUnitTableJoinerTest
             .build();
 
         assertEquals( "left join analytics_ownership_prabcdefgha as own on ax.\"tei\" = own.\"teiuid\" " +
-            "and cast(ax.\"daily\" as date) + INTERVAL '1 day' between own.\"startdate\" and own.\"enddate\" " +
+            "and '2023-01-02' between own.\"startdate\" and own.\"enddate\" " +
             "left join _orgunitstructure as ous on ax.\"enrollmentou\" = ous.\"organisationunituid\" " +
             "left join _organisationunitgroupsetstructure as ougs on ous.\"organisationunitid\" = ougs.\"organisationunitid\" ",
             joinOrgUnitTables( params, EVENT ) );
 
         assertEquals( "left join analytics_ownership_prabcdefgha as own on ax.\"tei\" = own.\"teiuid\" " +
-            "and cast(ax.\"daily\" as date) + INTERVAL '1 day' between own.\"startdate\" and own.\"enddate\" ",
+            "and '2023-01-02' between own.\"startdate\" and own.\"enddate\" ",
             joinOrgUnitTables( params, ENROLLMENT ) );
     }
 
@@ -220,16 +218,14 @@ class OrgUnitTableJoinerTest
             .addDimension( ouGroupSetA )
             .build();
 
-        assertEquals( "left join _periodstructure periodstruct on ax.\"monthly\" = periodstruct.\"iso\" " +
-            "left join analytics_ownership_prabcdefgha as own on ax.\"tei\" = own.\"teiuid\" " +
-            "and periodstruct.\"enddate\" + INTERVAL '1 day' between own.\"startdate\" and own.\"enddate\" " +
+        assertEquals( "left join analytics_ownership_prabcdefgha as own on ax.\"tei\" = own.\"teiuid\" " +
+            "and '2022-02-01' between own.\"startdate\" and own.\"enddate\" " +
             "left join _orgunitstructure as ous on ax.\"enrollmentou\" = ous.\"organisationunituid\" " +
             "left join _organisationunitgroupsetstructure as ougs on ous.\"organisationunitid\" = ougs.\"organisationunitid\" ",
             joinOrgUnitTables( params, EVENT ) );
 
-        assertEquals( "left join _periodstructure periodstruct on ax.\"monthly\" = periodstruct.\"iso\" " +
-            "left join analytics_ownership_prabcdefgha as own on ax.\"tei\" = own.\"teiuid\" " +
-            "and periodstruct.\"enddate\" + INTERVAL '1 day' between own.\"startdate\" and own.\"enddate\" ",
+        assertEquals( "left join analytics_ownership_prabcdefgha as own on ax.\"tei\" = own.\"teiuid\" " +
+            "and '2022-02-01' between own.\"startdate\" and own.\"enddate\" ",
             joinOrgUnitTables( params, ENROLLMENT ) );
     }
 

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -1910,6 +1910,12 @@ public abstract class DhisConvenienceTest
     public static ProgramIndicator createProgramIndicator( char uniqueCharacter, AnalyticsType analyticsType,
         Program program, String expression, String filter )
     {
+        return createProgramIndicator( uniqueCharacter, analyticsType, program, expression, filter, null, 0 );
+    }
+
+    public static ProgramIndicator createProgramIndicator( char uniqueCharacter, AnalyticsType analyticsType,
+        Program program, String expression, String filter, PeriodType afterStartPeriodType, int afterStartPeriods )
+    {
         ProgramIndicator indicator = new ProgramIndicator();
         indicator.setAutoFields();
         indicator.setName( "Indicator" + uniqueCharacter );
@@ -1927,14 +1933,16 @@ public abstract class DhisConvenienceTest
             boundaries.add( new AnalyticsPeriodBoundary( AnalyticsPeriodBoundary.EVENT_DATE,
                 AnalyticsPeriodBoundaryType.BEFORE_END_OF_REPORTING_PERIOD, null, 0 ) );
             boundaries.add( new AnalyticsPeriodBoundary( AnalyticsPeriodBoundary.EVENT_DATE,
-                AnalyticsPeriodBoundaryType.AFTER_START_OF_REPORTING_PERIOD, null, 0 ) );
+                AnalyticsPeriodBoundaryType.AFTER_START_OF_REPORTING_PERIOD, afterStartPeriodType,
+                afterStartPeriods ) );
         }
         else if ( analyticsType == AnalyticsType.ENROLLMENT )
         {
             boundaries.add( new AnalyticsPeriodBoundary( AnalyticsPeriodBoundary.ENROLLMENT_DATE,
                 AnalyticsPeriodBoundaryType.BEFORE_END_OF_REPORTING_PERIOD, null, 0 ) );
             boundaries.add( new AnalyticsPeriodBoundary( AnalyticsPeriodBoundary.ENROLLMENT_DATE,
-                AnalyticsPeriodBoundaryType.AFTER_START_OF_REPORTING_PERIOD, null, 0 ) );
+                AnalyticsPeriodBoundaryType.AFTER_START_OF_REPORTING_PERIOD, afterStartPeriodType,
+                afterStartPeriods ) );
         }
 
         for ( AnalyticsPeriodBoundary boundary : boundaries )

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -1587,11 +1587,6 @@ public abstract class DhisConvenienceTest
         return userGroup;
     }
 
-    public static UserRole createUserRole( char uniqueCharacter )
-    {
-        return createUserRole( uniqueCharacter, new String[] {} );
-    }
-
     public static UserRole createUserRole( char uniqueCharacter, String... auths )
     {
         UserRole role = new UserRole();
@@ -1894,11 +1889,9 @@ public abstract class DhisConvenienceTest
     public static ProgramMessage createProgramMessage( String text, String subject,
         ProgramMessageRecipients recipients, ProgramMessageStatus status, Set<DeliveryChannel> channels )
     {
-        ProgramMessage message = ProgramMessage.builder().text( text )
+        return ProgramMessage.builder().text( text )
             .subject( subject ).recipients( recipients )
             .messageStatus( status ).deliveryChannels( channels ).build();
-
-        return message;
     }
 
     public static ProgramIndicator createProgramIndicator( char uniqueCharacter, Program program, String expression,
@@ -1989,15 +1982,15 @@ public abstract class DhisConvenienceTest
         RelationshipType relationshipType )
     {
         Relationship relationship = new Relationship();
-        RelationshipItem _from = new RelationshipItem();
-        RelationshipItem _to = new RelationshipItem();
+        RelationshipItem riFrom = new RelationshipItem();
+        RelationshipItem riTo = new RelationshipItem();
 
-        _from.setTrackedEntityInstance( from );
-        _to.setTrackedEntityInstance( to );
+        riFrom.setTrackedEntityInstance( from );
+        riTo.setTrackedEntityInstance( to );
 
         relationship.setRelationshipType( relationshipType );
-        relationship.setFrom( _from );
-        relationship.setTo( _to );
+        relationship.setFrom( riFrom );
+        relationship.setTo( riTo );
         relationship.setKey( RelationshipUtils.generateRelationshipKey( relationship ) );
         relationship.setInvertedKey( RelationshipUtils.generateRelationshipInvertedKey( relationship ) );
 
@@ -2010,15 +2003,15 @@ public abstract class DhisConvenienceTest
         RelationshipType relationshipType )
     {
         Relationship relationship = new Relationship();
-        RelationshipItem _from = new RelationshipItem();
-        RelationshipItem _to = new RelationshipItem();
+        RelationshipItem riFrom = new RelationshipItem();
+        RelationshipItem riTo = new RelationshipItem();
 
-        _from.setTrackedEntityInstance( from );
-        _to.setProgramInstance( to );
+        riFrom.setTrackedEntityInstance( from );
+        riTo.setProgramInstance( to );
 
         relationship.setRelationshipType( relationshipType );
-        relationship.setFrom( _from );
-        relationship.setTo( _to );
+        relationship.setFrom( riFrom );
+        relationship.setTo( riTo );
         relationship.setKey( RelationshipUtils.generateRelationshipKey( relationship ) );
         relationship.setInvertedKey( RelationshipUtils.generateRelationshipInvertedKey( relationship ) );
 
@@ -2032,15 +2025,15 @@ public abstract class DhisConvenienceTest
         RelationshipType relationshipType )
     {
         Relationship relationship = new Relationship();
-        RelationshipItem _from = new RelationshipItem();
-        RelationshipItem _to = new RelationshipItem();
+        RelationshipItem riFrom = new RelationshipItem();
+        RelationshipItem riTo = new RelationshipItem();
 
-        _from.setTrackedEntityInstance( from );
-        _to.setProgramStageInstance( to );
+        riFrom.setTrackedEntityInstance( from );
+        riTo.setProgramStageInstance( to );
 
         relationship.setRelationshipType( relationshipType );
-        relationship.setFrom( _from );
-        relationship.setTo( _to );
+        relationship.setFrom( riFrom );
+        relationship.setTo( riTo );
         relationship.setKey( RelationshipUtils.generateRelationshipKey( relationship ) );
         relationship.setInvertedKey( RelationshipUtils.generateRelationshipInvertedKey( relationship ) );
 
@@ -2620,20 +2613,21 @@ public abstract class DhisConvenienceTest
 
     protected User createUserWithId( String username, String uid, String... authorities )
     {
-        return _createUser( username, Optional.of( uid ), null, authorities );
+        return createUserInternal( username, Optional.of( uid ), null, authorities );
     }
 
     protected User createUserWithAuth( String username, String... authorities )
     {
-        return _createUser( username, Optional.empty(), null, authorities );
+        return createUserInternal( username, Optional.empty(), null, authorities );
     }
 
     protected User createOpenIDUser( String username, String openIDIdentifier )
     {
-        return _createUser( username, Optional.empty(), openIDIdentifier );
+        return createUserInternal( username, Optional.empty(), openIDIdentifier );
     }
 
-    private User _createUser( String username, Optional<String> uid, String openIDIdentifier, String... authorities )
+    private User createUserInternal( String username, Optional<String> uid, String openIDIdentifier,
+        String... authorities )
     {
         checkUserServiceWasInjected();
 
@@ -2896,7 +2890,7 @@ public abstract class DhisConvenienceTest
         Set<OrganisationUnit> dataViewOrganisationUnits = dataViewOrganisationUnit != null
             ? newHashSet( dataViewOrganisationUnit )
             : new HashSet<>( organisationUnits );
-        User user = _createUserAndRole( superUserFlag, userName, organisationUnits, dataViewOrganisationUnits, auths );
+        User user = createUserAndRole( superUserFlag, userName, organisationUnits, dataViewOrganisationUnits, auths );
 
         persistUserAndRoles( user );
 
@@ -2906,7 +2900,7 @@ public abstract class DhisConvenienceTest
     protected User createAndAddUser( boolean superUserFlag, String userName, Set<OrganisationUnit> orgUnits,
         Set<OrganisationUnit> dataViewOrgUnits, String... auths )
     {
-        User user = _createUserAndRole( superUserFlag, userName, (orgUnits),
+        User user = createUserAndRole( superUserFlag, userName, (orgUnits),
             dataViewOrgUnits != null ? (dataViewOrgUnits) : (orgUnits),
             auths );
 
@@ -2915,7 +2909,7 @@ public abstract class DhisConvenienceTest
         return user;
     }
 
-    private User _createUserAndRole( boolean superUserFlag, String username,
+    private User createUserAndRole( boolean superUserFlag, String username,
         Set<OrganisationUnit> organisationUnits,
         Set<OrganisationUnit> dataViewOrganisationUnits, String... auths )
     {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
@@ -43,6 +43,7 @@ import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getList;
 import static org.hisp.dhis.common.ValueType.INTEGER;
 import static org.hisp.dhis.common.ValueType.ORGANISATION_UNIT;
+import static org.hisp.dhis.period.PeriodType.getPeriodTypeByName;
 import static org.hisp.dhis.program.AnalyticsType.ENROLLMENT;
 import static org.hisp.dhis.program.AnalyticsType.EVENT;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -89,7 +90,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitLevel;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
-import org.hisp.dhis.period.PeriodService;
+import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.program.AnalyticsType;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramIndicator;
@@ -136,9 +137,6 @@ class EventAnalyticsServiceTest
 
     @Autowired
     private List<AnalyticsTableService> analyticsTableServices;
-
-    @Autowired
-    private PeriodService periodService;
 
     @Autowired
     private DataElementService dataElementService;
@@ -200,6 +198,8 @@ class EventAnalyticsServiceTest
 
     private List<OrganisationUnit> level3Ous;
 
+    // Note: The periods are not persisted. They don't need to be for event
+    // analytics, so the tests should work without them being persisted.
     private Period peJan = createPeriod( "2017-01" );
 
     private Period peFeb = createPeriod( "2017-02" );
@@ -330,14 +330,10 @@ class EventAnalyticsServiceTest
         // Default Category Option Combo
         CategoryOptionCombo cocDefault = categoryService.getDefaultCategoryOptionCombo();
 
-        // Periods
-        periodService.addPeriod( peJan );
-        periodService.addPeriod( peFeb );
-        periodService.addPeriod( peMar );
-
         Date jan1 = new GregorianCalendar( 2017, JANUARY, 1 ).getTime();
         Date jan15 = new GregorianCalendar( 2017, JANUARY, 15 ).getTime();
         Date feb15 = new GregorianCalendar( 2017, FEBRUARY, 15 ).getTime();
+        Date feb15Noon = new GregorianCalendar( 2017, FEBRUARY, 15, 12, 0 ).getTime();
         Date mar15 = new GregorianCalendar( 2017, MARCH, 15 ).getTime();
 
         // Data Elements
@@ -413,11 +409,13 @@ class EventAnalyticsServiceTest
         // Change programA / teiA ownership through time:
         // Jan 1 (enrollment) - Jan 15: ouE
         // Jan 15 - Feb 15: ouF
-        // Feb 15 - Mar 15: ouG
+        // Feb 15 - Feb 15 Noon: ouE
+        // Feb 15 Noon - Mar 15: ouG
         // Mar 15 - present: ouH
         addProgramOwnershipHistory( programA, teiA, ouE, piA.getEnrollmentDate(), jan15 );
         addProgramOwnershipHistory( programA, teiA, ouF, jan15, feb15 );
-        addProgramOwnershipHistory( programA, teiA, ouG, feb15, mar15 );
+        addProgramOwnershipHistory( programA, teiA, ouE, feb15, feb15Noon );
+        addProgramOwnershipHistory( programA, teiA, ouG, feb15Noon, mar15 );
         trackedEntityProgramOwnerService.createOrUpdateTrackedEntityProgramOwner( teiA, programA, ouH );
 
         // Program Stage Instances (Events)
@@ -956,7 +954,7 @@ class EventAnalyticsServiceTest
     @Test
     void testEventProgramIndicatorWithNoOrgUnitField()
     {
-        ProgramIndicator pi = createProgramIndicatorA( EVENT, "#{progrStageA.deInteger0A}", null );
+        ProgramIndicator pi = createProgramIndicatorA( EVENT, "#{progrStageA.deInteger0A}", null, null, 0 );
 
         EventQueryParams params = getBaseEventQueryParamsBuilder()
             .withAggregateData( true )
@@ -981,7 +979,7 @@ class EventAnalyticsServiceTest
     @Test
     void testEventProgramIndicatorWithOrgUnitFieldAtStart()
     {
-        ProgramIndicator pi = createProgramIndicatorA( EVENT, "#{progrStageA.deInteger0A}", "OWNER_AT_START" );
+        ProgramIndicator pi = createProgramIndicatorA( EVENT, "#{progrStageA.deInteger0A}", "OWNER_AT_START", null, 0 );
 
         EventQueryParams params = getBaseEventQueryParamsBuilder()
             .withAggregateData( true )
@@ -1006,7 +1004,7 @@ class EventAnalyticsServiceTest
     @Test
     void testEventProgramIndicatorWithOrgUnitFieldAtEnd()
     {
-        ProgramIndicator pi = createProgramIndicatorA( EVENT, "#{progrStageA.deInteger0A}", "OWNER_AT_END" );
+        ProgramIndicator pi = createProgramIndicatorA( EVENT, "#{progrStageA.deInteger0A}", "OWNER_AT_END", null, 0 );
 
         EventQueryParams params = getBaseEventQueryParamsBuilder()
             .withAggregateData( true )
@@ -1031,12 +1029,13 @@ class EventAnalyticsServiceTest
     @Test
     void testEnrollmentProgramIndicatorWithOrgUnitFieldAtStart()
     {
-        ProgramIndicator pi = createProgramIndicatorA( ENROLLMENT, "#{progrStageA.deInteger0A}", "OWNER_AT_START" );
+        ProgramIndicator pi = createProgramIndicatorA( ENROLLMENT, "#{progrStageA.deInteger0A}", "OWNER_AT_START",
+            getPeriodTypeByName( "Yearly" ), -10 );
 
         EventQueryParams params = getBaseEventQueryParamsBuilder()
             .withAggregateData( true )
             .addItemProgramIndicator( pi )
-            .withPeriods( List.of( peJan ), "Monthly" )
+            .withPeriods( List.of( peJan, peFeb, peMar ), "Monthly" )
             .withOrganisationUnits( level3Ous )
             .build();
 
@@ -1047,19 +1046,22 @@ class EventAnalyticsServiceTest
             List.of( "dy", "pe", "ou", "value" ),
             // Grid
             List.of(
-                List.of( "programIndA", "201701", "ouabcdefghE", "4.0" ) ),
+                List.of( "programIndA", "201701", "ouabcdefghE", "4.0" ),
+                List.of( "programIndA", "201702", "ouabcdefghF", "4.0" ),
+                List.of( "programIndA", "201703", "ouabcdefghG", "4.0" ) ),
             grid );
     }
 
     @Test
     void testEnrollmentProgramIndicatorWithOrgUnitFieldAtEnd()
     {
-        ProgramIndicator pi = createProgramIndicatorA( ENROLLMENT, "#{progrStageA.deInteger0A}", "OWNER_AT_END" );
+        ProgramIndicator pi = createProgramIndicatorA( ENROLLMENT, "#{progrStageA.deInteger0A}", "OWNER_AT_END",
+            getPeriodTypeByName( "Yearly" ), -10 );
 
         EventQueryParams params = getBaseEventQueryParamsBuilder()
             .withAggregateData( true )
             .addItemProgramIndicator( pi )
-            .withPeriods( List.of( peJan ), "Monthly" )
+            .withPeriods( List.of( peJan, peFeb, peMar ), "Monthly" )
             .withOrganisationUnits( level3Ous )
             .build();
 
@@ -1070,7 +1072,9 @@ class EventAnalyticsServiceTest
             List.of( "dy", "pe", "ou", "value" ),
             // Grid
             List.of(
-                List.of( "programIndA", "201701", "ouabcdefghF", "4.0" ) ),
+                List.of( "programIndA", "201701", "ouabcdefghF", "4.0" ),
+                List.of( "programIndA", "201702", "ouabcdefghG", "4.0" ),
+                List.of( "programIndA", "201703", "ouabcdefghH", "4.0" ) ),
             grid );
     }
 
@@ -1131,9 +1135,10 @@ class EventAnalyticsServiceTest
      * Creates program indicator A.
      */
     private ProgramIndicator createProgramIndicatorA( AnalyticsType analyticsType, String expression,
-        String orgUnitField )
+        String orgUnitField, PeriodType afterStartPeriodType, int afterStartPeriods )
     {
-        ProgramIndicator pi = createProgramIndicator( 'A', analyticsType, programA, expression, null );
+        ProgramIndicator pi = createProgramIndicator( 'A', analyticsType, programA, expression, null,
+            afterStartPeriodType, afterStartPeriods );
         pi.setUid( "programIndA" );
         pi.setOrgUnitField( orgUnitField );
         return pi;


### PR DESCRIPTION
This PR addresses the three problems found while investigating Brian O'Donnell's comment [here](https://dhis2.atlassian.net/browse/DHIS2-13373?focusedCommentId=181405) in [DHIS2-13373](https://dhis2.atlassian.net/browse/DHIS2-13373). The problems, as reported [here](https://dhis2.atlassian.net/browse/DHIS2-13373?focusedCommentId=181428) in that ticket, are:

> 1. When multiple TEI ownership changes happen within the same day, the ownership analytics table is not correctly built for that day. This may result in the owning organisation unit reported for a period ending on or after that day as one of the owning organisation units during that day and not the owning organisation unit as of the end of that day.
> 2. Incorrect owning organisation units are reported when the reporting period is not persisted in the database. Instead of reporting the true owning organisation unit for such a period, the event organisation unit (for event analytics), or the enrollment organization unit (for enrollment analytics) are reported instead.
> 3. When using an enrollment program indicator with non-default analytics period boundaries, reporting is allowed for a period that does not contain the enrollment. When this is the case, the owning organisation unit will be reported at the start or end of the period containing the enrollment rather than ownership at the start or end of period being reported on.

Problem 1 is fixed in `JdbcOwnershipWriter` by stripping the time part from the ownership end date/time so duplicate dates will be correctly merged into one output row, and by moving both the OU and ENDDATE into the merged row. JavaDoc comments are added to make the code intention clearer.

Problems 2 and 3 are both fixed by changing the way the `analytics_ownership_{programUid}` table is joined. Previously, the event or enrollment period was joined to the period in `_periodstructure` to get the period start or end date. This caused both problems because the enrollment period was being joined instead of the reporting period and because `_periodstructure` contains entries only for persisted periods.

Now, `DefaultEventQueryPlanner` requires that any analytics query for ownership will create one query for each period. This allows `OrgUnitTableJoiner` to join the `analytics_ownership_{programUid}` table based only on `params.getEarliestStartDate()` or `params.getLatestEndDate()` which greatly simplifies the table joining logic. `_periodstructure` is no longer used.

Test cases are added to `EventAnalyticsServiceTest` for multiple ownership changes in a day and an enrollment program indicator with non-default analytics period boundaries that tracks the ownership changes after the enrollment period. Also the test periods are not persisted because this is not needed for events, and a comment is added to that effect.

The test described by Brian O'Donnell in [DHIS2-13373](https://dhis2.atlassian.net/browse/DHIS2-13373) now works as expected.

P.S. I also fixed the 7 "New" [not] code smells in `DhisConvenienceTest` that SonarCloud was failing on just because the PR touched something unrelated in that class.

[DHIS2-13373]: https://dhis2.atlassian.net/browse/DHIS2-13373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-13373]: https://dhis2.atlassian.net/browse/DHIS2-13373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ