### PR TITLE
feat: cleanup job for expired lock exceptions [DHIS2-7763]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/DataSetService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/DataSetService.java
@@ -287,6 +287,16 @@ public interface DataSetService extends DataSetDataIntegrityProvider
     void deleteLockExceptions( OrganisationUnit organisationUnit );
 
     /**
+     * Deletes all lock exceptions that are considered expired. This means their
+     * creation date is before the given date.
+     *
+     * @param createdBefore The threshold date, any {@link LockException} with
+     *        an older created date is deleted
+     * @return number of deleted lock exceptions
+     */
+    int deleteExpiredLockExceptions( Date createdBefore );
+
+    /**
      * Checks whether the period is locked for data entry for the given input,
      * checking the dataset's expiryDays and lockExceptions.
      *

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/LockException.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/LockException.java
@@ -27,6 +27,11 @@
  */
 package org.hisp.dhis.dataset;
 
+import java.util.Date;
+
+import lombok.Setter;
+import lombok.ToString;
+
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.PrimaryKeyObject;
@@ -41,6 +46,8 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@Setter
+@ToString
 @JacksonXmlRootElement( localName = "lockException", namespace = DxfNamespaces.DXF_2_0 )
 public class LockException implements PrimaryKeyObject
 {
@@ -51,6 +58,8 @@ public class LockException implements PrimaryKeyObject
     private OrganisationUnit organisationUnit;
 
     private DataSet dataSet;
+
+    private Date created;
 
     public LockException()
     {
@@ -87,21 +96,11 @@ public class LockException implements PrimaryKeyObject
         return id;
     }
 
-    public void setId( long id )
-    {
-        this.id = id;
-    }
-
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public Period getPeriod()
     {
         return period;
-    }
-
-    public void setPeriod( Period period )
-    {
-        this.period = period;
     }
 
     @JsonProperty
@@ -112,11 +111,6 @@ public class LockException implements PrimaryKeyObject
         return organisationUnit;
     }
 
-    public void setOrganisationUnit( OrganisationUnit organisationUnit )
-    {
-        this.organisationUnit = organisationUnit;
-    }
-
     @JsonProperty
     @JsonSerialize( as = BaseIdentifiableObject.class )
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
@@ -125,19 +119,23 @@ public class LockException implements PrimaryKeyObject
         return dataSet;
     }
 
-    public void setDataSet( DataSet dataSet )
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public Date getCreated()
     {
-        this.dataSet = dataSet;
+        return created;
     }
 
-    @Override
-    public String toString()
+    /**
+     * Set auto-generated fields on save or update
+     */
+    public void setAutoFields()
     {
-        return "LockException{" +
-            "id=" + id +
-            ", period=" + period +
-            ", organisationUnit=" + organisationUnit +
-            ", dataSet=" + dataSet +
-            '}';
+        Date date = new Date();
+
+        if ( created == null )
+        {
+            created = date;
+        }
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
@@ -36,6 +36,7 @@ import org.hisp.dhis.scheduling.parameters.DataIntegrityJobParameters;
 import org.hisp.dhis.scheduling.parameters.DataSynchronizationJobParameters;
 import org.hisp.dhis.scheduling.parameters.DisableInactiveUsersJobParameters;
 import org.hisp.dhis.scheduling.parameters.EventProgramsDataSynchronizationJobParameters;
+import org.hisp.dhis.scheduling.parameters.LockExceptionCleanupJobParameters;
 import org.hisp.dhis.scheduling.parameters.MetadataSyncJobParameters;
 import org.hisp.dhis.scheduling.parameters.MockJobParameters;
 import org.hisp.dhis.scheduling.parameters.MonitoringJobParameters;
@@ -102,6 +103,7 @@ public enum JobType
     TRACKER_IMPORT_NOTIFICATION_JOB( false ),
     TRACKER_IMPORT_RULE_ENGINE_JOB( false ),
     MATERIALIZED_SQL_VIEW_UPDATE( true, SchedulingType.CRON, SqlViewUpdateParameters.class, null ),
+    LOCK_EXCEPTION_CLEANUP( true, SchedulingType.CRON, LockExceptionCleanupJobParameters.class, null ),
 
     // Internal jobs
     LEADER_ELECTION( false ),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/LockExceptionCleanupJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/LockExceptionCleanupJobParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2023, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,46 +25,41 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.dataset;
+package org.hisp.dhis.scheduling.parameters;
 
-import java.util.Date;
-import java.util.List;
+import java.util.Optional;
 
-import org.hisp.dhis.common.GenericStore;
-import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.period.Period;
+import org.hisp.dhis.common.DxfNamespaces;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.scheduling.JobParameters;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Jan Bernitt
  */
-public interface LockExceptionStore
-    extends GenericStore<LockException>
+@JacksonXmlRootElement( localName = "jobParameters", namespace = DxfNamespaces.DXF_2_0 )
+public class LockExceptionCleanupJobParameters implements JobParameters
 {
-    List<LockException> getLockExceptions( List<DataSet> dataSets );
-
-    List<LockException> getLockExceptionCombinations();
-
-    void deleteLockExceptions( DataSet dataSet, Period period );
-
-    void deleteLockExceptions( DataSet dataSet, Period period, OrganisationUnit organisationUnit );
-
-    void deleteLockExceptions( OrganisationUnit organisationUnit );
-
     /**
-     * Deletes all lock exceptions that are considered expired. This means their
-     * creation date is before the given date.
-     *
-     * @param createdBefore The threshold date, any {@link LockException} with
-     *        an older created date is deleted
-     * @return number of deleted lock exceptions
+     * Number of month (from its created date) when a
+     * {@link org.hisp.dhis.dataset.LockException}s is considered expired and
+     * subject to cleanup.
      */
-    int deleteExpiredLockExceptions( Date createdBefore );
+    private Integer expiresAfterMonths;
 
-    long getCount( DataElement dataElement, Period period, OrganisationUnit organisationUnit );
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public Integer getExpiresAfterMonths()
+    {
+        return expiresAfterMonths;
+    }
 
-    long getCount( DataSet dataSet, Period period, OrganisationUnit organisationUnit );
-
-    boolean anyExists();
-
+    @Override
+    public Optional<ErrorReport> validate()
+    {
+        return Optional.empty();
+    }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/LockExceptionCleanupJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/LockExceptionCleanupJobParameters.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.scheduling.parameters;
 import java.util.Optional;
 
 import org.hisp.dhis.common.DxfNamespaces;
+import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.scheduling.JobParameters;
 
@@ -46,7 +47,7 @@ public class LockExceptionCleanupJobParameters implements JobParameters
     /**
      * Number of month (from its created date) when a
      * {@link org.hisp.dhis.dataset.LockException}s is considered expired and
-     * subject to cleanup.
+     * subject to clean-up.
      */
     private Integer expiresAfterMonths;
 
@@ -60,6 +61,11 @@ public class LockExceptionCleanupJobParameters implements JobParameters
     @Override
     public Optional<ErrorReport> validate()
     {
+        if ( expiresAfterMonths != null && (expiresAfterMonths < 1 || expiresAfterMonths > 12) )
+        {
+            return Optional.of(
+                new ErrorReport( getClass(), ErrorCode.E4008, "expiresAfterMonths", 1, 12, expiresAfterMonths ) );
+        }
         return Optional.empty();
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/jackson/LockExceptionCleanupJobParametersDeserializer.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/jackson/LockExceptionCleanupJobParametersDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2023, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,46 +25,22 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.dataset;
+package org.hisp.dhis.scheduling.parameters.jackson;
 
-import java.util.Date;
-import java.util.List;
+import org.hisp.dhis.scheduling.parameters.LockExceptionCleanupJobParameters;
 
-import org.hisp.dhis.common.GenericStore;
-import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.period.Period;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-/**
- * @author Morten Olav Hansen <mortenoh@gmail.com>
- */
-public interface LockExceptionStore
-    extends GenericStore<LockException>
+public class LockExceptionCleanupJobParametersDeserializer
+    extends AbstractJobParametersDeserializer<LockExceptionCleanupJobParameters>
 {
-    List<LockException> getLockExceptions( List<DataSet> dataSets );
+    public LockExceptionCleanupJobParametersDeserializer()
+    {
+        super( LockExceptionCleanupJobParameters.class, CustomJobParameters.class );
+    }
 
-    List<LockException> getLockExceptionCombinations();
-
-    void deleteLockExceptions( DataSet dataSet, Period period );
-
-    void deleteLockExceptions( DataSet dataSet, Period period, OrganisationUnit organisationUnit );
-
-    void deleteLockExceptions( OrganisationUnit organisationUnit );
-
-    /**
-     * Deletes all lock exceptions that are considered expired. This means their
-     * creation date is before the given date.
-     *
-     * @param createdBefore The threshold date, any {@link LockException} with
-     *        an older created date is deleted
-     * @return number of deleted lock exceptions
-     */
-    int deleteExpiredLockExceptions( Date createdBefore );
-
-    long getCount( DataElement dataElement, Period period, OrganisationUnit organisationUnit );
-
-    long getCount( DataSet dataSet, Period period, OrganisationUnit organisationUnit );
-
-    boolean anyExists();
-
+    @JsonDeserialize
+    public static class CustomJobParameters extends LockExceptionCleanupJobParameters
+    {
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/DefaultDataSetService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/DefaultDataSetService.java
@@ -345,6 +345,13 @@ public class DefaultDataSetService
     }
 
     @Override
+    @Transactional
+    public int deleteExpiredLockExceptions( Date createdBefore )
+    {
+        return lockExceptionStore.deleteExpiredLockExceptions( createdBefore );
+    }
+
+    @Override
     @Transactional( readOnly = true )
     public boolean isLocked( User user, DataSet dataSet, Period period, OrganisationUnit organisationUnit, Date now )
     {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateLockExceptionStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateLockExceptionStore.java
@@ -32,6 +32,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import javax.persistence.criteria.CriteriaBuilder;
@@ -93,6 +94,7 @@ public class HibernateLockExceptionStore
     public void save( LockException lockException )
     {
         lockException.setPeriod( periodService.reloadPeriod( lockException.getPeriod() ) );
+        lockException.setAutoFields();
 
         super.save( lockException );
     }
@@ -101,6 +103,7 @@ public class HibernateLockExceptionStore
     public void update( LockException lockException )
     {
         lockException.setPeriod( periodService.reloadPeriod( lockException.getPeriod() ) );
+        lockException.setAutoFields();
 
         super.update( lockException );
     }
@@ -173,6 +176,14 @@ public class HibernateLockExceptionStore
         getQuery( hql )
             .setParameter( "organisationUnit", organisationUnit )
             .executeUpdate();
+    }
+
+    @Override
+    public int deleteExpiredLockExceptions( Date createdBefore )
+    {
+        String sql = "delete from lockexception where created < :date";
+
+        return getSession().createNativeQuery( sql ).setParameter( "date", createdBefore ).executeUpdate();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/job/LockExceptionCleanupJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/job/LockExceptionCleanupJob.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dataset.job;
+
+import static java.lang.String.format;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+import lombok.RequiredArgsConstructor;
+
+import org.hisp.dhis.dataset.LockExceptionStore;
+import org.hisp.dhis.scheduling.Job;
+import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
+import org.hisp.dhis.scheduling.JobType;
+import org.hisp.dhis.scheduling.parameters.LockExceptionCleanupJobParameters;
+import org.springframework.stereotype.Component;
+
+/**
+ * Job to clean-up expired {@link org.hisp.dhis.dataset.LockException}s.
+ *
+ * @author Jan Bernitt
+ */
+@Component
+@RequiredArgsConstructor
+public class LockExceptionCleanupJob implements Job
+{
+    private static final int DEFAULT_EXPIRY_AFTER_MONTHS = 6;
+
+    private final LockExceptionStore lockExceptionStore;
+
+    @Override
+    public JobType getJobType()
+    {
+        return JobType.LOCK_EXCEPTION_CLEANUP;
+    }
+
+    @Override
+    public void execute( JobConfiguration config, JobProgress progress )
+    {
+        progress.startingProcess( "Clean up expired lock exceptions" );
+
+        LockExceptionCleanupJobParameters params = (LockExceptionCleanupJobParameters) config.getJobParameters();
+        Integer months = params == null ? null : params.getExpiresAfterMonths();
+        int expiryAfterMonth = months == null ? DEFAULT_EXPIRY_AFTER_MONTHS : months;
+        ZoneId zoneId = ZoneId.systemDefault();
+        Date createdBefore = Date.from(
+            LocalDate.now( zoneId ).minusMonths( expiryAfterMonth ).atStartOfDay().atZone( zoneId ).toInstant() );
+
+        progress.startingStage( format( "Clearing lock exceptions created before %1$tY-%1$tm-%1$td", createdBefore ) );
+        progress.runStage( 0,
+            deletedCount -> format( "%d lock exceptions deleted", deletedCount ),
+            () -> lockExceptionStore.deleteExpiredLockExceptions( createdBefore ) );
+
+        progress.completedProcess( null );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/SchedulerStart.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/SchedulerStart.java
@@ -96,6 +96,8 @@ public class SchedulerStart extends AbstractStartupRoutine
             "Dataset notification" ),
         REMOVE_EXPIRED_OR_USED_RESERVED_VALUES( CRON_DAILY_2AM, "uwWCT2BMmlq", REMOVE_USED_OR_EXPIRED_RESERVED_VALUES,
             "Remove expired or used reserved values" ),
+        REMOVE_EXPIRED_LOCK_EXCEPTIONS( CRON_DAILY_2AM, "OQ9KeLgqy20", JobType.LOCK_EXCEPTION_CLEANUP,
+            "Remove lock exceptions older than 6 months" ),
         LEADER_ELECTION( LEADER_JOB_CRON_FORMAT, "MoUd5BTQ3lY", JobType.LEADER_ELECTION,
             "Leader election in cluster" );
 
@@ -204,6 +206,7 @@ public class SchedulerStart extends AbstractStartupRoutine
         addDefaultJob( SystemJob.DATA_SET_NOTIFICATION, jobConfigurations );
         addDefaultJob( SystemJob.REMOVE_EXPIRED_OR_USED_RESERVED_VALUES, jobConfigurations );
         addDefaultJob( SystemJob.SYSTEM_VERSION_UPDATE_CHECK, jobConfigurations );
+        addDefaultJob( SystemJob.REMOVE_EXPIRED_LOCK_EXCEPTIONS, jobConfigurations );
 
         if ( redisEnabled && verifyNoJobExist( SystemJob.LEADER_ELECTION.name, jobConfigurations ) )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataset/hibernate/LockException.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataset/hibernate/LockException.hbm.xml
@@ -10,6 +10,8 @@
       <generator class="native" />
     </id>
 
+    <property name="created" type="timestamp" not-null="true" />
+
     <many-to-one name="organisationUnit" class="org.hisp.dhis.organisationunit.OrganisationUnit"
         foreign-key="fk_lockexception_organisationunitid" column="organisationunitid" />
 

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_3__Add_lock_exception_created_column.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_3__Add_lock_exception_created_column.sql
@@ -1,1 +1,1 @@
-alter table lockexception add column if not exists created timestamp without time zone NOT NULL default now();
+alter table lockexception add column if not exists created timestamp without time zone not null default now();

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_3__Add_lock_exception_created_column.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_3__Add_lock_exception_created_column.sql
@@ -1,0 +1,1 @@
+alter table lockexception add column if not exists created timestamp without time zone NOT NULL default now();


### PR DESCRIPTION
### Summary
Adds a `created` date to `LockException`s. 

Existing entries are initialised with "now". 

Also adds a job that runs nightly which removes lock exceptions older than 6 months. 
The job is added automatically on startup if it does not exist but it is also configurable by users.
The number of months before lock exceptions expire can be configured between 1-12 months. 

That means existing entries are first cleaned 6 months later. This should allow installations to smoothly transition with this new behaviour.

### Manual Testing
* check the existing lock exception count (e.g. `/api/lockExceptions?fields=id,period[name],organisationUnit[id,name],created,dataSet[id,name]` )
* goto scheduler app
* there should be a job already to cleanup lock exceptions, run it manually
* check existing lock exceptions again, normally none should have been removed as none is old enough
* also check `/api/scheduling/completed/LOCK_EXCEPTION_CLEANUP` , the stage summary tells how many were deleted by the job
* edit `created` date of some of the lock exceptions in the database, for example by changing the date 8 month backwards
```sql
update lockexception set created = now() - interval '8 month' where organisationunitid = 525;
```
* double check some rows in the database were affected
* run job again (either in scheduler app or `POST /api/jobConfigurations/OQ9KeLgqy20/execute`
* check `/api/scheduling/completed/LOCK_EXCEPTION_CLEANUP`  again, now some lock exceptions should have been deleted
* also check `/api/lockExceptions?fields=id,period[name],organisationUnit[id,name],created,dataSet[id,name]` again
