### PR TITLE
chore: make new tracker relationships service independent of dhis-service-dxf2 TECH-1514

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstance.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstance.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.trackedentity;
 
 import java.util.Date;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.hisp.dhis.audit.AuditAttribute;
@@ -63,7 +64,7 @@ public class TrackedEntityInstance
 
     private Date lastUpdatedAtClient;
 
-    private Set<TrackedEntityAttributeValue> trackedEntityAttributeValues = new HashSet<>();
+    private Set<TrackedEntityAttributeValue> trackedEntityAttributeValues = new LinkedHashSet<>();
 
     private Set<RelationshipItem> relationshipItems = new HashSet<>();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-tracker/pom.xml
@@ -29,10 +29,6 @@
     </dependency>
     <dependency>
       <groupId>org.hisp.dhis</groupId>
-      <artifactId>dhis-service-dxf2</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-service-acl</artifactId>
     </dependency>
     <dependency>
@@ -227,8 +223,34 @@
       <artifactId>joda-time</artifactId>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>org.hisp.dhis:dhis-service-dxf2</exclude>
+                    <message>New tracker should not depend on old tracker code which will be removed. Parts of old tracker are located in dhis-service-dxf2.</message>
+                  </excludes>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
   <properties>
     <rootDir>../../</rootDir>
   </properties>

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/enrollment/EnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/enrollment/EnrollmentService.java
@@ -34,5 +34,7 @@ public interface EnrollmentService
 {
     ProgramInstance getEnrollment( String uid, EnrollmentParams params );
 
+    ProgramInstance getEnrollment( ProgramInstance enrollment, EnrollmentParams params );
+
     Enrollments getEnrollments( ProgramInstanceQueryParams params );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/event/EventService.java
@@ -39,8 +39,5 @@ public interface EventService
 
     ProgramStageInstance getEvent( ProgramStageInstance programStageInstance, EventParams eventParams );
 
-    ProgramStageInstance getEvent( ProgramStageInstance programStageInstance, boolean isSynchronizationQuery,
-        boolean skipOwnershipCheck, EventParams eventParams );
-
     void validate( EventSearchParams params, User user );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/relationship/DefaultRelationshipService.java
@@ -27,42 +27,30 @@
  */
 package org.hisp.dhis.tracker.relationship;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 
-import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.category.CategoryOption;
-import org.hisp.dhis.category.CategoryOptionCombo;
-import org.hisp.dhis.commons.util.TextUtils;
-import org.hisp.dhis.dxf2.events.EnrollmentParams;
-import org.hisp.dhis.dxf2.events.EventParams;
-import org.hisp.dhis.dxf2.events.TrackedEntityInstanceParams;
-import org.hisp.dhis.dxf2.events.enrollment.EnrollmentService;
-import org.hisp.dhis.dxf2.events.event.EventService;
-import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstanceService;
-import org.hisp.dhis.eventdatavalue.EventDataValue;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.program.Program;
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.ProgramInstance;
-import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.relationship.RelationshipType;
-import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
-import org.hisp.dhis.trackedentity.TrackedEntityProgramOwner;
-import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
-import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
-import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
+import org.hisp.dhis.tracker.enrollment.EnrollmentParams;
+import org.hisp.dhis.tracker.enrollment.EnrollmentService;
+import org.hisp.dhis.tracker.event.EventParams;
+import org.hisp.dhis.tracker.event.EventService;
+import org.hisp.dhis.tracker.trackedentity.TrackedEntityParams;
+import org.hisp.dhis.tracker.trackedentity.TrackedEntityService;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -78,7 +66,7 @@ public class DefaultRelationshipService implements RelationshipService
 
     private final org.hisp.dhis.relationship.RelationshipStore relationshipStore;
 
-    private final TrackedEntityInstanceService trackedEntityInstanceService;
+    private final TrackedEntityService trackedEntityService;
 
     private final EnrollmentService enrollmentService;
 
@@ -88,46 +76,51 @@ public class DefaultRelationshipService implements RelationshipService
     public List<Relationship> getRelationshipsByTrackedEntityInstance(
         TrackedEntityInstance tei,
         PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter )
+        throws ForbiddenException,
+        NotFoundException
     {
-        User user = currentUserService.getCurrentUser();
 
-        return relationshipStore
+        List<Relationship> relationships = relationshipStore
             .getByTrackedEntityInstance( tei, pagingAndSortingCriteriaAdapter )
             .stream()
-            .filter( r -> trackerAccessManager.canRead( user, r ).isEmpty() )
-            .map( this::map )
+            .filter( r -> trackerAccessManager.canRead( currentUserService.getCurrentUser(), r ).isEmpty() )
             .collect( Collectors.toList() );
+        return map( relationships );
     }
 
     @Override
     public List<Relationship> getRelationshipsByProgramInstance( ProgramInstance pi,
         PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter )
+        throws ForbiddenException,
+        NotFoundException
     {
-        User user = currentUserService.getCurrentUser();
 
-        return relationshipStore
+        List<Relationship> relationships = relationshipStore
             .getByProgramInstance( pi, pagingAndSortingCriteriaAdapter ).stream()
-            .filter( r -> trackerAccessManager.canRead( user, r ).isEmpty() )
-            .map( this::map )
+            .filter( r -> trackerAccessManager.canRead( currentUserService.getCurrentUser(), r ).isEmpty() )
             .collect( Collectors.toList() );
+        return map( relationships );
     }
 
     @Override
     public List<Relationship> getRelationshipsByProgramStageInstance( ProgramStageInstance psi,
         PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter )
+        throws ForbiddenException,
+        NotFoundException
     {
-        User user = currentUserService.getCurrentUser();
 
-        return relationshipStore
+        List<Relationship> relationships = relationshipStore
             .getByProgramStageInstance( psi, pagingAndSortingCriteriaAdapter )
             .stream()
-            .filter( r -> trackerAccessManager.canRead( user, r ).isEmpty() )
-            .map( this::map )
+            .filter( r -> trackerAccessManager.canRead( currentUserService.getCurrentUser(), r ).isEmpty() )
             .collect( Collectors.toList() );
+        return map( relationships );
     }
 
     @Override
     public Optional<Relationship> findRelationshipByUid( String uid )
+        throws ForbiddenException,
+        NotFoundException
     {
         Relationship relationship = relationshipStore.getByUid( uid );
 
@@ -150,7 +143,21 @@ public class DefaultRelationshipService implements RelationshipService
     /**
      * Map to a non-proxied Relationship to prevent hibernate exceptions.
      */
+    private List<Relationship> map( List<Relationship> relationships )
+        throws ForbiddenException,
+        NotFoundException
+    {
+        List<Relationship> result = new ArrayList<>( relationships.size() );
+        for ( Relationship relationship : relationships )
+        {
+            result.add( map( relationship ) );
+        }
+        return result;
+    }
+
     private Relationship map( Relationship relationship )
+        throws ForbiddenException,
+        NotFoundException
     {
         Relationship result = new Relationship();
         result.setUid( relationship.getUid() );
@@ -167,279 +174,35 @@ public class DefaultRelationshipService implements RelationshipService
     }
 
     private RelationshipItem withNestedEntity( RelationshipItem item )
+        throws ForbiddenException,
+        NotFoundException
     {
+        // relationships of relationship items are not mapped to JSON so there is no need to fetch them
         RelationshipItem result = new RelationshipItem();
 
+        // the call to the individual services is to detach and apply some logic like filtering out attribute values
+        // for tracked entity type attributes from programInstance.entityInstance. Enrollment attributes are actually
+        // owned by the TEI and cannot be set on the ProgramInstance. When returning enrollments in our API an enrollment
+        // should only have the program tracked entity attributes.
         if ( item.getTrackedEntityInstance() != null )
         {
-            result.setTrackedEntityInstance( map( trackedEntityInstanceService
-                .getTrackedEntityInstance( item.getTrackedEntityInstance(), TrackedEntityInstanceParams.TRUE ) ) );
+            result.setTrackedEntityInstance( trackedEntityService
+                .getTrackedEntity( item.getTrackedEntityInstance(),
+                    TrackedEntityParams.TRUE.withIncludeRelationships( false ) ) );
         }
         else if ( item.getProgramInstance() != null )
         {
             result.setProgramInstance(
-                map( enrollmentService.getEnrollment( item.getProgramInstance(), EnrollmentParams.TRUE ) ) );
+                enrollmentService.getEnrollment( item.getProgramInstance(),
+                    EnrollmentParams.TRUE.withIncludeRelationships( false ) ) );
         }
         else if ( item.getProgramStageInstance() != null )
         {
             result.setProgramStageInstance(
-                map( eventService.getEvent( item.getProgramStageInstance(), EventParams.FALSE ) ) );
+                eventService.getEvent( item.getProgramStageInstance(),
+                    EventParams.TRUE.withIncludeRelationships( false ) ) );
         }
 
-        return result;
-    }
-
-    /**
-     * Reverse mapping of the one done in
-     * {@link org.hisp.dhis.dxf2.events.trackedentity.AbstractTrackedEntityInstanceService#getTei}.
-     * NOTE: remove once we have a new tracker service returning
-     * org.hisp.dhis.trackedentity.TrackedEntityInstance while providing the
-     * logic (ACL checks, ...) we have in the dxf2 services.
-     */
-    private TrackedEntityInstance map( org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstance tei )
-    {
-        TrackedEntityInstance result = new TrackedEntityInstance();
-        result.setUid( tei.getTrackedEntityInstance() );
-        OrganisationUnit orgUnit = new OrganisationUnit();
-        orgUnit.setUid( tei.getOrgUnit() );
-        result.setOrganisationUnit( orgUnit );
-        TrackedEntityType trackedEntityType = new TrackedEntityType();
-        trackedEntityType.setUid( tei.getTrackedEntityType() );
-        result.setTrackedEntityType( trackedEntityType );
-        result.setCreated( DateUtils.parseDate( tei.getCreated() ) );
-        result.setCreatedAtClient( DateUtils.parseDate( tei.getCreatedAtClient() ) );
-        result.setLastUpdated( DateUtils.parseDate( tei.getLastUpdated() ) );
-        result.setLastUpdatedAtClient( DateUtils.parseDate( tei.getLastUpdatedAtClient() ) );
-        result.setInactive( tei.isInactive() );
-        result.setGeometry( tei.getGeometry() );
-        result.setDeleted( tei.isDeleted() );
-        result.setPotentialDuplicate( tei.isPotentialDuplicate() );
-        result.setStoredBy( tei.getStoredBy() );
-        result.setCreatedByUserInfo( tei.getCreatedByUserInfo() );
-        result.setLastUpdatedByUserInfo( tei.getLastUpdatedByUserInfo() );
-
-        // NOTE: skipping mapping of trackedEntity.relationships as /tracker/relationships models do not include the
-        // relationships fields of each of its nested entities as relationship items would then end in an infinite recursion
-
-        result.setProgramInstances( tei.getEnrollments().stream().map( this::map ).collect( Collectors.toSet() ) );
-        result.setProgramOwners( tei.getProgramOwners().stream().map( this::map ).collect( Collectors.toSet() ) );
-        result.setTrackedEntityAttributeValues(
-            tei.getAttributes().stream().map( this::map ).collect( Collectors.toSet() ) );
-
-        return result;
-    }
-
-    private TrackedEntityProgramOwner map( org.hisp.dhis.dxf2.events.trackedentity.ProgramOwner programOwner )
-    {
-        TrackedEntityInstance trackedEntityInstance = new TrackedEntityInstance();
-        trackedEntityInstance.setUid( programOwner.getTrackedEntityInstance() );
-
-        Program program = new Program();
-        program.setUid( programOwner.getProgram() );
-
-        OrganisationUnit organisationUnit = new OrganisationUnit();
-        organisationUnit.setUid( programOwner.getOwnerOrgUnit() );
-
-        return new TrackedEntityProgramOwner( trackedEntityInstance, program, organisationUnit );
-    }
-
-    private TrackedEntityAttributeValue map( org.hisp.dhis.dxf2.events.trackedentity.Attribute att )
-    {
-        TrackedEntityAttribute attribute = new TrackedEntityAttribute();
-        attribute.setUid( att.getAttribute() );
-        attribute.setValueType( att.getValueType() );
-        // note: dxf2 only stores the displayName which is cannot be set on TEA as it's computed from the name
-        // this mapping is going to be removed once we have migrated the aggregate code (very soon!)
-        attribute.setName( att.getDisplayName() );
-        attribute.setCode( att.getCode() );
-        attribute.setSkipSynchronization( att.isSkipSynchronization() );
-        TrackedEntityAttributeValue result = new TrackedEntityAttributeValue();
-        result.setAttribute( attribute );
-        result.setCreated( DateUtils.parseDate( att.getCreated() ) );
-        result.setLastUpdated( DateUtils.parseDate( att.getLastUpdated() ) );
-        result.setValue( att.getValue() );
-        result.setStoredBy( att.getStoredBy() );
-        return result;
-    }
-
-    private ProgramInstance map( org.hisp.dhis.dxf2.events.enrollment.Enrollment enrollment )
-    {
-        ProgramInstance result = new ProgramInstance();
-        result.setUid( enrollment.getEnrollment() );
-
-        if ( StringUtils.isNotEmpty( enrollment.getTrackedEntityInstance() ) )
-        {
-            TrackedEntityInstance tei = new TrackedEntityInstance();
-            TrackedEntityType type = new TrackedEntityType();
-            type.setUid( enrollment.getTrackedEntityType() );
-            tei.setTrackedEntityType( type );
-            tei.setUid( enrollment.getTrackedEntityInstance() );
-
-            // tei owns all attributes in trackedEntityAttributeValues while programs only present a subset of them
-            // the program attributes are the ones attached to the enrollment
-            tei.setTrackedEntityAttributeValues(
-                enrollment.getAttributes().stream().map( this::map )
-                    .collect( Collectors.toSet() ) );
-
-            result.setEntityInstance( tei );
-        }
-
-        if ( StringUtils.isNotEmpty( enrollment.getOrgUnit() ) )
-        {
-            OrganisationUnit orgUnit = new OrganisationUnit();
-            orgUnit.setUid( enrollment.getOrgUnit() );
-            orgUnit.setName( enrollment.getOrgUnitName() );
-            result.setOrganisationUnit( orgUnit );
-        }
-
-        result.setGeometry( enrollment.getGeometry() );
-        result.setCreated( DateUtils.parseDate( enrollment.getCreated() ) );
-        result.setCreatedAtClient( DateUtils.parseDate( enrollment.getCreatedAtClient() ) );
-        result.setLastUpdated( DateUtils.parseDate( enrollment.getLastUpdated() ) );
-        result.setLastUpdatedAtClient( DateUtils.parseDate( enrollment.getLastUpdatedAtClient() ) );
-
-        Program program = new Program();
-        program.setUid( enrollment.getProgram() );
-        result.setProgram( program );
-
-        result.setStatus( enrollment.getStatus().getProgramStatus() );
-        result.setEnrollmentDate( enrollment.getEnrollmentDate() );
-        result.setIncidentDate( enrollment.getIncidentDate() );
-        result.setFollowup( enrollment.getFollowup() );
-        result.setEndDate( enrollment.getCompletedDate() );
-        result.setCompletedBy( enrollment.getCompletedBy() );
-        result.setStoredBy( enrollment.getStoredBy() );
-        result.setCreatedByUserInfo( enrollment.getCreatedByUserInfo() );
-        result.setLastUpdatedByUserInfo( enrollment.getLastUpdatedByUserInfo() );
-        result.setDeleted( enrollment.isDeleted() );
-
-        result
-            .setProgramStageInstances( enrollment.getEvents().stream().map( this::map ).collect( Collectors.toSet() ) );
-        result.setComments( enrollment.getNotes().stream().map( this::map ).collect( Collectors.toList() ) );
-
-        return result;
-    }
-
-    private TrackedEntityComment map( org.hisp.dhis.dxf2.events.event.Note note )
-    {
-        TrackedEntityComment result = new TrackedEntityComment();
-        result.setUid( note.getNote() );
-        result.setCommentText( note.getValue() );
-        result.setCreator( note.getStoredBy() );
-        result.setCreated( DateUtils.parseDate( note.getStoredDate() ) );
-        result.setLastUpdated( note.getLastUpdated() );
-        if ( note.getLastUpdatedBy() != null )
-        {
-            User user = new User();
-            user.setId( note.getLastUpdatedBy().getId() );
-            user.setUid( note.getLastUpdatedBy().getUid() );
-            user.setCode( note.getLastUpdatedBy().getCode() );
-            user.setUsername( note.getLastUpdatedBy().getUsername() );
-            user.setFirstName( note.getLastUpdatedBy().getFirstName() );
-            user.setSurname( note.getLastUpdatedBy().getSurname() );
-            result.setLastUpdatedBy( user );
-        }
-        return result;
-    }
-
-    private ProgramStageInstance map( org.hisp.dhis.dxf2.events.event.Event event )
-    {
-        ProgramStageInstance result = new ProgramStageInstance();
-        result.setUid( event.getEvent() );
-        result.setStatus( event.getStatus() );
-        result.setExecutionDate( DateUtils.parseDate( event.getEventDate() ) );
-        result.setDueDate( DateUtils.parseDate( event.getDueDate() ) );
-        result.setStoredBy( event.getStoredBy() );
-        result.setCompletedBy( event.getCompletedBy() );
-        result.setCompletedDate( DateUtils.parseDate( event.getCompletedDate() ) );
-        result.setCreated( DateUtils.parseDate( event.getCreated() ) );
-        result.setCreatedByUserInfo( event.getCreatedByUserInfo() );
-        result.setLastUpdatedByUserInfo( event.getLastUpdatedByUserInfo() );
-        result.setCreatedAtClient( DateUtils.parseDate( event.getCreatedAtClient() ) );
-        result.setLastUpdated( DateUtils.parseDate( event.getLastUpdated() ) );
-        result.setLastUpdatedAtClient( DateUtils.parseDate( event.getLastUpdatedAtClient() ) );
-        result.setGeometry( event.getGeometry() );
-        result.setDeleted( event.isDeleted() );
-
-        if ( StringUtils.isNotEmpty( event.getAssignedUser() ) )
-        {
-            User assignedUser = new User();
-            assignedUser.setUid( event.getAssignedUser() );
-            assignedUser.setUsername( event.getAssignedUserUsername() );
-            assignedUser.setName( event.getAssignedUserDisplayName() );
-            assignedUser.setFirstName( event.getAssignedUserFirstName() );
-            assignedUser.setSurname( event.getAssignedUserSurname() );
-            result.setAssignedUser( assignedUser );
-        }
-
-        if ( StringUtils.isNotEmpty( event.getOrgUnit() ) )
-        {
-            OrganisationUnit orgUnit = new OrganisationUnit();
-            orgUnit.setUid( event.getOrgUnit() );
-            orgUnit.setName( event.getOrgUnitName() );
-            result.setOrganisationUnit( orgUnit );
-        }
-
-        ProgramInstance programInstance = new ProgramInstance();
-        result.setProgramInstance( programInstance );
-        programInstance.setUid( event.getEnrollment() );
-        programInstance.setFollowup( event.getFollowup() );
-        programInstance.setStatus( event.getEnrollmentStatus().getProgramStatus() );
-
-        Program program = new Program();
-        program.setUid( event.getProgram() );
-        programInstance.setProgram( program );
-
-        if ( StringUtils.isNotEmpty( event.getTrackedEntityInstance() ) )
-        {
-            TrackedEntityInstance tei = new TrackedEntityInstance();
-            tei.setUid( event.getTrackedEntityInstance() );
-            programInstance.setEntityInstance( tei );
-        }
-
-        ProgramStage programStage = new ProgramStage();
-        programStage.setUid( event.getProgramStage() );
-        result.setProgramStage( programStage );
-
-        if ( StringUtils.isNotEmpty( event.getAttributeOptionCombo() ) )
-        {
-            CategoryOptionCombo coc = new CategoryOptionCombo();
-            coc.setUid( event.getAttributeOptionCombo() );
-            result.setAttributeOptionCombo( coc );
-            if ( StringUtils.isNotEmpty( event.getAttributeCategoryOptions() ) )
-            {
-                Set<CategoryOption> cos = TextUtils
-                    .splitToSet( event.getAttributeCategoryOptions(), TextUtils.SEMICOLON ).stream().map( o -> {
-                        CategoryOption co = new CategoryOption();
-                        co.setUid( o );
-                        return co;
-                    } ).collect( Collectors.toSet() );
-                coc.setCategoryOptions( cos );
-            }
-        }
-
-        // NOTE: skipping mapping of event.relationships as /tracker/relationships models do not include the
-        // relationships fields of each of its nested entities as relationship items would then end in an infinite recursion
-
-        result.setEventDataValues(
-            event.getDataValues().stream().map( this::map ).collect( Collectors.toSet() ) );
-        result.setComments(
-            event.getNotes().stream().map( this::map ).collect( Collectors.toList() ) );
-
-        return result;
-    }
-
-    private EventDataValue map( org.hisp.dhis.dxf2.events.event.DataValue dataValue )
-    {
-        EventDataValue result = new EventDataValue();
-        result.setCreated( DateUtils.parseDate( dataValue.getCreated() ) );
-        result.setCreatedByUserInfo( dataValue.getCreatedByUserInfo() );
-        result.setLastUpdated( DateUtils.parseDate( dataValue.getLastUpdated() ) );
-        result.setLastUpdatedByUserInfo( dataValue.getLastUpdatedByUserInfo() );
-        result.setDataElement( dataValue.getDataElement() );
-        result.setValue( dataValue.getValue() );
-        result.setProvidedElsewhere( dataValue.getProvidedElsewhere() );
-        result.setStoredBy( dataValue.getStoredBy() );
         return result;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/relationship/RelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/relationship/RelationshipService.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.tracker.relationship;
 import java.util.List;
 import java.util.Optional;
 
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.relationship.Relationship;
@@ -39,13 +41,21 @@ import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteria
 public interface RelationshipService
 {
     List<Relationship> getRelationshipsByTrackedEntityInstance( TrackedEntityInstance tei,
-        PagingAndSortingCriteriaAdapter criteria );
+        PagingAndSortingCriteriaAdapter criteria )
+        throws ForbiddenException,
+        NotFoundException;
 
     List<Relationship> getRelationshipsByProgramInstance( ProgramInstance pi,
-        PagingAndSortingCriteriaAdapter criteria );
+        PagingAndSortingCriteriaAdapter criteria )
+        throws ForbiddenException,
+        NotFoundException;
 
     List<Relationship> getRelationshipsByProgramStageInstance( ProgramStageInstance psi,
-        PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter );
+        PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter )
+        throws ForbiddenException,
+        NotFoundException;
 
-    Optional<Relationship> findRelationshipByUid( String id );
+    Optional<Relationship> findRelationshipByUid( String id )
+        throws ForbiddenException,
+        NotFoundException;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/trackedentity/DefaultTrackedEntityService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.tracker.trackedentity;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -61,7 +62,10 @@ import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.trackedentity.TrackerOwnershipManager;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
-import org.hisp.dhis.tracker.relationship.RelationshipService;
+import org.hisp.dhis.tracker.enrollment.EnrollmentParams;
+import org.hisp.dhis.tracker.enrollment.EnrollmentService;
+import org.hisp.dhis.tracker.event.EventParams;
+import org.hisp.dhis.tracker.event.EventService;
 import org.hisp.dhis.tracker.trackedentity.aggregates.TrackedEntityAggregate;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
@@ -90,11 +94,15 @@ public class DefaultTrackedEntityService implements TrackedEntityService
 
     private final ProgramService programService;
 
-    private final RelationshipService relationshipService;
+    private final EnrollmentService enrollmentService;
+
+    private final EventService eventService;
 
     @Override
     public List<TrackedEntityInstance> getTrackedEntities( TrackedEntityInstanceQueryParams queryParams,
         TrackedEntityParams params )
+        throws ForbiddenException,
+        NotFoundException
     {
         if ( queryParams == null )
         {
@@ -110,20 +118,36 @@ public class DefaultTrackedEntityService implements TrackedEntityService
 
         List<TrackedEntityInstance> trackedEntityInstances = this.trackedEntityAggregate.find( ids, params,
             queryParams );
-        // We need to return the full models for relationship items (i.e. trackedEntity, enrollment and event). The
-        // getRelationship() implementations of the stores do not provide that functionality right now.
+        // We need to return the full models for relationship items (i.e. trackedEntity, enrollment and event) in our API. The aggregate stores currently do not support that, so we need to fetch the entities individually.
         if ( params.isIncludeRelationships() )
         {
-            trackedEntityInstances.forEach( this::mapRelationshipItem );
+            for ( TrackedEntityInstance trackedEntity : trackedEntityInstances )
+            {
+                mapRelationshipItem( trackedEntity );
+            }
         }
         if ( params.getEnrollmentParams().isIncludeRelationships() )
         {
-            trackedEntityInstances.forEach( t -> t.getProgramInstances().forEach( this::mapRelationshipItem ) );
+            for ( TrackedEntityInstance trackedEntity : trackedEntityInstances )
+            {
+                for ( ProgramInstance programInstance : trackedEntity.getProgramInstances() )
+                {
+                    mapRelationshipItem( trackedEntity, programInstance );
+                }
+            }
         }
         if ( params.getEventParams().isIncludeRelationships() )
         {
-            trackedEntityInstances.forEach( t -> t.getProgramInstances()
-                .forEach( e -> e.getProgramStageInstances().forEach( this::mapRelationshipItem ) ) );
+            for ( TrackedEntityInstance trackedEntity : trackedEntityInstances )
+            {
+                for ( ProgramInstance enrollment : trackedEntity.getProgramInstances() )
+                {
+                    for ( ProgramStageInstance event : enrollment.getProgramStageInstances() )
+                    {
+                        mapRelationshipItem( trackedEntity, event );
+                    }
+                }
+            }
         }
 
         addSearchAudit( trackedEntityInstances, queryParams.getUser() );
@@ -132,23 +156,28 @@ public class DefaultTrackedEntityService implements TrackedEntityService
     }
 
     private void mapRelationshipItem( TrackedEntityInstance trackedEntity )
+        throws ForbiddenException,
+        NotFoundException
     {
         Set<RelationshipItem> result = new HashSet<>();
 
         for ( RelationshipItem item : trackedEntity.getRelationshipItems() )
         {
-            Relationship rel = relationshipService.findRelationshipByUid( item.getRelationship().getUid() ).get();
+            Relationship rel = item.getRelationship();
+            RelationshipItem from = withNestedEntity( trackedEntity, rel.getFrom() );
+            from.setRelationship( rel );
+            rel.setFrom( from );
+            RelationshipItem to = withNestedEntity( trackedEntity, rel.getTo() );
+            to.setRelationship( rel );
+            rel.setTo( to );
+
             if ( rel.getFrom().getTrackedEntityInstance() != null
                 && trackedEntity.getUid().equals( rel.getFrom().getTrackedEntityInstance().getUid() ) )
             {
-                RelationshipItem from = rel.getFrom();
-                from.setRelationship( rel );
                 result.add( from );
             }
             else
             {
-                RelationshipItem to = rel.getTo();
-                to.setRelationship( rel );
                 result.add( to );
             }
         }
@@ -156,24 +185,29 @@ public class DefaultTrackedEntityService implements TrackedEntityService
         trackedEntity.setRelationshipItems( result );
     }
 
-    private void mapRelationshipItem( ProgramInstance enrollment )
+    private void mapRelationshipItem( TrackedEntityInstance trackedEntity, ProgramInstance enrollment )
+        throws ForbiddenException,
+        NotFoundException
     {
         Set<RelationshipItem> result = new HashSet<>();
 
         for ( RelationshipItem item : enrollment.getRelationshipItems() )
         {
-            Relationship rel = relationshipService.findRelationshipByUid( item.getRelationship().getUid() ).get();
+            Relationship rel = item.getRelationship();
+            RelationshipItem from = withNestedEntity( trackedEntity, rel.getFrom() );
+            from.setRelationship( rel );
+            rel.setFrom( from );
+            RelationshipItem to = withNestedEntity( trackedEntity, rel.getTo() );
+            to.setRelationship( rel );
+            rel.setTo( to );
+
             if ( rel.getFrom().getTrackedEntityInstance() != null
                 && enrollment.getUid().equals( rel.getFrom().getTrackedEntityInstance().getUid() ) )
             {
-                RelationshipItem from = rel.getFrom();
-                from.setRelationship( rel );
                 result.add( from );
             }
             else
             {
-                RelationshipItem to = rel.getTo();
-                to.setRelationship( rel );
                 result.add( to );
             }
         }
@@ -181,24 +215,29 @@ public class DefaultTrackedEntityService implements TrackedEntityService
         enrollment.setRelationshipItems( result );
     }
 
-    private void mapRelationshipItem( ProgramStageInstance event )
+    private void mapRelationshipItem( TrackedEntityInstance trackedEntity, ProgramStageInstance event )
+        throws ForbiddenException,
+        NotFoundException
     {
         Set<RelationshipItem> result = new HashSet<>();
 
         for ( RelationshipItem item : event.getRelationshipItems() )
         {
-            Relationship rel = relationshipService.findRelationshipByUid( item.getRelationship().getUid() ).get();
+            Relationship rel = item.getRelationship();
+            RelationshipItem from = withNestedEntity( trackedEntity, rel.getFrom() );
+            from.setRelationship( rel );
+            rel.setFrom( from );
+            RelationshipItem to = withNestedEntity( trackedEntity, rel.getTo() );
+            to.setRelationship( rel );
+            rel.setTo( to );
+
             if ( rel.getFrom().getTrackedEntityInstance() != null
                 && event.getUid().equals( rel.getFrom().getTrackedEntityInstance().getUid() ) )
             {
-                RelationshipItem from = rel.getFrom();
-                from.setRelationship( rel );
                 result.add( from );
             }
             else
             {
-                RelationshipItem to = rel.getTo();
-                to.setRelationship( rel );
                 result.add( to );
             }
         }
@@ -239,8 +278,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService
     }
 
     @Override
-    public TrackedEntityInstance getTrackedEntity( String uid, String programIdentifier,
-        TrackedEntityParams params )
+    public TrackedEntityInstance getTrackedEntity( String uid, TrackedEntityParams params )
         throws NotFoundException,
         ForbiddenException
     {
@@ -258,16 +296,32 @@ public class DefaultTrackedEntityService implements TrackedEntityService
             throw new ForbiddenException( errors.toString() );
         }
 
+        return getTrackedEntity( daoTrackedEntityInstance, params, user );
+    }
+
+    @Override
+    public TrackedEntityInstance getTrackedEntity( String uid, String programIdentifier, TrackedEntityParams params )
+        throws NotFoundException,
+        ForbiddenException
+    {
+        Program program = null;
+
         if ( StringUtils.isNotEmpty( programIdentifier ) )
         {
-            Program program = programService.getProgram( programIdentifier );
+            program = programService.getProgram( programIdentifier );
 
             if ( program == null )
             {
                 throw new NotFoundException( Program.class, programIdentifier );
             }
+        }
 
-            if ( !trackerAccessManager.canRead( user, daoTrackedEntityInstance, program, false ).isEmpty() )
+        TrackedEntityInstance trackedEntity = getTrackedEntity( uid, params );
+
+        if ( program != null )
+        {
+            if ( !trackerAccessManager.canRead( currentUserService.getCurrentUser(), trackedEntity, program, false )
+                .isEmpty() )
             {
                 if ( program.getAccessLevel() == AccessLevel.CLOSED )
                 {
@@ -275,41 +329,71 @@ public class DefaultTrackedEntityService implements TrackedEntityService
                 }
                 throw new ForbiddenException( TrackerOwnershipManager.OWNERSHIP_ACCESS_DENIED );
             }
+
+            if ( params.isIncludeProgramOwners() )
+            {
+                Set<TrackedEntityProgramOwner> filteredProgramOwners = trackedEntity.getProgramOwners()
+                    .stream()
+                    .filter( tei -> tei.getProgram().getUid().equals( programIdentifier ) )
+                    .collect( Collectors.toSet() );
+                trackedEntity.setProgramOwners( filteredProgramOwners );
+            }
         }
-        return getTei( daoTrackedEntityInstance, programIdentifier, params, user );
+        else
+        {
+            // return only tracked entity type attributes
+            TrackedEntityType trackedEntityType = trackedEntity.getTrackedEntityType();
+            if ( trackedEntityType != null )
+            {
+                Set<String> tetAttributes = trackedEntityType.getTrackedEntityAttributes().stream()
+                    .map( TrackedEntityAttribute::getUid ).collect( Collectors.toSet() );
+                Set<TrackedEntityAttributeValue> tetAttributeValues = trackedEntity.getTrackedEntityAttributeValues()
+                    .stream()
+                    .filter( att -> tetAttributes.contains( att.getAttribute().getUid() ) )
+                    .collect( Collectors.toSet() );
+                trackedEntity.setTrackedEntityAttributeValues( tetAttributeValues );
+            }
+        }
+
+        return trackedEntity;
     }
 
-    private TrackedEntityInstance getTei( TrackedEntityInstance daoTrackedEntityInstance,
-        String programIdentifier,
-        TrackedEntityParams params, User user )
+    @Override
+    public TrackedEntityInstance getTrackedEntity( TrackedEntityInstance trackedEntity, TrackedEntityParams params )
     {
-        if ( daoTrackedEntityInstance == null )
+        return getTrackedEntity( trackedEntity, params, currentUserService.getCurrentUser() );
+    }
+
+    private TrackedEntityInstance getTrackedEntity( TrackedEntityInstance trackedEntity, TrackedEntityParams params,
+        User user )
+    {
+        if ( trackedEntity == null )
         {
             return null;
         }
 
         TrackedEntityInstance result = new TrackedEntityInstance();
-        result.setUid( daoTrackedEntityInstance.getUid() );
-        result.setOrganisationUnit( daoTrackedEntityInstance.getOrganisationUnit() );
-        result.setTrackedEntityType( daoTrackedEntityInstance.getTrackedEntityType() );
-        result.setCreated( daoTrackedEntityInstance.getCreated() );
-        result.setCreatedAtClient( daoTrackedEntityInstance.getCreatedAtClient() );
-        result.setLastUpdated( daoTrackedEntityInstance.getLastUpdated() );
-        result.setLastUpdatedAtClient( daoTrackedEntityInstance.getLastUpdatedAtClient() );
-        result.setInactive( daoTrackedEntityInstance.isInactive() );
-        result.setGeometry( daoTrackedEntityInstance.getGeometry() );
-        result.setDeleted( daoTrackedEntityInstance.isDeleted() );
-        result.setPotentialDuplicate( daoTrackedEntityInstance.isPotentialDuplicate() );
-        result.setStoredBy( daoTrackedEntityInstance.getStoredBy() );
-        result.setCreatedByUserInfo( daoTrackedEntityInstance.getCreatedByUserInfo() );
-        result.setLastUpdatedByUserInfo( daoTrackedEntityInstance.getLastUpdatedByUserInfo() );
-        result.setGeometry( daoTrackedEntityInstance.getGeometry() );
+        result.setUid( trackedEntity.getUid() );
+        result.setOrganisationUnit( trackedEntity.getOrganisationUnit() );
+        result.setTrackedEntityType( trackedEntity.getTrackedEntityType() );
+        result.setCreated( trackedEntity.getCreated() );
+        result.setCreatedAtClient( trackedEntity.getCreatedAtClient() );
+        result.setLastUpdated( trackedEntity.getLastUpdated() );
+        result.setLastUpdatedAtClient( trackedEntity.getLastUpdatedAtClient() );
+        result.setInactive( trackedEntity.isInactive() );
+        result.setGeometry( trackedEntity.getGeometry() );
+        result.setDeleted( trackedEntity.isDeleted() );
+        result.setPotentialDuplicate( trackedEntity.isPotentialDuplicate() );
+        result.setStoredBy( trackedEntity.getStoredBy() );
+        result.setCreatedByUserInfo( trackedEntity.getCreatedByUserInfo() );
+        result.setLastUpdatedByUserInfo( trackedEntity.getLastUpdatedByUserInfo() );
+        result.setGeometry( trackedEntity.getGeometry() );
 
         if ( params.isIncludeRelationships() )
         {
             Set<RelationshipItem> items = new HashSet<>();
 
-            for ( RelationshipItem relationshipItem : daoTrackedEntityInstance.getRelationshipItems() )
+            for ( RelationshipItem relationshipItem : trackedEntity.getRelationshipItems() )
             {
                 org.hisp.dhis.relationship.Relationship daoRelationship = relationshipItem.getRelationship();
 
@@ -327,7 +411,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService
         {
             Set<ProgramInstance> programInstances = new HashSet<>();
 
-            for ( ProgramInstance programInstance : daoTrackedEntityInstance.getProgramInstances() )
+            for ( ProgramInstance programInstance : trackedEntity.getProgramInstances() )
             {
                 if ( trackerAccessManager.canRead( user, programInstance, false ).isEmpty()
                     && (params.isIncludeDeleted() || !programInstance.isDeleted()) )
@@ -350,25 +434,14 @@ public class DefaultTrackedEntityService implements TrackedEntityService
 
         if ( params.isIncludeProgramOwners() )
         {
-            if ( StringUtils.isNotEmpty( programIdentifier ) )
-            {
-                Set<TrackedEntityProgramOwner> filteredProgramOwners = daoTrackedEntityInstance.getProgramOwners()
-                    .stream()
-                    .filter( tei -> tei.getProgram().getUid().equals( programIdentifier ) )
-                    .collect( Collectors.toSet() );
-                result.setProgramOwners( filteredProgramOwners );
-            }
-            else
-            {
-                result.setProgramOwners( daoTrackedEntityInstance.getProgramOwners() );
-            }
+            result.setProgramOwners( trackedEntity.getProgramOwners() );
         }
 
         Set<TrackedEntityAttribute> readableAttributes = trackedEntityAttributeService
             .getAllUserReadableTrackedEntityAttributes( user );
-        Set<TrackedEntityAttributeValue> attributeValues = new HashSet<>();
+        Set<TrackedEntityAttributeValue> attributeValues = new LinkedHashSet<>();
 
-        for ( TrackedEntityAttributeValue attributeValue : daoTrackedEntityInstance.getTrackedEntityAttributeValues() )
+        for ( TrackedEntityAttributeValue attributeValue : trackedEntity.getTrackedEntityAttributeValues() )
         {
             if ( readableAttributes.contains( attributeValue.getAttribute() ) )
             {
@@ -377,19 +450,41 @@ public class DefaultTrackedEntityService implements TrackedEntityService
         }
         result.setTrackedEntityAttributeValues( attributeValues );
 
-        if ( StringUtils.isEmpty( programIdentifier ) )
+        return result;
+    }
+
+    private RelationshipItem withNestedEntity( TrackedEntityInstance trackedEntity, RelationshipItem item )
+        throws ForbiddenException,
+        NotFoundException
+    {
+        // relationships of relationship items are not mapped to JSON so there is no need to fetch them
+        RelationshipItem result = new RelationshipItem();
+
+        if ( item.getTrackedEntityInstance() != null )
         {
-            // return only tracked entity type attributes
-            TrackedEntityType trackedEntityType = daoTrackedEntityInstance.getTrackedEntityType();
-            if ( trackedEntityType != null )
+            if ( trackedEntity.getUid().equals( item.getTrackedEntityInstance().getUid() ) )
             {
-                Set<String> tetAttributes = trackedEntityType.getTrackedEntityAttributes().stream()
-                    .map( TrackedEntityAttribute::getUid ).collect( Collectors.toSet() );
-                Set<TrackedEntityAttributeValue> tetAttributeValues = result.getTrackedEntityAttributeValues().stream()
-                    .filter( att -> tetAttributes.contains( att.getAttribute().getUid() ) )
-                    .collect( Collectors.toSet() );
-                result.setTrackedEntityAttributeValues( tetAttributeValues );
+                // only fetch the TEI if we do not already have access to it. meaning the TEI owns the item
+                // this is just mapping the TEI
+                result.setTrackedEntityInstance( trackedEntity );
             }
+            else
+            {
+                result.setTrackedEntityInstance( getTrackedEntity( item.getTrackedEntityInstance().getUid(),
+                    TrackedEntityParams.TRUE.withIncludeRelationships( false ) ) );
+            }
+        }
+        else if ( item.getProgramInstance() != null )
+        {
+            result.setProgramInstance(
+                enrollmentService.getEnrollment( item.getProgramInstance().getUid(),
+                    EnrollmentParams.TRUE.withIncludeRelationships( false ) ) );
+        }
+        else if ( item.getProgramStageInstance() != null )
+        {
+            result.setProgramStageInstance(
+                eventService.getEvent( item.getProgramStageInstance(),
+                    EventParams.TRUE.withIncludeRelationships( false ) ) );
         }
 
         return result;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/trackedentity/TrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/trackedentity/TrackedEntityService.java
@@ -36,6 +36,18 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams;
 
 public interface TrackedEntityService
 {
+    TrackedEntityInstance getTrackedEntity( String uid, TrackedEntityParams params )
+        throws NotFoundException,
+        ForbiddenException;
+
+    TrackedEntityInstance getTrackedEntity( TrackedEntityInstance trackedEntity, TrackedEntityParams params )
+        throws NotFoundException,
+        ForbiddenException;
+
+    TrackedEntityInstance getTrackedEntity( String uid, String programIdentifier, TrackedEntityParams params )
+        throws NotFoundException,
+        ForbiddenException;
+
     /**
      * Fetches {@see TrackedEntityInstance}s based on the specified parameters.
      *
@@ -53,16 +65,4 @@ public interface TrackedEntityService
 
     int getTrackedEntityCount( TrackedEntityInstanceQueryParams params, boolean skipAccessValidation,
         boolean skipSearchScopeValidation );
-
-    TrackedEntityInstance getTrackedEntity( String uid, TrackedEntityParams params )
-        throws NotFoundException,
-        ForbiddenException;
-
-    TrackedEntityInstance getTrackedEntity( TrackedEntityInstance trackedEntity, TrackedEntityParams params )
-        throws NotFoundException,
-        ForbiddenException;
-
-    TrackedEntityInstance getTrackedEntity( String uid, String programIdentifier, TrackedEntityParams params )
-        throws NotFoundException,
-        ForbiddenException;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/trackedentity/TrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/trackedentity/TrackedEntityService.java
@@ -47,10 +47,20 @@ public interface TrackedEntityService
      * @return {@see TrackedEntityInstance}s
      */
     List<TrackedEntityInstance> getTrackedEntities( TrackedEntityInstanceQueryParams queryParams,
-        TrackedEntityParams params );
+        TrackedEntityParams params )
+        throws ForbiddenException,
+        NotFoundException;
 
     int getTrackedEntityCount( TrackedEntityInstanceQueryParams params, boolean skipAccessValidation,
         boolean skipSearchScopeValidation );
+
+    TrackedEntityInstance getTrackedEntity( String uid, TrackedEntityParams params )
+        throws NotFoundException,
+        ForbiddenException;
+
+    TrackedEntityInstance getTrackedEntity( TrackedEntityInstance trackedEntity, TrackedEntityParams params )
+        throws NotFoundException,
+        ForbiddenException;
 
     TrackedEntityInstance getTrackedEntity( String uid, String programIdentifier, TrackedEntityParams params )
         throws NotFoundException,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/trackedentity/aggregates/EnrollmentAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/trackedentity/aggregates/EnrollmentAggregate.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.tracker.trackedentity.aggregates.ThreadPoolManager.g
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -123,7 +124,8 @@ public class EnrollmentAggregate
                 if ( ctx.getParams().getTeiEnrollmentParams().isIncludeAttributes() )
                 {
                     enrollment.getEntityInstance()
-                        .setTrackedEntityAttributeValues( new HashSet<>( attributes.get( enrollment.getUid() ) ) );
+                        .setTrackedEntityAttributeValues(
+                            new LinkedHashSet<>( attributes.get( enrollment.getUid() ) ) );
                 }
 
                 enrollment.setComments( new ArrayList<>( notes.get( enrollment.getUid() ) ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/trackedentity/aggregates/TrackedEntityAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/trackedentity/aggregates/TrackedEntityAggregate.java
@@ -34,6 +34,7 @@ import static org.hisp.dhis.tracker.trackedentity.aggregates.ThreadPoolManager.g
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -279,12 +280,9 @@ public class TrackedEntityAggregate
         Set<TrackedEntityAttribute> trackedEntityTypeAttributes, Map<Program, Set<TrackedEntityAttribute>> teaByProgram,
         Context ctx )
     {
-        Set<TrackedEntityAttributeValue> attributeList = new HashSet<>();
-
-        // Nothing to filter from, return empty
         if ( attributes.isEmpty() )
         {
-            return attributeList;
+            return Set.of();
         }
 
         // Add all tet attributes
@@ -302,15 +300,16 @@ public class TrackedEntityAggregate
             }
         }
 
+        Set<TrackedEntityAttributeValue> result = new LinkedHashSet<>();
         for ( TrackedEntityAttributeValue attributeValue : attributes )
         {
             if ( allowedAttributeUids.contains( attributeValue.getAttribute().getUid() ) )
             {
-                attributeList.add( attributeValue );
+                result.add( attributeValue );
             }
         }
 
-        return attributeList;
+        return result;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/trackedentity/aggregates/TrackedEntityAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/trackedentity/aggregates/TrackedEntityAggregate.java
@@ -300,16 +300,9 @@ public class TrackedEntityAggregate
             }
         }
 
-        Set<TrackedEntityAttributeValue> result = new LinkedHashSet<>();
-        for ( TrackedEntityAttributeValue attributeValue : attributes )
-        {
-            if ( allowedAttributeUids.contains( attributeValue.getAttribute().getUid() ) )
-            {
-                result.add( attributeValue );
-            }
-        }
-
-        return result;
+        return attributes.stream()
+            .filter( av -> allowedAttributeUids.contains( av.getAttribute().getUid() ) )
+            .collect( Collectors.toCollection( LinkedHashSet::new ) );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/trackedentity/aggregates/mapper/EventRowCallbackHandler.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/trackedentity/aggregates/mapper/EventRowCallbackHandler.java
@@ -37,6 +37,7 @@ import java.sql.SQLException;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.commons.util.TextUtils;
@@ -127,16 +128,24 @@ public class EventRowCallbackHandler
         categoryOptionCombo.setCategoryOptions( categoryOptions );
         event.setAttributeOptionCombo( categoryOptionCombo );
 
-        User assignedUser = new User();
-        assignedUser.setUid( rs.getString( getColumnName( COLUMNS.ASSIGNED_USER ) ) );
-        assignedUser.setUsername( rs.getString( getColumnName( COLUMNS.ASSIGNED_USER_USERNAME ) ) );
-        assignedUser.setFirstName( rs.getString( getColumnName( COLUMNS.ASSIGNED_USER_FIRST_NAME ) ) );
-        assignedUser.setSurname( rs.getString( getColumnName( COLUMNS.ASSIGNED_USER_SURNAME ) ) );
-        if ( assignedUser.getFirstName() != null && assignedUser.getSurname() != null )
+        String assignedUserUid = rs.getString( getColumnName( COLUMNS.ASSIGNED_USER ) );
+        String assignedUserUsername = rs.getString( getColumnName( COLUMNS.ASSIGNED_USER_USERNAME ) );
+        String assignedUserFirstName = rs.getString( getColumnName( COLUMNS.ASSIGNED_USER_FIRST_NAME ) );
+        String assignedUserSurname = rs.getString( getColumnName( COLUMNS.ASSIGNED_USER_SURNAME ) );
+        if ( StringUtils.isNotEmpty( assignedUserUid ) || StringUtils.isNotEmpty( assignedUserUsername )
+            || StringUtils.isNotEmpty( assignedUserFirstName ) || StringUtils.isNotEmpty( assignedUserSurname ) )
         {
-            assignedUser.setName( assignedUser.getFirstName() + " " + assignedUser.getSurname() );
+            User assignedUser = new User();
+            assignedUser.setUid( assignedUserUid );
+            assignedUser.setUsername( assignedUserUsername );
+            assignedUser.setFirstName( assignedUserFirstName );
+            assignedUser.setSurname( assignedUserSurname );
+            if ( assignedUser.getFirstName() != null && assignedUser.getSurname() != null )
+            {
+                assignedUser.setName( assignedUser.getFirstName() + " " + assignedUser.getSurname() );
+            }
+            event.setAssignedUser( assignedUser );
         }
-        event.setAssignedUser( assignedUser );
 
         return event;
     }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/relationship/RelationshipServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/relationship/RelationshipServiceTest.java
@@ -38,6 +38,8 @@ import java.util.stream.Collectors;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.commons.util.RelationshipUtils;
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
@@ -98,8 +100,6 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase
 
     private ProgramInstance piA;
 
-    private ProgramInstance piB;
-
     @Override
     protected void setUpTest()
         throws Exception
@@ -155,7 +155,7 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase
         psiA.setOrganisationUnit( orgUnit );
         manager.save( psiA, false );
 
-        piB = programInstanceService.enrollTrackedEntityInstance( teiB, program, new Date(), new Date(),
+        ProgramInstance piB = programInstanceService.enrollTrackedEntityInstance( teiB, program, new Date(), new Date(),
             orgUnit );
         inaccessiblePsi = new ProgramStageInstance();
         inaccessiblePsi.setProgramInstance( piB );
@@ -223,6 +223,8 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase
 
     @Test
     void shouldNotReturnRelationshipByTrackedEntityInstanceIfUserHasNoAccessToTrackedEntityType()
+        throws ForbiddenException,
+        NotFoundException
     {
         Relationship accessible = relationship( teiA, teiB );
         relationship( teiA, inaccessibleTei, teiToInaccessibleTeiType );
@@ -236,6 +238,8 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase
 
     @Test
     void shouldNotReturnRelationshipByProgramInstanceIfUserHasNoAccessToRelationshipType()
+        throws ForbiddenException,
+        NotFoundException
     {
         Relationship accessible = relationship( teiA, piA );
         relationship( teiB, piA, teiToPiInaccessibleType );
@@ -249,6 +253,8 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase
 
     @Test
     void shouldNotReturnRelationshipByProgramStageInstanceIfUserHasNoAccessToProgramStage()
+        throws ForbiddenException,
+        NotFoundException
     {
         Relationship accessible = relationship( teiA, psiA );
         relationship( psiA, inaccessiblePsi );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/trackedentity/TrackedEntityServiceTest.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker.trackedentity.aggregates;
+package org.hisp.dhis.tracker.trackedentity;
 
 import static org.hisp.dhis.util.DateUtils.parseDate;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
@@ -89,9 +89,6 @@ import org.hisp.dhis.trackedentity.TrackerOwnershipManager;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
-import org.hisp.dhis.tracker.trackedentity.TrackedEntityEnrollmentParams;
-import org.hisp.dhis.tracker.trackedentity.TrackedEntityParams;
-import org.hisp.dhis.tracker.trackedentity.TrackedEntityService;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserAccess;
@@ -103,7 +100,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 /**
  * @author Luciano Fiandesio
  */
-class TrackedEntityAggregateTest extends IntegrationTestBase
+class TrackedEntityServiceTest extends IntegrationTestBase
 {
     @Autowired
     private TrackedEntityService trackedEntityService;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/trackedentity/aggregates/TrackedEntityAggregateTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/trackedentity/aggregates/TrackedEntityAggregateTest.java
@@ -62,6 +62,8 @@ import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.commons.util.RelationshipUtils;
 import org.hisp.dhis.event.EventStatus;
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
@@ -388,6 +390,8 @@ class TrackedEntityAggregateTest extends IntegrationTestBase
 
     @Test
     void shouldReturnEmptyCollectionGivenUserHasNoAccessToTrackedEntityType()
+        throws ForbiddenException,
+        NotFoundException
     {
         TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
         queryParams.setOrganisationUnits( Set.of( orgUnitA ) );
@@ -406,6 +410,8 @@ class TrackedEntityAggregateTest extends IntegrationTestBase
 
     @Test
     void shouldReturnTrackedEntitiesGivenUserHasDataReadAccessToTrackedEntityType()
+        throws ForbiddenException,
+        NotFoundException
     {
         TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
         queryParams.setOrganisationUnits( Set.of( orgUnitA, orgUnitB ) );
@@ -420,6 +426,8 @@ class TrackedEntityAggregateTest extends IntegrationTestBase
 
     @Test
     void shouldIncludeAllAttributesOfGivenTrackedEntity()
+        throws ForbiddenException,
+        NotFoundException
     {
         TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
         queryParams.setOrganisationUnits( Set.of( orgUnitA ) );
@@ -436,6 +444,8 @@ class TrackedEntityAggregateTest extends IntegrationTestBase
 
     @Test
     void shouldReturnTrackedEntityIncludingAllAttributesEnrollmentsEventsRelationshipsOwners()
+        throws ForbiddenException,
+        NotFoundException
     {
         // this was declared as "remove ownership"; unclear to me how this is removing ownership
         trackerOwnershipManager.assignOwnership( trackedEntityA, programB, orgUnitB, true, true );
@@ -466,6 +476,8 @@ class TrackedEntityAggregateTest extends IntegrationTestBase
 
     @Test
     void shouldReturnTrackedEntityIncludeAllAttributesInProtectedProgramNoAccess()
+        throws ForbiddenException,
+        NotFoundException
     {
         // this was declared as "remove ownership"; unclear to me how this is removing ownership
         trackerOwnershipManager.assignOwnership( trackedEntityA, programB, orgUnitB, true, true );
@@ -485,6 +497,8 @@ class TrackedEntityAggregateTest extends IntegrationTestBase
 
     @Test
     void shouldReturnTrackedEntityIncludeSpecificProtectedProgram()
+        throws ForbiddenException,
+        NotFoundException
     {
         TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
         queryParams.setOrganisationUnits( Set.of( orgUnitA ) );
@@ -500,6 +514,8 @@ class TrackedEntityAggregateTest extends IntegrationTestBase
 
     @Test
     void shouldTrackedEntityIncludeSpecificOpenProgram()
+        throws ForbiddenException,
+        NotFoundException
     {
         TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
         queryParams.setOrganisationUnits( Set.of( orgUnitA ) );
@@ -515,6 +531,8 @@ class TrackedEntityAggregateTest extends IntegrationTestBase
 
     @Test
     void shouldReturnEmptyCollectionGivenSingleQuoteInAttributeSearchInput()
+        throws ForbiddenException,
+        NotFoundException
     {
         TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
         queryParams.setOrganisationUnits( Set.of( orgUnitA ) );
@@ -530,6 +548,8 @@ class TrackedEntityAggregateTest extends IntegrationTestBase
 
     @Test
     void shouldReturnTrackedEntityWithLastUpdatedParameter()
+        throws ForbiddenException,
+        NotFoundException
     {
         TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
         queryParams.setOrganisationUnits( Set.of( orgUnitA ) );
@@ -551,6 +571,8 @@ class TrackedEntityAggregateTest extends IntegrationTestBase
     @Test
     @Disabled( "12098 This test is not working" )
     void shouldReturnTrackedEntityWithEventFilters()
+        throws ForbiddenException,
+        NotFoundException
     {
         TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
         queryParams.setUserWithAssignedUsers( null, user, null );
@@ -593,6 +615,8 @@ class TrackedEntityAggregateTest extends IntegrationTestBase
 
     @Test
     void shouldIncludeDeletedEnrollmentAndEvents()
+        throws ForbiddenException,
+        NotFoundException
     {
         TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
         queryParams.setOrganisationUnits( Set.of( orgUnitA ) );
@@ -652,6 +676,8 @@ class TrackedEntityAggregateTest extends IntegrationTestBase
 
     @Test
     void shouldReturnTrackedEntityAndEnrollmentsGivenTheyShouldBeIncluded()
+        throws ForbiddenException,
+        NotFoundException
     {
         TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
         queryParams.setOrganisationUnits( Set.of( orgUnitA ) );
@@ -676,6 +702,8 @@ class TrackedEntityAggregateTest extends IntegrationTestBase
 
     @Test
     void shouldReturnTrackedEntityWithoutEnrollmentsGivenTheyShouldNotBeIncluded()
+        throws ForbiddenException,
+        NotFoundException
     {
         TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
         queryParams.setOrganisationUnits( Set.of( orgUnitA ) );
@@ -692,6 +720,8 @@ class TrackedEntityAggregateTest extends IntegrationTestBase
 
     @Test
     void shouldReturnTrackedEntityWithEventsAndNotesGivenTheyShouldBeIncluded()
+        throws ForbiddenException,
+        NotFoundException
     {
         TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
         queryParams.setOrganisationUnits( Set.of( orgUnitA ) );
@@ -717,6 +747,8 @@ class TrackedEntityAggregateTest extends IntegrationTestBase
 
     @Test
     void shouldReturnTrackedEntityWithoutEventsGivenTheyShouldNotBeIncluded()
+        throws ForbiddenException,
+        NotFoundException
     {
         TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
         queryParams.setOrganisationUnits( Set.of( orgUnitA ) );
@@ -738,6 +770,8 @@ class TrackedEntityAggregateTest extends IntegrationTestBase
 
     @Test
     void shouldReturnTrackedEntityMappedCorrectly()
+        throws ForbiddenException,
+        NotFoundException
     {
         final Date currentTime = new Date();
         TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
@@ -765,6 +799,8 @@ class TrackedEntityAggregateTest extends IntegrationTestBase
 
     @Test
     void shouldReturnEnrollmentMappedCorrectly()
+        throws ForbiddenException,
+        NotFoundException
     {
         final Date currentTime = new Date();
         TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
@@ -803,6 +839,8 @@ class TrackedEntityAggregateTest extends IntegrationTestBase
 
     @Test
     void shouldReturnEventMappedCorrectly()
+        throws ForbiddenException,
+        NotFoundException
     {
         final Date currentTime = new Date();
         TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
@@ -848,6 +886,8 @@ class TrackedEntityAggregateTest extends IntegrationTestBase
 
     @Test
     void shouldReturnTrackedEntityWithRelationshipsTei2Tei()
+        throws ForbiddenException,
+        NotFoundException
     {
         TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
         queryParams.setOrganisationUnits( Set.of( orgUnitA ) );
@@ -869,6 +909,8 @@ class TrackedEntityAggregateTest extends IntegrationTestBase
 
     @Test
     void returnTrackedEntityRelationshipsWithTei2Enrollment()
+        throws ForbiddenException,
+        NotFoundException
     {
         TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
         queryParams.setOrganisationUnits( Set.of( orgUnitA ) );
@@ -891,6 +933,8 @@ class TrackedEntityAggregateTest extends IntegrationTestBase
 
     @Test
     void shouldReturnTrackedEntityRelationshipsWithTei2Event()
+        throws ForbiddenException,
+        NotFoundException
     {
         TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
         queryParams.setOrganisationUnits( Set.of( orgUnitA ) );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportControllerTest.java
@@ -493,9 +493,9 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
             to.getUid() )
                 .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
 
-        JsonAttribute enrollmentAttr = relationships.get( 0 ).getFrom().getEnrollment().getAttributes().get( 0 );
-        assertEquals( tea2.getUid(), enrollmentAttr.getAttribute() );
-        assertEquals( "24", enrollmentAttr.getValue() );
+        JsonList<JsonAttribute> enrollmentAttr = relationships.get( 0 ).getFrom().getEnrollment().getAttributes();
+        assertContainsAll( List.of( tea2.getUid() ), enrollmentAttr, JsonAttribute::getAttribute );
+        assertContainsAll( List.of( "24" ), enrollmentAttr, JsonAttribute::getValue );
         JsonList<JsonAttribute> teiAttributes = relationships.get( 0 ).getTo().getTrackedEntity().getAttributes();
         assertContainsAll( List.of( tea.getUid(), tea2.getUid() ), teiAttributes, JsonAttribute::getAttribute );
         assertContainsAll( List.of( "12", "24" ), teiAttributes, JsonAttribute::getValue );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
@@ -116,7 +116,8 @@ public class TrackerTrackedEntitiesExportController
     PagingWrapper<ObjectNode> getTrackedEntities( TrackerTrackedEntityCriteria criteria,
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
         throws BadRequestException,
-        ForbiddenException
+        ForbiddenException,
+        NotFoundException
     {
         TrackedEntityInstanceQueryParams queryParams = criteriaMapper.map( criteria );
 
@@ -155,7 +156,8 @@ public class TrackerTrackedEntitiesExportController
         @RequestParam( required = false, defaultValue = "false" ) boolean skipHeader )
         throws IOException,
         BadRequestException,
-        ForbiddenException
+        ForbiddenException,
+        NotFoundException
     {
         TrackedEntityInstanceQueryParams queryParams = criteriaMapper.map( criteria );
         TrackedEntityParams trackedEntityInstanceParams = fieldsMapper.map( CSV_FIELDS,


### PR DESCRIPTION
follow up to https://github.com/dhis2/dhis2-core/pull/13540

- 🎉 remove new relationship service dependency on dxf2
- 🎉 ban dxf2 dependency from dhis-service-tracker module
- ⚠️ dhis-api `TrackedEntityInstance.trackedEntityAttributeValues` is a `Set` using a `HashSet`. Since we need to be able to sort the attribute values we need to use an ordered set like `LinkedHashSet`. 
- remove some sync related code in event which is not used as new tracker does not yet support sync
- expose private service methods like `ProgramInstance getEnrollment( ProgramInstance uid, EnrollmentParams params );`. These are used to detach from hibernate proxies but also to implement some logic. For enrollments `programInstance.entityInstance.trackedEntityAttributeValues` are filtered to only include program attributes. These methods need to be called from `DefaultRelationshipService`.

# Next PRs

- https://github.com/dhis2/dhis2-core/pull/13625
- https://github.com/dhis2/dhis2-core/pull/13626
- https://github.com/dhis2/dhis2-core/pull/13630
- https://dhis2.atlassian.net/browse/DHIS2-14752 I think I have a simple idea 😅 