### PR TITLE
ci: remove explicit host ports for e2e docker compose [skip ci]

### DIFF
--- a/dhis-2/dhis-e2e-test/docker-compose.yml
+++ b/dhis-2/dhis-e2e-test/docker-compose.yml
@@ -3,9 +3,10 @@ version: "3.8"
 services:
   web:
     image: "${DHIS2_IMAGE:-dhis2/core-dev:local}"
+    # Only container ports are specified, as the E2E tests run in parallel in Jenkins and using explicit host ports causes collision
     ports:
-      - 127.0.0.1:8080:8080 # DHIS2
-      - 127.0.0.1:8081:8081 # Debugger: connect using commandline flag -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8081
+      - "8080" # DHIS2
+      - "8081" # Debugger: connect using commandline flag -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8081
     volumes:
       - ./config/dhis2_home/dhis.conf:/opt/dhis2/dhis.conf:ro
     environment:


### PR DESCRIPTION
Using explicit host ports for the E2E tests causes a port allocation error when we [run the tests in parallel on Jenkins](https://github.com/dhis2/dhis2-core/blob/master/jenkinsfiles/dev#L108). With only a container port specified (like `"8080"`), [a random port is chosen on the host](https://docs.docker.com/compose/compose-file/compose-file-v3/#ports).