### PR TITLE
fix: Shortname column in ExpressionDimensionItem [DHIS2-15010] (#13430)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/expressiondimensionitem/hibernate/ExpressionDimensionItem.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/expressiondimensionitem/hibernate/ExpressionDimensionItem.hbm.xml
@@ -18,7 +18,7 @@
 
         <property name="name" column="name" not-null="true" unique="true" length="230" />
 
-        <property name="shortName" type="text"/>
+        <property name="shortName" not-null="true" unique="true" type="text" length="50" />
 
         <property name="formName" type="text" />
 

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.40/V2_40_21__Update_shortname_in_expressiondimensionitem.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.40/V2_40_21__Update_shortname_in_expressiondimensionitem.sql
@@ -1,0 +1,13 @@
+-- DHIS2-15010
+-- Make shortname mandatory/unique for the expressiondimensionitem table.
+
+-- In expressiondimensionitem "name" and "shortname" always hold the same value. This is the current rule on the client app.
+update expressiondimensionitem set shortname = name;
+alter table expressiondimensionitem alter column shortname set not null;
+
+-- Constraints. Delete and create to make them idempotent.
+alter table expressiondimensionitem drop constraint if exists expressiondimensionitem_shortname_key;
+alter table expressiondimensionitem drop constraint if exists expressiondimensionitem_name_key;
+
+alter table expressiondimensionitem add constraint expressiondimensionitem_shortname_key unique (shortname);
+alter table expressiondimensionitem add constraint expressiondimensionitem_name_key unique (name);


### PR DESCRIPTION
**_[Backport from master/2.41]_**

Currently, the property `shortName` is not mandatory. It should be required and unique (for consistency with the `name`, which is already unique).

On top of that, the current behaviour should enforce that `name` and `shortName` are the same.
The `length="50"` was also set because most of `shortName` in the codebase has this length set. The respective database column has the same length.

These changes should address those points.

This table was created in 2.40.0. So, these migration changes should be safe as the table affected will still be empty in production. For Play and local environments, it should work just fine as well.
