### PR TITLE
fix: Set builder default value for collection fields [DHIS2-15002]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programstageworkinglist/ProgramStageQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programstageworkinglist/ProgramStageQueryCriteria.java
@@ -112,6 +112,7 @@ public class ProgramStageQueryCriteria implements Serializable
      * Property which contains the order of output columns
      */
     @JsonProperty
+    @Builder.Default
     private List<String> displayColumnOrder = Collections.emptyList();
 
     /**
@@ -138,12 +139,14 @@ public class ProgramStageQueryCriteria implements Serializable
      * event filter.
      */
     @JsonProperty
+    @Builder.Default
     private Set<String> assignedUsers = Collections.emptySet();
 
     /**
      * Property which contains the filters to be used when querying events.
      */
     @JsonProperty
+    @Builder.Default
     private List<EventDataFilter> dataFilters = Collections.emptyList();
 
     /**
@@ -151,5 +154,6 @@ public class ProgramStageQueryCriteria implements Serializable
      * attribute values
      */
     @JsonProperty
+    @Builder.Default
     private List<AttributeValueFilter> attributeValueFilters = Collections.emptyList();
 }


### PR DESCRIPTION
We got a warning because of initializing fields while using the lombok Builder annotation at class level.
To solve this, we needed to add the annotation `@Builder.Default` to make sure lombok initializes the fields with the explicit value.

Ticket: https://dhis2.atlassian.net/browse/DHIS2-15002