### PR TITLE
fix: Perf issue in /analytics [DHIS2-15093]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -58,6 +58,7 @@ import org.hisp.dhis.dxf2.datavalueset.DataValueSet;
 import org.hisp.dhis.system.grid.ListGrid;
 import org.hisp.dhis.visualization.Visualization;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Lars Helge Overland
@@ -82,6 +83,7 @@ public class DefaultAnalyticsService
     // -------------------------------------------------------------------------
 
     @Override
+    @Transactional( readOnly = true )
     public Grid getAggregatedDataValues( DataQueryParams params )
     {
         params = checkSecurityConstraints( params );
@@ -100,6 +102,7 @@ public class DefaultAnalyticsService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Grid getAggregatedDataValues( DataQueryParams params, List<String> columns, List<String> rows )
     {
         return isTableLayout( columns, rows ) ? getAggregatedDataValuesTableLayout( params, columns, rows )
@@ -107,6 +110,7 @@ public class DefaultAnalyticsService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Grid getAggregatedDataValues( AnalyticalObject object )
     {
         DataQueryParams params = dataQueryService.getFromAnalyticalObject( object );
@@ -115,6 +119,7 @@ public class DefaultAnalyticsService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Grid getRawDataValues( DataQueryParams params )
     {
         params = checkSecurityConstraints( params );
@@ -125,6 +130,7 @@ public class DefaultAnalyticsService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DataValueSet getAggregatedDataValueSet( DataQueryParams params )
     {
         params = checkSecurityConstraints( params );
@@ -135,6 +141,7 @@ public class DefaultAnalyticsService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Grid getAggregatedDataValueSetAsGrid( DataQueryParams params )
     {
         params = checkSecurityConstraints( params );
@@ -145,6 +152,7 @@ public class DefaultAnalyticsService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Map<String, Object> getAggregatedDataValueMapping( DataQueryParams params )
     {
         Grid grid = getAggregatedDataValues( newBuilder( params )
@@ -154,6 +162,7 @@ public class DefaultAnalyticsService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Map<String, Object> getAggregatedDataValueMapping( AnalyticalObject object )
     {
         DataQueryParams params = dataQueryService.getFromAnalyticalObject( object );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
@@ -131,6 +131,7 @@ import org.hisp.dhis.user.UserSettingKey;
 import org.hisp.dhis.user.UserSettingService;
 import org.hisp.dhis.util.ObjectUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Lars Helge Overland
@@ -167,6 +168,7 @@ public class DefaultDataQueryService
     // -------------------------------------------------------------------------
 
     @Override
+    @Transactional( readOnly = true )
     public DataQueryParams getFromRequest( DataQueryRequest request )
     {
         I18nFormat format = i18nManager.getI18nFormat();
@@ -237,6 +239,7 @@ public class DefaultDataQueryService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DataQueryParams getFromAnalyticalObject( AnalyticalObject object )
     {
         notNull( object );
@@ -285,6 +288,7 @@ public class DefaultDataQueryService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public List<DimensionalObject> getDimensionalObjects( Set<String> dimensionParams,
         Date relativePeriodDate, String userOrgUnit, I18nFormat format, IdScheme inputIdScheme )
     {
@@ -314,6 +318,7 @@ public class DefaultDataQueryService
     // instead of fetching all org units one by one.
 
     @Override
+    @Transactional( readOnly = true )
     public DimensionalObject getDimension( String dimension, List<String> items, EventDataQueryRequest request,
         List<OrganisationUnit> userOrgUnits, I18nFormat format, boolean allowNull, IdScheme inputIdScheme )
     {
@@ -322,6 +327,7 @@ public class DefaultDataQueryService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DimensionalObject getDimension( String dimension, List<String> items, Date relativePeriodDate,
         List<OrganisationUnit> userOrgUnits, I18nFormat format, boolean allowNull, IdScheme inputIdScheme )
     {
@@ -719,6 +725,7 @@ public class DefaultDataQueryService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public List<OrganisationUnit> getUserOrgUnits( DataQueryParams params, String userOrgUnit )
     {
         final List<OrganisationUnit> units = new ArrayList<>();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -158,6 +158,7 @@ import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.util.Timer;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * This component is responsible for handling and retrieving data based on the
@@ -222,7 +223,8 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the {@link Grid}.
      */
-    void addIndicatorValues( DataQueryParams params, Grid grid )
+    @Transactional( readOnly = true )
+    public void addIndicatorValues( DataQueryParams params, Grid grid )
     {
         if ( !params.getIndicators().isEmpty() && !params.isSkipData() )
         {
@@ -321,7 +323,8 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
-    void addDataElementValues( DataQueryParams params, Grid grid )
+    @Transactional( readOnly = true )
+    public void addDataElementValues( DataQueryParams params, Grid grid )
     {
         if ( !params.getAllDataElements().isEmpty() && (!params.isSkipData() || params.analyzeOnly()) )
         {
@@ -354,7 +357,8 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
-    void addProgramDataElementAttributeIndicatorValues( DataQueryParams params, Grid grid )
+    @Transactional( readOnly = true )
+    public void addProgramDataElementAttributeIndicatorValues( DataQueryParams params, Grid grid )
     {
         if ( (!params.getAllProgramDataElementsAndAttributes().isEmpty() || !params.getProgramIndicators().isEmpty())
             && !params.isSkipData() )
@@ -400,7 +404,8 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
-    void addReportingRates( DataQueryParams params, Grid grid )
+    @Transactional( readOnly = true )
+    public void addReportingRates( DataQueryParams params, Grid grid )
     {
         if ( !params.getReportingRates().isEmpty() && !params.isSkipData() )
         {
@@ -424,7 +429,8 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
-    void addDataElementOperandValues( DataQueryParams params, Grid grid )
+    @Transactional( readOnly = true )
+    public void addDataElementOperandValues( DataQueryParams params, Grid grid )
     {
         if ( !params.getDataElementOperands().isEmpty() && !params.isSkipData() )
         {
@@ -446,7 +452,8 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
-    void addDynamicDimensionValues( DataQueryParams params, Grid grid )
+    @Transactional( readOnly = true )
+    public void addDynamicDimensionValues( DataQueryParams params, Grid grid )
     {
         if ( params.getDataDimensionAndFilterOptions().isEmpty() && !params.isSkipData() )
         {
@@ -464,7 +471,8 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
-    void addValidationResultValues( DataQueryParams params, Grid grid )
+    @Transactional( readOnly = true )
+    public void addValidationResultValues( DataQueryParams params, Grid grid )
     {
         if ( !params.getAllValidationResults().isEmpty() && !params.isSkipData() )
         {
@@ -485,7 +493,8 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
-    void addRawData( DataQueryParams params, Grid grid )
+    @Transactional( readOnly = true )
+    public void addRawData( DataQueryParams params, Grid grid )
     {
         if ( !params.isSkipData() )
         {
@@ -503,7 +512,8 @@ public class DataHandler
      *
      * @param params the {@link DataQueryParams}.
      */
-    DataQueryParams prepareForRawDataQuery( DataQueryParams params )
+    @Transactional( readOnly = true )
+    public DataQueryParams prepareForRawDataQuery( DataQueryParams params )
     {
         DataQueryParams.Builder builder = newBuilder( params )
             .withEarliestStartDateLatestEndDate()

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/MetadataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/MetadataHandler.java
@@ -62,6 +62,7 @@ import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.PeriodType;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.google.common.collect.Sets;
 
@@ -83,7 +84,8 @@ public class MetadataHandler
      * @param params the {@link DataQueryParams}.
      * @param the {@link Grid}.
      */
-    void addMetaData( DataQueryParams params, Grid grid )
+    @Transactional( readOnly = true )
+    public void addMetaData( DataQueryParams params, Grid grid )
     {
         if ( !params.isSkipMeta() )
         {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManager.java
@@ -66,6 +66,7 @@ import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Lars Helge Overland
@@ -93,6 +94,7 @@ public class DefaultAnalyticsSecurityManager
     // -------------------------------------------------------------------------
 
     @Override
+    @Transactional( readOnly = true )
     public void decideAccess( DataQueryParams params )
     {
         User user = currentUserService.getCurrentUser();
@@ -146,7 +148,8 @@ public class DefaultAnalyticsSecurityManager
      * @param user the user to check.
      * @throws IllegalQueryException if user does not have access.
      */
-    void decideAccessDataReadObjects( DataQueryParams params, User user )
+    @Transactional( readOnly = true )
+    public void decideAccessDataReadObjects( DataQueryParams params, User user )
         throws IllegalQueryException
     {
         Set<IdentifiableObject> objects = new HashSet<>();
@@ -175,6 +178,7 @@ public class DefaultAnalyticsSecurityManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public void decideAccessEventQuery( EventQueryParams params )
     {
         decideAccess( params );
@@ -202,6 +206,7 @@ public class DefaultAnalyticsSecurityManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public User getCurrentUser( DataQueryParams params )
     {
         return params != null && params.hasCurrentUser() ? params.getCurrentUser()
@@ -209,6 +214,7 @@ public class DefaultAnalyticsSecurityManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DataQueryParams withDataApprovalConstraints( DataQueryParams params )
     {
         DataQueryParams.Builder paramsBuilder = DataQueryParams.newBuilder( params );
@@ -257,6 +263,7 @@ public class DefaultAnalyticsSecurityManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DataQueryParams withUserConstraints( DataQueryParams params )
     {
         DataQueryParams.Builder builder = DataQueryParams.newBuilder( params );
@@ -268,6 +275,7 @@ public class DefaultAnalyticsSecurityManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public EventQueryParams withUserConstraints( EventQueryParams params )
     {
         EventQueryParams.Builder builder = new EventQueryParams.Builder( params );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DataDimensionExtractor.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DataDimensionExtractor.java
@@ -60,6 +60,7 @@ import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramTrackedEntityAttributeDimensionItem;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * This component is only encapsulating specific methods responsible for
@@ -156,7 +157,8 @@ public class DataDimensionExtractor
      * @return a map from each class of atomic objects to a map that associates
      *         each id of that class with an atomic object.
      */
-    MapMap<Class<? extends IdentifiableObject>, String, IdentifiableObject> getAtomicObjects(
+    @Transactional( readOnly = true )
+    public MapMap<Class<? extends IdentifiableObject>, String, IdentifiableObject> getAtomicObjects(
         final SetMap<Class<? extends IdentifiableObject>, String> atomicIds )
     {
         final MapMap<Class<? extends IdentifiableObject>, String, IdentifiableObject> atomicObjects = new MapMap<>();
@@ -171,7 +173,8 @@ public class DataDimensionExtractor
         return atomicObjects;
     }
 
-    MapMap<Class<? extends IdentifiableObject>, String, IdentifiableObject> getNoAclAtomicObjects(
+    @Transactional( readOnly = true )
+    public MapMap<Class<? extends IdentifiableObject>, String, IdentifiableObject> getNoAclAtomicObjects(
         final SetMap<Class<? extends IdentifiableObject>, String> atomicIds )
     {
         final MapMap<Class<? extends IdentifiableObject>, String, IdentifiableObject> atomicObjects = new MapMap<>();
@@ -223,7 +226,8 @@ public class DataDimensionExtractor
      * @param dataSetId the data set identifier.
      * @param metric the reporting rate metric.
      */
-    ReportingRate getReportingRate( final IdScheme idScheme, final String dataSetId, final String metric )
+    @Transactional( readOnly = true )
+    public ReportingRate getReportingRate( final IdScheme idScheme, final String dataSetId, final String metric )
     {
         final DataSet dataSet = idObjectManager.getObject( DataSet.class, idScheme, dataSetId );
         final boolean metricValid = isValidEnum( ReportingRateMetric.class, metric );
@@ -243,7 +247,8 @@ public class DataDimensionExtractor
      * @param programId the program identifier.
      * @param attributeId the attribute identifier.
      */
-    ProgramTrackedEntityAttributeDimensionItem getProgramAttributeDimensionItem( final IdScheme idScheme,
+    @Transactional( readOnly = true )
+    public ProgramTrackedEntityAttributeDimensionItem getProgramAttributeDimensionItem( final IdScheme idScheme,
         final String programId, final String attributeId )
     {
         final Program program = idObjectManager.getObject( Program.class, idScheme, programId );
@@ -265,7 +270,9 @@ public class DataDimensionExtractor
      * @param programId the program identifier.
      * @param dataElementId the data element identifier.
      */
-    ProgramDataElementDimensionItem getProgramDataElementDimensionItem( final IdScheme idScheme, final String programId,
+    @Transactional( readOnly = true )
+    public ProgramDataElementDimensionItem getProgramDataElementDimensionItem( final IdScheme idScheme,
+        final String programId,
         final String dataElementId )
     {
         final Program program = idObjectManager.getObject( Program.class, idScheme, programId );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
@@ -120,6 +120,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityProgramIndicatorDimension;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.google.common.collect.Sets;
 
@@ -152,6 +153,7 @@ public class DefaultDimensionService
     // --------------------------------------------------------------------------
 
     @Override
+    @Transactional( readOnly = true )
     public List<DimensionalItemObject> getCanReadDimensionItems( String uid )
     {
         DimensionalObject dimension = idObjectManager.get( DimensionalObject.DYNAMIC_DIMENSION_CLASSES, uid );
@@ -169,6 +171,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public <T extends IdentifiableObject> List<T> getCanReadObjects( List<T> objects )
     {
         User user = currentUserService.getCurrentUser();
@@ -177,6 +180,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public <T extends IdentifiableObject> List<T> getCanReadObjects( User user, List<T> objects )
     {
         List<T> list = new ArrayList<>( objects );
@@ -187,6 +191,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DimensionType getDimensionType( String uid )
     {
         Category cat = idObjectManager.get( Category.class, uid );
@@ -248,6 +253,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public List<DimensionalObject> getAllDimensions()
     {
         Collection<Category> dcs = idObjectManager.getDataDimensions( Category.class );
@@ -268,6 +274,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public List<DimensionalObject> getDimensionConstraints()
     {
         Collection<CategoryOptionGroupSet> cogs = idObjectManager.getDataDimensions( CategoryOptionGroupSet.class );
@@ -282,6 +289,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public void mergeAnalyticalObject( BaseAnalyticalObject object )
     {
         if ( object != null )
@@ -304,6 +312,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public void mergeEventAnalyticalObject( EventAnalyticalObject object )
     {
         if ( object != null )
@@ -332,6 +341,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DimensionalObject getDimensionalObjectCopy( String uid, boolean filterCanRead )
     {
         BaseDimensionalObject dimension = idObjectManager.get( DimensionalObject.DYNAMIC_DIMENSION_CLASSES, uid );
@@ -354,6 +364,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DimensionalItemObject getDataDimensionalItemObject( IdScheme idScheme, String dimensionItem )
     {
         if ( DimensionalObjectUtils.isCompositeDimensionalObject( dimensionItem ) )
@@ -401,6 +412,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DimensionalItemObject getDataDimensionalItemObject( DimensionalItemId itemId )
     {
         Collection<DimensionalItemObject> items = getDataDimensionalItemObjectMap( Sets.newHashSet( itemId ) ).values();
@@ -409,6 +421,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Map<DimensionalItemId, DimensionalItemObject> getDataDimensionalItemObjectMap(
         Set<DimensionalItemId> itemIds )
     {
@@ -421,6 +434,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Map<DimensionalItemId, DimensionalItemObject> getNoAclDataDimensionalItemObjectMap(
         Set<DimensionalItemId> itemIds )
     {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
@@ -358,6 +358,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DimensionalItemObject getDataDimensionalItemObject( String dimensionItem )
     {
         return getDataDimensionalItemObject( IdScheme.UID, dimensionItem );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -365,6 +365,7 @@ public class DefaultExpressionService
     // -------------------------------------------------------------------------
 
     @Override
+    @Transactional( readOnly = true )
     public Map<DimensionalItemId, DimensionalItemObject> getIndicatorDimensionalItemMap(
         Collection<Indicator> indicators )
     {
@@ -378,6 +379,7 @@ public class DefaultExpressionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public List<OrganisationUnitGroup> getOrgUnitGroupCountGroups( Collection<Indicator> indicators )
     {
         if ( indicators == null )
@@ -397,6 +399,7 @@ public class DefaultExpressionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public IndicatorValue getIndicatorValueObject( Indicator indicator, List<Period> periods,
         Map<DimensionalItemId, DimensionalItemObject> itemMap, Map<DimensionalItemObject, Object> valueMap,
         Map<String, Integer> orgUnitCountMap )
@@ -478,7 +481,7 @@ public class DefaultExpressionService
     // -------------------------------------------------------------------------
 
     @Override
-    @Transactional
+    @Transactional( readOnly = true )
     public ExpressionValidationOutcome expressionIsValid( String expression, ParseType parseType )
     {
         try
@@ -690,6 +693,7 @@ public class DefaultExpressionService
     // -------------------------------------------------------------------------
 
     @Override
+    @Transactional( readOnly = true )
     public Map<String, Constant> getConstantMap()
     {
         return constantMapCache.get( "x", key -> constantService.getConstantMap() );


### PR DESCRIPTION
The logs in Glowroot, in a server in HISP South Africa, show that in release 2.38 we have many JDBC commits happening for each `/analytics` request.

These commits represent a few hundred thousand times each request, going over 1 million on several cases.
The goal of this PR is to make the respective operations `read-only`, as it was in 2.35.

These changes have been tested and drastically reduced the overall response time of analytics requests.
Comparing 2.35 with this branch, on the client's environment, we could see response times ~20% to ~45% faster on average.

The client also executed some tests on this patch version and gave us positive feedback.

-----------------------

Initially, I thought that the introduction of some transactional annotations could be triggering this problem, as in 2.35 we don't have any transaction annotations at all in the same flows. After removing a few of them, and profiling the requests, we could still see those transactions being created in write mode.

So, I thought that for some reason, (in 2.38) we needed to annotate the parent service calls as read-only in order to force and propagate this behaviour across all service calls in the chain (the ones that are loading data through Hibernate).

Based on that, I started with a single flow and made it read-only. After a round of profiling, I could see the number of transactions and commits dropping. I went ahead and made all flows read-only. After another round of profiling, I could not see any transactions or commits being created anymore.

This PR will add the transaction annotation in `read-only` mode on several methods so we can guarantee they are correctly propagated today and in the future.

Moving forward, we should keep this approach for new service methods introduced that interact with the persistence layer.

As a bonus, we got a significant performance improvement.