### PR TITLE
fix: TEI query fails when search text contains a comma [ DHIS2-9324 ]

### DIFF
--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/helpers/QueryParamsBuilder.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/helpers/QueryParamsBuilder.java
@@ -63,19 +63,17 @@ public class QueryParamsBuilder
         String[] split = param.split( "=" );
         Optional<MutablePair<String, String>> pairOptional = getByKey( split[0] );
 
-        if ( pairOptional.isPresent() )
+        if ( pairOptional.isEmpty()
+            || pairOptional.get().getKey().equals( "filter" )
+            || pairOptional.get().getKey().equals( "attribute" ) )
+        {
+            queryParams.add( MutablePair.of( split[0], split[1] ) );
+        }
+        else
         {
             MutablePair<String, String> existingPair = pairOptional.get();
-
-            if ( !existingPair.getKey().equals( "filter" ) && !existingPair.getKey().equals( "attribute" ) )
-            {
-                existingPair.setRight( split[1] );
-            }
-
-            return this;
+            existingPair.setRight( split[1] );
         }
-
-        queryParams.add( MutablePair.of( split[0], split[1] ) );
 
         return this;
     }

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/helpers/QueryParamsBuilder.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/helpers/QueryParamsBuilder.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.helpers;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.commons.lang3.tuple.MutablePair;
 
@@ -51,6 +52,8 @@ public class QueryParamsBuilder
 
     /**
      * Adds or updates the query param. Format: key=value
+     * <p>
+     * We allow multiple values for filter and attribute
      *
      * @param param
      * @return
@@ -58,11 +61,17 @@ public class QueryParamsBuilder
     public QueryParamsBuilder add( String param )
     {
         String[] split = param.split( "=" );
-        MutablePair pair = getByKey( split[0] );
+        Optional<MutablePair<String, String>> pairOptional = getByKey( split[0] );
 
-        if ( pair != null && !pair.getKey().equals( "filter" ) )
+        if ( pairOptional.isPresent() )
         {
-            pair.setRight( split[1] );
+            MutablePair<String, String> existingPair = pairOptional.get();
+
+            if ( !existingPair.getKey().equals( "filter" ) && !existingPair.getKey().equals( "attribute" ) )
+            {
+                existingPair.setRight( split[1] );
+            }
+
             return this;
         }
 
@@ -81,17 +90,16 @@ public class QueryParamsBuilder
         return this;
     }
 
-    private MutablePair getByKey( String key )
+    private Optional<MutablePair<String, String>> getByKey( String key )
     {
         return queryParams.stream()
             .filter( p -> p.getLeft().equals( key ) )
-            .findFirst()
-            .orElse( null );
+            .findFirst();
     }
 
     public String build()
     {
-        if ( queryParams.size() == 0 )
+        if ( queryParams.isEmpty() )
         {
             return "";
         }

--- a/dhis-2/dhis-e2e-test/src/main/resources/config.properties
+++ b/dhis-2/dhis-e2e-test/src/main/resources/config.properties
@@ -1,6 +1,6 @@
 # property pointing to running DHIS2 instance.
 # must include /api
-instance.url=http://localhost:8080/api
+instance.url=http://localhost:9090/api
 # properties for user set up on the instance.
 # user must be able to import metadata.
 user.default.username=system

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/TrackerExportTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/TrackerExportTests.java
@@ -157,6 +157,31 @@ public class TrackerExportTests
     }
 
     @Test
+    public void shouldGetTeisWhenFilterByAttributeValueWithDelimiter()
+    {
+        trackerActions.getTrackedEntities(
+            new QueryParamsBuilder()
+                .add( "filter", "kZeSYCgaHTk:eq:Test,Test" )
+                .add( "program", "f1AyMswryyQ" )
+                .add( "orgUnit", "O6uvpzGd5pu" ) )
+            .validate().statusCode( 200 )
+            .body( "instances", hasSize( 1 ) );
+    }
+
+    @Test
+    public void shouldGetTeisWhenFilterByMultipleAttributeValueWithDelimiter()
+    {
+        trackerActions.getTrackedEntities(
+            new QueryParamsBuilder()
+                .add( "attribute", "kZeSYCgaHTk:eq:Test,Test" )
+                .add( "attribute", "dIVt4l5vIOa:eq:Test" )
+                .add( "program", "f1AyMswryyQ" )
+                .add( "orgUnit", "O6uvpzGd5pu" ) )
+            .validate().statusCode( 200 )
+            .body( "instances", hasSize( 1 ) );
+    }
+
+    @Test
     public void shouldGetSingleTeiWithNoEventsWhenEventsAreSoftDeleted()
     {
         TrackerApiResponse response = trackerActions.postAndGetJobReport(
@@ -384,7 +409,8 @@ public class TrackerExportTests
             .body( "event", equalTo( "ZwwuwNp6gVd" ) );
     }
 
-    @Test // TODO(tracker): remove with old tracker
+    @Test
+    // TODO(tracker): remove with old tracker
     void shouldReturnInvalidPropertyWhenOrderOnLegacyCreatedField()
     {
         ApiResponse response = trackerActions.get( "events?order=created:desc" );

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/teis/TEIimportTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/teis/TEIimportTest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.tracker.teis;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.stringContainsInOrder;
@@ -130,6 +131,29 @@ public class TEIimportTest
 
         response.validate().statusCode( 404 );
 
+    }
+
+    @Test
+    void shouldGetTeisWhenFilterByAttributeValueWithDelimiter()
+    {
+        teiActions.get( new QueryParamsBuilder().addAll(
+            "filter=kZeSYCgaHTk:eq:Test,Test",
+            "trackedEntityType=" + "Q9GufDoplCL",
+            "ou=" + "O6uvpzGd5pu" ) )
+            .validate().statusCode( 200 )
+            .body( "trackedEntityInstances", hasSize( 1 ) );
+    }
+
+    @Test
+    void shouldGetTeisWhenFilterByMultipleAttributeValueWithDelimiter()
+    {
+        teiActions.get( new QueryParamsBuilder().addAll(
+            "attribute=kZeSYCgaHTk:eq:Test,Test",
+            "attribute=dIVt4l5vIOa:eq:Test",
+            "trackedEntityType=" + "Q9GufDoplCL",
+            "ou=" + "O6uvpzGd5pu" ) )
+            .validate().statusCode( 200 )
+            .body( "trackedEntityInstances", hasSize( 1 ) );
     }
 
     @Test

--- a/dhis-2/dhis-e2e-test/src/test/resources/setup/tracker_metadata.json
+++ b/dhis-2/dhis-e2e-test/src/test/resources/setup/tracker_metadata.json
@@ -1725,7 +1725,7 @@
       "lastUpdated": "2022-02-22T09:08:57.901",
       "translations": [],
       "createdBy": {
-        "id": "M5zQapPyTZI",
+        "id": "GOLswS44mh8",
         "code": "admin",
         "name": "admin admin",
         "displayName": "admin admin",

--- a/dhis-2/dhis-e2e-test/src/test/resources/tracker/importer/teis/teisWithEnrollmentsAndEvents.json
+++ b/dhis-2/dhis-e2e-test/src/test/resources/tracker/importer/teis/teisWithEnrollmentsAndEvents.json
@@ -126,7 +126,7 @@
           "displayName": "TA Last name",
           "valueType": "TEXT",
           "attribute": "kZeSYCgaHTk",
-          "value": "Test"
+          "value": "Test,Test"
         },
         {
           "displayName": "TA First name",

--- a/dhis-2/dhis-e2e-test/src/test/resources/tracker/teis/teisWithEventsAndEnrollments.json
+++ b/dhis-2/dhis-e2e-test/src/test/resources/tracker/teis/teisWithEventsAndEnrollments.json
@@ -193,7 +193,7 @@
           "created": "2019-08-19T13:34:36.646",
           "valueType": "TEXT",
           "attribute": "kZeSYCgaHTk",
-          "value": "Test"
+          "value": "Test,Test"
         },
         {
           "lastUpdated": "2019-08-19T13:34:36.644",

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/MvcTestConfig.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/MvcTestConfig.java
@@ -59,6 +59,7 @@ import org.hisp.dhis.webapi.mvc.messageconverter.MetadataExportParamsMessageConv
 import org.hisp.dhis.webapi.mvc.messageconverter.StreamingJsonRootMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.XmlMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.XmlPathMappingJackson2XmlHttpMessageConverter;
+import org.hisp.dhis.webapi.mvc.requestconverter.StringToSetConverter;
 import org.hisp.dhis.webapi.view.CustomPathExtensionContentNegotiationStrategy;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -284,6 +285,7 @@ public class MvcTestConfig implements WebMvcConfigurer
     public void addFormatters( FormatterRegistry registry )
     {
         registry.addConverter( new FieldPathConverter() );
+        registry.addConverter( new StringToSetConverter() );
     }
 
     @Bean

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -203,7 +203,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
     void getTrackedEntitiesCannotHaveRepeatedAttributes()
     {
         assertContains( "Filter for attribute " + TEA_UID + " was specified more than once.",
-            GET( "/tracker/trackedEntities?filter=" + TEA_UID + ":eq:test," + TEA_UID + ":gt:test2" )
+            GET( "/tracker/trackedEntities?filter=" + TEA_UID + ":eq:test&filter=" + TEA_UID + ":gt:test2" )
                 .error( HttpStatus.BAD_REQUEST )
                 .getMessage() );
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemSettingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemSettingController.java
@@ -33,7 +33,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -288,24 +287,21 @@ public class SystemSettingController
 
     private Set<SettingKey> getSettingKeysToFetch( Set<String> keys )
     {
-        Set<SettingKey> settingKeys;
-
         if ( keys != null )
         {
-            keys.removeIf( systemSettingManager::isConfidential );
-            settingKeys = keys.stream()
+            return keys.stream()
+                .filter( k -> !systemSettingManager.isConfidential( k ) )
                 .map( SettingKey::getByName )
                 .filter( Optional::isPresent )
                 .map( Optional::get )
-                .collect( Collectors.toSet() );
+                .collect( Collectors.toUnmodifiableSet() );
         }
         else
         {
-            settingKeys = new HashSet<>( Arrays.asList( SettingKey.values() ) );
-            settingKeys.removeIf( key -> systemSettingManager.isConfidential( key.getName() ) );
+            return Arrays.stream( SettingKey.values() )
+                .filter( k -> !systemSettingManager.isConfidential( k.getName() ) )
+                .collect( Collectors.toUnmodifiableSet() );
         }
-
-        return settingKeys;
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/requestconverter/StringToOrderCriteriaListConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/requestconverter/StringToOrderCriteriaListConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.mvc.requestconverter;
+
+import java.util.List;
+
+import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
+import org.springframework.core.convert.converter.Converter;
+
+/**
+ * String to Order Criterias converter for MVC requests
+ *
+ * @author Giuseppe Nespolino <g.nespolino@gmail.com>
+ */
+public class StringToOrderCriteriaListConverter implements Converter<String, List<OrderCriteria>>
+{
+    @Override
+    public List<OrderCriteria> convert( String source )
+    {
+        return OrderCriteria.fromOrderString( source );
+    }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/requestconverter/StringToSetConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/requestconverter/StringToSetConverter.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.mvc.requestconverter;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/requestconverter/StringToSetConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/requestconverter/StringToSetConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2023, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,23 +25,23 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.security.config;
+package org.hisp.dhis.webapi.mvc.requestconverter;
 
-import java.util.List;
+import java.util.Set;
 
-import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.springframework.core.convert.converter.Converter;
 
 /**
- * String to Order Criterias converter for MVC requests
+ * This converter avoid a request parameter to be split by the Spring's default
+ * delimiter
  *
- * @author Giuseppe Nespolino <g.nespolino@gmail.com>
+ * @author Luca Cambi
  */
-class StringToOrderCriteriaListConverter implements Converter<String, List<OrderCriteria>>
+public class StringToSetConverter implements Converter<String, Set<String>>
 {
     @Override
-    public List<OrderCriteria> convert( String source )
+    public Set<String> convert( String source )
     {
-        return OrderCriteria.fromOrderString( source );
+        return Set.of( source );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/requestconverter/StringToSetConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/requestconverter/StringToSetConverter.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.webapi.mvc.requestconverter;
 
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.springframework.core.convert.converter.Converter;
@@ -44,6 +42,6 @@ public class StringToSetConverter implements Converter<String, Set<String>>
     @Override
     public Set<String> convert( String source )
     {
-        return new HashSet<>( List.of( source ) );
+        return Set.of( source );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/requestconverter/StringToSetConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/requestconverter/StringToSetConverter.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.webapi.mvc.requestconverter;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.springframework.core.convert.converter.Converter;
@@ -42,6 +45,6 @@ public class StringToSetConverter implements Converter<String, Set<String>>
     @Override
     public Set<String> convert( String source )
     {
-        return Set.of( source );
+        return new HashSet<>( List.of( source ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java
@@ -56,6 +56,8 @@ import org.hisp.dhis.webapi.mvc.messageconverter.MetadataExportParamsMessageConv
 import org.hisp.dhis.webapi.mvc.messageconverter.StreamingJsonRootMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.XmlMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.XmlPathMappingJackson2XmlHttpMessageConverter;
+import org.hisp.dhis.webapi.mvc.requestconverter.StringToOrderCriteriaListConverter;
+import org.hisp.dhis.webapi.mvc.requestconverter.StringToSetConverter;
 import org.hisp.dhis.webapi.view.CustomPathExtensionContentNegotiationStrategy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -223,6 +225,7 @@ public class WebMvcConfig extends DelegatingWebMvcConfiguration
     {
         registry.addConverter( new StringToOrderCriteriaListConverter() );
         registry.addConverter( new FieldPathConverter() );
+        registry.addConverter( new StringToSetConverter() );
     }
 
     @Primary


### PR DESCRIPTION
Spring uses converters to parse request parameters. When a request parameter as a String is converted to a Set, it will use a comma (`,`) as a delimiter and split the string.
This is not used in the code base and shouldn't be as default, so we add a custom converter to undo this default split with this PR.
This PR also put all MVC converters in `mvc/requestconverter` folder so it is clear what is used for