### PR TITLE
feat: reverse lookup for file resource by storage key [DHIS2-4308]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueKey.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueKey.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.datavalue;
+
+import lombok.Value;
+import lombok.experimental.Accessors;
+
+/**
+ * Data record for a usual data value key (with no attribute option combo).
+ *
+ * @author Jan Bernitt
+ */
+@Value
+@Accessors( fluent = true )
+public class DataValueKey
+{
+    String de;
+
+    String ou;
+
+    long pe;
+
+    String co;
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceOwner.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceOwner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2023, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,53 +27,53 @@
  */
 package org.hisp.dhis.fileresource;
 
-import java.util.List;
-import java.util.Optional;
-
-import javax.annotation.Nonnull;
-
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Value;
-import lombok.experimental.Accessors;
 
-import org.hisp.dhis.common.IdentifiableObjectStore;
-import org.joda.time.DateTime;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-public interface FileResourceStore extends IdentifiableObjectStore<FileResource>
+/**
+ * Backwards reference from a storage key to the object that is associated with
+ * the {@link FileResource}.
+ *
+ * A {@link FileResourceDomain#DATA_VALUE} uses the 4 data value keys
+ * {@link #de}, {@link #ou}, {@link #pe} and {@link #co}, all other types use
+ * only the {@link #id}.
+ *
+ * @author Jan Bernitt
+ */
+@Value
+@AllArgsConstructor( access = AccessLevel.PRIVATE )
+public class FileResourceOwner
 {
-    List<FileResource> getExpiredFileResources( DateTime expires );
+    @JsonProperty
+    FileResourceDomain domain;
 
-    List<FileResource> getAllUnProcessedImages();
+    // for data values
+    @JsonProperty
+    String de;
 
-    Optional<FileResource> findByStorageKey( @Nonnull String storageKey );
+    @JsonProperty
+    String ou;
 
-    /**
-     * Returns the organisation unit UID(s) with an image that links to the
-     * {@link FileResource} with the provided uid.
-     *
-     * @param uid of the file resource UID for the organisation unit image
-     * @return usually none or exactly one but in theory it could be multiple
-     *         linked to the same file resource
-     */
-    List<String> findOrganisationUnitsByImageFileResource( @Nonnull String uid );
+    @JsonProperty
+    String pe;
 
-    List<String> findUsersByAvatarFileResource( @Nonnull String uid );
+    @JsonProperty
+    String co;
 
-    List<String> findDocumentsByFileResource( @Nonnull String uid );
+    // for any other domain
+    @JsonProperty
+    String id;
 
-    List<String> findMessagesByFileResource( @Nonnull String uid );
-
-    @Value
-    @Accessors( fluent = true )
-    class DataValueKey
+    public FileResourceOwner( FileResourceDomain domain, String id )
     {
-        String de;
-
-        String ou;
-
-        long pe;
-
-        String co;
+        this( domain, null, null, null, null, id );
     }
 
-    List<DataValueKey> findDataValuesByFileResourceValue( @Nonnull String uid );
+    public FileResourceOwner( String de, String ou, String pe, String co )
+    {
+        this( FileResourceDomain.DATA_VALUE, de, ou, pe, co, null );
+    }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
@@ -50,8 +50,25 @@ public interface FileResourceService
 
     List<FileResource> getOrphanedFileResources();
 
+    /**
+     * Lookup a {@link FileResource} by storage key property.
+     *
+     * @param storageKey key to look up
+     * @return the {@link FileResource} associated with the given storage key
+     */
     Optional<FileResource> findByStorageKey( @CheckForNull String storageKey );
 
+    /**
+     * Reverse lookup the objects associated with a {@link FileResource} by the
+     * storage key property.
+     *
+     * @param storageKey key to look up
+     * @return list of objects that are associated with the {@link FileResource}
+     *         of the given storage key. This is either none, most often one,
+     *         but in theory can also be more than one. For example when the
+     *         same data value would be associated with the same file resource
+     *         value.
+     */
     List<FileResourceOwner> findOwnersByStorageKey( @CheckForNull String storageKey );
 
     void saveFileResource( FileResource fileResource, File file );

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
@@ -34,7 +34,9 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 /**
@@ -48,6 +50,10 @@ public interface FileResourceService
 
     List<FileResource> getOrphanedFileResources();
 
+    Optional<FileResource> findByStorageKey( @CheckForNull String storageKey );
+
+    List<FileResourceOwner> findOwnersByStorageKey( @CheckForNull String storageKey );
+
     void saveFileResource( FileResource fileResource, File file );
 
     String saveFileResource( FileResource fileResource, byte[] bytes );
@@ -60,12 +66,6 @@ public interface FileResourceService
 
     /**
      * Copy fileResource content to outputStream and Return File content length
-     *
-     * @param fileResource
-     * @param outputStream
-     * @return
-     * @throws IOException
-     * @throws NoSuchElementException
      */
     void copyFileResourceContent( FileResource fileResource, OutputStream outputStream )
         throws IOException,
@@ -73,11 +73,6 @@ public interface FileResourceService
 
     /**
      * Copy fileResource content to a byte array
-     *
-     * @param fileResource
-     * @return a byte array of the content
-     * @throws IOException
-     * @throws NoSuchElementException
      */
     byte[] copyFileResourceContent( FileResource fileResource )
         throws IOException,

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceStore.java
@@ -32,10 +32,8 @@ import java.util.Optional;
 
 import javax.annotation.Nonnull;
 
-import lombok.Value;
-import lombok.experimental.Accessors;
-
 import org.hisp.dhis.common.IdentifiableObjectStore;
+import org.hisp.dhis.datavalue.DataValueKey;
 import org.joda.time.DateTime;
 
 public interface FileResourceStore extends IdentifiableObjectStore<FileResource>
@@ -44,6 +42,11 @@ public interface FileResourceStore extends IdentifiableObjectStore<FileResource>
 
     List<FileResource> getAllUnProcessedImages();
 
+    /**
+     * @param storageKey key to look up
+     * @return the file resource with the given storage key or nothing if no
+     *         such file resource exists
+     */
     Optional<FileResource> findByStorageKey( @Nonnull String storageKey );
 
     /**
@@ -56,24 +59,39 @@ public interface FileResourceStore extends IdentifiableObjectStore<FileResource>
      */
     List<String> findOrganisationUnitsByImageFileResource( @Nonnull String uid );
 
+    /**
+     * Lookup of user ID(s) for avatar image file resource id.
+     *
+     * @param uid of a file resource
+     * @return UID(s) of users that have an avatar image with the given file
+     *         resource uid
+     */
     List<String> findUsersByAvatarFileResource( @Nonnull String uid );
 
+    /**
+     * Lookup of document ID(s) for a document file resource id.
+     *
+     * @param uid of a file resource
+     * @return UID(s) of documents that have a file resource with the given uid
+     */
     List<String> findDocumentsByFileResource( @Nonnull String uid );
 
+    /**
+     * Lookup of message ID(s) for a message attachment file resource id.
+     *
+     * @param uid of a file resource
+     * @return UID(s) of messages that have an attachment with the given file
+     *         resource uid
+     */
     List<String> findMessagesByFileResource( @Nonnull String uid );
 
-    @Value
-    @Accessors( fluent = true )
-    class DataValueKey
-    {
-        String de;
-
-        String ou;
-
-        long pe;
-
-        String co;
-    }
-
+    /**
+     * Lookup of data value(s) key combinations with a given file resource
+     * value.
+     *
+     * @param uid of a file resource
+     * @return data value(s) key combinations that have the given file resource
+     *         as value.
+     */
     List<DataValueKey> findDataValuesByFileResourceValue( @Nonnull String uid );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/DefaultFileResourceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/DefaultFileResourceService.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.fileresource;
 
+import static java.util.stream.Collectors.toUnmodifiableList;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -35,9 +37,11 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 import lombok.RequiredArgsConstructor;
@@ -49,6 +53,7 @@ import org.hisp.dhis.fileresource.events.BinaryFileSavedEvent;
 import org.hisp.dhis.fileresource.events.FileDeletedEvent;
 import org.hisp.dhis.fileresource.events.FileSavedEvent;
 import org.hisp.dhis.fileresource.events.ImageFileSavedEvent;
+import org.hisp.dhis.period.PeriodService;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.Hours;
@@ -73,6 +78,8 @@ public class DefaultFileResourceService
     // -------------------------------------------------------------------------
 
     private final FileResourceStore fileResourceStore;
+
+    private final PeriodService periodService;
 
     private final SessionFactory sessionFactory;
 
@@ -109,6 +116,51 @@ public class DefaultFileResourceService
         return fileResourceStore.getAllLeCreated( new DateTime().minus( IS_ORPHAN_TIME_DELTA ).toDate() ).stream()
             .filter( IS_ORPHAN_PREDICATE )
             .collect( Collectors.toList() );
+    }
+
+    @Override
+    @Transactional( readOnly = true )
+    public Optional<FileResource> findByStorageKey( @CheckForNull String storageKey )
+    {
+        return storageKey == null ? Optional.empty() : fileResourceStore.findByStorageKey( storageKey );
+    }
+
+    @Override
+    @Transactional( readOnly = true )
+    public List<FileResourceOwner> findOwnersByStorageKey( @CheckForNull String storageKey )
+    {
+        Optional<FileResource> maybeFr = findByStorageKey( storageKey );
+        if ( maybeFr.isEmpty() )
+            return List.of();
+        FileResource fr = maybeFr.get();
+        String uid = fr.getUid();
+        switch ( fr.getDomain() )
+        {
+        case PUSH_ANALYSIS:
+            return List.of();
+        case ORG_UNIT:
+            return fileResourceStore.findOrganisationUnitsByImageFileResource( uid ).stream()
+                .map( id -> new FileResourceOwner( FileResourceDomain.ORG_UNIT, id ) )
+                .collect( toUnmodifiableList() );
+        case DOCUMENT:
+            return fileResourceStore.findDocumentsByFileResource( uid ).stream()
+                .map( id -> new FileResourceOwner( FileResourceDomain.DOCUMENT, id ) )
+                .collect( toUnmodifiableList() );
+        case MESSAGE_ATTACHMENT:
+            return fileResourceStore.findMessagesByFileResource( uid ).stream()
+                .map( id -> new FileResourceOwner( FileResourceDomain.MESSAGE_ATTACHMENT, id ) )
+                .collect( toUnmodifiableList() );
+        case USER_AVATAR:
+            return fileResourceStore.findUsersByAvatarFileResource( uid ).stream()
+                .map( id -> new FileResourceOwner( FileResourceDomain.USER_AVATAR, id ) )
+                .collect( toUnmodifiableList() );
+        case DATA_VALUE:
+            return fileResourceStore.findDataValuesByFileResourceValue( uid ).stream()
+                .map( dv -> new FileResourceOwner( dv.de(), dv.ou(), periodService.getPeriod( dv.pe() ).getIsoDate(),
+                    dv.co() ) )
+                .collect( toUnmodifiableList() );
+        }
+        return List.of();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/hibernate/HibernateFileResourceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/hibernate/HibernateFileResourceStore.java
@@ -37,6 +37,7 @@ import javax.annotation.Nonnull;
 
 import org.hibernate.SessionFactory;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
+import org.hisp.dhis.datavalue.DataValueKey;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.fileresource.FileResourceDomain;
 import org.hisp.dhis.fileresource.FileResourceStore;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/hibernate/HibernateFileResourceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/hibernate/HibernateFileResourceStore.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 
@@ -106,21 +107,21 @@ public class HibernateFileResourceStore
     public List<String> findOrganisationUnitsByImageFileResource( @Nonnull String uid )
     {
         String sql = "select o.uid from organisationunit o left join fileresource fr on fr.fileresourceid = o.image where fr.uid = :uid";
-        return getSession().createNativeQuery( sql, String.class ).setParameter( "uid", uid ).list();
+        return getSession().createNativeQuery( sql ).setParameter( "uid", uid ).list();
     }
 
     @Override
     public List<String> findUsersByAvatarFileResource( @Nonnull String uid )
     {
         String sql = "select u.uid from userinfo u left join fileresource fr on fr.fileresourceid = u.avatar where fr.uid = :uid";
-        return getSession().createNativeQuery( sql, String.class ).setParameter( "uid", uid ).list();
+        return getSession().createNativeQuery( sql ).setParameter( "uid", uid ).list();
     }
 
     @Override
     public List<String> findDocumentsByFileResource( @Nonnull String uid )
     {
         String sql = "select d.uid from document d left join fileresource fr on fr.fileresourceid = d.fileresource where fr.uid = :uid";
-        return getSession().createNativeQuery( sql, String.class ).setParameter( "uid", uid ).list();
+        return getSession().createNativeQuery( sql ).setParameter( "uid", uid ).list();
     }
 
     @Override
@@ -129,19 +130,21 @@ public class HibernateFileResourceStore
         String sql = "select m.uid from message m "
             + "left join messageattachments ma on m.messageid = ma.messageid "
             + "left join fileresource fr on fr.fileresourceid = ma.fileresourceid where fr.uid = :uid";
-        return getSession().createNativeQuery( sql, String.class ).setParameter( "uid", uid ).list();
+        return getSession().createNativeQuery( sql ).setParameter( "uid", uid ).list();
     }
 
     @Override
     public List<DataValueKey> findDataValuesByFileResourceValue( @Nonnull String uid )
     {
-        String sql = "select de.uid, o.uid, dv.periodid, co.uid from dataelement de"
-            + " inner JOIN datavalue dv ON de.dataelementid = dv.dataelementid"
+        String sql = "select de.uid as de, o.uid as ou, dv.periodid as pe, co.uid as co from dataelement de"
+            + " inner join datavalue dv on de.dataelementid = dv.dataelementid"
             + " inner join organisationunit o on dv.sourceid = o.organisationunitid"
             + " inner join categoryoptioncombo co on dv.categoryoptioncomboid = co.categoryoptioncomboid"
             + " where de.valuetype = 'FILE_RESOURCE' and dv.value = :uid";
-        return getSession().createNativeQuery( sql, Object[].class ).setParameter( "uid", uid ).stream()
-            .map( col -> new DataValueKey( (String) col[0], (String) col[1], (long) col[2], (String) col[3] ) )
+        Stream<Object[]> stream = getSession().createNativeQuery( sql ).setParameter( "uid", uid ).stream();
+        return stream
+            .map( col -> new DataValueKey( (String) (col)[0], (String) col[1], ((Number) col[2]).longValue(),
+                (String) col[3] ) )
             .collect( Collectors.toUnmodifiableList() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceServiceTest.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.fileresource.events.FileDeletedEvent;
 import org.hisp.dhis.fileresource.events.FileSavedEvent;
 import org.hisp.dhis.fileresource.events.ImageFileSavedEvent;
+import org.hisp.dhis.period.PeriodService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -64,6 +65,9 @@ class FileResourceServiceTest
 {
     @Mock
     private FileResourceStore fileResourceStore;
+
+    @Mock
+    private PeriodService periodService;
 
     @Mock
     private SessionFactory sessionFactory;
@@ -94,7 +98,8 @@ class FileResourceServiceTest
     @BeforeEach
     public void setUp()
     {
-        subject = new DefaultFileResourceService( fileResourceStore, sessionFactory, fileResourceContentStore,
+        subject = new DefaultFileResourceService( fileResourceStore, periodService, sessionFactory,
+            fileResourceContentStore,
             imageProcessingService, fileEventPublisher );
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.unauthorized;
 
 import java.io.IOException;
+import java.util.List;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -48,6 +49,7 @@ import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.feedback.Status;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.fileresource.FileResourceDomain;
+import org.hisp.dhis.fileresource.FileResourceOwner;
 import org.hisp.dhis.fileresource.FileResourceService;
 import org.hisp.dhis.fileresource.ImageFileDimension;
 import org.hisp.dhis.schema.descriptors.FileResourceSchemaDescriptor;
@@ -157,6 +159,12 @@ public class FileResourceController
         webMessage.setResponse( new FileResourceWebMessageResponse( fileResource ) );
 
         return webMessage;
+    }
+
+    @GetMapping( "/owners" )
+    public List<FileResourceOwner> getFileResourceOwners( @RequestParam String storageKey )
+    {
+        return fileResourceService.findOwnersByStorageKey( storageKey );
     }
 
     /**


### PR DESCRIPTION
### Summary
Adds a reverse lookup for file resources.
This allows to find the objects associated with a file resource by the storage key of the file.
The associated objects are proposed to be named "owner" in this context.

The new endpoint is

    /api/fileResources/owners?storageKey={key}

This cannot use a path variable because the storage keys themselves contain a `/` which either is misunderstood or when escaped considered an attempt to circumvent security. 

The result is a list of matches as theoretically multiple owners can be linked to the same file resource.
For user avatar images, organisation unit images, documents and message attachments a result entry looks like this
```json
  {
    "domain": "DOCUMENT",
    "id": "M3Sc7m4iIsG"
  }
```
For a data value the result has `de`, `ou`, `pe` and `co` instead of a single `id`.


### Manual Testing
Goal is to create one file resource of each domain type.

* create a data element with value type file
* add a data value with file (e.g. use `POST /api/dataValues/file`)
* edit an organisation unit and provide an image
* edit a user and provide a profile image
* create a document (apps => Reports => Resource)
* create a message with attachment (user messages at top right, open a message, reply with an attachment)

The storage key of each of these needs to be looked up. Easiest would be directly in the database 
```sql
select uid, domain, storagekey from fileresource;
```
Alternatively if #13495 gets accepted usual search `/api/fileResources` can be used.
If none of these is available the reverse lookup needs to be done manually first to find the storage key.
This means for example find data values for the created data element. Their value is the file resource.
Then use `/api/fileResource/{uid}` to get the details including the storage key.

Once the storage key is found the new `owners` endpoint method can be used.

    /api/fileResources/owners?storageKey={key}

For any key it lists the object that is "owning" the file. So the data value, organisation unit, user, document or message.