### PR TITLE
fix: completion lastUpdatedBy [TECH-1440]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/DefaultCompleteDataSetRegistrationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/DefaultCompleteDataSetRegistrationService.java
@@ -131,10 +131,7 @@ public class DefaultCompleteDataSetRegistrationService
     {
         registration.setLastUpdated( new Date() );
 
-        if ( !registration.hasLastUpdatedBy() )
-        {
-            registration.setLastUpdatedBy( currentUserService.getCurrentUsername() );
-        }
+        registration.setLastUpdatedBy( currentUserService.getCurrentUsername() );
 
         completeDataSetRegistrationStore.updateCompleteDataSetRegistration( registration );
     }


### PR DESCRIPTION
See [TECH-1440](https://dhis2.atlassian.net/jira/software/c/projects/TECH/issues/TECH-1440)

With the implementation of dataEntry/dataSetCompletion endpoint,`lastUpdatedBy` value for completion is not updated . That is, currently the user associated with the `lastUpdatedBy` remains the user who initially completed.

(The completeDataSetRegistrations endpoint updated the lastUpdatedBy user, and when we discussed a few months ago, we assumed the change was unintentional. We did not implement this due to other priorities, but I am revisiting because I did some other front end clean up for completions recently)

[TECH-1440]: https://dhis2.atlassian.net/browse/TECH-1440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ