### PR TITLE
fix: category option groups are consistently named categoryOptionGroups [BETA-52]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOption.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOption.java
@@ -303,8 +303,10 @@ public class CategoryOption
         this.categoryOptionCombos = categoryOptionCombos;
     }
 
-    @JsonProperty
+    @JsonProperty( "categoryOptionGroups" )
     @JsonSerialize( contentAs = BaseIdentifiableObject.class )
+    @JacksonXmlElementWrapper( localName = "categoryOptionGroups", namespace = DxfNamespaces.DXF_2_0 )
+    @JacksonXmlProperty( localName = "categoryOptionGroup", namespace = DxfNamespaces.DXF_2_0 )
     public Set<CategoryOptionGroup> getGroups()
     {
         return groups;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOption.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOption.java
@@ -305,8 +305,6 @@ public class CategoryOption
 
     @JsonProperty
     @JsonSerialize( contentAs = BaseIdentifiableObject.class )
-    @JacksonXmlElementWrapper( localName = "categoryOptionGroups", namespace = DxfNamespaces.DXF_2_0 )
-    @JacksonXmlProperty( localName = "categoryOptionGroup", namespace = DxfNamespaces.DXF_2_0 )
     public Set<CategoryOptionGroup> getGroups()
     {
         return groups;


### PR DESCRIPTION
The issue is caused by XML annotations considering the property to be named `categoryOptionGroups` while for Java and JSON it is just `groups`. During the schema building the XML annotations presence overrides the actual property name `groups` with `categoryOptionGroups`. This then causes a couple of issues one of which is that when the object is converted to JSON the JSON mapper is restricted to only map the explicitly listed properties. If that includes `categoryOptionGroups` it will always be empty since for Java and JSON the property is called `groups`.

To keep backwards compatibility the JSON name is also changed to `categoryOptionGroups`.