### PR TITLE
fix: Only owners can see EDIs in /dataItems [DHIS2-15059]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ExpressionDimensionItemQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ExpressionDimensionItemQuery.java
@@ -49,8 +49,7 @@ import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_LEFT_PARE
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_RIGHT_PARENTHESIS;
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_SELECT;
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_WHERE;
-import static org.hisp.dhis.dataitem.query.shared.UserAccessStatement.READ_ACCESS;
-import static org.hisp.dhis.dataitem.query.shared.UserAccessStatement.sharingConditions;
+import static org.hisp.dhis.dataitem.query.shared.UserAccessStatement.checkOwnerConditions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -126,7 +125,7 @@ public class ExpressionDimensionItemQuery implements DataItemQuery
         // Applying filters, ordering and limits.
 
         // Mandatory filters. They do not respect the root junction filtering.
-        sql.append( always( sharingConditions( "t.item_sharing", READ_ACCESS, paramsMap ) ) );
+        sql.append( always( checkOwnerConditions( "t.item_sharing" ) ) );
 
         // Optional filters, based on the current root junction.
         OptionalFilterBuilder optionalFilters = new OptionalFilterBuilder( paramsMap );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/UserAccessStatement.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/UserAccessStatement.java
@@ -92,6 +92,19 @@ public class UserAccessStatement
     }
 
     /**
+     * Creates a sharing statement for the given column that checks if given
+     * sharing settings present in the column belongs to the current logged
+     * user.
+     *
+     * @param column the sharing column
+     * @return the sharing SQL statement for the current user
+     */
+    public static String checkOwnerConditions( String column )
+    {
+        return "(" + EXTRACT_PATH_TEXT + "(" + column + ", 'owner') = :userUid)";
+    }
+
+    /**
      * Creates a sharing statement for the given columns, based on the
      * paramsMap. It will also take consideration user groups if this is set in
      * the paramsMap. This statement will check sharing conditions for Metadata

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataitem/query/ExpressionDimensionItemQueryTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataitem/query/ExpressionDimensionItemQueryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dataitem.query;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+
+/**
+ * Unit tests for {@link ExpressionDimensionItemQuery} class.
+ *
+ * @author maikel arabori
+ */
+class ExpressionDimensionItemQueryTest
+{
+    @Test
+    void testGetStatementContainsOwnerCheck()
+    {
+        // Given
+        MapSqlParameterSource anyMap = new MapSqlParameterSource();
+        ExpressionDimensionItemQuery query = new ExpressionDimensionItemQuery();
+
+        // When
+        String statement = query.getStatement( anyMap );
+
+        // Then
+        assertTrue( statement.contains( "(jsonb_extract_path_text(t.item_sharing, 'owner') = :userUid)" ) );
+    }
+}


### PR DESCRIPTION
The `/dataItems` endpoint needs special handling for Expression Dimension Items (EDI).

Only the creators/owners of the EDI should be able to see them through the endpoint `/dataItems`.

This PR will add this restriction.