### PR TITLE
fix: Allow multiple filters for words range in attributes filtering [DHIS2-10215]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
@@ -67,7 +67,9 @@ public enum QueryOperator
 
     private static final Set<QueryOperator> LIKE_OPERATORS = EnumSet.of( LIKE, NLIKE, ILIKE, NILIKE );
 
-    private static final Set<QueryOperator> COMPARISON_OPERATORS = EnumSet.of( GT, GE, LT, LE );
+    private static final Set<QueryOperator> DATE_OR_NUMERIC_RANGE_OPERATORS = EnumSet.of( GT, GE, LT, LE );
+
+    private static final Set<QueryOperator> WORD_RANGE_OPERATORS = EnumSet.of( SW, EW );
 
     private final String value;
 
@@ -115,8 +117,13 @@ public enum QueryOperator
         return IN == this;
     }
 
-    public boolean isComparison()
+    public boolean isDateOrNumericComparison()
     {
-        return COMPARISON_OPERATORS.contains( this );
+        return DATE_OR_NUMERIC_RANGE_OPERATORS.contains( this );
+    }
+
+    public boolean isWordComparison()
+    {
+        return WORD_RANGE_OPERATORS.contains( this );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
@@ -66,7 +66,7 @@ class RequestParamUtils
     }
 
     private static final String COMPARISON_OPERATOR = EnumSet.allOf( QueryOperator.class ).stream()
-        .filter( QueryOperator::isComparison ).map( Enum::toString )
+        .filter( QueryOperator::isDateOrNumericComparison ).map( Enum::toString )
         .collect( Collectors.joining( "|" ) );
 
     /**

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapperTest.java
@@ -356,6 +356,22 @@ class TrackerTrackedEntityCriteriaMapperTest
     }
 
     @Test
+    void shouldCreateQueryFiltersWhenAttributesHasMultipleFiltersForWordRange()
+        throws ForbiddenException,
+        BadRequestException
+    {
+        criteria.setFilter( Set.of( TEA_1_UID + ":sw:hello", TEA_1_UID + ":ew:world" ) );
+
+        List<QueryFilter> queryFilters = mapper.map( criteria ).getFilters().stream()
+            .flatMap( f -> f.getFilters().stream() )
+            .collect( Collectors.toList() );
+
+        assertContainsOnly( List.of(
+            new QueryFilter( QueryOperator.SW, "hello" ),
+            new QueryFilter( QueryOperator.EW, "world" ) ), queryFilters );
+    }
+
+    @Test
     void testFilterWhenMultipleTEAFiltersAreRepeated()
     {
         criteria.setFilter( Set.of( TEA_1_UID + ":gt:10", TEA_1_UID + ":lt:20",


### PR DESCRIPTION
Should complete the work for https://dhis2.atlassian.net/browse/DHIS2-10215

Allow a pair of multiple attribute filters in case it is a word range (`SW` and `EW` operators)