### PR TITLE
fix: Perf issue in /analytics [DHIS2-15093]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -57,6 +57,7 @@ import org.hisp.dhis.system.grid.ListGrid;
 import org.hisp.dhis.visualization.Visualization;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Lars Helge Overland
@@ -97,6 +98,7 @@ public class DefaultAnalyticsService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Grid getAggregatedDataValues( DataQueryParams params )
     {
         params = checkSecurityConstraints( params );
@@ -115,6 +117,7 @@ public class DefaultAnalyticsService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Grid getAggregatedDataValues( DataQueryParams params, List<String> columns, List<String> rows )
     {
         return isTableLayout( columns, rows ) ? getAggregatedDataValuesTableLayout( params, columns, rows )
@@ -122,6 +125,7 @@ public class DefaultAnalyticsService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Grid getRawDataValues( DataQueryParams params )
     {
         params = checkSecurityConstraints( params );
@@ -132,6 +136,7 @@ public class DefaultAnalyticsService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DataValueSet getAggregatedDataValueSet( DataQueryParams params )
     {
         params = checkSecurityConstraints( params );
@@ -149,6 +154,7 @@ public class DefaultAnalyticsService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Grid getAggregatedDataValues( AnalyticalObject object )
     {
         DataQueryParams params = dataQueryService.getFromAnalyticalObject( object );
@@ -157,6 +163,7 @@ public class DefaultAnalyticsService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Map<String, Object> getAggregatedDataValueMapping( DataQueryParams params )
     {
         Grid grid = getAggregatedDataValues( newBuilder( params )
@@ -166,6 +173,7 @@ public class DefaultAnalyticsService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Map<String, Object> getAggregatedDataValueMapping( AnalyticalObject object )
     {
         DataQueryParams params = dataQueryService.getFromAnalyticalObject( object );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
@@ -123,6 +123,7 @@ import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.ObjectUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
 /**
@@ -181,6 +182,7 @@ public class DefaultDataQueryService
     // -------------------------------------------------------------------------
 
     @Override
+    @Transactional( readOnly = true )
     public DataQueryParams getFromRequest( DataQueryRequest request )
     {
         I18nFormat format = i18nManager.getI18nFormat();
@@ -249,6 +251,7 @@ public class DefaultDataQueryService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DataQueryParams getFromAnalyticalObject( AnalyticalObject object )
     {
         Assert.notNull( object, "Analytical object cannot be null" );
@@ -292,6 +295,7 @@ public class DefaultDataQueryService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public List<DimensionalObject> getDimensionalObjects( Set<String> dimensionParams,
         Date relativePeriodDate, String userOrgUnit, I18nFormat format, boolean allowAllPeriods,
         IdScheme inputIdScheme )
@@ -322,6 +326,7 @@ public class DefaultDataQueryService
     // instead of fetching all org units one by one.
 
     @Override
+    @Transactional( readOnly = true )
     public DimensionalObject getDimension( String dimension, List<String> items, Date relativePeriodDate,
         List<OrganisationUnit> userOrgUnits, I18nFormat format, boolean allowNull, boolean allowAllPeriodItems,
         IdScheme inputIdScheme )
@@ -712,6 +717,7 @@ public class DefaultDataQueryService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public List<OrganisationUnit> getUserOrgUnits( DataQueryParams params, String userOrgUnit )
     {
         final List<OrganisationUnit> units = new ArrayList<>();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -152,6 +152,7 @@ import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.util.Timer;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * This component is responsible for handling and retrieving data based on the
@@ -242,6 +243,7 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
+    @Transactional( readOnly = true )
     void addIndicatorValues( DataQueryParams params, Grid grid )
     {
         if ( !params.getIndicators().isEmpty() && !params.isSkipData() )
@@ -341,6 +343,7 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
+    @Transactional( readOnly = true )
     void addDataElementValues( DataQueryParams params, Grid grid )
     {
         if ( !params.getAllDataElements().isEmpty() && (!params.isSkipData() || params.analyzeOnly()) )
@@ -374,6 +377,7 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
+    @Transactional( readOnly = true )
     void addProgramDataElementAttributeIndicatorValues( DataQueryParams params, Grid grid )
     {
         if ( (!params.getAllProgramDataElementsAndAttributes().isEmpty() || !params.getProgramIndicators().isEmpty())
@@ -420,6 +424,7 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
+    @Transactional( readOnly = true )
     void addReportingRates( DataQueryParams params, Grid grid )
     {
         if ( !params.getReportingRates().isEmpty() && !params.isSkipData() )
@@ -444,6 +449,7 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
+    @Transactional( readOnly = true )
     void addDataElementOperandValues( DataQueryParams params, Grid grid )
     {
         if ( !params.getDataElementOperands().isEmpty() && !params.isSkipData() )
@@ -466,6 +472,7 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
+    @Transactional( readOnly = true )
     void addDynamicDimensionValues( DataQueryParams params, Grid grid )
     {
         if ( params.getDataDimensionAndFilterOptions().isEmpty() && !params.isSkipData() )
@@ -484,6 +491,7 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
+    @Transactional( readOnly = true )
     void addValidationResultValues( DataQueryParams params, Grid grid )
     {
         if ( !params.getAllValidationResults().isEmpty() && !params.isSkipData() )
@@ -505,6 +513,7 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
+    @Transactional( readOnly = true )
     void addRawData( DataQueryParams params, Grid grid )
     {
         if ( !params.isSkipData() )
@@ -523,6 +532,7 @@ public class DataHandler
      *
      * @param params the {@link DataQueryParams}.
      */
+    @Transactional( readOnly = true )
     DataQueryParams prepareForRawDataQuery( DataQueryParams params )
     {
         DataQueryParams.Builder builder = newBuilder( params )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/MetadataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/MetadataHandler.java
@@ -61,6 +61,7 @@ import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.PeriodType;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.google.common.collect.Sets;
 
@@ -90,6 +91,7 @@ public class MetadataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
+    @Transactional( readOnly = true )
     void addMetaData( DataQueryParams params, Grid grid )
     {
         if ( !params.isSkipMeta() )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManager.java
@@ -60,6 +60,7 @@ import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Lars Helge Overland
@@ -103,6 +104,7 @@ public class DefaultAnalyticsSecurityManager
     // -------------------------------------------------------------------------
 
     @Override
+    @Transactional( readOnly = true )
     public void decideAccess( DataQueryParams params )
     {
         User user = currentUserService.getCurrentUser();
@@ -185,6 +187,7 @@ public class DefaultAnalyticsSecurityManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public void decideAccessEventQuery( EventQueryParams params )
     {
         decideAccess( params );
@@ -212,6 +215,7 @@ public class DefaultAnalyticsSecurityManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public User getCurrentUser( DataQueryParams params )
     {
         return params != null && params.hasCurrentUser() ? params.getCurrentUser()
@@ -219,6 +223,7 @@ public class DefaultAnalyticsSecurityManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DataQueryParams withDataApprovalConstraints( DataQueryParams params )
     {
         DataQueryParams.Builder paramsBuilder = DataQueryParams.newBuilder( params );
@@ -267,6 +272,7 @@ public class DefaultAnalyticsSecurityManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DataQueryParams withUserConstraints( DataQueryParams params )
     {
         DataQueryParams.Builder builder = DataQueryParams.newBuilder( params );
@@ -278,6 +284,7 @@ public class DefaultAnalyticsSecurityManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public EventQueryParams withUserConstraints( EventQueryParams params )
     {
         EventQueryParams.Builder builder = new EventQueryParams.Builder( params );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/calendar/DefaultCalendarService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/calendar/DefaultCalendarService.java
@@ -107,6 +107,7 @@ public class DefaultCalendarService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Calendar getSystemCalendar()
     {
         String calendarKey = settingManager.getStringSetting( SettingKey.CALENDAR );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/calendar/DefaultCalendarService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/calendar/DefaultCalendarService.java
@@ -107,7 +107,6 @@ public class DefaultCalendarService
     }
 
     @Override
-    @Transactional( readOnly = true )
     public Calendar getSystemCalendar()
     {
         String calendarKey = settingManager.getStringSetting( SettingKey.CALENDAR );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
@@ -121,6 +121,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityProgramIndicatorDimension;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.google.common.collect.Sets;
 
@@ -350,12 +351,14 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DimensionalItemObject getDataDimensionalItemObject( String dimensionItem )
     {
         return getDataDimensionalItemObject( IdScheme.UID, dimensionItem );
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DimensionalItemObject getDataDimensionalItemObject( IdScheme idScheme, String dimensionItem )
     {
         if ( DimensionalObjectUtils.isCompositeDimensionalObject( dimensionItem ) )
@@ -403,6 +406,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DimensionalItemObject getDataDimensionalItemObject( DimensionalItemId itemId )
     {
         Collection<DimensionalItemObject> items = getDataDimensionalItemObjectMap( Sets.newHashSet( itemId ) ).values();
@@ -411,6 +415,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Map<DimensionalItemId, DimensionalItemObject> getDataDimensionalItemObjectMap(
         Set<DimensionalItemId> itemIds )
     {
@@ -423,6 +428,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Map<DimensionalItemId, DimensionalItemObject> getNoAclDataDimensionalItemObjectMap(
         Set<DimensionalItemId> itemIds )
     {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -347,6 +347,7 @@ public class DefaultExpressionService
     // -------------------------------------------------------------------------
 
     @Override
+    @Transactional( readOnly = true )
     public Map<DimensionalItemId, DimensionalItemObject> getIndicatorDimensionalItemMap(
         Collection<Indicator> indicators )
     {
@@ -360,6 +361,7 @@ public class DefaultExpressionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public List<OrganisationUnitGroup> getOrgUnitGroupCountGroups( Collection<Indicator> indicators )
     {
         if ( indicators == null )
@@ -379,6 +381,7 @@ public class DefaultExpressionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public IndicatorValue getIndicatorValueObject( Indicator indicator, List<Period> periods,
         Map<DimensionalItemId, DimensionalItemObject> itemMap, Map<DimensionalItemObject, Object> valueMap,
         Map<String, Integer> orgUnitCountMap )
@@ -459,7 +462,7 @@ public class DefaultExpressionService
     // -------------------------------------------------------------------------
 
     @Override
-    @Transactional
+    @Transactional( readOnly = true )
     public ExpressionValidationOutcome expressionIsValid( String expression, ParseType parseType )
     {
         try
@@ -510,6 +513,7 @@ public class DefaultExpressionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public ExpressionInfo getExpressionInfo( ExpressionParams params )
     {
         if ( StringUtils.isEmpty( params.getExpression() ) )
@@ -525,6 +529,7 @@ public class DefaultExpressionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public ExpressionParams getBaseExpressionParams( ExpressionInfo info )
     {
         return ExpressionParams.builder()
@@ -536,6 +541,7 @@ public class DefaultExpressionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Set<String> getExpressionElementAndOptionComboIds( String expression, ParseType parseType )
     {
         return getExpressionDimensionalItemIds( expression, parseType ).stream()
@@ -545,6 +551,7 @@ public class DefaultExpressionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Set<String> getExpressionDataElementIds( String expression, ParseType parseType )
     {
         return getExpressionDimensionalItemIds( expression, parseType ).stream()
@@ -554,6 +561,7 @@ public class DefaultExpressionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Set<String> getExpressionOptionComboIds( String expression, ParseType parseType )
     {
         Set<String> categoryOptionComboIds = new HashSet<>();
@@ -577,6 +585,7 @@ public class DefaultExpressionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Set<DimensionalItemId> getExpressionDimensionalItemIds( String expression, ParseType parseType )
     {
         Set<DimensionalItemId> itemIds = new HashSet<>();
@@ -587,6 +596,7 @@ public class DefaultExpressionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Set<String> getExpressionOrgUnitGroupIds( String expression, ParseType parseType )
     {
         if ( isEmpty( expression ) )
@@ -607,6 +617,7 @@ public class DefaultExpressionService
     // -------------------------------------------------------------------------
 
     @Override
+    @Transactional( readOnly = true )
     public Object getExpressionValue( ExpressionParams params )
     {
         if ( isEmpty( params.getExpression() ) )
@@ -667,6 +678,7 @@ public class DefaultExpressionService
     // -------------------------------------------------------------------------
 
     @Override
+    @Transactional( readOnly = true )
     public Map<String, Constant> getConstantMap()
     {
         return constantMapCache.get( "x", key -> constantService.getConstantMap() );

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
@@ -76,7 +76,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.header.HeaderWriterFilter;
 import org.springframework.security.web.util.matcher.RequestMatcher;
-import org.springframework.session.web.http.DefaultCookieSerializer;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;


### PR DESCRIPTION
**DO NOT MERGE IT! NEEDS APPROVAL FROM RCB**

The logs in Glowroot, in a server in HISP South Africa, show that in release 2.38 we have many JDBC commits happening for each `/analytics` request.

These commits represent a few hundred thousand times each request, going over 1 million on several cases.
The goal of this PR is to make the respective operations `read-only`, as it was in 2.35.

These changes have been tested and drastically reduced the overall response time of analytics requests.
Comparing 2.35 with this branch, on the client's environment, we could see response times ~20% to ~45% faster on average.

The client is going to run some tests on this patch version and give us feedback. Once we have the confirmation from them we can proceed and merge this PR, and finally get a patched release version.

-----------------------

Initially, I thought that the introduction of some transactional annotations could be triggering this problem, as in 2.35 we don't have any transaction annotations at all in the same flows. After removing a few of them, and profiling the requests, we could still see those transactions being created in write mode.

So, I thought that for some reason, (in 2.38) we needed to annotate the parent service calls as read-only in order to force and propagate this behaviour across all service calls in the chain (the ones that are loading data through Hibernate).

Based on that, I started with a single flow and made it read-only. After a round of profiling, I could see the number of transactions and commits dropping. I went ahead and made all flows read-only. After another round of profiling, I could not see any transactions or commits being created anymore.

This PR will add the transaction annotation in `read-only` mode on several methods so we can guarantee they are correctly propagated today and in the future.

Moving forward, we should keep this approach for new service methods introduced that interact with the persistence layer.

As a bonus, we got a significant performance improvement.