### PR TITLE
chore: remove translation of legacy names in new tracker export criteria TECH-1514

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingAndSortingCriteriaAdapter.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingAndSortingCriteriaAdapter.java
@@ -30,12 +30,10 @@ package org.hisp.dhis.webapi.controller.event.webrequest;
 import static java.util.stream.Collectors.partitioningBy;
 import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import lombok.AccessLevel;
 import lombok.Data;
@@ -78,24 +76,7 @@ public abstract class PagingAndSortingCriteriaAdapter implements PagingCriteria,
     /**
      * order params
      */
-    private List<OrderCriteria> order;
-
-    /**
-     * TODO: legacy flag can be removed when new tracker will have it's own
-     * services. All new tracker export Criteria class extending this, will
-     * override isLegacy returning false, so that it's true only for older ones.
-     */
-    private boolean isLegacy = true;
-
-    private final Function<List<OrderCriteria>, List<OrderCriteria>> dtoNameToDatabaseNameTranslator = orderCriteria -> CollectionUtils
-        .emptyIfNull( orderCriteria )
-        .stream()
-        .filter( Objects::nonNull )
-        .map( oc -> OrderCriteria.of(
-            translateField( oc.getField(), isLegacy() )
-                .orElse( oc.getField() ),
-            oc.getDirection() ) )
-        .collect( Collectors.toList() );
+    private List<OrderCriteria> order = new ArrayList<>();
 
     public boolean isPagingRequest()
     {
@@ -107,7 +88,7 @@ public abstract class PagingAndSortingCriteriaAdapter implements PagingCriteria,
     {
         if ( getAllowedOrderingFields().isEmpty() )
         {
-            return dtoNameToDatabaseNameTranslator.apply( order );
+            return order;
         }
 
         Map<Boolean, List<OrderCriteria>> orderCriteriaPartitionedByAllowance = CollectionUtils.emptyIfNull( order )
@@ -118,7 +99,7 @@ public abstract class PagingAndSortingCriteriaAdapter implements PagingCriteria,
         CollectionUtils.emptyIfNull( orderCriteriaPartitionedByAllowance.get( false ) )
             .forEach( disallowedOrderFieldConsumer() );
 
-        return dtoNameToDatabaseNameTranslator.apply( orderCriteriaPartitionedByAllowance.get( true ) );
+        return orderCriteriaPartitionedByAllowance.get( true );
     }
 
     private boolean isAllowed( OrderCriteria orderCriteria )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/SortingCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/SortingCriteria.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.webapi.controller.event.webrequest;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Sorting parameters
@@ -46,22 +45,11 @@ public interface SortingCriteria
 
     /**
      * Implementors should return a list of fields on which it is allowed to
-     * perform ordering Defaults to empty list which means all fields are
-     * allowed for ordering
+     * perform ordering. Defaults to empty list which means all fields are
+     * allowed for ordering.
      */
     default List<String> getAllowedOrderingFields()
     {
         return Collections.emptyList();
     }
-
-    /**
-     * By default it does not translate any field
-     *
-     * @return
-     */
-    default Optional<String> translateField( String dtoFieldName, boolean isLegacy )
-    {
-        return Optional.ofNullable( dtoFieldName );
-    }
-
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingAndSortingCriteriaAdapterTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingAndSortingCriteriaAdapterTest.java
@@ -37,7 +37,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import lombok.SneakyThrows;
@@ -94,12 +93,6 @@ class PagingAndSortingCriteriaAdapterTest
             {
                 return List.of( "field1", "field2" );
             }
-
-            @Override
-            public Optional<String> translateField( String dtoFieldName, boolean isLegacy )
-            {
-                return Optional.of( dtoFieldName.equals( "field1" ) ? "translatedField1" : dtoFieldName );
-            }
         };
         tested.setOrder( List.of( OrderCriteria.of( "field1", SortDirection.ASC ),
             OrderCriteria.of( "field2", SortDirection.ASC ),
@@ -107,6 +100,6 @@ class PagingAndSortingCriteriaAdapterTest
         Collection<String> orderField = tested.getOrder().stream().map( OrderCriteria::getField )
             .collect( Collectors.toList() );
         assertThat( orderField, hasSize( 2 ) );
-        assertThat( orderField, containsInAnyOrder( "translatedField1", "field2" ) );
+        assertThat( orderField, containsInAnyOrder( "field1", "field2" ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/EnrollmentCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/EnrollmentCriteria.java
@@ -27,15 +27,10 @@
  */
 package org.hisp.dhis.webapi.controller.event.webrequest;
 
-import static org.hisp.dhis.webapi.controller.event.webrequest.tracker.FieldTranslatorSupport.translate;
-
 import java.util.Date;
-import java.util.Optional;
 
 import lombok.Data;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.program.ProgramStatus;
@@ -76,35 +71,4 @@ public class EnrollmentCriteria extends PagingAndSortingCriteriaAdapter
     private boolean includeDeleted;
 
     private Boolean paging;
-
-    @Override
-    public Optional<String> translateField( String dtoFieldName, boolean isLegacy )
-    {
-        return translate( dtoFieldName, LegacyDtoToEntityFieldTranslator.values() );
-    }
-
-    /**
-     * Dto to database field translator for old tracker Enrollment export
-     * controller
-     */
-    @RequiredArgsConstructor
-    private enum LegacyDtoToEntityFieldTranslator implements EntityNameSupplier
-    {
-        /**
-         * this enum names must be the same as
-         * org.hisp.dhis.dxf2.events.enrollment.Enrollment fields, just with
-         * different case
-         *
-         * example: org.hisp.dhis.dxf2.events.enrollment.Enrollment.lastUpdated
-         * --> LAST_UPDATED
-         */
-        ENROLLMENT( "uid" ),
-        TRACKED_ENTITY( "pi.entityInstance.uid" ),
-        TRACKED_ENTITY_INSTANCE( "pi.entityInstance.uid" );
-
-        @Getter
-        private final String entityName;
-
-    }
-
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteria.java
@@ -27,15 +27,10 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export;
 
-import static org.hisp.dhis.webapi.controller.event.webrequest.tracker.FieldTranslatorSupport.translate;
-
 import java.util.Date;
-import java.util.Optional;
 
 import lombok.Data;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.program.ProgramStatus;
@@ -80,41 +75,4 @@ public class TrackerEnrollmentCriteria extends PagingAndSortingCriteriaAdapter
     {
         return false;
     }
-
-    @Override
-    public Optional<String> translateField( String dtoFieldName, boolean isLegacy )
-    {
-        return translate( dtoFieldName, DtoToEntityFieldTranslator.values() );
-    }
-
-    /**
-     * Dto to database field translator for new tracker Enrollment export
-     * controller
-     */
-    @RequiredArgsConstructor
-    private enum DtoToEntityFieldTranslator implements EntityNameSupplier
-    {
-        /**
-         * this enum names must be the same as
-         * org.hisp.dhis.tracker.domain.Enrollment fields, just with different
-         * case
-         *
-         * example: org.hisp.dhis.tracker.domain.Enrollment.updatedAtClient -->
-         * UPDATED_AT_CLIENT
-         */
-        ENROLLMENT( "uid" ),
-        CREATED_AT( "created" ),
-        UPDATED_AT( "lastUpdated" ),
-        UPDATED_AT_CLIENT( "lastUpdatedAtClient" ),
-        TRACKED_ENTITY( "pi.entityInstance.uid" ),
-        TRACKED_ENTITY_INSTANCE( "pi.entityInstance.uid" ),
-        ENROLLED_AT( "enrollmentDate" ),
-        OCCURRED_AT( "incidentDate" ),
-        COMPLETED_AT( "endDate" );
-
-        @Getter
-        private final String entityName;
-
-    }
-
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteria.java
@@ -69,10 +69,4 @@ public class TrackerEnrollmentCriteria extends PagingAndSortingCriteriaAdapter
     private String enrollment;
 
     private boolean includeDeleted;
-
-    @Override
-    public boolean isLegacy()
-    {
-        return false;
-    }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteria.java
@@ -113,10 +113,4 @@ class TrackerEventCriteria extends PagingAndSortingCriteriaAdapter
     private Set<String> enrollments = new HashSet<>();
 
     private IdSchemes idSchemes = new IdSchemes();
-
-    @Override
-    public boolean isLegacy()
-    {
-        return false;
-    }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteria.java
@@ -113,4 +113,10 @@ class TrackerEventCriteria extends PagingAndSortingCriteriaAdapter
     private Set<String> enrollments = new HashSet<>();
 
     private IdSchemes idSchemes = new IdSchemes();
+
+    @Override
+    public boolean isLegacy()
+    {
+        return false;
+    }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipCriteria.java
@@ -27,14 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export;
 
-import static org.hisp.dhis.webapi.controller.event.webrequest.tracker.FieldTranslatorSupport.translate;
-
-import java.util.Optional;
-
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 import org.apache.commons.lang3.StringUtils;
@@ -144,57 +138,4 @@ class TrackerRelationshipCriteria extends PagingAndSortingCriteriaAdapter
     {
         return false;
     }
-
-    @Override
-    public Optional<String> translateField( String dtoFieldName, boolean isLegacy )
-    {
-        return isLegacy ? translate( dtoFieldName, LegacyDtoToEntityFieldTranslator.values() )
-            : translate( dtoFieldName, DtoToEntityFieldTranslator.values() );
-    }
-
-    /**
-     * Dto to database field translator for new tracker Enrollment export
-     * controller
-     */
-    @RequiredArgsConstructor
-    private enum DtoToEntityFieldTranslator implements EntityNameSupplier
-    {
-        /**
-         * this enum names must be the same as
-         * org.hisp.dhis.tracker.domain.Enrollment fields, just with different
-         * case
-         * <p>
-         * example: org.hisp.dhis.tracker.domain.Enrollment.updatedAtClient -->
-         * UPDATED_AT_CLIENT
-         */
-        CREATED_AT( "created" ),
-        UPDATED_AT( "lastUpdated" );
-
-        @Getter
-        private final String entityName;
-
-    }
-
-    /**
-     * Dto to database field translator for old tracker Enrollment export
-     * controller
-     */
-    @RequiredArgsConstructor
-    private enum LegacyDtoToEntityFieldTranslator implements EntityNameSupplier
-    {
-        /**
-         * this enum names must be the same as
-         * org.hisp.dhis.dxf2.events.enrollment.Enrollment fields, just with
-         * different case
-         * <p>
-         * example: org.hisp.dhis.dxf2.events.enrollment.Enrollment.lastUpdated
-         * --> LAST_UPDATED
-         */
-        RELATIONSHIP( "uid" );
-
-        @Getter
-        private final String entityName;
-
-    }
-
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipCriteria.java
@@ -132,10 +132,4 @@ class TrackerRelationshipCriteria extends PagingAndSortingCriteriaAdapter
         }
         return this.identifierClass;
     }
-
-    @Override
-    public boolean isLegacy()
-    {
-        return false;
-    }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteria.java
@@ -186,10 +186,4 @@ class TrackerTrackedEntityCriteria extends PagingAndSortingCriteriaAdapter
      * is a potentialDuplicate or not
      */
     private Boolean potentialDuplicate;
-
-    @Override
-    public boolean isLegacy()
-    {
-        return false;
-    }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteria.java
@@ -162,7 +162,7 @@ class TrackerTrackedEntityCriteria extends PagingAndSortingCriteriaAdapter
     private Date eventOccurredBefore;
 
     /**
-     * Indicates whether not to include meta data in the response.
+     * Indicates whether not to include metadata in the response.
      */
     private boolean skipMeta;
 


### PR DESCRIPTION
We do not need to translate between old and new tracker field names anymore. This was needed when the criteria classes were used in old and new tracker. Old and new tracker now have their own criteria classes representing the request parameters and their own services.

If I understood correctly https://github.com/dhis2/dhis2-core/blob/a3457cc8b5552584caf3e0c4e917e1c83e6898da/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingAndSortingCriteriaAdapter.java#L83-L88 `isLegacy` can be removed.
 