### PR TITLE
chore: make new tracker enrollment web independent of dhis-service-dxf2 TECH-1525

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-tracker/pom.xml
@@ -142,6 +142,10 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-xml</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.locationtech.jts</groupId>
       <artifactId>jts-core</artifactId>
     </dependency>

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/enrollment/DefaultEnrollmentService.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.enrollment;
+
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static org.hisp.dhis.common.Pager.DEFAULT_PAGE_SIZE;
+import static org.hisp.dhis.common.SlimPager.FIRST_PAGE;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.common.Pager;
+import org.hisp.dhis.common.SlimPager;
+import org.hisp.dhis.program.ProgramInstance;
+import org.hisp.dhis.program.ProgramInstanceQueryParams;
+import org.hisp.dhis.program.ProgramInstanceService;
+import org.hisp.dhis.program.ProgramStageInstance;
+import org.hisp.dhis.relationship.RelationshipItem;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
+import org.hisp.dhis.trackedentity.TrackerAccessManager;
+import org.hisp.dhis.trackedentity.TrackerOwnershipManager;
+import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service( "org.hisp.dhis.tracker.enrollment.EnrollmentService" )
+public class DefaultEnrollmentService implements EnrollmentService
+{
+    private final ProgramInstanceService programInstanceService;
+
+    private final TrackerOwnershipManager trackerOwnershipAccessManager;
+
+    private final TrackedEntityAttributeService trackedEntityAttributeService;
+
+    private final CurrentUserService currentUserService;
+
+    private final TrackerAccessManager trackerAccessManager;
+
+    @Override
+    public ProgramInstance getEnrollment( String uid, EnrollmentParams params )
+    {
+        ProgramInstance programInstance = programInstanceService.getProgramInstance( uid );
+        return programInstance != null ? getEnrollment( programInstance, params ) : null;
+    }
+
+    private ProgramInstance getEnrollment( ProgramInstance programInstance, EnrollmentParams params )
+    {
+        return getEnrollment( currentUserService.getCurrentUser(), programInstance, params, false );
+    }
+
+    private ProgramInstance getEnrollment( User user, ProgramInstance programInstance, EnrollmentParams params,
+        boolean skipOwnershipCheck )
+    {
+        List<String> errors = trackerAccessManager.canRead( user, programInstance, skipOwnershipCheck );
+        if ( !errors.isEmpty() )
+        {
+            throw new IllegalQueryException( errors.toString() );
+        }
+
+        ProgramInstance result = new ProgramInstance();
+        result.setUid( programInstance.getUid() );
+        result.setEntityInstance( programInstance.getEntityInstance() );
+        result.setOrganisationUnit( programInstance.getOrganisationUnit() );
+        result.setGeometry( programInstance.getGeometry() );
+        result.setCreated( programInstance.getCreated() );
+        result.setCreatedAtClient( programInstance.getCreatedAtClient() );
+        result.setLastUpdated( programInstance.getLastUpdated() );
+        result.setLastUpdatedAtClient( programInstance.getLastUpdatedAtClient() );
+        result.setProgram( programInstance.getProgram() );
+        result.setStatus( programInstance.getStatus() );
+        result.setEnrollmentDate( programInstance.getEnrollmentDate() );
+        result.setIncidentDate( programInstance.getIncidentDate() );
+        result.setFollowup( programInstance.getFollowup() );
+        result.setEndDate( programInstance.getEndDate() );
+        result.setCompletedBy( programInstance.getCompletedBy() );
+        result.setStoredBy( programInstance.getStoredBy() );
+        result.setCreatedByUserInfo( programInstance.getCreatedByUserInfo() );
+        result.setLastUpdatedByUserInfo( programInstance.getLastUpdatedByUserInfo() );
+        result.setDeleted( programInstance.isDeleted() );
+        result.setComments( programInstance.getComments() );
+
+        if ( params.isIncludeEvents() )
+        {
+            for ( ProgramStageInstance programStageInstance : programInstance.getProgramStageInstances() )
+            {
+                Set<ProgramStageInstance> programStageInstances = new HashSet<>();
+
+                if ( (params.isIncludeDeleted() || !programStageInstance.isDeleted())
+                    && trackerAccessManager.canRead( user, programStageInstance, true ).isEmpty() )
+                {
+                    programStageInstances.add( programStageInstance );
+                }
+
+                result.setProgramStageInstances( programStageInstances );
+            }
+        }
+
+        if ( params.isIncludeRelationships() )
+        {
+            Set<RelationshipItem> relationshipItems = new HashSet<>();
+
+            for ( RelationshipItem relationshipItem : programInstance.getRelationshipItems() )
+            {
+                org.hisp.dhis.relationship.Relationship daoRelationship = relationshipItem.getRelationship();
+                if ( trackerAccessManager.canRead( user, daoRelationship ).isEmpty()
+                    && (params.isIncludeDeleted() || !daoRelationship.isDeleted()) )
+                {
+                    relationshipItems.add( relationshipItem );
+                }
+            }
+
+            result.setRelationshipItems( relationshipItems );
+        }
+
+        if ( params.isIncludeAttributes() )
+        {
+            Set<TrackedEntityAttribute> readableAttributes = trackedEntityAttributeService
+                .getAllUserReadableTrackedEntityAttributes( user, List.of( programInstance.getProgram() ), null );
+            Set<TrackedEntityAttributeValue> attributeValues = new HashSet<>();
+
+            for ( TrackedEntityAttributeValue trackedEntityAttributeValue : programInstance.getEntityInstance()
+                .getTrackedEntityAttributeValues() )
+            {
+                if ( readableAttributes.contains( trackedEntityAttributeValue.getAttribute() ) )
+                {
+                    attributeValues.add( trackedEntityAttributeValue );
+                }
+            }
+            result.getEntityInstance().setTrackedEntityAttributeValues( attributeValues );
+        }
+        return result;
+    }
+
+    @Override
+    public Enrollments getEnrollments( ProgramInstanceQueryParams params )
+    {
+        Enrollments enrollments = new Enrollments();
+        List<ProgramInstance> programInstances = new ArrayList<>();
+
+        if ( !params.isPaging() && !params.isSkipPaging() )
+        {
+            params.setDefaultPaging();
+        }
+
+        programInstances.addAll( programInstanceService.getProgramInstances( params ) );
+
+        if ( !params.isSkipPaging() )
+        {
+            Pager pager;
+
+            if ( params.isTotalPages() )
+            {
+                int count = programInstanceService.countProgramInstances( params );
+                pager = new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() );
+            }
+            else
+            {
+                pager = handleLastPageFlag( params, programInstances );
+            }
+
+            enrollments.setPager( pager );
+        }
+
+        enrollments.setEnrollments( getEnrollments( programInstances ) );
+
+        return enrollments;
+    }
+
+    /**
+     * This method will apply the logic related to the parameter
+     * 'totalPages=false'. This works in conjunction with the method:
+     * {@link org.hisp.dhis.program.hibernate.HibernateProgramInstanceStore#getProgramInstances(ProgramInstanceQueryParams)}
+     *
+     * This is needed because we need to query (pageSize + 1) at DB level. The
+     * resulting query will allow us to evaluate if we are in the last page or
+     * not. And this is what his method does, returning the respective Pager
+     * object.
+     *
+     * @param params the request params
+     * @param programInstances the reference to the list of ProgramInstance
+     * @return the populated SlimPager instance
+     */
+    private Pager handleLastPageFlag( ProgramInstanceQueryParams params,
+        List<ProgramInstance> programInstances )
+    {
+        Integer originalPage = defaultIfNull( params.getPage(), FIRST_PAGE );
+        Integer originalPageSize = defaultIfNull( params.getPageSize(), DEFAULT_PAGE_SIZE );
+        boolean isLastPage = false;
+
+        if ( isNotEmpty( programInstances ) )
+        {
+            isLastPage = programInstances.size() <= originalPageSize;
+            if ( !isLastPage )
+            {
+                // Get the same number of elements of the pageSize, forcing
+                // the removal of the last additional element added at querying
+                // time.
+                programInstances.retainAll( programInstances.subList( 0, originalPageSize ) );
+            }
+        }
+
+        return new SlimPager( originalPage, originalPageSize, isLastPage );
+    }
+
+    private List<ProgramInstance> getEnrollments( Iterable<ProgramInstance> programInstances )
+    {
+        List<ProgramInstance> enrollments = new ArrayList<>();
+        User user = currentUserService.getCurrentUser();
+
+        for ( ProgramInstance programInstance : programInstances )
+        {
+            if ( programInstance != null && trackerOwnershipAccessManager
+                .hasAccess( user, programInstance.getEntityInstance(), programInstance.getProgram() ) )
+            {
+                enrollments.add( getEnrollment( user, programInstance, EnrollmentParams.FALSE, true ) );
+            }
+        }
+
+        return enrollments;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/enrollment/EnrollmentParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/enrollment/EnrollmentParams.java
@@ -25,29 +25,43 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.tracker.export;
+package org.hisp.dhis.tracker.enrollment;
 
-import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstance;
-import org.hisp.dhis.webapi.controller.tracker.view.InstantMapper;
-import org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
+import lombok.Value;
+import lombok.With;
 
-@Mapper( uses = {
-    Dxf2RelationshipMapper.class,
-    AttributeMapper.class,
-    Dxf2EnrollmentMapper.class,
-    ProgramOwnerMapper.class,
-    InstantMapper.class,
-    UserMapper.class } )
-interface TrackedEntityMapper extends ViewMapper<TrackedEntityInstance, TrackedEntity>
+import org.hisp.dhis.dxf2.events.EnrollmentEventsParams;
+
+@With
+@Value
+public class EnrollmentParams
 {
-    @Mapping( target = "trackedEntity", source = "trackedEntityInstance" )
-    @Mapping( target = "createdAt", source = "created" )
-    @Mapping( target = "createdAtClient", source = "createdAtClient" )
-    @Mapping( target = "updatedAt", source = "lastUpdated" )
-    @Mapping( target = "updatedAtClient", source = "lastUpdatedAtClient" )
-    @Mapping( target = "createdBy", source = "createdByUserInfo" )
-    @Mapping( target = "updatedBy", source = "lastUpdatedByUserInfo" )
-    TrackedEntity from( TrackedEntityInstance trackedEntityInstance );
+    public static final EnrollmentParams TRUE = new EnrollmentParams( EnrollmentEventsParams.TRUE, true, true, false,
+        false );
+
+    public static final EnrollmentParams FALSE = new EnrollmentParams( EnrollmentEventsParams.FALSE, false, false,
+        false, false );
+
+    EnrollmentEventsParams enrollmentEventsParams;
+
+    boolean includeRelationships;
+
+    boolean includeAttributes;
+
+    boolean includeDeleted;
+
+    boolean dataSynchronizationQuery;
+
+    public boolean isIncludeEvents()
+    {
+        return enrollmentEventsParams.isIncludeEvents();
+    }
+
+    public EnrollmentParams withIncludeEvents( boolean includeEvents )
+    {
+        return this.enrollmentEventsParams.isIncludeEvents() == includeEvents ? this
+            : new EnrollmentParams( enrollmentEventsParams.withIncludeEvents( includeEvents ),
+                this.includeRelationships, this.includeAttributes, this.includeDeleted,
+                this.dataSynchronizationQuery );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/enrollment/EnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/enrollment/EnrollmentService.java
@@ -25,29 +25,14 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.tracker.export;
+package org.hisp.dhis.tracker.enrollment;
 
-import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstance;
-import org.hisp.dhis.webapi.controller.tracker.view.InstantMapper;
-import org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
+import org.hisp.dhis.program.ProgramInstance;
+import org.hisp.dhis.program.ProgramInstanceQueryParams;
 
-@Mapper( uses = {
-    Dxf2RelationshipMapper.class,
-    AttributeMapper.class,
-    Dxf2EnrollmentMapper.class,
-    ProgramOwnerMapper.class,
-    InstantMapper.class,
-    UserMapper.class } )
-interface TrackedEntityMapper extends ViewMapper<TrackedEntityInstance, TrackedEntity>
+public interface EnrollmentService
 {
-    @Mapping( target = "trackedEntity", source = "trackedEntityInstance" )
-    @Mapping( target = "createdAt", source = "created" )
-    @Mapping( target = "createdAtClient", source = "createdAtClient" )
-    @Mapping( target = "updatedAt", source = "lastUpdated" )
-    @Mapping( target = "updatedAtClient", source = "lastUpdatedAtClient" )
-    @Mapping( target = "createdBy", source = "createdByUserInfo" )
-    @Mapping( target = "updatedBy", source = "lastUpdatedByUserInfo" )
-    TrackedEntity from( TrackedEntityInstance trackedEntityInstance );
+    ProgramInstance getEnrollment( String uid, EnrollmentParams params );
+
+    Enrollments getEnrollments( ProgramInstanceQueryParams params );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/enrollment/Enrollments.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/enrollment/Enrollments.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.enrollment;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.hisp.dhis.common.DxfNamespaces;
+import org.hisp.dhis.common.Pager;
+import org.hisp.dhis.program.ProgramInstance;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+@JacksonXmlRootElement( localName = "enrollments", namespace = DxfNamespaces.DXF_2_0 )
+public class Enrollments
+{
+    private List<ProgramInstance> enrollments = new ArrayList<>();
+
+    private Pager pager;
+
+    public Enrollments()
+    {
+    }
+
+    @JsonProperty( "enrollments" )
+    @JacksonXmlElementWrapper( localName = "enrollments", useWrapping = false, namespace = DxfNamespaces.DXF_2_0 )
+    @JacksonXmlProperty( localName = "enrollment", namespace = DxfNamespaces.DXF_2_0 )
+    public List<ProgramInstance> getEnrollments()
+    {
+        return enrollments;
+    }
+
+    public void setEnrollments( List<ProgramInstance> enrollments )
+    {
+        this.enrollments = enrollments;
+    }
+
+    public Pager getPager()
+    {
+        return this.pager;
+    }
+
+    public void setPager( Pager pager )
+    {
+        this.pager = pager;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        Enrollments that = (Enrollments) o;
+
+        return Objects.equals( enrollments, that.enrollments );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = 0;
+        result = 31 * result + (enrollments != null ? enrollments.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "Enrollments{" +
+            "enrollments=" + enrollments +
+            '}';
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/relationship/DefaultRelationshipService.java
@@ -271,7 +271,8 @@ public class DefaultRelationshipService implements RelationshipService
             // tei owns all attributes in trackedEntityAttributeValues while programs only present a subset of them
             // the program attributes are the ones attached to the enrollment
             tei.setTrackedEntityAttributeValues(
-                enrollment.getAttributes().stream().map( this::map ).collect( Collectors.toSet() ) );
+                enrollment.getAttributes().stream().map( this::map )
+                    .collect( Collectors.toSet() ) );
 
             result.setEntityInstance( tei );
         }
@@ -413,8 +414,10 @@ public class DefaultRelationshipService implements RelationshipService
         // NOTE: skipping mapping of event.relationships as /tracker/relationships models do not include the
         // relationships fields of each of its nested entities as relationship items would then end in an infinite recursion
 
-        result.setEventDataValues( event.getDataValues().stream().map( this::map ).collect( Collectors.toSet() ) );
-        result.setComments( event.getNotes().stream().map( this::map ).collect( Collectors.toList() ) );
+        result.setEventDataValues(
+            event.getDataValues().stream().map( this::map ).collect( Collectors.toSet() ) );
+        result.setComments(
+            event.getNotes().stream().map( this::map ).collect( Collectors.toList() ) );
 
         return result;
     }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/enrollment/EnrollmentServiceTest.java
@@ -1,0 +1,437 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.enrollment;
+
+import static org.hisp.dhis.utils.Assertions.assertContains;
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.common.OrganisationUnitSelectionMode;
+import org.hisp.dhis.commons.util.RelationshipUtils;
+import org.hisp.dhis.dxf2.events.EnrollmentEventsParams;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramInstance;
+import org.hisp.dhis.program.ProgramInstanceQueryParams;
+import org.hisp.dhis.program.ProgramInstanceService;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramStageInstance;
+import org.hisp.dhis.program.ProgramType;
+import org.hisp.dhis.relationship.Relationship;
+import org.hisp.dhis.relationship.RelationshipEntity;
+import org.hisp.dhis.relationship.RelationshipItem;
+import org.hisp.dhis.relationship.RelationshipType;
+import org.hisp.dhis.security.acl.AccessStringHelper;
+import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class EnrollmentServiceTest extends TransactionalIntegrationTest
+{
+    @Autowired
+    private EnrollmentService enrollmentService;
+
+    @Autowired
+    protected UserService _userService;
+
+    @Autowired
+    private ProgramInstanceService programInstanceService;
+
+    @Autowired
+    private IdentifiableObjectManager manager;
+
+    private User admin;
+
+    private User user;
+
+    private User userWithoutOrgUnit;
+
+    private Program programA;
+
+    private ProgramStage programStageA;
+
+    private ProgramInstance programInstanceA;
+
+    private ProgramInstance programInstanceB;
+
+    private ProgramStageInstance programStageInstanceA;
+
+    private TrackedEntityInstance trackedEntityA;
+
+    private TrackedEntityType trackedEntityTypeA;
+
+    private TrackedEntityAttribute trackedEntityAttributeA;
+
+    private RelationshipType relationshipTypeA;
+
+    private Relationship relationshipA;
+
+    @Override
+    protected void setUpTest()
+        throws Exception
+    {
+        userService = _userService;
+        admin = preCreateInjectAdminUser();
+
+        OrganisationUnit orgUnitA = createOrganisationUnit( 'A' );
+        manager.save( orgUnitA, false );
+        OrganisationUnit orgUnitB = createOrganisationUnit( 'B' );
+        manager.save( orgUnitB, false );
+        OrganisationUnit orgUnitC = createOrganisationUnit( 'C' );
+        manager.save( orgUnitC, false );
+
+        user = createAndAddUser( false, "user", Set.of( orgUnitA ), Set.of( orgUnitA ),
+            "F_EXPORT_DATA" );
+        user.setTeiSearchOrganisationUnits( Set.of( orgUnitA, orgUnitB, orgUnitC ) );
+        userWithoutOrgUnit = createUserWithAuth( "userWithoutOrgUnit" );
+
+        trackedEntityTypeA = createTrackedEntityType( 'A' );
+        trackedEntityTypeA.getSharing().setOwner( user );
+        manager.save( trackedEntityTypeA, false );
+
+        trackedEntityA = createTrackedEntityInstance( orgUnitA );
+        trackedEntityA.setTrackedEntityType( trackedEntityTypeA );
+        manager.save( trackedEntityA, false );
+
+        TrackedEntityInstance trackedEntityB = createTrackedEntityInstance( orgUnitB );
+        trackedEntityB.setTrackedEntityType( trackedEntityTypeA );
+        manager.save( trackedEntityB, false );
+
+        TrackedEntityInstance trackedEntityC = createTrackedEntityInstance( orgUnitC );
+        trackedEntityC.setTrackedEntityType( trackedEntityTypeA );
+        manager.save( trackedEntityC, false );
+
+        programA = createProgram( 'A', new HashSet<>(), orgUnitA );
+        programA.setProgramType( ProgramType.WITH_REGISTRATION );
+        programA.setTrackedEntityType( trackedEntityTypeA );
+        programA.getSharing().setOwner( admin );
+        programA.getSharing().setPublicAccess( AccessStringHelper.DATA_READ );
+        manager.save( programA, false );
+
+        trackedEntityAttributeA = createTrackedEntityAttribute( 'A' );
+        trackedEntityAttributeA.getSharing().setOwner( admin );
+        manager.save( trackedEntityAttributeA, false );
+        TrackedEntityAttributeValue trackedEntityAttributeValueA = new TrackedEntityAttributeValue();
+        trackedEntityAttributeValueA.setAttribute( trackedEntityAttributeA );
+        trackedEntityAttributeValueA.setEntityInstance( trackedEntityA );
+        trackedEntityAttributeValueA.setValue( "12" );
+        trackedEntityA.setTrackedEntityAttributeValues( Set.of( trackedEntityAttributeValueA ) );
+        manager.update( trackedEntityA );
+        programA.setProgramAttributes(
+            List.of( createProgramTrackedEntityAttribute( programA, trackedEntityAttributeA ) ) );
+        manager.update( programA );
+
+        programStageA = createProgramStage( 'A', programA );
+        manager.save( programStageA, false );
+        ProgramStage inaccessibleProgramStage = createProgramStage( 'B', programA );
+        inaccessibleProgramStage.getSharing().setOwner( admin );
+        inaccessibleProgramStage.setPublicAccess( AccessStringHelper.DEFAULT );
+        manager.save( inaccessibleProgramStage, false );
+        programA.setProgramStages( Set.of( programStageA, inaccessibleProgramStage ) );
+        manager.save( programA, false );
+
+        relationshipTypeA = createRelationshipType( 'A' );
+        relationshipTypeA.getFromConstraint()
+            .setRelationshipEntity( RelationshipEntity.TRACKED_ENTITY_INSTANCE );
+        relationshipTypeA.getFromConstraint().setTrackedEntityType( trackedEntityTypeA );
+        relationshipTypeA.getToConstraint()
+            .setRelationshipEntity( RelationshipEntity.PROGRAM_INSTANCE );
+        relationshipTypeA.getToConstraint().setProgram( programA );
+        relationshipTypeA.getSharing().setOwner( user );
+        manager.save( relationshipTypeA, false );
+
+        relationshipA = new Relationship();
+        relationshipA.setUid( CodeGenerator.generateUid() );
+        relationshipA.setRelationshipType( relationshipTypeA );
+        RelationshipItem from = new RelationshipItem();
+        from.setTrackedEntityInstance( trackedEntityA );
+        from.setRelationship( relationshipA );
+        relationshipA.setFrom( from );
+        RelationshipItem to = new RelationshipItem();
+        to.setProgramInstance( programInstanceA );
+        to.setRelationship( relationshipA );
+        relationshipA.setTo( to );
+        relationshipA.setKey( RelationshipUtils.generateRelationshipKey( relationshipA ) );
+        relationshipA.setInvertedKey( RelationshipUtils.generateRelationshipInvertedKey( relationshipA ) );
+        manager.save( relationshipA, false );
+
+        programInstanceA = programInstanceService.enrollTrackedEntityInstance( trackedEntityA, programA, new Date(),
+            new Date(),
+            orgUnitA );
+        programStageInstanceA = new ProgramStageInstance();
+        programStageInstanceA.setProgramInstance( programInstanceA );
+        programStageInstanceA.setProgramStage( programStageA );
+        programStageInstanceA.setOrganisationUnit( orgUnitA );
+        manager.save( programStageInstanceA, false );
+        programInstanceA.setProgramStageInstances( Set.of( programStageInstanceA ) );
+        programInstanceA.setRelationshipItems( Set.of( from, to ) );
+        manager.save( programInstanceA, false );
+
+        programInstanceB = programInstanceService.enrollTrackedEntityInstance( trackedEntityB, programA, new Date(),
+            new Date(),
+            orgUnitB );
+
+        injectSecurityContext( user );
+    }
+
+    @Test
+    void shouldGetEnrollmentWhenUserHasReadWriteAccessToProgramAndAccessToOrgUnit()
+    {
+        programA.getSharing().setPublicAccess( AccessStringHelper.DATA_READ_WRITE );
+        manager.updateNoAcl( programA );
+
+        ProgramInstance enrollment = enrollmentService.getEnrollment( programInstanceA.getUid(),
+            EnrollmentParams.FALSE );
+
+        assertNotNull( enrollment );
+        assertEquals( programInstanceA.getUid(), enrollment.getUid() );
+    }
+
+    @Test
+    void shouldGetEnrollmentWhenUserHasReadAccessToProgramAndAccessToOrgUnit()
+    {
+        programA.getSharing().setPublicAccess( AccessStringHelper.DATA_READ );
+        manager.updateNoAcl( programA );
+
+        ProgramInstance enrollment = enrollmentService.getEnrollment( programInstanceA.getUid(),
+            EnrollmentParams.FALSE );
+
+        assertNotNull( enrollment );
+        assertEquals( programInstanceA.getUid(), enrollment.getUid() );
+    }
+
+    @Test
+    void shouldGetEnrollmentWithEventsWhenUserHasAccessToEvent()
+    {
+        EnrollmentParams params = EnrollmentParams.FALSE;
+        params = params.withEnrollmentEventsParams( EnrollmentEventsParams.TRUE );
+
+        ProgramInstance enrollment = enrollmentService.getEnrollment( programInstanceA.getUid(), params );
+
+        assertNotNull( enrollment );
+        assertContainsOnly( List.of( programStageInstanceA.getUid() ), enrollment.getProgramStageInstances().stream()
+            .map( ProgramStageInstance::getUid ).collect( Collectors.toList() ) );
+    }
+
+    @Test
+    void shouldGetEnrollmentWithoutEventsWhenUserHasNoAccessToProgramStage()
+    {
+        programStageA.getSharing().setOwner( admin );
+        programStageA.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
+        manager.updateNoAcl( programStageA );
+
+        EnrollmentParams params = EnrollmentParams.FALSE;
+        params = params.withIncludeEvents( true );
+
+        ProgramInstance enrollment = enrollmentService.getEnrollment( programInstanceA.getUid(), params );
+
+        assertNotNull( enrollment );
+        assertIsEmpty( enrollment.getProgramStageInstances() );
+    }
+
+    @Test
+    void shouldGetEnrollmentWithRelationshipsWhenUserHasAccessToThem()
+    {
+        EnrollmentParams params = EnrollmentParams.FALSE;
+        params = params.withIncludeRelationships( true );
+
+        ProgramInstance enrollment = enrollmentService.getEnrollment( programInstanceA.getUid(), params );
+
+        assertNotNull( enrollment );
+        assertContainsOnly( Set.of( relationshipA.getUid() ), relationshipUids( enrollment ) );
+    }
+
+    @Test
+    void shouldGetEnrollmentWithoutRelationshipsWhenUserHasAccessToThem()
+    {
+        relationshipTypeA.getSharing().setOwner( admin );
+        relationshipTypeA.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
+
+        EnrollmentParams params = EnrollmentParams.FALSE;
+        params = params.withIncludeRelationships( true );
+
+        ProgramInstance enrollment = enrollmentService.getEnrollment( programInstanceA.getUid(), params );
+
+        assertNotNull( enrollment );
+        assertIsEmpty( enrollment.getRelationshipItems() );
+    }
+
+    @Test
+    void shouldGetEnrollmentWithAttributesWhenUserHasAccessToThem()
+    {
+        EnrollmentParams params = EnrollmentParams.FALSE;
+        params = params.withIncludeAttributes( true );
+
+        ProgramInstance enrollment = enrollmentService.getEnrollment( programInstanceA.getUid(), params );
+
+        assertNotNull( enrollment );
+        assertContainsOnly( List.of( trackedEntityAttributeA.getUid() ), attributeUids( enrollment ) );
+    }
+
+    @Test
+    void shouldFailGettingEnrollmentWhenUserHasNoAccessToProgramsTrackedEntityType()
+    {
+        trackedEntityTypeA.getSharing().setOwner( admin );
+        trackedEntityTypeA.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
+        manager.updateNoAcl( trackedEntityTypeA );
+
+        IllegalQueryException exception = assertThrows( IllegalQueryException.class,
+            () -> enrollmentService.getEnrollment( programInstanceA.getUid(), EnrollmentParams.FALSE ) );
+        assertContains( "access to tracked entity type", exception.getMessage() );
+    }
+
+    @Test
+    void shouldFailGettingEnrollmentWhenUserHasReadAccessToProgramButNoAccessToOrgUnit()
+    {
+        programA.getSharing().setPublicAccess( AccessStringHelper.DATA_READ );
+        manager.updateNoAcl( programA );
+
+        injectSecurityContext( userWithoutOrgUnit );
+
+        IllegalQueryException exception = assertThrows( IllegalQueryException.class,
+            () -> enrollmentService.getEnrollment( programInstanceA.getUid(), EnrollmentParams.FALSE ) );
+        assertContains( "OWNERSHIP_ACCESS_DENIED", exception.getMessage() );
+    }
+
+    @Test
+    void shouldFailGettingEnrollmentWhenUserHasReadWriteAccessToProgramButNoAccessToOrgUnit()
+    {
+        programA.getSharing().setPublicAccess( AccessStringHelper.DATA_READ_WRITE );
+        manager.updateNoAcl( programA );
+
+        injectSecurityContext( userWithoutOrgUnit );
+
+        IllegalQueryException exception = assertThrows( IllegalQueryException.class,
+            () -> enrollmentService.getEnrollment( programInstanceA.getUid(), EnrollmentParams.FALSE ) );
+        assertContains( "OWNERSHIP_ACCESS_DENIED", exception.getMessage() );
+    }
+
+    @Test
+    void shouldFailGettingEnrollmentWhenUserHasNoAccessToProgramButAccessToOrgUnit()
+    {
+        programA.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
+        manager.updateNoAcl( programA );
+
+        IllegalQueryException exception = assertThrows( IllegalQueryException.class,
+            () -> enrollmentService.getEnrollment( programInstanceA.getUid(), EnrollmentParams.FALSE ) );
+        assertContains( "access to program", exception.getMessage() );
+    }
+
+    @Test
+    void shouldGetEnrollmentsWhenUserHasReadAccessToProgramAndSearchScopeAccessToOrgUnit()
+    {
+        programA.getSharing().setPublicAccess( AccessStringHelper.DATA_READ );
+        manager.updateNoAcl( programA );
+
+        ProgramInstanceQueryParams params = new ProgramInstanceQueryParams();
+        params.setProgram( programA );
+        params.setOrganisationUnitMode( OrganisationUnitSelectionMode.ACCESSIBLE );
+        params.setUser( user );
+
+        Enrollments enrollments = enrollmentService.getEnrollments( params );
+
+        assertNotNull( enrollments );
+        assertContainsOnly( List.of( programInstanceA.getUid(), programInstanceB.getUid() ), toUid( enrollments ) );
+    }
+
+    @Test
+    void shouldGetEnrollmentsByTrackedEntityWhenUserHasAccessToTrackedEntityType()
+    {
+        programA.getSharing().setPublicAccess( AccessStringHelper.DATA_READ );
+        manager.updateNoAcl( programA );
+
+        ProgramInstanceQueryParams params = new ProgramInstanceQueryParams();
+        params.setOrganisationUnits( Set.of( trackedEntityA.getOrganisationUnit() ) );
+        params.setTrackedEntityInstanceUid( trackedEntityA.getUid() );
+        params.setUser( user );
+
+        Enrollments enrollments = enrollmentService.getEnrollments( params );
+
+        assertNotNull( enrollments );
+        assertContainsOnly( List.of( programInstanceA.getUid() ), toUid( enrollments ) );
+    }
+
+    @Test
+    void shouldFailGettingEnrollmentsByTrackedEntityWhenUserHasNoAccessToTrackedEntityType()
+    {
+        programA.getSharing().setPublicAccess( AccessStringHelper.DATA_READ );
+        manager.updateNoAcl( programA );
+
+        trackedEntityTypeA.getSharing().setOwner( admin );
+        trackedEntityTypeA.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
+        manager.updateNoAcl( trackedEntityTypeA );
+
+        ProgramInstanceQueryParams params = new ProgramInstanceQueryParams();
+        params.setOrganisationUnits( Set.of( trackedEntityA.getOrganisationUnit() ) );
+        params.setTrackedEntityInstanceUid( trackedEntityA.getUid() );
+        params.setUser( user );
+
+        IllegalQueryException exception = assertThrows( IllegalQueryException.class,
+            () -> enrollmentService.getEnrollments( params ) );
+        assertContains( "access to tracked entity type", exception.getMessage() );
+    }
+
+    private static List<String> toUid( Enrollments enrollments )
+    {
+        return enrollments.getEnrollments().stream()
+            .map( ProgramInstance::getUid )
+            .collect( Collectors.toList() );
+    }
+
+    private static List<String> attributeUids( ProgramInstance programInstance )
+    {
+        return programInstance.getEntityInstance().getTrackedEntityAttributeValues().stream()
+            .map( v -> v.getAttribute().getUid() )
+            .collect( Collectors.toList() );
+    }
+
+    private static Set<String> relationshipUids( ProgramInstance programInstance )
+    {
+        return programInstance.getRelationshipItems().stream()
+            .map( r -> r.getRelationship().getUid() )
+            .collect( Collectors.toSet() );
+    }
+}

--- a/dhis-2/dhis-web-api-test/pom.xml
+++ b/dhis-2/dhis-web-api-test/pom.xml
@@ -56,6 +56,7 @@
             <ignoredNonTestScopedDependency>org.hisp.dhis:dhis-support-jdbc</ignoredNonTestScopedDependency>
             <ignoredNonTestScopedDependency>org.hisp.dhis:dhis-service-validation</ignoredNonTestScopedDependency>
             <ignoredNonTestScopedDependency>org.hisp.dhis:dhis-support-system</ignoredNonTestScopedDependency>
+            <ignoredNonTestScopedDependency>org.hisp.dhis:dhis-service-tracker</ignoredNonTestScopedDependency>
           </ignoredNonTestScopedDependencies>
         </configuration>
       </plugin>
@@ -165,6 +166,11 @@
     <dependency>
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-service-analytics</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hisp.dhis</groupId>
+      <artifactId>dhis-service-tracker</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAttribute.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAttribute.java
@@ -40,6 +40,11 @@ public interface JsonAttribute extends JsonObject
         return getString( "attribute" ).string();
     }
 
+    default String getValueType()
+    {
+        return getString( "valueType" ).string();
+    }
+
     default String getValue()
     {
         return getString( "value" ).string();

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonEnrollment.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonEnrollment.java
@@ -25,29 +25,59 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.tracker.export;
+package org.hisp.dhis.webapi.controller.tracker;
 
-import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstance;
-import org.hisp.dhis.webapi.controller.tracker.view.InstantMapper;
-import org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
+import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.jsontree.JsonObject;
 
-@Mapper( uses = {
-    Dxf2RelationshipMapper.class,
-    AttributeMapper.class,
-    Dxf2EnrollmentMapper.class,
-    ProgramOwnerMapper.class,
-    InstantMapper.class,
-    UserMapper.class } )
-interface TrackedEntityMapper extends ViewMapper<TrackedEntityInstance, TrackedEntity>
+/**
+ * Representation of
+ * {@link org.hisp.dhis.webapi.controller.tracker.view.Enrollment}.
+ */
+public interface JsonEnrollment extends JsonObject
 {
-    @Mapping( target = "trackedEntity", source = "trackedEntityInstance" )
-    @Mapping( target = "createdAt", source = "created" )
-    @Mapping( target = "createdAtClient", source = "createdAtClient" )
-    @Mapping( target = "updatedAt", source = "lastUpdated" )
-    @Mapping( target = "updatedAtClient", source = "lastUpdatedAtClient" )
-    @Mapping( target = "createdBy", source = "createdByUserInfo" )
-    @Mapping( target = "updatedBy", source = "lastUpdatedByUserInfo" )
-    TrackedEntity from( TrackedEntityInstance trackedEntityInstance );
+    default String getEnrollment()
+    {
+        return getString( "enrollment" ).string();
+    }
+
+    default String getTrackedEntity()
+    {
+        return getString( "trackedEntity" ).string();
+    }
+
+    default String getProgram()
+    {
+        return getString( "program" ).string();
+    }
+
+    default String getStatus()
+    {
+        return getString( "status" ).string();
+    }
+
+    default String getOrgUnit()
+    {
+        return getString( "orgUnit" ).string();
+    }
+
+    default String getOrgUnitName()
+    {
+        return getString( "orgUnitName" ).string();
+    }
+
+    default JsonList<JsonEvent> getEvents()
+    {
+        return get( "events" ).asList( JsonEvent.class );
+    }
+
+    default JsonList<JsonAttribute> getAttributes()
+    {
+        return get( "attributes" ).asList( JsonAttribute.class );
+    }
+
+    default JsonList<JsonNote> getNotes()
+    {
+        return get( "notes" ).asList( JsonNote.class );
+    }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonEvent.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonEvent.java
@@ -25,29 +25,73 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.tracker.export;
+package org.hisp.dhis.webapi.controller.tracker;
 
-import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstance;
-import org.hisp.dhis.webapi.controller.tracker.view.InstantMapper;
-import org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
+import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.jsontree.JsonObject;
 
-@Mapper( uses = {
-    Dxf2RelationshipMapper.class,
-    AttributeMapper.class,
-    Dxf2EnrollmentMapper.class,
-    ProgramOwnerMapper.class,
-    InstantMapper.class,
-    UserMapper.class } )
-interface TrackedEntityMapper extends ViewMapper<TrackedEntityInstance, TrackedEntity>
+/**
+ * Representation of {@link org.hisp.dhis.webapi.controller.tracker.view.Event}.
+ */
+public interface JsonEvent extends JsonObject
 {
-    @Mapping( target = "trackedEntity", source = "trackedEntityInstance" )
-    @Mapping( target = "createdAt", source = "created" )
-    @Mapping( target = "createdAtClient", source = "createdAtClient" )
-    @Mapping( target = "updatedAt", source = "lastUpdated" )
-    @Mapping( target = "updatedAtClient", source = "lastUpdatedAtClient" )
-    @Mapping( target = "createdBy", source = "createdByUserInfo" )
-    @Mapping( target = "updatedBy", source = "lastUpdatedByUserInfo" )
-    TrackedEntity from( TrackedEntityInstance trackedEntityInstance );
+    default String getEvent()
+    {
+        return getString( "event" ).string();
+    }
+
+    default String getStatus()
+    {
+        return getString( "status" ).string();
+    }
+
+    default String getProgram()
+    {
+        return getString( "program" ).string();
+    }
+
+    default String getProgramStage()
+    {
+        return getString( "programStage" ).string();
+    }
+
+    default String getEnrollment()
+    {
+        return getString( "enrollment" ).string();
+    }
+
+    default String getTrackedEntity()
+    {
+        return getString( "trackedEntity" ).string();
+    }
+
+    default String getOrgUnit()
+    {
+        return getString( "orgUnit" ).string();
+    }
+
+    default String getOrgUnitName()
+    {
+        return getString( "orgUnitName" ).string();
+    }
+
+    default Boolean getDeleted()
+    {
+        return getBoolean( "deleted" ).bool();
+    }
+
+    default JsonUser getAssignedUser()
+    {
+        return get( "assignedUser" ).as( JsonUser.class );
+    }
+
+    default JsonList<JsonDataValue> getDataValues()
+    {
+        return get( "dataValues" ).asList( JsonDataValue.class );
+    }
+
+    default JsonList<JsonNote> getNotes()
+    {
+        return get( "notes" ).asList( JsonNote.class );
+    }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/EnrollmentFieldsMapperTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/EnrollmentFieldsMapperTest.java
@@ -32,8 +32,8 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.stream.Stream;
 
-import org.hisp.dhis.dxf2.events.EnrollmentParams;
 import org.hisp.dhis.fieldfiltering.FieldFilterParser;
+import org.hisp.dhis.tracker.enrollment.EnrollmentParams;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/Dxf2EnrollmentMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/Dxf2EnrollmentMapper.java
@@ -27,27 +27,37 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export;
 
-import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.webapi.controller.tracker.view.Enrollment;
 import org.hisp.dhis.webapi.controller.tracker.view.InstantMapper;
-import org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
+/**
+ * tracker.export is currently made independent of dxf2. We are in a transition
+ * period where some mappers are duplicated. This mapper will be removed once
+ * tracker.export is independent of dxf2.
+ */
 @Mapper( uses = {
     Dxf2RelationshipMapper.class,
     AttributeMapper.class,
-    Dxf2EnrollmentMapper.class,
-    ProgramOwnerMapper.class,
+    NoteMapper.class,
+    EventMapper.class,
     InstantMapper.class,
     UserMapper.class } )
-interface TrackedEntityMapper extends ViewMapper<TrackedEntityInstance, TrackedEntity>
+interface Dxf2EnrollmentMapper extends ViewMapper<org.hisp.dhis.dxf2.events.enrollment.Enrollment, Enrollment>
 {
-    @Mapping( target = "trackedEntity", source = "trackedEntityInstance" )
+    @Mapping( target = "enrollment", source = "enrollment" )
     @Mapping( target = "createdAt", source = "created" )
     @Mapping( target = "createdAtClient", source = "createdAtClient" )
     @Mapping( target = "updatedAt", source = "lastUpdated" )
     @Mapping( target = "updatedAtClient", source = "lastUpdatedAtClient" )
+    @Mapping( target = "trackedEntity", source = "trackedEntityInstance" )
+    @Mapping( target = "enrolledAt", source = "enrollmentDate" )
+    @Mapping( target = "occurredAt", source = "incidentDate" )
+    @Mapping( target = "followUp", source = "followup" )
+    @Mapping( target = "completedAt", source = "completedDate" )
     @Mapping( target = "createdBy", source = "createdByUserInfo" )
     @Mapping( target = "updatedBy", source = "lastUpdatedByUserInfo" )
-    TrackedEntity from( TrackedEntityInstance trackedEntityInstance );
+    @Override
+    Enrollment from( org.hisp.dhis.dxf2.events.enrollment.Enrollment enrollment );
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/EnrollmentMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/EnrollmentMapper.java
@@ -27,31 +27,121 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.program.ProgramInstance;
+import org.hisp.dhis.webapi.controller.tracker.view.Attribute;
+import org.hisp.dhis.webapi.controller.tracker.view.DataValue;
 import org.hisp.dhis.webapi.controller.tracker.view.Enrollment;
+import org.hisp.dhis.webapi.controller.tracker.view.Event;
 import org.hisp.dhis.webapi.controller.tracker.view.InstantMapper;
+import org.hisp.dhis.webapi.controller.tracker.view.Note;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper( uses = {
-    Dxf2RelationshipMapper.class,
-    AttributeMapper.class,
-    NoteMapper.class,
-    EventMapper.class,
+    RelationshipMapper.class,
     InstantMapper.class,
     UserMapper.class } )
-interface EnrollmentMapper extends ViewMapper<org.hisp.dhis.dxf2.events.enrollment.Enrollment, Enrollment>
+interface EnrollmentMapper extends ViewMapper<ProgramInstance, Enrollment>
 {
-    @Mapping( target = "enrollment", source = "enrollment" )
+    @Mapping( target = "enrollment", source = "uid" )
     @Mapping( target = "createdAt", source = "created" )
     @Mapping( target = "createdAtClient", source = "createdAtClient" )
     @Mapping( target = "updatedAt", source = "lastUpdated" )
     @Mapping( target = "updatedAtClient", source = "lastUpdatedAtClient" )
-    @Mapping( target = "trackedEntity", source = "trackedEntityInstance" )
+    @Mapping( target = "trackedEntity", source = "entityInstance.uid" )
+    @Mapping( target = "program", source = "program.uid" )
+    @Mapping( target = "orgUnit", source = "organisationUnit.uid" )
+    @Mapping( target = "orgUnitName", source = "organisationUnit.name" )
     @Mapping( target = "enrolledAt", source = "enrollmentDate" )
     @Mapping( target = "occurredAt", source = "incidentDate" )
     @Mapping( target = "followUp", source = "followup" )
+    @Mapping( target = "completedAt", source = "endDate" )
+    @Mapping( target = "createdBy", source = "createdByUserInfo" )
+    @Mapping( target = "updatedBy", source = "lastUpdatedByUserInfo" )
+    @Mapping( target = "events", source = "programStageInstances" )
+    @Mapping( target = "relationships", source = "relationshipItems" )
+    @Mapping( target = "attributes", source = "entityInstance.trackedEntityAttributeValues" )
+    @Mapping( target = "notes", source = "comments" )
+    @Override
+    Enrollment from( ProgramInstance programInstance );
+
+    /**
+     * Maps {@link ProgramInstance#getRelationshipItems()} to
+     * {@link org.hisp.dhis.relationship.Relationship} which is then mapped by
+     * {@link RelationshipMapper}.
+     *
+     */
+    default Set<org.hisp.dhis.relationship.Relationship> map(
+        Set<org.hisp.dhis.relationship.RelationshipItem> relationshipItems )
+    {
+        if ( relationshipItems == null )
+        {
+            return Set.of();
+        }
+
+        return relationshipItems.stream().map( org.hisp.dhis.relationship.RelationshipItem::getRelationship )
+            .collect( Collectors.toSet() );
+    }
+
+    @Mapping( target = "event", source = "uid" )
+    @Mapping( target = "program", source = "programInstance.program.uid" )
+    @Mapping( target = "programStage", source = "programStage.uid" )
+    @Mapping( target = "enrollment", source = "programInstance.uid" )
+    @Mapping( target = "trackedEntity", source = "programInstance.entityInstance.uid" )
+    @Mapping( target = "orgUnit", source = "organisationUnit.uid" )
+    @Mapping( target = "orgUnitName", source = "organisationUnit.name" )
+    @Mapping( target = "occurredAt", source = "executionDate" )
+    @Mapping( target = "scheduledAt", source = "dueDate" )
+    @Mapping( target = "followup", source = "programInstance.followup" )
+    @Mapping( target = "createdAt", source = "created" )
+    @Mapping( target = "createdAtClient", source = "createdAtClient" )
+    @Mapping( target = "updatedAt", source = "lastUpdated" )
+    @Mapping( target = "updatedAtClient", source = "lastUpdatedAtClient" )
+    @Mapping( target = "attributeOptionCombo", source = "attributeOptionCombo.uid" )
+    @Mapping( target = "attributeCategoryOptions", source = "attributeOptionCombo.categoryOptions" )
     @Mapping( target = "completedAt", source = "completedDate" )
     @Mapping( target = "createdBy", source = "createdByUserInfo" )
     @Mapping( target = "updatedBy", source = "lastUpdatedByUserInfo" )
-    Enrollment from( org.hisp.dhis.dxf2.events.enrollment.Enrollment enrollment );
+    @Mapping( target = "dataValues", source = "eventDataValues" )
+    @Mapping( target = "notes", source = "comments" )
+    Event from( org.hisp.dhis.program.ProgramStageInstance event );
+
+    @Mapping( target = "attribute", source = "attribute.uid" )
+    @Mapping( target = "code", source = "attribute.code" )
+    @Mapping( target = "displayName", source = "attribute.displayName" )
+    @Mapping( target = "createdAt", source = "created" )
+    @Mapping( target = "updatedAt", source = "lastUpdated" )
+    @Mapping( target = "valueType", source = "attribute.valueType" )
+    Attribute from( org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue attribute );
+
+    @Mapping( target = "note", source = "uid" )
+    @Mapping( target = "storedAt", source = "created" )
+    @Mapping( target = "value", source = "commentText" )
+    @Mapping( target = "createdBy", source = "lastUpdatedBy" )
+    @Mapping( target = "storedBy", source = "creator" )
+    Note from( org.hisp.dhis.trackedentitycomment.TrackedEntityComment comment );
+
+    // NOTE: right now we only support categoryOptionComboIdScheme on export. If we were to add a categoryOptionIdScheme
+    // we could not simply export the UIDs.
+    default String from( Set<CategoryOption> categoryOptions )
+    {
+        if ( categoryOptions == null || categoryOptions.isEmpty() )
+        {
+            return "";
+        }
+
+        return categoryOptions.stream()
+            .map( CategoryOption::getUid )
+            .collect( Collectors.joining( ";" ) );
+    }
+
+    @Mapping( target = "createdAt", source = "created" )
+    @Mapping( target = "updatedAt", source = "lastUpdated" )
+    @Mapping( target = "createdBy", source = "createdByUserInfo" )
+    @Mapping( target = "updatedBy", source = "lastUpdatedByUserInfo" )
+    DataValue from( org.hisp.dhis.eventdatavalue.EventDataValue dataValue );
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportController.java
@@ -40,15 +40,16 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.commons.util.TextUtils;
-import org.hisp.dhis.dxf2.events.EnrollmentParams;
-import org.hisp.dhis.dxf2.events.enrollment.EnrollmentService;
-import org.hisp.dhis.dxf2.events.enrollment.Enrollments;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
+import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceQueryParams;
+import org.hisp.dhis.tracker.enrollment.EnrollmentParams;
+import org.hisp.dhis.tracker.enrollment.EnrollmentService;
+import org.hisp.dhis.tracker.enrollment.Enrollments;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
 import org.hisp.dhis.webapi.controller.tracker.export.fieldsmapper.EnrollmentFieldsParamMapper;
 import org.hisp.dhis.webapi.controller.tracker.view.Enrollment;
@@ -93,7 +94,7 @@ public class TrackerEnrollmentsExportController
     {
         PagingWrapper<ObjectNode> pagingWrapper = new PagingWrapper<>();
 
-        List<org.hisp.dhis.dxf2.events.enrollment.Enrollment> enrollmentList;
+        List<ProgramInstance> enrollmentList;
 
         EnrollmentParams enrollmentParams = fieldsMapper.map( fields )
             .withIncludeDeleted( trackerEnrollmentCriteria.isIncludeDeleted() );
@@ -111,7 +112,6 @@ public class TrackerEnrollmentsExportController
             }
 
             enrollmentList = enrollments.getEnrollments();
-
         }
         else
         {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/EnrollmentFieldsParamMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/EnrollmentFieldsParamMapper.java
@@ -37,10 +37,10 @@ import java.util.Map;
 
 import lombok.RequiredArgsConstructor;
 
-import org.hisp.dhis.dxf2.events.EnrollmentParams;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.fieldfiltering.FieldPreset;
+import org.hisp.dhis.tracker.enrollment.EnrollmentParams;
 import org.hisp.dhis.webapi.controller.tracker.view.Enrollment;
 import org.springframework.stereotype.Component;
 


### PR DESCRIPTION
repeating what we did in https://github.com/dhis2/dhis2-core/pull/13283 now for enrollment.

* add new tracker service for enrollments. Note that for enrollments we call out to ProgramInstanceService which we cannot simply replace with the ProgramInstanceStore like we did for relationships. We cannot because ProgramInstanceService contains more logic we will need to copy/transfer it later on.

NOTE: we are still in the 🚧 phase going with broad strokes through web/service/repo layers. We will come back to all these layers and have discussions on how we want to adapt them. First goal is for new tracker to become independent from dxf2. All code that maps from `dxf2` to `dhis-api` will be removed very soon 👷🏻 Please comment if you spot a bug but don't comment on its style 💅🏻 

# Next

* create a new tracker service for events
* then tracked entity
* remove dxf2 dependencies in new tracker relationship service
* make sure we have a new tracker store for every entity and do not need to rely on dxf2 or dhis-api stores