### PR TITLE
fix: hibernate lazy collection issue in attributeCache [DHIS2-10331]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/attribute/DefaultAttributeService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/attribute/DefaultAttributeService.java
@@ -105,7 +105,11 @@ public class DefaultAttributeService implements AttributeService
     @Transactional( readOnly = true )
     public Attribute getAttribute( String uid )
     {
-        return attributeCache.get( uid, attr -> attributeStore.getByUid( uid ) );
+        return attributeCache.get( uid, attr -> {
+            Attribute attribute = attributeStore.getByUid( uid );
+            HibernateProxyUtils.unproxy( attribute );
+            return attribute;
+        } );
     }
 
     @Override


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-10331

Issue:
- Hibernate throw error `could not initialize proxy [org.hisp.dhis.option.OptionSet#1505799] - no Session` when requesting metadata with dependencies using `api/dataSets/{uid}/metadata`. This has been fixed and tested in https://dhis2.atlassian.net/browse/DHIS2-11846 but now it's occurring again.

Fix:
- After debugging in 2.40.0 I found the issue that when adding `Attribute` object to the cache, property `Attribute.optionSet` has not been initialized by hibernate. 
- Calling `HibernateProxyUtils.unproxy( attribute );` solved the issue.

Test:

- Configure a text option set with multiple options
- Create a custom attribute of type text to apply to objects of type DataSet. Also in Attribute form, set the OptionSet value to the OptionSet created in step 1. 
- Edit a DataSet, select a value for the attribute and save the change
- Test the endpoint with the UID of the program updated in step 3
- Expected: DataSet metadata with dependencies load successfully from `api/dataSets/{uid}/metadata.json`