### PR TITLE
fix: category option groups are consistently named categoryOptionGroups [BETA-52] (2.39)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOption.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOption.java
@@ -301,7 +301,7 @@ public class CategoryOption
         this.categoryOptionCombos = categoryOptionCombos;
     }
 
-    @JsonProperty
+    @JsonProperty( "categoryOptionGroups" )
     @JsonSerialize( contentAs = BaseIdentifiableObject.class )
     @JacksonXmlElementWrapper( localName = "categoryOptionGroups", namespace = DxfNamespaces.DXF_2_0 )
     @JacksonXmlProperty( localName = "categoryOptionGroup", namespace = DxfNamespaces.DXF_2_0 )


### PR DESCRIPTION
backport of #13673