### PR TITLE
fix: event analytic tables will now use client-side timestamps when possible [DHIS2-14981]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -126,8 +126,16 @@ public class JdbcEventAnalyticsTableManager
         new AnalyticsTableColumn( quote( "executiondate" ), TIMESTAMP, "psi.executiondate" ),
         new AnalyticsTableColumn( quote( "duedate" ), TIMESTAMP, "psi.duedate" ),
         new AnalyticsTableColumn( quote( "completeddate" ), TIMESTAMP, "psi.completeddate" ),
-        new AnalyticsTableColumn( quote( "created" ), TIMESTAMP, "psi.created" ),
-        new AnalyticsTableColumn( quote( "lastupdated" ), TIMESTAMP, "psi.lastupdated" ),
+
+        /*
+         * DHIS2-14981: Use the client-side timestamp if available, otherwise
+         * the server-side timestamp. Applies to both created and lastupdated.
+         */
+        new AnalyticsTableColumn( quote( "created" ), TIMESTAMP,
+            firstIfNotNullOrElse( "psi.createdatclient", "psi.created" ) ),
+        new AnalyticsTableColumn( quote( "lastupdated" ), TIMESTAMP,
+            firstIfNotNullOrElse( "psi.lastupdatedatclient", "psi.lastupdated" ) ),
+
         new AnalyticsTableColumn( quote( "storedby" ), VARCHAR_255, "psi.storedby" ),
         new AnalyticsTableColumn( quote( "createdbyusername" ), VARCHAR_255,
             "psi.createdbyuserinfo ->> 'username' as createdbyusername" ),
@@ -166,6 +174,19 @@ public class JdbcEventAnalyticsTableManager
             "coalesce(registrationou.uid,ou.uid)" ),
         new AnalyticsTableColumn( quote( "enrollmentou" ), CHARACTER_11, NOT_NULL,
             "coalesce(enrollmentou.uid,ou.uid)" ) );
+
+    /**
+     * Returns a SQL expression that returns the first argument if it is not
+     * null, otherwise the second argument.
+     *
+     * @param first the first argument
+     * @param second the second argument
+     * @return a SQL expression
+     */
+    private static String firstIfNotNullOrElse( String first, String second )
+    {
+        return "CASE WHEN " + first + " IS NOT NULL THEN " + first + " ELSE " + second + " END";
+    }
 
     @Override
     public AnalyticsTableType getAnalyticsTableType()


### PR DESCRIPTION
In Event Analytics Tables, we store `created` and `lastUpdated`.
These values represent when an event was written the first time on the database and the last time it was updated.
However these are server-side timestamps and in the case of Android apps, they will not reflect when a user has created or modified a given event.
This PR will address this inconsistency by using when possible `createdAtClient` and `lastUpdatedAtClient` timestamps, which are sent in the payload.
