### PR TITLE
fix: Sort when no sortable attributes found [DHIS2-15020]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -1298,10 +1298,10 @@ public class HibernateTrackedEntityInstanceStore
      */
     private String getQueryOrderBy( boolean innerOrder, TrackedEntityInstanceQueryParams params, boolean isGridQuery )
     {
-        Set<QueryItem> sortableAttributesAndFilters = sortableAttributesAndFilters( params );
-        if ( !isGridQuery || !sortableAttributesAndFilters.isEmpty() )
+        if ( !isGridQuery || !params.getAttributes().isEmpty() )
         {
             List<String> orderFields = new ArrayList<>();
+            Set<QueryItem> sortableAttributesAndFilters = sortableAttributesAndFilters( params );
 
             for ( OrderParam order : params.getOrders() )
             {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceServiceTest.java
@@ -619,6 +619,79 @@ class TrackedEntityInstanceServiceTest
         assertEquals( 0, trackedEntitiesCounter );
     }
 
+    @Test
+    void shouldSortGridByTrackedEntityInstanceIdAscendingWhenParamCreatedAscendingProvided()
+    {
+        injectSecurityContext( superUser );
+        trackedEntityAttribute.setDisplayInListNoProgram( true );
+        attributeService.addTrackedEntityAttribute( trackedEntityAttribute );
+
+        User user = createAndAddUser( false, "attributeFilterUser", Set.of( organisationUnit ),
+            Set.of( organisationUnit ) );
+        injectSecurityContext( user );
+
+        initializeEntityInstance( entityInstanceA1 );
+        initializeEntityInstance( entityInstanceB1 );
+
+        TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
+        params.setOrganisationUnits( Set.of( organisationUnit ) );
+        params.setTrackedEntityType( trackedEntityType );
+        params.setOrders( List.of( new OrderParam( "created", SortDirection.ASC ) ) );
+        params.setQuery( new QueryFilter( QueryOperator.LIKE, ATTRIBUTE_VALUE ) );
+
+        Grid grid = entityInstanceService.getTrackedEntityInstancesGrid( params );
+
+        assertEquals( 2, grid.getRows().size(),
+            "Expected to find 2 rows in the grid, but found " + grid.getRows().size() + " instead" );
+        assertEquals( "UID-A1", grid.getRows().get( 0 ).get( 0 ) );
+        assertEquals( "UID-B1", grid.getRows().get( 1 ).get( 0 ) );
+    }
+
+    @Test
+    void shouldSortGridByTrackedEntityInstanceIdDescendingWhenParamCreatedDescendingProvided()
+    {
+        injectSecurityContext( superUser );
+        trackedEntityAttribute.setDisplayInListNoProgram( true );
+        attributeService.addTrackedEntityAttribute( trackedEntityAttribute );
+
+        User user = createAndAddUser( false, "attributeFilterUser", Set.of( organisationUnit ),
+            Set.of( organisationUnit ) );
+        injectSecurityContext( user );
+
+        initializeEntityInstance( entityInstanceA1 );
+        initializeEntityInstance( entityInstanceB1 );
+
+        TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
+        params.setOrganisationUnits( Set.of( organisationUnit ) );
+        params.setTrackedEntityType( trackedEntityType );
+        params.setOrders( List.of( new OrderParam( "created", SortDirection.DESC ) ) );
+        params.setQuery( new QueryFilter( QueryOperator.LIKE, ATTRIBUTE_VALUE ) );
+
+        Grid grid = entityInstanceService.getTrackedEntityInstancesGrid( params );
+
+        assertEquals( 2, grid.getRows().size(),
+            "Expected to find 2 rows in the grid, but found " + grid.getRows().size() + " instead" );
+        assertEquals( "UID-B1", grid.getRows().get( 0 ).get( 0 ) );
+        assertEquals( "UID-A1", grid.getRows().get( 1 ).get( 0 ) );
+    }
+
+    private void initializeEntityInstance( TrackedEntityInstance entityInstance )
+    {
+        entityInstance.setTrackedEntityType( trackedEntityType );
+        entityInstanceService.addTrackedEntityInstance( entityInstance );
+        attributeValueService.addTrackedEntityAttributeValue( createTrackedEntityAttributeValue( entityInstance ) );
+    }
+
+    private TrackedEntityAttributeValue createTrackedEntityAttributeValue( TrackedEntityInstance trackedEntityInstance )
+    {
+        TrackedEntityAttributeValue trackedEntityAttributeValue = new TrackedEntityAttributeValue();
+        trackedEntityAttributeValue.setAttribute( trackedEntityAttribute );
+        trackedEntityAttributeValue.setEntityInstance( trackedEntityInstance );
+        trackedEntityAttributeValue.setValue( ATTRIBUTE_VALUE );
+
+        return trackedEntityAttributeValue;
+    }
+
     private void addEnrollment( TrackedEntityInstance entityInstance, Date enrollmentDate, char programStage )
     {
         ProgramStage stage = createProgramStage( programStage, program );


### PR DESCRIPTION
In case of a grid query we didn't sort the tracked entity instances correctly when the order parameter requested was not in the attributes list. 
With this fix we let the user sort by the default values set in `OrderColumn` too. 

Ticket: https://dhis2.atlassian.net/browse/DHIS2-15020