### PR TITLE
ci: remove conflicting maven options

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,7 +1,7 @@
 name: Test
 env:
   # This is to make sure Maven don't timeout fetching dependencies. See: https://github.com/actions/virtual-environments/issues/1499
-  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
+  MAVEN_OPTS: -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
 on:
   push:
     branches:

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -235,7 +235,7 @@
   <repositories>
     <repository>
       <id>central</id>
-      <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+      <url>https://repo1.maven.org/maven2</url>
       <releases>
         <enabled>true</enabled>
       </releases>


### PR DESCRIPTION
-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false are conflicting with
reusing HTTP connections as per options httpconnectionManager and .http.retryHandler

testing how these options affect the stability of the build