### PR TITLE
chore: fix sonarqube linting issues in tracker web TECH-1514

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/ControllerSupport.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/ControllerSupport.java
@@ -27,7 +27,12 @@
  */
 package org.hisp.dhis.webapi.controller.tracker;
 
-public class TrackerControllerSupport
+public class ControllerSupport
 {
+    private ControllerSupport()
+    {
+        throw new IllegalStateException( "Utility class" );
+    }
+
     public static final String RESOURCE_PATH = "/tracker";
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/AttributeMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/AttributeMapper.java
@@ -45,5 +45,5 @@ public interface AttributeMapper
     @Mapping( target = "updatedAt", source = "lastUpdated" )
     @Mapping( target = "valueType", source = "attribute.valueType" )
     @Override
-    Attribute from( org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue attribute );
+    Attribute from( TrackedEntityAttributeValue attribute );
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/DataValueMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/DataValueMapper.java
@@ -43,5 +43,5 @@ public interface DataValueMapper extends ViewMapper<EventDataValue, DataValue>
     @Mapping( target = "createdBy", source = "createdByUserInfo" )
     @Mapping( target = "updatedBy", source = "lastUpdatedByUserInfo" )
     @Override
-    DataValue from( org.hisp.dhis.eventdatavalue.EventDataValue dataValue );
+    DataValue from( EventDataValue dataValue );
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/NoteMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/NoteMapper.java
@@ -43,5 +43,5 @@ public interface NoteMapper extends ViewMapper<TrackedEntityComment, Note>
     @Mapping( target = "createdBy", source = "lastUpdatedBy" )
     @Mapping( target = "storedBy", source = "creator" )
     @Override
-    Note from( org.hisp.dhis.trackedentitycomment.TrackedEntityComment comment );
+    Note from( TrackedEntityComment comment );
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/ProgramOwnerMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/ProgramOwnerMapper.java
@@ -41,5 +41,5 @@ public interface ProgramOwnerMapper
     @Mapping( target = "trackedEntity", source = "entityInstance.uid" )
     @Mapping( target = "program", source = "program.uid" )
     @Override
-    ProgramOwner from( org.hisp.dhis.trackedentity.TrackedEntityProgramOwner trackedEntityProgramOwner );
+    ProgramOwner from( TrackedEntityProgramOwner trackedEntityProgramOwner );
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/UserMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/UserMapper.java
@@ -35,5 +35,6 @@ import org.mapstruct.Mapper;
 @Mapper
 public interface UserMapper extends ViewMapper<UserInfoSnapshot, User>
 {
+    @Override
     User from( UserInfoSnapshot user );
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentMapper.java
@@ -27,19 +27,13 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.enrollment;
 
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.program.ProgramInstance;
-import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.webapi.controller.tracker.export.AttributeMapper;
-import org.hisp.dhis.webapi.controller.tracker.export.DataValueMapper;
 import org.hisp.dhis.webapi.controller.tracker.export.NoteMapper;
 import org.hisp.dhis.webapi.controller.tracker.export.UserMapper;
+import org.hisp.dhis.webapi.controller.tracker.export.event.EventMapper;
 import org.hisp.dhis.webapi.controller.tracker.export.relationship.RelationshipMapper;
 import org.hisp.dhis.webapi.controller.tracker.view.Enrollment;
-import org.hisp.dhis.webapi.controller.tracker.view.Event;
 import org.hisp.dhis.webapi.controller.tracker.view.InstantMapper;
 import org.hisp.dhis.webapi.controller.tracker.view.ViewMapper;
 import org.mapstruct.Mapper;
@@ -47,11 +41,12 @@ import org.mapstruct.Mapping;
 
 @Mapper( uses = {
     AttributeMapper.class,
-    DataValueMapper.class,
+    EventMapper.class,
     InstantMapper.class,
     NoteMapper.class,
     RelationshipMapper.class,
-    UserMapper.class } )
+    UserMapper.class
+} )
 public interface EnrollmentMapper extends ViewMapper<ProgramInstance, Enrollment>
 {
     @Mapping( target = "enrollment", source = "uid" )
@@ -75,42 +70,4 @@ public interface EnrollmentMapper extends ViewMapper<ProgramInstance, Enrollment
     @Mapping( target = "notes", source = "comments" )
     @Override
     Enrollment from( ProgramInstance programInstance );
-
-    @Mapping( target = "event", source = "uid" )
-    @Mapping( target = "program", source = "programInstance.program.uid" )
-    @Mapping( target = "programStage", source = "programStage.uid" )
-    @Mapping( target = "enrollment", source = "programInstance.uid" )
-    @Mapping( target = "trackedEntity", source = "programInstance.entityInstance.uid" )
-    @Mapping( target = "orgUnit", source = "organisationUnit.uid" )
-    @Mapping( target = "orgUnitName", source = "organisationUnit.name" )
-    @Mapping( target = "occurredAt", source = "executionDate" )
-    @Mapping( target = "scheduledAt", source = "dueDate" )
-    @Mapping( target = "followup", source = "programInstance.followup" )
-    @Mapping( target = "createdAt", source = "created" )
-    @Mapping( target = "createdAtClient", source = "createdAtClient" )
-    @Mapping( target = "updatedAt", source = "lastUpdated" )
-    @Mapping( target = "updatedAtClient", source = "lastUpdatedAtClient" )
-    @Mapping( target = "attributeOptionCombo", source = "attributeOptionCombo.uid" )
-    @Mapping( target = "attributeCategoryOptions", source = "attributeOptionCombo.categoryOptions" )
-    @Mapping( target = "completedAt", source = "completedDate" )
-    @Mapping( target = "createdBy", source = "createdByUserInfo" )
-    @Mapping( target = "updatedBy", source = "lastUpdatedByUserInfo" )
-    @Mapping( target = "relationships", source = "relationshipItems" )
-    @Mapping( target = "dataValues", source = "eventDataValues" )
-    @Mapping( target = "notes", source = "comments" )
-    Event from( ProgramStageInstance event );
-
-    // NOTE: right now we only support categoryOptionComboIdScheme on export. If we were to add a categoryOptionIdScheme
-    // we could not simply export the UIDs.
-    default String from( Set<CategoryOption> categoryOptions )
-    {
-        if ( categoryOptions == null || categoryOptions.isEmpty() )
-        {
-            return "";
-        }
-
-        return categoryOptions.stream()
-            .map( CategoryOption::getUid )
-            .collect( Collectors.joining( ";" ) );
-    }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentMapper.java
@@ -76,24 +76,6 @@ public interface EnrollmentMapper extends ViewMapper<ProgramInstance, Enrollment
     @Override
     Enrollment from( ProgramInstance programInstance );
 
-    /**
-     * Maps {@link ProgramInstance#getRelationshipItems()} to
-     * {@link org.hisp.dhis.relationship.Relationship} which is then mapped by
-     * {@link RelationshipMapper}.
-     *
-     */
-    default Set<org.hisp.dhis.relationship.Relationship> map(
-        Set<org.hisp.dhis.relationship.RelationshipItem> relationshipItems )
-    {
-        if ( relationshipItems == null )
-        {
-            return Set.of();
-        }
-
-        return relationshipItems.stream().map( org.hisp.dhis.relationship.RelationshipItem::getRelationship )
-            .collect( Collectors.toSet() );
-    }
-
     @Mapping( target = "event", source = "uid" )
     @Mapping( target = "program", source = "programInstance.program.uid" )
     @Mapping( target = "programStage", source = "programStage.uid" )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentMapper.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.program.ProgramInstance;
+import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.webapi.controller.tracker.export.AttributeMapper;
 import org.hisp.dhis.webapi.controller.tracker.export.DataValueMapper;
 import org.hisp.dhis.webapi.controller.tracker.export.NoteMapper;
@@ -115,7 +116,7 @@ public interface EnrollmentMapper extends ViewMapper<ProgramInstance, Enrollment
     @Mapping( target = "relationships", source = "relationshipItems" )
     @Mapping( target = "dataValues", source = "eventDataValues" )
     @Mapping( target = "notes", source = "comments" )
-    Event from( org.hisp.dhis.program.ProgramStageInstance event );
+    Event from( ProgramStageInstance event );
 
     // NOTE: right now we only support categoryOptionComboIdScheme on export. If we were to add a categoryOptionIdScheme
     // we could not simply export the UIDs.

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
@@ -33,7 +33,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 
@@ -118,7 +117,7 @@ public class EnrollmentsExportController
                 TextUtils.SEMICOLON );
             enrollmentList = enrollmentIds != null
                 ? enrollmentIds.stream().map( e -> enrollmentService.getEnrollment( e, enrollmentParams ) )
-                    .collect( Collectors.toList() )
+                    .toList()
                 : Collections.emptyList();
         }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.enrollment;
 
-import static org.hisp.dhis.webapi.controller.tracker.TrackerControllerSupport.RESOURCE_PATH;
+import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.RESOURCE_PATH;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.Collections;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/CategoryOptionMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/CategoryOptionMapper.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.export.event;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.hisp.dhis.category.CategoryOption;
+import org.mapstruct.Mapper;
+
+@Mapper
+public interface CategoryOptionMapper
+{
+
+    // NOTE: right now we only support categoryOptionComboIdScheme on export. If we were to add a categoryOptionIdScheme
+    // we could not simply export the UIDs.
+    default String from( Set<CategoryOption> categoryOptions )
+    {
+        if ( categoryOptions == null || categoryOptions.isEmpty() )
+        {
+            return null;
+        }
+
+        return categoryOptions.stream()
+            .map( CategoryOption::getUid )
+            .collect( Collectors.joining( ";" ) );
+    }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventCriteriaMapper.java
@@ -284,7 +284,7 @@ class EventCriteriaMapper
         List<QueryItem> filterItems = parseAttributeQueryItems( filterAttributes, attributes );
         List<QueryItem> orderItems = attributeQueryItemsFromOrder( filterItems, attributes, attributeOrderParams );
 
-        return Stream.concat( filterItems.stream(), orderItems.stream() ).collect( Collectors.toList() );
+        return Stream.concat( filterItems.stream(), orderItems.stream() ).toList();
     }
 
     private List<QueryItem> attributeQueryItemsFromOrder( List<QueryItem> filterAttributes,
@@ -295,7 +295,7 @@ class EventCriteriaMapper
             .filter( att -> !containsAttributeFilter( filterAttributes, att ) )
             .map( attributes::get )
             .map( at -> new QueryItem( at, null, at.getValueType(), at.getAggregationType(), at.getOptionSet() ) )
-            .collect( Collectors.toList() );
+            .toList();
     }
 
     private boolean containsAttributeFilter( List<QueryItem> attributeFilters, String attributeUid )
@@ -416,6 +416,6 @@ class EventCriteriaMapper
     {
         return orders.entrySet().stream()
             .map( e -> new OrderParam( e.getKey(), e.getValue() ) )
-            .collect( Collectors.toList() );
+            .toList();
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventMapper.java
@@ -31,7 +31,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.hisp.dhis.category.CategoryOption;
-import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.webapi.controller.tracker.export.DataValueMapper;
 import org.hisp.dhis.webapi.controller.tracker.export.NoteMapper;
@@ -74,24 +73,6 @@ interface EventMapper extends ViewMapper<ProgramStageInstance, Event>
     @Mapping( target = "relationships", source = "relationshipItems" )
     @Mapping( target = "notes", source = "comments" )
     Event from( ProgramStageInstance event );
-
-    /**
-     * Maps {@link ProgramInstance#getRelationshipItems()} to
-     * {@link org.hisp.dhis.relationship.Relationship} which is then mapped by
-     * {@link RelationshipMapper}.
-     *
-     */
-    default Set<org.hisp.dhis.relationship.Relationship> map(
-        Set<org.hisp.dhis.relationship.RelationshipItem> relationshipItems )
-    {
-        if ( relationshipItems == null )
-        {
-            return Set.of();
-        }
-
-        return relationshipItems.stream().map( org.hisp.dhis.relationship.RelationshipItem::getRelationship )
-            .collect( Collectors.toSet() );
-    }
 
     // NOTE: right now we only support categoryOptionComboIdScheme on export. If we were to add a categoryOptionIdScheme
     // we could not simply export the UIDs.

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventMapper.java
@@ -27,10 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.event;
 
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.webapi.controller.tracker.export.DataValueMapper;
 import org.hisp.dhis.webapi.controller.tracker.export.NoteMapper;
@@ -44,6 +40,7 @@ import org.mapstruct.Mapping;
 
 @Mapper( uses = {
     DataValueMapper.class,
+    CategoryOptionMapper.class,
     InstantMapper.class,
     NoteMapper.class,
     RelationshipMapper.class,
@@ -73,18 +70,4 @@ public interface EventMapper extends ViewMapper<ProgramStageInstance, Event>
     @Mapping( target = "relationships", source = "relationshipItems" )
     @Mapping( target = "notes", source = "comments" )
     Event from( ProgramStageInstance event );
-
-    // NOTE: right now we only support categoryOptionComboIdScheme on export. If we were to add a categoryOptionIdScheme
-    // we could not simply export the UIDs.
-    default String from( Set<CategoryOption> categoryOptions )
-    {
-        if ( categoryOptions == null || categoryOptions.isEmpty() )
-        {
-            return "";
-        }
-
-        return categoryOptions.stream()
-            .map( CategoryOption::getUid )
-            .collect( Collectors.joining( ";" ) );
-    }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventMapper.java
@@ -43,12 +43,12 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper( uses = {
-    InstantMapper.class,
     DataValueMapper.class,
+    InstantMapper.class,
     NoteMapper.class,
     RelationshipMapper.class,
     UserMapper.class } )
-interface EventMapper extends ViewMapper<ProgramStageInstance, Event>
+public interface EventMapper extends ViewMapper<ProgramStageInstance, Event>
 {
     @Mapping( target = "event", source = "uid" )
     @Mapping( target = "program", source = "programInstance.program.uid" )
@@ -80,7 +80,7 @@ interface EventMapper extends ViewMapper<ProgramStageInstance, Event>
     {
         if ( categoryOptions == null || categoryOptions.isEmpty() )
         {
-            return null;
+            return "";
         }
 
         return categoryOptions.stream()

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.event;
 
-import static org.hisp.dhis.webapi.controller.tracker.TrackerControllerSupport.RESOURCE_PATH;
+import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.RESOURCE_PATH;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_CSV;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_CSV_GZIP;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_TEXT_CSV;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipItemMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipItemMapper.java
@@ -27,16 +27,13 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.relationship;
 
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.webapi.controller.tracker.export.AttributeMapper;
 import org.hisp.dhis.webapi.controller.tracker.export.DataValueMapper;
 import org.hisp.dhis.webapi.controller.tracker.export.NoteMapper;
 import org.hisp.dhis.webapi.controller.tracker.export.ProgramOwnerMapper;
 import org.hisp.dhis.webapi.controller.tracker.export.UserMapper;
+import org.hisp.dhis.webapi.controller.tracker.export.event.CategoryOptionMapper;
 import org.hisp.dhis.webapi.controller.tracker.view.EnrollmentStatus;
 import org.hisp.dhis.webapi.controller.tracker.view.InstantMapper;
 import org.hisp.dhis.webapi.controller.tracker.view.RelationshipItem;
@@ -47,6 +44,7 @@ import org.mapstruct.Mapping;
 
 @Mapper( uses = {
     AttributeMapper.class,
+    CategoryOptionMapper.class,
     DataValueMapper.class,
     InstantMapper.class,
     NoteMapper.class,
@@ -124,18 +122,4 @@ interface RelationshipItemMapper
 
     @Mapping( target = "displayName", source = "name" )
     User from( org.hisp.dhis.user.User user );
-
-    // NOTE: right now we only support categoryOptionComboIdScheme on export. If we were to add a categoryOptionIdScheme
-    // we could not simply export the UIDs.
-    default String from( Set<CategoryOption> categoryOptions )
-    {
-        if ( categoryOptions == null || categoryOptions.isEmpty() )
-        {
-            return "";
-        }
-
-        return categoryOptions.stream()
-            .map( CategoryOption::getUid )
-            .collect( Collectors.joining( ";" ) );
-    }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipMapper.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.relationship;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.hisp.dhis.webapi.controller.tracker.view.InstantMapper;
 import org.hisp.dhis.webapi.controller.tracker.view.Relationship;
 import org.hisp.dhis.webapi.controller.tracker.view.ViewMapper;
@@ -47,4 +50,23 @@ public interface RelationshipMapper
     @Mapping( target = "updatedAt", source = "lastUpdated" )
     @Override
     Relationship from( org.hisp.dhis.relationship.Relationship relationship );
+
+    /**
+     * Maps {@code Set}'s of
+     * {@link org.hisp.dhis.relationship.RelationshipItem}'s to
+     * {@link org.hisp.dhis.relationship.Relationship} which is then mapped by
+     * {@link #from(org.hisp.dhis.relationship.Relationship)}.
+     *
+     */
+    default Set<org.hisp.dhis.relationship.Relationship> map(
+        Set<org.hisp.dhis.relationship.RelationshipItem> relationshipItems )
+    {
+        if ( relationshipItems == null )
+        {
+            return Set.of();
+        }
+
+        return relationshipItems.stream().map( org.hisp.dhis.relationship.RelationshipItem::getRelationship )
+            .collect( Collectors.toSet() );
+    }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.relationship;
 
-import static org.hisp.dhis.webapi.controller.tracker.TrackerControllerSupport.RESOURCE_PATH;
+import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.RESOURCE_PATH;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.List;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
@@ -193,11 +193,6 @@ public class RelationshipsExportController
         throws NotFoundException,
         ForbiddenException
     {
-        if ( identifier == null )
-        {
-            return null;
-        }
-
         Object object = getObjectRetriever( type ).apply( identifier );
         if ( object == null )
         {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.trackedentity;
 
-import static org.hisp.dhis.webapi.controller.tracker.TrackerControllerSupport.RESOURCE_PATH;
+import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.RESOURCE_PATH;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_CSV;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_CSV_GZIP;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_CSV_ZIP;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityCriteriaMapper.java
@@ -188,10 +188,10 @@ public class TrackedEntityCriteriaMapper
             List<String> errorMessages = new ArrayList<>();
             for ( DimensionalItemObject duplicatedAttribute : duplicatedAttributes )
             {
-                List<String> duplicateDFilters = getDuplicateDFilters( attributeItems, duplicatedAttribute );
+                List<String> duplicatedFilters = getDuplicatedFilters( attributeItems, duplicatedAttribute );
                 String message = MessageFormat.format( "Filter for attribute {0} was specified more than once. " +
                     "Try to define a single filter with multiple operators [{0}:{1}]",
-                    duplicatedAttribute.getUid(), StringUtils.join( duplicateDFilters, ':' ) );
+                    duplicatedAttribute.getUid(), StringUtils.join( duplicatedFilters, ':' ) );
                 errorMessages.add( message );
             }
 
@@ -199,14 +199,14 @@ public class TrackedEntityCriteriaMapper
         }
     }
 
-    private List<String> getDuplicateDFilters( List<QueryItem> attributeItems,
+    private List<String> getDuplicatedFilters( List<QueryItem> attributeItems,
         DimensionalItemObject duplicatedAttribute )
     {
         return attributeItems.stream()
             .filter( q -> Objects.equals( q.getItem(), duplicatedAttribute ) )
             .flatMap( q -> q.getFilters().stream() )
             .map( f -> f.getOperator() + ":" + f.getFilter() )
-            .collect( Collectors.toList() );
+            .toList();
     }
 
     private Set<DimensionalItemObject> getDuplicatedAttributes( List<QueryItem> attributeItems )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityMapper.java
@@ -40,11 +40,11 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper( uses = {
-    RelationshipMapper.class,
     AttributeMapper.class,
     EnrollmentMapper.class,
-    ProgramOwnerMapper.class,
     InstantMapper.class,
+    ProgramOwnerMapper.class,
+    RelationshipMapper.class,
     UserMapper.class } )
 interface TrackedEntityMapper extends ViewMapper<TrackedEntityInstance, TrackedEntity>
 {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityMapper.java
@@ -61,5 +61,5 @@ interface TrackedEntityMapper extends ViewMapper<TrackedEntityInstance, TrackedE
     @Mapping( target = "attributes", source = "trackedEntityAttributeValues" )
     @Mapping( target = "enrollments", source = "programInstances" )
     @Override
-    TrackedEntity from( org.hisp.dhis.trackedentity.TrackedEntityInstance trackedEntityInstance );
+    TrackedEntity from( TrackedEntityInstance trackedEntityInstance );
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/DomainMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/DomainMapper.java
@@ -35,11 +35,11 @@ import java.util.stream.Collectors;
 
 import org.hisp.dhis.tracker.imports.TrackerIdSchemeParams;
 
-public interface DomainMapper<FROM, TO>
+public interface DomainMapper<T, R>
 {
-    TO from( FROM from, TrackerIdSchemeParams idSchemeParams );
+    R from( T from, TrackerIdSchemeParams idSchemeParams );
 
-    default List<TO> fromCollection( Collection<FROM> froms, TrackerIdSchemeParams idSchemeParams )
+    default List<R> fromCollection( Collection<T> froms, TrackerIdSchemeParams idSchemeParams )
     {
         return Optional.ofNullable( froms )
             .orElse( Collections.emptySet() )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.webapi.controller.tracker.imports;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
-import static org.hisp.dhis.webapi.controller.tracker.TrackerControllerSupport.RESOURCE_PATH;
+import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.RESOURCE_PATH;
 import static org.hisp.dhis.webapi.utils.ContextUtils.setNoStore;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/InstantMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/InstantMapper.java
@@ -47,9 +47,9 @@ public interface InstantMapper
 
     default Instant fromDate( Date date )
     {
-        if ( date instanceof java.sql.Date )
+        if ( date instanceof java.sql.Date sqlDate )
         {
-            return fromSqlDate( (java.sql.Date) date );
+            return fromSqlDate( sqlDate );
         }
         return DateUtils.instantFromDate( date );
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/ViewMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/ViewMapper.java
@@ -33,11 +33,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-public interface ViewMapper<FROM, TO>
+public interface ViewMapper<T, R>
 {
-    TO from( FROM from );
+    R from( T from );
 
-    default List<TO> fromCollection( Collection<FROM> froms )
+    default List<R> fromCollection( Collection<T> froms )
     {
         return Optional.ofNullable( froms )
             .orElse( Collections.emptySet() )

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
@@ -62,7 +62,7 @@ import org.hisp.dhis.tracker.imports.report.Status;
 import org.hisp.dhis.tracker.imports.report.TimingsStats;
 import org.hisp.dhis.tracker.imports.report.ValidationReport;
 import org.hisp.dhis.webapi.controller.CrudControllerAdvice;
-import org.hisp.dhis.webapi.controller.tracker.TrackerControllerSupport;
+import org.hisp.dhis.webapi.controller.tracker.ControllerSupport;
 import org.hisp.dhis.webapi.controller.tracker.export.CsvService;
 import org.hisp.dhis.webapi.controller.tracker.view.Event;
 import org.junit.jupiter.api.BeforeEach;
@@ -81,7 +81,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 class TrackerImportControllerTest
 {
 
-    private final static String ENDPOINT = TrackerControllerSupport.RESOURCE_PATH;
+    private final static String ENDPOINT = ControllerSupport.RESOURCE_PATH;
 
     private MockMvc mockMvc;
 


### PR DESCRIPTION
* remove unreachable code in `RelationshipsExportController`. As `RelationshipCriteria.getIdentifierParam()` throws a BadRequestException
if the identifier is blank
* remove unnecessary qualifiers in mappers as we have imports for these classes
* use `stream().toList()` which returns an unmodifiable list instead of a modifiable as does `.collect(Collectors.toList())` https://sonarcloud.io/project/issues?open=AYeQ5r9JQL2WH7zBGnAE&id=dhis2_dhis2-core
* use instanceof pattern matching
* use generic paramter like in java.util.Function `T, R`
* reuse mapper for `Set<RelationshipItem>` and `CategoryOptions`
