### PR TITLE
fix: Support for lastUpdatedAtClient/createdAtClient in analytics [DHIS2-14981]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -126,8 +126,16 @@ public class JdbcEventAnalyticsTableManager
         new AnalyticsTableColumn( quote( "executiondate" ), TIMESTAMP, "psi.executiondate" ),
         new AnalyticsTableColumn( quote( "duedate" ), TIMESTAMP, "psi.duedate" ),
         new AnalyticsTableColumn( quote( "completeddate" ), TIMESTAMP, "psi.completeddate" ),
-        new AnalyticsTableColumn( quote( "created" ), TIMESTAMP, "psi.created" ),
-        new AnalyticsTableColumn( quote( "lastupdated" ), TIMESTAMP, "psi.lastupdated" ),
+
+        /*
+         * DHIS2-14981: Use the client-side timestamp if available, otherwise
+         * the server-side timestamp. Applies to both created and lastupdated.
+         */
+        new AnalyticsTableColumn( quote( "created" ), TIMESTAMP,
+            firstIfNotNullOrElse( "psi.createdatclient", "psi.created" ) ),
+        new AnalyticsTableColumn( quote( "lastupdated" ), TIMESTAMP,
+            firstIfNotNullOrElse( "psi.lastupdatedatclient", "psi.lastupdated" ) ),
+
         new AnalyticsTableColumn( quote( "storedby" ), VARCHAR_255, "psi.storedby" ),
         new AnalyticsTableColumn( quote( "createdbyusername" ), VARCHAR_255,
             "psi.createdbyuserinfo ->> 'username' as createdbyusername" ),
@@ -166,6 +174,19 @@ public class JdbcEventAnalyticsTableManager
             "coalesce(registrationou.uid,ou.uid)" ),
         new AnalyticsTableColumn( quote( "enrollmentou" ), CHARACTER_11, NOT_NULL,
             "coalesce(enrollmentou.uid,ou.uid)" ) );
+
+    /**
+     * Returns a SQL expression that returns the first argument if it is not
+     * null, otherwise the second argument.
+     *
+     * @param first the first argument
+     * @param second the second argument
+     * @return a SQL expression
+     */
+    private static String firstIfNotNullOrElse( String first, String second )
+    {
+        return "CASE WHEN " + first + " IS NOT NULL THEN " + first + " ELSE " + second + " END";
+    }
 
     @Override
     public AnalyticsTableType getAnalyticsTableType()

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -298,12 +298,11 @@ public class JdbcEventStore implements EventStore
         COMPLETEDBY.getColumnName(),    // 12
         DELETED.getColumnName(),        // 13
         "code",                         // 14
-        CREATEDCLIENT.getColumnName(),  // 15
-        UPDATEDCLIENT.getColumnName(),  // 16
-        GEOMETRY.getColumnName(),       // 17
-        "assigneduserid",               // 18
-        "eventdatavalues",              // 19
-        UID.getColumnName() );          // 20
+        UPDATEDCLIENT.getColumnName(),  // 15
+        GEOMETRY.getColumnName(),       // 16
+        "assigneduserid",               // 17
+        "eventdatavalues",              // 18
+        UID.getColumnName() );          // 19
 
     private static final String UPDATE_EVENT_SQL;
 
@@ -584,7 +583,7 @@ public class JdbcEventStore implements EventStore
             {
                 try
                 {
-                    parameters[i] = getSqlParameters( programStageInstances.get( i ) );
+                    parameters[i] = getSqlParametersForUpdate( programStageInstances.get( i ) );
                 }
                 catch ( SQLException | JsonProcessingException e )
                 {
@@ -2094,7 +2093,7 @@ public class JdbcEventStore implements EventStore
         // @formatter:on
     }
 
-    private MapSqlParameterSource getSqlParameters( ProgramStageInstance programStageInstance )
+    private MapSqlParameterSource getSqlParametersForUpdate( ProgramStageInstance programStageInstance )
         throws SQLException,
         JsonProcessingException
     {
@@ -2117,8 +2116,6 @@ public class JdbcEventStore implements EventStore
             .addValue( COMPLETEDBY.getColumnName(), programStageInstance.getCompletedBy() )
             .addValue( DELETED.getColumnName(), programStageInstance.isDeleted() )
             .addValue( "code", programStageInstance.getCode() )
-            .addValue( CREATEDCLIENT.getColumnName(),
-                JdbcEventSupport.toTimestamp( programStageInstance.getCreatedAtClient() ) )
             .addValue( UPDATEDCLIENT.getColumnName(),
                 JdbcEventSupport.toTimestamp( programStageInstance.getLastUpdatedAtClient() ) )
             .addValue( GEOMETRY.getColumnName(), JdbcEventSupport.toGeometry( programStageInstance.getGeometry() ) )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/mapper/ProgramStageInstanceMapper.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/mapper/ProgramStageInstanceMapper.java
@@ -144,8 +144,7 @@ public class ProgramStageInstanceMapper extends AbstractMapper<Event, ProgramSta
             psi.setAssignedUser( this.workContext.getAssignedUserMap().get( event.getUid() ) );
         }
 
-        // CREATED AT CLIENT + UPDATED AT CLIENT
-        psi.setCreatedAtClient( parseDate( event.getCreatedAtClient() ) );
+        // UPDATED AT CLIENT
         psi.setLastUpdatedAtClient( parseDate( event.getLastUpdatedAtClient() ) );
 
         psi.setStoredBy( event.getStoredBy() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
@@ -218,11 +218,11 @@ public class EventTrackerConverterService
             programStageInstance.setCreated( now );
             programStageInstance.setStoredBy( event.getStoredBy() );
             programStageInstance.setCreatedByUserInfo( UserInfoSnapshot.from( preheat.getUser() ) );
+            programStageInstance.setCreatedAtClient( DateUtils.fromInstant( event.getCreatedAtClient() ) );
         }
         programStageInstance.setLastUpdatedByUserInfo( UserInfoSnapshot.from( preheat.getUser() ) );
         programStageInstance.setLastUpdated( now );
         programStageInstance.setDeleted( false );
-        programStageInstance.setCreatedAtClient( DateUtils.fromInstant( event.getCreatedAtClient() ) );
         programStageInstance.setLastUpdatedAtClient( DateUtils.fromInstant( event.getUpdatedAtClient() ) );
         programStageInstance.setProgramInstance(
             getProgramInstance( preheat, event.getEnrollment(), program ) );


### PR DESCRIPTION
### Do not merge it. NEEDS APPROVAL FROM RCB.
This PR aims to always provide consistent `lastUpdatedAtClient` and `createdAtClient`.
In particular this affects (in a positive way) the way a user can access data on when a given event was created/updated even when it happened using an Android device.
Before this PR, it could be possible that those information could get lost/overwritten.
Moreover Analytics can now expose a consistent `lastUpdated` and `created` time dimension, representing when a user created/updated a given event, rather than when it was written in the database (which could be different in case of android devices)