### PR TITLE
chore: rename ProgramStageInstanceService to EventService

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventService.java
@@ -39,89 +39,89 @@ import org.hisp.dhis.user.User;
 /**
  * @author Abyot Asalefew
  */
-public interface ProgramStageInstanceService
+public interface EventService
 {
-    String ID = ProgramStageInstanceService.class.getName();
+    String ID = EventService.class.getName();
 
     /**
-     * Adds a {@link Event}
+     * Adds an {@link Event}
      *
      * @param event The Event to add.
      * @return A generated unique id of the added {@link Event}.
      */
-    long addProgramStageInstance( Event event );
+    long addEvent( Event event );
 
     /**
-     * Adds a {@link Event}
+     * Adds an {@link Event}
      *
      * @param event The Event to add.
      * @param user the current user.
      * @return A generated unique id of the added {@link Event}.
      */
-    long addProgramStageInstance( Event event, User user );
+    long addEvent( Event event, User user );
 
     /**
-     * Soft deletes a {@link Event}.
+     * Soft deletes an {@link Event}.
      *
      */
-    void deleteProgramStageInstance( Event event );
+    void deleteEvent( Event event );
 
     /**
-     * Updates a {@link Event}.
+     * Updates an {@link Event}.
      *
      * @param event the Event to update.
      */
-    void updateProgramStageInstance( Event event );
+    void updateEvent( Event event );
 
     /**
-     * Updates a {@link Event}.
+     * Updates an {@link Event}.
      *
      * @param event the Event to update.
      * @param user the current user.
      */
-    void updateProgramStageInstance( Event event, User user );
+    void updateEvent( Event event, User user );
 
     /**
-     * Updates a last sync timestamp on specified ProgramStageInstances
+     * Updates a last sync timestamp on specified events
      *
-     * @param programStageInstanceUIDs UIDs of ProgramStageInstances where the
-     *        lastSynchronized flag should be updated
+     * @param eventUids UIDs of events where the lastSynchronized flag should be
+     *        updated
      * @param lastSynchronized The date of last successful sync
      */
-    void updateProgramStageInstancesSyncTimestamp( List<String> programStageInstanceUIDs, Date lastSynchronized );
+    void updateEventsSyncTimestamp( List<String> eventUids, Date lastSynchronized );
 
     /**
-     * Checks whether a {@link Event} with the given identifier exists. Doesn't
+     * Checks whether an {@link Event} with the given identifier exists. Doesn't
      * take into account the deleted values.
      *
      * @param uid the identifier.
      */
-    boolean programStageInstanceExists( String uid );
+    boolean eventExists( String uid );
 
     /**
-     * Checks whether a {@link Event} with the given identifier exists. Takes
+     * Checks whether an {@link Event} with the given identifier exists. Takes
      * into accound also the deleted values.
      *
      * @param uid the identifier.
      */
-    boolean programStageInstanceExistsIncludingDeleted( String uid );
+    boolean eventExistsIncludingDeleted( String uid );
 
     /**
-     * Returns UIDs of existing ProgramStageInstances (including deleted) from
-     * the provided UIDs
+     * Returns UIDs of existing events (including deleted) from the provided
+     * UIDs
      *
-     * @param uids PSI UIDs to check
-     * @return Set containing UIDs of existing PSIs (including deleted)
+     * @param uids event UIDs to check
+     * @return Set containing UIDs of existing events (including deleted)
      */
-    List<String> getProgramStageInstanceUidsIncludingDeleted( List<String> uids );
+    List<String> getEventUidsIncludingDeleted( List<String> uids );
 
     /**
-     * Returns a {@link Event}.
+     * Returns an {@link Event}.
      *
      * @param id the id of the Event to return.
      * @return the Event with the given id.
      */
-    Event getProgramStageInstance( long id );
+    Event getEvent( long id );
 
     /**
      * Returns the {@link Event} with the given UID.
@@ -129,19 +129,18 @@ public interface ProgramStageInstanceService
      * @param uid the UID.
      * @return the Event with the given UID, or null if no match.
      */
-    Event getProgramStageInstance( String uid );
+    Event getEvent( String uid );
 
     /**
-     * Gets the number of ProgramStageInstances added since the given number of
-     * days.
+     * Gets the number of events added since the given number of days.
      *
      * @param days number of days.
      * @return the number of ProgramStageInstances.
      */
-    long getProgramStageInstanceCount( int days );
+    long getEventCount( int days );
 
     /**
-     * Creates a program stage instance.
+     * Creates an event.
      *
      * @param programInstance the ProgramInstance.
      * @param programStage the ProgramStage.
@@ -150,7 +149,7 @@ public interface ProgramStageInstanceService
      * @param organisationUnit the OrganisationUnit where the event took place.
      * @return Event the Event which was created.
      */
-    Event createProgramStageInstance( ProgramInstance programInstance, ProgramStage programStage,
+    Event createEvent( ProgramInstance programInstance, ProgramStage programStage,
         Date enrollmentDate, Date incidentDate, OrganisationUnit organisationUnit );
 
     /**
@@ -162,6 +161,6 @@ public interface ProgramStageInstanceService
      * @param dataElementEventDataValueMap the map of DataElements and related
      *        EventDataValues to update
      */
-    void saveEventDataValuesAndSaveProgramStageInstance( Event event,
+    void saveEventDataValuesAndSaveEvent( Event event,
         Map<DataElement, EventDataValue> dataElementEventDataValueMap );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageDataElementService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageDataElementService.java
@@ -41,7 +41,7 @@ import org.hisp.dhis.dataelement.DataElement;
  */
 public interface ProgramStageDataElementService
 {
-    String ID = ProgramStageInstanceService.class.getName();
+    String ID = ProgramStageDataElementService.class.getName();
 
     /**
      * Adds an {@link ProgramStageDataElement}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventService.java
@@ -61,9 +61,9 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Abyot Asalefew
  */
 @RequiredArgsConstructor
-@Service( "org.hisp.dhis.program.ProgramStageInstanceService" )
-public class DefaultProgramStageInstanceService
-    implements ProgramStageInstanceService
+@Service( "org.hisp.dhis.program.EventService" )
+public class DefaultEventService
+    implements EventService
 {
     private final ProgramStageInstanceStore programStageInstanceStore;
 
@@ -79,7 +79,7 @@ public class DefaultProgramStageInstanceService
 
     @Override
     @Transactional
-    public long addProgramStageInstance( Event event )
+    public long addEvent( Event event )
     {
         event.setAutoFields();
         programStageInstanceStore.save( event );
@@ -88,7 +88,7 @@ public class DefaultProgramStageInstanceService
 
     @Override
     @Transactional
-    public long addProgramStageInstance( Event event, User user )
+    public long addEvent( Event event, User user )
     {
         event.setAutoFields();
         programStageInstanceStore.save( event, user );
@@ -97,28 +97,28 @@ public class DefaultProgramStageInstanceService
 
     @Override
     @Transactional
-    public void deleteProgramStageInstance( Event event )
+    public void deleteEvent( Event event )
     {
         programStageInstanceStore.delete( event );
     }
 
     @Override
     @Transactional( readOnly = true )
-    public Event getProgramStageInstance( long id )
+    public Event getEvent( long id )
     {
         return programStageInstanceStore.get( id );
     }
 
     @Override
     @Transactional( readOnly = true )
-    public Event getProgramStageInstance( String uid )
+    public Event getEvent( String uid )
     {
         return programStageInstanceStore.getByUid( uid );
     }
 
     @Override
     @Transactional
-    public void updateProgramStageInstance( Event event )
+    public void updateEvent( Event event )
     {
         event.setAutoFields();
         programStageInstanceStore.update( event );
@@ -126,7 +126,7 @@ public class DefaultProgramStageInstanceService
 
     @Override
     @Transactional
-    public void updateProgramStageInstance( Event event, User user )
+    public void updateEvent( Event event, User user )
     {
         event.setAutoFields();
         programStageInstanceStore.update( event, user );
@@ -134,36 +134,36 @@ public class DefaultProgramStageInstanceService
 
     @Override
     @Transactional
-    public void updateProgramStageInstancesSyncTimestamp( List<String> programStageInstanceUIDs, Date lastSynchronized )
+    public void updateEventsSyncTimestamp( List<String> eventUids, Date lastSynchronized )
     {
-        programStageInstanceStore.updateProgramStageInstancesSyncTimestamp( programStageInstanceUIDs,
+        programStageInstanceStore.updateProgramStageInstancesSyncTimestamp( eventUids,
             lastSynchronized );
     }
 
     @Override
     @Transactional( readOnly = true )
-    public boolean programStageInstanceExists( String uid )
+    public boolean eventExists( String uid )
     {
         return programStageInstanceStore.exists( uid );
     }
 
     @Override
     @Transactional( readOnly = true )
-    public boolean programStageInstanceExistsIncludingDeleted( String uid )
+    public boolean eventExistsIncludingDeleted( String uid )
     {
         return programStageInstanceStore.existsIncludingDeleted( uid );
     }
 
     @Override
     @Transactional( readOnly = true )
-    public List<String> getProgramStageInstanceUidsIncludingDeleted( List<String> uids )
+    public List<String> getEventUidsIncludingDeleted( List<String> uids )
     {
         return programStageInstanceStore.getUidsIncludingDeleted( uids );
     }
 
     @Override
     @Transactional( readOnly = true )
-    public long getProgramStageInstanceCount( int days )
+    public long getEventCount( int days )
     {
         Calendar cal = PeriodType.createCalendarInstance();
         cal.add( Calendar.DAY_OF_YEAR, (days * -1) );
@@ -173,7 +173,7 @@ public class DefaultProgramStageInstanceService
 
     @Override
     @Transactional
-    public Event createProgramStageInstance( ProgramInstance programInstance, ProgramStage programStage,
+    public Event createEvent( ProgramInstance programInstance, ProgramStage programStage,
         Date enrollmentDate, Date incidentDate, OrganisationUnit organisationUnit )
     {
         Event event = null;
@@ -207,7 +207,7 @@ public class DefaultProgramStageInstanceService
                 event.setStatus( EventStatus.ACTIVE );
             }
 
-            addProgramStageInstance( event );
+            addEvent( event );
         }
 
         return event;
@@ -215,13 +215,13 @@ public class DefaultProgramStageInstanceService
 
     @Override
     @Transactional
-    public void saveEventDataValuesAndSaveProgramStageInstance( Event event,
+    public void saveEventDataValuesAndSaveEvent( Event event,
         Map<DataElement, EventDataValue> dataElementEventDataValueMap )
     {
         validateEventDataValues( dataElementEventDataValueMap );
         Set<EventDataValue> eventDataValues = new HashSet<>( dataElementEventDataValueMap.values() );
         event.setEventDataValues( eventDataValues );
-        addProgramStageInstance( event );
+        addEvent( event );
 
         for ( Map.Entry<DataElement, EventDataValue> entry : dataElementEventDataValueMap.entrySet() )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageInstanceDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageInstanceDeletionHandler.java
@@ -43,7 +43,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ProgramStageInstanceDeletionHandler extends IdObjectDeletionHandler<Event>
 {
-    private final ProgramStageInstanceService programStageInstanceService;
+    private final EventService eventService;
 
     @Override
     protected void registerHandler()
@@ -65,7 +65,7 @@ public class ProgramStageInstanceDeletionHandler extends IdObjectDeletionHandler
     {
         for ( Event event : programInstance.getEvents() )
         {
-            programStageInstanceService.deleteProgramStageInstance( event );
+            eventService.deleteEvent( event );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationInstanceService.java
@@ -32,8 +32,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramInstanceService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -49,7 +49,7 @@ public class DefaultProgramNotificationInstanceService
 
     private final ProgramInstanceService programInstanceService;
 
-    private final ProgramStageInstanceService programStageInstanceService;
+    private final EventService eventService;
 
     @Override
     @Transactional( readOnly = true )
@@ -81,7 +81,7 @@ public class DefaultProgramNotificationInstanceService
 
         if ( params.hasProgramStageInstance() )
         {
-            if ( !programStageInstanceService.programStageInstanceExists( params.getEvent().getUid() ) )
+            if ( !eventService.eventExists( params.getEvent().getUid() ) )
             {
                 throw new IllegalQueryException(
                     String.format( "Program stage instance %s does not exist",

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultTrackerNotificationWebHookService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultTrackerNotificationWebHookService.java
@@ -38,9 +38,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.notification.ProgramNotificationMessageRenderer;
 import org.hisp.dhis.notification.ProgramStageNotificationMessageRenderer;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.sms.config.SmsGateway;
 import org.hisp.dhis.system.util.ValidationUtils;
@@ -67,7 +67,7 @@ public class DefaultTrackerNotificationWebHookService implements TrackerNotifica
 {
     private final ProgramInstanceService programInstanceService;
 
-    private final ProgramStageInstanceService programStageInstanceService;
+    private final EventService eventService;
 
     private final ProgramNotificationTemplateService templateService;
 
@@ -104,7 +104,7 @@ public class DefaultTrackerNotificationWebHookService implements TrackerNotifica
     @Transactional
     public void handleEvent( String psi )
     {
-        Event instance = programStageInstanceService.getProgramStageInstance( psi );
+        Event instance = eventService.getEvent( psi );
 
         if ( instance == null
             || !templateService.isProgramStageLinkedToWebHookNotification( instance.getProgramStage() ) )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListener.java
@@ -50,8 +50,8 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
 import org.hisp.dhis.smscompression.SmsConsts.SubmissionType;
@@ -83,12 +83,12 @@ public class AggregateDataSetSMSListener extends CompressionSMSListener
         @Qualifier( "smsMessageSender" ) MessageSender smsSender, UserService userService,
         TrackedEntityTypeService trackedEntityTypeService, TrackedEntityAttributeService trackedEntityAttributeService,
         ProgramService programService, OrganisationUnitService organisationUnitService, CategoryService categoryService,
-        DataElementService dataElementService, ProgramStageInstanceService programStageInstanceService,
+        DataElementService dataElementService, EventService eventService,
         DataSetService dataSetService, DataValueService dataValueService,
         CompleteDataSetRegistrationService registrationService, IdentifiableObjectManager identifiableObjectManager )
     {
         super( incomingSmsService, smsSender, userService, trackedEntityTypeService, trackedEntityAttributeService,
-            programService, organisationUnitService, categoryService, dataElementService, programStageInstanceService,
+            programService, organisationUnitService, categoryService, dataElementService, eventService,
             identifiableObjectManager );
 
         this.dataSetService = dataSetService;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CommandSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CommandSMSListener.java
@@ -48,9 +48,9 @@ import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.sms.command.SMSCommand;
@@ -86,14 +86,14 @@ public abstract class CommandSMSListener extends BaseSMSListener
 
     protected final CategoryService dataElementCategoryService;
 
-    protected final ProgramStageInstanceService programStageInstanceService;
+    protected final EventService eventService;
 
     protected final UserService userService;
 
     protected final CurrentUserService currentUserService;
 
     public CommandSMSListener( ProgramInstanceService programInstanceService,
-        CategoryService dataElementCategoryService, ProgramStageInstanceService programStageInstanceService,
+        CategoryService dataElementCategoryService, EventService eventService,
         UserService userService, CurrentUserService currentUserService, IncomingSmsService incomingSmsService,
         MessageSender smsSender )
     {
@@ -101,13 +101,13 @@ public abstract class CommandSMSListener extends BaseSMSListener
 
         checkNotNull( programInstanceService );
         checkNotNull( dataElementCategoryService );
-        checkNotNull( programStageInstanceService );
+        checkNotNull( eventService );
         checkNotNull( userService );
         checkNotNull( currentUserService );
 
         this.programInstanceService = programInstanceService;
         this.dataElementCategoryService = dataElementCategoryService;
-        this.programStageInstanceService = programStageInstanceService;
+        this.eventService = eventService;
         this.userService = userService;
         this.currentUserService = currentUserService;
     }
@@ -272,7 +272,7 @@ public abstract class CommandSMSListener extends BaseSMSListener
             }
         }
 
-        programStageInstanceService.saveEventDataValuesAndSaveProgramStageInstance( event,
+        eventService.saveEventDataValuesAndSaveEvent( event,
             dataElementsAndEventDataValues );
 
         update( sms, SmsMessageStatus.PROCESSED, true );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
@@ -52,11 +52,11 @@ import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.relationship.RelationshipType;
@@ -113,7 +113,7 @@ public abstract class CompressionSMSListener
 
     protected final DataElementService dataElementService;
 
-    protected final ProgramStageInstanceService programStageInstanceService;
+    protected final EventService eventService;
 
     protected final IdentifiableObjectManager identifiableObjectManager;
 
@@ -121,7 +121,7 @@ public abstract class CompressionSMSListener
         UserService userService, TrackedEntityTypeService trackedEntityTypeService,
         TrackedEntityAttributeService trackedEntityAttributeService, ProgramService programService,
         OrganisationUnitService organisationUnitService, CategoryService categoryService,
-        DataElementService dataElementService, ProgramStageInstanceService programStageInstanceService,
+        DataElementService dataElementService, EventService eventService,
         IdentifiableObjectManager identifiableObjectManager )
     {
         super( incomingSmsService, smsSender );
@@ -133,7 +133,7 @@ public abstract class CompressionSMSListener
         checkNotNull( organisationUnitService );
         checkNotNull( categoryService );
         checkNotNull( dataElementService );
-        checkNotNull( programStageInstanceService );
+        checkNotNull( eventService );
 
         this.userService = userService;
         this.trackedEntityTypeService = trackedEntityTypeService;
@@ -142,7 +142,7 @@ public abstract class CompressionSMSListener
         this.organisationUnitService = organisationUnitService;
         this.categoryService = categoryService;
         this.dataElementService = dataElementService;
-        this.programStageInstanceService = programStageInstanceService;
+        this.eventService = eventService;
         this.identifiableObjectManager = identifiableObjectManager;
     }
 
@@ -268,9 +268,9 @@ public abstract class CompressionSMSListener
         Event event;
         // If we aren't given a Uid for the event, it will be auto-generated
 
-        if ( programStageInstanceService.programStageInstanceExists( eventUid ) )
+        if ( eventService.eventExists( eventUid ) )
         {
-            event = programStageInstanceService.getProgramStageInstance( eventUid );
+            event = eventService.getEvent( eventUid );
         }
         else
         {
@@ -332,7 +332,7 @@ public abstract class CompressionSMSListener
             }
         }
 
-        programStageInstanceService.saveEventDataValuesAndSaveProgramStageInstance( event,
+        eventService.saveEventDataValuesAndSaveEvent( event,
             dataElementsAndEventDataValues );
 
         return errorUids;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DataValueSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DataValueSMSListener.java
@@ -53,8 +53,8 @@ import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramInstanceService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.sms.command.CompletenessMethod;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
@@ -97,14 +97,14 @@ public class DataValueSMSListener extends CommandSMSListener
     private final DataElementService dataElementService;
 
     public DataValueSMSListener( ProgramInstanceService programInstanceService,
-        CategoryService dataElementCategoryService, ProgramStageInstanceService programStageInstanceService,
+        CategoryService dataElementCategoryService, EventService eventService,
         UserService userService, CurrentUserService currentUserService, IncomingSmsService incomingSmsService,
         @Qualifier( "smsMessageSender" ) MessageSender smsSender,
         CompleteDataSetRegistrationService registrationService, DataValueService dataValueService,
         CategoryService dataElementCategoryService1, SMSCommandService smsCommandService, DataSetService dataSetService,
         DataElementService dataElementService )
     {
-        super( programInstanceService, dataElementCategoryService, programStageInstanceService, userService,
+        super( programInstanceService, dataElementCategoryService, eventService, userService,
             currentUserService, incomingSmsService, smsSender );
 
         this.registrationService = registrationService;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DeleteEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DeleteEventSMSListener.java
@@ -33,8 +33,8 @@ import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
 import org.hisp.dhis.smscompression.SmsConsts.SubmissionType;
@@ -57,11 +57,11 @@ public class DeleteEventSMSListener extends CompressionSMSListener
         @Qualifier( "smsMessageSender" ) MessageSender smsSender, UserService userService,
         TrackedEntityTypeService trackedEntityTypeService, TrackedEntityAttributeService trackedEntityAttributeService,
         ProgramService programService, OrganisationUnitService organisationUnitService, CategoryService categoryService,
-        DataElementService dataElementService, ProgramStageInstanceService programStageInstanceService,
+        DataElementService dataElementService, EventService eventService,
         IdentifiableObjectManager identifiableObjectManager )
     {
         super( incomingSmsService, smsSender, userService, trackedEntityTypeService, trackedEntityAttributeService,
-            programService, organisationUnitService, categoryService, dataElementService, programStageInstanceService,
+            programService, organisationUnitService, categoryService, dataElementService, eventService,
             identifiableObjectManager );
     }
 
@@ -72,14 +72,14 @@ public class DeleteEventSMSListener extends CompressionSMSListener
         DeleteSmsSubmission subm = (DeleteSmsSubmission) submission;
 
         Uid eventid = subm.getEvent();
-        Event event = programStageInstanceService.getProgramStageInstance( eventid.getUid() );
+        Event event = eventService.getEvent( eventid.getUid() );
 
         if ( event == null )
         {
             throw new SMSProcessingException( SmsResponse.INVALID_EVENT.set( eventid ) );
         }
 
-        programStageInstanceService.deleteProgramStageInstance( event );
+        eventService.deleteEvent( event );
 
         return SmsResponse.SUCCESS;
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DhisMessageAlertListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DhisMessageAlertListener.java
@@ -43,8 +43,8 @@ import org.hisp.dhis.message.MessageConversationParams;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.message.MessageType;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramInstanceService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
@@ -71,12 +71,12 @@ public class DhisMessageAlertListener extends CommandSMSListener
     private final MessageService messageService;
 
     public DhisMessageAlertListener( ProgramInstanceService programInstanceService,
-        CategoryService dataElementCategoryService, ProgramStageInstanceService programStageInstanceService,
+        CategoryService dataElementCategoryService, EventService eventService,
         UserService userService, CurrentUserService currentUserService, IncomingSmsService incomingSmsService,
         @Qualifier( "smsMessageSender" ) MessageSender smsSender, SMSCommandService smsCommandService,
         MessageService messageService )
     {
-        super( programInstanceService, dataElementCategoryService, programStageInstanceService, userService,
+        super( programInstanceService, dataElementCategoryService, eventService, userService,
             currentUserService, incomingSmsService, smsSender );
 
         checkNotNull( smsCommandService );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
@@ -42,12 +42,12 @@ import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
@@ -92,12 +92,12 @@ public class EnrollmentSMSListener extends CompressionSMSListener
         TrackedEntityTypeService trackedEntityTypeService, TrackedEntityAttributeService trackedEntityAttributeService,
         ProgramService programService, OrganisationUnitService organisationUnitService, CategoryService categoryService,
         DataElementService dataElementService, ProgramStageService programStageService,
-        ProgramStageInstanceService programStageInstanceService,
+        EventService eventService,
         TrackedEntityAttributeValueService attributeValueService, TrackedEntityInstanceService teiService,
         ProgramInstanceService programInstanceService, IdentifiableObjectManager identifiableObjectManager )
     {
         super( incomingSmsService, smsSender, userService, trackedEntityTypeService, trackedEntityAttributeService,
-            programService, organisationUnitService, categoryService, dataElementService, programStageInstanceService,
+            programService, organisationUnitService, categoryService, dataElementService, eventService,
             identifiableObjectManager );
 
         this.teiService = teiService;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/J2MEDataValueSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/J2MEDataValueSMSListener.java
@@ -55,8 +55,8 @@ import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.period.QuarterlyPeriodType;
 import org.hisp.dhis.period.WeeklyPeriodType;
 import org.hisp.dhis.period.YearlyPeriodType;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramInstanceService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
 import org.hisp.dhis.sms.command.code.SMSCode;
@@ -91,13 +91,13 @@ public class J2MEDataValueSMSListener extends CommandSMSListener
     private final CompleteDataSetRegistrationService registrationService;
 
     public J2MEDataValueSMSListener( ProgramInstanceService programInstanceService,
-        CategoryService dataElementCategoryService, ProgramStageInstanceService programStageInstanceService,
+        CategoryService dataElementCategoryService, EventService eventService,
         UserService userService, CurrentUserService currentUserService, IncomingSmsService incomingSmsService,
         @Qualifier( "smsMessageSender" ) MessageSender smsSender, DataValueService dataValueService,
         CategoryService dataElementCategoryService1, SMSCommandService smsCommandService,
         CompleteDataSetRegistrationService registrationService )
     {
-        super( programInstanceService, dataElementCategoryService, programStageInstanceService, userService,
+        super( programInstanceService, dataElementCategoryService, eventService, userService,
             currentUserService, incomingSmsService, smsSender );
 
         checkNotNull( dataValueService );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/ProgramStageDataEntrySMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/ProgramStageDataEntrySMSListener.java
@@ -42,10 +42,10 @@ import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
@@ -86,14 +86,14 @@ public class ProgramStageDataEntrySMSListener extends CommandSMSListener
     private final ProgramInstanceService programInstanceService;
 
     public ProgramStageDataEntrySMSListener( ProgramInstanceService programInstanceService,
-        CategoryService dataElementCategoryService, ProgramStageInstanceService programStageInstanceService,
+        CategoryService dataElementCategoryService, EventService eventService,
         UserService userService, CurrentUserService currentUserService, IncomingSmsService incomingSmsService,
         @Qualifier( "smsMessageSender" ) MessageSender smsSender,
         TrackedEntityInstanceService trackedEntityInstanceService,
         TrackedEntityAttributeService trackedEntityAttributeService, SMSCommandService smsCommandService,
         ProgramInstanceService programInstanceService1 )
     {
-        super( programInstanceService, dataElementCategoryService, programStageInstanceService, userService,
+        super( programInstanceService, dataElementCategoryService, eventService, userService,
             currentUserService, incomingSmsService, smsSender );
 
         checkNotNull( trackedEntityAttributeService );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/RelationshipSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/RelationshipSMSListener.java
@@ -35,10 +35,10 @@ import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.relationship.RelationshipEntity;
 import org.hisp.dhis.relationship.RelationshipItem;
@@ -83,13 +83,13 @@ public class RelationshipSMSListener extends CompressionSMSListener
         @Qualifier( "smsMessageSender" ) MessageSender smsSender, UserService userService,
         TrackedEntityTypeService trackedEntityTypeService, TrackedEntityAttributeService trackedEntityAttributeService,
         ProgramService programService, OrganisationUnitService organisationUnitService, CategoryService categoryService,
-        DataElementService dataElementService, ProgramStageInstanceService programStageInstanceService,
+        DataElementService dataElementService, EventService eventService,
         RelationshipService relationshipService, RelationshipTypeService relationshipTypeService,
         TrackedEntityInstanceService trackedEntityInstanceService, ProgramInstanceService programInstanceService,
         IdentifiableObjectManager identifiableObjectManager )
     {
         super( incomingSmsService, smsSender, userService, trackedEntityTypeService, trackedEntityAttributeService,
-            programService, organisationUnitService, categoryService, dataElementService, programStageInstanceService,
+            programService, organisationUnitService, categoryService, dataElementService, eventService,
             identifiableObjectManager );
 
         this.relationshipService = relationshipService;
@@ -168,7 +168,7 @@ public class RelationshipSMSListener extends CompressionSMSListener
             break;
 
         case PROGRAM_STAGE_INSTANCE:
-            Event event = programStageInstanceService.getProgramStageInstance( objId.getUid() );
+            Event event = eventService.getEvent( objId.getUid() );
             if ( event == null )
             {
                 throw new SMSProcessingException( SmsResponse.INVALID_EVENT.set( objId ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
@@ -39,12 +39,12 @@ import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
@@ -71,11 +71,11 @@ public class SimpleEventSMSListener extends CompressionSMSListener
         @Qualifier( "smsMessageSender" ) MessageSender smsSender, UserService userService,
         TrackedEntityTypeService trackedEntityTypeService, TrackedEntityAttributeService trackedEntityAttributeService,
         ProgramService programService, OrganisationUnitService organisationUnitService, CategoryService categoryService,
-        DataElementService dataElementService, ProgramStageInstanceService programStageInstanceService,
+        DataElementService dataElementService, EventService eventService,
         ProgramInstanceService programInstanceService, IdentifiableObjectManager identifiableObjectManager )
     {
         super( incomingSmsService, smsSender, userService, trackedEntityTypeService, trackedEntityAttributeService,
-            programService, organisationUnitService, categoryService, dataElementService, programStageInstanceService,
+            programService, organisationUnitService, categoryService, dataElementService, eventService,
             identifiableObjectManager );
 
         this.programInstanceService = programInstanceService;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SingleEventListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SingleEventListener.java
@@ -37,9 +37,9 @@ import java.util.Set;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
@@ -65,12 +65,12 @@ public class SingleEventListener extends CommandSMSListener
     private final ProgramInstanceService programInstanceService;
 
     public SingleEventListener( ProgramInstanceService programInstanceService,
-        CategoryService dataElementCategoryService, ProgramStageInstanceService programStageInstanceService,
+        CategoryService dataElementCategoryService, EventService eventService,
         UserService userService, CurrentUserService currentUserService, IncomingSmsService incomingSmsService,
         @Qualifier( "smsMessageSender" ) MessageSender smsSender, SMSCommandService smsCommandService,
         ProgramInstanceService programInstanceService1 )
     {
-        super( programInstanceService, dataElementCategoryService, programStageInstanceService, userService,
+        super( programInstanceService, dataElementCategoryService, eventService, userService,
             currentUserService, incomingSmsService, smsSender );
 
         checkNotNull( smsCommandService );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationSMSListener.java
@@ -39,10 +39,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
 import org.hisp.dhis.sms.command.code.SMSCode;
@@ -85,12 +85,12 @@ public class TrackedEntityRegistrationSMSListener extends CommandSMSListener
 
     public TrackedEntityRegistrationSMSListener( ProgramService programService,
         ProgramInstanceService programInstanceService,
-        CategoryService dataElementCategoryService, ProgramStageInstanceService programStageInstanceService,
+        CategoryService dataElementCategoryService, EventService eventService,
         UserService userService, CurrentUserService currentUserService, IncomingSmsService incomingSmsService,
         @Qualifier( "smsMessageSender" ) MessageSender smsSender, SMSCommandService smsCommandService,
         TrackedEntityTypeService trackedEntityTypeService, TrackedEntityInstanceService trackedEntityInstanceService )
     {
-        super( programInstanceService, dataElementCategoryService, programStageInstanceService, userService,
+        super( programInstanceService, dataElementCategoryService, eventService, userService,
             currentUserService, incomingSmsService, smsSender );
 
         checkNotNull( smsCommandService );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackerEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackerEventSMSListener.java
@@ -36,11 +36,11 @@ import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
@@ -69,12 +69,12 @@ public class TrackerEventSMSListener extends CompressionSMSListener
         @Qualifier( "smsMessageSender" ) MessageSender smsSender, UserService userService,
         TrackedEntityTypeService trackedEntityTypeService, TrackedEntityAttributeService trackedEntityAttributeService,
         ProgramService programService, OrganisationUnitService organisationUnitService, CategoryService categoryService,
-        DataElementService dataElementService, ProgramStageInstanceService programStageInstanceService,
+        DataElementService dataElementService, EventService eventService,
         ProgramStageService programStageService, ProgramInstanceService programInstanceService,
         IdentifiableObjectManager identifiableObjectManager )
     {
         super( incomingSmsService, smsSender, userService, trackedEntityTypeService, trackedEntityAttributeService,
-            programService, organisationUnitService, categoryService, dataElementService, programStageInstanceService,
+            programService, organisationUnitService, categoryService, dataElementService, eventService,
             identifiableObjectManager );
 
         this.programStageService = programStageService;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/UnregisteredSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/UnregisteredSMSListener.java
@@ -36,8 +36,8 @@ import org.hisp.dhis.message.MessageConversationParams;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.message.MessageType;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramInstanceService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
@@ -64,12 +64,12 @@ public class UnregisteredSMSListener extends CommandSMSListener
     private final MessageService messageService;
 
     public UnregisteredSMSListener( ProgramInstanceService programInstanceService,
-        CategoryService dataElementCategoryService, ProgramStageInstanceService programStageInstanceService,
+        CategoryService dataElementCategoryService, EventService eventService,
         UserService userService, CurrentUserService currentUserService, IncomingSmsService incomingSmsService,
         @Qualifier( "smsMessageSender" ) MessageSender smsSender, SMSCommandService smsCommandService,
         UserService userService1, MessageService messageService )
     {
-        super( programInstanceService, dataElementCategoryService, programStageInstanceService, userService,
+        super( programInstanceService, dataElementCategoryService, eventService, userService,
             currentUserService, incomingSmsService, smsSender );
 
         checkNotNull( smsCommandService );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/TrackerNotificationWebHookServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/TrackerNotificationWebHookServiceTest.java
@@ -48,11 +48,11 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
@@ -114,7 +114,7 @@ class TrackerNotificationWebHookServiceTest extends DhisConvenienceTest
     private ProgramInstanceService programInstanceService;
 
     @Mock
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     @Mock
     private ProgramNotificationTemplateService templateService;
@@ -218,7 +218,7 @@ class TrackerNotificationWebHookServiceTest extends DhisConvenienceTest
     @Test
     void testTrackerEventNotificationWebHook()
     {
-        when( programStageInstanceService.getProgramStageInstance( anyString() ) ).thenReturn( event );
+        when( eventService.getEvent( anyString() ) ).thenReturn( event );
         when( templateService.isProgramStageLinkedToWebHookNotification( any( ProgramStage.class ) ) )
             .thenReturn( true );
         when( templateService.getProgramStageLinkedToWebHookNotifications( any( ProgramStage.class ) ) )

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListenerTest.java
@@ -53,8 +53,8 @@ import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
 import org.hisp.dhis.smscompression.SmsCompressionException;
@@ -109,7 +109,7 @@ class AggregateDataSetSMSListenerTest
     private CategoryService categoryService;
 
     @Mock
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     // Needed for this test
 
@@ -157,7 +157,7 @@ class AggregateDataSetSMSListenerTest
     {
         subject = new AggregateDataSetSMSListener( incomingSmsService, smsSender, userService, trackedEntityTypeService,
             trackedEntityAttributeService, programService, organisationUnitService, categoryService, dataElementService,
-            programStageInstanceService, dataSetService, dataValueService, registrationService,
+            eventService, dataSetService, dataValueService, registrationService,
             identifiableObjectManager );
 
         setUpInstances();

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/DataValueListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/DataValueListenerTest.java
@@ -62,8 +62,8 @@ import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
 import org.hisp.dhis.period.Period;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramInstanceService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
 import org.hisp.dhis.sms.command.SMSSpecialCharacter;
@@ -123,7 +123,7 @@ class DataValueListenerTest extends DhisConvenienceTest
     private CategoryService dataElementCategoryService;
 
     @Mock
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     @Mock
     private UserService userService;
@@ -216,7 +216,7 @@ class DataValueListenerTest extends DhisConvenienceTest
     public void initTest()
     {
         subject = new DataValueSMSListener( programInstanceService, dataElementCategoryService,
-            programStageInstanceService, userService, currentUserService, incomingSmsService, smsSender,
+            eventService, userService, currentUserService, incomingSmsService, smsSender,
             registrationService, dataValueService, dataElementCategoryService, smsCommandService, dataSetService,
             dataElementService );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/DeleteEventSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/DeleteEventSMSListenerTest.java
@@ -44,8 +44,8 @@ import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
 import org.hisp.dhis.smscompression.SmsCompressionException;
@@ -94,7 +94,7 @@ class DeleteEventSMSListenerTest
     private CategoryService categoryService;
 
     @Mock
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     @Mock
     private IdentifiableObjectManager identifiableObjectManager;
@@ -121,7 +121,7 @@ class DeleteEventSMSListenerTest
     {
         subject = new DeleteEventSMSListener( incomingSmsService, smsSender, userService, trackedEntityTypeService,
             trackedEntityAttributeService, programService, organisationUnitService, categoryService, dataElementService,
-            programStageInstanceService, identifiableObjectManager );
+            eventService, identifiableObjectManager );
 
         setUpInstances();
 
@@ -131,7 +131,7 @@ class DeleteEventSMSListenerTest
             message = (String) invocation.getArguments()[1];
             return response;
         } );
-        when( programStageInstanceService.getProgramStageInstance( anyString() ) ).thenReturn( event );
+        when( eventService.getEvent( anyString() ) ).thenReturn( event );
 
         doAnswer( invocation -> {
             updatedIncomingSms = (IncomingSms) invocation.getArguments()[0];

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/EnrollmentSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/EnrollmentSMSListenerTest.java
@@ -52,12 +52,12 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.sms.incoming.IncomingSms;
@@ -125,7 +125,7 @@ class EnrollmentSMSListenerTest
     private ProgramStageService programStageService;
 
     @Mock
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     // Needed for this test
 
@@ -195,7 +195,7 @@ class EnrollmentSMSListenerTest
     {
         subject = new EnrollmentSMSListener( incomingSmsService, smsSender, userService, trackedEntityTypeService,
             trackedEntityAttributeService, programService, organisationUnitService, categoryService, dataElementService,
-            programStageService, programStageInstanceService, attributeValueService, teiService, programInstanceService,
+            programStageService, eventService, attributeValueService, teiService, programInstanceService,
             identifiableObjectManager );
 
         setUpInstances();

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/RelationshipSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/RelationshipSMSListenerTest.java
@@ -43,10 +43,10 @@ import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.relationship.RelationshipConstraint;
 import org.hisp.dhis.relationship.RelationshipEntity;
 import org.hisp.dhis.relationship.RelationshipService;
@@ -101,7 +101,7 @@ class RelationshipSMSListenerTest
     private CategoryService categoryService;
 
     @Mock
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     @Mock
     private IdentifiableObjectManager identifiableObjectManager;
@@ -142,7 +142,7 @@ class RelationshipSMSListenerTest
     {
         subject = new RelationshipSMSListener( incomingSmsService, smsSender, userService, trackedEntityTypeService,
             trackedEntityAttributeService, programService, organisationUnitService, categoryService, dataElementService,
-            programStageInstanceService, relationshipService, relationshipTypeService, trackedEntityInstanceService,
+            eventService, relationshipService, relationshipTypeService, trackedEntityInstanceService,
             programInstanceService, identifiableObjectManager );
 
         setUpInstances();

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/SimpleEventSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/SimpleEventSMSListenerTest.java
@@ -52,11 +52,11 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
 import org.hisp.dhis.smscompression.SmsCompressionException;
@@ -110,7 +110,7 @@ class SimpleEventSMSListenerTest
     private CategoryService categoryService;
 
     @Mock
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     @Mock
     private IdentifiableObjectManager identifiableObjectManager;
@@ -152,7 +152,7 @@ class SimpleEventSMSListenerTest
     {
         subject = new SimpleEventSMSListener( incomingSmsService, smsSender, userService, trackedEntityTypeService,
             trackedEntityAttributeService, programService, organisationUnitService, categoryService, dataElementService,
-            programStageInstanceService, programInstanceService, identifiableObjectManager );
+            eventService, programInstanceService, identifiableObjectManager );
 
         setUpInstances();
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationListenerTest.java
@@ -46,10 +46,10 @@ import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
@@ -98,7 +98,7 @@ class TrackedEntityRegistrationListenerTest extends DhisConvenienceTest
     private CategoryService dataElementCategoryService;
 
     @Mock
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     @Mock
     private UserService userService;
@@ -159,7 +159,7 @@ class TrackedEntityRegistrationListenerTest extends DhisConvenienceTest
     {
         subject = new TrackedEntityRegistrationSMSListener( programService, programInstanceService,
             dataElementCategoryService,
-            programStageInstanceService, userService, currentUserService, incomingSmsService, smsSender,
+            eventService, userService, currentUserService, incomingSmsService, smsSender,
             smsCommandService,
             trackedEntityTypeService, trackedEntityInstanceService );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackerEventSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackerEventSMSListenerTest.java
@@ -51,12 +51,12 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
@@ -114,7 +114,7 @@ class TrackerEventSMSListenerTest
     private CategoryService categoryService;
 
     @Mock
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     @Mock
     private IdentifiableObjectManager identifiableObjectManager;
@@ -163,7 +163,7 @@ class TrackerEventSMSListenerTest
     {
         subject = new TrackerEventSMSListener( incomingSmsService, smsSender, userService, trackedEntityTypeService,
             trackedEntityAttributeService, programService, organisationUnitService, categoryService, dataElementService,
-            programStageInstanceService, programStageService, programInstanceService, identifiableObjectManager );
+            eventService, programStageService, programInstanceService, identifiableObjectManager );
 
         setUpInstances();
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -65,7 +65,6 @@ import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.events.EnrollmentParams;
 import org.hisp.dhis.dxf2.events.NoteHelper;
 import org.hisp.dhis.dxf2.events.RelationshipParams;
-import org.hisp.dhis.dxf2.events.event.EventService;
 import org.hisp.dhis.dxf2.events.event.Note;
 import org.hisp.dhis.dxf2.events.relationship.RelationshipService;
 import org.hisp.dhis.dxf2.events.trackedentity.Attribute;
@@ -79,12 +78,12 @@ import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.organisationunit.FeatureType;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceQueryParams;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.program.UserInfoSnapshot;
@@ -138,7 +137,7 @@ public abstract class AbstractEnrollmentService
 
     protected ProgramInstanceService programInstanceService;
 
-    protected ProgramStageInstanceService programStageInstanceService;
+    protected EventService programStageInstanceService;
 
     protected ProgramService programService;
 
@@ -166,7 +165,7 @@ public abstract class AbstractEnrollmentService
 
     protected DbmsManager dbmsManager;
 
-    protected EventService eventService;
+    protected org.hisp.dhis.dxf2.events.event.EventService eventService;
 
     protected TrackerAccessManager trackerAccessManager;
 
@@ -1230,7 +1229,7 @@ public abstract class AbstractEnrollmentService
             {
                 delete.add( event.getEvent() );
             }
-            else if ( !programStageInstanceService.programStageInstanceExists( event.getEvent() ) )
+            else if ( !programStageInstanceService.eventExists( event.getEvent() ) )
             {
                 create.add( event );
             }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/JacksonEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/JacksonEnrollmentService.java
@@ -40,16 +40,15 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.dxf2.common.ImportOptions;
-import org.hisp.dhis.dxf2.events.event.EventService;
 import org.hisp.dhis.dxf2.events.relationship.RelationshipService;
 import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.dxf2.metadata.feedback.ImportReportMode;
 import org.hisp.dhis.i18n.I18nManager;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.query.QueryService;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.system.notification.Notifier;
@@ -82,7 +81,7 @@ public class JacksonEnrollmentService extends AbstractEnrollmentService
 {
     public JacksonEnrollmentService(
         ProgramInstanceService programInstanceService,
-        ProgramStageInstanceService programStageInstanceService,
+        EventService programStageInstanceService,
         ProgramService programService,
         TrackedEntityInstanceService trackedEntityInstanceService,
         TrackerOwnershipManager trackerOwnershipAccessManager,
@@ -96,7 +95,7 @@ public class JacksonEnrollmentService extends AbstractEnrollmentService
         I18nManager i18nManager,
         UserService userService,
         DbmsManager dbmsManager,
-        EventService eventService,
+        org.hisp.dhis.dxf2.events.event.EventService eventService,
         TrackerAccessManager trackerAccessManager,
         SchemaService schemaService,
         QueryService queryService,

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JacksonEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JacksonEventService.java
@@ -48,9 +48,9 @@ import org.hisp.dhis.dxf2.events.relationship.RelationshipService;
 import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
 import org.hisp.dhis.fileresource.FileResourceService;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.query.QueryService;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.system.notification.Notifier;
@@ -94,7 +94,7 @@ public class JacksonEventService extends AbstractEventService
     public JacksonEventService( EventImporter eventImporter, EventManager eventManager,
         WorkContextLoader workContextLoader, EventServiceFacade jacksonEventServiceFacade,
         ProgramService programService, ProgramInstanceService programInstanceService,
-        ProgramStageInstanceService programStageInstanceService, OrganisationUnitService organisationUnitService,
+        EventService eventService, OrganisationUnitService organisationUnitService,
         CurrentUserService currentUserService, TrackedEntityInstanceService entityInstanceService,
         TrackedEntityCommentService commentService, EventStore eventStore, Notifier notifier, DbmsManager dbmsManager,
         IdentifiableObjectManager manager, CategoryService categoryService, FileResourceService fileResourceService,
@@ -110,7 +110,7 @@ public class JacksonEventService extends AbstractEventService
         checkNotNull( jacksonEventServiceFacade );
         checkNotNull( programService );
         checkNotNull( programInstanceService );
-        checkNotNull( programStageInstanceService );
+        checkNotNull( eventService );
         checkNotNull( organisationUnitService );
         checkNotNull( currentUserService );
         checkNotNull( entityInstanceService );
@@ -136,7 +136,7 @@ public class JacksonEventService extends AbstractEventService
         this.jacksonEventServiceFacade = jacksonEventServiceFacade;
         this.programService = programService;
         this.programInstanceService = programInstanceService;
-        this.programStageInstanceService = programStageInstanceService;
+        this.eventService = eventService;
         this.organisationUnitService = organisationUnitService;
         this.currentUserService = currentUserService;
         this.entityInstanceService = entityInstanceService;

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEngineService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEngineService.java
@@ -36,11 +36,11 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.programrule.ProgramRule;
 import org.hisp.dhis.rules.models.RuleEffect;
 import org.hisp.dhis.rules.models.RuleValidationResult;
@@ -70,7 +70,7 @@ public class DefaultProgramRuleEngineService
 
     private final ProgramInstanceService programInstanceService;
 
-    private final ProgramStageInstanceService programStageInstanceService;
+    private final EventService eventService;
 
     private final ProgramService programService;
 
@@ -123,7 +123,7 @@ public class DefaultProgramRuleEngineService
             return Lists.newArrayList();
         }
 
-        Event psi = programStageInstanceService.getProgramStageInstance( event );
+        Event psi = eventService.getEvent( event );
 
         return evaluateEventAndRunEffects( psi );
     }

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/NotificationRuleActionImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/NotificationRuleActionImplementer.java
@@ -38,9 +38,9 @@ import org.hisp.dhis.notification.logging.ExternalNotificationLogEntry;
 import org.hisp.dhis.notification.logging.NotificationLoggingService;
 import org.hisp.dhis.notification.logging.NotificationValidationResult;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplateService;
 import org.hisp.dhis.rules.models.RuleAction;
@@ -68,7 +68,7 @@ abstract class NotificationRuleActionImplementer implements RuleActionImplemente
 
     protected final ProgramInstanceService programInstanceService;
 
-    protected final ProgramStageInstanceService programStageInstanceService;
+    protected final EventService eventService;
 
     protected ExternalNotificationLogEntry createLogEntry( String key, String templateUid )
     {

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionScheduleMessageImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionScheduleMessageImplementer.java
@@ -37,9 +37,9 @@ import org.hisp.dhis.notification.logging.NotificationLoggingService;
 import org.hisp.dhis.notification.logging.NotificationTriggerEvent;
 import org.hisp.dhis.notification.logging.NotificationValidationResult;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.notification.ProgramNotificationInstance;
 import org.hisp.dhis.program.notification.ProgramNotificationInstanceService;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
@@ -72,12 +72,12 @@ public class RuleActionScheduleMessageImplementer extends NotificationRuleAction
     public RuleActionScheduleMessageImplementer( ProgramNotificationTemplateService programNotificationTemplateService,
         NotificationLoggingService notificationLoggingService,
         ProgramInstanceService programInstanceService,
-        ProgramStageInstanceService programStageInstanceService,
+        EventService eventService,
         ProgramNotificationInstanceService programNotificationInstanceService,
         NotificationTemplateService notificationTemplateService )
     {
         super( programNotificationTemplateService, notificationLoggingService, programInstanceService,
-            programStageInstanceService );
+            eventService );
         this.programNotificationInstanceService = programNotificationInstanceService;
         this.notificationTemplateService = notificationTemplateService;
     }

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionSendMessageImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionSendMessageImplementer.java
@@ -34,9 +34,9 @@ import org.hisp.dhis.notification.logging.NotificationLoggingService;
 import org.hisp.dhis.notification.logging.NotificationTriggerEvent;
 import org.hisp.dhis.notification.logging.NotificationValidationResult;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.notification.*;
 import org.hisp.dhis.program.notification.event.ProgramRuleEnrollmentEvent;
 import org.hisp.dhis.program.notification.event.ProgramRuleStageEvent;
@@ -70,11 +70,11 @@ public class RuleActionSendMessageImplementer extends NotificationRuleActionImpl
     public RuleActionSendMessageImplementer( ProgramNotificationTemplateService programNotificationTemplateService,
         NotificationLoggingService notificationLoggingService,
         ProgramInstanceService programInstanceService,
-        ProgramStageInstanceService programStageInstanceService,
+        EventService eventService,
         ApplicationEventPublisher publisher )
     {
         super( programNotificationTemplateService, notificationLoggingService, programInstanceService,
-            programStageInstanceService );
+            eventService );
         this.publisher = publisher;
     }
 

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineServiceTest.java
@@ -50,12 +50,12 @@ import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.programrule.ProgramRule;
 import org.hisp.dhis.programrule.ProgramRuleAction;
@@ -99,7 +99,7 @@ class ProgramRuleEngineServiceTest extends DhisConvenienceTest
     private ProgramInstanceService programInstanceService;
 
     @Mock
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     @Mock
     private ProgramRuleEngine programRuleEngine;
@@ -213,7 +213,7 @@ class ProgramRuleEngineServiceTest extends DhisConvenienceTest
         List<RuleEffect> effects = new ArrayList<>();
         effects.add( RuleEffect.create( "", RuleActionSendMessage.create( NOTIFICATION_UID, DATA ) ) );
 
-        when( programStageInstanceService.getProgramStageInstance( anyString() ) ).thenReturn( event );
+        when( eventService.getEvent( anyString() ) ).thenReturn( event );
         when( programInstanceService.getProgramInstance( anyLong() ) ).thenReturn( programInstance );
 
         when( programRuleEngine.getProgramRules( any(), any() ) ).thenReturn( List.of( programRuleA ) );
@@ -252,7 +252,7 @@ class ProgramRuleEngineServiceTest extends DhisConvenienceTest
         Event programEvent = createProgramStageInstance( programStage, programInstance,
             createOrganisationUnit( 'A' ) );
 
-        when( programStageInstanceService.getProgramStageInstance( programEvent.getUid() ) ).thenReturn( programEvent );
+        when( eventService.getEvent( programEvent.getUid() ) ).thenReturn( programEvent );
 
         when( programRuleEngine.getProgramRules( program, List.of( programStage ) ) )
             .thenReturn( List.of( programRuleA ) );
@@ -280,7 +280,7 @@ class ProgramRuleEngineServiceTest extends DhisConvenienceTest
     @Test
     void shouldNotTryToEvaluateWhenThereAreNoRulesToRun()
     {
-        when( programStageInstanceService.getProgramStageInstance( anyString() ) ).thenReturn( event );
+        when( eventService.getEvent( anyString() ) ).thenReturn( event );
         when( programInstanceService.getProgramInstance( anyLong() ) ).thenReturn( programInstance );
 
         when( programRuleEngine.getProgramRules( any(), any() ) ).thenReturn( List.of() );

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
@@ -46,7 +46,7 @@ import org.hisp.dhis.datasummary.DataSummary;
 import org.hisp.dhis.datavalue.DataValueService;
 import org.hisp.dhis.eventvisualization.EventVisualizationStore;
 import org.hisp.dhis.indicator.Indicator;
-import org.hisp.dhis.program.ProgramStageInstanceService;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.statistics.StatisticsProvider;
 import org.hisp.dhis.system.SystemInfo;
@@ -82,7 +82,7 @@ public class DefaultDataStatisticsService
 
     private final StatisticsProvider statisticsProvider;
 
-    private final ProgramStageInstanceService programStageInstanceService;
+    private final EventService eventService;
 
     private final EventVisualizationStore eventVisualizationStore;
 
@@ -241,10 +241,10 @@ public class DefaultDataStatisticsService
         // Events
         Map<Integer, Long> eventCount = new HashMap<>();
 
-        eventCount.put( 0, programStageInstanceService.getProgramStageInstanceCount( 0 ) );
-        eventCount.put( 1, programStageInstanceService.getProgramStageInstanceCount( 1 ) );
-        eventCount.put( 7, programStageInstanceService.getProgramStageInstanceCount( 7 ) );
-        eventCount.put( 30, programStageInstanceService.getProgramStageInstanceCount( 30 ) );
+        eventCount.put( 0, eventService.getEventCount( 0 ) );
+        eventCount.put( 1, eventService.getEventCount( 1 ) );
+        eventCount.put( 7, eventService.getEventCount( 7 ) );
+        eventCount.put( 30, eventService.getEventCount( 30 ) );
 
         statistics.setEventCount( eventCount );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/DefaultTrackerObjectsDeletionService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/DefaultTrackerObjectsDeletionService.java
@@ -34,9 +34,9 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.relationship.RelationshipService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
@@ -65,7 +65,7 @@ public class DefaultTrackerObjectsDeletionService
 
     private final TrackedEntityInstanceService teiService;
 
-    private final ProgramStageInstanceService programStageInstanceService;
+    private final EventService eventService;
 
     private final RelationshipService relationshipService;
 
@@ -124,11 +124,11 @@ public class DefaultTrackerObjectsDeletionService
 
             Entity objectReport = new Entity( TrackerType.EVENT, uid, idx );
 
-            Event event = programStageInstanceService.getProgramStageInstance( uid );
+            Event event = eventService.getEvent( uid );
 
             ProgramInstance programInstance = event.getProgramInstance();
 
-            programStageInstanceService.deleteProgramStageInstance( event );
+            eventService.deleteEvent( event );
 
             if ( event.getProgramStage().getProgram().isRegistration() )
             {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/HandleRelationshipsTrackedEntityInstanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/HandleRelationshipsTrackedEntityInstanceServiceTest.java
@@ -71,7 +71,7 @@ class HandleRelationshipsTrackedEntityInstanceServiceTest extends SingleSetupInt
     private ProgramInstanceService programInstanceService;
 
     @Autowired
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     @Autowired
     private IdentifiableObjectManager manager;
@@ -126,7 +126,7 @@ class HandleRelationshipsTrackedEntityInstanceServiceTest extends SingleSetupInt
         manager.save( categoryComboA );
         manager.save( categoryOptionComboA );
         eventA.setAttributeOptionCombo( categoryOptionComboA );
-        programStageInstanceService.addProgramStageInstance( eventA );
+        eventService.addEvent( eventA );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/NoRegistrationSingleEventServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/NoRegistrationSingleEventServiceTest.java
@@ -38,18 +38,17 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dxf2.events.event.DataValue;
-import org.hisp.dhis.dxf2.events.event.EventService;
 import org.hisp.dhis.dxf2.importsummary.ImportStatus;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.program.ProgramStageDataElementService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
 import org.hisp.dhis.user.UserService;
@@ -63,7 +62,7 @@ class NoRegistrationSingleEventServiceTest extends TransactionalIntegrationTest
 {
 
     @Autowired
-    private EventService eventService;
+    private org.hisp.dhis.dxf2.events.event.EventService eventService;
 
     @Autowired
     private ProgramStageDataElementService programStageDataElementService;
@@ -72,7 +71,7 @@ class NoRegistrationSingleEventServiceTest extends TransactionalIntegrationTest
     private ProgramInstanceService programInstanceService;
 
     @Autowired
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService programStageInstanceService;
 
     @Autowired
     private IdentifiableObjectManager identifiableObjectManager;
@@ -130,8 +129,7 @@ class NoRegistrationSingleEventServiceTest extends TransactionalIntegrationTest
         ImportSummary importSummary = eventService.addEvent( event, null, false );
         assertEquals( ImportStatus.SUCCESS, importSummary.getStatus() );
         assertNotNull( importSummary.getReference() );
-        Event programStageInstance = programStageInstanceService
-            .getProgramStageInstance( importSummary.getReference() );
+        Event programStageInstance = programStageInstanceService.getEvent( importSummary.getReference() );
         assertNotNull( programStageInstance );
         assertNotNull( eventService.getEvent( programStageInstance, EventParams.FALSE ) );
     }
@@ -144,7 +142,7 @@ class NoRegistrationSingleEventServiceTest extends TransactionalIntegrationTest
         ImportSummary importSummary = eventService.addEvent( event, null, false );
         assertEquals( ImportStatus.SUCCESS, importSummary.getStatus() );
         assertNotNull( importSummary.getReference() );
-        assertNotNull( programStageInstanceService.getProgramStageInstance( importSummary.getReference() ) );
+        assertNotNull( programStageInstanceService.getEvent( importSummary.getReference() ) );
     }
 
     @Test
@@ -157,7 +155,7 @@ class NoRegistrationSingleEventServiceTest extends TransactionalIntegrationTest
         assertEquals( 0, importSummary.getConflictCount() );
         assertNotNull( importSummary.getReference() );
         event = eventService
-            .getEvent( programStageInstanceService.getProgramStageInstance( importSummary.getReference() ),
+            .getEvent( programStageInstanceService.getEvent( importSummary.getReference() ),
                 EventParams.FALSE );
         assertNotNull( event );
         assertEquals( 1, event.getDataValues().size() );
@@ -171,9 +169,9 @@ class NoRegistrationSingleEventServiceTest extends TransactionalIntegrationTest
         ImportSummary importSummary = eventService.addEvent( event, null, false );
         assertEquals( ImportStatus.SUCCESS, importSummary.getStatus() );
         assertNotNull( importSummary.getReference() );
-        assertNotNull( programStageInstanceService.getProgramStageInstance( importSummary.getReference() ) );
+        assertNotNull( programStageInstanceService.getEvent( importSummary.getReference() ) );
         eventService.deleteEvent( event.getEvent() );
-        assertNull( programStageInstanceService.getProgramStageInstance( importSummary.getReference() ) );
+        assertNull( programStageInstanceService.getEvent( importSummary.getReference() ) );
     }
 
     private org.hisp.dhis.dxf2.events.event.Event createEvent( String program, String programStage, String orgUnit )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/ProgramStageValidationStrategyTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/ProgramStageValidationStrategyTest.java
@@ -48,7 +48,6 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dxf2.events.event.DataValue;
-import org.hisp.dhis.dxf2.events.event.EventService;
 import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.dxf2.importsummary.ImportStatus;
@@ -58,11 +57,11 @@ import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.program.ValidationStrategy;
 import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
@@ -80,7 +79,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class ProgramStageValidationStrategyTest extends TransactionalIntegrationTest
 {
     @Autowired
-    private EventService eventService;
+    private org.hisp.dhis.dxf2.events.event.EventService eventService;
 
     @Autowired
     private TrackedEntityInstanceService trackedEntityInstanceService;
@@ -95,7 +94,7 @@ class ProgramStageValidationStrategyTest extends TransactionalIntegrationTest
     protected CurrentUserService currentUserService;
 
     @Autowired
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService programStageInstanceService;
 
     private TrackedEntityInstance trackedEntityInstanceMaleA;
 
@@ -565,7 +564,7 @@ class ProgramStageValidationStrategyTest extends TransactionalIntegrationTest
     private Event getPsi( String event )
     {
         sessionFactory.getCurrentSession().clear();
-        return programStageInstanceService.getProgramStageInstance( event );
+        return programStageInstanceService.getEvent( event );
     }
 
     private void assertDataValuesOnPsi( String event, DataValueAsserter... dataValues )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/security/EventSecurityTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/security/EventSecurityTest.java
@@ -45,18 +45,17 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.events.EventParams;
 import org.hisp.dhis.dxf2.events.event.DataValue;
-import org.hisp.dhis.dxf2.events.event.EventService;
 import org.hisp.dhis.dxf2.importsummary.ImportStatus;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.program.ProgramStageDataElementService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.security.acl.AccessStringHelper;
 import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
@@ -74,13 +73,13 @@ class EventSecurityTest extends TransactionalIntegrationTest
 {
 
     @Autowired
-    private EventService eventService;
+    private org.hisp.dhis.dxf2.events.event.EventService eventService;
 
     @Autowired
     private ProgramInstanceService programInstanceService;
 
     @Autowired
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService programStageInstanceService;
 
     @Autowired
     private ProgramStageDataElementService programStageDataElementService;
@@ -268,9 +267,8 @@ class EventSecurityTest extends TransactionalIntegrationTest
         manager.update( programStageA );
         User user = createUserWithAuth( "user1" ).setOrganisationUnits( Sets.newHashSet( organisationUnitA ) );
         injectSecurityContext( user );
-        assertTrue( programStageInstanceService.programStageInstanceExists( event.getEvent() ) );
-        Event programStageInstance = programStageInstanceService
-            .getProgramStageInstance( event.getUid() );
+        assertTrue( programStageInstanceService.eventExists( event.getEvent() ) );
+        Event programStageInstance = programStageInstanceService.getEvent( event.getUid() );
         assertNotNull( programStageInstance );
         org.hisp.dhis.dxf2.events.event.Event eventFromPsi = eventService.getEvent( programStageInstance,
             EventParams.FALSE );
@@ -300,9 +298,8 @@ class EventSecurityTest extends TransactionalIntegrationTest
         manager.update( programStageA );
         User user = createUserWithAuth( "user1" ).setOrganisationUnits( Sets.newHashSet( organisationUnitA ) );
         injectSecurityContext( user );
-        assertTrue( programStageInstanceService.programStageInstanceExists( event.getEvent() ) );
-        Event programStageInstance = programStageInstanceService
-            .getProgramStageInstance( event.getUid() );
+        assertTrue( programStageInstanceService.eventExists( event.getEvent() ) );
+        Event programStageInstance = programStageInstanceService.getEvent( event.getUid() );
         assertNotNull( programStageInstance );
         org.hisp.dhis.dxf2.events.event.Event eventFromPsi = eventService.getEvent( programStageInstance,
             EventParams.FALSE );
@@ -332,9 +329,8 @@ class EventSecurityTest extends TransactionalIntegrationTest
         manager.update( programStageA );
         User user = createUserWithAuth( "user1" );
         injectSecurityContext( user );
-        assertTrue( programStageInstanceService.programStageInstanceExists( event.getEvent() ) );
-        Event programStageInstance = programStageInstanceService
-            .getProgramStageInstance( event.getUid() );
+        assertTrue( programStageInstanceService.eventExists( event.getEvent() ) );
+        Event programStageInstance = programStageInstanceService.getEvent( event.getUid() );
         assertNotNull( programStageInstance );
         assertThrows( IllegalQueryException.class,
             () -> eventService.getEvent( programStageInstance, EventParams.FALSE ) );
@@ -362,9 +358,8 @@ class EventSecurityTest extends TransactionalIntegrationTest
         manager.update( programStageA );
         User user = createUserWithAuth( "user1" );
         injectSecurityContext( user );
-        assertTrue( programStageInstanceService.programStageInstanceExists( event.getEvent() ) );
-        Event programStageInstance = programStageInstanceService
-            .getProgramStageInstance( event.getUid() );
+        assertTrue( programStageInstanceService.eventExists( event.getEvent() ) );
+        Event programStageInstance = programStageInstanceService.getEvent( event.getUid() );
         assertNotNull( programStageInstance );
         assertThrows( IllegalQueryException.class,
             () -> eventService.getEvent( programStageInstance, EventParams.FALSE ) );
@@ -391,9 +386,8 @@ class EventSecurityTest extends TransactionalIntegrationTest
         manager.update( programStageA );
         User user = createUserWithAuth( "user1" ).setOrganisationUnits( Sets.newHashSet( organisationUnitA ) );
         injectSecurityContext( user );
-        assertTrue( programStageInstanceService.programStageInstanceExists( event.getEvent() ) );
-        Event programStageInstance = programStageInstanceService
-            .getProgramStageInstance( event.getUid() );
+        assertTrue( programStageInstanceService.eventExists( event.getEvent() ) );
+        Event programStageInstance = programStageInstanceService.getEvent( event.getUid() );
         assertNotNull( programStageInstance );
         assertThrows( IllegalQueryException.class,
             () -> eventService.getEvent( programStageInstance, EventParams.FALSE ) );
@@ -420,9 +414,8 @@ class EventSecurityTest extends TransactionalIntegrationTest
         manager.update( programStageA );
         User user = createUserWithAuth( "user1" ).setOrganisationUnits( Sets.newHashSet( organisationUnitA ) );
         injectSecurityContext( user );
-        assertTrue( programStageInstanceService.programStageInstanceExists( event.getEvent() ) );
-        Event programStageInstance = programStageInstanceService
-            .getProgramStageInstance( event.getUid() );
+        assertTrue( programStageInstanceService.eventExists( event.getEvent() ) );
+        Event programStageInstance = programStageInstanceService.getEvent( event.getUid() );
         assertNotNull( programStageInstance );
         org.hisp.dhis.dxf2.events.event.Event eventFromPsi = eventService.getEvent( programStageInstance,
             EventParams.FALSE );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
@@ -51,12 +51,12 @@ import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.program.message.ProgramMessage;
 import org.hisp.dhis.program.message.ProgramMessageRecipients;
@@ -111,7 +111,7 @@ class MaintenanceServiceTest extends IntegrationTestBase
     private ProgramStageService programStageService;
 
     @Autowired
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     @Autowired
     private RelationshipService relationshipService;
@@ -215,7 +215,7 @@ class MaintenanceServiceTest extends IntegrationTestBase
         eventWithTeiAssociation.setOrganisationUnit( organisationUnit );
         eventWithTeiAssociation.setProgramInstance( programInstanceWithTeiAssociation );
         eventWithTeiAssociation.setExecutionDate( new Date() );
-        programStageInstanceService.addProgramStageInstance( eventWithTeiAssociation );
+        eventService.addEvent( eventWithTeiAssociation );
         relationshipType = createPersonToPersonRelationshipType( 'A', program, trackedEntityType, false );
         relationshipTypeService.addRelationshipType( relationshipType );
     }
@@ -285,16 +285,16 @@ class MaintenanceServiceTest extends IntegrationTestBase
         ProgramMessage message = ProgramMessage.builder().subject( "subject" ).text( "text" )
             .recipients( programMessageRecipients ).deliveryChannels( Sets.newHashSet( DeliveryChannel.EMAIL ) )
             .event( event ).build();
-        long idA = programStageInstanceService.addProgramStageInstance( event );
+        long idA = eventService.addEvent( event );
         programMessageService.saveProgramMessage( message );
-        assertNotNull( programStageInstanceService.getProgramStageInstance( idA ) );
-        programStageInstanceService.deleteProgramStageInstance( event );
-        assertNull( programStageInstanceService.getProgramStageInstance( idA ) );
+        assertNotNull( eventService.getEvent( idA ) );
+        eventService.deleteEvent( event );
+        assertNull( eventService.getEvent( idA ) );
         assertTrue(
-            programStageInstanceService.programStageInstanceExistsIncludingDeleted( event.getUid() ) );
+            eventService.eventExistsIncludingDeleted( event.getUid() ) );
         maintenanceService.deleteSoftDeletedProgramStageInstances();
         assertFalse(
-            programStageInstanceService.programStageInstanceExistsIncludingDeleted( event.getUid() ) );
+            eventService.eventExistsIncludingDeleted( event.getUid() ) );
     }
 
     @Test
@@ -327,7 +327,7 @@ class MaintenanceServiceTest extends IntegrationTestBase
             program.getProgramStageByStage( 1 ) );
         eventA.setDueDate( enrollmentDate );
         eventA.setUid( "UID-A" );
-        programStageInstanceService.addProgramStageInstance( eventA );
+        eventService.addEvent( eventA );
         TrackedEntityDataValueAudit trackedEntityDataValueAudit = new TrackedEntityDataValueAudit( dataElement,
             eventA, "value", "modifiedBy", false, org.hisp.dhis.common.AuditType.UPDATE );
         trackedEntityDataValueAuditService.addTrackedEntityDataValueAudit( trackedEntityDataValueAudit );
@@ -354,7 +354,7 @@ class MaintenanceServiceTest extends IntegrationTestBase
             program.getProgramStageByStage( 1 ) );
         eventA.setDueDate( enrollmentDate );
         eventA.setUid( "UID-A" );
-        long idA = programStageInstanceService.addProgramStageInstance( eventA );
+        long idA = eventService.addEvent( eventA );
         Relationship r = new Relationship();
         RelationshipItem rItem1 = new RelationshipItem();
         rItem1.setEvent( eventA );
@@ -366,17 +366,17 @@ class MaintenanceServiceTest extends IntegrationTestBase
         r.setKey( RelationshipUtils.generateRelationshipKey( r ) );
         r.setInvertedKey( RelationshipUtils.generateRelationshipInvertedKey( r ) );
         relationshipService.addRelationship( r );
-        assertNotNull( programStageInstanceService.getProgramStageInstance( idA ) );
+        assertNotNull( eventService.getEvent( idA ) );
         assertNotNull( relationshipService.getRelationship( r.getId() ) );
-        programStageInstanceService.deleteProgramStageInstance( eventA );
-        assertNull( programStageInstanceService.getProgramStageInstance( idA ) );
+        eventService.deleteEvent( eventA );
+        assertNull( eventService.getEvent( idA ) );
         assertNull( relationshipService.getRelationship( r.getId() ) );
         assertTrue(
-            programStageInstanceService.programStageInstanceExistsIncludingDeleted( eventA.getUid() ) );
+            eventService.eventExistsIncludingDeleted( eventA.getUid() ) );
         assertTrue( relationshipService.relationshipExistsIncludingDeleted( r.getUid() ) );
         maintenanceService.deleteSoftDeletedProgramStageInstances();
         assertFalse(
-            programStageInstanceService.programStageInstanceExistsIncludingDeleted( eventA.getUid() ) );
+            eventService.eventExistsIncludingDeleted( eventA.getUid() ) );
         assertFalse( relationshipService.relationshipExistsIncludingDeleted( r.getUid() ) );
     }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/merge/orgunit/handler/TrackerOrgUnitMergeHandlerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/merge/orgunit/handler/TrackerOrgUnitMergeHandlerTest.java
@@ -34,11 +34,11 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.merge.orgunit.OrgUnitMergeRequest;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
@@ -60,7 +60,7 @@ class TrackerOrgUnitMergeHandlerTest extends SingleSetupIntegrationTestBase
     private ProgramInstanceService piService;
 
     @Autowired
-    private ProgramStageInstanceService psiService;
+    private EventService psiService;
 
     @Autowired
     private IdentifiableObjectManager idObjectManager;
@@ -127,9 +127,9 @@ class TrackerOrgUnitMergeHandlerTest extends SingleSetupIntegrationTestBase
         psiA = new Event( piA, psA, ouA );
         psiB = new Event( piB, psA, ouB );
         psiC = new Event( piC, psA, ouA );
-        psiService.addProgramStageInstance( psiA );
-        psiService.addProgramStageInstance( psiB );
-        psiService.addProgramStageInstance( psiC );
+        psiService.addEvent( psiA );
+        psiService.addEvent( psiB );
+        psiService.addEvent( psiC );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/notification/ProgramNotificationMessageRendererTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/notification/ProgramNotificationMessageRendererTest.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
@@ -52,7 +53,6 @@ import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.program.ProgramStageDataElementService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.program.ProgramTrackedEntityAttributeStore;
@@ -156,7 +156,7 @@ class ProgramNotificationMessageRendererTest extends TransactionalIntegrationTes
     private ProgramInstanceService programInstanceService;
 
     @Autowired
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     @Autowired
     private ProgramNotificationTemplateStore programNotificationTemplateStore;
@@ -245,7 +245,7 @@ class ProgramNotificationMessageRendererTest extends TransactionalIntegrationTes
         eventDataValueB.setAutoFields();
         eventDataValueB.setValue( "dataElementB-Text" );
         eventA.setEventDataValues( Sets.newHashSet( eventDataValueA, eventDataValueB ) );
-        programStageInstanceService.addProgramStageInstance( eventA );
+        eventService.addEvent( eventA );
         programInstanceA.getEvents().add( eventA );
         programInstanceService.updateProgramInstance( programInstanceA );
         programNotificationTemplate = new ProgramNotificationTemplate();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/EventPredictionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/EventPredictionServiceTest.java
@@ -61,6 +61,7 @@ import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.program.AnalyticsType;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramIndicatorService;
@@ -68,7 +69,6 @@ import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.system.grid.ListGrid;
 import org.hisp.dhis.test.integration.IntegrationTestBase;
@@ -122,7 +122,7 @@ class EventPredictionServiceTest extends IntegrationTestBase
     private ProgramIndicatorService programIndicatorService;
 
     @Autowired
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     @Autowired
     private OrganisationUnitService organisationUnitService;
@@ -276,16 +276,16 @@ class EventPredictionServiceTest extends IntegrationTestBase
         ProgramInstance programInstance = programInstanceService.enrollTrackedEntityInstance( entityInstance, program,
             dateMar20, dateMar20, orgUnitA );
         programInstanceService.addProgramInstance( programInstance );
-        Event stageInstanceA = programStageInstanceService.createProgramStageInstance( programInstance,
+        Event stageInstanceA = eventService.createEvent( programInstance,
             stageA, dateMar20, dateMar20, orgUnitA );
-        Event stageInstanceB = programStageInstanceService.createProgramStageInstance( programInstance,
+        Event stageInstanceB = eventService.createEvent( programInstance,
             stageA, dateApr10, dateApr10, orgUnitA );
         stageInstanceA.setExecutionDate( dateMar20 );
         stageInstanceB.setExecutionDate( dateApr10 );
         stageInstanceA.setAttributeOptionCombo( defaultCombo );
         stageInstanceB.setAttributeOptionCombo( defaultCombo );
-        programStageInstanceService.addProgramStageInstance( stageInstanceA );
-        programStageInstanceService.addProgramStageInstance( stageInstanceB );
+        eventService.addEvent( stageInstanceA );
+        eventService.addEvent( stageInstanceB );
         categoryManager.addAndPruneAllOptionCombos();
         Expression expressionA = new Expression( EXPRESSION_A, "ProgramTrackedEntityAttribute" );
         Expression expressionD = new Expression( EXPRESSION_D, "ProgramDataElement" );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventServiceTest.java
@@ -60,7 +60,7 @@ class EventServiceTest extends TransactionalIntegrationTest
 {
 
     @Autowired
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     @Autowired
     private ProgramStageDataElementService programStageDataElementService;
@@ -246,10 +246,10 @@ class EventServiceTest extends TransactionalIntegrationTest
         /*
          * Prepare data for EventDataValues manipulation tests
          */
-        programStageInstanceService.addProgramStageInstance( eventA );
+        eventService.addEvent( eventA );
         // Check that there are no EventDataValues assigned to PSI
-        Event tempPsiA = programStageInstanceService
-            .getProgramStageInstance( eventA.getUid() );
+        Event tempPsiA = eventService
+            .getEvent( eventA.getUid() );
         assertEquals( 0, tempPsiA.getEventDataValues().size() );
         // Prepare EventDataValues to manipulate with
         dataElementMap.put( dataElementA.getUid(), dataElementA );
@@ -261,54 +261,54 @@ class EventServiceTest extends TransactionalIntegrationTest
     @Test
     void testAddProgramStageInstance()
     {
-        long idA = programStageInstanceService.addProgramStageInstance( eventA );
-        long idB = programStageInstanceService.addProgramStageInstance( eventB );
-        assertNotNull( programStageInstanceService.getProgramStageInstance( idA ) );
-        assertNotNull( programStageInstanceService.getProgramStageInstance( idB ) );
+        long idA = eventService.addEvent( eventA );
+        long idB = eventService.addEvent( eventB );
+        assertNotNull( eventService.getEvent( idA ) );
+        assertNotNull( eventService.getEvent( idB ) );
     }
 
     @Test
     void testDeleteProgramStageInstance()
     {
-        long idA = programStageInstanceService.addProgramStageInstance( eventA );
-        long idB = programStageInstanceService.addProgramStageInstance( eventB );
-        assertNotNull( programStageInstanceService.getProgramStageInstance( idA ) );
-        assertNotNull( programStageInstanceService.getProgramStageInstance( idB ) );
-        programStageInstanceService.deleteProgramStageInstance( eventA );
-        assertNull( programStageInstanceService.getProgramStageInstance( idA ) );
-        assertNotNull( programStageInstanceService.getProgramStageInstance( idB ) );
-        programStageInstanceService.deleteProgramStageInstance( eventB );
-        assertNull( programStageInstanceService.getProgramStageInstance( idA ) );
-        assertNull( programStageInstanceService.getProgramStageInstance( idB ) );
+        long idA = eventService.addEvent( eventA );
+        long idB = eventService.addEvent( eventB );
+        assertNotNull( eventService.getEvent( idA ) );
+        assertNotNull( eventService.getEvent( idB ) );
+        eventService.deleteEvent( eventA );
+        assertNull( eventService.getEvent( idA ) );
+        assertNotNull( eventService.getEvent( idB ) );
+        eventService.deleteEvent( eventB );
+        assertNull( eventService.getEvent( idA ) );
+        assertNull( eventService.getEvent( idB ) );
     }
 
     @Test
     void testUpdateProgramStageInstance()
     {
-        long idA = programStageInstanceService.addProgramStageInstance( eventA );
-        assertNotNull( programStageInstanceService.getProgramStageInstance( idA ) );
+        long idA = eventService.addEvent( eventA );
+        assertNotNull( eventService.getEvent( idA ) );
         eventA.setName( "B" );
-        programStageInstanceService.updateProgramStageInstance( eventA );
-        assertEquals( "B", programStageInstanceService.getProgramStageInstance( idA ).getName() );
+        eventService.updateEvent( eventA );
+        assertEquals( "B", eventService.getEvent( idA ).getName() );
     }
 
     @Test
     void testGetProgramStageInstanceById()
     {
-        long idA = programStageInstanceService.addProgramStageInstance( eventA );
-        long idB = programStageInstanceService.addProgramStageInstance( eventB );
-        assertEquals( eventA, programStageInstanceService.getProgramStageInstance( idA ) );
-        assertEquals( eventB, programStageInstanceService.getProgramStageInstance( idB ) );
+        long idA = eventService.addEvent( eventA );
+        long idB = eventService.addEvent( eventB );
+        assertEquals( eventA, eventService.getEvent( idA ) );
+        assertEquals( eventB, eventService.getEvent( idB ) );
     }
 
     @Test
     void testGetProgramStageInstanceByUid()
     {
-        long idA = programStageInstanceService.addProgramStageInstance( eventA );
-        long idB = programStageInstanceService.addProgramStageInstance( eventB );
-        assertEquals( eventA, programStageInstanceService.getProgramStageInstance( idA ) );
-        assertEquals( eventB, programStageInstanceService.getProgramStageInstance( idB ) );
-        assertEquals( eventA, programStageInstanceService.getProgramStageInstance( "UID-A" ) );
-        assertEquals( eventB, programStageInstanceService.getProgramStageInstance( "UID-B" ) );
+        long idA = eventService.addEvent( eventA );
+        long idB = eventService.addEvent( eventB );
+        assertEquals( eventA, eventService.getEvent( idA ) );
+        assertEquals( eventB, eventService.getEvent( idB ) );
+        assertEquals( eventA, eventService.getEvent( "UID-A" ) );
+        assertEquals( eventB, eventService.getEvent( "UID-B" ) );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceTest.java
@@ -104,7 +104,7 @@ class ProgramIndicatorServiceTest extends TransactionalIntegrationTest
     private TrackedEntityAttributeValueService attributeValueService;
 
     @Autowired
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     @Autowired
     private ConstantService constantService;
@@ -271,9 +271,9 @@ class ProgramIndicatorServiceTest extends TransactionalIntegrationTest
         // ---------------------------------------------------------------------
         // TrackedEntityDataValue
         // ---------------------------------------------------------------------
-        Event stageInstanceA = programStageInstanceService.createProgramStageInstance( programInstance,
+        Event stageInstanceA = eventService.createEvent( programInstance,
             psA, enrollmentDate, incidentDate, organisationUnit );
-        Event stageInstanceB = programStageInstanceService.createProgramStageInstance( programInstance,
+        Event stageInstanceB = eventService.createEvent( programInstance,
             psB, enrollmentDate, incidentDate, organisationUnit );
         Set<Event> events = new HashSet<>();
         events.add( stageInstanceA );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramInstanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramInstanceServiceTest.java
@@ -71,7 +71,7 @@ class ProgramInstanceServiceTest extends TransactionalIntegrationTest
     private ProgramStageService programStageService;
 
     @Autowired
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     private Date incidentDate;
 
@@ -181,14 +181,14 @@ class ProgramInstanceServiceTest extends TransactionalIntegrationTest
     void testSoftDeleteProgramInstanceAndLinkedProgramStageInstance()
     {
         long idA = programInstanceService.addProgramInstance( programInstanceA );
-        long psiIdA = programStageInstanceService.addProgramStageInstance( eventA );
+        long psiIdA = eventService.addEvent( eventA );
         programInstanceA.setEvents( Sets.newHashSet( eventA ) );
         programInstanceService.updateProgramInstance( programInstanceA );
         assertNotNull( programInstanceService.getProgramInstance( idA ) );
-        assertNotNull( programStageInstanceService.getProgramStageInstance( psiIdA ) );
+        assertNotNull( eventService.getEvent( psiIdA ) );
         programInstanceService.deleteProgramInstance( programInstanceA );
         assertNull( programInstanceService.getProgramInstance( idA ) );
-        assertNull( programStageInstanceService.getProgramStageInstance( psiIdA ) );
+        assertNull( eventService.getEvent( psiIdA ) );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineTest.java
@@ -47,6 +47,7 @@ import org.hisp.dhis.notification.logging.NotificationLoggingService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
@@ -54,7 +55,6 @@ import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.program.ProgramStageDataElementService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.program.ProgramTrackedEntityAttributeStore;
@@ -193,7 +193,7 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
     private ProgramStageService programStageService;
 
     @Autowired
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     @Autowired
     private ProgramStageDataElementService programStageDataElementService;
@@ -327,7 +327,7 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
     void testSendMessageForEvent()
     {
         ProgramRule programRule = setUpSendMessageForEnrollment();
-        Event event = programStageInstanceService.getProgramStageInstance( "UID-PS1" );
+        Event event = eventService.getEvent( "UID-PS1" );
         List<RuleEffect> ruleEffects = programRuleEngine.evaluate( event.getProgramInstance(),
             event, Sets.newHashSet(), List.of( programRule ) );
         assertEquals( 1, ruleEffects.size() );
@@ -346,7 +346,7 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
     void testSendMessageForEnrollmentAndEvent()
     {
         setUpSendMessageForEnrollment();
-        Event event = programStageInstanceService.getProgramStageInstance( "UID-PS1" );
+        Event event = eventService.getEvent( "UID-PS1" );
         List<RuleEffects> ruleEffects = programRuleEngine.evaluateEnrollmentAndEvents(
             event.getProgramInstance(), Sets.newHashSet( event ), Lists.newArrayList() );
         assertEquals( 2, ruleEffects.size() );
@@ -426,7 +426,7 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
     void testAssignValueTypeDate()
     {
         ProgramRule programRule = setUpAssignValueDate();
-        Event event = programStageInstanceService.getProgramStageInstance( "UID-PS12" );
+        Event event = eventService.getEvent( "UID-PS12" );
         List<RuleEffect> ruleEffects = programRuleEngine.evaluate( event.getProgramInstance(),
             event, Sets.newHashSet(), List.of( programRule ) );
         assertNotNull( ruleEffects );
@@ -437,7 +437,7 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
     void testAssignValueTypeDateEnrollmentAndEvent()
     {
         setUpAssignValueDate();
-        Event event = programStageInstanceService.getProgramStageInstance( "UID-PS12" );
+        Event event = eventService.getEvent( "UID-PS12" );
         List<RuleEffects> ruleEffects = programRuleEngine.evaluateEnrollmentAndEvents(
             event.getProgramInstance(), Sets.newHashSet( event ), Lists.newArrayList() );
         assertNotNull( ruleEffects );
@@ -451,7 +451,7 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
     void testAssignValueTypeAge()
     {
         ProgramRule programRule = setUpAssignValueAge();
-        Event event = programStageInstanceService.getProgramStageInstance( "UID-PS13" );
+        Event event = eventService.getEvent( "UID-PS13" );
         List<RuleEffect> ruleEffects = programRuleEngine.evaluate( event.getProgramInstance(),
             event, Sets.newHashSet(), List.of( programRule ) );
         assertNotNull( ruleEffects );
@@ -575,7 +575,7 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
         eventA.setDueDate( enrollmentDate );
         eventA.setExecutionDate( new Date() );
         eventA.setUid( "UID-PS1" );
-        programStageInstanceService.addProgramStageInstance( eventA );
+        eventService.addEvent( eventA );
         eventDataValueDate = new EventDataValue();
         eventDataValueDate.setDataElement( dataElementDate.getUid() );
         eventDataValueDate.setAutoFields();
@@ -589,23 +589,23 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
         eventDate.setExecutionDate( psEventDate );
         eventDate.setUid( "UID-PS12" );
         eventDate.setEventDataValues( Sets.newHashSet( eventDataValueDate ) );
-        programStageInstanceService.addProgramStageInstance( eventDate );
+        eventService.addEvent( eventDate );
         Event eventAge = new Event( programInstanceA, programStageAge );
         eventAge.setDueDate( enrollmentDate );
         eventAge.setExecutionDate( psEventDate );
         eventAge.setUid( "UID-PS13" );
         eventAge.setEventDataValues( Sets.newHashSet( eventDataValueAge ) );
-        programStageInstanceService.addProgramStageInstance( eventAge );
+        eventService.addEvent( eventAge );
         Event eventB = new Event( programInstanceA, programStageB );
         eventB.setDueDate( enrollmentDate );
         eventB.setExecutionDate( new Date() );
         eventB.setUid( "UID-PS2" );
-        programStageInstanceService.addProgramStageInstance( eventB );
+        eventService.addEvent( eventB );
         Event eventC = new Event( programInstanceA, programStageC );
         eventC.setDueDate( enrollmentDate );
         eventC.setExecutionDate( new Date() );
         eventC.setUid( "UID-PS3" );
-        programStageInstanceService.addProgramStageInstance( eventC );
+        eventService.addEvent( eventC );
         programInstanceA.getEvents().addAll( Sets.newHashSet( eventA,
             eventB, eventC, eventAge ) );
         programInstanceService.updateProgramInstance( programInstanceA );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/relationship/hibernate/RelationshipStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/relationship/hibernate/RelationshipStoreTest.java
@@ -43,12 +43,12 @@ import org.hisp.dhis.commons.util.RelationshipUtils;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.relationship.Relationship;
@@ -77,7 +77,7 @@ class RelationshipStoreTest extends TransactionalIntegrationTest
     private OrganisationUnitService organisationUnitService;
 
     @Autowired
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     @Autowired
     private ProgramService programService;
@@ -276,7 +276,7 @@ class RelationshipStoreTest extends TransactionalIntegrationTest
         event.setProgramInstance( programInstance );
         event.setAutoFields();
 
-        programStageInstanceService.addProgramStageInstance( event );
+        eventService.addEvent( event );
         return event;
     }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityDataValueAuditStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityDataValueAuditStoreTest.java
@@ -44,12 +44,12 @@ import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
@@ -89,7 +89,7 @@ class TrackedEntityDataValueAuditStoreTest extends SingleSetupIntegrationTestBas
     private ProgramInstanceService programInstanceService;
 
     @Autowired
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     private OrganisationUnit ouA;
 
@@ -179,11 +179,11 @@ class TrackedEntityDataValueAuditStoreTest extends SingleSetupIntegrationTestBas
         psiC = createProgramStageInstance( piA, psA, ouC, Set.of( dvA, dvB ) );
         psiD = createProgramStageInstance( piA, psB, ouD, Set.of( dvC, dvD ) );
         psiE = createProgramStageInstance( piA, psA, ouE, Set.of( dvA, dvE ) );
-        programStageInstanceService.addProgramStageInstance( psiA );
-        programStageInstanceService.addProgramStageInstance( psiB );
-        programStageInstanceService.addProgramStageInstance( psiC );
-        programStageInstanceService.addProgramStageInstance( psiD );
-        programStageInstanceService.addProgramStageInstance( psiE );
+        eventService.addEvent( psiA );
+        eventService.addEvent( psiB );
+        eventService.addEvent( psiC );
+        eventService.addEvent( psiD );
+        eventService.addEvent( psiE );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceServiceTest.java
@@ -44,12 +44,12 @@ import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.security.acl.AccessStringHelper;
 import org.hisp.dhis.test.integration.IntegrationTestBase;
@@ -82,7 +82,7 @@ class TrackedEntityInstanceServiceTest
     private ProgramStageService programStageService;
 
     @Autowired
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     @Autowired
     private ProgramInstanceService programInstanceService;
@@ -225,21 +225,21 @@ class TrackedEntityInstanceServiceTest
     {
         long idA = entityInstanceService.addTrackedEntityInstance( entityInstanceA1 );
         long psIdA = programInstanceService.addProgramInstance( programInstance );
-        long psiIdA = programStageInstanceService.addProgramStageInstance( event );
+        long psiIdA = eventService.addEvent( event );
         programInstance.setEvents( Set.of( event ) );
         entityInstanceA1.setProgramInstances( Set.of( programInstance ) );
         programInstanceService.updateProgramInstance( programInstance );
         entityInstanceService.updateTrackedEntityInstance( entityInstanceA1 );
         TrackedEntityInstance teiA = entityInstanceService.getTrackedEntityInstance( idA );
         ProgramInstance psA = programInstanceService.getProgramInstance( psIdA );
-        Event psiA = programStageInstanceService.getProgramStageInstance( psiIdA );
+        Event psiA = eventService.getEvent( psiIdA );
         assertNotNull( teiA );
         assertNotNull( psA );
         assertNotNull( psiA );
         entityInstanceService.deleteTrackedEntityInstance( entityInstanceA1 );
         assertNull( entityInstanceService.getTrackedEntityInstance( teiA.getUid() ) );
         assertNull( programInstanceService.getProgramInstance( psIdA ) );
-        assertNull( programStageInstanceService.getProgramStageInstance( psiIdA ) );
+        assertNull( eventService.getEvent( psiIdA ) );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -66,11 +66,11 @@ import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.program.ProgramType;
@@ -111,7 +111,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase
     private ProgramInstanceService programInstanceService;
 
     @Autowired
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     @Autowired
     private IdentifiableObjectManager manager;
@@ -634,7 +634,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase
         assertIsEmpty( deletedEvents );
 
         programInstanceService.deleteProgramInstance( programInstanceA );
-        programStageInstanceService.deleteProgramStageInstance( eventA );
+        eventService.deleteEvent( eventA );
 
         trackedEntities = trackedEntityService.getTrackedEntities( queryParams, TrackedEntityParams.TRUE );
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventDataValueTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventDataValueTest.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.ProgramStageInstanceService;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
@@ -64,7 +64,7 @@ class EventDataValueTest extends TrackerTest
     private IdentifiableObjectManager manager;
 
     @Autowired
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     @Override
     protected void initTest()
@@ -130,8 +130,8 @@ class EventDataValueTest extends TrackerTest
         assertNoErrors( importReport );
         List<Event> updatedEvents = manager.getAll( Event.class );
         assertEquals( 1, updatedEvents.size() );
-        Event updatedPsi = programStageInstanceService
-            .getProgramStageInstance( updatedEvents.get( 0 ).getUid() );
+        Event updatedPsi = eventService
+            .getEvent( updatedEvents.get( 0 ).getUid() );
         assertEquals( 3, updatedPsi.getEventDataValues().size() );
         List<String> values = updatedPsi.getEventDataValues().stream().map( EventDataValue::getValue )
             .collect( Collectors.toList() );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
@@ -53,7 +53,7 @@ import lombok.SneakyThrows;
 
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.ProgramStageInstanceService;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 import org.hisp.dhis.tracker.TrackerTest;
@@ -77,7 +77,7 @@ class EventImportValidationTest extends TrackerTest
     protected TrackedEntityInstanceService trackedEntityInstanceService;
 
     @Autowired
-    private ProgramStageInstanceService programStageServiceInstance;
+    private EventService programStageServiceInstance;
 
     @Autowired
     private TrackerImportService trackerImportService;
@@ -366,10 +366,10 @@ class EventImportValidationTest extends TrackerTest
     {
         // Given -> Creates an event
         createEvent( "tracker/validations/events-with-notes-data.json" );
-        Event event = programStageServiceInstance.getProgramStageInstance( "uLxFbxfYDQE" );
+        Event event = programStageServiceInstance.getEvent( "uLxFbxfYDQE" );
         assertNotNull( event );
         // When -> Soft-delete the event
-        programStageServiceInstance.deleteProgramStageInstance( event );
+        programStageServiceInstance.deleteEvent( event );
         TrackerImportParams trackerBundleParams = fromJson(
             "tracker/validations/events-with-notes-data.json" );
         trackerBundleParams.setImportStrategy( importStrategy );
@@ -434,6 +434,6 @@ class EventImportValidationTest extends TrackerTest
         final Map<TrackerType, TrackerTypeReport> typeReportMap = importReport.getPersistenceReport()
             .getTypeReportMap();
         String newEvent = typeReportMap.get( TrackerType.EVENT ).getEntityReportMap().get( 0 ).getUid();
-        return programStageServiceInstance.getProgramStageInstance( newEvent );
+        return programStageServiceInstance.getEvent( newEvent );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventSecurityImportValidationTest.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
@@ -52,7 +53,6 @@ import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.program.ProgramStageDataElementService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.security.acl.AccessStringHelper;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
@@ -82,7 +82,7 @@ class EventSecurityImportValidationTest extends TrackerTest
     private TrackerImportService trackerImportService;
 
     @Autowired
-    private ProgramStageInstanceService programStageServiceInstance;
+    private EventService programStageServiceInstance;
 
     @Autowired
     private TrackedEntityProgramOwnerService trackedEntityProgramOwnerService;
@@ -253,7 +253,7 @@ class EventSecurityImportValidationTest extends TrackerTest
         ImportReport importReport = trackerImportService.importTracker( params );
         assertNoErrors( importReport );
         // Change just inserted Event to status COMPLETED...
-        Event zwwuwNp6gVd = programStageServiceInstance.getProgramStageInstance( "ZwwuwNp6gVd" );
+        Event zwwuwNp6gVd = programStageServiceInstance.getEvent( "ZwwuwNp6gVd" );
         zwwuwNp6gVd.setStatus( EventStatus.COMPLETED );
         manager.update( zwwuwNp6gVd );
         TrackerImportParams trackerBundleParams = fromJson(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/AnalyticsValidationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/AnalyticsValidationServiceTest.java
@@ -71,6 +71,7 @@ import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramIndicatorService;
@@ -78,7 +79,6 @@ import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.system.grid.ListGrid;
@@ -125,7 +125,7 @@ class AnalyticsValidationServiceTest extends TransactionalIntegrationTest
     private ProgramIndicatorService programIndicatorService;
 
     @Autowired
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     @Autowired
     private OrganisationUnitService organisationUnitService;
@@ -249,16 +249,16 @@ class AnalyticsValidationServiceTest extends TransactionalIntegrationTest
         ProgramInstance programInstance = programInstanceService.enrollTrackedEntityInstance( entityInstance, program,
             dateMar20, dateMar20, orgUnitA );
         programInstanceService.addProgramInstance( programInstance );
-        Event stageInstanceA = programStageInstanceService.createProgramStageInstance( programInstance,
+        Event stageInstanceA = eventService.createEvent( programInstance,
             stageA, dateMar20, dateMar20, orgUnitA );
-        Event stageInstanceB = programStageInstanceService.createProgramStageInstance( programInstance,
+        Event stageInstanceB = eventService.createEvent( programInstance,
             stageA, dateApr10, dateApr10, orgUnitA );
         stageInstanceA.setExecutionDate( dateMar20 );
         stageInstanceB.setExecutionDate( dateApr10 );
         stageInstanceA.setAttributeOptionCombo( defaultCombo );
         stageInstanceB.setAttributeOptionCombo( defaultCombo );
-        programStageInstanceService.addProgramStageInstance( stageInstanceA );
-        programStageInstanceService.addProgramStageInstance( stageInstanceB );
+        eventService.addEvent( stageInstanceA );
+        eventService.addEvent( stageInstanceB );
         categoryManager.addAndPruneAllOptionCombos();
         Expression expressionA = new Expression( EXPRESSION_A, "ProgramTrackedEntityAttribute" );
         Expression expressionD = new Expression( EXPRESSION_D, "ProgramDataElement" );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
@@ -84,7 +84,6 @@ import org.hisp.dhis.dxf2.events.EventParams;
 import org.hisp.dhis.dxf2.events.event.DataValue;
 import org.hisp.dhis.dxf2.events.event.Event;
 import org.hisp.dhis.dxf2.events.event.EventSearchParams;
-import org.hisp.dhis.dxf2.events.event.EventService;
 import org.hisp.dhis.dxf2.events.event.Events;
 import org.hisp.dhis.dxf2.events.event.ImportEventsTask;
 import org.hisp.dhis.dxf2.events.event.csv.CsvEventService;
@@ -111,8 +110,8 @@ import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.node.NodeUtils;
 import org.hisp.dhis.node.Preset;
 import org.hisp.dhis.node.types.RootNode;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.query.QueryUtils;
 import org.hisp.dhis.render.RenderService;
@@ -169,7 +168,7 @@ public class EventController
 
     private final AsyncTaskExecutor taskExecutor;
 
-    private final EventService eventService;
+    private final org.hisp.dhis.dxf2.events.event.EventService eventService;
 
     private final CsvEventService<Event> csvEventService;
 
@@ -181,7 +180,7 @@ public class EventController
 
     private final RenderService renderService;
 
-    private final ProgramStageInstanceService programStageInstanceService;
+    private final EventService programStageInstanceService;
 
     private final FileResourceService fileResourceService;
 
@@ -728,7 +727,7 @@ public class EventController
         Model model, HttpServletRequest request )
         throws Exception
     {
-        Event event = eventService.getEvent( programStageInstanceService.getProgramStageInstance( uid ),
+        Event event = eventService.getEvent( programStageInstanceService.getEvent( uid ),
             EventParams.TRUE );
 
         if ( event == null )
@@ -747,7 +746,7 @@ public class EventController
         HttpServletResponse response, HttpServletRequest request )
         throws Exception
     {
-        Event event = eventService.getEvent( programStageInstanceService.getProgramStageInstance( eventUid ),
+        Event event = eventService.getEvent( programStageInstanceService.getEvent( eventUid ),
             EventParams.TRUE );
 
         if ( event == null )
@@ -921,7 +920,7 @@ public class EventController
         HttpServletRequest request, ImportOptions importOptions )
         throws IOException
     {
-        if ( !programStageInstanceService.programStageInstanceExists( uid ) )
+        if ( !programStageInstanceService.eventExists( uid ) )
         {
             return notFound( "Event not found for ID " + uid );
         }
@@ -1017,7 +1016,7 @@ public class EventController
         @PathVariable( "uid" ) String uid, ImportOptions importOptions )
         throws IOException
     {
-        if ( !programStageInstanceService.programStageInstanceExists( uid ) )
+        if ( !programStageInstanceService.eventExists( uid ) )
         {
             return notFound( "Event not found for ID " + uid );
         }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceController.java
@@ -32,8 +32,8 @@ import java.util.List;
 
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramInstanceService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.notification.ProgramNotificationInstance;
 import org.hisp.dhis.program.notification.ProgramNotificationInstanceParam;
 import org.hisp.dhis.program.notification.ProgramNotificationInstanceService;
@@ -60,16 +60,16 @@ public class ProgramNotificationInstanceController
 
     private final ProgramInstanceService programInstanceService;
 
-    private final ProgramStageInstanceService programStageInstanceService;
+    private final EventService eventService;
 
     public ProgramNotificationInstanceController(
         ProgramNotificationInstanceService programNotificationInstanceService,
         ProgramInstanceService programInstanceService,
-        ProgramStageInstanceService programStageInstanceService )
+        EventService eventService )
     {
         this.programNotificationInstanceService = programNotificationInstanceService;
         this.programInstanceService = programInstanceService;
-        this.programStageInstanceService = programStageInstanceService;
+        this.eventService = eventService;
     }
 
     // -------------------------------------------------------------------------
@@ -88,7 +88,7 @@ public class ProgramNotificationInstanceController
     {
         ProgramNotificationInstanceParam params = ProgramNotificationInstanceParam.builder()
             .programInstance( programInstanceService.getProgramInstance( programInstance ) )
-            .event( programStageInstanceService.getProgramStageInstance( programStageInstance ) )
+            .event( eventService.getEvent( programStageInstance ) )
             .skipPaging( skipPaging )
             .page( page )
             .pageSize( pageSize )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/RelationshipController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/RelationshipController.java
@@ -57,8 +57,8 @@ import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramInstanceService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.schema.descriptors.RelationshipSchemaDescriptor;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.webapi.controller.event.webrequest.RelationshipCriteria;
@@ -95,7 +95,7 @@ public class RelationshipController
 
     private final ProgramInstanceService programInstanceService;
 
-    private final ProgramStageInstanceService programStageInstanceService;
+    private final EventService eventService;
 
     // -------------------------------------------------------------------------
     // READ
@@ -126,8 +126,8 @@ public class RelationshipController
         }
         else if ( relationshipCriteria.getEvent() != null )
         {
-            return Optional.ofNullable( programStageInstanceService
-                .getProgramStageInstance( relationshipCriteria.getEvent() ) )
+            return Optional.ofNullable( eventService
+                .getEvent( relationshipCriteria.getEvent() ) )
                 .map( psi -> relationshipService.getRelationshipsByProgramStageInstance( psi,
                     relationshipCriteria, false ) )
                 .orElseThrow( () -> new WebMessageException(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -54,10 +54,9 @@ import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.ProgramStageInstanceService;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.tracker.export.event.EventParams;
 import org.hisp.dhis.tracker.export.event.EventSearchParams;
-import org.hisp.dhis.tracker.export.event.EventService;
 import org.hisp.dhis.tracker.export.event.Events;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
 import org.hisp.dhis.webapi.controller.tracker.export.CsvService;
@@ -88,13 +87,13 @@ public class EventsExportController
     private static final EventMapper EVENTS_MAPPER = Mappers.getMapper( EventMapper.class );
 
     @Nonnull
-    private final EventService eventService;
+    private final org.hisp.dhis.tracker.export.event.EventService eventService;
 
     @Nonnull
     private final EventCriteriaMapper requestToSearchParams;
 
     @Nonnull
-    private final ProgramStageInstanceService programStageInstanceService;
+    private final EventService programStageInstanceService;
 
     @Nonnull
     private final CsvService<org.hisp.dhis.webapi.controller.tracker.view.Event> csvEventService;
@@ -180,7 +179,7 @@ public class EventsExportController
         throws NotFoundException
     {
         EventParams eventParams = eventsMapper.map( fields );
-        Event event = eventService.getEvent( programStageInstanceService.getProgramStageInstance( uid ),
+        Event event = eventService.getEvent( programStageInstanceService.getEvent( uid ),
             eventParams );
         if ( event == null )
         {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
@@ -48,9 +48,9 @@ import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
@@ -90,7 +90,7 @@ public class RelationshipsExportController
     private final ProgramInstanceService programInstanceService;
 
     @Nonnull
-    private final ProgramStageInstanceService programStageInstanceService;
+    private final EventService eventService;
 
     @Nonnull
     private final RelationshipService relationshipService;
@@ -115,7 +115,7 @@ public class RelationshipsExportController
         objectRetrievers = ImmutableMap.<Class<?>, Function<String, ?>> builder()
             .put( TrackedEntityInstance.class, trackedEntityInstanceService::getTrackedEntityInstance )
             .put( ProgramInstance.class, programInstanceService::getProgramInstance )
-            .put( Event.class, programStageInstanceService::getProgramStageInstance )
+            .put( Event.class, eventService::getEvent )
             .build();
 
         relationshipRetrievers = ImmutableMap

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/RelationshipControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/RelationshipControllerTest.java
@@ -40,9 +40,9 @@ import java.util.Optional;
 import org.hisp.dhis.dxf2.events.relationship.RelationshipService;
 import org.hisp.dhis.dxf2.events.trackedentity.Relationship;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceService;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.junit.jupiter.api.BeforeEach;
@@ -89,7 +89,7 @@ class RelationshipControllerTest
     private ProgramInstanceService programInstanceService;
 
     @Mock
-    private ProgramStageInstanceService programStageInstanceService;
+    private EventService eventService;
 
     @InjectMocks
     private RelationshipController relationshipController;
@@ -136,10 +136,10 @@ class RelationshipControllerTest
     void verifyEndpointWithEvent()
         throws Exception
     {
-        when( programStageInstanceService.getProgramStageInstance( EVENT_ID ) ).thenReturn( event );
+        when( eventService.getEvent( EVENT_ID ) ).thenReturn( event );
         mockMvc.perform( get( ENDPOINT ).param( "event", EVENT_ID ) ).andExpect( status().isOk() );
 
-        verify( programStageInstanceService ).getProgramStageInstance( EVENT_ID );
+        verify( eventService ).getEvent( EVENT_ID );
         verify( relationshipService ).getRelationshipsByProgramStageInstance( eq( event ), any(), eq( false ) );
     }
 


### PR DESCRIPTION
follow up to https://github.com/dhis2/dhis2-core/pull/13731

* rename `ProgramStageInstanceService` to `EventService`
* replace `programStageInstance` in `EventService` method names

# Next

* rename `ProgramStageInstanceStore` to `EventStore`
* rename variables/parameters like `psi`, `psis`, `programStageInstance`, `programStageInstances`
* rename the rest like enums
* maybe rename aliases in queries or leave that for https://dhis2.atlassian.net/browse/TECH-1542