### PR TITLE
feat: ignore nested payloads on old patch endpoints (#13447)

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
@@ -115,6 +115,21 @@ class AbstractCrudControllerTest extends DhisControllerConvenienceTest
     }
 
     @Test
+    void testPartialUpdateObjectWithOldPatch()
+    {
+        assertStatus( HttpStatus.NO_CONTENT, PATCH_OLD( "/users/" + "M5zQapPyTZI",
+            "{'surname': 'Peter'}" ) );
+        assertEquals( "Peter", GET( "/users/{id}", "M5zQapPyTZI" ).content().as( JsonUser.class ).getSurname() );
+    }
+
+    @Test
+    void testPartialUpdateObjectNestedObjects()
+    {
+        assertStatus( HttpStatus.BAD_REQUEST, PATCH_OLD( "/users/" + "M5zQapPyTZI",
+            "{'user': {'surname' : 'Peter'}}" ) );
+    }
+
+    @Test
     void testPatchRemoveById()
     {
         String ou1 = assertStatus( HttpStatus.CREATED,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -114,6 +114,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -1259,6 +1260,15 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         {
             throw new BadRequestException( "Unknown payload format." );
         }
-        return patchService.diff( new PatchParams( mapper.readTree( request.getInputStream() ) ) );
+        JsonNode jsonNode = mapper.readTree( request.getInputStream() );
+        for ( JsonNode node : jsonNode )
+        {
+            if ( node.isContainerNode() )
+            {
+                throw new BadRequestException( "Payload can not contain objects or arrays." );
+            }
+        }
+
+        return patchService.diff( new PatchParams( jsonNode ) );
     }
 }


### PR DESCRIPTION
(cherry picked from commit 7cd3f338c4f56b2e5e20adaa2ac81e895f6f63e6)