### PR TITLE
chore: job parameters validation as default empty

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobParameters.java
@@ -42,5 +42,8 @@ import org.hisp.dhis.feedback.ErrorReport;
 public interface JobParameters
     extends Serializable, EmbeddedObject
 {
-    Optional<ErrorReport> validate();
+    default Optional<ErrorReport> validate()
+    {
+        return Optional.empty();
+    }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/AnalyticsJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/AnalyticsJobParameters.java
@@ -28,12 +28,10 @@
 package org.hisp.dhis.scheduling.parameters;
 
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 
 import org.hisp.dhis.analytics.AnalyticsTableType;
 import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.scheduling.JobParameters;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -119,11 +117,5 @@ public class AnalyticsJobParameters
     public void setSkipResourceTables( boolean skipResourceTables )
     {
         this.skipResourceTables = skipResourceTables;
-    }
-
-    @Override
-    public Optional<ErrorReport> validate()
-    {
-        return Optional.empty();
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/ContinuousAnalyticsJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/ContinuousAnalyticsJobParameters.java
@@ -28,12 +28,10 @@
 package org.hisp.dhis.scheduling.parameters;
 
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 
 import org.hisp.dhis.analytics.AnalyticsTableType;
 import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.scheduling.JobParameters;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -113,11 +111,5 @@ public class ContinuousAnalyticsJobParameters
     public void setSkipTableTypes( Set<AnalyticsTableType> skipTableTypes )
     {
         this.skipTableTypes = skipTableTypes;
-    }
-
-    @Override
-    public Optional<ErrorReport> validate()
-    {
-        return Optional.empty();
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/DataIntegrityJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/DataIntegrityJobParameters.java
@@ -27,14 +27,12 @@
  */
 package org.hisp.dhis.scheduling.parameters;
 
-import java.util.Optional;
 import java.util.Set;
 
 import lombok.Getter;
 import lombok.Setter;
 
 import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.scheduling.JobParameters;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -65,11 +63,5 @@ public class DataIntegrityJobParameters implements JobParameters
     @JsonProperty( required = false )
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private DataIntegrityReportType type;
-
-    @Override
-    public Optional<ErrorReport> validate()
-    {
-        return Optional.empty();
-    }
 
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/MockJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/MockJobParameters.java
@@ -27,9 +27,6 @@
  */
 package org.hisp.dhis.scheduling.parameters;
 
-import java.util.Optional;
-
-import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.scheduling.JobParameters;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -65,11 +62,5 @@ public class MockJobParameters
     public void setMessage( String message )
     {
         this.message = message;
-    }
-
-    @Override
-    public Optional<ErrorReport> validate()
-    {
-        return Optional.empty();
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/PredictorJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/PredictorJobParameters.java
@@ -29,10 +29,8 @@ package org.hisp.dhis.scheduling.parameters;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.scheduling.JobParameters;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -118,11 +116,5 @@ public class PredictorJobParameters
     public void setPredictorGroups( List<String> predictorGroups )
     {
         this.predictorGroups = predictorGroups;
-    }
-
-    @Override
-    public Optional<ErrorReport> validate()
-    {
-        return Optional.empty();
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/SmsJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/SmsJobParameters.java
@@ -29,10 +29,8 @@ package org.hisp.dhis.scheduling.parameters;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.scheduling.JobParameters;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -101,11 +99,5 @@ public class SmsJobParameters
     public void setMessage( String message )
     {
         this.message = message;
-    }
-
-    @Override
-    public Optional<ErrorReport> validate()
-    {
-        return Optional.empty();
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/SqlViewUpdateParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/SqlViewUpdateParameters.java
@@ -29,10 +29,8 @@ package org.hisp.dhis.scheduling.parameters;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.scheduling.JobParameters;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -54,11 +52,5 @@ public class SqlViewUpdateParameters implements JobParameters
     public void setSqlViews( List<String> sqlViews )
     {
         this.sqlViews = sqlViews;
-    }
-
-    @Override
-    public Optional<ErrorReport> validate()
-    {
-        return Optional.empty();
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/TestJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/TestJobParameters.java
@@ -27,10 +27,7 @@
  */
 package org.hisp.dhis.scheduling.parameters;
 
-import java.util.Optional;
-
 import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.scheduling.JobParameters;
 import org.hisp.dhis.scheduling.JobProgress.FailurePolicy;
 
@@ -208,11 +205,5 @@ public class TestJobParameters implements JobParameters
     public void setRunStagesParallel( boolean runStagesParallel )
     {
         this.runStagesParallel = runStagesParallel;
-    }
-
-    @Override
-    public Optional<ErrorReport> validate()
-    {
-        return Optional.empty();
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/TrackerTrigramIndexJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/TrackerTrigramIndexJobParameters.java
@@ -28,14 +28,12 @@
 package org.hisp.dhis.scheduling.parameters;
 
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.scheduling.JobParameters;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -82,11 +80,5 @@ public class TrackerTrigramIndexJobParameters
     public void setSkipIndexDeletion( boolean skipIndexDeletion )
     {
         this.skipIndexDeletion = skipIndexDeletion;
-    }
-
-    @Override
-    public Optional<ErrorReport> validate()
-    {
-        return Optional.empty();
     }
 }


### PR DESCRIPTION
Just makes `return Optional.empty()` the default implementation so `JobParameters` do not have to implement it as such.