### PR TITLE
fix: Enrollments POST API failure with caching issue

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramService.java
@@ -171,9 +171,9 @@ public interface ProgramService
     SetValuedMap<String, String> getProgramOrganisationUnitsAssociationsForCurrentUser( Set<String> programUids );
 
     /**
-     * Get all the organisation unit associated for a set of program uids. This
-     * method uses jdbc to directly fetch the associated org unit uids for every
-     * program uid. This method returns all the associations irrespective of the
+     * Look for a program - org Unit association in a Cache. If the association
+     * exists we return true, otherwise we do a database lookup in the Store and
+     * add to the cache. This method checks the associations irrespective of the
      * sharing settings or org unit scopes.
      *
      * @param program input program uid

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramService.java
@@ -176,9 +176,9 @@ public interface ProgramService
      * program uid. This method returns all the associations irrespective of the
      * sharing settings or org unit scopes.
      *
-     * @param programUids A set of program uids
-     * @return A object of {@link IdentifiableObjectAssociations} containing
-     *         association for each programUid
+     * @param program input program uid
+     * @param orgUnit
+     * @return whether a org Unit is associated to the input program
      */
-    SetValuedMap<String, String> getProgramOrganisationUnitsAssociations( Set<String> programUids );
+    boolean checkProgramOrganisationUnitsAssociations( String program, String orgUnit );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/association/jdbc/JdbcOrgUnitAssociationsStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/association/jdbc/JdbcOrgUnitAssociationsStore.java
@@ -79,15 +79,6 @@ public class JdbcOrgUnitAssociationsStore
             } );
     }
 
-    /**
-     * Look for a program - org Unit association in a Cache. If the association
-     * exists we return true, otherwise we do a database lookup, check if the
-     * input org Unit is associated with the program and add to the cache
-     *
-     * @param program
-     * @param orgUnit
-     * @return
-     */
     public boolean checkOrganisationUnitsAssociations( String program, String orgUnit )
     {
         if ( orgUnitAssociationCache.get( program ).isEmpty()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramService.java
@@ -198,9 +198,9 @@ public class DefaultProgramService
     }
 
     @Override
-    public SetValuedMap<String, String> getProgramOrganisationUnitsAssociations( Set<String> programUids )
+    public boolean checkProgramOrganisationUnitsAssociations( String program, String orgUnit )
     {
-        return jdbcOrgUnitAssociationsStore.getOrganisationUnitsAssociations( programUids );
+        return jdbcOrgUnitAssociationsStore.checkOrganisationUnitsAssociations( program, orgUnit );
     }
 
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/jdbc/JdbcOrgUnitAssociationsStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/jdbc/JdbcOrgUnitAssociationsStoreTest.java
@@ -52,7 +52,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -64,7 +63,7 @@ import org.springframework.jdbc.core.ResultSetExtractor;
  * @author <luca@dhis2.org>
  */
 @ExtendWith( MockitoExtension.class )
-public class JdbcOrgUnitAssociationsStoreTest
+class JdbcOrgUnitAssociationsStoreTest
 {
     private JdbcOrgUnitAssociationsStore jdbcOrgUnitAssociationsStore;
 
@@ -125,10 +124,10 @@ public class JdbcOrgUnitAssociationsStoreTest
 
                     when( resultSet.next() ).thenReturn( true, false );
 
-                    Mockito.when( resultSet.getString( ArgumentMatchers.eq( 1 ) ) )
+                    Mockito.when( resultSet.getString( 1 ) )
                         .thenReturn( program );
 
-                    Mockito.when( resultSet.getArray( ArgumentMatchers.eq( 2 ) ) )
+                    Mockito.when( resultSet.getArray( 2 ) )
                         .thenReturn( orgUnitArray );
 
                     return resultSetExtractor.extractData( resultSet );
@@ -181,10 +180,10 @@ public class JdbcOrgUnitAssociationsStoreTest
 
                     when( resultSet.next() ).thenReturn( true, false );
 
-                    Mockito.when( resultSet.getString( ArgumentMatchers.eq( 1 ) ) )
+                    Mockito.when( resultSet.getString( 1 ) )
                         .thenReturn( program );
 
-                    Mockito.when( resultSet.getArray( ArgumentMatchers.eq( 2 ) ) )
+                    Mockito.when( resultSet.getArray( 2 ) )
                         .thenReturn( orgUnitArray );
 
                     return resultSetExtractor.extractData( resultSet );
@@ -214,10 +213,10 @@ public class JdbcOrgUnitAssociationsStoreTest
 
                     when( resultSet.next() ).thenReturn( true, false );
 
-                    Mockito.when( resultSet.getString( ArgumentMatchers.eq( 1 ) ) )
+                    Mockito.when( resultSet.getString( 1 ) )
                         .thenReturn( program );
 
-                    Mockito.when( resultSet.getArray( ArgumentMatchers.eq( 2 ) ) )
+                    Mockito.when( resultSet.getArray( 2 ) )
                         .thenReturn( orgUnitArray );
 
                     return resultSetExtractor.extractData( resultSet );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/jdbc/JdbcOrgUnitAssociationsStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/jdbc/JdbcOrgUnitAssociationsStoreTest.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.sql.Array;
 import java.sql.ResultSet;
 import java.util.Collections;
 import java.util.HashSet;
@@ -56,7 +57,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.postgresql.jdbc.PgArray;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.ResultSetExtractor;
 
@@ -75,7 +75,7 @@ public class JdbcOrgUnitAssociationsStoreTest
     private AbstractOrganisationUnitAssociationsQueryBuilder queryBuilder;
 
     @Mock
-    private PgArray orgUnitArray;
+    private Array orgUnitArray;
 
     @Mock
     private ResultSet resultSet;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/jdbc/JdbcOrgUnitAssociationsStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/jdbc/JdbcOrgUnitAssociationsStoreTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.program.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.ResultSet;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.hisp.dhis.association.AbstractOrganisationUnitAssociationsQueryBuilder;
+import org.hisp.dhis.association.jdbc.JdbcOrgUnitAssociationsStore;
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.TestCache;
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.user.CurrentUserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.postgresql.jdbc.PgArray;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.ResultSetExtractor;
+
+/**
+ * @author <luca@dhis2.org>
+ */
+@ExtendWith( MockitoExtension.class )
+public class JdbcOrgUnitAssociationsStoreTest
+{
+    private JdbcOrgUnitAssociationsStore jdbcOrgUnitAssociationsStore;
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @Mock
+    private AbstractOrganisationUnitAssociationsQueryBuilder queryBuilder;
+
+    @Mock
+    private PgArray orgUnitArray;
+
+    @Mock
+    private ResultSet resultSet;
+
+    @Captor
+    private ArgumentCaptor<ResultSetExtractor<?>> resultSetExtractorArgumentCaptor;
+
+    private final Cache<Set<String>> programToOrgUnitCache = new TestCache<>();
+
+    private final String program = CodeGenerator.generateUid();
+
+    private final String orgUnitA = CodeGenerator.generateUid();
+
+    private final String orgUnitB = CodeGenerator.generateUid();
+
+    @BeforeEach
+    void setUpTest()
+    {
+        jdbcOrgUnitAssociationsStore = new JdbcOrgUnitAssociationsStore( mock( CurrentUserService.class ), jdbcTemplate,
+            queryBuilder, programToOrgUnitCache );
+    }
+
+    @Test
+    void shouldFindAssociationWhenOrgUnitIsCached()
+    {
+        programToOrgUnitCache.put( program, Set.of( orgUnitA ) );
+
+        assertTrue( jdbcOrgUnitAssociationsStore.checkOrganisationUnitsAssociations( program, orgUnitA ) );
+        verify( jdbcTemplate, times( 0 ) ).query( anyString(), resultSetExtractorArgumentCaptor.capture() );
+    }
+
+    @Test
+    void shouldNotFindAssociationWhenProgramHasNoOrgUnitAssociation()
+    {
+        when( queryBuilder
+            .buildSqlQueryForRawAssociation( new HashSet<>( Collections.singletonList( program ) ) ) )
+                .thenReturn( "query" );
+
+        when( jdbcTemplate.query(
+            anyString(), resultSetExtractorArgumentCaptor.capture() ) )
+                .thenAnswer( ( invocation ) -> {
+
+                    when( orgUnitArray.getArray() ).thenReturn( new String[] { orgUnitA } );
+
+                    ResultSetExtractor<Map<Integer, String>> resultSetExtractor = invocation
+                        .getArgument( 1 );
+
+                    when( resultSet.next() ).thenReturn( true, false );
+
+                    Mockito.when( resultSet.getString( ArgumentMatchers.eq( 1 ) ) )
+                        .thenReturn( program );
+
+                    Mockito.when( resultSet.getArray( ArgumentMatchers.eq( 2 ) ) )
+                        .thenReturn( orgUnitArray );
+
+                    return resultSetExtractor.extractData( resultSet );
+                } );
+
+        assertFalse( jdbcOrgUnitAssociationsStore.checkOrganisationUnitsAssociations( program, orgUnitB ) );
+        verify( jdbcTemplate, times( 1 ) ).query( anyString(), resultSetExtractorArgumentCaptor.capture() );
+    }
+
+    @Test
+    void shouldNotFindAssociationWhenProgramOrgUnitDoNotExists()
+    {
+        when( queryBuilder
+            .buildSqlQueryForRawAssociation( new HashSet<>( Collections.singletonList( program ) ) ) )
+                .thenReturn( "query" );
+
+        when( jdbcTemplate.query(
+            anyString(), resultSetExtractorArgumentCaptor.capture() ) )
+                .thenAnswer( ( invocation ) -> {
+
+                    ResultSetExtractor<Map<Integer, String>> resultSetExtractor = invocation
+                        .getArgument( 1 );
+
+                    when( resultSet.next() ).thenReturn( false );
+
+                    return resultSetExtractor.extractData( resultSet );
+                } );
+
+        assertFalse( jdbcOrgUnitAssociationsStore.checkOrganisationUnitsAssociations( program, orgUnitA ) );
+        verify( jdbcTemplate, times( 1 ) ).query( anyString(), resultSetExtractorArgumentCaptor.capture() );
+    }
+
+    @Test
+    void shouldFindAssociationWhenOrgUnitIsNotCachedButProgramOrgUnitExists()
+    {
+        programToOrgUnitCache.put( program, Set.of( orgUnitA ) );
+
+        when( queryBuilder
+            .buildSqlQueryForRawAssociation( new HashSet<>( Collections.singletonList( program ) ) ) )
+                .thenReturn( "query" );
+
+        when( jdbcTemplate.query(
+            anyString(), resultSetExtractorArgumentCaptor.capture() ) )
+                .thenAnswer( ( invocation ) -> {
+
+                    when( orgUnitArray.getArray() ).thenReturn( new String[] { orgUnitA, orgUnitB } );
+
+                    ResultSetExtractor<Map<Integer, String>> resultSetExtractor = invocation
+                        .getArgument( 1 );
+
+                    when( resultSet.next() ).thenReturn( true, false );
+
+                    Mockito.when( resultSet.getString( ArgumentMatchers.eq( 1 ) ) )
+                        .thenReturn( program );
+
+                    Mockito.when( resultSet.getArray( ArgumentMatchers.eq( 2 ) ) )
+                        .thenReturn( orgUnitArray );
+
+                    return resultSetExtractor.extractData( resultSet );
+                } );
+
+        assertTrue( jdbcOrgUnitAssociationsStore.checkOrganisationUnitsAssociations( program, orgUnitB ) );
+        verify( jdbcTemplate, times( 1 ) ).query( anyString(), resultSetExtractorArgumentCaptor.capture() );
+    }
+
+    @Test
+    void shouldNotFindAssociationWhenOrgUnitIsNotCachedAndProgramOrgUnitNotExists()
+    {
+        programToOrgUnitCache.put( program, Set.of( orgUnitA ) );
+
+        when( queryBuilder
+            .buildSqlQueryForRawAssociation( new HashSet<>( Collections.singletonList( program ) ) ) )
+                .thenReturn( "query" );
+
+        when( jdbcTemplate.query(
+            anyString(), resultSetExtractorArgumentCaptor.capture() ) )
+                .thenAnswer( ( invocation ) -> {
+
+                    when( orgUnitArray.getArray() ).thenReturn( new String[] { orgUnitA } );
+
+                    ResultSetExtractor<Map<Integer, String>> resultSetExtractor = invocation
+                        .getArgument( 1 );
+
+                    when( resultSet.next() ).thenReturn( true, false );
+
+                    Mockito.when( resultSet.getString( ArgumentMatchers.eq( 1 ) ) )
+                        .thenReturn( program );
+
+                    Mockito.when( resultSet.getArray( ArgumentMatchers.eq( 2 ) ) )
+                        .thenReturn( orgUnitArray );
+
+                    return resultSetExtractor.extractData( resultSet );
+                } );
+
+        assertFalse( jdbcOrgUnitAssociationsStore.checkOrganisationUnitsAssociations( program, orgUnitB ) );
+        verify( jdbcTemplate, times( 1 ) ).query( anyString(), resultSetExtractorArgumentCaptor.capture() );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -37,7 +37,6 @@ import static org.hisp.dhis.trackedentity.TrackedEntityAttributeService.TEA_VALU
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -49,7 +48,6 @@ import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
-import org.apache.commons.collections4.SetValuedMap;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdSchemes;
@@ -60,7 +58,6 @@ import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.SlimPager;
 import org.hisp.dhis.common.exception.InvalidIdentifierReferenceException;
 import org.hisp.dhis.commons.collection.CachingMap;
-import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.commons.util.DebugUtils;
 import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.dxf2.Constants;
@@ -825,16 +822,12 @@ public abstract class AbstractEnrollmentService
                 " is a program without registration. An enrollment cannot be created into program without registration.";
         }
 
-        SetValuedMap<String, String> programAssociations = programService
-            .getProgramOrganisationUnitsAssociations( Collections.singleton( program.getUid() ) );
-
-        if ( !CollectionUtils.isEmpty( programAssociations.get( program.getUid() ) ) )
+        if ( !programService
+            .checkProgramOrganisationUnitsAssociations( program.getUid(), orgUnit.getUid() ) )
         {
-            if ( !programAssociations.get( program.getUid() ).contains( orgUnit.getUid() ) )
-            {
-                return "Program is not assigned to this Organisation Unit: " + enrollment.getOrgUnit();
-            }
+            return "Program is not assigned to this Organisation Unit: " + enrollment.getOrgUnit();
         }
+
         return null;
     }
 


### PR DESCRIPTION
Currently with a post to /enrollments, when we check a program to orgunit association, we create a cache for a program only once, so subsequent requests for a new orgunit will fail.
With this fix, we check for a program and program to orgunit in the cache. If not exists we do a database lookup and update the cache for that specific org unit