### PR TITLE
fix: [2.40.0] program indicator period is not wrapped in parentheses when empty [BETA-55]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.analytics.event.data;
 
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.hisp.dhis.util.DateUtils.getMediumDateString;
 
 import java.util.ArrayList;
@@ -72,6 +73,11 @@ public abstract class TimeFieldSqlRenderer
         else // Periods condition only for pivot table (aggregated).
         {
             sql.append( getAggregatedConditionForPeriods( params ) );
+        }
+
+        if ( isEmpty( sql ) )
+        {
+            return sql.toString();
         }
 
         return "(" + sql + ")";

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
@@ -32,9 +32,14 @@ import static org.hisp.dhis.analytics.TimeField.LAST_UPDATED;
 import static org.hisp.dhis.analytics.TimeField.SCHEDULED_DATE;
 import static org.hisp.dhis.common.DimensionType.PERIOD;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
+import static org.hisp.dhis.commons.util.TextUtils.EMPTY;
+import static org.hisp.dhis.program.AnalyticsPeriodBoundaryType.BEFORE_END_OF_REPORTING_PERIOD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Set;
 
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.analytics.event.EventQueryParams;
@@ -42,6 +47,8 @@ import org.hisp.dhis.common.BaseDimensionalObject;
 import org.hisp.dhis.jdbc.statementbuilder.PostgreSQLStatementBuilder;
 import org.hisp.dhis.period.MonthlyPeriodType;
 import org.hisp.dhis.period.Period;
+import org.hisp.dhis.program.AnalyticsPeriodBoundary;
+import org.hisp.dhis.program.ProgramIndicator;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -185,5 +192,24 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
         assertEquals( "((ax.\"duedate\" >= '2022-03-01' and ax.\"duedate\" < '2022-04-01') " +
             "or (ax.\"duedate\" >= '2022-09-01' and ax.\"duedate\" < '2022-10-01'))",
             timeFieldSqlRenderer.renderPeriodTimeFieldSql( params ) );
+    }
+
+    @Test
+    void testEnrollmentTimeFieldWithEventDate()
+    {
+        TimeFieldSqlRenderer timeFieldSqlRenderer = new EnrollmentTimeFieldSqlRenderer(
+            new PostgreSQLStatementBuilder() );
+
+        Set<AnalyticsPeriodBoundary> boundaries = Set.of(
+            new AnalyticsPeriodBoundary( "EVENT_DATE", BEFORE_END_OF_REPORTING_PERIOD ) );
+
+        ProgramIndicator programIndicator = mock( ProgramIndicator.class );
+        when( programIndicator.getAnalyticsPeriodBoundaries() ).thenReturn( boundaries );
+
+        EventQueryParams eventQueryParams = mock( EventQueryParams.class );
+        when( eventQueryParams.getProgramIndicator() ).thenReturn( programIndicator );
+        when( eventQueryParams.hasNonDefaultBoundaries() ).thenReturn( true );
+
+        assertEquals( EMPTY, timeFieldSqlRenderer.renderPeriodTimeFieldSql( eventQueryParams ) );
     }
 }


### PR DESCRIPTION
### TO BE APPROVED BY RCB
when a Program Indicator is of type enrollment and it has only event date boundaries, the resulting query is malformed and generates an exception.
This PR aims to fix the query generation.