### PR TITLE
feat: job next execution time as computed property [DHIS2-14902]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.scheduling.JobStatus.DISABLED;
 import static org.hisp.dhis.scheduling.JobStatus.SCHEDULED;
 import static org.hisp.dhis.schema.annotation.Property.Value.FALSE;
 
+import java.time.Clock;
 import java.util.Date;
 
 import javax.annotation.Nonnull;
@@ -120,7 +121,7 @@ public class JobConfiguration extends BaseIdentifiableObject implements Secondar
 
     private JobStatus jobStatus;
 
-    private Date nextExecutionTime;
+    private transient Date nextExecutionTime;
 
     private JobStatus lastExecutedStatus = JobStatus.NOT_STARTED;
 
@@ -298,6 +299,7 @@ public class JobConfiguration extends BaseIdentifiableObject implements Secondar
     public void setCronExpression( String cronExpression )
     {
         this.cronExpression = cronExpression;
+        this.nextExecutionTime = null; // invalidate
     }
 
     @JacksonXmlProperty
@@ -380,27 +382,22 @@ public class JobConfiguration extends BaseIdentifiableObject implements Secondar
     @JsonProperty( access = JsonProperty.Access.READ_ONLY )
     public Date getNextExecutionTime()
     {
-        return nextExecutionTime;
+        return nextExecutionTimeAfter( Clock.systemDefaultZone() );
     }
 
-    /**
-     * Only set next execution time if the job is not continuous.
-     */
-    public void setNextExecutionTime( Date nextExecutionTime )
+    public Date nextExecutionTimeAfter( Clock time )
     {
-        if ( cronExpression == null || cronExpression.equals( "" ) || cronExpression.equals( "* * * * * ?" ) )
+        if ( time == null || cronExpression == null || cronExpression.equals( "" )
+            || cronExpression.equals( "* * * * * ?" ) )
         {
-            return;
+            return null;
         }
-
-        if ( nextExecutionTime != null )
+        if ( nextExecutionTime == null || !nextExecutionTime.toInstant().isAfter( time.instant() ) )
         {
-            this.nextExecutionTime = nextExecutionTime;
+            this.nextExecutionTime = new CronTrigger( cronExpression )
+                .nextExecutionTime( new SimpleTriggerContext( time ) );
         }
-        else
-        {
-            this.nextExecutionTime = new CronTrigger( cronExpression ).nextExecutionTime( new SimpleTriggerContext() );
-        }
+        return nextExecutionTime;
     }
 
     @JacksonXmlProperty

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobConfigurationSerializationTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobConfigurationSerializationTest.java
@@ -31,7 +31,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -69,7 +68,6 @@ class JobConfigurationSerializationTest
                 + "      \"jobStatus\": \"SCHEDULED\",\n" + "      \"displayName\": \"Test Analytic\",\n"
                 + "      \"enabled\": true,\n" + "      \"leaderOnlyJob\": true,\n"
                 + "      \"externalAccess\": false,\n" + "      \"jobType\": \"ANALYTICS_TABLE\",\n"
-                + "      \"nextExecutionTime\": \"2019-03-27T02:00:00.000\",\n"
                 + "      \"cronExpression\": \"0 0 12 ? * MON-FRI\",\n"
                 + "      \"lastRuntimeExecution\": \"00:00:00.060\",\n"
                 + "      \"lastExecutedStatus\": \"COMPLETED\",\n"
@@ -89,7 +87,6 @@ class JobConfigurationSerializationTest
         assertTrue( jc.isEnabled() );
         assertTrue( jc.isLeaderOnlyJob() );
         assertEquals( JobType.ANALYTICS_TABLE, jc.getJobType() );
-        assertNull( jc.getNextExecutionTime() );
         assertEquals( "0 0 12 ? * MON-FRI", jc.getCronExpression() );
         assertNotNull( jc.getJobParameters() );
         assertEquals( (Integer) 2, ((AnalyticsJobParameters) jc.getJobParameters()).getLastYears() );
@@ -115,7 +112,6 @@ class JobConfigurationSerializationTest
                 + "      \"jobStatus\": \"SCHEDULED\",\n" + "      \"displayName\": \"Test Analytic\",\n"
                 + "      \"enabled\": false,\n" + "      \"leaderOnlyJob\": true,\n"
                 + "      \"externalAccess\": false,\n" + "      \"jobType\": \"ANALYTICS_TABLE\",\n"
-                + "      \"nextExecutionTime\": \"2019-03-27T02:00:00.000\",\n"
                 + "      \"cronExpression\": \"0 0 12 ? * MON-FRI\",\n"
                 + "      \"lastRuntimeExecution\": \"00:00:00.060\",\n"
                 + "      \"lastExecutedStatus\": \"COMPLETED\",\n"
@@ -135,7 +131,6 @@ class JobConfigurationSerializationTest
         assertFalse( jc.isEnabled() );
         assertTrue( jc.isLeaderOnlyJob() );
         assertEquals( JobType.ANALYTICS_TABLE, jc.getJobType() );
-        assertNull( jc.getNextExecutionTime() );
         assertEquals( "0 0 12 ? * MON-FRI", jc.getCronExpression() );
         assertNotNull( jc.getJobParameters() );
         assertEquals( (Integer) 2, ((AnalyticsJobParameters) jc.getJobParameters()).getLastYears() );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
@@ -382,7 +382,6 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
             log.debug( "Job executed successfully: '{}'. Time used: '{}'", configuration.getName(), duration );
         }
         configuration.setJobStatus( JobStatus.SCHEDULED );
-        configuration.setNextExecutionTime( null );
         configuration.setLastExecuted( new Date( clock.getStartTime() ) );
         configuration.setLastRuntimeExecution( duration );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/scheduling/hibernate/JobConfiguration.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/scheduling/hibernate/JobConfiguration.hbm.xml
@@ -52,8 +52,6 @@
 
         <property name="lastRuntimeExecution" type="text" />
 
-        <property name="nextExecutionTime" type="timestamp" />
-
         <property name="enabled" not-null="true" type="boolean" />
 
         <property name="leaderOnlyJob" not-null="true" type="boolean">

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
@@ -85,7 +85,6 @@ public class JobConfigurationObjectBundleHook
         List<ErrorReport> errorReports = box[0];
         if ( errorReports == null || errorReports.isEmpty() )
         {
-            jobConfiguration.setNextExecutionTime( null );
             log.info( "Validation succeeded for job configuration: '{}'", jobConfiguration.getName() );
         }
         else

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_5__Remove_nextexecutiontime_column_from_jobconfiguration.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_5__Remove_nextexecutiontime_column_from_jobconfiguration.sql
@@ -1,0 +1,1 @@
+alter table jobconfiguration drop column if exists nextexecutiontime;


### PR DESCRIPTION
### Summary
Makes the `nextExecutionTime` property of `JobConfiguration` to be computed on the fly instead of being persisted in database. 

This means the next execution time does not need to be maintained when the job status changes due to execution. It always is a time relative to current time. This makes sure the next execution time is always the next future execution even if the job did not run when it should have and no status changes had occured.

To still detect if an execution was missed on startup the `lastExecuted` time is used as basis. With "now" stubbed to 1 second after the last execution start time the next time after that is computed. If that is not a future time compared to the actual "now" at least one execution was missed in the meantime. 

### Manual Testing
* open scheduler app and check next execution time shown makes sense
* check the API itself, e.g. `/api/jobConfigurations?fields=id,name,nextExecutionTime`