### PR TITLE
chore: capture app version 100.27.0

### DIFF
--- a/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
+++ b/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
@@ -3,7 +3,7 @@
     "https://github.com/d2-ci/approval-app#v100.0.7",
     "https://github.com/d2-ci/app-management-app#v100.2.23",
     "https://github.com/d2-ci/cache-cleaner-app#v100.1.9",
-    "https://github.com/d2-ci/capture-app#v100.26.1",
+    "https://github.com/d2-ci/capture-app#v100.27.0",
     "https://github.com/d2-ci/dashboard-app#patch/2.40.0",
     "https://github.com/d2-ci/data-administration-app#patch/2.40.0",
     "https://github.com/d2-ci/data-visualizer-app#v100.0.2",


### PR DESCRIPTION
Update capture version to 100.27.0, to include https://dhis2.atlassian.net/browse/DHIS2-13804 in the 2.40.0 build.