### PR TITLE
fix: Set builder default value for fields in Stats

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/Stats.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/Stats.java
@@ -44,15 +44,19 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class Stats
 {
     @JsonProperty
+    @Builder.Default
     private int created = 0;
 
     @JsonProperty
+    @Builder.Default
     private int updated = 0;
 
     @JsonProperty
+    @Builder.Default
     private int deleted = 0;
 
     @JsonProperty
+    @Builder.Default
     private int ignored = 0;
 
     @JsonProperty


### PR DESCRIPTION
We got a warning because of initializing fields while using the lombok Builder annotation at class level.
To solve this, we needed to add the annotation @Builder.Default to make sure lombok initializes the fields with the explicit value.