### PR TITLE
fix: backward comp for update analytics dimension restrictions [DHIS2-14870]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/User.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/User.java
@@ -1586,6 +1586,22 @@ public class User
                 newUser.setUserRoles( userRoles );
             }
 
+            Set<Category> oldCatDimCon = oldUser.getCatDimensionConstraints();
+            Set<CategoryOptionGroupSet> oldCogDimCon = oldUser.getCogsDimensionConstraints();
+
+            Set<Category> newCatDimCon = newUserCredentialsRaw.getCatDimensionConstraints();
+            Set<CategoryOptionGroupSet> newCogDimCon = newUserCredentialsRaw.getCogsDimensionConstraints();
+
+            if ( oldCatDimCon != null && newCatDimCon != null && !oldCatDimCon.equals( newCatDimCon ) )
+            {
+                newUser.setCatDimensionConstraints( newCatDimCon );
+            }
+
+            if ( oldCogDimCon != null && newCogDimCon != null && !oldCogDimCon.equals( newCogDimCon ) )
+            {
+                newUser.setCogsDimensionConstraints( newCogDimCon );
+            }
+
             newUser.removeLegacyUserCredentials();
         }
     }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -37,7 +37,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Set;
 
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.category.CategoryOptionGroupSet;
 import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.jsontree.JsonValue;
@@ -57,6 +61,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
+import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 
@@ -318,6 +323,60 @@ class UserControllerTest extends DhisControllerConvenienceTest
 
         User userAfter = userService.getUser( peter.getUid() );
         assertEquals( "test", userAfter.getOpenId() );
+    }
+
+    @Test
+    void testRemoveCogCatDimFromUserCredentialsLegacyFormat()
+    {
+        CategoryOption coA = createCategoryOption( 'A' );
+        CategoryOption coB = createCategoryOption( 'B' );
+        categoryService.addCategoryOption( coA );
+        categoryService.addCategoryOption( coB );
+
+        Category caA = createCategory( 'A', coA );
+        Category caB = createCategory( 'B', coB );
+        categoryService.addCategory( caA );
+        categoryService.addCategory( caB );
+
+        Set<Category> catDimensionConstraints = Sets.newHashSet( caA, caB );
+
+        CategoryOptionGroupSet categoryOptionGroupSet = new CategoryOptionGroupSet();
+        categoryOptionGroupSet.setAutoFields();
+        categoryOptionGroupSet.setName( "cogA" );
+        categoryOptionGroupSet.setShortName( "cogA" );
+        manager.save( categoryOptionGroupSet );
+
+        User userByUsername = userService.getUserByUsername( peter.getUsername() );
+
+        userByUsername.setCogsDimensionConstraints( Sets.newHashSet( categoryOptionGroupSet ) );
+        userByUsername.setCatDimensionConstraints( catDimensionConstraints );
+
+        userService.updateUser( userByUsername );
+
+        JsonObject user = GET( "/users/{id}", peter.getUid() ).content();
+
+        JsonArray constraints = user.getArray( "catDimensionConstraints" );
+        assertEquals( 2, constraints.size() );
+
+        String emptyCatDim = "{'catDimensionConstraints':[]}";
+        JsonElement emptyCatDimJsonElm = new Gson().fromJson( emptyCatDim, JsonElement.class );
+        String emptyCogDim = "{'cogsDimensionConstraints':[]}";
+        JsonElement emptyCogDimJsonElm = new Gson().fromJson( emptyCogDim, JsonElement.class );
+
+        com.google.gson.JsonObject userJsonObject = new Gson().fromJson( user.toString(), JsonElement.class )
+            .getAsJsonObject();
+
+        userJsonObject.add( "userCredentials", emptyCatDimJsonElm );
+        userJsonObject.add( "userCredentials", emptyCogDimJsonElm );
+
+        PUT( "/37/users/" + peter.getUid(), userJsonObject.toString() );
+
+        User userAfter = userService.getUser( peter.getUid() );
+        Set<CategoryOptionGroupSet> cogsDimensionConstraintsAfter = userAfter.getCogsDimensionConstraints();
+        Set<Category> catDimensionConstraintsAfter = userAfter.getCatDimensionConstraints();
+
+        assertEquals( 0, cogsDimensionConstraintsAfter.size() );
+        assertEquals( 0, catDimensionConstraintsAfter.size() );
     }
 
     @Test


### PR DESCRIPTION
## Summary:
Fixes broken backward compatibility when using the “simulated” (old) UserCredentials object to save analytics dimension restrictions.
Before this fix, updates to the analytics dimension collections on the UserCredentials object would not be reflected in the real object when using PUT.

### Automatic test:
UserControllerTest#testRemoveCogCatDimFromUserCredentialsLegacyFormat()

Jira: [DHIS2-14870](https://dhis2.atlassian.net/browse/DHIS2-14870)

[DHIS2-14870]: https://dhis2.atlassian.net/browse/DHIS2-14870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ