### PR TITLE
fix: Predictor white space parsing [DHIS2-14635] (#13749)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/PredictorExpressionTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/PredictorExpressionTest.java
@@ -54,12 +54,12 @@ class PredictorExpressionTest
     @Test
     void testPredictorExpression()
     {
-        String expression = "forEach ?de in :DEG:G1234567890 --> #{?de.A1234567890}";
+        String expression = "forEach\t?de\nin\r:DEG:G1234567890 -->\t #{?de.A1234567890}";
         PredictorExpression pe = new PredictorExpression( expression );
 
         assertFalse( pe.isSimple() );
         assertEquals( expression, pe.getExpression() );
-        assertEquals( "forEach ?de in :DEG:G1234567890", pe.getPrefix() );
+        assertEquals( "forEach\t?de\nin\r:DEG:G1234567890 -->\t ", pe.getPrefix() );
         assertEquals( "#{?de.A1234567890}", pe.getMain() );
         assertEquals( "?de", pe.getVariable() );
         assertEquals( ":DEG:G1234567890", pe.getTaggedDegUid() );
@@ -72,11 +72,11 @@ class PredictorExpressionTest
         // bad expression
 
         assertEquals(
-            "Couldn't find preprocessor termination ' --> ' in 'forEach ?de in :DEG:G1234567890 #{?de.A1234567890}'",
-            testError( "forEach ?de in :DEG:G1234567890 #{?de.A1234567890}" ) );
+            "Couldn't find preprocessor termination '-->' in 'forEach ?de in :DEG:G1234567890 1 + #{?de.A1234567890}'",
+            testError( "forEach ?de in :DEG:G1234567890 1 + #{?de.A1234567890}" ) );
 
         assertEquals(
-            "Predictor preprocessor expression should have four parts: 'forEach ?de :DEG:G1234567890 --> #{?de.A1234567890}'",
+            "Predictor expression with preprocessing should have six parts: 'forEach ?de :DEG:G1234567890 --> #{?de.A1234567890}'",
             testError( "forEach ?de :DEG:G1234567890 --> #{?de.A1234567890}" ) );
 
         // bad forEach

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictionPreprocessor.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictionPreprocessor.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.predictor;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static org.hisp.dhis.expression.ParseType.PREDICTOR_EXPRESSION;
-import static org.hisp.dhis.expression.PreprocessorExpression.PREPROCESSOR_SEPARATOR;
 
 import java.util.List;
 import java.util.Map;
@@ -158,7 +157,7 @@ public class PredictionPreprocessor
         }
 
         // Return the complete description
-        return prefixDescription + PREPROCESSOR_SEPARATOR + mainDescription;
+        return prefixDescription + mainDescription;
     }
 
     /**


### PR DESCRIPTION
* fix: Predictor white space parsing [DHIS2-14635]

* fix: Use static pattern for split [DHIS2-14635]

* chore: Comments for expression parts [DHIS2-14635]

(cherry picked from commit 05efcde1264b205aa71ec3194c5a6d98fb9366de)

[DHIS2-14635]: https://dhis2.atlassian.net/browse/DHIS2-14635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-14635]: https://dhis2.atlassian.net/browse/DHIS2-14635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-14635]: https://dhis2.atlassian.net/browse/DHIS2-14635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ