### PR TITLE
fix: remove sync job availability validation [DHIS2-8967]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJob.java
@@ -43,9 +43,7 @@ import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncService;
 import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncSummary;
 import org.hisp.dhis.dxf2.metadata.sync.exception.DhisVersionMismatchException;
 import org.hisp.dhis.dxf2.metadata.sync.exception.MetadataSyncServiceException;
-import org.hisp.dhis.dxf2.sync.SyncUtils;
 import org.hisp.dhis.dxf2.synch.SynchronizationManager;
-import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.metadata.version.MetadataVersion;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
@@ -134,13 +132,6 @@ public class MetadataSyncJob implements Job
             String customMessage = "Exception occurred while executing metadata sync task." + e.getMessage();
             log.error( customMessage, e );
         }
-    }
-
-    @Override
-    public ErrorReport validate()
-    {
-        return SyncUtils.validateRemoteServerAvailability( synchronizationManager, MetadataSyncJob.class )
-            .orElse( null );
     }
 
     protected void runSyncTask( MetadataRetryContext context, MetadataSyncJobParameters params,

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/EventProgramsDataSynchronizationJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/EventProgramsDataSynchronizationJob.java
@@ -29,8 +29,6 @@ package org.hisp.dhis.dxf2.sync;
 
 import lombok.AllArgsConstructor;
 
-import org.hisp.dhis.dxf2.synch.SynchronizationManager;
-import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobProgress;
@@ -48,8 +46,6 @@ public class EventProgramsDataSynchronizationJob implements Job
 {
     private final EventSynchronization eventSync;
 
-    private final SynchronizationManager syncManager;
-
     @Override
     public JobType getJobType()
     {
@@ -62,12 +58,5 @@ public class EventProgramsDataSynchronizationJob implements Job
         EventProgramsDataSynchronizationJobParameters params = (EventProgramsDataSynchronizationJobParameters) config
             .getJobParameters();
         eventSync.synchronizeData( params.getPageSize(), progress );
-    }
-
-    @Override
-    public ErrorReport validate()
-    {
-        return SyncUtils.validateRemoteServerAvailability( syncManager, EventProgramsDataSynchronizationJob.class )
-            .orElse( null );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/SyncUtils.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/SyncUtils.java
@@ -40,13 +40,10 @@ import org.hisp.dhis.dxf2.importsummary.ImportStatus;
 import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.dxf2.synch.AvailabilityStatus;
-import org.hisp.dhis.dxf2.synch.SynchronizationManager;
 import org.hisp.dhis.dxf2.synch.SystemInstance;
 import org.hisp.dhis.dxf2.webmessage.AbstractWebMessageResponse;
 import org.hisp.dhis.dxf2.webmessage.WebMessageParseException;
 import org.hisp.dhis.dxf2.webmessage.utils.WebMessageParseUtils;
-import org.hisp.dhis.feedback.ErrorCode;
-import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.util.CodecUtils;
@@ -497,18 +494,5 @@ public class SyncUtils
         systemInstance.setUrl( systemInstance.getUrl() + SyncUtils.IMPORT_STRATEGY_SYNC_SUFFIX );
 
         return systemInstance;
-    }
-
-    public static Optional<ErrorReport> validateRemoteServerAvailability( SynchronizationManager synchronizationManager,
-        Class<?> klass )
-    {
-        AvailabilityStatus isRemoteServerAvailable = synchronizationManager.isRemoteServerAvailable();
-
-        if ( !isRemoteServerAvailable.isAvailable() )
-        {
-            return Optional.of( new ErrorReport( klass, ErrorCode.E7010, isRemoteServerAvailable.getMessage() ) );
-        }
-
-        return Optional.empty();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerProgramsDataSynchronizationJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerProgramsDataSynchronizationJob.java
@@ -29,8 +29,6 @@ package org.hisp.dhis.dxf2.sync;
 
 import lombok.AllArgsConstructor;
 
-import org.hisp.dhis.dxf2.synch.SynchronizationManager;
-import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobProgress;
@@ -48,8 +46,6 @@ public class TrackerProgramsDataSynchronizationJob implements Job
 {
     private final TrackerSynchronization trackerSync;
 
-    private final SynchronizationManager syncManager;
-
     @Override
     public JobType getJobType()
     {
@@ -62,12 +58,5 @@ public class TrackerProgramsDataSynchronizationJob implements Job
         TrackerProgramsDataSynchronizationJobParameters params = (TrackerProgramsDataSynchronizationJobParameters) config
             .getJobParameters();
         trackerSync.synchronizeData( params.getPageSize(), progress );
-    }
-
-    @Override
-    public ErrorReport validate()
-    {
-        return SyncUtils.validateRemoteServerAvailability( syncManager, TrackerProgramsDataSynchronizationJob.class )
-            .orElse( null );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/synch/DataSynchronizationJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/synch/DataSynchronizationJob.java
@@ -31,8 +31,6 @@ import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.dxf2.sync.CompleteDataSetRegistrationSynchronization;
 import org.hisp.dhis.dxf2.sync.DataValueSynchronization;
-import org.hisp.dhis.dxf2.sync.SyncUtils;
-import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobProgress;
@@ -49,8 +47,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class DataSynchronizationJob implements Job
 {
-    private final SynchronizationManager syncManager;
-
     private final DataValueSynchronization dataValueSync;
 
     private final CompleteDataSetRegistrationSynchronization completenessSync;
@@ -69,12 +65,5 @@ public class DataSynchronizationJob implements Job
 
         dataValueSync.synchronizeData( params.getPageSize(), progress );
         completenessSync.synchronizeData( progress );
-    }
-
-    @Override
-    public ErrorReport validate()
-    {
-        return SyncUtils.validateRemoteServerAvailability( syncManager, DataSynchronizationJob.class )
-            .orElse( null );
     }
 }


### PR DESCRIPTION
Removes the availability validation from the synchronisation jobs. The processing already had a step/stage for checking availability at the beginning so no further addition of the removed validation was needed in the actual processing.
 