### PR TITLE
fix: remove TEA from protected tables for SQL views [DHIS2-12941] (2.40.0)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sqlview/SqlView.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sqlview/SqlView.java
@@ -56,7 +56,7 @@ public class SqlView
     public static final String PREFIX_VIEWNAME = "_view";
 
     public static final Set<String> PROTECTED_TABLES = Set.of(
-        "users", "userinfo", "trackedentityattribute", "trackedentityattributevalue",
+        "users", "userinfo", "trackedentityattributevalue",
         "oauth_access_token", "oauth2client" );
 
     public static final Set<String> ILLEGAL_KEYWORDS = Set.of(


### PR DESCRIPTION
cherry-pick backport of #13479

# OBS! Not authorized yet!