### PR TITLE
fix: Filter out from sync teis updated before last sync [DHIS2-15223]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -663,7 +663,7 @@ public class HibernateTrackedEntityInstanceStore
         if ( params.isSynchronizationQuery() )
         {
             trackedEntity.append( whereAnd.whereAnd() )
-                .append( " TEI.lastupdated >= TEI.lastSynchronized " );
+                .append( " TEI.lastupdated >= TEI.lastsynchronized " );
             if ( params.getSkipChangedBefore() != null )
             {
                 trackedEntity.append( " AND TEI.lastupdated >= '" )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -660,6 +660,17 @@ public class HibernateTrackedEntityInstanceStore
                     .append( SINGLE_QUOTE );
             }
         }
+        if ( params.isSynchronizationQuery() )
+        {
+            trackedEntity.append( whereAnd.whereAnd() )
+                .append( " TEI.lastupdated >= TEI.lastSynchronized " );
+            if ( params.getSkipChangedBefore() != null )
+            {
+                trackedEntity.append( " AND TEI.lastupdated >= '" )
+                    .append( getMediumDateString( params.getSkipChangedBefore() ) )
+                    .append( SINGLE_QUOTE );
+            }
+        }
 
         if ( !params.isIncludeDeleted() )
         {


### PR DESCRIPTION
When retrieving teis in sync mode, teis that were not updated after last sync were included in the process.
Changed the query to not include teis that were updated before last sync and also consider `skipChangedBefore` parameter to ignore teis that were updated before a specific date