### PR TITLE
fix: Predictor w/multiple queryMods [DHIS2-15061]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataExportParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataExportParams.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.datavalue;
 
+import static org.hisp.dhis.common.OrganisationUnitSelectionMode.DESCENDANTS;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.SELECTED;
 
 import java.util.Date;
@@ -260,6 +261,14 @@ public class DataExportParams
     public boolean hasLimit()
     {
         return limit != null;
+    }
+
+    public boolean needsOrgUnitDetails()
+    {
+        return isOrderByOrgUnitPath()
+            || hasOrgUnitLevel()
+            || getOuMode() == DESCENDANTS
+            || isIncludeDescendants();
     }
 
     /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DeflatedDataValue.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DeflatedDataValue.java
@@ -113,8 +113,8 @@ public class DeflatedDataValue
         this.deleted = dataValue.isDeleted();
     }
 
-    public DeflatedDataValue( Integer dataElementId, Integer periodId, Integer sourceId,
-        Integer categoryOptionComboId, Integer attributeOptionComboId, String value,
+    public DeflatedDataValue( Long dataElementId, Long periodId, Long sourceId,
+        Long categoryOptionComboId, Long attributeOptionComboId, String value,
         String storedBy, Date created, Date lastUpdated,
         String comment, boolean followup, boolean deleted )
     {
@@ -132,15 +132,10 @@ public class DeflatedDataValue
         this.deleted = deleted;
     }
 
-    public DeflatedDataValue( Integer dataElementId, Integer periodId, Integer sourceId,
-        Integer categoryOptionComboId, Integer attributeOptionComboId, String value )
+    public DeflatedDataValue( Long dataElementId, Long categoryOptionComboId )
     {
         this.dataElementId = dataElementId;
-        this.periodId = periodId;
-        this.sourceId = sourceId;
         this.categoryOptionComboId = categoryOptionComboId;
-        this.attributeOptionComboId = attributeOptionComboId;
-        this.value = value;
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictionDataConsolidator.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictionDataConsolidator.java
@@ -78,10 +78,8 @@ public class PredictionDataConsolidator
     public PredictionDataConsolidator( Set<DimensionalItemObject> items, boolean includeDescendants,
         PredictionDataValueFetcher dataValueFetcher, PredictionAnalyticsDataFetcher analyticsFetcher )
     {
-        this.dataValueFetcher = dataValueFetcher;
+        this.dataValueFetcher = dataValueFetcher.setIncludeDescendants( includeDescendants );
         this.analyticsFetcher = analyticsFetcher;
-
-        dataValueFetcher.setIncludeDeleted( true ).setIncludeDescendants( includeDescendants );
 
         dataElements = new HashSet<>();
         dataElementOperands = new HashSet<>();
@@ -93,22 +91,23 @@ public class PredictionDataConsolidator
     /**
      * Initializes for data retrieval.
      *
-     * @param orgUnits organisation units to fetch
      * @param orgUnitLevel level of organisation units to fetch
+     * @param orgUnits organisation units to fetch
      * @param dataValueQueryPeriods existing periods for data value queries
      * @param analyticsQueryPeriods existing periods for analytics queries
+     * @param existingOutputPeriods existing output periods
      * @param outputDataElementOperand prediction output data element operand
      */
-    public void init( Set<OrganisationUnit> currentUserOrgUnits, int orgUnitLevel, List<OrganisationUnit> orgUnits,
-        Set<Period> dataValueQueryPeriods, Set<Period> analyticsQueryPeriods, Set<Period> existingOutputPeriods,
+    public void init( int orgUnitLevel, List<OrganisationUnit> orgUnits, Set<Period> dataValueQueryPeriods,
+        Set<Period> analyticsQueryPeriods, Set<Period> existingOutputPeriods,
         DataElementOperand outputDataElementOperand )
     {
         orgUnitsRemaining = new ArrayDeque<>( orgUnits );
 
         readyPredictionData = new ArrayDeque<>();
 
-        dataValueFetcher.init( currentUserOrgUnits, orgUnitLevel, orgUnits, dataValueQueryPeriods,
-            existingOutputPeriods, dataElements, dataElementOperands, outputDataElementOperand );
+        dataValueFetcher.init( orgUnitLevel, orgUnits, dataValueQueryPeriods, existingOutputPeriods, dataElements,
+            dataElementOperands, outputDataElementOperand );
 
         analyticsFetcher.init( analyticsQueryPeriods, analyticsItems );
     }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictionDataValueFetcher.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictionDataValueFetcher.java
@@ -27,6 +27,10 @@
  */
 package org.hisp.dhis.predictor;
 
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toMap;
+import static org.hisp.dhis.common.DimensionalObjectUtils.COMPOSITE_DIM_OBJECT_PLAIN_SEP;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.DESCENDANTS;
 import static org.hisp.dhis.commons.collection.CollectionUtils.isEmpty;
 import static org.hisp.dhis.datavalue.DataValueStore.DDV_QUEUE_TIMEOUT_UNIT;
@@ -34,6 +38,7 @@ import static org.hisp.dhis.datavalue.DataValueStore.DDV_QUEUE_TIMEOUT_VALUE;
 import static org.hisp.dhis.datavalue.DataValueStore.END_OF_DDV_DATA;
 import static org.hisp.dhis.system.util.MathUtils.addDoubleObjects;
 import static org.hisp.dhis.system.util.ValidationUtils.getObjectValue;
+import static org.hisp.dhis.util.ObjectUtils.firstNonNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -82,7 +87,7 @@ import org.hisp.dhis.period.Period;
  * collects data values until it has all the data for an organisation unit, and
  * then it returns them to the caller.
  * <p>
- * The returned data values may optionally include deleted values, because
+ * The returned data includes deleted values for the predictor output because
  * predictor processing needs to know where the former predicted values are
  * present, even when they are deleted, because they might be replaced with new,
  * undeleted values.
@@ -102,40 +107,97 @@ public class PredictionDataValueFetcher
 
     private final CategoryService categoryService;
 
-    private Set<OrganisationUnit> currentUserOrgUnits;
+    /**
+     * Organisation units assigned to the current user.
+     */
+    private final Set<OrganisationUnit> currentUserOrgUnits;
 
+    /*
+     * Organisation unit level at which we are fetching data.
+     */
     private int orgUnitLevel;
 
+    /*
+     * Periods at which we are fetching input data.
+     */
     private Set<Period> queryPeriods;
 
+    /**
+     * Periods at which we are fetching previous predictions (deleted or not).
+     */
     private Set<Period> outputPeriods;
 
+    /**
+     * Data elements to fetch.
+     */
     private Set<DataElement> dataElements;
 
+    /**
+     * Data element operands to fetch.
+     */
     private Set<DataElementOperand> dataElementOperands;
 
+    /**
+     * Output data element (and optionally category option combo) for the
+     * predictor output (to fetch previous values, deleted or not).
+     */
     private DataElementOperand outputDataElementOperand;
 
+    /**
+     * Whether to include organisation unit descendants.
+     */
     private boolean includeDescendants = false;
 
-    private boolean includeDeleted = false;
-
+    /**
+     * Find organisation unit (or ancestor orgUnit) for a data value.
+     */
     private Map<String, OrganisationUnit> orgUnitLookup;
 
+    /**
+     * Find data element for a data value. For this purpose it does not matter
+     * whether the DataElement object has query modifiers.
+     */
     private Map<Long, DataElement> dataElementLookup;
 
+    /**
+     * Find period for a data value.
+     */
     private Map<Long, Period> periodLookup;
 
+    /**
+     * Find catOptionCombo & attributeOptionCombo for a data value.
+     */
     private CachingMap<Long, CategoryOptionCombo> cocLookup;
 
+    /**
+     * Requested data elements, by data element UID.
+     */
+    private Map<String, List<DataElement>> dataElementRequests;
+
+    /**
+     * Requested data element operands, by data element operand UID.
+     */
+    private Map<String, List<DataElementOperand>> dataElementOperandRequests;
+
+    /**
+     * Next (lookahead) deflated data value. Processed immediately if it is for
+     * the current organisation unit, otherwise saved for the next orgUnit.
+     */
     private DeflatedDataValue nextDeflatedDataValue;
 
+    /**
+     * Organisation unit for the next deflated data value.
+     */
     private OrganisationUnit nextOrgUnit;
 
+    /**
+     * Exception (if any) on the producer side, waiting to be reported.
+     */
     private RuntimeException producerException;
 
-    private ExecutorService executor;
-
+    /**
+     * Queue to receive deflated data values from asynchronous thread.
+     */
     private BlockingQueue<DeflatedDataValue> blockingQueue;
 
     /**
@@ -149,7 +211,6 @@ public class PredictionDataValueFetcher
     /**
      * Initializes for datavalue retrieval.
      *
-     * @param currentUserOrgUnits orgUnits assigned to current user.
      * @param orgUnitLevel level of organisation units to fetch.
      * @param orgUnits organisation units to fetch.
      * @param queryPeriods periods to fetch.
@@ -158,11 +219,10 @@ public class PredictionDataValueFetcher
      * @param dataElementOperands data element operands to fetch.
      */
     public void init(
-        Set<OrganisationUnit> currentUserOrgUnits, int orgUnitLevel, List<OrganisationUnit> orgUnits,
-        Set<Period> queryPeriods, Set<Period> outputPeriods, Set<DataElement> dataElements,
-        Set<DataElementOperand> dataElementOperands, DataElementOperand outputDataElementOperand )
+        int orgUnitLevel, List<OrganisationUnit> orgUnits, Set<Period> queryPeriods, Set<Period> outputPeriods,
+        Set<DataElement> dataElements, Set<DataElementOperand> dataElementOperands,
+        DataElementOperand outputDataElementOperand )
     {
-        this.currentUserOrgUnits = currentUserOrgUnits;
         this.orgUnitLevel = orgUnitLevel;
         this.queryPeriods = queryPeriods;
         this.outputPeriods = outputPeriods;
@@ -172,11 +232,16 @@ public class PredictionDataValueFetcher
 
         orgUnitLookup = orgUnits.stream().collect( Collectors.toMap( OrganisationUnit::getPath, Function.identity() ) );
         dataElementLookup = dataElements.stream()
-            .collect( Collectors.toMap( DataElement::getId, Function.identity() ) );
+            .collect( toMap( DataElement::getId, Function.identity(), ( de1, de2 ) -> de1 ) );
         dataElementLookup.putAll( dataElementOperands.stream().map( DataElementOperand::getDataElement )
-            .distinct().collect( Collectors.toMap( DataElement::getId, Function.identity() ) ) );
+            .distinct().collect( toMap( DataElement::getId, Function.identity(), ( deo1, deo2 ) -> deo1 ) ) );
         periodLookup = queryPeriods.stream().collect( Collectors.toMap( Period::getId, Function.identity() ) );
         cocLookup = new CachingMap<>();
+
+        dataElementRequests = dataElements.stream()
+            .collect( groupingBy( DataElement::getUid ) );
+        dataElementOperandRequests = dataElementOperands.stream()
+            .collect( groupingBy( DataElementOperand::getUid ) );
 
         producerException = null;
 
@@ -189,7 +254,7 @@ public class PredictionDataValueFetcher
             return;
         }
 
-        executor = Executors.newSingleThreadExecutor();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
         executor.execute( this ); // Invoke run() on another thread
         executor.shutdown();
 
@@ -212,7 +277,7 @@ public class PredictionDataValueFetcher
         params.setBlockingQueue( blockingQueue );
         params.setOrderByOrgUnitPath( true );
         params.setIncludeDescendants( includeDescendants );
-        params.setIncludeDeleted( includeDeleted );
+        params.setIncludeDeleted( true );
 
         try
         {
@@ -272,18 +337,6 @@ public class PredictionDataValueFetcher
     public PredictionDataValueFetcher setIncludeDescendants( boolean includeDescendants )
     {
         this.includeDescendants = includeDescendants;
-        return this;
-    }
-
-    /**
-     * Sets whether the data should include deleted values.
-     *
-     * @param includeDeleted whether the data should include deleted values.
-     * @return this object (for method chaining).
-     */
-    public PredictionDataValueFetcher setIncludeDeleted( boolean includeDeleted )
-    {
-        this.includeDeleted = includeDeleted;
         return this;
     }
 
@@ -391,15 +444,17 @@ public class PredictionDataValueFetcher
     /**
      * Adds a non-deleted value to the value map.
      * <p>
-     * The two types of dimensional item object that are needed from the data
-     * value table are DataElement (the sum of all category option combos for
-     * that data element) and DataElementOperand (a particular combination of
-     * DataElement and CategoryOptionCombo).
-     * <p>
-     * In the case of disaggregated predictions, a "wildcard" DataElementOperand
-     * may also be requested where the DataElementOperand contains only a
-     * DataElement and no CategoryOptionCombo. This means to collect all
-     * CategoryOptionCombos for this DataElement.
+     * There are three types of dimensional item objects that any data value may
+     * be returned for:
+     * <ol>
+     * <li>DataElement: sum values across all catOptionCombos</li>
+     * <li>DataElementOperand: specified catOptionCombo</li>
+     * <li>Wildcard DataElement (represented as a DataElementOperand with a null
+     * catOptionCombo): return a DataElementOperand for each different
+     * catOptionCombo (for use in disaggregated predictions)</li>
+     * </ol>
+     * Note that for any of these three types there may be multiple dimension
+     * item objects for any data value if they have different query modifiers.
      */
     private void addValueToMap( DataValue dv,
         MapMapMap<CategoryOptionCombo, Period, DimensionalItemObject, Object> map )
@@ -408,23 +463,43 @@ public class PredictionDataValueFetcher
 
         if ( value != null )
         {
-            DataElementOperand dataElementOperand = new DataElementOperand(
-                dv.getDataElement(), dv.getCategoryOptionCombo() );
-
-            DataElementOperand wildcardDataElementOperand = new DataElementOperand(
-                dv.getDataElement() );
-
-            if ( dataElementOperands.contains( dataElementOperand ) ||
-                dataElementOperands.contains( wildcardDataElementOperand ) )
+            // Add value to any requested data elements
+            for ( DataElement de : getDataElementRequestList( dv.getDataElement().getUid() ) )
             {
-                addToMap( dataElementOperand, dv, value, map );
+                addToMap( de, dv, value, map );
             }
 
-            if ( dataElements.contains( dv.getDataElement() ) )
+            // Add value to any requested data element operands
+            for ( DataElementOperand deo : getDataElementOperandRequestList( dv.getDataElement().getUid()
+                + COMPOSITE_DIM_OBJECT_PLAIN_SEP + dv.getCategoryOptionCombo().getUid() ) )
             {
-                addToMap( dv.getDataElement(), dv, value, map );
+                addToMap( deo, dv, value, map );
+            }
+
+            // Record value for any requested wildcard data element operands
+            for ( DataElementOperand deo : getDataElementOperandRequestList( dv.getDataElement().getUid() ) )
+            {
+                DataElementOperand newDeo = new DataElementOperand( dv.getDataElement(), dv.getCategoryOptionCombo() );
+                newDeo.setQueryMods( deo.getQueryMods() );
+                addToMap( newDeo, dv, value, map );
             }
         }
+    }
+
+    /**
+     * Returns matching data element requests or empty list if none.
+     */
+    private List<DataElement> getDataElementRequestList( String uid )
+    {
+        return firstNonNull( dataElementRequests.get( uid ), emptyList() );
+    }
+
+    /**
+     * Returns matching data element operands requests or empty list if none.
+     */
+    private List<DataElementOperand> getDataElementOperandRequestList( String uid )
+    {
+        return firstNonNull( dataElementOperandRequests.get( uid ), emptyList() );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionDataConsolidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionDataConsolidatorTest.java
@@ -344,7 +344,6 @@ class PredictionDataConsolidatorTest
 
         outputDataElementOperand = dataElementOperandX;
 
-        when( dataValueFetcher.setIncludeDeleted( true ) ).thenReturn( dataValueFetcher );
         when( dataValueFetcher.setIncludeDescendants( INCLUDE_DESCENDANTS ) ).thenReturn( dataValueFetcher );
 
         consolidator = new PredictionDataConsolidator( items, INCLUDE_DESCENDANTS, dataValueFetcher, analyticsFetcher );
@@ -438,8 +437,8 @@ class PredictionDataConsolidatorTest
         // Test the data
         // ---------------------------------------------------------------------
 
-        consolidator.init( currentUserOrgUnits, 1, levelOneOrgUnits,
-            dataValueQueryPeriods, analyticsQueryPeriods, existingOutputPeriods, outputDataElementOperand );
+        consolidator.init( 1, levelOneOrgUnits, dataValueQueryPeriods, analyticsQueryPeriods,
+            existingOutputPeriods, outputDataElementOperand );
 
         // Expected to be returned in this order:
         assertEquals( expectedB, consolidator.getData() );

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionDataValueFetcherTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionDataValueFetcherTest.java
@@ -318,7 +318,7 @@ class PredictionDataValueFetcherTest
         foundValueE = new FoundDimensionItemValue( orgUnitB, periodC, aocC, dataElementOperandX, 50.0 );
         foundValueAB = new FoundDimensionItemValue( orgUnitB, periodA, aocC, dataElementOperandAB, 75.0 );
 
-        fetcher = new PredictionDataValueFetcher( dataValueService, categoryService );
+        fetcher = new PredictionDataValueFetcher( dataValueService, categoryService, currentUserOrgUnits );
     }
 
     // -------------------------------------------------------------------------
@@ -347,7 +347,7 @@ class PredictionDataValueFetcherTest
             return new ArrayList<>();
         } );
 
-        fetcher.init( currentUserOrgUnits, ORG_UNIT_LEVEl, levelOneOrgUnits, queryPeriods, outputPeriods,
+        fetcher.init( ORG_UNIT_LEVEl, levelOneOrgUnits, queryPeriods, outputPeriods,
             dataElements, dataElementOperands, dataElementOperandX );
 
         PredictionData data1 = fetcher.getData();
@@ -393,7 +393,7 @@ class PredictionDataValueFetcherTest
             return new ArrayList<>();
         } );
 
-        fetcher.init( currentUserOrgUnits, ORG_UNIT_LEVEl, levelOneOrgUnits, queryPeriods, outputPeriods,
+        fetcher.init( ORG_UNIT_LEVEl, levelOneOrgUnits, queryPeriods, outputPeriods,
             dataElements, dataElementOperands, dataElementOperandZ );
 
         PredictionData data1 = fetcher.getData();
@@ -422,7 +422,7 @@ class PredictionDataValueFetcherTest
             return new ArrayList<>();
         } );
 
-        fetcher.init( currentUserOrgUnits, ORG_UNIT_LEVEl, levelOneOrgUnits, queryPeriods, outputPeriods,
+        fetcher.init( ORG_UNIT_LEVEl, levelOneOrgUnits, queryPeriods, outputPeriods,
             dataElements, dataElementOperands, dataElementOperandX );
 
         assertNull( fetcher.getData() );
@@ -434,8 +434,7 @@ class PredictionDataValueFetcherTest
         when( dataValueService.getDeflatedDataValues( any() ) ).thenAnswer( p -> {
             throw new ArithmeticException();
         } );
-        assertThrows( ArithmeticException.class, () -> fetcher.init( currentUserOrgUnits, ORG_UNIT_LEVEl,
-            levelOneOrgUnits, queryPeriods, outputPeriods, dataElements, dataElementOperands, dataElementOperandX ) );
-
+        assertThrows( ArithmeticException.class, () -> fetcher.init( ORG_UNIT_LEVEl, levelOneOrgUnits,
+            queryPeriods, outputPeriods, dataElements, dataElementOperands, dataElementOperandX ) );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/PredictionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/PredictionServiceTest.java
@@ -89,7 +89,6 @@ import com.google.common.collect.Sets;
  */
 class PredictionServiceTest extends IntegrationTestBase
 {
-
     private final JobProgress progress = NoopJobProgress.INSTANCE;
 
     @Autowired
@@ -1619,6 +1618,21 @@ class PredictionServiceTest extends IntegrationTestBase
 
         predictionService.predict( p, monthStart( 2022, 10 ), monthStart( 2022, 11 ), summary );
         assertEquals( "Pred 1 Ins 1 Upd 0 Del 0 Unch 0", shortSummary( summary ) );
+        assertEquals( expectedValue, getDataValue( dataElementC, defaultCombo, sourceA, makeMonth( 2022, 10 ) ) );
+
+        // Now try with one data element both without and with modifiers:
+        expectedValue = String.valueOf( 8 + 16 + (2 * 16) + 32 );
+
+        expr = "sum( #{" + dataElementB.getUid() + "} + 2 * #{" +
+            dataElementB.getUid() + "}.minDate(2022-8-1).maxDate(2022-9-1) )";
+
+        expression = new Expression( expr, "description" );
+        p = createPredictor( dataElementC, null, "P", expression, null, periodTypeMonthly,
+            orgUnitLevel1, 3, 0, 0 );
+
+        summary = new PredictionSummary();
+        predictionService.predict( p, monthStart( 2022, 10 ), monthStart( 2022, 11 ), summary );
+        assertEquals( "Pred 1 Ins 0 Upd 1 Del 0 Unch 0", shortSummary( summary ) );
         assertEquals( expectedValue, getDataValue( dataElementC, defaultCombo, sourceA, makeMonth( 2022, 10 ) ) );
     }
 


### PR DESCRIPTION
Problem statement from [DHIS2-15061](https://dhis2.atlassian.net/browse/DHIS2-15061):

> A predictor fails with an internal error and generates no predictions if its generator expression has two different QueryModifiers on the same DataElement or DataElementOperand. (This includes the case where the same DataElement or DataElementOperand appears both with and without QueryModifiers in the same expression.)

The problem is that the datavalue-fetching code had assumed only one `DataElement` object for each data element, and only one `DataElementOperand` for each data element operand. The logic needed to be fixed in several places in `PredictionDataValueFetcher` and `HibernateDataValueStore`. Along the way a few other code improvements were made as well, mostly to avoid SonarLint "errors".

Fix:

### PredictionDataValueFetcher

1. The `dataElementLookup` Map is used for lookups to "inflate" a deflated data value. It is made from the requested `DataElements` and `DataElementOperands` so the database foreign key to a dataelement can be resolved to a `DataElement` object. The code is fixed to allow multiple `DataElement` or `DataElementOperand` objects that differ only by `QueryModifiers`. This is done in the init method by using the three-argument version of `Collectors.toMap`, where the third argument tells how to resolve a conflict when trying to put two values into the map that have the same key. When there is a conflict, the first object is chosen because for this purpose it does not matter whether the resulting `DataElement` has `QueryModifiers`. (This is noted in the field JavaDoc.)

2. `addValueToMap` needed a major refactor because it used to assume that each returned `DataValue` would match only one `DataElement` and/or only one `DataElementOperand`. Now there can be multiple of either of these objects if they have different `QueryModifiers` (or none at all). To allow this, two new multi-value `Maps` are introduced, `dataElementRequests` which maps a data element UID to potentially many `DataElements` that are querying for that data element, and `dataElementOperandRequests` which maps a data element operand UID to potentially many `DataElementOperands` that are querying for that data element / category option combo pair. These Maps of Lists are built ahead of time in the `init` method. `addValueToMap` now needs to do three things: (a) Add the data value to any requested data elements, (b) add the data value to any requested data element operands, and (c) Return the data value as a `DataElementOperand` if there was a wildcard request to individually return each `DataElementOperand` for a given data element. In case (3), the wildcard request is contained in a `DataElementOperand` with a null COC (so the UID of the `DataElementOperand` is just the UID of the `DataElement`). In this case, a fully-specific `DataElementOperand` is created with a non-null category option combo, and it must contain the same `QueryModifiers` as the requested wildcard data element.

3. JavaDoc descriptions of the fields in this class were added to enhance readability. 

4. The `includeDeleted` field in this class was removed. It was a hold-over from an earlier version of the code where there were two different `PredictionDataValueFetcher` objects, one for input data values in the predictor generator expression with `includeDeleted = false`, and one for existing predicted values with `includeDeleted = true`. (This is needed when outputting a predicted value to know whether it should be inserted or updated.) Now for efficiency a single instance of `PredictionDataValueFetcher` is used for both kinds of input, and it always gets the deleted values, then determines whether it needs them or not.

5. The `currentUserOrgUnits` field was moved from init to the constructor to avoid the SonarLint error of the init method having 8 parameters instead of 7.

To accommodate these changes in `PredictionDataValueFetcher`, updates were also made to `DefaultPredictionService`, `PredictionDataConsolidator`, `PredictionDataConsolidatorTest`, and `PredictionDataValueFetcherTest`.

### HibernateDataValueStore

1. This class also made the now-incorrect assumption that there would be only one `DataElement` object for each requested data element, and only one `DataElementOperand` object for each requested pair of data element and category option combo. When duplicate objects were present, it would join the datavalues table duplicate times for the de or deo, resulting in double-counting. After considering a number of different ways to eliminate the double-counting, this logic is now in `getDdvDataElementLists`. As part of this method I needed to get a unique set of data element / category option combo foreign key pairs. As is sometimes the case in Java it wasn't initially clear to me what object I should use to for storing the pairs. I finally opted for `DeflatedDataValue` objects with just these two ids filled in. To support this I created a new `DeflatedDataValue` constructor for just these two items and removed a constructor that is no longer used. I kept the somewhat awkward interface of a `List<Long>` for the data element ids and category option combo ids, because that is what is supported in `statementBuilder.literalLongLongTable`. This method has already been tested for PostgreSQL and non-PostgreSQL databases and I didn't want to mess with it at this point.

2. Since I was already changing the logic in `getDeflatedDataValues`, I decided to (a) break up the method to get rid of the SonarLint complexity errors, (b) use `StringBuilder` to assemble the strings instead of concatenation, (c) define `String` constants for "deleted" and "lastUpdated", and (d) break up `getDataValues` to get rid of its SonarLint complexity error. For code readability I put these two broken-up methods into their own sections at the bottom of the class with the public method followed directly by the private methods it uses. This is not our usual convention but I think it makes the logic easier to follow.

3. I added `DataExportParams.needsOrgUnitDetails` to keep the test in one place and to avoid needing an extra parameter to pass to `getDdvSelectFrom` and `getDdvOrgUnits`.

4. I changed `Integer` to `Long` for object ids here and in `DeflatedDataValue`.

### PredictionServiceTest

I expanded `testPredictMinMaxDate` to test all this new logic. (Without the changes it fails spectacularly!)

[DHIS2-15061]: https://dhis2.atlassian.net/browse/DHIS2-15061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ