### PR TITLE
feat: use add authority for data value and min/max deletion [DHIS2-13776]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/DefaultAdminUserPopulator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/DefaultAdminUserPopulator.java
@@ -90,7 +90,6 @@ public class DefaultAdminUserPopulator
         "F_ORG_UNIT_PROFILE_ADD",
         "F_TRACKED_ENTITY_MERGE",
         "F_DATAVALUE_ADD",
-        "F_DATAVALUE_DELETE",
         "F_IMPERSONATE_USER" );
 
     public static final Set<String> ALL_RESTRICTIONS = Set.of( TWO_FACTOR_AUTH_REQUIRED_RESTRICTION_NAME );

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/MinMaxDataElementSchemaDescriptor.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/MinMaxDataElementSchemaDescriptor.java
@@ -53,7 +53,7 @@ public class MinMaxDataElementSchemaDescriptor implements SchemaDescriptor
         schema.setRelativeApiEndpoint( API_ENDPOINT );
 
         schema.add( new Authority( AuthorityType.CREATE, Lists.newArrayList( "F_MINMAX_DATAELEMENT_ADD" ) ) );
-        schema.add( new Authority( AuthorityType.DELETE, Lists.newArrayList( "F_MINMAX_DATAELEMENT_DELETE" ) ) );
+        schema.add( new Authority( AuthorityType.DELETE, Lists.newArrayList( "F_MINMAX_DATAELEMENT_ADD" ) ) );
 
         return schema;
     }

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_1__Merge_add_delete_authorities.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_1__Merge_add_delete_authorities.sql
@@ -1,0 +1,2 @@
+delete from userroleauthorities where authority = 'F_DATAVALUE_DELETE';
+delete from userroleauthorities where authority = 'F_MINMAX_DATAELEMENT_DELETE';

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxDataElementController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxDataElementController.java
@@ -161,7 +161,7 @@ public class MinMaxDataElementController
     // --------------------------------------------------------------------------
 
     @DeleteMapping( consumes = APPLICATION_JSON_VALUE )
-    @PreAuthorize( "hasRole('ALL') or hasRole('F_MINMAX_DATAELEMENT_DELETE')" )
+    @PreAuthorize( "hasRole('ALL') or hasRole('F_MINMAX_DATAELEMENT_ADD')" )
     @ResponseBody
     public WebMessage deleteObject( HttpServletRequest request )
         throws Exception

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/MinMaxValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/MinMaxValueController.java
@@ -71,7 +71,7 @@ public class MinMaxValueController
         saveOrUpdateMinMaxDataElement( valueDto );
     }
 
-    @PreAuthorize( "hasRole('ALL') or hasRole('F_MINMAX_DATAELEMENT_DELETE')" )
+    @PreAuthorize( "hasRole('ALL') or hasRole('F_MINMAX_DATAELEMENT_ADD')" )
     @DeleteMapping( "/minMaxValues" )
     @ResponseStatus( value = HttpStatus.NO_CONTENT )
     public void removeMinMaxValue( MinMaxValueQueryParams params )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
@@ -441,7 +441,7 @@ public class DataValueController
     // DELETE
     // ---------------------------------------------------------------------
 
-    @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_DELETE')" )
+    @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_ADD')" )
     @DeleteMapping
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteDataValue(


### PR DESCRIPTION
Delete authorities are replaced with the corresponding add authority.
Deletion authorities just get removed from roles as it is assumed that any role with deletion also already has add. 