### PR TITLE
fix: Do not set default rounding for EDIs [DHIS2-15055]

### DIFF
--- a/.github/workflows/run-api-analytics-tests.yml
+++ b/.github/workflows/run-api-analytics-tests.yml
@@ -19,7 +19,7 @@ jobs:
       DOCKER_CHANNEL: "dhis2/core-pr"
       SIERRA_LEONE_DB_PATH: "/tmp/db/sierra-leone"
       SIERRA_LEONE_DB_VERSION: "2.39.0"
-    
+
     runs-on: ubuntu-latest
     if: "contains(github.event.pull_request.labels.*.name, 'run-api-analytics-tests')"
     steps:
@@ -43,13 +43,13 @@ jobs:
         id: cache-sierra-leone-db
         with:
           path: ${{ env.SIERRA_LEONE_DB_PATH }}
-          key: sierra-leone-db-${{ env.SIERRA_LEONE_DB_VERSION }}
+          key: sierra-leone-db-analytics-${{ env.SIERRA_LEONE_DB_VERSION }}
 
       - name: Download Sierra Leone DB
         if: ${{ steps.cache-sierra-leone-db.outputs.cache-hit != 'true' }}
         run: |
           mkdir -p ${{ env.SIERRA_LEONE_DB_PATH }}
-          wget https://databases.dhis2.org/sierra-leone/${{ env.SIERRA_LEONE_DB_VERSION }}/dhis2-db-sierra-leone.sql.gz --no-clobber --directory-prefix ${{ env.SIERRA_LEONE_DB_PATH }}
+          wget https://databases.dhis2.org/sierra-leone/${{ env.SIERRA_LEONE_DB_VERSION }}/analytics_be/dhis2-db-sierra-leone.sql.gz --no-clobber --directory-prefix ${{ env.SIERRA_LEONE_DB_PATH }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expressiondimensionitem/ExpressionDimensionItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expressiondimensionitem/ExpressionDimensionItem.java
@@ -32,6 +32,8 @@ import org.hisp.dhis.common.DimensionItemType;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.expression.MissingValueStrategy;
+import org.hisp.dhis.indicator.Indicator;
+import org.hisp.dhis.indicator.IndicatorType;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -169,5 +171,29 @@ public class ExpressionDimensionItem
     public DimensionItemType getDimensionItemType()
     {
         return DimensionItemType.EXPRESSION_DIMENSION_ITEM;
+    }
+
+    /**
+     * Converts the current object to {@Indicator}.
+     *
+     * @return the {@link Indicator} object.
+     */
+    public Indicator toIndicator()
+    {
+        IndicatorType indicatorType = new IndicatorType();
+        indicatorType.setNumber( true );
+        indicatorType.setFactor( 1 );
+
+        Indicator indicator = new Indicator();
+        indicator.setUid( getUid() );
+        indicator.setName( getName() );
+        indicator.setCode( getCode() );
+        indicator.setIndicatorType( indicatorType );
+        indicator.setNumerator( getExpression() );
+        indicator.setNumeratorDescription( getDescription() );
+        indicator.setDenominator( "1" );
+        indicator.setAnnualized( false );
+
+        return indicator;
     }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/expressiondimensionitem/ExpressionDimensionItemTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/expressiondimensionitem/ExpressionDimensionItemTest.java
@@ -59,10 +59,11 @@ class ExpressionDimensionItemTest
         assertEquals( "anyCode", indicator.getCode() );
         assertEquals( "anyName", indicator.getName() );
         assertEquals( "#{R4KStuS8qt7.LbkJRbDblhe} / #{o0fOD1HLuv8.LbkJRbDblhe}", indicator.getNumerator() );
-        assertNull( indicator.getDescription() );
         assertEquals( "1", indicator.getDenominator() );
+        assertEquals( 1, indicator.getIndicatorType().getFactor() );
+        assertNull( indicator.getDescription() );
+        assertNull( indicator.getDecimals() );
         assertFalse( indicator.isAnnualized() );
         assertTrue( indicator.getIndicatorType().isNumber() );
-        assertEquals( 1, indicator.getIndicatorType().getFactor() );
     }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/expressiondimensionitem/ExpressionDimensionItemTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/expressiondimensionitem/ExpressionDimensionItemTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.expressiondimensionitem;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hisp.dhis.indicator.Indicator;
+import org.junit.jupiter.api.Test;
+
+class ExpressionDimensionItemTest
+{
+    @Test
+    void testToIndicator()
+    {
+        // Given
+        ExpressionDimensionItem expressionDimensionItem = new ExpressionDimensionItem();
+        expressionDimensionItem.setExpression( "#{R4KStuS8qt7.LbkJRbDblhe} / #{o0fOD1HLuv8.LbkJRbDblhe}" );
+        expressionDimensionItem.setUid( "anyUid" );
+        expressionDimensionItem.setCode( "anyCode" );
+        expressionDimensionItem.setName( "anyName" );
+        expressionDimensionItem.setDescription( "anyDescription" );
+
+        // When
+        Indicator indicator = expressionDimensionItem.toIndicator();
+
+        // Then
+        assertEquals( "anyUid", indicator.getUid() );
+        assertEquals( "anyCode", indicator.getCode() );
+        assertEquals( "anyName", indicator.getName() );
+        assertEquals( "#{R4KStuS8qt7.LbkJRbDblhe} / #{o0fOD1HLuv8.LbkJRbDblhe}", indicator.getNumerator() );
+        assertNull( indicator.getDescription() );
+        assertEquals( "1", indicator.getDenominator() );
+        assertFalse( indicator.isAnnualized() );
+        assertTrue( indicator.getIndicatorType().isNumber() );
+        assertEquals( 1, indicator.getIndicatorType().getFactor() );
+    }
+}

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/expressiondimensionitem/ExpressionDimensionItemTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/expressiondimensionitem/ExpressionDimensionItemTest.java
@@ -35,6 +35,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.hisp.dhis.indicator.Indicator;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Unit tests for {@link ExpressionDimensionItem}.
+ */
 class ExpressionDimensionItemTest
 {
     @Test

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/analytics/event/EventQueryTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/analytics/event/EventQueryTest.java
@@ -57,38 +57,39 @@ public class EventQueryTest extends AnalyticsApiTest
     public void queryWithProgramAndProgramStageWhenTotalPagesIsFalse()
     {
         // Given
-        QueryParamsBuilder params = new QueryParamsBuilder();
-        params.add( "dimension=pe:LAST_12_MONTHS,ou:ImspTQPwCqd" )
-            .add( "stage=dBwrot7S420" )
-            .add( "displayProperty=NAME" )
-            .add( "outputType=EVENT" )
-            .add( "totalPages=false" )
-            .add( "relativePeriodDate=2022-09-27" );
+        QueryParamsBuilder params = new QueryParamsBuilder()
+                .add( "dimension=pe:LAST_12_MONTHS,ou:ImspTQPwCqd" )
+                .add( "stage=dBwrot7S420" )
+                .add( "displayProperty=NAME" )
+                .add( "outputType=EVENT" )
+                .add( "totalPages=false" )
+                .add( "desc=lastupdated" )
+                .add( "relativePeriodDate=2022-09-27" );
 
         // When
         ApiResponse response = analyticsEventActions.query().get( "lxAQ7Zs9VYR", JSON, JSON, params );
 
         // Then
         response.validate()
-            .statusCode( 200 )
-            .body( "headers", hasSize( equalTo( 16 ) ) )
-            .body( "rows", hasSize( equalTo( 3 ) ) )
-            .body( "metaData.pager.page", equalTo( 1 ) )
-            .body( "metaData.pager.pageSize", equalTo( 50 ) )
-            .body( "metaData.pager.isLastPage", is( true ) )
-            .body( "metaData.pager", not( hasKey( "total" ) ) )
-            .body( "metaData.pager", not( hasKey( "pageCount" ) ) )
-            .body( "metaData.items.ImspTQPwCqd.name", equalTo( "Sierra Leone" ) )
-            .body( "metaData.items.dBwrot7S420.name", equalTo( "Antenatal care visit" ) )
-            .body( "metaData.items.ou.name", equalTo( "Organisation unit" ) )
-            .body( "metaData.items.lxAQ7Zs9VYR.name", equalTo( "Antenatal care visit" ) )
-            .body( "metaData.items.LAST_12_MONTHS.name", equalTo( "Last 12 months" ) )
-            .body( "metaData.dimensions.pe", hasSize( equalTo( 0 ) ) )
-            .body( "metaData.dimensions.ou", hasSize( equalTo( 1 ) ) )
-            .body( "metaData.dimensions.ou", hasItem( "ImspTQPwCqd" ) )
-            .body( "height", equalTo( 3 ) )
-            .body( "width", equalTo( 16 ) )
-            .body( "headerWidth", equalTo( 16 ) );
+                .statusCode( 200 )
+                .body( "headers", hasSize( equalTo( 17 ) ) )
+                .body( "rows", hasSize( equalTo( 3 ) ) )
+                .body( "metaData.pager.page", equalTo( 1 ) )
+                .body( "metaData.pager.pageSize", equalTo( 50 ) )
+                .body( "metaData.pager.isLastPage", is( true ) )
+                .body( "metaData.pager", not( hasKey( "total" ) ) )
+                .body( "metaData.pager", not( hasKey( "pageCount" ) ) )
+                .body( "metaData.items.ImspTQPwCqd.name", equalTo( "Sierra Leone" ) )
+                .body( "metaData.items.dBwrot7S420.name", equalTo( "Antenatal care visit" ) )
+                .body( "metaData.items.ou.name", equalTo( "Organisation unit" ) )
+                .body( "metaData.items.lxAQ7Zs9VYR.name", equalTo( "Antenatal care visit" ) )
+                .body( "metaData.items.LAST_12_MONTHS.name", equalTo( "Last 12 months" ) )
+                .body( "metaData.dimensions.pe", hasSize( equalTo( 0 ) ) )
+                .body( "metaData.dimensions.ou", hasSize( equalTo( 1 ) ) )
+                .body( "metaData.dimensions.ou", hasItem( "ImspTQPwCqd" ) )
+                .body( "height", equalTo( 3 ) )
+                .body( "width", equalTo( 17 ) )
+                .body( "headerWidth", equalTo( 17 ) );
 
         // Validate headers
         validateHeader( response, 0, "psi", "Event", "TEXT", "java.lang.String", false, true );
@@ -96,111 +97,117 @@ public class EventQueryTest extends AnalyticsApiTest
         validateHeader( response, 2, "eventdate", "Visit date", "DATE", "java.time.LocalDate", false, true );
         validateHeader( response, 3, "storedby", "Stored by", "TEXT", "java.lang.String", false, true );
         validateHeader( response, 4, "createdbydisplayname", "Created by", "TEXT", "java.lang.String",
-            false, true );
+                false, true );
         validateHeader( response, 5, "lastupdatedbydisplayname", "Last updated by", "TEXT",
-            "java.lang.String", false, true );
+                "java.lang.String", false, true );
         validateHeader( response, 6, "lastupdated", "Last updated on", "DATE", "java.time.LocalDate", false, true );
         validateHeader( response, 7, "scheduleddate", "Scheduled date", "DATE", "java.time.LocalDate", false, true );
         validateHeader( response, 8, "geometry", "Geometry", "TEXT", "java.lang.String", false, true );
         validateHeader( response, 9, "longitude", "Longitude", "NUMBER", "java.lang.Double", false, true );
         validateHeader( response, 10, "latitude", "Latitude", "NUMBER", "java.lang.Double", false, true );
         validateHeader( response, 11, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, true );
-        validateHeader( response, 12, "oucode", "Organisation unit code", "TEXT", "java.lang.String", false, true );
-        validateHeader( response, 13, "programstatus", "Program status", "TEXT", "java.lang.String", false, true );
-        validateHeader( response, 14, "eventstatus", "Event status", "TEXT", "java.lang.String", false, true );
-        validateHeader( response, 15, "ou", "Organisation unit", "TEXT", "java.lang.String", false, true );
+        validateHeader( response, 12, "ounamehierarchy", "Organisation unit name hierarchy", "TEXT", "java.lang.String",
+                false, true );
+        validateHeader( response, 13, "oucode", "Organisation unit code", "TEXT", "java.lang.String", false, true );
+        validateHeader( response, 14, "programstatus", "Program status", "TEXT", "java.lang.String", false, true );
+        validateHeader( response, 15, "eventstatus", "Event status", "TEXT", "java.lang.String", false, true );
+        validateHeader( response, 16, "ou", "Organisation unit", "TEXT", "java.lang.String", false, true );
 
         // Validate the first three rows, as samples.
         validateRow( response, 0,
-            List.of( "A7vnB73x5Xw",
-                "dBwrot7S420",
-                "2022-04-01 00:00:00.0",
-                "",
-                "",
-                "",
-                "2018-04-12 16:05:16.957",
-                "",
-                "{\"type\":\"Point\",\"coordinates\":[-11.4197,8.1039]}",
-                "0.0",
-                "0.0",
-                "Ngelehun CHC",
-                "OU_559",
-                "ACTIVE",
-                "ACTIVE",
-                "DiszpKrYNg8" ) );
+                List.of( "ohAH6BXIMad",
+                        "dBwrot7S420",
+                        "2022-04-07 00:00:00.0",
+                        "",
+                        "",
+                        "",
+                        "2018-04-12 16:05:41.933",
+                        "",
+                        "",
+                        "0.0",
+                        "0.0",
+                        "Ngelehun CHC",
+                        "Sierra Leone / Bo / Badjia / Ngelehun CHC",
+                        "OU_559",
+                        "ACTIVE",
+                        "ACTIVE",
+                        "DiszpKrYNg8" ) );
 
         validateRow( response, 1,
-            List.of( "onXW2DQHRGS",
-                "dBwrot7S420",
-                "2022-04-01 00:00:00.0",
-                "",
-                "",
-                "",
-                "2018-04-12 16:05:28.015",
-                "",
-                "{\"type\":\"Point\",\"coordinates\":[-11.4197,8.1039]}",
-                "0.0",
-                "0.0",
-                "Ngelehun CHC",
-                "OU_559",
-                "ACTIVE",
-                "ACTIVE",
-                "DiszpKrYNg8" ) );
+                List.of( "onXW2DQHRGS",
+                        "dBwrot7S420",
+                        "2022-04-01 00:00:00.0",
+                        "",
+                        "",
+                        "",
+                        "2018-04-12 16:05:28.015",
+                        "",
+                        "",
+                        "0.0",
+                        "0.0",
+                        "Ngelehun CHC",
+                        "Sierra Leone / Bo / Badjia / Ngelehun CHC",
+                        "OU_559",
+                        "ACTIVE",
+                        "ACTIVE",
+                        "DiszpKrYNg8" ) );
 
         validateRow( response, 2,
-            List.of( "ohAH6BXIMad",
-                "dBwrot7S420",
-                "2022-04-07 00:00:00.0",
-                "",
-                "",
-                "",
-                "2018-04-12 16:05:41.933",
-                "",
-                "{\"type\":\"Point\",\"coordinates\":[-11.4197,8.1039]}",
-                "0.0",
-                "0.0",
-                "Ngelehun CHC",
-                "OU_559",
-                "ACTIVE",
-                "ACTIVE",
-                "DiszpKrYNg8" ) );
+                List.of( "A7vnB73x5Xw",
+                        "dBwrot7S420",
+                        "2022-04-01 00:00:00.0",
+                        "",
+                        "",
+                        "",
+                        "2018-04-12 16:05:16.957",
+                        "",
+                        "",
+                        "0.0",
+                        "0.0",
+                        "Ngelehun CHC",
+                        "Sierra Leone / Bo / Badjia / Ngelehun CHC",
+                        "OU_559",
+                        "ACTIVE",
+                        "ACTIVE",
+                        "DiszpKrYNg8" ) );
     }
 
     @Test
     public void queryWithProgramAndProgramStageWhenTotalPagesIsTrueByDefault()
     {
         // Given
-        QueryParamsBuilder params = new QueryParamsBuilder();
-        params.add( "dimension=pe:LAST_12_MONTHS,ou:ImspTQPwCqd" )
-            .add( "stage=dBwrot7S420" )
-            .add( "displayProperty=NAME" )
-            .add( "outputType=EVENT" )
-            .add( "relativePeriodDate=2022-09-22" );
+        QueryParamsBuilder params = new QueryParamsBuilder()
+                .add( "dimension=pe:LAST_12_MONTHS,ou:ImspTQPwCqd" )
+                .add( "stage=dBwrot7S420" )
+                .add( "displayProperty=NAME" )
+                .add( "outputType=EVENT" )
+                .add( "desc=lastupdated" )
+                .add( "relativePeriodDate=2022-09-22" );
 
         // When
         ApiResponse response = analyticsEventActions.query().get( "lxAQ7Zs9VYR", JSON, JSON, params );
 
         // Then
         response.validate()
-            .statusCode( 200 )
-            .body( "headers", hasSize( equalTo( 16 ) ) )
-            .body( "rows", hasSize( equalTo( 3 ) ) )
-            .body( "metaData.pager.page", equalTo( 1 ) )
-            .body( "metaData.pager.pageSize", equalTo( 50 ) )
-            .body( "metaData.pager.total", equalTo( 3 ) )
-            .body( "metaData.pager.pageCount", equalTo( 1 ) )
-            .body( "metaData.pager", not( hasKey( "isLastPage" ) ) )
-            .body( "metaData.items.ImspTQPwCqd.name", equalTo( "Sierra Leone" ) )
-            .body( "metaData.items.dBwrot7S420.name", equalTo( "Antenatal care visit" ) )
-            .body( "metaData.items.ou.name", equalTo( "Organisation unit" ) )
-            .body( "metaData.items.lxAQ7Zs9VYR.name", equalTo( "Antenatal care visit" ) )
-            .body( "metaData.items.LAST_12_MONTHS.name", equalTo( "Last 12 months" ) )
-            .body( "metaData.dimensions.pe", hasSize( equalTo( 0 ) ) )
-            .body( "metaData.dimensions.ou", hasSize( equalTo( 1 ) ) )
-            .body( "metaData.dimensions.ou", hasItem( "ImspTQPwCqd" ) )
-            .body( "height", equalTo( 3 ) )
-            .body( "width", equalTo( 16 ) )
-            .body( "headerWidth", equalTo( 16 ) );
+                .statusCode( 200 )
+                .body( "headers", hasSize( equalTo( 17 ) ) )
+                .body( "rows", hasSize( equalTo( 3 ) ) )
+                .body( "metaData.pager.page", equalTo( 1 ) )
+                .body( "metaData.pager.pageSize", equalTo( 50 ) )
+                .body( "metaData.pager.total", equalTo( 3 ) )
+                .body( "metaData.pager.pageCount", equalTo( 1 ) )
+                .body( "metaData.pager", not( hasKey( "isLastPage" ) ) )
+                .body( "metaData.items.ImspTQPwCqd.name", equalTo( "Sierra Leone" ) )
+                .body( "metaData.items.dBwrot7S420.name", equalTo( "Antenatal care visit" ) )
+                .body( "metaData.items.ou.name", equalTo( "Organisation unit" ) )
+                .body( "metaData.items.lxAQ7Zs9VYR.name", equalTo( "Antenatal care visit" ) )
+                .body( "metaData.items.LAST_12_MONTHS.name", equalTo( "Last 12 months" ) )
+                .body( "metaData.dimensions.pe", hasSize( equalTo( 0 ) ) )
+                .body( "metaData.dimensions.ou", hasSize( equalTo( 1 ) ) )
+                .body( "metaData.dimensions.ou", hasItem( "ImspTQPwCqd" ) )
+                .body( "height", equalTo( 3 ) )
+                .body( "width", equalTo( 17 ) )
+                .body( "headerWidth", equalTo( 17 ) );
 
         // Validate headers
         validateHeader( response, 0, "psi", "Event", "TEXT", "java.lang.String", false, true );
@@ -208,73 +215,78 @@ public class EventQueryTest extends AnalyticsApiTest
         validateHeader( response, 2, "eventdate", "Visit date", "DATE", "java.time.LocalDate", false, true );
         validateHeader( response, 3, "storedby", "Stored by", "TEXT", "java.lang.String", false, true );
         validateHeader( response, 4, "createdbydisplayname", "Created by", "TEXT", "java.lang.String",
-            false, true );
+                false, true );
         validateHeader( response, 5, "lastupdatedbydisplayname", "Last updated by", "TEXT",
-            "java.lang.String", false, true );
+                "java.lang.String", false, true );
         validateHeader( response, 6, "lastupdated", "Last updated on", "DATE", "java.time.LocalDate", false, true );
         validateHeader( response, 7, "scheduleddate", "Scheduled date", "DATE", "java.time.LocalDate", false, true );
         validateHeader( response, 8, "geometry", "Geometry", "TEXT", "java.lang.String", false, true );
         validateHeader( response, 9, "longitude", "Longitude", "NUMBER", "java.lang.Double", false, true );
         validateHeader( response, 10, "latitude", "Latitude", "NUMBER", "java.lang.Double", false, true );
         validateHeader( response, 11, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, true );
-        validateHeader( response, 12, "oucode", "Organisation unit code", "TEXT", "java.lang.String", false, true );
-        validateHeader( response, 13, "programstatus", "Program status", "TEXT", "java.lang.String", false, true );
-        validateHeader( response, 14, "eventstatus", "Event status", "TEXT", "java.lang.String", false, true );
-        validateHeader( response, 15, "ou", "Organisation unit", "TEXT", "java.lang.String", false, true );
+        validateHeader( response, 12, "ounamehierarchy", "Organisation unit name hierarchy", "TEXT", "java.lang.String",
+                false, true );
+        validateHeader( response, 13, "oucode", "Organisation unit code", "TEXT", "java.lang.String", false, true );
+        validateHeader( response, 14, "programstatus", "Program status", "TEXT", "java.lang.String", false, true );
+        validateHeader( response, 15, "eventstatus", "Event status", "TEXT", "java.lang.String", false, true );
+        validateHeader( response, 16, "ou", "Organisation unit", "TEXT", "java.lang.String", false, true );
 
         // Validate the first three rows, as samples.
         validateRow( response, 0,
-            List.of( "A7vnB73x5Xw",
-                "dBwrot7S420",
-                "2022-04-01 00:00:00.0",
-                "",
-                "",
-                "",
-                "2018-04-12 16:05:16.957",
-                "",
-                "{\"type\":\"Point\",\"coordinates\":[-11.4197,8.1039]}",
-                "0.0",
-                "0.0",
-                "Ngelehun CHC",
-                "OU_559",
-                "ACTIVE",
-                "ACTIVE",
-                "DiszpKrYNg8" ) );
+                List.of( "ohAH6BXIMad",
+                        "dBwrot7S420",
+                        "2022-04-07 00:00:00.0",
+                        "",
+                        "",
+                        "",
+                        "2018-04-12 16:05:41.933",
+                        "",
+                        "",
+                        "0.0",
+                        "0.0",
+                        "Ngelehun CHC",
+                        "Sierra Leone / Bo / Badjia / Ngelehun CHC",
+                        "OU_559",
+                        "ACTIVE",
+                        "ACTIVE",
+                        "DiszpKrYNg8" ) );
 
         validateRow( response, 1,
-            List.of( "onXW2DQHRGS",
-                "dBwrot7S420",
-                "2022-04-01 00:00:00.0",
-                "",
-                "",
-                "",
-                "2018-04-12 16:05:28.015",
-                "",
-                "{\"type\":\"Point\",\"coordinates\":[-11.4197,8.1039]}",
-                "0.0",
-                "0.0",
-                "Ngelehun CHC",
-                "OU_559",
-                "ACTIVE",
-                "ACTIVE",
-                "DiszpKrYNg8" ) );
+                List.of( "onXW2DQHRGS",
+                        "dBwrot7S420",
+                        "2022-04-01 00:00:00.0",
+                        "",
+                        "",
+                        "",
+                        "2018-04-12 16:05:28.015",
+                        "",
+                        "",
+                        "0.0",
+                        "0.0",
+                        "Ngelehun CHC",
+                        "Sierra Leone / Bo / Badjia / Ngelehun CHC",
+                        "OU_559",
+                        "ACTIVE",
+                        "ACTIVE",
+                        "DiszpKrYNg8" ) );
 
         validateRow( response, 2,
-            List.of( "ohAH6BXIMad",
-                "dBwrot7S420",
-                "2022-04-07 00:00:00.0",
-                "",
-                "",
-                "",
-                "2018-04-12 16:05:41.933",
-                "",
-                "{\"type\":\"Point\",\"coordinates\":[-11.4197,8.1039]}",
-                "0.0",
-                "0.0",
-                "Ngelehun CHC",
-                "OU_559",
-                "ACTIVE",
-                "ACTIVE",
-                "DiszpKrYNg8" ) );
+                List.of( "A7vnB73x5Xw",
+                        "dBwrot7S420",
+                        "2022-04-01 00:00:00.0",
+                        "",
+                        "",
+                        "",
+                        "2018-04-12 16:05:16.957",
+                        "",
+                        "",
+                        "0.0",
+                        "0.0",
+                        "Ngelehun CHC",
+                        "Sierra Leone / Bo / Badjia / Ngelehun CHC",
+                        "OU_559",
+                        "ACTIVE",
+                        "ACTIVE",
+                        "DiszpKrYNg8" ) );
     }
 }

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/analytics/event/EventQueryTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/analytics/event/EventQueryTest.java
@@ -58,38 +58,38 @@ public class EventQueryTest extends AnalyticsApiTest
     {
         // Given
         QueryParamsBuilder params = new QueryParamsBuilder()
-                .add( "dimension=pe:LAST_12_MONTHS,ou:ImspTQPwCqd" )
-                .add( "stage=dBwrot7S420" )
-                .add( "displayProperty=NAME" )
-                .add( "outputType=EVENT" )
-                .add( "totalPages=false" )
-                .add( "desc=lastupdated" )
-                .add( "relativePeriodDate=2022-09-27" );
+            .add( "dimension=pe:LAST_12_MONTHS,ou:ImspTQPwCqd" )
+            .add( "stage=dBwrot7S420" )
+            .add( "displayProperty=NAME" )
+            .add( "outputType=EVENT" )
+            .add( "totalPages=false" )
+            .add( "desc=lastupdated" )
+            .add( "relativePeriodDate=2022-09-27" );
 
         // When
         ApiResponse response = analyticsEventActions.query().get( "lxAQ7Zs9VYR", JSON, JSON, params );
 
         // Then
         response.validate()
-                .statusCode( 200 )
-                .body( "headers", hasSize( equalTo( 17 ) ) )
-                .body( "rows", hasSize( equalTo( 3 ) ) )
-                .body( "metaData.pager.page", equalTo( 1 ) )
-                .body( "metaData.pager.pageSize", equalTo( 50 ) )
-                .body( "metaData.pager.isLastPage", is( true ) )
-                .body( "metaData.pager", not( hasKey( "total" ) ) )
-                .body( "metaData.pager", not( hasKey( "pageCount" ) ) )
-                .body( "metaData.items.ImspTQPwCqd.name", equalTo( "Sierra Leone" ) )
-                .body( "metaData.items.dBwrot7S420.name", equalTo( "Antenatal care visit" ) )
-                .body( "metaData.items.ou.name", equalTo( "Organisation unit" ) )
-                .body( "metaData.items.lxAQ7Zs9VYR.name", equalTo( "Antenatal care visit" ) )
-                .body( "metaData.items.LAST_12_MONTHS.name", equalTo( "Last 12 months" ) )
-                .body( "metaData.dimensions.pe", hasSize( equalTo( 0 ) ) )
-                .body( "metaData.dimensions.ou", hasSize( equalTo( 1 ) ) )
-                .body( "metaData.dimensions.ou", hasItem( "ImspTQPwCqd" ) )
-                .body( "height", equalTo( 3 ) )
-                .body( "width", equalTo( 17 ) )
-                .body( "headerWidth", equalTo( 17 ) );
+            .statusCode( 200 )
+            .body( "headers", hasSize( equalTo( 17 ) ) )
+            .body( "rows", hasSize( equalTo( 3 ) ) )
+            .body( "metaData.pager.page", equalTo( 1 ) )
+            .body( "metaData.pager.pageSize", equalTo( 50 ) )
+            .body( "metaData.pager.isLastPage", is( true ) )
+            .body( "metaData.pager", not( hasKey( "total" ) ) )
+            .body( "metaData.pager", not( hasKey( "pageCount" ) ) )
+            .body( "metaData.items.ImspTQPwCqd.name", equalTo( "Sierra Leone" ) )
+            .body( "metaData.items.dBwrot7S420.name", equalTo( "Antenatal care visit" ) )
+            .body( "metaData.items.ou.name", equalTo( "Organisation unit" ) )
+            .body( "metaData.items.lxAQ7Zs9VYR.name", equalTo( "Antenatal care visit" ) )
+            .body( "metaData.items.LAST_12_MONTHS.name", equalTo( "Last 12 months" ) )
+            .body( "metaData.dimensions.pe", hasSize( equalTo( 0 ) ) )
+            .body( "metaData.dimensions.ou", hasSize( equalTo( 1 ) ) )
+            .body( "metaData.dimensions.ou", hasItem( "ImspTQPwCqd" ) )
+            .body( "height", equalTo( 3 ) )
+            .body( "width", equalTo( 17 ) )
+            .body( "headerWidth", equalTo( 17 ) );
 
         // Validate headers
         validateHeader( response, 0, "psi", "Event", "TEXT", "java.lang.String", false, true );
@@ -97,9 +97,9 @@ public class EventQueryTest extends AnalyticsApiTest
         validateHeader( response, 2, "eventdate", "Visit date", "DATE", "java.time.LocalDate", false, true );
         validateHeader( response, 3, "storedby", "Stored by", "TEXT", "java.lang.String", false, true );
         validateHeader( response, 4, "createdbydisplayname", "Created by", "TEXT", "java.lang.String",
-                false, true );
+            false, true );
         validateHeader( response, 5, "lastupdatedbydisplayname", "Last updated by", "TEXT",
-                "java.lang.String", false, true );
+            "java.lang.String", false, true );
         validateHeader( response, 6, "lastupdated", "Last updated on", "DATE", "java.time.LocalDate", false, true );
         validateHeader( response, 7, "scheduleddate", "Scheduled date", "DATE", "java.time.LocalDate", false, true );
         validateHeader( response, 8, "geometry", "Geometry", "TEXT", "java.lang.String", false, true );
@@ -107,7 +107,7 @@ public class EventQueryTest extends AnalyticsApiTest
         validateHeader( response, 10, "latitude", "Latitude", "NUMBER", "java.lang.Double", false, true );
         validateHeader( response, 11, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, true );
         validateHeader( response, 12, "ounamehierarchy", "Organisation unit name hierarchy", "TEXT", "java.lang.String",
-                false, true );
+            false, true );
         validateHeader( response, 13, "oucode", "Organisation unit code", "TEXT", "java.lang.String", false, true );
         validateHeader( response, 14, "programstatus", "Program status", "TEXT", "java.lang.String", false, true );
         validateHeader( response, 15, "eventstatus", "Event status", "TEXT", "java.lang.String", false, true );
@@ -115,61 +115,61 @@ public class EventQueryTest extends AnalyticsApiTest
 
         // Validate the first three rows, as samples.
         validateRow( response, 0,
-                List.of( "ohAH6BXIMad",
-                        "dBwrot7S420",
-                        "2022-04-07 00:00:00.0",
-                        "",
-                        "",
-                        "",
-                        "2018-04-12 16:05:41.933",
-                        "",
-                        "",
-                        "0.0",
-                        "0.0",
-                        "Ngelehun CHC",
-                        "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-                        "OU_559",
-                        "ACTIVE",
-                        "ACTIVE",
-                        "DiszpKrYNg8" ) );
+            List.of( "ohAH6BXIMad",
+                "dBwrot7S420",
+                "2022-04-07 00:00:00.0",
+                "",
+                "",
+                "",
+                "2018-04-12 16:05:41.933",
+                "",
+                "",
+                "0.0",
+                "0.0",
+                "Ngelehun CHC",
+                "Sierra Leone / Bo / Badjia / Ngelehun CHC",
+                "OU_559",
+                "ACTIVE",
+                "ACTIVE",
+                "DiszpKrYNg8" ) );
 
         validateRow( response, 1,
-                List.of( "onXW2DQHRGS",
-                        "dBwrot7S420",
-                        "2022-04-01 00:00:00.0",
-                        "",
-                        "",
-                        "",
-                        "2018-04-12 16:05:28.015",
-                        "",
-                        "",
-                        "0.0",
-                        "0.0",
-                        "Ngelehun CHC",
-                        "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-                        "OU_559",
-                        "ACTIVE",
-                        "ACTIVE",
-                        "DiszpKrYNg8" ) );
+            List.of( "onXW2DQHRGS",
+                "dBwrot7S420",
+                "2022-04-01 00:00:00.0",
+                "",
+                "",
+                "",
+                "2018-04-12 16:05:28.015",
+                "",
+                "",
+                "0.0",
+                "0.0",
+                "Ngelehun CHC",
+                "Sierra Leone / Bo / Badjia / Ngelehun CHC",
+                "OU_559",
+                "ACTIVE",
+                "ACTIVE",
+                "DiszpKrYNg8" ) );
 
         validateRow( response, 2,
-                List.of( "A7vnB73x5Xw",
-                        "dBwrot7S420",
-                        "2022-04-01 00:00:00.0",
-                        "",
-                        "",
-                        "",
-                        "2018-04-12 16:05:16.957",
-                        "",
-                        "",
-                        "0.0",
-                        "0.0",
-                        "Ngelehun CHC",
-                        "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-                        "OU_559",
-                        "ACTIVE",
-                        "ACTIVE",
-                        "DiszpKrYNg8" ) );
+            List.of( "A7vnB73x5Xw",
+                "dBwrot7S420",
+                "2022-04-01 00:00:00.0",
+                "",
+                "",
+                "",
+                "2018-04-12 16:05:16.957",
+                "",
+                "",
+                "0.0",
+                "0.0",
+                "Ngelehun CHC",
+                "Sierra Leone / Bo / Badjia / Ngelehun CHC",
+                "OU_559",
+                "ACTIVE",
+                "ACTIVE",
+                "DiszpKrYNg8" ) );
     }
 
     @Test
@@ -177,37 +177,37 @@ public class EventQueryTest extends AnalyticsApiTest
     {
         // Given
         QueryParamsBuilder params = new QueryParamsBuilder()
-                .add( "dimension=pe:LAST_12_MONTHS,ou:ImspTQPwCqd" )
-                .add( "stage=dBwrot7S420" )
-                .add( "displayProperty=NAME" )
-                .add( "outputType=EVENT" )
-                .add( "desc=lastupdated" )
-                .add( "relativePeriodDate=2022-09-22" );
+            .add( "dimension=pe:LAST_12_MONTHS,ou:ImspTQPwCqd" )
+            .add( "stage=dBwrot7S420" )
+            .add( "displayProperty=NAME" )
+            .add( "outputType=EVENT" )
+            .add( "desc=lastupdated" )
+            .add( "relativePeriodDate=2022-09-22" );
 
         // When
         ApiResponse response = analyticsEventActions.query().get( "lxAQ7Zs9VYR", JSON, JSON, params );
 
         // Then
         response.validate()
-                .statusCode( 200 )
-                .body( "headers", hasSize( equalTo( 17 ) ) )
-                .body( "rows", hasSize( equalTo( 3 ) ) )
-                .body( "metaData.pager.page", equalTo( 1 ) )
-                .body( "metaData.pager.pageSize", equalTo( 50 ) )
-                .body( "metaData.pager.total", equalTo( 3 ) )
-                .body( "metaData.pager.pageCount", equalTo( 1 ) )
-                .body( "metaData.pager", not( hasKey( "isLastPage" ) ) )
-                .body( "metaData.items.ImspTQPwCqd.name", equalTo( "Sierra Leone" ) )
-                .body( "metaData.items.dBwrot7S420.name", equalTo( "Antenatal care visit" ) )
-                .body( "metaData.items.ou.name", equalTo( "Organisation unit" ) )
-                .body( "metaData.items.lxAQ7Zs9VYR.name", equalTo( "Antenatal care visit" ) )
-                .body( "metaData.items.LAST_12_MONTHS.name", equalTo( "Last 12 months" ) )
-                .body( "metaData.dimensions.pe", hasSize( equalTo( 0 ) ) )
-                .body( "metaData.dimensions.ou", hasSize( equalTo( 1 ) ) )
-                .body( "metaData.dimensions.ou", hasItem( "ImspTQPwCqd" ) )
-                .body( "height", equalTo( 3 ) )
-                .body( "width", equalTo( 17 ) )
-                .body( "headerWidth", equalTo( 17 ) );
+            .statusCode( 200 )
+            .body( "headers", hasSize( equalTo( 17 ) ) )
+            .body( "rows", hasSize( equalTo( 3 ) ) )
+            .body( "metaData.pager.page", equalTo( 1 ) )
+            .body( "metaData.pager.pageSize", equalTo( 50 ) )
+            .body( "metaData.pager.total", equalTo( 3 ) )
+            .body( "metaData.pager.pageCount", equalTo( 1 ) )
+            .body( "metaData.pager", not( hasKey( "isLastPage" ) ) )
+            .body( "metaData.items.ImspTQPwCqd.name", equalTo( "Sierra Leone" ) )
+            .body( "metaData.items.dBwrot7S420.name", equalTo( "Antenatal care visit" ) )
+            .body( "metaData.items.ou.name", equalTo( "Organisation unit" ) )
+            .body( "metaData.items.lxAQ7Zs9VYR.name", equalTo( "Antenatal care visit" ) )
+            .body( "metaData.items.LAST_12_MONTHS.name", equalTo( "Last 12 months" ) )
+            .body( "metaData.dimensions.pe", hasSize( equalTo( 0 ) ) )
+            .body( "metaData.dimensions.ou", hasSize( equalTo( 1 ) ) )
+            .body( "metaData.dimensions.ou", hasItem( "ImspTQPwCqd" ) )
+            .body( "height", equalTo( 3 ) )
+            .body( "width", equalTo( 17 ) )
+            .body( "headerWidth", equalTo( 17 ) );
 
         // Validate headers
         validateHeader( response, 0, "psi", "Event", "TEXT", "java.lang.String", false, true );
@@ -215,9 +215,9 @@ public class EventQueryTest extends AnalyticsApiTest
         validateHeader( response, 2, "eventdate", "Visit date", "DATE", "java.time.LocalDate", false, true );
         validateHeader( response, 3, "storedby", "Stored by", "TEXT", "java.lang.String", false, true );
         validateHeader( response, 4, "createdbydisplayname", "Created by", "TEXT", "java.lang.String",
-                false, true );
+            false, true );
         validateHeader( response, 5, "lastupdatedbydisplayname", "Last updated by", "TEXT",
-                "java.lang.String", false, true );
+            "java.lang.String", false, true );
         validateHeader( response, 6, "lastupdated", "Last updated on", "DATE", "java.time.LocalDate", false, true );
         validateHeader( response, 7, "scheduleddate", "Scheduled date", "DATE", "java.time.LocalDate", false, true );
         validateHeader( response, 8, "geometry", "Geometry", "TEXT", "java.lang.String", false, true );
@@ -225,7 +225,7 @@ public class EventQueryTest extends AnalyticsApiTest
         validateHeader( response, 10, "latitude", "Latitude", "NUMBER", "java.lang.Double", false, true );
         validateHeader( response, 11, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, true );
         validateHeader( response, 12, "ounamehierarchy", "Organisation unit name hierarchy", "TEXT", "java.lang.String",
-                false, true );
+            false, true );
         validateHeader( response, 13, "oucode", "Organisation unit code", "TEXT", "java.lang.String", false, true );
         validateHeader( response, 14, "programstatus", "Program status", "TEXT", "java.lang.String", false, true );
         validateHeader( response, 15, "eventstatus", "Event status", "TEXT", "java.lang.String", false, true );
@@ -233,60 +233,60 @@ public class EventQueryTest extends AnalyticsApiTest
 
         // Validate the first three rows, as samples.
         validateRow( response, 0,
-                List.of( "ohAH6BXIMad",
-                        "dBwrot7S420",
-                        "2022-04-07 00:00:00.0",
-                        "",
-                        "",
-                        "",
-                        "2018-04-12 16:05:41.933",
-                        "",
-                        "",
-                        "0.0",
-                        "0.0",
-                        "Ngelehun CHC",
-                        "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-                        "OU_559",
-                        "ACTIVE",
-                        "ACTIVE",
-                        "DiszpKrYNg8" ) );
+            List.of( "ohAH6BXIMad",
+                "dBwrot7S420",
+                "2022-04-07 00:00:00.0",
+                "",
+                "",
+                "",
+                "2018-04-12 16:05:41.933",
+                "",
+                "",
+                "0.0",
+                "0.0",
+                "Ngelehun CHC",
+                "Sierra Leone / Bo / Badjia / Ngelehun CHC",
+                "OU_559",
+                "ACTIVE",
+                "ACTIVE",
+                "DiszpKrYNg8" ) );
 
         validateRow( response, 1,
-                List.of( "onXW2DQHRGS",
-                        "dBwrot7S420",
-                        "2022-04-01 00:00:00.0",
-                        "",
-                        "",
-                        "",
-                        "2018-04-12 16:05:28.015",
-                        "",
-                        "",
-                        "0.0",
-                        "0.0",
-                        "Ngelehun CHC",
-                        "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-                        "OU_559",
-                        "ACTIVE",
-                        "ACTIVE",
-                        "DiszpKrYNg8" ) );
+            List.of( "onXW2DQHRGS",
+                "dBwrot7S420",
+                "2022-04-01 00:00:00.0",
+                "",
+                "",
+                "",
+                "2018-04-12 16:05:28.015",
+                "",
+                "",
+                "0.0",
+                "0.0",
+                "Ngelehun CHC",
+                "Sierra Leone / Bo / Badjia / Ngelehun CHC",
+                "OU_559",
+                "ACTIVE",
+                "ACTIVE",
+                "DiszpKrYNg8" ) );
 
         validateRow( response, 2,
-                List.of( "A7vnB73x5Xw",
-                        "dBwrot7S420",
-                        "2022-04-01 00:00:00.0",
-                        "",
-                        "",
-                        "",
-                        "2018-04-12 16:05:16.957",
-                        "",
-                        "",
-                        "0.0",
-                        "0.0",
-                        "Ngelehun CHC",
-                        "Sierra Leone / Bo / Badjia / Ngelehun CHC",
-                        "OU_559",
-                        "ACTIVE",
-                        "ACTIVE",
-                        "DiszpKrYNg8" ) );
+            List.of( "A7vnB73x5Xw",
+                "dBwrot7S420",
+                "2022-04-01 00:00:00.0",
+                "",
+                "",
+                "",
+                "2018-04-12 16:05:16.957",
+                "",
+                "",
+                "0.0",
+                "0.0",
+                "Ngelehun CHC",
+                "Sierra Leone / Bo / Badjia / Ngelehun CHC",
+                "OU_559",
+                "ACTIVE",
+                "ACTIVE",
+                "DiszpKrYNg8" ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -286,7 +286,6 @@ public class DataHandler
                 indicator.setNumerator( edi.getExpression() );
                 indicator.setNumeratorDescription( edi.getDescription() );
                 indicator.setDenominator( "1" );
-                indicator.setDecimals( 1 );
                 indicator.setAnnualized( false );
 
                 return indicator;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -149,7 +149,6 @@ import org.hisp.dhis.dataelement.DataElementOperand.TotalType;
 import org.hisp.dhis.expression.ExpressionService;
 import org.hisp.dhis.expressiondimensionitem.ExpressionDimensionItem;
 import org.hisp.dhis.indicator.Indicator;
-import org.hisp.dhis.indicator.IndicatorType;
 import org.hisp.dhis.indicator.IndicatorValue;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
@@ -273,23 +272,7 @@ public class DataHandler
         List<ExpressionDimensionItem> expressionDimensionItems )
     {
         return expressionDimensionItems.stream()
-            .map( edi -> {
-                IndicatorType indicatorType = new IndicatorType();
-                indicatorType.setNumber( true );
-                indicatorType.setFactor( 1 );
-
-                Indicator indicator = new Indicator();
-                indicator.setUid( edi.getUid() );
-                indicator.setName( edi.getName() );
-                indicator.setCode( edi.getCode() );
-                indicator.setIndicatorType( indicatorType );
-                indicator.setNumerator( edi.getExpression() );
-                indicator.setNumeratorDescription( edi.getDescription() );
-                indicator.setDenominator( "1" );
-                indicator.setAnnualized( false );
-
-                return indicator;
-            } ).collect( toList() );
+            .map( edi -> edi.toIndicator() ).collect( toList() );
     }
 
     private void addIndicatorValues( DataQueryParams dataQueryParams, DataQueryParams dataSourceParams,


### PR DESCRIPTION
**_[DO NOT MERGE IT. NEEDS APPROVAL FROM RCB]_**

Small fix to make EDIs behave like a default Indicator regarding rounding.

Basically, the end result value of an EDI should be rounded following the same behaviour as an Indicator that is created with default rounding (which means no rounding is set at creating time).

In order to achieve it, we simply leave the `decimals` property unset when converting the EDI to Indicator. The current flow will take care of the correct rounding approach (applying all the same existing rounding rules).

_This fix needs to go into the current frozen version 2.40.0, so I tried to make as less changes as possible._