### PR TITLE
fix: apply sharing check for getEntity() [DHIS2-12926]

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/CrudControllerIntegrationTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/CrudControllerIntegrationTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.web.WebClientUtils.assertStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.web.HttpStatus;
+import org.hisp.dhis.webapi.DhisControllerIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+class CrudControllerIntegrationTest extends DhisControllerIntegrationTest
+{
+    @Test
+    void testGetNonAccessibleObject()
+    {
+        User admin = getCurrentUser();
+        String id = assertStatus( HttpStatus.CREATED,
+            POST( "/dataSets/",
+                "{'name':'My data set', 'shortName': 'MDS', 'periodType':'Monthly', 'sharing':{'public':'--------','owner': '"
+                    + admin.getUid() + "'}}" ) );
+
+        User testUser = createAndAddUser( "test" );
+        injectSecurityContext( testUser );
+
+        GET( "/dataSets/{id}", id ).content( HttpStatus.NOT_FOUND );
+    }
+
+    @Test
+    void testGetAccessibleObject()
+    {
+        User testUser = createAndAddUser( "test", null, "F_DATASET_PRIVATE_ADD" );
+        injectSecurityContext( testUser );
+        String id = assertStatus( HttpStatus.CREATED,
+            POST( "/dataSets/",
+                "{'name':'My data set', 'shortName': 'MDS', 'periodType':'Monthly', 'sharing':{'public':'--------','owner': '"
+                    + testUser.getUid() + "'}}" ) );
+
+        DataSet dataSet = manager.get( DataSet.class, id );
+        assertEquals( testUser.getUid(), dataSet.getSharing().getOwner() );
+
+        GET( "/dataSets/{id}", id ).content( HttpStatus.OK );
+    }
+
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
@@ -670,7 +670,7 @@ public abstract class AbstractFullReadOnlyController<T extends IdentifiableObjec
 
     protected final <E extends IdentifiableObject> java.util.Optional<E> getEntity( String uid, Class<E> entityType )
     {
-        return java.util.Optional.ofNullable( manager.getNoAcl( entityType, uid ) );
+        return java.util.Optional.ofNullable( manager.get( entityType, uid ) );
     }
 
     protected final Schema getSchema( Class<?> klass )


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-14942
### Issue
- Right now without METADATA_READ permission, a User can still get details of a metadata object by sending GET request to `api/{metadata class}/{uid}` such as `api/dataElement/{uid}`

### Fix 
- Apply ACL check for `getEntity` method in `AbstractCrudController`.
- This is a breaking change in 2.41. 
- After this is merged, some Users may not be able to see shared Dashboard because they don't have READ permission of DashboardItem's objects. In this case, user needs to be granted READ permission by using Dashboard Cascade sharing feature.

### Test
- Added unit tests.
- Can manually test by sending a GET request to `api/dataElement/{uid}` with accessible and inaccessible object.
