### PR TITLE
feat: list rejected indexes in data value set import [DHIS2-4678]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
@@ -772,6 +772,7 @@ public class DefaultDataValueSetService
         if ( importValidator.skipDataValue( dataValue, context, dataSetContext, valueContext ) )
         {
             importCount.incrementIgnored();
+            context.addRejected( valueContext.getIndex() );
             return;
         }
 
@@ -821,6 +822,7 @@ public class DefaultDataValueSetService
             else
             {
                 importCount.incrementIgnored();
+                context.addRejected( valueContext.getIndex() );
             }
         }
         else
@@ -832,6 +834,7 @@ public class DefaultDataValueSetService
             else
             {
                 importCount.incrementIgnored();
+                context.addRejected( valueContext.getIndex() );
             }
         }
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/ImportContext.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/ImportContext.java
@@ -212,6 +212,11 @@ public final class ImportContext
         return this;
     }
 
+    public void addRejected( int index )
+    {
+        summary.addRejected( index );
+    }
+
     public void addConflict( String object, String value )
     {
         summary.addConflict( object, value );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/importsummary/ImportSummary.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/importsummary/ImportSummary.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.dxf2.importsummary;
 
 import static org.hisp.dhis.dxf2.importsummary.ImportStatus.ERROR;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,6 +62,8 @@ public class ImportSummary extends AbstractWebMessageResponse implements ImportC
     private int totalConflictOccurrenceCount = 0;
 
     private final Map<String, ImportConflict> conflicts = new LinkedHashMap<>();
+
+    private final List<Integer> rejectedIndexes = new ArrayList<>();
 
     private String dataSetComplete;
 
@@ -182,6 +185,18 @@ public class ImportSummary extends AbstractWebMessageResponse implements ImportC
     {
         this.importCount = importCount;
         return this;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public List<Integer> getRejectedIndexes()
+    {
+        return rejectedIndexes;
+    }
+
+    public void addRejected( int index )
+    {
+        rejectedIndexes.add( index );
     }
 
     @Override


### PR DESCRIPTION
### Summary
Adds a list of indexes to the response for `dataValues` input array indexes that got rejected.
This means they had an error or were inappropriate for the used import mode.

In contrast to `ignored` the `rejectedIndexes` does not list rows that got ignored because they had no effect simply because they already agreed with the database state.

### Manual Testing
* open import/export app
* open data export
* select root in org tree
* select `ART monthly summary`
* select JSON uncompressed and export to a file
* open data import and do a dry run import of the exported file
* check the network tab of the browser developer tools view
* when the input is processed the last request shown for `/api/system/taskSummaries/...` has a response that contains a new information like in the below example with a `rejectedIndexes` list:

```json
{
   ...
   "rejectedIndexes": [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 18, 22, 38, 39, 540, 625, 626, 627, 628, 629, 630, 631, 632, 633, 634, 635, 636, 637, 638, 639, 640, 641, 642, 643, 644, 645, 646, 648, 748, 750, 752, 755, 757, 761, 762, 763, 768, 771, 773, 775, 777, 778, 779, 780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 796, 815, 820, 821, 824, 826, 829, 832, 833, 834, 837, 839, 841, 843, 844, 845, 848, 850, 851, 853, 855, 856, 858, 860, 862, 863, 865, 867, 868, 869, 870, 871, 872, 873, 874, 876, 878, 880, 882, 884, 888, 891, 892, 895, 896, 897, 899, 901, 909, 912, 916, 920, 924, 928, 929, 932, 935, 937, 942, 947, 949, 974, 977, 981, 983, 994, 1008, 1009, 1011, 1014, 1015, 1022, 1023, 1026, 1027, 1031, 1034, 1037, 1043, 1046, 1047, 1048, 1049, 1050, 1051, 1052, 1053, 1060, 1063, 1064, 1067, 1070, 1071, 1072, 1073, 1077, 1079, 1081, 1084, 1086, 1087, 1089, 1090, 1092, 1094, 1095, 1098, 1100, 1102, 1107, 1111, 1116, 1119, 1122, 1125, 1132, 1135, 1137, 1141, 1142, 1145, 1149, 1185, 1189, 1198, 1210, 1215, 1217, 1225, 1226, 1227, 1228, 1229, 1230, 1231, 1232, 1233, 1236, 1238, 1240, 1245, 1247, 1250, 1254, 1256, 1257, 1259, 1260, 1263, 1265, 1268, 1271, 1274, 1275, 1277, 1279, 1280, 1284, 1286, 1291, 1294, 1298, 1300, 1302, 1304, 1306, 1308, 1310, 1326, 1332, 1334, 1337, 1352, 1357, 1385, 1388, 1391, 1397, 1399, 1414, 1425, 1432, 1436, 1438, 1442, 1453, 1463, 1466, 1472, 1479, 1485, 1498, 1504, 1515, 1516, 1518, 1521, 1525, 1530, 1537, 1539, 1540, 1544, 1546, 1548, 1550, 1552, 1555, 1566, 1576, 1580, 1588, 1593, 1599, 1604, 1613, 1616, 1621, 1626, 1629, 1643, 1647, 1652, 1655, 1668, 1670, 1672, 1674, 1677, 1680, 1684, 1686, 1691, 1692, 1694, 1697, 1699, 1701, 1703, 1705, 1708, 1711, 1714, 1716, 1718, 1720, 1721, 1722, 1724, 1727, 1729, 1732, 1734, 1737, 1738, 1741, 1743, 1746, 1748, 1750, 1752, 1763, 1766, 1767, 1771],
    "dataSetComplete": "false"
}
``` 

Note: The app does not yet (and maybe never will) use this information but other apps or external programs can use it to reflect back to the user which rows of a file got rejected. Together with the information on the errors this even allows to indicate the reason for the rejection.