### PR TITLE
fix: Only owners can see EDIs in /dataItems [DHIS2-15059]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ExpressionDimensionItemQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/ExpressionDimensionItemQuery.java
@@ -49,8 +49,7 @@ import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_LEFT_PARE
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_RIGHT_PARENTHESIS;
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_SELECT;
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.SPACED_WHERE;
-import static org.hisp.dhis.dataitem.query.shared.UserAccessStatement.READ_ACCESS;
-import static org.hisp.dhis.dataitem.query.shared.UserAccessStatement.sharingConditions;
+import static org.hisp.dhis.dataitem.query.shared.UserAccessStatement.checkOwnerConditions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -126,7 +125,7 @@ public class ExpressionDimensionItemQuery implements DataItemQuery
         // Applying filters, ordering and limits.
 
         // Mandatory filters. They do not respect the root junction filtering.
-        sql.append( always( sharingConditions( "t.item_sharing", READ_ACCESS, paramsMap ) ) );
+        sql.append( always( checkOwnerConditions( "t.item_sharing" ) ) );
 
         // Optional filters, based on the current root junction.
         OptionalFilterBuilder optionalFilters = new OptionalFilterBuilder( paramsMap );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/UserAccessStatement.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataitem/query/shared/UserAccessStatement.java
@@ -92,6 +92,19 @@ public class UserAccessStatement
     }
 
     /**
+     * Creates a sharing statement for the given column that checks if given
+     * sharing settings present in the column belongs to the current logged
+     * user.
+     *
+     * @param column the sharing column
+     * @return the sharing SQL statement for the current user
+     */
+    public static String checkOwnerConditions( String column )
+    {
+        return "(" + EXTRACT_PATH_TEXT + "(" + column + ", 'owner') = :userUid)";
+    }
+
+    /**
      * Creates a sharing statement for the given columns, based on the
      * paramsMap. It will also take consideration user groups if this is set in
      * the paramsMap. This statement will check sharing conditions for Metadata

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataitem/query/ExpressionDimensionItemQueryTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataitem/query/ExpressionDimensionItemQueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2023, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,32 +25,31 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.schema.descriptors;
+package org.hisp.dhis.dataitem.query;
 
-import org.hisp.dhis.expressiondimensionitem.ExpressionDimensionItem;
-import org.hisp.dhis.schema.Schema;
-import org.hisp.dhis.schema.SchemaDescriptor;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 
 /**
- * @author Dusan Bernat
+ * Unit tests for {@link ExpressionDimensionItemQuery} class.
+ *
+ * @author maikel arabori
  */
-public class ExpressionDimensionItemSchemaDescriptor
-    implements SchemaDescriptor
+class ExpressionDimensionItemQueryTest
 {
-    public static final String SINGULAR = "expressionDimensionItem";
-
-    public static final String PLURAL = "expressionDimensionItems";
-
-    public static final String API_ENDPOINT = "/" + PLURAL;
-
-    @Override
-    public Schema getSchema()
+    @Test
+    void testGetStatementContainsOwnerCheck()
     {
-        Schema schema = new Schema( ExpressionDimensionItem.class, SINGULAR, PLURAL );
+        // Given
+        MapSqlParameterSource anyMap = new MapSqlParameterSource();
+        ExpressionDimensionItemQuery query = new ExpressionDimensionItemQuery();
 
-        schema.setOrder( 1000 );
-        schema.setDefaultPrivate( true );
+        // When
+        String statement = query.getStatement( anyMap );
 
-        return schema;
+        // Then
+        assertTrue( statement.contains( "(jsonb_extract_path_text(t.item_sharing, 'owner') = :userUid)" ) );
     }
 }


### PR DESCRIPTION
**_DO NOT MERGE IT. NEEDS APPROVAL FROM RCB._**

**_[Backporting from master/2.41]_**

The `/dataItems` endpoint needs special handling for Expression Dimension Items (EDI).

Only the creators/owners of the EDI should be able to see them through the endpoint `/dataItems`.

This PR will add this restriction.