### PR TITLE
fix: Check codes of option set instead of names [DHIS2-14190]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/executor/event/AssignDataValueExecutor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/executor/event/AssignDataValueExecutor.java
@@ -86,7 +86,7 @@ public class AssignDataValueExecutor implements RuleActionExecutor<Event>
             .orElse( null );
 
         // Hopefully we will be able to remove this special case once rule engine will support optionSets
-        if ( dataElement.isOptionSetValue() && !dataElement.getOptionSet().getOptionValues().contains( value ) )
+        if ( dataElement.isOptionSetValue() && !dataElement.getOptionSet().getOptionCodes().contains( value ) )
         {
             return assignInvalidOptionDataElement( payloadDataValue, canOverwrite, event );
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/executor/event/AssignDataValueExecutorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/executor/event/AssignDataValueExecutorTest.java
@@ -128,9 +128,9 @@ class AssignDataValueExecutorTest extends DhisConvenienceTest
         optionSetDataElement = createDataElement( 'P' );
         optionSetDataElement.setUid( OPTION_SET_DATA_ELEMENT_ID );
         OptionSet optionSet = new OptionSet();
-        Option option = new Option( "10", "10" );
+        Option option = new Option( "ten", "10" );
         optionSet.setOptions( List.of( option ) );
-        optionSet.setValueType( ValueType.NUMBER );
+        optionSet.setValueType( ValueType.TEXT );
         optionSetDataElement.setOptionSet( optionSet );
         ProgramStageDataElement programStageDataElementOptionSet = createProgramStageDataElement( secondProgramStage,
             optionSetDataElement, 0 );
@@ -165,6 +165,27 @@ class AssignDataValueExecutorTest extends DhisConvenienceTest
         Optional<DataValue> dataValue = findDataValueByUid( bundle, EVENT_ID, OPTION_SET_DATA_ELEMENT_ID );
 
         assertDataValueWasNotAssignedAndErrorIsPresent( VALID_OPTION_VALUE, dataValue, warning );
+    }
+
+    @Test
+    void shouldAssignDataValueWhenAssignedValueIsValidOptionAndDataValueIsEmpty()
+    {
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
+        Event eventWithOptionDataValue = getEventWithOptionSetDataValueWithValidValue();
+        List<Event> events = List.of( eventWithOptionDataValue );
+        bundle.setEvents( events );
+
+        AssignDataValueExecutor executor = new AssignDataValueExecutor( systemSettingManager,
+            "", VALID_OPTION_VALUE, OPTION_SET_DATA_ELEMENT_ID, eventWithOptionDataValue.getDataValues() );
+
+        Optional<ProgramRuleIssue> warning = executor.executeRuleAction( bundle, eventWithOptionDataValue );
+
+        Optional<DataValue> dataValue = findDataValueByUid( bundle, EVENT_ID, OPTION_SET_DATA_ELEMENT_ID );
+
+        assertTrue( dataValue.isPresent() );
+        assertEquals( VALID_OPTION_VALUE, dataValue.get().getValue() );
+        assertTrue( warning.isPresent() );
+        assertEquals( WARNING, warning.get().getIssueType() );
     }
 
     @Test


### PR DESCRIPTION
When a program rule was trying to assign a value to a data element with an option set and the option has different code and name, it was failing to do so as we were comparing options on names instead of codes