### PR TITLE
fix: quote strings that would be YAML aliases during OpenAPI generation

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/JsonGenerator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/JsonGenerator.java
@@ -371,7 +371,8 @@ public class JsonGenerator
         if ( Character.isDigit( unescaped.charAt( 0 ) )
             || "true".equals( unescaped )
             || "false".equals( unescaped )
-            || unescaped.contains( "#" ) )
+            || unescaped.contains( "#" )
+            || unescaped.startsWith( "*" ) )
             return "\"" + unescaped + "\"";
         return unescaped;
     }


### PR DESCRIPTION
YAML has a feature called alias where any string value starting with a `*` is considered an alias. Therefore if this is the case we have to quote them so they are not missunderstood. 