### PR TITLE
chore: use interface methods for method refs

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PrefixedDimension.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/PrefixedDimension.java
@@ -66,7 +66,7 @@ public class PrefixedDimension
     {
         return Stream.of( program, programStage )
             .filter( Objects::nonNull )
-            .map( BaseIdentifiableObject::getUid )
+            .map( IdentifiableObject::getUid )
             .collect( Collectors.joining( DIMENSION_IDENTIFIER_SEP ) );
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryItem.java
@@ -303,7 +303,7 @@ public class QueryItem implements GroupableItem
         return getQueryFilterItems().stream()
             .map( code -> optionSet.getOptionByCode( code ) )
             .filter( Objects::nonNull )
-            .map( BaseIdentifiableObject::getUid )
+            .map( IdentifiableObject::getUid )
             .collect( Collectors.toList() );
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/predictor/PredictorGroup.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/predictor/PredictorGroup.java
@@ -35,6 +35,7 @@ import java.util.Set;
 
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.schema.annotation.PropertyRange;
 
@@ -102,7 +103,7 @@ public class PredictorGroup
     {
         List<Predictor> predictors = new ArrayList<>( members );
 
-        predictors.sort( Comparator.comparing( BaseIdentifiableObject::getName ) );
+        predictors.sort( Comparator.comparing( IdentifiableObject::getName ) );
 
         return predictors;
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/processing/CommonQueryRequestMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/processing/CommonQueryRequestMapper.java
@@ -73,9 +73,9 @@ import org.hisp.dhis.analytics.common.params.dimension.DimensionParam;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionParamType;
 import org.hisp.dhis.analytics.common.params.dimension.StringUid;
 import org.hisp.dhis.analytics.event.EventDataQueryService;
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.DisplayProperty;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -121,7 +121,7 @@ public class CommonQueryRequestMapper
 
         programs.stream()
             .flatMap( program -> getProgramAttributes( List.of( program ) )
-                .map( BaseIdentifiableObject::getUid )
+                .map( IdentifiableObject::getUid )
                 // We need fully qualified dimension identifiers.
                 .map( attributeUid -> Pair.of( program, attributeUid ) ) )
             .forEach( fullyQualifiedDimension -> dimensionsByUid.put(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -87,7 +87,6 @@ import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
 import org.hisp.dhis.analytics.common.ProgramIndicatorSubqueryBuilder;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.util.AnalyticsUtils;
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
@@ -95,6 +94,7 @@ import org.hisp.dhis.common.DisplayProperty;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
 import org.hisp.dhis.common.IdScheme;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.InQueryFilter;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
@@ -1196,7 +1196,7 @@ public abstract class AbstractJdbcEventAnalyticsManager
     {
         String programStageId = Optional.of( queryItem )
             .map( QueryItem::getProgramStage )
-            .map( BaseIdentifiableObject::getUid )
+            .map( IdentifiableObject::getUid )
             .orElse( "" );
         return programStageId + "." + queryItem.getItem().getUid();
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupResolver.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupResolver.java
@@ -41,8 +41,8 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.category.CategoryOptionComboStore;
 import org.hisp.dhis.category.CategoryOptionGroup;
 import org.hisp.dhis.category.CategoryOptionGroupStore;
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DimensionalItemId;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.expression.ExpressionService;
 import org.springframework.stereotype.Service;
 
@@ -121,7 +121,7 @@ public class CategoryOptionGroupResolver implements ExpressionResolver
             CategoryOptionGroup cog = categoryOptionGroupStore.loadByUid( cogUid );
             List<String> cocUids = categoryOptionComboStore
                 .getCategoryOptionCombosByGroupUid( cog.getUid(), dataElementId ).stream()
-                .map( BaseIdentifiableObject::getUid )
+                .map( IdentifiableObject::getUid )
                 .collect( Collectors.toList() );
 
             if ( cocUidIntersection.isEmpty() )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupTaglessResolver.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupTaglessResolver.java
@@ -45,8 +45,8 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.category.CategoryOptionComboStore;
 import org.hisp.dhis.category.CategoryOptionGroup;
 import org.hisp.dhis.category.CategoryOptionGroupStore;
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DimensionalItemId;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.expression.ExpressionService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -71,7 +71,7 @@ public class CategoryOptionGroupTaglessResolver
     {
         return categoryOptionComboStore.getCategoryOptionCombosByGroupUid( categoryOptionGroupUid, dataElementUid )
             .stream()
-            .map( BaseIdentifiableObject::getUid ).collect( Collectors.toSet() );
+            .map( IdentifiableObject::getUid ).collect( Collectors.toSet() );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/DefaultTeiAnalyticsDimensionsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/DefaultTeiAnalyticsDimensionsService.java
@@ -43,7 +43,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.event.EnrollmentAnalyticsDimensionsService;
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.PrefixedDimension;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
@@ -99,7 +99,7 @@ class DefaultTeiAnalyticsDimensionsService implements TeiAnalyticsDimensionsServ
     {
         return Optional.of( program )
             .map( Program::getTrackedEntityType )
-            .map( BaseIdentifiableObject::getUid )
+            .map( IdentifiableObject::getUid )
             .filter( uid -> StringUtils.equals( uid, trackedEntityTypeId ) )
             .isPresent();
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/TeiQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/TeiQueryParams.java
@@ -36,7 +36,7 @@ import lombok.Setter;
 import org.hisp.dhis.analytics.QueryKey;
 import org.hisp.dhis.analytics.common.params.CommonParams;
 import org.hisp.dhis.analytics.common.params.IdentifiableKey;
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 
 /**
@@ -69,7 +69,7 @@ public class TeiQueryParams implements IdentifiableKey
         key.addIgnoreNull( "displayProperty", commonParams.getDisplayProperty() );
         key.addIgnoreNull( "userOrgUnit",
             commonParams.getUserOrgUnit().stream()
-                .map( BaseIdentifiableObject::getUid )
+                .map( IdentifiableObject::getUid )
                 .sorted()
                 .collect( Collectors.joining( ";" ) ) );
         key.addIgnoreNull( "ouMode", commonParams.getOuMode() );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/TeiQueryRequestMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/TeiQueryRequestMapper.java
@@ -38,7 +38,7 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.analytics.common.QueryRequest;
 import org.hisp.dhis.analytics.common.processing.CommonQueryRequestMapper;
 import org.hisp.dhis.analytics.common.processing.Processor;
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
@@ -76,7 +76,7 @@ public class TeiQueryRequestMapper
         // Adding tracked entity type attributes to the list of dimensions.
         queryRequest.getCommonQueryRequest().getDimension().addAll(
             getTrackedEntityAttributes( trackedEntityType )
-                .map( BaseIdentifiableObject::getUid )
+                .map( IdentifiableObject::getUid )
                 .collect( toList() ) );
 
         return teiQueryParamPostProcessor.process(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/OrganisationUnitCondition.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/OrganisationUnitCondition.java
@@ -56,8 +56,8 @@ import org.hisp.dhis.analytics.common.query.OrCondition;
 import org.hisp.dhis.analytics.common.query.Renderable;
 import org.hisp.dhis.analytics.tei.TeiQueryParams;
 import org.hisp.dhis.analytics.tei.query.context.sql.QueryContext;
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 
@@ -103,7 +103,7 @@ public class OrganisationUnitCondition extends BaseRenderable
         if ( ouMode == SELECTED )
         {
             List<String> items = organisationUnits.stream()
-                .map( BaseIdentifiableObject::getUid )
+                .map( IdentifiableObject::getUid )
                 .collect( Collectors.toList() );
 
             return isEmpty( items ) ? FALSE_CONDITION
@@ -120,7 +120,7 @@ public class OrganisationUnitCondition extends BaseRenderable
             List<String> items = organisationUnits.stream()
                 .map( OrganisationUnit::getChildren )
                 .flatMap( Collection::stream )
-                .map( BaseIdentifiableObject::getUid )
+                .map( IdentifiableObject::getUid )
                 .collect( Collectors.toList() );
 
             return isEmpty( items ) ? FALSE_CONDITION

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/TeiFields.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/TeiFields.java
@@ -58,9 +58,9 @@ import org.hisp.dhis.analytics.common.params.dimension.DimensionParam;
 import org.hisp.dhis.analytics.common.query.Field;
 import org.hisp.dhis.analytics.tei.TeiQueryParams;
 import org.hisp.dhis.analytics.tei.query.context.TeiStaticField;
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.RepeatableStageParams;
 import org.hisp.dhis.common.ValueType;
@@ -106,7 +106,7 @@ public class TeiFields
             teiQueryParams.getTrackedEntityType() )
                 .filter( programTrackedEntityAttribute -> !programAttributesUids
                     .contains( programTrackedEntityAttribute.getUid() ) )
-                .map( BaseIdentifiableObject::getUid )
+                .map( IdentifiableObject::getUid )
                 .map( attr -> Field.of( TEI_ALIAS, () -> attr, attr ) );
 
         // TET and program attribute uids.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/context/querybuilder/ProgramEnrolledQueryBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/context/querybuilder/ProgramEnrolledQueryBuilder.java
@@ -36,7 +36,7 @@ import org.hisp.dhis.analytics.common.query.GroupableCondition;
 import org.hisp.dhis.analytics.tei.query.EnrolledInProgramCondition;
 import org.hisp.dhis.analytics.tei.query.context.sql.QueryContext;
 import org.hisp.dhis.analytics.tei.query.context.sql.SqlQueryBuilderAdaptor;
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.springframework.stereotype.Service;
 
 /**
@@ -53,7 +53,7 @@ public class ProgramEnrolledQueryBuilder extends SqlQueryBuilderAdaptor
     {
         return queryContext.getTeiQueryParams().getCommonParams()
             .getPrograms().stream()
-            .map( BaseIdentifiableObject::getUid )
+            .map( IdentifiableObject::getUid )
             .map( ProgramEnrolledQueryBuilder::asUngroupedEnrolledInProgramCondition );
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceDimensionItemKeywordTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceDimensionItemKeywordTest.java
@@ -47,12 +47,12 @@ import java.util.stream.Stream;
 
 import org.hisp.dhis.analytics.AnalyticsSecurityManager;
 import org.hisp.dhis.analytics.DataQueryParams;
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DataQueryRequest;
 import org.hisp.dhis.common.DimensionItemKeywords;
 import org.hisp.dhis.common.DimensionService;
 import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.UserOrgUnitType;
 import org.hisp.dhis.dataelement.DataElement;
@@ -644,7 +644,7 @@ class DataQueryServiceDimensionItemKeywordTest
             builder.add( s );
         }
 
-        return builder.build().map( BaseIdentifiableObject::getUid ).collect( Collectors.joining( ";" ) );
+        return builder.build().map( IdentifiableObject::getUid ).collect( Collectors.joining( ";" ) );
     }
 
     class RequestBuilder

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deduplication/DeduplicationHelper.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deduplication/DeduplicationHelper.java
@@ -35,7 +35,6 @@ import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.commons.collection.ListUtils;
@@ -97,7 +96,7 @@ public class DeduplicationHelper
             .map( rel -> rel.getRelationship().getUid() ).collect( Collectors.toSet() );
 
         Set<String> validEnrollments = duplicate.getProgramInstances().stream()
-            .map( BaseIdentifiableObject::getUid )
+            .map( IdentifiableObject::getUid )
             .collect( Collectors.toSet() );
 
         for ( String tea : mergeObject.getTrackedEntityAttributes() )
@@ -144,13 +143,13 @@ public class DeduplicationHelper
 
         Set<String> programUidOfExistingEnrollments = original.getProgramInstances().stream()
             .map( ProgramInstance::getProgram )
-            .map( BaseIdentifiableObject::getUid )
+            .map( IdentifiableObject::getUid )
             .collect( Collectors.toSet() );
 
         String duplicateEnrollment = duplicate.getProgramInstances().stream()
             .filter( pi -> mergeObject.getEnrollments().contains( pi.getUid() ) )
             .map( ProgramInstance::getProgram )
-            .map( BaseIdentifiableObject::getUid )
+            .map( IdentifiableObject::getUid )
             .filter( programUidOfExistingEnrollments::contains )
             .findAny()
             .orElse( null );
@@ -164,12 +163,12 @@ public class DeduplicationHelper
          * Step 4: Make sure no relationships will become self-referencing.
          */
         Set<String> relationshipsToMergeUids = relationshipsToMerge.stream()
-            .map( BaseIdentifiableObject::getUid )
+            .map( IdentifiableObject::getUid )
             .collect( Collectors.toSet() );
 
         String selfReferencingRelationship = original.getRelationshipItems().stream()
             .map( RelationshipItem::getRelationship )
-            .map( BaseIdentifiableObject::getUid )
+            .map( IdentifiableObject::getUid )
             .filter( relationshipsToMergeUids::contains )
             .findFirst()
             .orElse( null );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -99,7 +99,6 @@ import org.hisp.dhis.antlr.Parser;
 import org.hisp.dhis.antlr.ParserException;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DimensionService;
 import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.common.DimensionalItemObject;
@@ -456,10 +455,10 @@ public class DefaultExpressionService
         }
 
         Map<String, Constant> constants = new CachingMap<String, Constant>()
-            .load( idObjectManager.getAllNoAcl( Constant.class ), BaseIdentifiableObject::getUid );
+            .load( idObjectManager.getAllNoAcl( Constant.class ), IdentifiableObject::getUid );
 
         Map<String, OrganisationUnitGroup> orgUnitGroups = new CachingMap<String, OrganisationUnitGroup>()
-            .load( idObjectManager.getAllNoAcl( OrganisationUnitGroup.class ), BaseIdentifiableObject::getUid );
+            .load( idObjectManager.getAllNoAcl( OrganisationUnitGroup.class ), IdentifiableObject::getUid );
 
         for ( Indicator indicator : indicators )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitDeletionHandler.java
@@ -30,7 +30,7 @@ package org.hisp.dhis.organisationunit;
 import static java.util.stream.Collectors.joining;
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.system.deletion.DeletionVeto;
@@ -101,7 +101,7 @@ public class OrganisationUnitDeletionHandler extends IdObjectDeletionHandler<Org
         return unit.getChildren().isEmpty()
             ? ACCEPT
             : new DeletionVeto( OrganisationUnit.class, unit.getChildren().stream()
-                .map( BaseIdentifiableObject::getName )
+                .map( IdentifiableObject::getName )
                 .collect( joining( "," ) ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaQueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaQueryUtils.java
@@ -44,7 +44,7 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.hibernate.jsonb.type.JsonbFunctions;
 import org.hisp.dhis.schema.Property;
@@ -422,7 +422,7 @@ public class JpaQueryUtils
 
     private static String getGroupsIds( User user )
     {
-        return getGroupsIds( user.getGroups().stream().map( BaseIdentifiableObject::getUid ).collect( toList() ) );
+        return getGroupsIds( user.getGroups().stream().map( IdentifiableObject::getUid ).collect( toList() ) );
     }
 
     private static String getGroupsIds( List<String> userGroupIds )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentityattributevalue/DefaultTrackedEntityAttributeValueAuditService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentityattributevalue/DefaultTrackedEntityAttributeValueAuditService.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.user.CurrentUserService;
@@ -77,7 +77,7 @@ public class DefaultTrackedEntityAttributeValueAuditService
 
         Set<String> allUserReadableTrackedEntityAttributes = trackedEntityAttributeService
             .getAllUserReadableTrackedEntityAttributes( currentUserService.getCurrentUser() ).stream()
-            .map( BaseIdentifiableObject::getUid ).collect( Collectors.toSet() );
+            .map( IdentifiableObject::getUid ).collect( Collectors.toSet() );
 
         return trackedEntityAttributeValueAudits.stream()
             .filter( audit -> allUserReadableTrackedEntityAttributes.contains( audit.getAttribute().getUid() ) )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentityattributevalue/TrackerTrigramIndexingJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentityattributevalue/TrackerTrigramIndexingJob.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
@@ -158,7 +158,7 @@ public class TrackerTrigramIndexingJob implements Job
         Set<Long> teaIds = new HashSet<>( teaIdList );
 
         // Collect tea ids of all indexable attributets
-        Set<Long> allIndexableAttributeIds = allIndexableAttributes.stream().map( BaseIdentifiableObject::getId )
+        Set<Long> allIndexableAttributeIds = allIndexableAttributes.stream().map( IdentifiableObject::getId )
             .collect(
                 Collectors.toSet() );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -64,7 +64,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.common.AuditLogUtil;
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.UserOrgUnitType;
 import org.hisp.dhis.commons.filter.FilterUtils;
 import org.hisp.dhis.dataset.DataSet;
@@ -713,7 +713,7 @@ public class DefaultUserService
         if ( userRoles != null )
         {
             List<UserRole> roles = userRoleStore.getByUid(
-                userRoles.stream().map( BaseIdentifiableObject::getUid ).collect( Collectors.toList() ) );
+                userRoles.stream().map( IdentifiableObject::getUid ).collect( Collectors.toList() ) );
 
             roles.forEach( ur -> {
                 if ( ur == null )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregate.java
@@ -49,7 +49,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.dxf2.events.TrackedEntityInstanceParams;
 import org.hisp.dhis.dxf2.events.enrollment.Enrollment;
@@ -133,7 +133,7 @@ public class TrackedEntityInstanceAggregate
                 && !CollectionUtils.isEmpty( user.get().getGroups() ) )
             {
                 userGroupUIDCache.put( user.get().getUid(),
-                    user.get().getGroups().stream().map( BaseIdentifiableObject::getUid )
+                    user.get().getGroups().stream().map( IdentifiableObject::getUid )
                         .collect( Collectors.toList() ) );
             }
         } );
@@ -287,7 +287,7 @@ public class TrackedEntityInstanceAggregate
         // skipSynchronization in case this is a dataSynchronization query
         Set<String> allowedAttributeUids = trackedEntityTypeAttributes.stream()
             .filter( att -> (!ctx.getParams().isDataSynchronizationQuery() || !att.getSkipSynchronization()) )
-            .map( BaseIdentifiableObject::getUid )
+            .map( IdentifiableObject::getUid )
             .collect( Collectors.toSet() );
 
         for ( Program program : teaByProgram.keySet() )
@@ -296,7 +296,7 @@ public class TrackedEntityInstanceAggregate
             {
                 allowedAttributeUids.addAll( teaByProgram.get( program ).stream()
                     .filter( att -> (!ctx.getParams().isDataSynchronizationQuery() || !att.getSkipSynchronization()) )
-                    .map( BaseIdentifiableObject::getUid )
+                    .map( IdentifiableObject::getUid )
                     .collect( Collectors.toSet() ) );
             }
         }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventServiceContextBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventServiceContextBuilder.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dxf2.events.report.EventRow;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
@@ -90,7 +90,7 @@ public class EventServiceContextBuilder
                 .collect( Collectors.toSet() ) )
             .stream()
             .collect( Collectors.toMap(
-                BaseIdentifiableObject::getUid,
+                IdentifiableObject::getUid,
                 program -> program ) );
 
         Map<Pair<String, String>, String> orgUnitByTeiUidAndProgramUidPairs = eventsByProgramUid.keySet().stream()
@@ -111,7 +111,7 @@ public class EventServiceContextBuilder
 
         Map<String, OrganisationUnit> orgUnitsByUid = organisationUnitService
             .getOrganisationUnitsByUid( orgUnitByTeiUidAndProgramUidPairs.values() ).stream()
-            .collect( Collectors.toMap( BaseIdentifiableObject::getUid, ou -> ou ) );
+            .collect( Collectors.toMap( IdentifiableObject::getUid, ou -> ou ) );
 
         return new EventContext( trackedEntityInstanceByUid, programsByUid, orgUnitByTeiUidAndProgramUidPairs,
             orgUnitsByUid );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -96,9 +96,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.AssignedUserSelectionMode;
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdSchemes;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
@@ -1999,7 +1999,7 @@ public class JdbcEventStore implements EventStore
          * Extract the primary keys from the created objects
          */
         List<Long> eventIds = batch.stream()
-            .map( BaseIdentifiableObject::getId )
+            .map( IdentifiableObject::getId )
             .collect( Collectors.toList() );
 
         /*

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ProgramOrgUnitSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ProgramOrgUnitSupplier.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.NotImplementedException;
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.events.event.Event;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -68,7 +68,7 @@ public class ProgramOrgUnitSupplier extends AbstractSupplier<Map<Long, List<Long
         // Collect all the org unit IDs to pass as SQL query
         // argument
         //
-        final Set<Long> orgUnitIds = orgUniMap.values().stream().map( BaseIdentifiableObject::getId )
+        final Set<Long> orgUnitIds = orgUniMap.values().stream().map( IdentifiableObject::getId )
             .collect( Collectors.toSet() );
 
         if ( isEmpty( orgUnitIds ) )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/shared/preprocess/FilteringOutUndeclaredDataElementsProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/shared/preprocess/FilteringOutUndeclaredDataElementsProcessor.java
@@ -33,8 +33,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdScheme;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dxf2.events.event.DataValue;
 import org.hisp.dhis.dxf2.events.event.Event;
 import org.hisp.dhis.dxf2.events.importer.Processor;
@@ -90,7 +90,7 @@ public class FilteringOutUndeclaredDataElementsProcessor implements Processor
             .map( ProgramStage::getDataElements )
             .orElse( Collections.emptySet() )
             .stream()
-            .map( BaseIdentifiableObject::getUid )
+            .map( IdentifiableObject::getUid )
             .collect( Collectors.toSet() );
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/DataSetObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/DataSetObjectBundleHook.java
@@ -33,7 +33,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import org.hibernate.Session;
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.dataset.DataInputPeriod;
@@ -88,7 +88,7 @@ public class DataSetObjectBundleHook extends AbstractObjectBundleHook<DataSet>
      */
     private void deleteCompulsoryDataElementOperands( DataSet importDataSet )
     {
-        Set<String> dataElementIds = importDataSet.getDataElements().stream().map( BaseIdentifiableObject::getUid )
+        Set<String> dataElementIds = importDataSet.getDataElements().stream().map( IdentifiableObject::getUid )
             .collect( Collectors.toSet() );
 
         importDataSet.setCompulsoryDataElementOperands(
@@ -104,7 +104,7 @@ public class DataSetObjectBundleHook extends AbstractObjectBundleHook<DataSet>
 
         Session session = sessionFactory.getCurrentSession();
 
-        List<String> importIds = importDataSet.getSections().stream().map( BaseIdentifiableObject::getUid )
+        List<String> importIds = importDataSet.getSections().stream().map( IdentifiableObject::getUid )
             .collect( Collectors.toList() );
 
         persistedDataSet.getSections().stream().filter( section -> !importIds.contains( section.getUid() ) )
@@ -124,7 +124,7 @@ public class DataSetObjectBundleHook extends AbstractObjectBundleHook<DataSet>
     {
         return section.getDataElements().stream().filter( de -> {
             Set<String> dataElements = importDataSet.getDataElements().stream()
-                .map( BaseIdentifiableObject::getUid ).collect( Collectors.toSet() );
+                .map( IdentifiableObject::getUid ).collect( Collectors.toSet() );
             return dataElements.contains( de.getUid() );
         } ).collect( Collectors.toList() );
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramStageObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramStageObjectBundleHook.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 
 import org.hibernate.Session;
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
@@ -103,7 +103,7 @@ public class ProgramStageObjectBundleHook extends AbstractObjectBundleHook<Progr
     private void deleteRemovedSection( ProgramStage persistedProgramStage, ProgramStage importProgramStage )
     {
         List<String> importIds = importProgramStage.getProgramStageSections().stream()
-            .map( BaseIdentifiableObject::getUid )
+            .map( IdentifiableObject::getUid )
             .collect( Collectors.toList() );
 
         List<ProgramStageSection> programStageSectionsToDelete = persistedProgramStage.getProgramStageSections()

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/RelationshipTypeObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/RelationshipTypeObjectBundleHook.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 
 import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
@@ -219,13 +219,13 @@ public class RelationshipTypeObjectBundleHook
             trackedEntityType = trackedEntityTypeService.getTrackedEntityType( trackedEntityType.getUid() );
 
             Set<String> trackedEntityTypeAttributes = Optional.ofNullable( trackedEntityType )
-                .map( t -> t.getTrackedEntityAttributes().stream().map( BaseIdentifiableObject::getUid )
+                .map( t -> t.getTrackedEntityAttributes().stream().map( IdentifiableObject::getUid )
                     .collect( Collectors.toSet() ) )
                 .orElse( new HashSet<>() );
 
             Set<String> programTrackedEntityAttributes = Optional.ofNullable( constraint.getProgram() )
                 .map( p -> programService.getProgram( p.getUid() ) )
-                .map( p -> p.getTrackedEntityAttributes().stream().map( BaseIdentifiableObject::getUid )
+                .map( p -> p.getTrackedEntityAttributes().stream().map( IdentifiableObject::getUid )
                     .collect( Collectors.toSet() ) )
                 .orElse( new HashSet<>() );
 
@@ -289,7 +289,7 @@ public class RelationshipTypeObjectBundleHook
             Program program = programService.getProgram( constraint.getProgram().getUid() );
 
             Set<String> trackedEntityAttributes = Optional.ofNullable( program ).filter( Program::isRegistration )
-                .map( p -> p.getTrackedEntityAttributes().stream().map( BaseIdentifiableObject::getUid )
+                .map( p -> p.getTrackedEntityAttributes().stream().map( IdentifiableObject::getUid )
                     .collect( Collectors.toSet() ) )
                 .orElse( new HashSet<>() );
 
@@ -340,18 +340,18 @@ public class RelationshipTypeObjectBundleHook
         }
 
         Program program = programService.getProgram(
-            Optional.ofNullable( constraint.getProgram() ).map( BaseIdentifiableObject::getUid )
+            Optional.ofNullable( constraint.getProgram() ).map( IdentifiableObject::getUid )
                 .orElse( StringUtils.EMPTY ) );
         ProgramStage programStage = constraint.getProgramStage();
 
         Set<String> dataElementIds = Optional.ofNullable( programStage )
             .map( ps -> programStageService.getProgramStage( ps.getUid() ) )
             .map(
-                s -> s.getDataElements().stream().map( BaseIdentifiableObject::getUid ).collect( Collectors.toSet() ) )
+                s -> s.getDataElements().stream().map( IdentifiableObject::getUid ).collect( Collectors.toSet() ) )
             .orElse( new HashSet<>() );
 
         Set<String> trackedEntityAttributesIds = Optional.ofNullable( program )
-            .map( p -> p.getTrackedEntityAttributes().stream().map( BaseIdentifiableObject::getUid )
+            .map( p -> p.getTrackedEntityAttributes().stream().map( IdentifiableObject::getUid )
                 .collect( Collectors.toSet() ) )
             .orElse( new HashSet<>() );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 
 import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.adapter.BaseIdentifiableObject_;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.external.conf.ConfigurationKey;
@@ -283,7 +283,7 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook<User>
     {
         Set<UserRole> roles = user
             .getUserRoles();
-        Set<String> currentRoles = roles.stream().map( BaseIdentifiableObject::getUid )
+        Set<String> currentRoles = roles.stream().map( IdentifiableObject::getUid )
             .collect( Collectors.toSet() );
 
         if ( userRoles != null )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/shared/preprocess/FilteringOutUndeclaredDataElementsProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/shared/preprocess/FilteringOutUndeclaredDataElementsProcessorTest.java
@@ -40,7 +40,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.events.event.DataValue;
 import org.hisp.dhis.dxf2.events.event.Event;
@@ -82,7 +82,7 @@ class FilteringOutUndeclaredDataElementsProcessorTest
         preProcessor.process( event, ctx );
         Set<String> allowedDataValues = ctx
             .getProgramStage( ctx.getImportOptions().getIdSchemes().getProgramStageIdScheme(), PROGRAMSTAGE )
-            .getDataElements().stream().map( BaseIdentifiableObject::getUid ).collect( Collectors.toSet() );
+            .getDataElements().stream().map( IdentifiableObject::getUid ).collect( Collectors.toSet() );
         Set<String> filteredEventDataValues = ctx.getEventDataValueMap().values().stream().flatMap( Collection::stream )
             .map( EventDataValue::getDataElement ).collect( Collectors.toSet() );
         assertTrue( allowedDataValues.containsAll( filteredEventDataValues ) );

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/ProgramRuleDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/ProgramRuleDeletionHandler.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageSection;
@@ -77,7 +77,7 @@ public class ProgramRuleDeletionHandler extends DeletionHandler
             .getProgramRule( programStage.getProgram() )
             .stream()
             .filter( pr -> isLinkedToProgramStageSection( programStageSection, pr ) )
-            .map( BaseIdentifiableObject::getName )
+            .map( IdentifiableObject::getName )
             .collect( Collectors.joining( ", " ) );
 
         return StringUtils.isBlank( programRules )
@@ -91,7 +91,7 @@ public class ProgramRuleDeletionHandler extends DeletionHandler
             .getProgramRule( programStage.getProgram() )
             .stream()
             .filter( pr -> isLinkedToProgramStage( programStage, pr ) )
-            .map( BaseIdentifiableObject::getName )
+            .map( IdentifiableObject::getName )
             .collect( Collectors.joining( ", " ) );
 
         return StringUtils.isBlank( programRules )

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/ProgramRuleVariableDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/ProgramRuleVariableDeletionHandler.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.system.deletion.DeletionHandler;
@@ -64,7 +64,7 @@ public class ProgramRuleVariableDeletionHandler extends DeletionHandler
             .getProgramRuleVariable( programStage.getProgram() )
             .stream()
             .filter( prv -> Objects.equals( prv.getProgramStage(), programStage ) )
-            .map( BaseIdentifiableObject::getName )
+            .map( IdentifiableObject::getName )
             .collect( Collectors.joining( ", " ) );
 
         return StringUtils.isBlank( programRuleVariables )

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DataValidationRunner.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DataValidationRunner.java
@@ -58,11 +58,11 @@ import org.hisp.dhis.analytics.AnalyticsService;
 import org.hisp.dhis.analytics.DataQueryParams;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.MapMap;
 import org.hisp.dhis.common.MapMapMap;
 import org.hisp.dhis.commons.util.DebugUtils;
@@ -700,7 +700,7 @@ public class DataValidationRunner
             int vlInx = grid.getWidth() - 1;
 
             Map<String, OrganisationUnit> ouLookup = orgUnits.stream()
-                .collect( Collectors.toMap( BaseIdentifiableObject::getUid, o -> o ) );
+                .collect( Collectors.toMap( IdentifiableObject::getUid, o -> o ) );
             Map<String, DimensionalItemObject> dxLookup = periodTypeX.getEventItems().stream()
                 .collect( Collectors.toMap( DimensionalItemObject::getDimensionItem, d -> d ) );
             dxLookup.putAll( periodTypeX.getIndicators().stream()

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/scheduling/MonitoringJob.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/scheduling/MonitoringJob.java
@@ -40,7 +40,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.SetUtils;
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
@@ -94,7 +94,7 @@ public class MonitoringJob implements Job
             Collection<ValidationRule> rules = getValidationRules( groupUIDs );
             progress.startingStage( "Preparing analysis parameters" );
             List<Period> periods = progress.runStage( List.of(),
-                ps -> rules.stream().map( BaseIdentifiableObject::getName ).collect( joining( ", " ) ),
+                ps -> rules.stream().map( IdentifiableObject::getName ).collect( joining( ", " ) ),
                 () -> getPeriods( params, rules ) );
 
             ValidationAnalysisParams parameters = validationService

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/ProgramRuleVariableSchemaDescriptor.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/ProgramRuleVariableSchemaDescriptor.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.programrule.ProgramRuleVariable;
 import org.hisp.dhis.schema.Schema;
@@ -70,7 +69,7 @@ public class ProgramRuleVariableSchemaDescriptor implements SchemaDescriptor
 
     private Function<IdentifiableObject, String> nameExtractor()
     {
-        return o -> castAndExtract( o, BaseIdentifiableObject::getName );
+        return o -> castAndExtract( o, IdentifiableObject::getName );
     }
 
     private Function<IdentifiableObject, String> programUidExtractor()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
@@ -43,7 +43,7 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
@@ -191,7 +191,7 @@ public class EventTrackerConverterService
             .map( DataValue::getDataElement )
             .map( preheat::getDataElement )
             .filter( java.util.Objects::nonNull )
-            .map( BaseIdentifiableObject::getUid )
+            .map( IdentifiableObject::getUid )
             .collect( Collectors.toSet() );
         for ( EventDataValue eventDataValue : programStageInstance.getEventDataValues() )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstancesWithAtLeastOneEventSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstancesWithAtLeastOneEventSupplier.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
@@ -69,7 +69,7 @@ public class ProgramInstancesWithAtLeastOneEventSupplier extends JdbcAbstractPre
     public void preheatAdd( TrackerImportParams params, TrackerPreheat preheat )
     {
         final Map<String, ProgramInstance> enrollments = preheat.getEnrollments();
-        List<Long> programStageIds = enrollments.values().stream().map( BaseIdentifiableObject::getId )
+        List<Long> programStageIds = enrollments.values().stream().map( IdentifiableObject::getId )
             .collect( Collectors.toList() );
 
         if ( !programStageIds.isEmpty() )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/TrackedEntityProgramInstanceSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/TrackedEntityProgramInstanceSupplier.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStatus;
@@ -94,7 +94,7 @@ public class TrackedEntityProgramInstanceSupplier extends JdbcAbstractPreheatSup
         List<String> trackedEntityList = params.getEnrollments().stream().map( Enrollment::getTrackedEntity )
             .collect( Collectors.toList() );
 
-        List<String> programList = preheat.getAll( Program.class ).stream().map( BaseIdentifiableObject::getUid )
+        List<String> programList = preheat.getAll( Program.class ).stream().map( IdentifiableObject::getUid )
             .collect( Collectors.toList() );
 
         List<List<String>> teiList = Lists.partition( new ArrayList<>( trackedEntityList ),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/RuleActionEventMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/RuleActionEventMapper.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.rules.models.RuleAction;
 import org.hisp.dhis.rules.models.RuleActionAssign;
@@ -151,7 +151,7 @@ class RuleActionEventMapper
 
         return programStage.getDataElements()
             .stream()
-            .map( BaseIdentifiableObject::getUid )
+            .map( IdentifiableObject::getUid )
             .anyMatch( de -> de.equals( dataElementUid ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/hibernate/HibernateValidationResultStore.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/hibernate/HibernateValidationResultStore.java
@@ -44,7 +44,7 @@ import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryOptionGroupSet;
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.commons.util.SqlHelper;
@@ -389,7 +389,7 @@ public class HibernateValidationResultStore
 
         if ( !u.getGroups().isEmpty() )
         {
-            Set<String> groups = u.getGroups().stream().map( BaseIdentifiableObject::getUid )
+            Set<String> groups = u.getGroups().stream().map( IdentifiableObject::getUid )
                 .collect( Collectors.toSet() );
             groupUids = "{" + String.join( ",", groups ) + "}";
         }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/security/CategorySecurityUtilsTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/security/CategorySecurityUtilsTest.java
@@ -44,10 +44,10 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryCombo;
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.program.Program;
 import org.junit.jupiter.api.Test;
 
@@ -130,7 +130,7 @@ class CategorySecurityUtilsTest
                 params.getFilters().stream() )
                 .collect( Collectors.toList() ) )
                     .stream()
-                    .map( BaseIdentifiableObject::getUid )
+                    .map( IdentifiableObject::getUid )
                     .collect( Collectors.toList() );
 
         assertThat( expected, containsInAnyOrder( actual.toArray() ) );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -71,10 +71,10 @@ import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DimensionItemType;
 import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.MapMap;
 import org.hisp.dhis.common.QueryModifiers;
@@ -1440,7 +1440,7 @@ class ExpressionServiceTest extends SingleSetupIntegrationTestBase
         List<Indicator> indicators = Arrays.asList( indicatorA, indicatorB );
         List<OrganisationUnitGroup> items = expressionService.getOrgUnitGroupCountGroups( indicators );
         assertEquals( 3, items.size() );
-        List<String> nameList = items.stream().map( BaseIdentifiableObject::getName ).sorted()
+        List<String> nameList = items.stream().map( IdentifiableObject::getName ).sorted()
             .collect( Collectors.toList() );
         String names = String.join( ",", nameList );
         assertEquals( "OugA,OugB,OugC", names );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentCriteriaMapper.java
@@ -37,7 +37,7 @@ import java.util.Set;
 
 import lombok.RequiredArgsConstructor;
 
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -165,7 +165,7 @@ public class EnrollmentCriteriaMapper
         params.setProgramEndDate( programEndDate );
         params.setTrackedEntityType( te );
         params.setTrackedEntityInstanceUid(
-            Optional.ofNullable( tei ).map( BaseIdentifiableObject::getUid ).orElse( null ) );
+            Optional.ofNullable( tei ).map( IdentifiableObject::getUid ).orElse( null ) );
         params.setOrganisationUnitMode( ouMode );
         params.setPage( page );
         params.setPageSize( pageSize );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityAttributeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityAttributeController.java
@@ -38,8 +38,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.reservedvalue.ReserveValueException;
@@ -213,7 +213,7 @@ public class TrackedEntityAttributeController
             .getAllTrigramIndexableTrackedEntityAttributes();
 
         StringBuilder sb = new StringBuilder( "id:in:" );
-        sb.append( indexableTeas.stream().map( BaseIdentifiableObject::getUid )
+        sb.append( indexableTeas.stream().map( IdentifiableObject::getUid )
             .collect( Collectors.joining( ",", "[", "]" ) ) );
 
         filters.add( sb.toString() );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteriaMapper.java
@@ -41,7 +41,7 @@ import javax.annotation.Nonnull;
 
 import lombok.RequiredArgsConstructor;
 
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -113,7 +113,7 @@ public class TrackerEnrollmentCriteriaMapper
         params.setProgramEndDate( criteria.getEnrolledBefore() );
         params.setTrackedEntityType( trackedEntityType );
         params.setTrackedEntityInstanceUid(
-            Optional.ofNullable( trackedEntity ).map( BaseIdentifiableObject::getUid ).orElse( null ) );
+            Optional.ofNullable( trackedEntity ).map( IdentifiableObject::getUid ).orElse( null ) );
         params.addOrganisationUnits( orgUnits );
         params.setOrganisationUnitMode( criteria.getOuMode() );
         params.setPage( criteria.getPage() );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/MeController.java
@@ -49,8 +49,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dataapproval.DataApprovalLevel;
@@ -185,10 +185,10 @@ public class MeController
         Map<String, Serializable> userSettings = userSettingService.getUserSettingsWithFallbackByUserAsMap(
             user, USER_SETTING_KEYS, true );
 
-        List<String> programs = programService.getCurrentUserPrograms().stream().map( BaseIdentifiableObject::getUid )
+        List<String> programs = programService.getCurrentUserPrograms().stream().map( IdentifiableObject::getUid )
             .collect( Collectors.toList() );
 
-        List<String> dataSets = dataSetService.getUserDataRead( user ).stream().map( BaseIdentifiableObject::getUid )
+        List<String> dataSets = dataSetService.getUserDataRead( user ).stream().map( IdentifiableObject::getUid )
             .collect( Collectors.toList() );
 
         MeDto meDto = new MeDto( user, userSettings, programs, dataSets );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/dimension/mappers/DataElementMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/dimension/mappers/DataElementMapper.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import lombok.Getter;
 
 import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.PrefixedDimension;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.webapi.dimension.DimensionResponse;
@@ -58,7 +59,7 @@ public class DataElementMapper extends BaseDimensionalItemObjectMapper
 
         return Optional.of( dataElement )
             .map( DataElement::getOptionSet )
-            .map( BaseIdentifiableObject::getUid )
+            .map( IdentifiableObject::getUid )
             .map( mapped::withOptionSet )
             .orElse( mapped );
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/dimension/mappers/ProgramStageDataElementMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/dimension/mappers/ProgramStageDataElementMapper.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import lombok.Getter;
 
 import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.PrefixedDimension;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.program.ProgramStageDataElement;
@@ -64,7 +65,7 @@ public class ProgramStageDataElementMapper extends BaseDimensionalItemObjectMapp
         return Optional.of( programStageDataElement )
             .map( ProgramStageDataElement::getDataElement )
             .map( DataElement::getOptionSet )
-            .map( BaseIdentifiableObject::getUid )
+            .map( IdentifiableObject::getUid )
             .map( mapped::withOptionSet )
             .orElse( mapped );
     }


### PR DESCRIPTION
Replaces `BaseIdentifiableObject` with `IdentifiableObject` where possible when using method references.