### PR TITLE
fix: Do not set default rounding for EDIs [DHIS2-15055] (#13592)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expressiondimensionitem/ExpressionDimensionItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expressiondimensionitem/ExpressionDimensionItem.java
@@ -32,6 +32,8 @@ import org.hisp.dhis.common.DimensionItemType;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.expression.MissingValueStrategy;
+import org.hisp.dhis.indicator.Indicator;
+import org.hisp.dhis.indicator.IndicatorType;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -169,5 +171,29 @@ public class ExpressionDimensionItem
     public DimensionItemType getDimensionItemType()
     {
         return DimensionItemType.EXPRESSION_DIMENSION_ITEM;
+    }
+
+    /**
+     * Converts the current object to {@link Indicator}.
+     *
+     * @return the {@link Indicator} object.
+     */
+    public Indicator toIndicator()
+    {
+        IndicatorType indicatorType = new IndicatorType();
+        indicatorType.setNumber( true );
+        indicatorType.setFactor( 1 );
+
+        Indicator indicator = new Indicator();
+        indicator.setUid( getUid() );
+        indicator.setName( getName() );
+        indicator.setCode( getCode() );
+        indicator.setIndicatorType( indicatorType );
+        indicator.setNumerator( getExpression() );
+        indicator.setNumeratorDescription( getDescription() );
+        indicator.setDenominator( "1" );
+        indicator.setAnnualized( false );
+
+        return indicator;
     }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/expressiondimensionitem/ExpressionDimensionItemTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/expressiondimensionitem/ExpressionDimensionItemTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.expressiondimensionitem;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hisp.dhis.indicator.Indicator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ExpressionDimensionItem}.
+ */
+class ExpressionDimensionItemTest
+{
+    @Test
+    void testToIndicator()
+    {
+        // Given
+        ExpressionDimensionItem expressionDimensionItem = new ExpressionDimensionItem();
+        expressionDimensionItem.setExpression( "#{R4KStuS8qt7.LbkJRbDblhe} / #{o0fOD1HLuv8.LbkJRbDblhe}" );
+        expressionDimensionItem.setUid( "anyUid" );
+        expressionDimensionItem.setCode( "anyCode" );
+        expressionDimensionItem.setName( "anyName" );
+        expressionDimensionItem.setDescription( "anyDescription" );
+
+        // When
+        Indicator indicator = expressionDimensionItem.toIndicator();
+
+        // Then
+        assertEquals( "anyUid", indicator.getUid() );
+        assertEquals( "anyCode", indicator.getCode() );
+        assertEquals( "anyName", indicator.getName() );
+        assertEquals( "#{R4KStuS8qt7.LbkJRbDblhe} / #{o0fOD1HLuv8.LbkJRbDblhe}", indicator.getNumerator() );
+        assertEquals( "1", indicator.getDenominator() );
+        assertEquals( 1, indicator.getIndicatorType().getFactor() );
+        assertNull( indicator.getDescription() );
+        assertNull( indicator.getDecimals() );
+        assertFalse( indicator.isAnnualized() );
+        assertTrue( indicator.getIndicatorType().isNumber() );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -149,7 +149,6 @@ import org.hisp.dhis.dataelement.DataElementOperand.TotalType;
 import org.hisp.dhis.expression.ExpressionService;
 import org.hisp.dhis.expressiondimensionitem.ExpressionDimensionItem;
 import org.hisp.dhis.indicator.Indicator;
-import org.hisp.dhis.indicator.IndicatorType;
 import org.hisp.dhis.indicator.IndicatorValue;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
@@ -273,24 +272,7 @@ public class DataHandler
         List<ExpressionDimensionItem> expressionDimensionItems )
     {
         return expressionDimensionItems.stream()
-            .map( edi -> {
-                IndicatorType indicatorType = new IndicatorType();
-                indicatorType.setNumber( true );
-                indicatorType.setFactor( 1 );
-
-                Indicator indicator = new Indicator();
-                indicator.setUid( edi.getUid() );
-                indicator.setName( edi.getName() );
-                indicator.setCode( edi.getCode() );
-                indicator.setIndicatorType( indicatorType );
-                indicator.setNumerator( edi.getExpression() );
-                indicator.setNumeratorDescription( edi.getDescription() );
-                indicator.setDenominator( "1" );
-                indicator.setDecimals( 1 );
-                indicator.setAnnualized( false );
-
-                return indicator;
-            } ).collect( toList() );
+            .map( edi -> edi.toIndicator() ).collect( toList() );
     }
 
     private void addIndicatorValues( DataQueryParams dataQueryParams, DataQueryParams dataSourceParams,


### PR DESCRIPTION
_[Backport from master/2.41]_

Small fix to make EDIs behave like a default Indicator regarding rounding.

Basically, the end result value of an EDI should be rounded following the same behaviour as an Indicator that is created with default rounding (which means no rounding is set at creating time).

In order to achieve it, we simply leave the `decimals` property unset when converting the EDI to Indicator. The current flow will take care of the correct rounding approach (applying all the same existing rounding rules).

* fix: Do not set default rounding for EDIs [DHIS2-15055]

* refactor: Make change testable + unit test [DHIS2-15055]

* chore: Missing javadoc [DHIS2-15055]

* fix: Add missing assertion to test [DHIS2-15055]

* chore: Fix Javadoc typo

[DHIS2-15055]: https://dhis2.atlassian.net/browse/DHIS2-15055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-15055]: https://dhis2.atlassian.net/browse/DHIS2-15055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-15055]: https://dhis2.atlassian.net/browse/DHIS2-15055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-15055]: https://dhis2.atlassian.net/browse/DHIS2-15055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ