### PR TITLE
fix: user can only add lock exceptions for org units in their data capture set [DHIS2-13908] (2.39)

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/LockExceptionControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/LockExceptionControllerTest.java
@@ -65,6 +65,16 @@ class LockExceptionControllerTest extends DhisControllerConvenienceTest
     }
 
     @Test
+    void testAddLockException_UnauthorizedUser()
+    {
+        switchToNewUser( "guest", "F_DATASET_PUBLIC_ADD" );
+
+        assertWebMessage( "Forbidden", 403, "ERROR",
+            "You can only add a lock exceptions to your data capture organisation units.",
+            POST( "/lockExceptions/?ou={ou}&pe=2021-01&ds={ds}", ouId, dsId ).content( HttpStatus.FORBIDDEN ) );
+    }
+
+    @Test
     void testAddLockException_DataSetNotLinked()
     {
         String dsId2 = assertStatus( HttpStatus.CREATED,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LockExceptionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LockExceptionController.java
@@ -48,6 +48,7 @@ import org.hisp.dhis.dataset.LockException;
 import org.hisp.dhis.dataset.comparator.LockExceptionNameComparator;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
+import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.hibernate.exception.ReadAccessDeniedException;
@@ -117,6 +118,9 @@ public class LockExceptionController extends AbstractGistReadOnlyController<Lock
 
     @Autowired
     private I18nManager i18nManager;
+
+    @Autowired
+    private CurrentUserService currentUserService;
 
     // -------------------------------------------------------------------------
     // Resources
@@ -222,6 +226,7 @@ public class LockExceptionController extends AbstractGistReadOnlyController<Lock
     public WebMessage addLockException( @RequestParam( "ou" ) String organisationUnitId,
         @RequestParam( "pe" ) String pe,
         @RequestParam( "ds" ) String ds )
+        throws ForbiddenException
     {
         User user = userService.getCurrentUser();
 
@@ -236,7 +241,7 @@ public class LockExceptionController extends AbstractGistReadOnlyController<Lock
 
         if ( !aclService.canUpdate( user, dataSet ) )
         {
-            throw new ReadAccessDeniedException( "You don't have the proper permissions to update this object" );
+            throw new ForbiddenException( "You don't have the proper permissions to update this object" );
         }
 
         List<String> listOrgUnitIds = new ArrayList<>();
@@ -264,6 +269,11 @@ public class LockExceptionController extends AbstractGistReadOnlyController<Lock
             if ( organisationUnit == null )
             {
                 return conflict( "Can't find OrganisationUnit with id =" + id );
+            }
+            if ( !canCapture( organisationUnit ) )
+            {
+                throw new ForbiddenException(
+                    "You can only add a lock exceptions to your data capture organisation units." );
             }
 
             if ( organisationUnit.getDataSets().contains( dataSet ) )
@@ -319,5 +329,12 @@ public class LockExceptionController extends AbstractGistReadOnlyController<Lock
         {
             dataSetService.deleteLockExceptionCombination( dataSet, period );
         }
+    }
+
+    private boolean canCapture( OrganisationUnit captureTarget )
+    {
+        return currentUserService.currentUserIsSuper()
+            || currentUserService.getCurrentUserOrganisationUnits().stream().anyMatch(
+                ou -> captureTarget.getPath().startsWith( ou.getPath() ) );
     }
 }


### PR DESCRIPTION
backport of #12851