### PR TITLE
Revert "fix: Respect sort event's order criteria [DHIS2-13735] [2.38]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventSearchParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventSearchParams.java
@@ -155,9 +155,9 @@ public class EventSearchParams
 
     private boolean includeRelationships;
 
-    private List<OrderParam> orders = Collections.emptyList();
+    private List<OrderParam> orders;
 
-    private List<OrderParam> gridOrders = Collections.emptyList();
+    private List<OrderParam> gridOrders;
 
     private boolean includeAttributes;
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -1583,17 +1583,34 @@ public class JdbcEventStore implements EventStore
     {
         ArrayList<String> orderFields = new ArrayList<>();
 
-        for ( OrderParam order : params.getOrders() )
+        if ( params.getGridOrders() != null )
         {
-            if ( QUERY_PARAM_COL_MAP.containsKey( order.getField() ) )
+            for ( OrderParam order : params.getGridOrders() )
             {
-                String orderText = QUERY_PARAM_COL_MAP.get( order.getField() );
-                orderText += " " + (order.getDirection().isAscending() ? "asc" : "desc");
-                orderFields.add( orderText );
+
+                Set<QueryItem> items = params.getDataElements();
+
+                for ( QueryItem item : items )
+                {
+                    if ( order.getField().equals( item.getItemId() ) )
+                    {
+                        orderFields.add( order.getField() + " " + order.getDirection() );
+                        break;
+                    }
+                }
             }
-            else if ( params.getGridOrders().contains( order ) )
+        }
+
+        if ( params.getOrders() != null )
+        {
+            for ( OrderParam order : params.getOrders() )
             {
-                orderFields.add( getDataElementsOrder( params.getDataElements(), order ) );
+                if ( QUERY_PARAM_COL_MAP.containsKey( order.getField() ) )
+                {
+                    String orderText = QUERY_PARAM_COL_MAP.get( order.getField() );
+                    orderText += " " + (order.getDirection().isAscending() ? "asc" : "desc");
+                    orderFields.add( orderText );
+                }
             }
         }
 
@@ -1605,19 +1622,6 @@ public class JdbcEventStore implements EventStore
         {
             return "order by psi_lastupdated desc ";
         }
-    }
-
-    private String getDataElementsOrder( Set<QueryItem> dataElements, OrderParam order )
-    {
-        for ( QueryItem item : dataElements )
-        {
-            if ( order.getField().equals( item.getItemId() ) )
-            {
-                return order.getField() + " " + order.getDirection();
-            }
-        }
-
-        return "";
     }
 
     private String getAttributeValueQuery()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -44,23 +44,19 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.IdSchemes;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.Pager;
-import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.SlimPager;
-import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dxf2.events.event.Event;
 import org.hisp.dhis.dxf2.events.event.EventSearchParams;
 import org.hisp.dhis.dxf2.events.event.EventService;
 import org.hisp.dhis.dxf2.events.event.Events;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 import org.junit.jupiter.api.Test;
@@ -426,55 +422,5 @@ class EventExporterTest extends TrackerTest
             () -> assertEquals( pageNumber, pager.getPage(), "number of current page" ),
             () -> assertEquals( pageSize, pager.getPageSize(), "page size" ),
             () -> assertEquals( totalCount, pager.getTotal(), "total page count" ) );
-    }
-
-    @Test
-    void shouldSortEntitiesRespectingOrderWhenOrderParamSuppliedBeforeDataElement()
-    {
-        EventSearchParams params = new EventSearchParams();
-        params.setOrgUnit( orgUnit );
-        params.addDataElements( List.of( queryItem( "DATAEL00001" ) ) );
-
-        params.setGridOrders(
-            List.of( OrderParam.builder().field( "DATAEL00001" ).direction( OrderParam.SortDirection.ASC ).build() ) );
-        params.setOrders(
-            List.of( OrderParam.builder().field( "orgUnitName" ).direction( OrderParam.SortDirection.DESC ).build(),
-                OrderParam.builder().field( "DATAEL00001" ).direction( OrderParam.SortDirection.ASC ).build() ) );
-
-        List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()
-            .map( Event::getTrackedEntityInstance )
-            .collect( Collectors.toList() );
-
-        assertEquals( List.of( "QS6w44flWAf", "dUE514NMOlo" ), trackedEntities );
-    }
-
-    @Test
-    void shouldSortEntitiesRespectingOrderWhenDataElementSuppliedBeforeOrderParam()
-    {
-        EventSearchParams params = new EventSearchParams();
-        params.setOrgUnit( orgUnit );
-        params.addDataElements( List.of( queryItem( "DATAEL00002" ) ) );
-
-        params.setGridOrders(
-            List.of( OrderParam.builder().field( "DATAEL00002" ).direction( OrderParam.SortDirection.ASC ).build() ) );
-        params.setOrders(
-            List.of( OrderParam.builder().field( "DATAEL00002" ).direction( OrderParam.SortDirection.DESC ).build(),
-                OrderParam.builder().field( "storedBy" ).direction( OrderParam.SortDirection.ASC ).build() ) );
-
-        List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()
-            .map( Event::getTrackedEntityInstance )
-            .collect( Collectors.toList() );
-
-        assertEquals( List.of( "dUE514NMOlo", "QS6w44flWAf" ), trackedEntities );
-    }
-
-    private static QueryItem queryItem( String teaUid )
-    {
-        TrackedEntityAttribute at = new TrackedEntityAttribute();
-        at.setUid( teaUid );
-        at.setValueType( ValueType.TEXT );
-        at.setAggregationType( AggregationType.NONE );
-        return new QueryItem( at, null, at.getValueType(), at.getAggregationType(), at.getOptionSet(),
-            at.isUnique() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_and_enrollment.json
@@ -113,7 +113,7 @@
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
-      "storedBy": "tracker",
+      "storedBy": "admin",
       "followup": false,
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
@@ -129,10 +129,6 @@
           "createdAt": "2021-07-01T12:05:00",
           "updatedAt": "2022-07-01T12:05:00",
           "providedElsewhere": false
-        },
-        {
-          "dataElement": "DATAEL00002",
-          "value": "value00002"
         },
         {
           "dataElement": "DATAEL00005",


### PR DESCRIPTION
This reverts commit d04e813f9b8b988c09c8893e130e24c3440fb894.

2.39+ handles the logic to sort events based on the order parameters in a different way than older versions. Since fixing it will require more time to analyze how is it handled in 2.38 and backwards and no one seems to be using it, we won't fix it for now.