### PR TITLE
fix: organisation unit special root based queries as sub-paths [DHIS2-13901]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionService.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.user.User;
 
 /**
@@ -56,7 +57,8 @@ public interface DimensionService
 
     List<DimensionalObject> getDimensionConstraints();
 
-    DimensionalObject getDimensionalObjectCopy( String uid, boolean filterCanRead );
+    DimensionalObject getDimensionalObjectCopy( String uid, boolean filterCanRead )
+        throws NotFoundException;
 
     void mergeAnalyticalObject( BaseAnalyticalObject object );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DefaultDimensionService.java
@@ -83,7 +83,6 @@ import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IdentifiableProperty;
-import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.MapMap;
 import org.hisp.dhis.common.ReportingRate;
 import org.hisp.dhis.common.SetMap;
@@ -97,6 +96,7 @@ import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.eventvisualization.Attribute;
 import org.hisp.dhis.eventvisualization.EventRepetition;
 import org.hisp.dhis.expression.ExpressionService;
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.legend.LegendSet;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
@@ -334,11 +334,12 @@ public class DefaultDimensionService
 
     @Override
     public DimensionalObject getDimensionalObjectCopy( String uid, boolean filterCanRead )
+        throws NotFoundException
     {
         BaseDimensionalObject dimension = idObjectManager.get( DimensionalObject.DYNAMIC_DIMENSION_CLASSES, uid );
         if ( dimension == null )
         {
-            throw new IllegalQueryException( "Dimension does not exist: " + uid );
+            throw new NotFoundException( "Dimension does not exist: " + uid );
         }
         BaseDimensionalObject copy = mergeService.clone( dimension );
 

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/web/HttpStatus.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/web/HttpStatus.java
@@ -80,6 +80,8 @@ public enum HttpStatus
     LENGTH_REQUIRED( 411, "Length Required" ),
     PRECONDITION_FAILED( 412, "Precondition Failed" ),
     PAYLOAD_TOO_LARGE( 413, "Payload Too Large" ),
+    REQUEST_URI_TOO_LONG( 414, "Request-URI Too Long" ),
+    UNSUPPORTED_MEDIA_TYPE( 415, "Unsupported Media Type" ),
     UNPROCESSABLE_ENTITY( 422, "Unprocessable Entity" ),
     LOCKED( 423, "Locked" ),
     FAILED_DEPENDENCY( 424, "Failed Dependency" ),

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/OrganisationUnitControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/OrganisationUnitControllerTest.java
@@ -96,6 +96,12 @@ class OrganisationUnitControllerTest extends DhisControllerConvenienceTest
         assertListOfOrganisationUnits( GET( "/organisationUnits/{id}/ancestors", ou22 ).content(), "L22", "L1", "L0" );
     }
 
+    @Test
+    void testGetParents()
+    {
+        assertListOfOrganisationUnits( GET( "/organisationUnits/{id}/parents", ou21 ).content(), "L1", "L0" );
+    }
+
     private void assertListOfOrganisationUnits( JsonObject response, String... names )
     {
         JsonList<JsonIdentifiableObject> units = response.getList( "organisationUnits", JsonIdentifiableObject.class );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/OrganisationUnitControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/OrganisationUnitControllerTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.hisp.dhis.web.WebClientUtils.assertStatus;
+import static org.hisp.dhis.web.WebClientUtils.objectReference;
+
+import java.util.List;
+
+import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.web.HttpStatus;
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.webapi.json.domain.JsonIdentifiableObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the {@link org.hisp.dhis.organisationunit.OrganisationUnit} using
+ * (mocked) REST requests.
+ *
+ * @author Jan Bernitt
+ */
+class OrganisationUnitControllerTest extends DhisControllerConvenienceTest
+{
+    private String ou0, ou1, ou21, ou22;
+
+    @BeforeEach
+    void setUp()
+    {
+        ou0 = addOrganisationUnit( "L0" );
+        ou1 = addOrganisationUnit( "L1", ou0 );
+        ou21 = addOrganisationUnit( "L21", ou1 );
+        ou22 = addOrganisationUnit( "L22", ou1 );
+        addOrganisationUnit( "L31", ou21 );
+        addOrganisationUnit( "L32", ou22 );
+
+        // what should not be matched but exists
+        String ou1x = addOrganisationUnit( "L1x", ou0 );
+        String ou2x = addOrganisationUnit( "L2x", ou1x );
+        addOrganisationUnit( "L3x", ou2x );
+    }
+
+    @Test
+    void testGetChildren()
+    {
+        assertListOfOrganisationUnits( GET( "/organisationUnits/{id}/children", ou0 ).content(), "L1", "L1x" );
+        assertListOfOrganisationUnits( GET( "/organisationUnits/{id}/children", ou1 ).content(), "L21", "L22" );
+        assertListOfOrganisationUnits( GET( "/organisationUnits/{id}/children", ou21 ).content(), "L31" );
+    }
+
+    @Test
+    void testGetChildrenWithLevel()
+    {
+        assertListOfOrganisationUnits( GET( "/organisationUnits/{id}/children?level=1", ou1 ).content(), "L21", "L22" );
+        assertListOfOrganisationUnits( GET( "/organisationUnits/{id}/children?level=2", ou1 ).content(), "L31", "L32" );
+    }
+
+    @Test
+    void testGetDescendants()
+    {
+        assertListOfOrganisationUnits( GET( "/organisationUnits/{id}/descendants", ou1 ).content(), "L1", "L21", "L22",
+            "L31", "L32" );
+        assertListOfOrganisationUnits( GET( "/organisationUnits/{id}/descendants", ou21 ).content(), "L21", "L31" );
+    }
+
+    @Test
+    void testGetAncestors()
+    {
+        assertListOfOrganisationUnits( GET( "/organisationUnits/{id}/ancestors", ou22 ).content(), "L22", "L1", "L0" );
+    }
+
+    private void assertListOfOrganisationUnits( JsonObject response, String... names )
+    {
+        JsonList<JsonIdentifiableObject> units = response.getList( "organisationUnits", JsonIdentifiableObject.class );
+        assertContainsOnly( List.of( names ), units.toList( JsonIdentifiableObject::getDisplayName ) );
+    }
+
+    private String addOrganisationUnit( String name )
+    {
+        return assertStatus( HttpStatus.CREATED,
+            POST( "/organisationUnits", "{'name':'" + name + "', 'shortName':'" + name + "', 'openingDate':'2021'}" ) );
+    }
+
+    private String addOrganisationUnit( String name, String parentId )
+    {
+        return assertStatus( HttpStatus.CREATED, POST( "/organisationUnits", "{'name':'" + name + "', 'shortName':'"
+            + name + "', 'openingDate':'2021', 'parent': " + objectReference( parentId ) + " }" ) );
+    }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -558,15 +558,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         {
             throw new ConflictException( "Objects of this class cannot be subscribed to" );
         }
-        @SuppressWarnings( "unchecked" )
-        List<SubscribableObject> entity = (List<SubscribableObject>) getEntity( pvUid );
-
-        if ( entity.isEmpty() )
-        {
-            throw new NotFoundException( getEntityClass(), pvUid );
-        }
-
-        SubscribableObject object = entity.get( 0 );
+        SubscribableObject object = (SubscribableObject) getEntity( pvUid );
 
         object.subscribe( currentUser );
         manager.updateNoAcl( object );
@@ -773,7 +765,6 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
 
     @DeleteMapping( value = "/{uid}/subscriber" )
     @ResponseBody
-    @SuppressWarnings( "unchecked" )
     public WebMessage unsubscribe( @OpenApi.Param( UID.class ) @PathVariable( "uid" ) String pvUid,
         @CurrentUser User currentUser )
         throws NotFoundException,
@@ -784,14 +775,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
             throw new ConflictException( "Objects of this class cannot be subscribed to" );
         }
 
-        List<SubscribableObject> entity = (List<SubscribableObject>) getEntity( pvUid );
-
-        if ( entity.isEmpty() )
-        {
-            throw new NotFoundException( getEntityClass(), pvUid );
-        }
-
-        SubscribableObject object = entity.get( 0 );
+        SubscribableObject object = (SubscribableObject) getEntity( pvUid );
 
         object.unsubscribe( currentUser );
         manager.updateNoAcl( object );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -190,14 +190,8 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         JsonPatchException
     {
         WebOptions options = new WebOptions( rpParameters );
-        List<T> entities = getEntity( pvUid, options );
 
-        if ( entities.isEmpty() )
-        {
-            throw new NotFoundException( getEntityClass(), pvUid );
-        }
-
-        T patchedObject = entities.get( 0 );
+        T patchedObject = getEntity( pvUid, options );
         T persistedObject = jsonPatchManager.apply( new JsonPatch( List.of() ), patchedObject );
 
         if ( !aclService.canUpdate( currentUser, patchedObject ) )
@@ -236,20 +230,13 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
     {
         WebOptions options = new WebOptions( rpParameters );
 
-        List<T> entities = getEntity( pvUid, options );
-
-        if ( entities.isEmpty() )
-        {
-            throw new NotFoundException( getEntityClass(), pvUid );
-        }
-
         if ( !getSchema().hasProperty( pvProperty ) )
         {
             throw new NotFoundException( "Property " + pvProperty + " does not exist on " + getEntityName() );
         }
 
         Property property = getSchema().getProperty( pvProperty );
-        T patchedObject = entities.get( 0 );
+        T patchedObject = getEntity( pvUid, options );
         T persistedObject = jsonPatchManager.apply( new JsonPatch( List.of() ), patchedObject );
 
         if ( !aclService.canUpdate( currentUser, patchedObject ) )
@@ -326,14 +313,8 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         ConflictException
     {
         WebOptions options = new WebOptions( rpParameters );
-        List<T> entities = getEntity( pvUid, options );
 
-        if ( entities.isEmpty() )
-        {
-            throw new NotFoundException( getEntityClass(), pvUid );
-        }
-
-        final T persistedObject = entities.get( 0 );
+        final T persistedObject = getEntity( pvUid, options );
 
         if ( !aclService.canUpdate( currentUser, persistedObject ) )
         {
@@ -558,14 +539,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
             throw new ConflictException( "Objects of this class cannot be set as favorite" );
         }
 
-        List<T> entity = getEntity( pvUid );
-
-        if ( entity.isEmpty() )
-        {
-            throw new NotFoundException( getEntityClass(), pvUid );
-        }
-
-        T object = entity.get( 0 );
+        T object = getEntity( pvUid );
 
         object.setAsFavorite( currentUser );
         manager.updateNoAcl( object );
@@ -618,14 +592,8 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         ConflictException,
         HttpRequestMethodNotSupportedException
     {
-        List<T> objects = getEntity( pvUid );
-
-        if ( objects.isEmpty() )
-        {
-            throw new NotFoundException( getEntityClass(), pvUid );
-        }
-
-        if ( !aclService.canUpdate( currentUser, objects.get( 0 ) ) )
+        T persisted = getEntity( pvUid );
+        if ( !aclService.canUpdate( currentUser, persisted ) )
         {
             throw new ForbiddenException( "You don't have the proper permissions to update this object." );
         }
@@ -633,7 +601,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         T parsed = deserializeJsonEntity( request );
         ((BaseIdentifiableObject) parsed).setUid( pvUid );
 
-        preUpdateEntity( objects.get( 0 ), parsed );
+        preUpdateEntity( persisted, parsed );
 
         MetadataImportParams params = importService.getParamsFromMap( contextService.getParameterValuesMap() );
 
@@ -676,14 +644,8 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         NotFoundException,
         ForbiddenException
     {
-        List<T> objects = getEntity( pvUid );
-
-        if ( objects.isEmpty() )
-        {
-            throw new NotFoundException( getEntityClass(), pvUid );
-        }
-
-        if ( !aclService.canUpdate( currentUser, objects.get( 0 ) ) )
+        T persisted = getEntity( pvUid );
+        if ( !aclService.canUpdate( currentUser, persisted ) )
         {
             throw new ForbiddenException( "You don't have the proper permissions to update this object." );
         }
@@ -691,7 +653,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         T parsed = deserializeXmlEntity( request );
         ((BaseIdentifiableObject) parsed).setUid( pvUid );
 
-        preUpdateEntity( objects.get( 0 ), parsed );
+        preUpdateEntity( persisted, parsed );
 
         MetadataImportParams params = importService.getParamsFromMap( contextService.getParameterValuesMap() )
             .setImportReportMode( ImportReportMode.FULL )
@@ -727,14 +689,8 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         IOException
     {
         WebOptions options = new WebOptions( rpParameters );
-        List<T> entities = getEntity( pvUid, options );
 
-        if ( entities.isEmpty() )
-        {
-            throw new NotFoundException( getEntityClass(), pvUid );
-        }
-
-        BaseIdentifiableObject persistedObject = (BaseIdentifiableObject) entities.get( 0 );
+        BaseIdentifiableObject persistedObject = (BaseIdentifiableObject) getEntity( pvUid, options );
 
         if ( !aclService.canUpdate( currentUser, persistedObject ) )
         {
@@ -774,25 +730,19 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         ConflictException,
         HttpRequestMethodNotSupportedException
     {
-        List<T> objects = getEntity( pvUid );
-
-        if ( objects.isEmpty() )
-        {
-            throw new NotFoundException( getEntityClass(), pvUid );
-        }
-
-        if ( !aclService.canDelete( currentUser, objects.get( 0 ) ) )
+        T persistedObject = getEntity( pvUid );
+        if ( !aclService.canDelete( currentUser, persistedObject ) )
         {
             throw new ForbiddenException( "You don't have the proper permissions to delete this object." );
         }
 
-        preDeleteEntity( objects.get( 0 ) );
+        preDeleteEntity( persistedObject );
 
         MetadataImportParams params = new MetadataImportParams()
             .setImportReportMode( ImportReportMode.FULL )
             .setUser( currentUser )
             .setImportStrategy( ImportStrategy.DELETE )
-            .addObject( objects.get( 0 ) );
+            .addObject( persistedObject );
 
         ImportReport importReport = importService.importMetadata( params );
 
@@ -813,14 +763,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
             throw new ConflictException( "Objects of this class cannot be set as favorite" );
         }
 
-        List<T> entity = getEntity( pvUid );
-
-        if ( entity.isEmpty() )
-        {
-            throw new NotFoundException( getEntityClass(), pvUid );
-        }
-
-        T object = entity.get( 0 );
+        T object = getEntity( pvUid );
 
         object.removeAsFavorite( currentUser );
         manager.updateNoAcl( object );
@@ -875,7 +818,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         NotFoundException,
         BadRequestException
     {
-        return addCollectionItems( pvProperty, getEntity( pvUid ).get( 0 ),
+        return addCollectionItems( pvProperty, getEntity( pvUid ),
             renderService.fromJson( request.getInputStream(), IdentifiableObjects.class ) );
     }
 
@@ -893,7 +836,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         NotFoundException,
         BadRequestException
     {
-        return addCollectionItems( pvProperty, getEntity( pvUid ).get( 0 ),
+        return addCollectionItems( pvProperty, getEntity( pvUid ),
             renderService.fromXml( request.getInputStream(), IdentifiableObjects.class ) );
     }
 
@@ -924,7 +867,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         NotFoundException,
         BadRequestException
     {
-        return replaceCollectionItems( pvProperty, getEntity( pvUid ).get( 0 ),
+        return replaceCollectionItems( pvProperty, getEntity( pvUid ),
             renderService.fromJson( request.getInputStream(), IdentifiableObjects.class ) );
     }
 
@@ -942,7 +885,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         NotFoundException,
         BadRequestException
     {
-        return replaceCollectionItems( pvProperty, getEntity( pvUid ).get( 0 ),
+        return replaceCollectionItems( pvProperty, getEntity( pvUid ),
             renderService.fromXml( request.getInputStream(), IdentifiableObjects.class ) );
     }
 
@@ -966,20 +909,13 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
     public WebMessage addCollectionItem(
         @OpenApi.Param( UID.class ) @PathVariable( "uid" ) String pvUid,
         @OpenApi.Param( PropertyNames.class ) @PathVariable( "property" ) String pvProperty,
-        @PathVariable( "itemId" ) String pvItemId,
-        HttpServletResponse response )
+        @PathVariable( "itemId" ) String pvItemId )
         throws NotFoundException,
         ConflictException,
         ForbiddenException,
         BadRequestException
     {
-        List<T> objects = getEntity( pvUid );
-        if ( objects.isEmpty() )
-        {
-            throw new NotFoundException( getEntityClass(), pvUid );
-        }
-
-        T object = objects.get( 0 );
+        T object = getEntity( pvUid );
         IdentifiableObjects items = new IdentifiableObjects();
         items.setAdditions( singletonList( new BaseIdentifiableObject( pvItemId, "", "" ) ) );
 
@@ -1004,7 +940,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         NotFoundException,
         BadRequestException
     {
-        return deleteCollectionItems( pvProperty, getEntity( pvUid ).get( 0 ),
+        return deleteCollectionItems( pvProperty, getEntity( pvUid ),
             renderService.fromJson( request.getInputStream(), IdentifiableObjects.class ) );
     }
 
@@ -1022,7 +958,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         NotFoundException,
         BadRequestException
     {
-        return deleteCollectionItems( pvProperty, getEntity( pvUid ).get( 0 ),
+        return deleteCollectionItems( pvProperty, getEntity( pvUid ),
             renderService.fromXml( request.getInputStream(), IdentifiableObjects.class ) );
     }
 
@@ -1052,15 +988,9 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         ConflictException,
         BadRequestException
     {
-        List<T> objects = getEntity( pvUid );
-        if ( objects.isEmpty() )
-        {
-            throw new NotFoundException( getEntityClass(), pvUid );
-        }
-
         IdentifiableObjects items = new IdentifiableObjects();
-        items.setIdentifiableObjects( singletonList( new BaseIdentifiableObject( pvItemId, "", "" ) ) );
-        return deleteCollectionItems( pvProperty, objects.get( 0 ), items );
+        items.setIdentifiableObjects( List.of( new BaseIdentifiableObject( pvItemId, "", "" ) ) );
+        return deleteCollectionItems( pvProperty, getEntity( pvUid ), items );
     }
 
     @OpenApi.Param( Sharing.class )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IdentifiableObjectController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IdentifiableObjectController.java
@@ -27,7 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import java.util.List;
+import static java.lang.String.format;
+
 import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
@@ -36,6 +37,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.user.CurrentUser;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
@@ -57,11 +59,15 @@ public class IdentifiableObjectController
 
     @Override
     @SuppressWarnings( "unchecked" )
-    public List<IdentifiableObject> getEntity( String uid, WebOptions options )
+    public IdentifiableObject getEntity( String uid, WebOptions options )
+        throws NotFoundException
     {
         Optional<IdentifiableObject> object = (Optional<IdentifiableObject>) manager.find( uid );
-
-        return object.isPresent() ? List.of( object.get() ) : List.of();
+        if ( object.isEmpty() )
+        {
+            throw new NotFoundException( format( "No identifiable object with id `%s` exists", uid ) );
+        }
+        return object.get();
     }
 
     @Override

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementGroupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementGroupController.java
@@ -34,7 +34,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang3.StringUtils;
@@ -48,6 +47,7 @@ import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dxf2.common.TranslateParams;
 import org.hisp.dhis.dxf2.metadata.MetadataExportParams;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.schema.descriptors.DataElementGroupSchemaDescriptor;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.hisp.dhis.webapi.webdomain.WebMetadata;
@@ -81,21 +81,15 @@ public class DataElementGroupController
     @GetMapping( "/{uid}/operands" )
     public String getOperands( @PathVariable( "uid" ) String uid, @RequestParam Map<String, String> parameters,
         Model model,
-        TranslateParams translateParams, HttpServletRequest request, HttpServletResponse response )
-        throws Exception
+        TranslateParams translateParams, HttpServletResponse response )
+        throws NotFoundException
     {
         WebOptions options = new WebOptions( parameters );
         setTranslationParams( translateParams );
-        List<DataElementGroup> dataElementGroups = getEntity( uid, NO_WEB_OPTIONS );
-
-        if ( dataElementGroups.isEmpty() )
-        {
-            throw new WebMessageException( notFound( "DataElementGroup not found for uid: " + uid ) );
-        }
 
         WebMetadata metadata = new WebMetadata();
         List<DataElementOperand> dataElementOperands = Lists
-            .newArrayList( dataElementCategoryService.getOperands( dataElementGroups.get( 0 ).getMembers() ) );
+            .newArrayList( dataElementCategoryService.getOperands( getEntity( uid ).getMembers() ) );
         Collections.sort( dataElementOperands );
 
         metadata.setDataElementOperands( dataElementOperands );
@@ -119,24 +113,17 @@ public class DataElementGroupController
     @GetMapping( "/{uid}/operands/query/{q}" )
     public String getOperandsByQuery( @PathVariable( "uid" ) String uid,
         @PathVariable( "q" ) String q, @RequestParam Map<String, String> parameters, TranslateParams translateParams,
-        Model model,
-        HttpServletRequest request, HttpServletResponse response )
-        throws Exception
+        Model model )
+        throws NotFoundException
     {
         WebOptions options = new WebOptions( parameters );
         setTranslationParams( translateParams );
-        List<DataElementGroup> dataElementGroups = getEntity( uid, NO_WEB_OPTIONS );
-
-        if ( dataElementGroups.isEmpty() )
-        {
-            throw new WebMessageException( notFound( "DataElementGroup not found for uid: " + uid ) );
-        }
 
         WebMetadata metadata = new WebMetadata();
         List<DataElementOperand> dataElementOperands = Lists.newArrayList();
 
         for ( DataElementOperand dataElementOperand : dataElementCategoryService
-            .getOperands( dataElementGroups.get( 0 ).getMembers() ) )
+            .getOperands( getEntity( uid ).getMembers() ) )
         {
             if ( dataElementOperand.getDisplayName().toLowerCase().contains( q.toLowerCase() ) )
             {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementGroupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementGroupController.java
@@ -34,8 +34,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.OpenApi;
@@ -81,7 +79,7 @@ public class DataElementGroupController
     @GetMapping( "/{uid}/operands" )
     public String getOperands( @PathVariable( "uid" ) String uid, @RequestParam Map<String, String> parameters,
         Model model,
-        TranslateParams translateParams, HttpServletResponse response )
+        TranslateParams translateParams )
         throws NotFoundException
     {
         WebOptions options = new WebOptions( parameters );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.organisationunit;
 
+import static java.lang.Math.max;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 import static org.hisp.dhis.system.util.GeoUtils.getCoordinatesFromGeometry;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -164,8 +165,8 @@ public class OrganisationUnitController
         NotFoundException
     {
         OrganisationUnit parent = getEntity( uid );
-        return getObjectList( rpParameters, orderParams, response, currentUser, false,
-            params -> organisationUnitService.getOrganisationUnitsAtLevel( parent.getLevel() + level, parent ) );
+        return getObjectList( rpParameters, orderParams, response, currentUser, false, params -> organisationUnitService
+            .getOrganisationUnitsAtLevel( parent.getLevel() + max( 0, level ), parent ) );
     }
 
     @OpenApi.Param( name = "fields", value = String[].class )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ApiTokenController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ApiTokenController.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.webapi.controller.security;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.objectReport;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -58,7 +57,6 @@ import org.hisp.dhis.user.CurrentUser;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
-import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -80,15 +78,6 @@ public class ApiTokenController extends AbstractCrudController<ApiToken>
     private static final List<String> VALID_METHODS = List.of( "GET", "POST", "PATCH", "PUT", "DELETE" );
 
     private final ApiTokenService apiTokenService;
-
-    // Overwritten to get full access control on GET single object
-    @Override
-    protected List<ApiToken> getEntity( String uid, WebOptions options )
-    {
-        ArrayList<ApiToken> list = new ArrayList<>();
-        java.util.Optional.ofNullable( manager.get( ApiToken.class, uid ) ).ifPresent( list::add );
-        return list;
-    }
 
     @Override
     public void partialUpdateObject( String pvUid, Map<String, String> rpParameters,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -49,6 +49,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -127,7 +128,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.Lists;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -262,14 +262,16 @@ public class UserController
     }
 
     @Override
-    protected List<User> getEntity( String uid, WebOptions options )
+    @Nonnull
+    protected User getEntity( String uid, WebOptions options )
+        throws NotFoundException
     {
-        List<User> users = Lists.newArrayList();
-        Optional<User> user = Optional.ofNullable( userService.getUser( uid ) );
-
-        user.ifPresent( users::add );
-
-        return users;
+        User user = userService.getUser( uid );
+        if ( user == null )
+        {
+            throw new NotFoundException( User.class, uid );
+        }
+        return user;
     }
 
     @Override
@@ -638,7 +640,8 @@ public class UserController
         HttpServletResponse response )
         throws IOException,
         ForbiddenException,
-        ConflictException
+        ConflictException,
+        NotFoundException
     {
         User parsed = renderService.fromXml( request.getInputStream(), getEntityClass() );
 
@@ -653,18 +656,15 @@ public class UserController
         HttpServletRequest request )
         throws IOException,
         ConflictException,
-        ForbiddenException
+        ForbiddenException,
+        NotFoundException
     {
         User inputUser = renderService.fromJson( request.getInputStream(), getEntityClass() );
 
-        List<User> users = getEntity( pvUid, NO_WEB_OPTIONS );
-        if ( users.isEmpty() )
-        {
-            throw new ConflictException( getEntityName() + " does not exist: " + pvUid );
-        }
+        User user = getEntity( pvUid );
 
         // TODO: To remove when we remove old UserCredentials compatibility
-        populateUserCredentialsDtoCopyOnlyChanges( users.get( 0 ), inputUser );
+        populateUserCredentialsDtoCopyOnlyChanges( user, inputUser );
 
         return importReport( updateUser( pvUid, inputUser ) )
             .withPlainResponseBefore( DhisApiVersion.V38 );
@@ -672,18 +672,14 @@ public class UserController
 
     protected ImportReport updateUser( String userUid, User inputUser )
         throws ConflictException,
-        ForbiddenException
+        ForbiddenException,
+        NotFoundException
     {
-        List<User> users = getEntity( userUid, NO_WEB_OPTIONS );
-
-        if ( users.isEmpty() )
-        {
-            throw new ConflictException( getEntityName() + " does not exist: " + userUid );
-        }
+        User user = getEntity( userUid );
 
         User currentUser = currentUserService.getCurrentUser();
 
-        if ( !aclService.canUpdate( currentUser, users.get( 0 ) ) )
+        if ( !aclService.canUpdate( currentUser, user ) )
         {
             throw new ForbiddenException( "You don't have the proper permissions to update this user." );
         }
@@ -693,16 +689,16 @@ public class UserController
         // (in case it gets detached)
         currentUser.getAllAuthorities();
 
-        inputUser.setId( users.get( 0 ).getId() );
+        inputUser.setId( user.getId() );
         inputUser.setUid( userUid );
-        mergeLastLoginAttribute( users.get( 0 ), inputUser );
+        mergeLastLoginAttribute( user, inputUser );
 
         boolean isPasswordChangeAttempt = inputUser.getPassword() != null;
 
         List<String> groupsUids = getUids( inputUser.getGroups() );
 
         if ( !userService.canAddOrUpdateUser( groupsUids, currentUser )
-            || !currentUser.canModifyUser( users.get( 0 ) ) )
+            || !currentUser.canModifyUser( user ) )
         {
             throw new ConflictException(
                 "You must have permissions to create user, " +


### PR DESCRIPTION
### Summary
Removes special parameters `includeChildren`, `includeDescendants` and `includeAncestors` as well as `level` from endpoint `/api/organisationUnits/{uid}`.

Instead these are used as dedicated paths (endpoints):
* `/api/organisationUnits/{uid}/children` (direct children)
* `/api/organisationUnits/{uid}/children?level=2` (children 2 levels down, that means all children of the direct children)
* `/api/organisationUnits/{uid}/descendants`
* `/api/organisationUnits/{uid}/ancestors`

This is **not** merely a change from a request parameter to a path. When this was solved as request parameter this was based on single object lookup with some special list lookup on top. This meant the result handling of the list items was the handling intended for single objects. Whereas the new path solution is using the same handling as the normal list `/api/organisationUnits` has. This is most notably in the default fields included which is just `id` and `displayName`  for a list whereas it is most of the properties for a single object.

### Cleanup
The special list for single object in the OU controller was the only reason the `getEntity` method was returning a list, not a single entity. With that now gone the method could change to just return the expected single object value.
In case the value does not exist a `NotFoundException` is thrown. This allowed to remove that check and throw code at most call sites. 

This is now also consistent with the existing `/api/organisationUnits/{uid}/parents` list which now is based on the same `getEntityList` implementation with special loading function.


### Compatibility
* With this behaviour propagating to all callers of `getEntity` this meant 2 callers for an update of a `User` would now throw `NotFoundException` instead of `ConflictException` when trying to update a user that does not exist.
* Special list now have same rendering as the usual list `/api/organisationUnits`. This means without the `fields` parameter they contain less properties then their former parameter counterparts would have returned.
* Special lists can now be used with `fields` and `filter` 

### Manual Testing
Use the 4 new API path described above and check they match the expectations. For example, check against the organisation tree shown in an app.

* `/api/organisationUnits/{uid}/children` (only direct children)
* `/api/organisationUnits/{uid}/children?level={n}` (children n level down, where 1 is direct children, 0 would the the unit itself )
* `/api/organisationUnits/{uid}/descendants` (the unit and all its children and grant-children - any depth)
* `/api/organisationUnits/{uid}/ancestors` (the unit and all its parents up to the root)
* `/api/organisationUnits/{uid}/parents` (only the parents of the unit but not the unit itself)

For example

* `/api/organisationUnits/Rp268JB6Ne4/descendants?fields=id,name,level`
* `/api/organisationUnits/Rp268JB6Ne4/parents?fields=id,name,level`
* `/api/organisationUnits/Rp268JB6Ne4/ancestors?fields=id,name,level`
* `/api/organisationUnits/ImspTQPwCqd/children?level=1`

### Automatic Testing
Added new controller test scenarios for the new endpoints. 