### PR TITLE
feat: job next execution time as computed property [DHIS2-14902] (2.39)

### DIFF
--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobConfigurationSerializationTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobConfigurationSerializationTest.java
@@ -31,7 +31,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -69,7 +68,6 @@ class JobConfigurationSerializationTest
                 + "      \"jobStatus\": \"SCHEDULED\",\n" + "      \"displayName\": \"Test Analytic\",\n"
                 + "      \"enabled\": true,\n" + "      \"leaderOnlyJob\": true,\n"
                 + "      \"externalAccess\": false,\n" + "      \"jobType\": \"ANALYTICS_TABLE\",\n"
-                + "      \"nextExecutionTime\": \"2019-03-27T02:00:00.000\",\n"
                 + "      \"cronExpression\": \"0 0 12 ? * MON-FRI\",\n"
                 + "      \"lastRuntimeExecution\": \"00:00:00.060\",\n"
                 + "      \"lastExecutedStatus\": \"COMPLETED\",\n"
@@ -89,7 +87,6 @@ class JobConfigurationSerializationTest
         assertTrue( jc.isEnabled() );
         assertTrue( jc.isLeaderOnlyJob() );
         assertEquals( JobType.ANALYTICS_TABLE, jc.getJobType() );
-        assertNull( jc.getNextExecutionTime() );
         assertEquals( "0 0 12 ? * MON-FRI", jc.getCronExpression() );
         assertNotNull( jc.getJobParameters() );
         assertEquals( (Integer) 2, ((AnalyticsJobParameters) jc.getJobParameters()).getLastYears() );
@@ -115,7 +112,6 @@ class JobConfigurationSerializationTest
                 + "      \"jobStatus\": \"SCHEDULED\",\n" + "      \"displayName\": \"Test Analytic\",\n"
                 + "      \"enabled\": false,\n" + "      \"leaderOnlyJob\": true,\n"
                 + "      \"externalAccess\": false,\n" + "      \"jobType\": \"ANALYTICS_TABLE\",\n"
-                + "      \"nextExecutionTime\": \"2019-03-27T02:00:00.000\",\n"
                 + "      \"cronExpression\": \"0 0 12 ? * MON-FRI\",\n"
                 + "      \"lastRuntimeExecution\": \"00:00:00.060\",\n"
                 + "      \"lastExecutedStatus\": \"COMPLETED\",\n"
@@ -135,7 +131,6 @@ class JobConfigurationSerializationTest
         assertFalse( jc.isEnabled() );
         assertTrue( jc.isLeaderOnlyJob() );
         assertEquals( JobType.ANALYTICS_TABLE, jc.getJobType() );
-        assertNull( jc.getNextExecutionTime() );
         assertEquals( "0 0 12 ? * MON-FRI", jc.getCronExpression() );
         assertNotNull( jc.getJobParameters() );
         assertEquals( (Integer) 2, ((AnalyticsJobParameters) jc.getJobParameters()).getLastYears() );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
@@ -331,7 +331,6 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
             log.debug( "Job executed successfully: '{}'. Time used: '{}'", configuration.getName(), duration );
         }
         configuration.setJobStatus( JobStatus.SCHEDULED );
-        configuration.setNextExecutionTime( null );
         configuration.setLastExecuted( new Date( clock.getStartTime() ) );
         configuration.setLastRuntimeExecution( duration );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/SchedulerStart.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/SchedulerStart.java
@@ -29,11 +29,12 @@ package org.hisp.dhis.startup;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
-import static org.hisp.dhis.scheduling.JobStatus.FAILED;
 import static org.hisp.dhis.scheduling.JobStatus.SCHEDULED;
 import static org.hisp.dhis.scheduling.JobType.FILE_RESOURCE_CLEANUP;
 import static org.hisp.dhis.scheduling.JobType.REMOVE_USED_OR_EXPIRED_RESERVED_VALUES;
 
+import java.time.Clock;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -160,18 +161,20 @@ public class SchedulerStart extends AbstractStartupRoutine
         jobConfigurations.forEach( (jobConfig -> {
             if ( jobConfig.isEnabled() )
             {
-                Date oldExecutionTime = jobConfig.getNextExecutionTime();
-
-                jobConfig.setNextExecutionTime( null );
                 jobConfig.setJobStatus( SCHEDULED );
                 jobConfigurationService.updateJobConfiguration( jobConfig );
 
-                if ( jobConfig.getLastExecutedStatus() == FAILED
-                    || (oldExecutionTime != null && oldExecutionTime.compareTo( now ) < 0) )
+                Date lastExecuted = jobConfig.getLastExecuted();
+                if ( lastExecuted != null )
                 {
-                    unexecutedJobs.add( "\nJob [" + jobConfig.getUid() + ", " + jobConfig.getName()
-                        + "] has status failed or was scheduled in server downtime. Actual execution time was supposed to be: "
-                        + oldExecutionTime );
+                    Date expectedFutureExecutionTime = jobConfig.nextExecutionTimeAfter( Clock.fixed(
+                        lastExecuted.toInstant().plusSeconds( 1 ), ZoneId.systemDefault() ) );
+                    if ( expectedFutureExecutionTime.before( now ) )
+                    {
+                        unexecutedJobs.add( "\nJob [" + jobConfig.getUid() + ", " + jobConfig.getName()
+                            + "] has status failed or was scheduled in server downtime. Actual execution time was supposed to be: "
+                            + expectedFutureExecutionTime );
+                    }
                 }
 
                 schedulingManager.schedule( jobConfig );
@@ -180,15 +183,9 @@ public class SchedulerStart extends AbstractStartupRoutine
 
         if ( !unexecutedJobs.isEmpty() )
         {
-            StringBuilder jobs = new StringBuilder();
-
-            for ( String unexecutedJob : unexecutedJobs )
-            {
-                jobs.append( unexecutedJob ).append( "\n" );
-            }
-
-            messageService.sendSystemErrorNotification( "Scheduler startup",
-                new Exception( "Scheduler started with one or more unexecuted jobs:\n" + jobs ) );
+            String msg = "Scheduler started with one or more unexecuted jobs:\n" + String.join( "", unexecutedJobs );
+            messageService.sendSystemErrorNotification( "Scheduler startup", new Exception( msg ) );
+            log.warn( msg );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/scheduling/hibernate/JobConfiguration.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/scheduling/hibernate/JobConfiguration.hbm.xml
@@ -48,8 +48,6 @@
 
         <property name="lastRuntimeExecution" type="text" />
 
-        <property name="nextExecutionTime" type="timestamp" />
-
         <property name="enabled" not-null="true" type="boolean" />
 
         <property name="leaderOnlyJob" not-null="true" type="boolean">

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
@@ -85,7 +85,6 @@ public class JobConfigurationObjectBundleHook
         List<ErrorReport> errorReports = box[0];
         if ( errorReports == null || errorReports.isEmpty() )
         {
-            jobConfiguration.setNextExecutionTime( null );
             log.info( "Validation succeeded for job configuration: '{}'", jobConfiguration.getName() );
         }
         else

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_5__Remove_nextexecutiontime_column_from_jobconfiguration.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_5__Remove_nextexecutiontime_column_from_jobconfiguration.sql
@@ -1,0 +1,1 @@
+alter table jobconfiguration drop column if exists nextexecutiontime;

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_5__Remove_nextexecutiontime_column_from_jobconfiguration.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_5__Remove_nextexecutiontime_column_from_jobconfiguration.sql
@@ -1,1 +1,0 @@
-alter table jobconfiguration drop column if exists nextexecutiontime;


### PR DESCRIPTION
backport of #13627 where the flyway script is removed but other changes are kept. This means the column in the database will still exist but have no use.