### PR TITLE
fix: user can only add lock exceptions for org units in their data capture set [DHIS2-13908] (2.38)

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/LockExceptionControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/LockExceptionControllerTest.java
@@ -65,6 +65,16 @@ class LockExceptionControllerTest extends DhisControllerConvenienceTest
     }
 
     @Test
+    void testAddLockException_UnauthorizedUser()
+    {
+        switchToNewUser( "guest", "F_DATASET_PUBLIC_ADD" );
+
+        assertWebMessage( "Forbidden", 403, "ERROR",
+            "You can only add a lock exceptions to your data capture organisation units.",
+            POST( "/lockExceptions/?ou={ou}&pe=2021-01&ds={ds}", ouId, dsId ).content( HttpStatus.FORBIDDEN ) );
+    }
+
+    @Test
     void testAddLockException_DataSetNotLinked()
     {
         String dsId2 = assertStatus( HttpStatus.CREATED,


### PR DESCRIPTION
backport of #12851