### PR TITLE
chore: use exceptions from feedback instead of dxf2 TECH-1515

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportControllerTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export;
 
+import static org.hisp.dhis.utils.Assertions.assertStartsWith;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertContainsAll;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertEnrollmentWithinRelationship;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertEventWithinRelationshipItem;
@@ -330,10 +331,8 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
     @Test
     void getRelationshipsByEventNotFound()
     {
-        assertEquals( "No event 'Hq3Kc6HK4OZ' found.",
-            GET( "/tracker/relationships?event=Hq3Kc6HK4OZ" )
-                .error( HttpStatus.NOT_FOUND )
-                .getMessage() );
+        assertStartsWith( "event with id Hq3Kc6HK4OZ",
+            GET( "/tracker/relationships?event=Hq3Kc6HK4OZ" ).error( HttpStatus.NOT_FOUND ).getMessage() );
     }
 
     @Test
@@ -425,10 +424,8 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
     @Test
     void getRelationshipsByEnrollmentNotFound()
     {
-        assertEquals( "No enrollment 'Hq3Kc6HK4OZ' found.",
-            GET( "/tracker/relationships?enrollment=Hq3Kc6HK4OZ" )
-                .error( HttpStatus.NOT_FOUND )
-                .getMessage() );
+        assertStartsWith( "enrollment with id Hq3Kc6HK4OZ",
+            GET( "/tracker/relationships?enrollment=Hq3Kc6HK4OZ" ).error( HttpStatus.NOT_FOUND ).getMessage() );
     }
 
     @Test
@@ -604,10 +601,8 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
     @Test
     void getRelationshipsByTrackedEntityNotFound()
     {
-        assertEquals( "No trackedEntity 'Hq3Kc6HK4OZ' found.",
-            GET( "/tracker/relationships?trackedEntity=Hq3Kc6HK4OZ" )
-                .error( HttpStatus.NOT_FOUND )
-                .getMessage() );
+        assertStartsWith( "trackedEntity with id Hq3Kc6HK4OZ",
+            GET( "/tracker/relationships?trackedEntity=Hq3Kc6HK4OZ" ).error( HttpStatus.NOT_FOUND ).getMessage() );
     }
 
     private TrackedEntityType trackedEntityTypeAccessible()

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipCriteria.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export;
 
-import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.badRequest;
 import static org.hisp.dhis.webapi.controller.event.webrequest.tracker.FieldTranslatorSupport.translate;
 
 import java.util.Optional;
@@ -39,7 +38,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.dxf2.webmessage.WebMessageException;
+import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
@@ -78,7 +77,7 @@ class TrackerRelationshipCriteria extends PagingAndSortingCriteriaAdapter
     }
 
     public String getIdentifierParam()
-        throws WebMessageException
+        throws BadRequestException
     {
         if ( this.identifier != null )
         {
@@ -110,19 +109,18 @@ class TrackerRelationshipCriteria extends PagingAndSortingCriteriaAdapter
 
         if ( count == 0 )
         {
-            throw new WebMessageException(
-                badRequest( "Missing required parameter 'trackedEntity', 'enrollment' or 'event'." ) );
+            throw new BadRequestException( "Missing required parameter 'trackedEntity', 'enrollment' or 'event'." );
         }
         else if ( count > 1 )
         {
-            throw new WebMessageException(
-                badRequest( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed." ) );
+            throw new BadRequestException(
+                "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed." );
         }
         return this.identifier;
     }
 
     public String getIdentifierName()
-        throws WebMessageException
+        throws BadRequestException
     {
         if ( this.identifierName == null )
         {
@@ -132,7 +130,7 @@ class TrackerRelationshipCriteria extends PagingAndSortingCriteriaAdapter
     }
 
     public Class<?> getIdentifierClass()
-        throws WebMessageException
+        throws BadRequestException
     {
         if ( this.identifierClass == null )
         {

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipCriteriaTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipCriteriaTest.java
@@ -29,9 +29,8 @@ package org.hisp.dhis.webapi.controller.tracker.export;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
-import org.hisp.dhis.dxf2.webmessage.WebMessageException;
+import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
@@ -41,7 +40,7 @@ class TrackerRelationshipCriteriaTest
 {
     @Test
     void getIdentifierParamIfTrackedEntityIsSet()
-        throws WebMessageException
+        throws BadRequestException
     {
 
         TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
@@ -53,7 +52,7 @@ class TrackerRelationshipCriteriaTest
 
     @Test
     void getIdentifierParamIfTeiIsSet()
-        throws WebMessageException
+        throws BadRequestException
     {
 
         TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
@@ -64,7 +63,7 @@ class TrackerRelationshipCriteriaTest
 
     @Test
     void getIdentifierNameIfTrackedEntityIsSet()
-        throws WebMessageException
+        throws BadRequestException
     {
 
         TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
@@ -75,7 +74,7 @@ class TrackerRelationshipCriteriaTest
 
     @Test
     void getIdentifierNameIfTeiIsSet()
-        throws WebMessageException
+        throws BadRequestException
     {
 
         TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
@@ -86,7 +85,7 @@ class TrackerRelationshipCriteriaTest
 
     @Test
     void getIdentifierClassIfTrackedEntityIsSet()
-        throws WebMessageException
+        throws BadRequestException
     {
 
         TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
@@ -97,7 +96,7 @@ class TrackerRelationshipCriteriaTest
 
     @Test
     void getIdentifierClassIfTeiIsSet()
-        throws WebMessageException
+        throws BadRequestException
     {
 
         TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
@@ -108,7 +107,7 @@ class TrackerRelationshipCriteriaTest
 
     @Test
     void getIdentifierParamIfEnrollmentIsSet()
-        throws WebMessageException
+        throws BadRequestException
     {
 
         TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
@@ -119,7 +118,7 @@ class TrackerRelationshipCriteriaTest
 
     @Test
     void getIdentifierNameIfEnrollmentIsSet()
-        throws WebMessageException
+        throws BadRequestException
     {
 
         TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
@@ -130,7 +129,7 @@ class TrackerRelationshipCriteriaTest
 
     @Test
     void getIdentifierClassIfEnrollmentIsSet()
-        throws WebMessageException
+        throws BadRequestException
     {
 
         TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
@@ -141,7 +140,7 @@ class TrackerRelationshipCriteriaTest
 
     @Test
     void getIdentifierParamIfEventIsSet()
-        throws WebMessageException
+        throws BadRequestException
     {
 
         TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
@@ -152,7 +151,7 @@ class TrackerRelationshipCriteriaTest
 
     @Test
     void getIdentifierNameIfEventIsSet()
-        throws WebMessageException
+        throws BadRequestException
     {
 
         TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
@@ -163,7 +162,7 @@ class TrackerRelationshipCriteriaTest
 
     @Test
     void getIdentifierClassIfEventIsSet()
-        throws WebMessageException
+        throws BadRequestException
     {
 
         TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
@@ -177,11 +176,10 @@ class TrackerRelationshipCriteriaTest
     {
         TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
 
-        WebMessageException exception = assertThrows( WebMessageException.class, criteria::getIdentifierParam );
+        BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierParam );
 
-        assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
         assertEquals( "Missing required parameter 'trackedEntity', 'enrollment' or 'event'.",
-            exception.getWebMessage().getMessage() );
+            exception.getMessage() );
     }
 
     @Test
@@ -189,11 +187,10 @@ class TrackerRelationshipCriteriaTest
     {
         TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
 
-        WebMessageException exception = assertThrows( WebMessageException.class, criteria::getIdentifierName );
+        BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierName );
 
-        assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
         assertEquals( "Missing required parameter 'trackedEntity', 'enrollment' or 'event'.",
-            exception.getWebMessage().getMessage() );
+            exception.getMessage() );
     }
 
     @Test
@@ -205,11 +202,10 @@ class TrackerRelationshipCriteriaTest
         criteria.setEnrollment( "Hq3Kc6HK4OZ" );
         criteria.setEvent( "Hq3Kc6HK4OZ" );
 
-        WebMessageException exception = assertThrows( WebMessageException.class, criteria::getIdentifierParam );
+        BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierParam );
 
-        assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
         assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
-            exception.getWebMessage().getMessage() );
+            exception.getMessage() );
     }
 
     @Test
@@ -221,11 +217,10 @@ class TrackerRelationshipCriteriaTest
         criteria.setEnrollment( "Hq3Kc6HK4OZ" );
         criteria.setEvent( "Hq3Kc6HK4OZ" );
 
-        WebMessageException exception = assertThrows( WebMessageException.class, criteria::getIdentifierName );
+        BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierName );
 
-        assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
         assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
-            exception.getWebMessage().getMessage() );
+            exception.getMessage() );
     }
 
     @Test
@@ -237,11 +232,10 @@ class TrackerRelationshipCriteriaTest
         criteria.setEnrollment( "Hq3Kc6HK4OZ" );
         criteria.setEvent( "Hq3Kc6HK4OZ" );
 
-        WebMessageException exception = assertThrows( WebMessageException.class, criteria::getIdentifierClass );
+        BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierClass );
 
-        assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
         assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
-            exception.getWebMessage().getMessage() );
+            exception.getMessage() );
     }
 
     @Test
@@ -251,11 +245,10 @@ class TrackerRelationshipCriteriaTest
         criteria.setTrackedEntity( "Hq3Kc6HK4OZ" );
         criteria.setEnrollment( "Hq3Kc6HK4OZ" );
 
-        WebMessageException exception = assertThrows( WebMessageException.class, criteria::getIdentifierParam );
+        BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierParam );
 
-        assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
         assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
-            exception.getWebMessage().getMessage() );
+            exception.getMessage() );
     }
 
     @Test
@@ -265,11 +258,10 @@ class TrackerRelationshipCriteriaTest
         criteria.setTei( "Hq3Kc6HK4OZ" );
         criteria.setEnrollment( "Hq3Kc6HK4OZ" );
 
-        WebMessageException exception = assertThrows( WebMessageException.class, criteria::getIdentifierParam );
+        BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierParam );
 
-        assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
         assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
-            exception.getWebMessage().getMessage() );
+            exception.getMessage() );
     }
 
     @Test
@@ -279,11 +271,10 @@ class TrackerRelationshipCriteriaTest
         criteria.setTrackedEntity( "Hq3Kc6HK4OZ" );
         criteria.setEnrollment( "Hq3Kc6HK4OZ" );
 
-        WebMessageException exception = assertThrows( WebMessageException.class, criteria::getIdentifierClass );
+        BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierClass );
 
-        assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
         assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
-            exception.getWebMessage().getMessage() );
+            exception.getMessage() );
     }
 
     @Test
@@ -293,11 +284,10 @@ class TrackerRelationshipCriteriaTest
         criteria.setTei( "Hq3Kc6HK4OZ" );
         criteria.setEnrollment( "Hq3Kc6HK4OZ" );
 
-        WebMessageException exception = assertThrows( WebMessageException.class, criteria::getIdentifierClass );
+        BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierClass );
 
-        assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
         assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
-            exception.getWebMessage().getMessage() );
+            exception.getMessage() );
     }
 
     @Test
@@ -307,10 +297,9 @@ class TrackerRelationshipCriteriaTest
         criteria.setEnrollment( "Hq3Kc6HK4OZ" );
         criteria.setEvent( "Hq3Kc6HK4OZ" );
 
-        WebMessageException exception = assertThrows( WebMessageException.class, criteria::getIdentifierParam );
+        BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierParam );
 
-        assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
         assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
-            exception.getWebMessage().getMessage() );
+            exception.getMessage() );
     }
 }


### PR DESCRIPTION
these should be used as they play nice with OpenAPI they are then turned into the appropriate HTTP status codes in the `CrudControllerAdvice`.

Bad request its for example is handled here https://github.com/dhis2/dhis2-core/blob/7c636f5401507f5a7c54445f9487f33c2794e930/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java#L140