### PR TITLE
chore: lombok version used in maven-delombok-plugin should be the same as code dependency

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -465,6 +465,13 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok-maven-plugin</artifactId>
             <version>${lombok-maven-plugin.version}</version>
+            <dependencies>
+              <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
+              </dependency>
+            </dependencies>
             <configuration>
               <addOutputDirectory>false</addOutputDirectory>
               <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>


### PR DESCRIPTION
The version of lombok, used in maven-delombok plugin, should be the same as the version we use in the code.
References:
https://github.com/projectlombok/lombok/issues/3087
http://anthonywhitford.com/lombok.maven/lombok-maven-plugin/faq.html#version-override