### PR TITLE
fix: Predictor white space parsing [DHIS2-14635]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/PredictorExpression.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/PredictorExpression.java
@@ -85,9 +85,7 @@ public class PredictorExpression
 
     private static final String IN = "in";
 
-    private static final String PREPROCESSOR_SEPARATOR = " --> ";
-
-    private static final int PREPROCESSOR_SEPARATOR_LENGTH = PREPROCESSOR_SEPARATOR.length();
+    private static final String PREPROCESSOR_SEPARATOR = "-->";
 
     /**
      * Accepts and parses a predictor expression with a preprocessor prefix:
@@ -112,22 +110,11 @@ public class PredictorExpression
 
         simple = false;
 
-        int mainSplit = expression.indexOf( PREPROCESSOR_SEPARATOR );
+        String[] parts = expression.split( "\\s+", 6 );
 
-        if ( mainSplit < 0 )
+        if ( parts.length != 6 )
         {
-            throw new ParserException(
-                format( "Couldn't find preprocessor termination '%s' in '%s'", PREPROCESSOR_SEPARATOR, expression ) );
-        }
-
-        prefix = this.expression.substring( 0, mainSplit );
-        main = this.expression.substring( mainSplit + PREPROCESSOR_SEPARATOR_LENGTH );
-
-        String[] parts = prefix.split( " " );
-
-        if ( parts.length != 4 )
-        {
-            throw new ParserException( format( "Predictor preprocessor expression should have four parts: '%s'",
+            throw new ParserException( format( "Predictor expression with preprocessing should have six parts: '%s'",
                 expression ) );
         }
 
@@ -166,6 +153,19 @@ public class PredictorExpression
                 "UID '%s' must start with a letter and contain 10 more letters and numbers in '%s'", degUid,
                 expression ) );
         }
+
+        // -->
+
+        if ( !PREPROCESSOR_SEPARATOR.equals( parts[4] ) )
+        {
+            throw new ParserException(
+                format( "Couldn't find preprocessor termination '%s' in '%s'", PREPROCESSOR_SEPARATOR, expression ) );
+        }
+
+        // Prefix and Main
+
+        main = parts[5];
+        prefix = expression.substring( 0, expression.length() - main.length() );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/PredictorExpression.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/PredictorExpression.java
@@ -79,6 +79,8 @@ public class PredictorExpression
      */
     final String degUid;
 
+    private static final Pattern WHITE_SPACE_PATTERN = Pattern.compile( "\\s+" );
+
     private static final Pattern VARIABLE_PATTERN = Pattern.compile( "^\\?[A-Za-z][A-Za-z0-9]*$" );
 
     private static final String FOR_EACH = "forEach";
@@ -110,7 +112,7 @@ public class PredictorExpression
 
         simple = false;
 
-        String[] parts = expression.split( "\\s+", 6 );
+        String[] parts = WHITE_SPACE_PATTERN.split( expression, 6 );
 
         if ( parts.length != 6 )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/PredictorExpression.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/PredictorExpression.java
@@ -90,7 +90,7 @@ public class PredictorExpression
     private static final String PREPROCESSOR_SEPARATOR = "-->";
 
     /**
-     * Accepts and parses a predictor expression with a preprocessor prefix:
+     * Accepts and parses a predictor expression with or without a prefix:
      * forEach ?variable in :DEG:degUid -->
      *
      * @param expression the expression to parse for preprocessing.
@@ -120,7 +120,7 @@ public class PredictorExpression
                 expression ) );
         }
 
-        // forEach
+        // 0. forEach
 
         if ( !parts[0].equals( FOR_EACH ) )
         {
@@ -128,19 +128,19 @@ public class PredictorExpression
                 expression ) );
         }
 
-        // variable
+        // 1. variable
 
         variable = parts[1];
         validateVariable( variable, expression );
 
-        // in
+        // 2. in
 
         if ( !parts[2].equals( IN ) )
         {
             throw new ParserException( format( "Keyword 'in' must be the third token in '%s'", expression ) );
         }
 
-        // :DEG:deGroupUid
+        // 3. :DEG:deGroupUid
 
         taggedDegUid = parts[3];
         if ( !taggedDegUid.startsWith( ":DEG:" ) )
@@ -156,7 +156,7 @@ public class PredictorExpression
                 expression ) );
         }
 
-        // -->
+        // 4. --> (separates main expression from prefix)
 
         if ( !PREPROCESSOR_SEPARATOR.equals( parts[4] ) )
         {
@@ -164,7 +164,7 @@ public class PredictorExpression
                 format( "Couldn't find preprocessor termination '%s' in '%s'", PREPROCESSOR_SEPARATOR, expression ) );
         }
 
-        // Prefix and Main
+        // 5. Main expression (Put the rest into prefix)
 
         main = parts[5];
         prefix = expression.substring( 0, expression.length() - main.length() );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/PredictorExpressionTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/PredictorExpressionTest.java
@@ -54,12 +54,12 @@ class PredictorExpressionTest
     @Test
     void testPredictorExpression()
     {
-        String expression = "forEach ?de in :DEG:G1234567890 --> #{?de.A1234567890}";
+        String expression = "forEach\t?de\nin\r:DEG:G1234567890 -->\t #{?de.A1234567890}";
         PredictorExpression pe = new PredictorExpression( expression );
 
         assertFalse( pe.isSimple() );
         assertEquals( expression, pe.getExpression() );
-        assertEquals( "forEach ?de in :DEG:G1234567890", pe.getPrefix() );
+        assertEquals( "forEach\t?de\nin\r:DEG:G1234567890 -->\t ", pe.getPrefix() );
         assertEquals( "#{?de.A1234567890}", pe.getMain() );
         assertEquals( "?de", pe.getVariable() );
         assertEquals( ":DEG:G1234567890", pe.getTaggedDegUid() );
@@ -72,11 +72,11 @@ class PredictorExpressionTest
         // bad expression
 
         assertEquals(
-            "Couldn't find preprocessor termination ' --> ' in 'forEach ?de in :DEG:G1234567890 #{?de.A1234567890}'",
-            testError( "forEach ?de in :DEG:G1234567890 #{?de.A1234567890}" ) );
+            "Couldn't find preprocessor termination '-->' in 'forEach ?de in :DEG:G1234567890 1 + #{?de.A1234567890}'",
+            testError( "forEach ?de in :DEG:G1234567890 1 + #{?de.A1234567890}" ) );
 
         assertEquals(
-            "Predictor preprocessor expression should have four parts: 'forEach ?de :DEG:G1234567890 --> #{?de.A1234567890}'",
+            "Predictor expression with preprocessing should have six parts: 'forEach ?de :DEG:G1234567890 --> #{?de.A1234567890}'",
             testError( "forEach ?de :DEG:G1234567890 --> #{?de.A1234567890}" ) );
 
         // bad forEach

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictionPreprocessor.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictionPreprocessor.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.predictor;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static org.hisp.dhis.expression.ParseType.PREDICTOR_EXPRESSION;
-import static org.hisp.dhis.expression.PreprocessorExpression.PREPROCESSOR_SEPARATOR;
 
 import java.util.List;
 import java.util.Map;
@@ -158,7 +157,7 @@ public class PredictionPreprocessor
         }
 
         // Return the complete description
-        return prefixDescription + PREPROCESSOR_SEPARATOR + mainDescription;
+        return prefixDescription + mainDescription;
     }
 
     /**


### PR DESCRIPTION
This is in support of [DHIS2-14635 Predictions by Data Element Group](https://dhis2.atlassian.net/browse/DHIS2-14635).

This PR changes the predictor expression preprocessing so that any whitespace characters can be used to separate tokens (not just the space character), and so all whitespace characters are faithfully copied to the prediction description.



