### PR TITLE
perf: prune periods with database statement [DHIS2-14996]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/maintenance/MaintenanceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/maintenance/MaintenanceService.java
@@ -88,7 +88,7 @@ public interface MaintenanceService
     int deleteSoftDeletedTrackedEntityInstances();
 
     /**
-     * Deletes periods which do not have data values associated with them.
+     * Deletes periods which are not associated with any other table.
      */
     void prunePeriods();
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/maintenance/MaintenanceStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/maintenance/MaintenanceStore.java
@@ -82,7 +82,7 @@ public interface MaintenanceStore
     int deleteSoftDeletedTrackedEntityInstances();
 
     /**
-     * Deletes periods which do not have data values associated with them.
+     * Deletes periods which are not associated with any other table.
      */
     void prunePeriods();
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/maintenance/MaintenanceStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/maintenance/MaintenanceStore.java
@@ -80,4 +80,9 @@ public interface MaintenanceStore
      * @return the number of deleted tracked entity instances
      */
     int deleteSoftDeletedTrackedEntityInstances();
+
+    /**
+     * Deletes periods which do not have data values associated with them.
+     */
+    void prunePeriods();
 }

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/maintenance/DefaultMaintenanceService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/maintenance/DefaultMaintenanceService.java
@@ -43,7 +43,6 @@ import org.hisp.dhis.dataset.CompleteDataSetRegistrationService;
 import org.hisp.dhis.datavalue.DataValueAuditService;
 import org.hisp.dhis.datavalue.DataValueService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueAuditService;
 import org.hisp.dhis.user.CurrentUserService;
@@ -155,23 +154,10 @@ public class DefaultMaintenanceService
     }
 
     @Override
+    @Transactional
     public void prunePeriods()
     {
-        for ( Period period : periodService.getAllPeriods() )
-        {
-            long periodId = period.getId();
-
-            try
-            {
-                periodService.deletePeriod( period );
-
-                log.info( "Deleted period with id: " + periodId );
-            }
-            catch ( DeleteNotAllowedException ex )
-            {
-                log.debug( "Period has associated objects and could not be deleted: " + periodId );
-            }
-        }
+        maintenanceStore.prunePeriods();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/maintenance/jdbc/JdbcMaintenanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/maintenance/jdbc/JdbcMaintenanceStore.java
@@ -315,23 +315,22 @@ public class JdbcMaintenanceStore implements MaintenanceStore
     public void prunePeriods()
     {
         String sql = "with period_ids(periodid) as ("
-            + "  select distinct periodid from completedatasetregistration"
-            + "  union select distinct periodid from dataapproval"
-            + "  union select distinct periodid from dataapprovalaudit"
-            + "  union select distinct periodid from datainputperiod"
-            + "  union select distinct periodid from datainputperiod"
-            + "  union select distinct periodid from datavalue"
-            + "  union select distinct periodid from datavalueaudit"
-            + "  union select distinct periodid from eventchart_periods"
-            + "  union select distinct periodid from eventreport_periods"
-            + "  union select distinct periodid from eventvisualization_periods"
-            + "  union select distinct periodid from interpretation"
-            + "  union select distinct periodid from lockexception"
-            + "  union select distinct periodid from mapview_periods"
-            + "  union select distinct periodid from validationresult"
-            + "  union select distinct periodid from visualization_periods)"
+            + "    select distinct periodid from completedatasetregistration"
+            + "    union select distinct periodid from dataapproval"
+            + "    union select distinct periodid from dataapprovalaudit"
+            + "    union select distinct periodid from datainputperiod"
+            + "    union select distinct periodid from datavalue"
+            + "    union select distinct periodid from datavalueaudit"
+            + "    union select distinct periodid from eventchart_periods"
+            + "    union select distinct periodid from eventreport_periods"
+            + "    union select distinct periodid from eventvisualization_periods"
+            + "    union select distinct periodid from interpretation where periodid is not null"
+            + "    union select distinct periodid from lockexception where periodid is not null"
+            + "    union select distinct periodid from mapview_periods"
+            + "    union select distinct periodid from validationresult where periodid is not null"
+            + "    union select distinct periodid from visualization_periods)"
             + "delete from period where periodid not in ("
-            + "  select periodid from period_ids);";
+            + "    select periodid from period_ids)";
         jdbcTemplate.batchUpdate( sql );
     }
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/maintenance/jdbc/JdbcMaintenanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/maintenance/jdbc/JdbcMaintenanceStore.java
@@ -304,26 +304,33 @@ public class JdbcMaintenanceStore implements MaintenanceStore
         return result;
     }
 
+    /**
+     * This SQL needs to consider any other table that has a foreign key
+     * reference to the period table. Following the DHIS2 convention this should
+     * mean they have a column named {@code periodid}. When such tables are
+     * dropped they need to be removed from the union here. When such new tables
+     * are added they need to be added to the union here.
+     */
     @Override
     public void prunePeriods()
     {
-        String sql = "with period_ids(periodid) as (\n"
-            + "  select distinct periodid from completedatasetregistration\n"
-            + "  union select distinct periodid from dataapproval\n"
-            + "  union select distinct periodid from dataapprovalaudit\n"
-            + "  union select distinct periodid from datainputperiod\n"
-            + "  union select distinct periodid from datainputperiod\n"
-            + "  union select distinct periodid from datavalue\n"
-            + "  union select distinct periodid from datavalueaudit\n"
-            + "  union select distinct periodid from eventchart_periods\n"
-            + "  union select distinct periodid from eventreport_periods\n"
-            + "  union select distinct periodid from eventvisualization_periods\n"
-            + "  union select distinct periodid from interpretation\n"
-            + "  union select distinct periodid from lockexception\n"
-            + "  union select distinct periodid from mapview_periods\n"
-            + "  union select distinct periodid from validationresult\n"
-            + "  union select distinct periodid from visualization_periods)\n"
-            + "delete from period where periodid not in (\n"
+        String sql = "with period_ids(periodid) as ("
+            + "  select distinct periodid from completedatasetregistration"
+            + "  union select distinct periodid from dataapproval"
+            + "  union select distinct periodid from dataapprovalaudit"
+            + "  union select distinct periodid from datainputperiod"
+            + "  union select distinct periodid from datainputperiod"
+            + "  union select distinct periodid from datavalue"
+            + "  union select distinct periodid from datavalueaudit"
+            + "  union select distinct periodid from eventchart_periods"
+            + "  union select distinct periodid from eventreport_periods"
+            + "  union select distinct periodid from eventvisualization_periods"
+            + "  union select distinct periodid from interpretation"
+            + "  union select distinct periodid from lockexception"
+            + "  union select distinct periodid from mapview_periods"
+            + "  union select distinct periodid from validationresult"
+            + "  union select distinct periodid from visualization_periods)"
+            + "delete from period where periodid not in ("
             + "  select periodid from period_ids);";
         jdbcTemplate.batchUpdate( sql );
     }

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/maintenance/jdbc/JdbcMaintenanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/maintenance/jdbc/JdbcMaintenanceStore.java
@@ -304,6 +304,30 @@ public class JdbcMaintenanceStore implements MaintenanceStore
         return result;
     }
 
+    @Override
+    public void prunePeriods()
+    {
+        String sql = "with period_ids(periodid) as (\n"
+            + "  select distinct periodid from completedatasetregistration\n"
+            + "  union select distinct periodid from dataapproval\n"
+            + "  union select distinct periodid from dataapprovalaudit\n"
+            + "  union select distinct periodid from datainputperiod\n"
+            + "  union select distinct periodid from datainputperiod\n"
+            + "  union select distinct periodid from datavalue\n"
+            + "  union select distinct periodid from datavalueaudit\n"
+            + "  union select distinct periodid from eventchart_periods\n"
+            + "  union select distinct periodid from eventreport_periods\n"
+            + "  union select distinct periodid from eventvisualization_periods\n"
+            + "  union select distinct periodid from interpretation\n"
+            + "  union select distinct periodid from lockexception\n"
+            + "  union select distinct periodid from mapview_periods\n"
+            + "  union select distinct periodid from validationresult\n"
+            + "  union select distinct periodid from visualization_periods)\n"
+            + "delete from period where periodid not in (\n"
+            + "  select periodid from period_ids);";
+        jdbcTemplate.batchUpdate( sql );
+    }
+
     private List<String> getDeletionEntities( String entitySql )
     {
         /*


### PR DESCRIPTION
Prunes unused periods using SQL instead of a code loop for performance reasons.

### Manual Testing
* count periods in database (`select count(*) from period;`)
* run the prune: `POST /api/maintenance/periodPruning`
* count periods again - in demo database this should remove some so count is now less

If no periods have been removed insert a period into the table before running the test (for demo DB this works): 
```sql
insert into period (periodid, periodtypeid, startdate, enddate) 
  values (4444, 11, '2029-01-01', '2029-12-31');
```