### PR TITLE
chore: Remove more dxf2 dependencies from tracker module

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/enrollment/EnrollmentEventsParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/enrollment/EnrollmentEventsParams.java
@@ -25,26 +25,28 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker.job;
+package org.hisp.dhis.tracker.enrollment;
 
-import lombok.Builder;
-import lombok.Data;
+import lombok.Value;
+import lombok.With;
 
-import org.hisp.dhis.webmessage.WebMessageResponse;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
+import org.hisp.dhis.tracker.event.EventParams;
 
 /**
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Luca Camnbi
+ *
+ *         Class used to define inclusion in {@link EnrollmentParams} of
+ *         {@link EventParams} properties
  */
-@Data
-@Builder
-public class TrackerJobWebMessageResponse
-    implements WebMessageResponse
+@With
+@Value
+public class EnrollmentEventsParams
 {
-    @JsonProperty
-    private final String id;
+    public static final EnrollmentEventsParams TRUE = new EnrollmentEventsParams( true, EventParams.TRUE );
 
-    @JsonProperty
-    private final String location;
+    public static final EnrollmentEventsParams FALSE = new EnrollmentEventsParams( false, EventParams.FALSE );
+
+    private boolean includeEvents;
+
+    private EventParams eventParams;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/enrollment/EnrollmentParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/enrollment/EnrollmentParams.java
@@ -30,8 +30,6 @@ package org.hisp.dhis.tracker.enrollment;
 import lombok.Value;
 import lombok.With;
 
-import org.hisp.dhis.dxf2.events.EnrollmentEventsParams;
-
 @With
 @Value
 public class EnrollmentParams

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/enrollment/EnrollmentServiceTest.java
@@ -45,7 +45,6 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.commons.util.RelationshipUtils;
-import org.hisp.dhis.dxf2.events.EnrollmentEventsParams;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;


### PR DESCRIPTION
Remove some more dependencies from dxf2 in `dhis-service-tracker`