### PR TITLE
fix: Perf issue in /analytics [DHIS2-15093]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultAnalyticsService.java
@@ -57,6 +57,7 @@ import org.hisp.dhis.system.grid.ListGrid;
 import org.hisp.dhis.visualization.Visualization;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Lars Helge Overland
@@ -97,6 +98,7 @@ public class DefaultAnalyticsService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Grid getAggregatedDataValues( DataQueryParams params )
     {
         params = checkSecurityConstraints( params );
@@ -115,6 +117,7 @@ public class DefaultAnalyticsService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Grid getAggregatedDataValues( DataQueryParams params, List<String> columns, List<String> rows )
     {
         return isTableLayout( columns, rows ) ? getAggregatedDataValuesTableLayout( params, columns, rows )
@@ -122,6 +125,7 @@ public class DefaultAnalyticsService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Grid getRawDataValues( DataQueryParams params )
     {
         params = checkSecurityConstraints( params );
@@ -132,6 +136,7 @@ public class DefaultAnalyticsService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DataValueSet getAggregatedDataValueSet( DataQueryParams params )
     {
         params = checkSecurityConstraints( params );
@@ -149,6 +154,7 @@ public class DefaultAnalyticsService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Grid getAggregatedDataValues( AnalyticalObject object )
     {
         DataQueryParams params = dataQueryService.getFromAnalyticalObject( object );
@@ -157,6 +163,7 @@ public class DefaultAnalyticsService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Map<String, Object> getAggregatedDataValueMapping( DataQueryParams params )
     {
         Grid grid = getAggregatedDataValues( newBuilder( params )
@@ -166,6 +173,7 @@ public class DefaultAnalyticsService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Map<String, Object> getAggregatedDataValueMapping( AnalyticalObject object )
     {
         DataQueryParams params = dataQueryService.getFromAnalyticalObject( object );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
@@ -126,6 +126,7 @@ import org.hisp.dhis.user.UserSettingKey;
 import org.hisp.dhis.user.UserSettingService;
 import org.hisp.dhis.util.ObjectUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
 /**
@@ -190,6 +191,7 @@ public class DefaultDataQueryService
     // -------------------------------------------------------------------------
 
     @Override
+    @Transactional( readOnly = true )
     public DataQueryParams getFromRequest( DataQueryRequest request )
     {
         I18nFormat format = i18nManager.getI18nFormat();
@@ -261,6 +263,7 @@ public class DefaultDataQueryService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DataQueryParams getFromAnalyticalObject( AnalyticalObject object )
     {
         Assert.notNull( object, "Analytical object cannot be null" );
@@ -309,6 +312,7 @@ public class DefaultDataQueryService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public List<DimensionalObject> getDimensionalObjects( Set<String> dimensionParams,
         Date relativePeriodDate, String userOrgUnit, I18nFormat format, boolean allowAllPeriods,
         IdScheme inputIdScheme )
@@ -339,6 +343,7 @@ public class DefaultDataQueryService
     // instead of fetching all org units one by one.
 
     @Override
+    @Transactional( readOnly = true )
     public DimensionalObject getDimension( String dimension, List<String> items, Date relativePeriodDate,
         List<OrganisationUnit> userOrgUnits, I18nFormat format, boolean allowNull, boolean allowAllPeriodItems,
         IdScheme inputIdScheme )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -514,7 +514,7 @@ public class DataHandler
      * @param grid the grid.
      */
     @Transactional( readOnly = true )
-    void addRawData( DataQueryParams params, Grid grid )
+    public void addRawData( DataQueryParams params, Grid grid )
     {
         if ( !params.isSkipData() )
         {
@@ -533,7 +533,7 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      */
     @Transactional( readOnly = true )
-    DataQueryParams prepareForRawDataQuery( DataQueryParams params )
+    public DataQueryParams prepareForRawDataQuery( DataQueryParams params )
     {
         DataQueryParams.Builder builder = newBuilder( params )
             .withEarliestStartDateLatestEndDate()

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -152,6 +152,7 @@ import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.util.Timer;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * This component is responsible for handling and retrieving data based on the
@@ -242,7 +243,8 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
-    void addIndicatorValues( DataQueryParams params, Grid grid )
+    @Transactional( readOnly = true )
+    public void addIndicatorValues( DataQueryParams params, Grid grid )
     {
         if ( !params.getIndicators().isEmpty() && !params.isSkipData() )
         {
@@ -341,7 +343,8 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
-    void addDataElementValues( DataQueryParams params, Grid grid )
+    @Transactional( readOnly = true )
+    public void addDataElementValues( DataQueryParams params, Grid grid )
     {
         if ( !params.getAllDataElements().isEmpty() && (!params.isSkipData() || params.analyzeOnly()) )
         {
@@ -374,7 +377,8 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
-    void addProgramDataElementAttributeIndicatorValues( DataQueryParams params, Grid grid )
+    @Transactional( readOnly = true )
+    public void addProgramDataElementAttributeIndicatorValues( DataQueryParams params, Grid grid )
     {
         if ( (!params.getAllProgramDataElementsAndAttributes().isEmpty() || !params.getProgramIndicators().isEmpty())
             && !params.isSkipData() )
@@ -420,7 +424,8 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
-    void addReportingRates( DataQueryParams params, Grid grid )
+    @Transactional( readOnly = true )
+    public void addReportingRates( DataQueryParams params, Grid grid )
     {
         if ( !params.getReportingRates().isEmpty() && !params.isSkipData() )
         {
@@ -444,7 +449,8 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
-    void addDataElementOperandValues( DataQueryParams params, Grid grid )
+    @Transactional( readOnly = true )
+    public void addDataElementOperandValues( DataQueryParams params, Grid grid )
     {
         if ( !params.getDataElementOperands().isEmpty() && !params.isSkipData() )
         {
@@ -466,7 +472,8 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
-    void addDynamicDimensionValues( DataQueryParams params, Grid grid )
+    @Transactional( readOnly = true )
+    public void addDynamicDimensionValues( DataQueryParams params, Grid grid )
     {
         if ( params.getDataDimensionAndFilterOptions().isEmpty() && !params.isSkipData() )
         {
@@ -484,7 +491,8 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
-    void addValidationResultValues( DataQueryParams params, Grid grid )
+    @Transactional( readOnly = true )
+    public void addValidationResultValues( DataQueryParams params, Grid grid )
     {
         if ( !params.getAllValidationResults().isEmpty() && !params.isSkipData() )
         {
@@ -505,6 +513,7 @@ public class DataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
+    @Transactional( readOnly = true )
     void addRawData( DataQueryParams params, Grid grid )
     {
         if ( !params.isSkipData() )
@@ -523,6 +532,7 @@ public class DataHandler
      *
      * @param params the {@link DataQueryParams}.
      */
+    @Transactional( readOnly = true )
     DataQueryParams prepareForRawDataQuery( DataQueryParams params )
     {
         DataQueryParams.Builder builder = newBuilder( params )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/MetadataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/MetadataHandler.java
@@ -61,6 +61,7 @@ import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.PeriodType;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.google.common.collect.Sets;
 
@@ -90,7 +91,8 @@ public class MetadataHandler
      * @param params the {@link DataQueryParams}.
      * @param grid the grid.
      */
-    void addMetaData( DataQueryParams params, Grid grid )
+    @Transactional( readOnly = true )
+    public void addMetaData( DataQueryParams params, Grid grid )
     {
         if ( !params.isSkipMeta() )
         {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManager.java
@@ -60,6 +60,7 @@ import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Lars Helge Overland
@@ -103,6 +104,7 @@ public class DefaultAnalyticsSecurityManager
     // -------------------------------------------------------------------------
 
     @Override
+    @Transactional( readOnly = true )
     public void decideAccess( DataQueryParams params )
     {
         User user = currentUserService.getCurrentUser();
@@ -156,7 +158,8 @@ public class DefaultAnalyticsSecurityManager
      * @param user the user to check.
      * @throws IllegalQueryException if user does not have access.
      */
-    void decideAccessDataReadObjects( DataQueryParams params, User user )
+    @Transactional( readOnly = true )
+    public void decideAccessDataReadObjects( DataQueryParams params, User user )
         throws IllegalQueryException
     {
         Set<IdentifiableObject> objects = new HashSet<>();
@@ -185,6 +188,7 @@ public class DefaultAnalyticsSecurityManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public void decideAccessEventQuery( EventQueryParams params )
     {
         decideAccess( params );
@@ -212,6 +216,7 @@ public class DefaultAnalyticsSecurityManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public User getCurrentUser( DataQueryParams params )
     {
         return params != null && params.hasCurrentUser() ? params.getCurrentUser()
@@ -219,6 +224,7 @@ public class DefaultAnalyticsSecurityManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DataQueryParams withDataApprovalConstraints( DataQueryParams params )
     {
         DataQueryParams.Builder paramsBuilder = DataQueryParams.newBuilder( params );
@@ -267,6 +273,7 @@ public class DefaultAnalyticsSecurityManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DataQueryParams withUserConstraints( DataQueryParams params )
     {
         DataQueryParams.Builder builder = DataQueryParams.newBuilder( params );
@@ -278,6 +285,7 @@ public class DefaultAnalyticsSecurityManager
     }
 
     @Override
+    @Transactional( readOnly = true )
     public EventQueryParams withUserConstraints( EventQueryParams params )
     {
         EventQueryParams.Builder builder = new EventQueryParams.Builder( params );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
@@ -121,6 +121,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityProgramIndicatorDimension;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.google.common.collect.Sets;
 
@@ -154,6 +155,7 @@ public class DefaultDimensionService
     // --------------------------------------------------------------------------
 
     @Override
+    @Transactional( readOnly = true )
     public List<DimensionalItemObject> getCanReadDimensionItems( String uid )
     {
         DimensionalObject dimension = idObjectManager.get( DimensionalObject.DYNAMIC_DIMENSION_CLASSES, uid );
@@ -171,6 +173,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public <T extends IdentifiableObject> List<T> getCanReadObjects( List<T> objects )
     {
         User user = currentUserService.getCurrentUser();
@@ -179,6 +182,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public <T extends IdentifiableObject> List<T> getCanReadObjects( User user, List<T> objects )
     {
         List<T> list = new ArrayList<>( objects );
@@ -189,6 +193,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DimensionType getDimensionType( String uid )
     {
         Category cat = idObjectManager.get( Category.class, uid );
@@ -250,6 +255,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public List<DimensionalObject> getAllDimensions()
     {
         Collection<Category> dcs = idObjectManager.getDataDimensions( Category.class );
@@ -270,6 +276,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public List<DimensionalObject> getDimensionConstraints()
     {
         Collection<CategoryOptionGroupSet> cogs = idObjectManager.getDataDimensions( CategoryOptionGroupSet.class );
@@ -284,6 +291,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public void mergeAnalyticalObject( BaseAnalyticalObject object )
     {
         if ( object != null )
@@ -306,6 +314,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public void mergeEventAnalyticalObject( EventAnalyticalObject object )
     {
         if ( object != null )
@@ -334,6 +343,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DimensionalObject getDimensionalObjectCopy( String uid, boolean filterCanRead )
     {
         BaseDimensionalObject dimension = idObjectManager.get( DimensionalObject.DYNAMIC_DIMENSION_CLASSES, uid );
@@ -350,12 +360,14 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DimensionalItemObject getDataDimensionalItemObject( String dimensionItem )
     {
         return getDataDimensionalItemObject( IdScheme.UID, dimensionItem );
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DimensionalItemObject getDataDimensionalItemObject( IdScheme idScheme, String dimensionItem )
     {
         if ( DimensionalObjectUtils.isCompositeDimensionalObject( dimensionItem ) )
@@ -403,6 +415,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public DimensionalItemObject getDataDimensionalItemObject( DimensionalItemId itemId )
     {
         Collection<DimensionalItemObject> items = getDataDimensionalItemObjectMap( Sets.newHashSet( itemId ) ).values();
@@ -411,6 +424,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Map<DimensionalItemId, DimensionalItemObject> getDataDimensionalItemObjectMap(
         Set<DimensionalItemId> itemIds )
     {
@@ -423,6 +437,7 @@ public class DefaultDimensionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public Map<DimensionalItemId, DimensionalItemObject> getNoAclDataDimensionalItemObjectMap(
         Set<DimensionalItemId> itemIds )
     {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -347,6 +347,7 @@ public class DefaultExpressionService
     // -------------------------------------------------------------------------
 
     @Override
+    @Transactional( readOnly = true )
     public Map<DimensionalItemId, DimensionalItemObject> getIndicatorDimensionalItemMap(
         Collection<Indicator> indicators )
     {
@@ -360,6 +361,7 @@ public class DefaultExpressionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public List<OrganisationUnitGroup> getOrgUnitGroupCountGroups( Collection<Indicator> indicators )
     {
         if ( indicators == null )
@@ -379,6 +381,7 @@ public class DefaultExpressionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public IndicatorValue getIndicatorValueObject( Indicator indicator, List<Period> periods,
         Map<DimensionalItemId, DimensionalItemObject> itemMap, Map<DimensionalItemObject, Object> valueMap,
         Map<String, Integer> orgUnitCountMap )
@@ -459,7 +462,7 @@ public class DefaultExpressionService
     // -------------------------------------------------------------------------
 
     @Override
-    @Transactional
+    @Transactional( readOnly = true )
     public ExpressionValidationOutcome expressionIsValid( String expression, ParseType parseType )
     {
         try
@@ -525,6 +528,7 @@ public class DefaultExpressionService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public ExpressionParams getBaseExpressionParams( ExpressionInfo info )
     {
         return ExpressionParams.builder()
@@ -667,6 +671,7 @@ public class DefaultExpressionService
     // -------------------------------------------------------------------------
 
     @Override
+    @Transactional( readOnly = true )
     public Map<String, Constant> getConstantMap()
     {
         return constantMapCache.get( "x", key -> constantService.getConstantMap() );


### PR DESCRIPTION
**DO NOT MERGE IT! NEEDS APPROVAL FROM RCB**

The logs in Glowroot, in a server in HISP South Africa, show that in release 2.38 we have many JDBC commits happening for each `/analytics` request.

These commits represent a few hundred thousand times each request, going over 1 million on several cases.
The goal of this PR is to make the respective operations `read-only`, as it was in 2.35.

These changes have been tested and drastically reduced the overall response time of analytics requests.
Comparing 2.35 with this branch, on the client's environment, we could see response times ~20% to ~45% faster on average.

The client also executed some tests on this patch version and gave us positive feedback.

-----------------------

Initially, I thought that the introduction of some transactional annotations could be triggering this problem, as in 2.35 we don't have any transaction annotations at all in the same flows. After removing a few of them, and profiling the requests, we could still see those transactions being created in write mode.

So, I thought that for some reason, (in 2.38) we needed to annotate the parent service calls as read-only in order to force and propagate this behaviour across all service calls in the chain (the ones that are loading data through Hibernate).

Based on that, I started with a single flow and made it read-only. After a round of profiling, I could see the number of transactions and commits dropping. I went ahead and made all flows read-only. After another round of profiling, I could not see any transactions or commits being created anymore.

This PR will add the transaction annotation in `read-only` mode on several methods so we can guarantee they are correctly propagated today and in the future.

Moving forward, we should keep this approach for new service methods introduced that interact with the persistence layer.

As a bonus, we got a significant performance improvement.