### PR TITLE
fix: remove TEA from protected tables for SQL views [DHIS2-12941] (2.39)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sqlview/SqlView.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sqlview/SqlView.java
@@ -57,7 +57,7 @@ public class SqlView
     public static final String PREFIX_VIEWNAME = "_view";
 
     public static final Set<String> PROTECTED_TABLES = ImmutableSet.<String> builder().add(
-        "users", "userinfo", "trackedentityattribute", "trackedentityattributevalue", "oauth_access_token",
+        "users", "userinfo", "trackedentityattributevalue", "oauth_access_token",
         "oauth2client" ).build();
 
     public static final Set<String> ILLEGAL_KEYWORDS = ImmutableSet.<String> builder().add(


### PR DESCRIPTION
reapplied patch #13479 in manually. 