### PR TITLE
chore: configure health checks [skip ci]

### DIFF
--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -199,6 +199,9 @@ pipeline {
                 FLYWAY_MIGRATE_OUT_OF_ORDER = "true"
                 FLYWAY_REPAIR_BEFORE_MIGRATION = "true"
                 INSTANCE_TTL = "315360000"
+                STARTUP_PROBE_FAILURE_THRESHOLD = "50"
+                LIVENESS_PROBE_TIMEOUT_SECONDS = "3"
+                READINESS_PROBE_TIMEOUT_SECONDS = "3"
             }
             steps {
                 script {


### PR DESCRIPTION
This PR applies more relaxed health checks than the defaults for im-play/dev for the sake of preventing downtime