### PR TITLE
feat: add support for subpath wildcards in route urls [DHIS2-15098]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/route/Route.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/route/Route.java
@@ -74,11 +74,25 @@ public class Route
     @JsonProperty
     private List<String> authorities = new ArrayList<>();
 
+    /**
+     * If the route url ends with /** return true. Otherwise return false.
+     *
+     * @return true if the route is configured to allow subpaths
+     */
     public boolean allowsSubpaths()
     {
         return url.endsWith( PATH_WILDCARD_SUFFIX );
     }
 
+    /**
+     * If this route supports sub-paths, return the base URL without the /**
+     * path wildcard suffix but including the trailing slash. For example, if
+     * the url is configured as https://google.com/**, return
+     * https://google.com/. If the route does not support sub-paths, return the
+     * full configured url.
+     *
+     * @return the base url String
+     */
     public String getBaseUrl()
     {
         if ( allowsSubpaths() )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/route/Route.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/route/Route.java
@@ -97,7 +97,7 @@ public class Route
     {
         if ( allowsSubpaths() )
         {
-            return url.substring( 0, -PATH_WILDCARD_SUFFIX.length() ) + "/";
+            return url.substring( 0, url.length() - PATH_WILDCARD_SUFFIX.length() ) + "/";
         }
         return url;
     }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/route/Route.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/route/Route.java
@@ -54,6 +54,8 @@ public class Route
     extends BaseIdentifiableObject
     implements MetadataObject
 {
+    public static final String PATH_WILDCARD_SUFFIX = "/**";
+
     @JsonProperty
     private String description;
 
@@ -71,4 +73,18 @@ public class Route
 
     @JsonProperty
     private List<String> authorities = new ArrayList<>();
+
+    public boolean allowsSubpaths()
+    {
+        return url.endsWith( PATH_WILDCARD_SUFFIX );
+    }
+
+    public String getBaseUrl()
+    {
+        if ( allowsSubpaths() )
+        {
+            return url.substring( 0, -PATH_WILDCARD_SUFFIX.length() ) + "/";
+        }
+        return url;
+    }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/route/RouteTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/route/RouteTest.java
@@ -62,11 +62,11 @@ class RouteTest
     @Test
     void testAllowsSubpaths()
     {
-        Assertions.assertEquals( false, tldRoute.allowsSubpaths() );
-        Assertions.assertEquals( false, routeWithSubPath.allowsSubpaths() );
-        Assertions.assertEquals( false, routeWithDirectorySubPath.allowsSubpaths() );
-        Assertions.assertEquals( true, routeWithPathWildcard.allowsSubpaths() );
-        Assertions.assertEquals( true, routeWithSubPathAndPathWildcard.allowsSubpaths() );
+        Assertions.assertFalse( tldRoute.allowsSubpaths() );
+        Assertions.assertFalse( routeWithSubPath.allowsSubpaths() );
+        Assertions.assertFalse( routeWithDirectorySubPath.allowsSubpaths() );
+        Assertions.assertTrue( routeWithPathWildcard.allowsSubpaths() );
+        Assertions.assertTrue( routeWithSubPathAndPathWildcard.allowsSubpaths() );
     }
 
     @Test

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/route/RouteTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/route/RouteTest.java
@@ -27,8 +27,11 @@
  */
 package org.hisp.dhis.route;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -62,20 +65,20 @@ class RouteTest
     @Test
     void testAllowsSubpaths()
     {
-        Assertions.assertFalse( tldRoute.allowsSubpaths() );
-        Assertions.assertFalse( routeWithSubPath.allowsSubpaths() );
-        Assertions.assertFalse( routeWithDirectorySubPath.allowsSubpaths() );
-        Assertions.assertTrue( routeWithPathWildcard.allowsSubpaths() );
-        Assertions.assertTrue( routeWithSubPathAndPathWildcard.allowsSubpaths() );
+        assertFalse( tldRoute.allowsSubpaths() );
+        assertFalse( routeWithSubPath.allowsSubpaths() );
+        assertFalse( routeWithDirectorySubPath.allowsSubpaths() );
+        assertTrue( routeWithPathWildcard.allowsSubpaths() );
+        assertTrue( routeWithSubPathAndPathWildcard.allowsSubpaths() );
     }
 
     @Test
     void testGetBaseUrl()
     {
-        Assertions.assertEquals( "https://thisisatest.com", tldRoute.getBaseUrl() );
-        Assertions.assertEquals( "https://thisisatest.com/some/path/123", routeWithSubPath.getBaseUrl() );
-        Assertions.assertEquals( "https://thisisatest.com/some/path/123/", routeWithDirectorySubPath.getBaseUrl() );
-        Assertions.assertEquals( "https://thisisatest.com/", routeWithPathWildcard.getBaseUrl() );
-        Assertions.assertEquals( "https://thisisatest.com/sub/path/", routeWithSubPathAndPathWildcard.getBaseUrl() );
+        assertEquals( "https://thisisatest.com", tldRoute.getBaseUrl() );
+        assertEquals( "https://thisisatest.com/some/path/123", routeWithSubPath.getBaseUrl() );
+        assertEquals( "https://thisisatest.com/some/path/123/", routeWithDirectorySubPath.getBaseUrl() );
+        assertEquals( "https://thisisatest.com/", routeWithPathWildcard.getBaseUrl() );
+        assertEquals( "https://thisisatest.com/sub/path/", routeWithSubPathAndPathWildcard.getBaseUrl() );
     }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/route/RouteTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/route/RouteTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.route;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RouteTest
+{
+    Route tldRoute = new Route();
+
+    Route routeWithSubPath = new Route();
+
+    Route routeWithDirectorySubPath = new Route();
+
+    Route routeWithPathWildcard = new Route();
+
+    Route routeWithSubPathAndPathWildcard = new Route();
+
+    @BeforeEach
+    void setUp()
+    {
+        tldRoute.setUrl( "https://thisisatest.com" );
+        routeWithSubPath.setUrl( "https://thisisatest.com/some/path/123" );
+        routeWithDirectorySubPath.setUrl( "https://thisisatest.com/some/path/123/" );
+        routeWithPathWildcard.setUrl( "https://thisisatest.com/**" );
+        routeWithSubPathAndPathWildcard.setUrl( "https://thisisatest.com/sub/path/**" );
+    }
+
+    @AfterEach
+    void tearDown()
+    {
+    }
+
+    @Test
+    void testAllowsSubpaths()
+    {
+        Assertions.assertEquals( false, tldRoute.allowsSubpaths() );
+        Assertions.assertEquals( false, routeWithSubPath.allowsSubpaths() );
+        Assertions.assertEquals( false, routeWithDirectorySubPath.allowsSubpaths() );
+        Assertions.assertEquals( true, routeWithPathWildcard.allowsSubpaths() );
+        Assertions.assertEquals( true, routeWithSubPathAndPathWildcard.allowsSubpaths() );
+    }
+
+    @Test
+    void testGetBaseUrl()
+    {
+        Assertions.assertEquals( "https://thisisatest.com", tldRoute.getBaseUrl() );
+        Assertions.assertEquals( "https://thisisatest.com/some/path/123", routeWithSubPath.getBaseUrl() );
+        Assertions.assertEquals( "https://thisisatest.com/some/path/123/", routeWithDirectorySubPath.getBaseUrl() );
+        Assertions.assertEquals( "https://thisisatest.com/", routeWithPathWildcard.getBaseUrl() );
+        Assertions.assertEquals( "https://thisisatest.com/sub/path/", routeWithSubPathAndPathWildcard.getBaseUrl() );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -201,6 +201,10 @@
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+    </dependency>
 
     <!-- Apache JClouds -->
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/route/RouteService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/route/RouteService.java
@@ -47,6 +47,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.hisp.dhis.common.auth.ApiTokenAuth;
 import org.hisp.dhis.common.auth.Auth;
 import org.hisp.dhis.common.auth.HttpBasicAuth;
+import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.user.User;
 import org.jasypt.encryption.pbe.PBEStringCleanablePasswordEncryptor;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -150,7 +151,7 @@ public class RouteService
 
     public ResponseEntity<String> exec( Route route, User user, Optional<String> subPath, HttpServletRequest request )
         throws IOException,
-        IllegalArgumentException
+        BadRequestException
     {
         HttpHeaders headers = forwardHeaders( request );
 
@@ -176,7 +177,7 @@ public class RouteService
         {
             if ( !route.allowsSubpaths() )
             {
-                throw new IllegalArgumentException(
+                throw new BadRequestException(
                     String.format( "Route %s does not allow subpaths", route.getId() ) );
             }
             uriComponentsBuilder.path( subPath.get() );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/route/RouteService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/route/RouteService.java
@@ -115,7 +115,7 @@ public class RouteService
         }
         catch ( JsonProcessingException ex )
         {
-            log.error( "Unable to create clone of Route with ID " + route.getUid() + ". Please check it's data." );
+            log.error( "Unable to create clone of Route with ID " + route.getUid() + ". Please check its data." );
             return null;
         }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/route/RouteService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/route/RouteService.java
@@ -82,8 +82,7 @@ public class RouteService
     private static final RestTemplate restTemplate = new RestTemplate();
 
     /*
-     * Sensitive headers to be removed from forwarded requests. TODO: make this
-     * configurable
+     * Sensitive headers to be removed from forwarded requests.
      */
     private static final List<String> sensitiveHeaderNames = List.of( "cookie", "authorization" );
 
@@ -208,8 +207,7 @@ public class RouteService
             if ( sensitiveHeaderNames.contains( lowercaseName ) || removeHopByHopHeaderNames.contains( lowercaseName )
                 || lowercaseName.equals( "host" ) )
             {
-                log.info( String.format( "Blocked header %s", name,
-                    Collections.list( request.getHeaders( name ) ).toString() ) );
+                log.info( String.format( "Blocked header %s", name ) );
                 return;
             }
             headers.addAll( name, Collections.list( request.getHeaders( name ) ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/route/RouteService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/route/RouteService.java
@@ -123,9 +123,15 @@ public class RouteService
         return route;
     }
 
-    public ResponseEntity<String> exec( Route route, User user, HttpServletRequest request )
-        throws IOException
+    public ResponseEntity<String> exec( Route route, User user, String subPath, HttpServletRequest request )
+        throws IOException,
+        IllegalArgumentException
     {
+        if ( subPath != null && !route.allowsSubpaths() )
+        {
+            throw new IllegalArgumentException( String.format( "Route %s does not allow subpaths", route.getId() ) );
+        }
+
         HttpHeaders headers = new HttpHeaders();
         route.getHeaders().forEach( headers::add );
 
@@ -142,7 +148,8 @@ public class RouteService
         HttpHeaders queryParameters = new HttpHeaders();
         request.getParameterMap().forEach( ( key, value ) -> queryParameters.addAll( key, List.of( value ) ) );
 
-        UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl( route.getUrl() )
+        UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromHttpUrl( route.getBaseUrl() )
+            .path( subPath )
             .queryParams( queryParameters );
 
         String body = StreamUtils.copyToString( request.getInputStream(), StandardCharsets.UTF_8 );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/route/RouteService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/route/RouteService.java
@@ -200,7 +200,7 @@ public class RouteService
         log.info( String.format( "Request %s %s responded with HTTP status %s via route %s (%s)", httpMethod, targetUri,
             response.getStatusCode().toString(), route.getName(), route.getUid() ) );
 
-        return new ResponseEntity<String>( responseBody, responseHeaders, response.getStatusCode() );
+        return new ResponseEntity<>( responseBody, responseHeaders, response.getStatusCode() );
     }
 
     private HttpHeaders filterHeaders( Iterable<String> names, List<String> allowedHeaders,
@@ -222,16 +222,13 @@ public class RouteService
 
     private HttpHeaders filterRequestHeaders( HttpServletRequest request )
     {
-        return filterHeaders( Collections.list( request.getHeaderNames() ), allowedRequestHeaders, ( String name ) -> {
-            return Collections.list( request.getHeaders( name ) );
-        } );
+        return filterHeaders( Collections.list( request.getHeaderNames() ), allowedRequestHeaders,
+            ( String name ) -> Collections.list( request.getHeaders( name ) ) );
     }
 
     private HttpHeaders filterResponseHeaders( HttpHeaders responseHeaders )
     {
-        return filterHeaders( responseHeaders.keySet(), allowedResponseHeaders, ( String name ) -> {
-            return responseHeaders.get( name );
-        } );
+        return filterHeaders( responseHeaders.keySet(), allowedResponseHeaders, responseHeaders::get );
     }
 
     private void decrypt( Route route )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/RouteController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/RouteController.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -96,7 +97,7 @@ public class RouteController
             throw new ForbiddenException( "User not authorized" );
         }
 
-        String subPath = getSubPath( request.getPathInfo(), id );
+        Optional<String> subPath = getSubPath( request.getPathInfo(), id );
 
         ResponseEntity<String> entity;
         try
@@ -120,14 +121,13 @@ public class RouteController
         return ResponseEntity.ok().headers( entity.getHeaders() ).body( entity.getBody() );
     }
 
-    private String getSubPath( String path, String id )
+    private Optional<String> getSubPath( String path, String id )
     {
         String prefix = String.format( "%s/%s/run/", RouteSchemaDescriptor.API_ENDPOINT, id );
-
         if ( path.startsWith( prefix ) )
         {
-            return path.substring( prefix.length() );
+            return Optional.of( path.substring( prefix.length() ) );
         }
-        return null;
+        return Optional.empty();
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/RouteController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/RouteController.java
@@ -50,8 +50,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.HttpServerErrorException;
 
 /**
  * @author Morten Olav Hansen
@@ -99,26 +97,17 @@ public class RouteController
 
         Optional<String> subPath = getSubPath( request.getPathInfo(), id );
 
-        ResponseEntity<String> entity;
+        ResponseEntity<String> response;
         try
         {
-            entity = routeService.exec( route, user, subPath, request );
+            response = routeService.exec( route, user, subPath, request );
         }
         catch ( IllegalArgumentException e )
         {
-            throw new BadRequestException( e.getMessage() );
+            throw new NotFoundException( e.getMessage() );
         }
 
-        if ( entity.getStatusCode().is4xxClientError() )
-        {
-            throw new HttpClientErrorException( entity.getStatusCode() );
-        }
-        else if ( entity.getStatusCode().is5xxServerError() )
-        {
-            throw new HttpServerErrorException( entity.getStatusCode() );
-        }
-
-        return ResponseEntity.ok().headers( entity.getHeaders() ).body( entity.getBody() );
+        return response;
     }
 
     private Optional<String> getSubPath( String path, String id )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/RouteController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/RouteController.java
@@ -97,17 +97,7 @@ public class RouteController
 
         Optional<String> subPath = getSubPath( request.getPathInfo(), id );
 
-        ResponseEntity<String> response;
-        try
-        {
-            response = routeService.exec( route, user, subPath, request );
-        }
-        catch ( IllegalArgumentException e )
-        {
-            throw new NotFoundException( e.getMessage() );
-        }
-
-        return response;
+        return routeService.exec( route, user, subPath, request );
     }
 
     private Optional<String> getSubPath( String path, String id )

--- a/dhis-2/dhis-web-embedded-jetty/pom.xml
+++ b/dhis-2/dhis-web-embedded-jetty/pom.xml
@@ -236,10 +236,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-orm</artifactId>
-    </dependency>
-    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
@@ -254,10 +250,6 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-webmvc</artifactId>
     </dependency>
     <dependency>
       <groupId>org.hisp.dhis</groupId>


### PR DESCRIPTION
Fixes [DHIS2-15098](https://dhis2.atlassian.net/browse/DHIS2-15098) - support path wildcard suffix `/**`
Fixes [DHIS2-15191](https://dhis2.atlassian.net/browse/DHIS2-15191) - pass through non-2xx responses
Fixes [DHIS2-15197](https://dhis2.atlassian.net/browse/DHIS2-15197) - disable cookie store
Fixes [DHIS2-15198](https://dhis2.atlassian.net/browse/DHIS2-15198) - filter request and response headers to exclude transport-level metadata

This adds support for sub-paths in Route URLs.  Subpaths are only supported if the route is configured with a URL ending in `/**`, and can be accessed via the route's Run API like so - `/api/routes/ABC123/run/sub/path/xyz`, which if route `ABC123` is configured with the URL `https://google.com/**` would proxy the request to `https://google.com/sub/path/xyz`

Attempting to access a subpath for a route which doesn't have the `/**` path wildcard suffix will result in a 400 Bad Request error (I'm not sure if this should be a 404 instead...)

This has been approved for 2.40.0 if we want to support it there (since this makes the routes API quite a bit more useful), though with this implementation it would also be a non-breaking extension to add `/**` support in v 40.1

---
In addition, prevent the HTTP Client used for upstream requests from remembering cookies
Finally, forward headers to the upstream request (stripping sensitive ones) and pass through the original response from the upstream server.

In the future we will want to add X-Forwarded-* headers.

[DHIS2-15098]: https://dhis2.atlassian.net/browse/DHIS2-15098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-15197]: https://dhis2.atlassian.net/browse/DHIS2-15197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-15191]: https://dhis2.atlassian.net/browse/DHIS2-15191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DHIS2-15198]: https://dhis2.atlassian.net/browse/DHIS2-15198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ