### PR TITLE
chore: rename programStageInstance to event TECH-1537

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventStore.java
@@ -68,7 +68,7 @@ public class HibernateEventStore
 {
     private final static String EVENT_HQL_BY_UIDS = "from Event as psi where psi.uid in (:uids)";
 
-    private final static Set<NotificationTrigger> SCHEDULED_PROGRAM_STAGE_INSTANCE_TRIGGERS = Sets.intersection(
+    private final static Set<NotificationTrigger> SCHEDULED_EVENT_TRIGGERS = Sets.intersection(
         NotificationTrigger.getAllApplicableToEvent(),
         NotificationTrigger.getAllScheduledTriggers() );
 
@@ -193,7 +193,7 @@ public class HibernateEventStore
         Date notificationDate )
     {
         if ( notificationDate == null
-            || !SCHEDULED_PROGRAM_STAGE_INSTANCE_TRIGGERS.contains( template.getNotificationTrigger() ) )
+            || !SCHEDULED_EVENT_TRIGGERS.contains( template.getNotificationTrigger() ) )
         {
             return Lists.newArrayList();
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationService.java
@@ -330,10 +330,10 @@ public class DefaultProgramNotificationService
 
         List<ProgramInstance> programInstances = programInstanceStore.getWithScheduledNotifications( template, day );
 
-        MessageBatch psiBatch = createEventMessageBatch( template, events );
+        MessageBatch eventBatch = createEventMessageBatch( template, events );
         MessageBatch psBatch = createProgramInstanceMessageBatch( template, programInstances );
 
-        return new MessageBatch( psiBatch, psBatch );
+        return new MessageBatch( eventBatch, psBatch );
     }
 
     private List<ProgramNotificationTemplate> getScheduledTemplates()
@@ -389,14 +389,14 @@ public class DefaultProgramNotificationService
         {
             batch.programMessages.addAll(
                 events.stream()
-                    .map( psi -> createProgramMessage( psi, template ) )
+                    .map( event -> createProgramMessage( event, template ) )
                     .collect( Collectors.toSet() ) );
         }
         else
         {
             batch.dhisMessages.addAll(
                 events.stream()
-                    .map( psi -> createDhisMessage( psi, template ) )
+                    .map( event -> createDhisMessage( event, template ) )
                     .collect( Collectors.toSet() ) );
         }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/hibernate/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/hibernate/HibernateRelationshipStore.java
@@ -73,7 +73,7 @@ public class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<R
 
     private static final String PROGRAM_INSTANCE = "programInstance";
 
-    private static final String PROGRAM_STAGE_INSTANCE = "event";
+    private static final String EVENT = "event";
 
     public HibernateRelationshipStore( SessionFactory sessionFactory, JdbcTemplate jdbcTemplate,
         ApplicationEventPublisher publisher, CurrentUserService currentUserService, AclService aclService )
@@ -161,7 +161,7 @@ public class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<R
         else if ( entity instanceof ProgramInstance )
             return PROGRAM_INSTANCE;
         else if ( entity instanceof Event )
-            return PROGRAM_STAGE_INSTANCE;
+            return EVENT;
         else
             throw new IllegalArgumentException( entity.getClass()
                 .getSimpleName() + " not supported in relationship" );
@@ -349,7 +349,7 @@ public class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<R
         else if ( relationshipItemDirection.getEvent() != null )
         {
             return builder.equal( root.join( direction )
-                .get( PROGRAM_STAGE_INSTANCE ), getItem( direction, relationship ).getEvent() );
+                .get( EVENT ), getItem( direction, relationship ).getEvent() );
         }
         else
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/TrackerImporterAssertErrors.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/TrackerImporterAssertErrors.java
@@ -64,8 +64,6 @@ public class TrackerImporterAssertErrors
 
     public static final String PROGRAM_STAGE_CANT_BE_NULL = "ProgramStage can't be null";
 
-    public static final String PROGRAM_STAGE_INSTANCE_CANT_BE_NULL = "Event can't be null";
-
     public static final String CATEGORY_OPTION_COMBO_CANT_BE_NULL = "CategoryOptionCombo can't be null";
 
     public static final String DATE_STRING_CANT_BE_NULL = "Date string can not be null";

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/TrackerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/TrackerTest.java
@@ -257,12 +257,12 @@ public abstract class TrackerTest extends IntegrationTestBase
         return _persistRelationship( from, to );
     }
 
-    public Relationship persistRelationship( TrackedEntityInstance tei, Event psi )
+    public Relationship persistRelationship( TrackedEntityInstance tei, Event event )
     {
         RelationshipItem from = new RelationshipItem();
         from.setTrackedEntityInstance( tei );
         RelationshipItem to = new RelationshipItem();
-        to.setEvent( psi );
+        to.setEvent( event );
         return _persistRelationship( from, to );
     }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
@@ -276,7 +276,7 @@ class MaintenanceServiceTest extends IntegrationTestBase
     }
 
     @Test
-    void testDeleteSoftDeletedProgramStageInstanceWithAProgramMessage()
+    void testDeleteSoftDeletedEventsWithAProgramMessage()
     {
         ProgramMessageRecipients programMessageRecipients = new ProgramMessageRecipients();
         programMessageRecipients.setEmailAddresses( Sets.newHashSet( "testemail" ) );
@@ -341,7 +341,7 @@ class MaintenanceServiceTest extends IntegrationTestBase
     }
 
     @Test
-    void testDeleteSoftDeletedProgramStageInstanceLinkedToARelationshipItem()
+    void testDeleteSoftDeletedEventLinkedToARelationshipItem()
     {
         RelationshipType rType = createRelationshipType( 'A' );
         rType.getFromConstraint().setRelationshipEntity( RelationshipEntity.PROGRAM_STAGE_INSTANCE );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/merge/orgunit/handler/TrackerOrgUnitMergeHandlerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/merge/orgunit/handler/TrackerOrgUnitMergeHandlerTest.java
@@ -60,7 +60,7 @@ class TrackerOrgUnitMergeHandlerTest extends SingleSetupIntegrationTestBase
     private ProgramInstanceService piService;
 
     @Autowired
-    private EventService psiService;
+    private EventService eventService;
 
     @Autowired
     private IdentifiableObjectManager idObjectManager;
@@ -93,11 +93,11 @@ class TrackerOrgUnitMergeHandlerTest extends SingleSetupIntegrationTestBase
 
     private ProgramInstance piC;
 
-    private Event psiA;
+    private Event eventA;
 
-    private Event psiB;
+    private Event eventB;
 
-    private Event psiC;
+    private Event eventC;
 
     @Override
     public void setUpTest()
@@ -124,12 +124,12 @@ class TrackerOrgUnitMergeHandlerTest extends SingleSetupIntegrationTestBase
         piService.addProgramInstance( piA );
         piService.addProgramInstance( piB );
         piService.addProgramInstance( piC );
-        psiA = new Event( piA, psA, ouA );
-        psiB = new Event( piB, psA, ouB );
-        psiC = new Event( piC, psA, ouA );
-        psiService.addEvent( psiA );
-        psiService.addEvent( psiB );
-        psiService.addEvent( psiC );
+        eventA = new Event( piA, psA, ouA );
+        eventB = new Event( piB, psA, ouB );
+        eventC = new Event( piC, psA, ouA );
+        eventService.addEvent( eventA );
+        eventService.addEvent( eventB );
+        eventService.addEvent( eventC );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventServiceTest.java
@@ -259,7 +259,7 @@ class EventServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testAddProgramStageInstance()
+    void testAddEvent()
     {
         long idA = eventService.addEvent( eventA );
         long idB = eventService.addEvent( eventB );
@@ -268,7 +268,7 @@ class EventServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testDeleteProgramStageInstance()
+    void testDeleteEvent()
     {
         long idA = eventService.addEvent( eventA );
         long idB = eventService.addEvent( eventB );
@@ -283,7 +283,7 @@ class EventServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testUpdateProgramStageInstance()
+    void testUpdateEvent()
     {
         long idA = eventService.addEvent( eventA );
         assertNotNull( eventService.getEvent( idA ) );
@@ -293,7 +293,7 @@ class EventServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testGetProgramStageInstanceById()
+    void testGetEventById()
     {
         long idA = eventService.addEvent( eventA );
         long idB = eventService.addEvent( eventB );
@@ -302,7 +302,7 @@ class EventServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testGetProgramStageInstanceByUid()
+    void testGetEventByUid()
     {
         long idA = eventService.addEvent( eventA );
         long idB = eventService.addEvent( eventB );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventStoreTest.java
@@ -228,7 +228,7 @@ class EventStoreTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testProgramStageInstanceExists()
+    void testEventExists()
     {
         eventStore.save( eventA );
         eventStore.save( eventB );
@@ -240,7 +240,7 @@ class EventStoreTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testGetProgramStageInstancesByInstanceListComplete()
+    void testGetEventsByInstanceListComplete()
     {
         eventA.setStatus( EventStatus.COMPLETED );
         eventB.setStatus( EventStatus.ACTIVE );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramInstanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramInstanceServiceTest.java
@@ -178,17 +178,17 @@ class ProgramInstanceServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testSoftDeleteProgramInstanceAndLinkedProgramStageInstance()
+    void testSoftDeleteProgramInstanceAndLinkedEvent()
     {
         long idA = programInstanceService.addProgramInstance( programInstanceA );
-        long psiIdA = eventService.addEvent( eventA );
+        long eventIdA = eventService.addEvent( eventA );
         programInstanceA.setEvents( Sets.newHashSet( eventA ) );
         programInstanceService.updateProgramInstance( programInstanceA );
         assertNotNull( programInstanceService.getProgramInstance( idA ) );
-        assertNotNull( eventService.getEvent( psiIdA ) );
+        assertNotNull( eventService.getEvent( eventIdA ) );
         programInstanceService.deleteProgramInstance( programInstanceA );
         assertNull( programInstanceService.getProgramInstance( idA ) );
-        assertNull( eventService.getEvent( psiIdA ) );
+        assertNull( eventService.getEvent( eventIdA ) );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramInstanceStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramInstanceStoreTest.java
@@ -168,7 +168,7 @@ class ProgramInstanceStoreTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testProgramStageInstanceExists()
+    void testEventExists()
     {
         programInstanceStore.save( programInstanceA );
         programInstanceStore.save( programInstanceB );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramMessageStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramMessageStoreTest.java
@@ -274,7 +274,7 @@ class ProgramMessageStoreTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testGetProgramMessageByProgramStageInstance()
+    void testGetProgramMessageByEvent()
     {
         programInstanceStore.save( programInstanceA );
         eventStore.save( eventA );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineTest.java
@@ -498,9 +498,9 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
     {
         setUpRuleActionForOptionSetName();
 
-        Event programStageInstance = eventService.getEvent( "UID-PS13" );
-        List<RuleEffect> ruleEffects = programRuleEngine.evaluate( programStageInstance.getProgramInstance(),
-            programStageInstance, Sets.newHashSet(), List.of( programRuleToTestOptionSet ) );
+        Event event = eventService.getEvent( "UID-PS13" );
+        List<RuleEffect> ruleEffects = programRuleEngine.evaluate( event.getProgramInstance(),
+            event, Sets.newHashSet(), List.of( programRuleToTestOptionSet ) );
 
         assertNotNull( ruleEffects );
         assertInstanceOf( RuleActionShowWarning.class, ruleEffects.get( 0 ).ruleAction() );
@@ -512,9 +512,9 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
     {
         setUpRuleActionForOptionSetCode();
 
-        Event programStageInstance = eventService.getEvent( "UID-PS13" );
-        List<RuleEffect> ruleEffects = programRuleEngine.evaluate( programStageInstance.getProgramInstance(),
-            programStageInstance, Sets.newHashSet(), List.of( programRuleToTestOptionSet ) );
+        Event event = eventService.getEvent( "UID-PS13" );
+        List<RuleEffect> ruleEffects = programRuleEngine.evaluate( event.getProgramInstance(),
+            event, Sets.newHashSet(), List.of( programRuleToTestOptionSet ) );
 
         assertNotNull( ruleEffects );
         assertInstanceOf( RuleActionShowError.class, ruleEffects.get( 0 ).ruleAction() );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/relationship/hibernate/RelationshipStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/relationship/hibernate/RelationshipStoreTest.java
@@ -121,7 +121,7 @@ class RelationshipStoreTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testGetByProgramStageInstance()
+    void testGetByEvent()
     {
         Program programA = addProgram();
 
@@ -129,12 +129,12 @@ class RelationshipStoreTest extends TransactionalIntegrationTest
 
         ProgramStage programStageA = addProgramStage( programA );
 
-        Event event = addProgramStageInstance( programInstance, programStageA );
+        Event event = addEvent( programInstance, programStageA );
 
         trackedEntityInstanceA = createTrackedEntityInstance( organisationUnit );
         trackedEntityInstanceService.addTrackedEntityInstance( trackedEntityInstanceA );
 
-        Relationship relationshipA = addTeiToProgramStageInstanceRelationship( trackedEntityInstanceA,
+        Relationship relationshipA = addTeiToEventRelationship( trackedEntityInstanceA,
             event );
 
         List<Relationship> relationshipList = relationshipService
@@ -230,7 +230,7 @@ class RelationshipStoreTest extends TransactionalIntegrationTest
         return teiRelationship;
     }
 
-    private Relationship addTeiToProgramStageInstanceRelationship( TrackedEntityInstance entityInstance,
+    private Relationship addTeiToEventRelationship( TrackedEntityInstance entityInstance,
         Event event )
     {
         RelationshipItem relationshipItemFrom = new RelationshipItem();
@@ -268,7 +268,7 @@ class RelationshipStoreTest extends TransactionalIntegrationTest
         return relationshipA;
     }
 
-    private Event addProgramStageInstance( ProgramInstance programInstance, ProgramStage programStageA )
+    private Event addEvent( ProgramInstance programInstance, ProgramStage programStageA )
     {
         Event event = new Event();
         event.setOrganisationUnit( organisationUnit );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityDataValueAuditStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityDataValueAuditStoreTest.java
@@ -111,15 +111,15 @@ class TrackedEntityDataValueAuditStoreTest extends SingleSetupIntegrationTestBas
 
     private DataElement deB;
 
-    private Event psiA;
+    private Event eventA;
 
-    private Event psiB;
+    private Event eventB;
 
-    private Event psiC;
+    private Event eventC;
 
-    private Event psiD;
+    private Event eventD;
 
-    private Event psiE;
+    private Event eventE;
 
     private EventDataValue dvA;
 
@@ -174,26 +174,26 @@ class TrackedEntityDataValueAuditStoreTest extends SingleSetupIntegrationTestBas
         dvD = new EventDataValue( deB.getUid(), "D", USER_SNAP_A );
         dvE = new EventDataValue( deB.getUid(), "E", USER_SNAP_A );
 
-        psiA = createEvent( piA, psA, ouA, Set.of( dvA, dvB ) );
-        psiB = createEvent( piA, psB, ouB, Set.of( dvC, dvD ) );
-        psiC = createEvent( piA, psA, ouC, Set.of( dvA, dvB ) );
-        psiD = createEvent( piA, psB, ouD, Set.of( dvC, dvD ) );
-        psiE = createEvent( piA, psA, ouE, Set.of( dvA, dvE ) );
-        eventService.addEvent( psiA );
-        eventService.addEvent( psiB );
-        eventService.addEvent( psiC );
-        eventService.addEvent( psiD );
-        eventService.addEvent( psiE );
+        eventA = createEvent( piA, psA, ouA, Set.of( dvA, dvB ) );
+        eventB = createEvent( piA, psB, ouB, Set.of( dvC, dvD ) );
+        eventC = createEvent( piA, psA, ouC, Set.of( dvA, dvB ) );
+        eventD = createEvent( piA, psB, ouD, Set.of( dvC, dvD ) );
+        eventE = createEvent( piA, psA, ouE, Set.of( dvA, dvE ) );
+        eventService.addEvent( eventA );
+        eventService.addEvent( eventB );
+        eventService.addEvent( eventC );
+        eventService.addEvent( eventD );
+        eventService.addEvent( eventE );
     }
 
     @Test
     void testGetTrackedEntityDataValueAuditsByDataElement()
     {
-        TrackedEntityDataValueAudit dvaA = new TrackedEntityDataValueAudit( deA, psiA,
+        TrackedEntityDataValueAudit dvaA = new TrackedEntityDataValueAudit( deA, eventA,
             dvA.getAuditValue(), USER_A, dvA.getProvidedElsewhere(), AuditType.UPDATE );
-        TrackedEntityDataValueAudit dvaB = new TrackedEntityDataValueAudit( deB, psiA,
+        TrackedEntityDataValueAudit dvaB = new TrackedEntityDataValueAudit( deB, eventA,
             dvB.getAuditValue(), USER_A, dvB.getProvidedElsewhere(), AuditType.UPDATE );
-        TrackedEntityDataValueAudit dvaC = new TrackedEntityDataValueAudit( deA, psiB,
+        TrackedEntityDataValueAudit dvaC = new TrackedEntityDataValueAudit( deA, eventB,
             dvC.getAuditValue(), USER_A, dvC.getProvidedElsewhere(), AuditType.UPDATE );
         auditStore.addTrackedEntityDataValueAudit( dvaA );
         auditStore.addTrackedEntityDataValueAudit( dvaB );
@@ -201,14 +201,14 @@ class TrackedEntityDataValueAuditStoreTest extends SingleSetupIntegrationTestBas
 
         TrackedEntityDataValueAuditQueryParams params = new TrackedEntityDataValueAuditQueryParams()
             .setDataElements( List.of( deA, deB ) )
-            .setEvents( List.of( psiA ) )
+            .setEvents( List.of( eventA ) )
             .setAuditTypes( List.of( AuditType.UPDATE ) );
         assertContainsOnly( List.of( dvaA, dvaB ), auditStore.getTrackedEntityDataValueAudits( params ) );
         assertEquals( 2, auditStore.countTrackedEntityDataValueAudits( params ) );
 
         params = new TrackedEntityDataValueAuditQueryParams()
             .setDataElements( List.of( deA ) )
-            .setEvents( List.of( psiA ) )
+            .setEvents( List.of( eventA ) )
             .setAuditTypes( List.of( AuditType.UPDATE ) );
         assertContainsOnly( List.of( dvaA ), auditStore.getTrackedEntityDataValueAudits( params ) );
         assertEquals( 1, auditStore.countTrackedEntityDataValueAudits( params ) );
@@ -217,11 +217,11 @@ class TrackedEntityDataValueAuditStoreTest extends SingleSetupIntegrationTestBas
     @Test
     void testGetTrackedEntityDataValueAuditsByOrgUnitSelected()
     {
-        TrackedEntityDataValueAudit dvaA = new TrackedEntityDataValueAudit( deA, psiA,
+        TrackedEntityDataValueAudit dvaA = new TrackedEntityDataValueAudit( deA, eventA,
             dvA.getAuditValue(), USER_A, dvA.getProvidedElsewhere(), AuditType.UPDATE );
-        TrackedEntityDataValueAudit dvaB = new TrackedEntityDataValueAudit( deB, psiA,
+        TrackedEntityDataValueAudit dvaB = new TrackedEntityDataValueAudit( deB, eventA,
             dvB.getAuditValue(), USER_A, dvB.getProvidedElsewhere(), AuditType.UPDATE );
-        TrackedEntityDataValueAudit dvaC = new TrackedEntityDataValueAudit( deA, psiB,
+        TrackedEntityDataValueAudit dvaC = new TrackedEntityDataValueAudit( deA, eventB,
             dvC.getAuditValue(), USER_A, dvC.getProvidedElsewhere(), AuditType.UPDATE );
         auditStore.addTrackedEntityDataValueAudit( dvaA );
         auditStore.addTrackedEntityDataValueAudit( dvaB );
@@ -243,15 +243,15 @@ class TrackedEntityDataValueAuditStoreTest extends SingleSetupIntegrationTestBas
     @Test
     void testGetTrackedEntityDataValueAuditsByOrgUnitDescendants()
     {
-        TrackedEntityDataValueAudit dvaA = new TrackedEntityDataValueAudit( deA, psiA,
+        TrackedEntityDataValueAudit dvaA = new TrackedEntityDataValueAudit( deA, eventA,
             dvA.getAuditValue(), USER_A, dvA.getProvidedElsewhere(), AuditType.UPDATE );
-        TrackedEntityDataValueAudit dvaB = new TrackedEntityDataValueAudit( deB, psiB,
+        TrackedEntityDataValueAudit dvaB = new TrackedEntityDataValueAudit( deB, eventB,
             dvB.getAuditValue(), USER_A, dvB.getProvidedElsewhere(), AuditType.UPDATE );
-        TrackedEntityDataValueAudit dvaC = new TrackedEntityDataValueAudit( deA, psiC,
+        TrackedEntityDataValueAudit dvaC = new TrackedEntityDataValueAudit( deA, eventC,
             dvC.getAuditValue(), USER_A, dvC.getProvidedElsewhere(), AuditType.UPDATE );
-        TrackedEntityDataValueAudit dvaD = new TrackedEntityDataValueAudit( deB, psiD,
+        TrackedEntityDataValueAudit dvaD = new TrackedEntityDataValueAudit( deB, eventD,
             dvD.getAuditValue(), USER_A, dvD.getProvidedElsewhere(), AuditType.UPDATE );
-        TrackedEntityDataValueAudit dvaE = new TrackedEntityDataValueAudit( deA, psiE,
+        TrackedEntityDataValueAudit dvaE = new TrackedEntityDataValueAudit( deA, eventE,
             dvE.getAuditValue(), USER_A, dvE.getProvidedElsewhere(), AuditType.UPDATE );
         auditStore.addTrackedEntityDataValueAudit( dvaA );
         auditStore.addTrackedEntityDataValueAudit( dvaB );
@@ -278,11 +278,11 @@ class TrackedEntityDataValueAuditStoreTest extends SingleSetupIntegrationTestBas
     @Test
     void testGetTrackedEntityDataValueAuditsByProgramStage()
     {
-        TrackedEntityDataValueAudit dvaA = new TrackedEntityDataValueAudit( deA, psiA,
+        TrackedEntityDataValueAudit dvaA = new TrackedEntityDataValueAudit( deA, eventA,
             dvA.getAuditValue(), USER_A, dvA.getProvidedElsewhere(), AuditType.UPDATE );
-        TrackedEntityDataValueAudit dvaB = new TrackedEntityDataValueAudit( deB, psiA,
+        TrackedEntityDataValueAudit dvaB = new TrackedEntityDataValueAudit( deB, eventA,
             dvB.getAuditValue(), USER_A, dvB.getProvidedElsewhere(), AuditType.UPDATE );
-        TrackedEntityDataValueAudit dvaC = new TrackedEntityDataValueAudit( deA, psiB,
+        TrackedEntityDataValueAudit dvaC = new TrackedEntityDataValueAudit( deA, eventB,
             dvC.getAuditValue(), USER_A, dvC.getProvidedElsewhere(), AuditType.UPDATE );
         auditStore.addTrackedEntityDataValueAudit( dvaA );
         auditStore.addTrackedEntityDataValueAudit( dvaB );
@@ -304,13 +304,13 @@ class TrackedEntityDataValueAuditStoreTest extends SingleSetupIntegrationTestBas
     @Test
     void testGetTrackedEntityDataValueAuditsByStartEndDate()
     {
-        TrackedEntityDataValueAudit dvaA = new TrackedEntityDataValueAudit( deA, psiA,
+        TrackedEntityDataValueAudit dvaA = new TrackedEntityDataValueAudit( deA, eventA,
             dvA.getAuditValue(), USER_A, dvA.getProvidedElsewhere(), AuditType.UPDATE );
         dvaA.setCreated( getDate( 2021, 6, 1 ) );
-        TrackedEntityDataValueAudit dvaB = new TrackedEntityDataValueAudit( deB, psiA,
+        TrackedEntityDataValueAudit dvaB = new TrackedEntityDataValueAudit( deB, eventA,
             dvB.getAuditValue(), USER_A, dvB.getProvidedElsewhere(), AuditType.UPDATE );
         dvaB.setCreated( getDate( 2021, 7, 1 ) );
-        TrackedEntityDataValueAudit dvaC = new TrackedEntityDataValueAudit( deA, psiB,
+        TrackedEntityDataValueAudit dvaC = new TrackedEntityDataValueAudit( deA, eventB,
             dvC.getAuditValue(), USER_A, dvC.getProvidedElsewhere(), AuditType.UPDATE );
         dvaC.setCreated( getDate( 2021, 8, 1 ) );
         auditStore.addTrackedEntityDataValueAudit( dvaA );
@@ -335,11 +335,11 @@ class TrackedEntityDataValueAuditStoreTest extends SingleSetupIntegrationTestBas
     @Test
     void testGetTrackedEntityDataValueAuditsByAuditType()
     {
-        TrackedEntityDataValueAudit dvaA = new TrackedEntityDataValueAudit( deA, psiA,
+        TrackedEntityDataValueAudit dvaA = new TrackedEntityDataValueAudit( deA, eventA,
             dvA.getAuditValue(), USER_A, dvA.getProvidedElsewhere(), AuditType.CREATE );
-        TrackedEntityDataValueAudit dvaB = new TrackedEntityDataValueAudit( deB, psiA,
+        TrackedEntityDataValueAudit dvaB = new TrackedEntityDataValueAudit( deB, eventA,
             dvB.getAuditValue(), USER_A, dvB.getProvidedElsewhere(), AuditType.UPDATE );
-        TrackedEntityDataValueAudit dvaC = new TrackedEntityDataValueAudit( deA, psiB,
+        TrackedEntityDataValueAudit dvaC = new TrackedEntityDataValueAudit( deA, eventB,
             dvC.getAuditValue(), USER_A, dvC.getProvidedElsewhere(), AuditType.DELETE );
         auditStore.addTrackedEntityDataValueAudit( dvaA );
         auditStore.addTrackedEntityDataValueAudit( dvaB );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceServiceTest.java
@@ -225,21 +225,21 @@ class TrackedEntityInstanceServiceTest
     {
         long idA = entityInstanceService.addTrackedEntityInstance( entityInstanceA1 );
         long psIdA = programInstanceService.addProgramInstance( programInstance );
-        long psiIdA = eventService.addEvent( event );
+        long eventIdA = eventService.addEvent( event );
         programInstance.setEvents( Set.of( event ) );
         entityInstanceA1.setProgramInstances( Set.of( programInstance ) );
         programInstanceService.updateProgramInstance( programInstance );
         entityInstanceService.updateTrackedEntityInstance( entityInstanceA1 );
         TrackedEntityInstance teiA = entityInstanceService.getTrackedEntityInstance( idA );
         ProgramInstance psA = programInstanceService.getProgramInstance( psIdA );
-        Event psiA = eventService.getEvent( psiIdA );
+        Event eventA = eventService.getEvent( eventIdA );
         assertNotNull( teiA );
         assertNotNull( psA );
-        assertNotNull( psiA );
+        assertNotNull( eventA );
         entityInstanceService.deleteTrackedEntityInstance( entityInstanceA1 );
         assertNull( entityInstanceService.getTrackedEntityInstance( teiA.getUid() ) );
         assertNull( programInstanceService.getProgramInstance( psIdA ) );
-        assertNull( eventService.getEvent( psiIdA ) );
+        assertNull( eventService.getEvent( eventIdA ) );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -703,7 +703,7 @@ class EventExporterTest extends TrackerTest
         params.setEnrollmentEnrolledBefore( parseDate( "2021-02-27T12:05:00.000" ) );
 
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getUid() )
+            .map( event -> event.getProgramInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertIsEmpty( enrollments );
@@ -717,7 +717,7 @@ class EventExporterTest extends TrackerTest
         params.setEnrollmentEnrolledBefore( parseDate( "2021-02-28T12:05:00.000" ) );
 
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getUid() )
+            .map( event -> event.getProgramInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertContainsOnly( List.of( "nxP7UnKhomJ" ), enrollments );
@@ -731,7 +731,7 @@ class EventExporterTest extends TrackerTest
         params.setEnrollmentEnrolledBefore( parseDate( "2021-02-28T13:05:00.000" ) );
 
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getUid() )
+            .map( event -> event.getProgramInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertContainsOnly( List.of( "nxP7UnKhomJ" ), enrollments );
@@ -745,7 +745,7 @@ class EventExporterTest extends TrackerTest
         params.setEnrollmentEnrolledAfter( parseDate( "2021-03-27T12:05:00.000" ) );
 
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getUid() )
+            .map( event -> event.getProgramInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertContainsOnly( List.of( "TvctPPhpD8z" ), enrollments );
@@ -759,7 +759,7 @@ class EventExporterTest extends TrackerTest
         params.setEnrollmentEnrolledAfter( parseDate( "2021-03-28T12:05:00.000" ) );
 
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getUid() )
+            .map( event -> event.getProgramInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertContainsOnly( List.of( "TvctPPhpD8z" ), enrollments );
@@ -773,7 +773,7 @@ class EventExporterTest extends TrackerTest
         params.setEnrollmentEnrolledAfter( parseDate( "2021-03-28T13:05:00.000" ) );
 
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getUid() )
+            .map( event -> event.getProgramInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertIsEmpty( enrollments );
@@ -787,7 +787,7 @@ class EventExporterTest extends TrackerTest
         params.setEnrollmentOccurredBefore( parseDate( "2021-02-27T12:05:00.000" ) );
 
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getUid() )
+            .map( event -> event.getProgramInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertIsEmpty( enrollments );
@@ -801,7 +801,7 @@ class EventExporterTest extends TrackerTest
         params.setEnrollmentOccurredBefore( parseDate( "2021-02-28T12:05:00.000" ) );
 
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getUid() )
+            .map( event -> event.getProgramInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertContainsOnly( List.of( "nxP7UnKhomJ" ), enrollments );
@@ -815,7 +815,7 @@ class EventExporterTest extends TrackerTest
         params.setEnrollmentOccurredBefore( parseDate( "2021-02-28T13:05:00.000" ) );
 
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getUid() )
+            .map( event -> event.getProgramInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertContainsOnly( List.of( "nxP7UnKhomJ" ), enrollments );
@@ -829,7 +829,7 @@ class EventExporterTest extends TrackerTest
         params.setEnrollmentOccurredAfter( parseDate( "2021-03-27T12:05:00.000" ) );
 
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getUid() )
+            .map( event -> event.getProgramInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertContainsOnly( List.of( "TvctPPhpD8z" ), enrollments );
@@ -843,7 +843,7 @@ class EventExporterTest extends TrackerTest
         params.setEnrollmentOccurredAfter( parseDate( "2021-03-28T12:05:00.000" ) );
 
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getUid() )
+            .map( event -> event.getProgramInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertContainsOnly( List.of( "TvctPPhpD8z" ), enrollments );
@@ -863,7 +863,7 @@ class EventExporterTest extends TrackerTest
         params.addFilterAttributes( queryItem );
 
         List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getEntityInstance().getUid() )
+            .map( event -> event.getProgramInstance().getEntityInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertContainsOnly( List.of( "dUE514NMOlo" ), trackedEntities );
@@ -878,7 +878,7 @@ class EventExporterTest extends TrackerTest
         params.addFilterAttributes( queryItem( "toUpdate000", QueryOperator.EQ, "summer day" ) );
 
         List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getEntityInstance().getUid() )
+            .map( event -> event.getProgramInstance().getEntityInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertContainsOnly( List.of( "QS6w44flWAf" ), trackedEntities );
@@ -895,7 +895,7 @@ class EventExporterTest extends TrackerTest
             queryItem( "notUpdated0", QueryOperator.EQ, "winter day" ) ) );
 
         List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getEntityInstance().getUid() )
+            .map( event -> event.getProgramInstance().getEntityInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertContainsOnly( List.of( "dUE514NMOlo" ), trackedEntities );
@@ -912,7 +912,7 @@ class EventExporterTest extends TrackerTest
         params.addFilterAttributes( item );
 
         List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getEntityInstance().getUid() )
+            .map( event -> event.getProgramInstance().getEntityInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertContainsOnly( List.of( "dUE514NMOlo" ), trackedEntities );
@@ -928,7 +928,7 @@ class EventExporterTest extends TrackerTest
         params.addOrders( params.getAttributeOrders() );
 
         List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getEntityInstance().getUid() )
+            .map( event -> event.getProgramInstance().getEntityInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertEquals( List.of( "dUE514NMOlo", "QS6w44flWAf" ), trackedEntities );
@@ -944,7 +944,7 @@ class EventExporterTest extends TrackerTest
         params.addOrders( params.getAttributeOrders() );
 
         List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getEntityInstance().getUid() )
+            .map( event -> event.getProgramInstance().getEntityInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertEquals( List.of( "QS6w44flWAf", "dUE514NMOlo" ), trackedEntities );
@@ -961,7 +961,7 @@ class EventExporterTest extends TrackerTest
         params.addOrders( params.getAttributeOrders() );
 
         List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getEntityInstance().getUid() )
+            .map( event -> event.getProgramInstance().getEntityInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertEquals( List.of( "QS6w44flWAf", "dUE514NMOlo" ), trackedEntities );
@@ -978,7 +978,7 @@ class EventExporterTest extends TrackerTest
         params.addOrders( params.getAttributeOrders() );
 
         List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getEntityInstance().getUid() )
+            .map( event -> event.getProgramInstance().getEntityInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertEquals( List.of( "dUE514NMOlo", "QS6w44flWAf" ), trackedEntities );
@@ -992,7 +992,7 @@ class EventExporterTest extends TrackerTest
         params.setEnrollmentOccurredAfter( parseDate( "2021-03-28T13:05:00.000" ) );
 
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getUid() )
+            .map( event -> event.getProgramInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertIsEmpty( enrollments );
@@ -1006,7 +1006,7 @@ class EventExporterTest extends TrackerTest
         params.addOrders( List.of( new OrderParam( "enrolledAt", SortDirection.DESC ) ) );
 
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getUid() )
+            .map( event -> event.getProgramInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertEquals( List.of( "TvctPPhpD8z", "nxP7UnKhomJ" ), enrollments );
@@ -1020,7 +1020,7 @@ class EventExporterTest extends TrackerTest
         params.addOrders( List.of( new OrderParam( "enrolledAt", SortDirection.ASC ) ) );
 
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getUid() )
+            .map( event -> event.getProgramInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertEquals( List.of( "nxP7UnKhomJ", "TvctPPhpD8z" ), enrollments );
@@ -1109,7 +1109,7 @@ class EventExporterTest extends TrackerTest
             new OrderParam( "enrolledAt", SortDirection.ASC ) ) );
 
         List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getEntityInstance().getUid() )
+            .map( event -> event.getProgramInstance().getEntityInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertEquals( List.of( "dUE514NMOlo", "QS6w44flWAf" ), trackedEntities );
@@ -1126,7 +1126,7 @@ class EventExporterTest extends TrackerTest
             new OrderParam( "toUpdate000", SortDirection.DESC ) ) );
 
         List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getEntityInstance().getUid() )
+            .map( event -> event.getProgramInstance().getEntityInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertEquals( List.of( "dUE514NMOlo", "QS6w44flWAf" ), trackedEntities );
@@ -1145,7 +1145,7 @@ class EventExporterTest extends TrackerTest
             new OrderParam( "enrolledAt", SortDirection.DESC ) ) );
 
         List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getEntityInstance().getUid() )
+            .map( event -> event.getProgramInstance().getEntityInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertEquals( List.of( "QS6w44flWAf", "dUE514NMOlo" ), trackedEntities );
@@ -1163,7 +1163,7 @@ class EventExporterTest extends TrackerTest
             new OrderParam( "DATAEL00006", SortDirection.DESC ) ) );
 
         List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()
-            .map( psi -> psi.getProgramInstance().getEntityInstance().getUid() )
+            .map( event -> event.getProgramInstance().getEntityInstance().getUid() )
             .collect( Collectors.toList() );
 
         assertEquals( List.of( "dUE514NMOlo", "QS6w44flWAf" ), trackedEntities );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipServiceTest.java
@@ -82,7 +82,7 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase
 
     private TrackedEntityInstance inaccessibleTei;
 
-    private Event psiA;
+    private Event eventA;
 
     private Event inaccessiblePsi;
 
@@ -96,7 +96,7 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase
 
     private final RelationshipType teiToPiInaccessibleType = createRelationshipType( 'E' );
 
-    private final RelationshipType psiToPsiType = createRelationshipType( 'F' );
+    private final RelationshipType eventToEventType = createRelationshipType( 'F' );
 
     private ProgramInstance piA;
 
@@ -149,11 +149,11 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase
 
         piA = programInstanceService.enrollTrackedEntityInstance( teiA, program, new Date(), new Date(),
             orgUnit );
-        psiA = new Event();
-        psiA.setProgramInstance( piA );
-        psiA.setProgramStage( programStage );
-        psiA.setOrganisationUnit( orgUnit );
-        manager.save( psiA, false );
+        eventA = new Event();
+        eventA.setProgramInstance( piA );
+        eventA.setProgramStage( programStage );
+        eventA.setOrganisationUnit( orgUnit );
+        manager.save( eventA, false );
 
         ProgramInstance piB = programInstanceService.enrollTrackedEntityInstance( teiB, program, new Date(), new Date(),
             orgUnit );
@@ -209,14 +209,14 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase
         teiToPsiType.getSharing().setOwner( user );
         manager.save( teiToPsiType, false );
 
-        psiToPsiType.getFromConstraint()
+        eventToEventType.getFromConstraint()
             .setRelationshipEntity( RelationshipEntity.PROGRAM_STAGE_INSTANCE );
-        psiToPsiType.getFromConstraint().setTrackedEntityType( trackedEntityType );
-        psiToPsiType.getToConstraint()
+        eventToEventType.getFromConstraint().setTrackedEntityType( trackedEntityType );
+        eventToEventType.getToConstraint()
             .setRelationshipEntity( RelationshipEntity.PROGRAM_STAGE_INSTANCE );
-        psiToPsiType.getToConstraint().setProgramStage( programStage );
-        psiToPsiType.getSharing().setOwner( user );
-        manager.save( psiToPsiType, false );
+        eventToEventType.getToConstraint().setProgramStage( programStage );
+        eventToEventType.getSharing().setOwner( user );
+        manager.save( eventToEventType, false );
 
         injectSecurityContext( user );
     }
@@ -252,14 +252,14 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase
     }
 
     @Test
-    void shouldNotReturnRelationshipByProgramStageInstanceIfUserHasNoAccessToProgramStage()
+    void shouldNotReturnRelationshipByEventIfUserHasNoAccessToProgramStage()
         throws ForbiddenException,
         NotFoundException
     {
-        Relationship accessible = relationship( teiA, psiA );
-        relationship( psiA, inaccessiblePsi );
+        Relationship accessible = relationship( teiA, eventA );
+        relationship( eventA, inaccessiblePsi );
 
-        List<Relationship> relationships = relationshipService.getRelationshipsByEvent( psiA,
+        List<Relationship> relationships = relationshipService.getRelationshipsByEvent( eventA,
             new Paging() );
 
         assertContainsOnly( List.of( accessible.getUid() ),
@@ -328,7 +328,7 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase
 
     private void relationship( Event from, Event to )
     {
-        relationship( from, to, psiToPsiType );
+        relationship( from, to, eventToEventType );
     }
 
     private void relationship( Event from, Event to, RelationshipType type )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventDataValueTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventDataValueTest.java
@@ -101,8 +101,8 @@ class EventDataValueTest extends TrackerTest
         assertNoErrors( importReport );
         List<Event> events = manager.getAll( Event.class );
         assertEquals( 1, events.size() );
-        Event psi = events.get( 0 );
-        Set<EventDataValue> eventDataValues = psi.getEventDataValues();
+        Event event = events.get( 0 );
+        Set<EventDataValue> eventDataValues = event.getEventDataValues();
         assertEquals( 4, eventDataValues.size() );
     }
 
@@ -116,8 +116,8 @@ class EventDataValueTest extends TrackerTest
         assertNoErrors( importReport );
         List<Event> events = manager.getAll( Event.class );
         assertEquals( 1, events.size() );
-        Event psi = events.get( 0 );
-        Set<EventDataValue> eventDataValues = psi.getEventDataValues();
+        Event event = events.get( 0 );
+        Set<EventDataValue> eventDataValues = event.getEventDataValues();
         assertEquals( 4, eventDataValues.size() );
         // update
         TrackerImportParams trackerImportParams = fromJson( "tracker/event_with_updated_data_values.json" );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/OwnershipTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/OwnershipTest.java
@@ -150,15 +150,15 @@ class OwnershipTest extends TrackerTest
             pi.getCreatedAtClient() );
         assertEquals( DateUtils.fromInstant( enrollmentParams.getEnrollments().get( 0 ).getUpdatedAtClient() ),
             pi.getLastUpdatedAtClient() );
-        Set<Event> psis = pi.getEvents();
-        assertEquals( 1, psis.size() );
-        Event psi = psis.iterator().next();
-        assertNotNull( psi.getCreatedAtClient() );
-        assertNotNull( psi.getLastUpdatedAtClient() );
+        Set<Event> events = pi.getEvents();
+        assertEquals( 1, events.size() );
+        Event event = events.iterator().next();
+        assertNotNull( event.getCreatedAtClient() );
+        assertNotNull( event.getLastUpdatedAtClient() );
         assertEquals( DateUtils.fromInstant( trackerImportParams.getEvents().get( 0 ).getCreatedAtClient() ),
-            psi.getCreatedAtClient() );
+            event.getCreatedAtClient() );
         assertEquals( DateUtils.fromInstant( trackerImportParams.getEvents().get( 0 ).getUpdatedAtClient() ),
-            psi.getLastUpdatedAtClient() );
+            event.getLastUpdatedAtClient() );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityDataValueAuditTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityDataValueAuditTest.java
@@ -72,7 +72,7 @@ public class TrackedEntityDataValueAuditTest extends TrackerTest
 
     private DataElement dataElement;
 
-    private Event psi;
+    private Event event;
 
     @Override
     protected void initTest()
@@ -94,24 +94,24 @@ public class TrackedEntityDataValueAuditTest extends TrackerTest
             trackerImportService.importTracker( fromJson( "tracker/event_with_data_values_for_delete_audit.json" ) ) );
 
         dataElement = manager.search( DataElement.class, DE );
-        psi = manager.search( Event.class, PSI );
+        event = manager.search( Event.class, PSI );
         assertNotNull( dataElement );
-        assertNotNull( psi );
+        assertNotNull( event );
 
         List<TrackedEntityDataValueAudit> createdAudit = dataValueAuditService.getTrackedEntityDataValueAudits(
             new TrackedEntityDataValueAuditQueryParams()
                 .setDataElements( List.of( dataElement ) )
-                .setEvents( List.of( psi ) )
+                .setEvents( List.of( event ) )
                 .setAuditTypes( List.of( AuditType.CREATE ) ) );
         List<TrackedEntityDataValueAudit> updatedAudit = dataValueAuditService.getTrackedEntityDataValueAudits(
             new TrackedEntityDataValueAuditQueryParams()
                 .setDataElements( List.of( dataElement ) )
-                .setEvents( List.of( psi ) )
+                .setEvents( List.of( event ) )
                 .setAuditTypes( List.of( AuditType.UPDATE ) ) );
         List<TrackedEntityDataValueAudit> deletedAudit = dataValueAuditService.getTrackedEntityDataValueAudits(
             new TrackedEntityDataValueAuditQueryParams()
                 .setDataElements( List.of( dataElement ) )
-                .setEvents( List.of( psi ) )
+                .setEvents( List.of( event ) )
                 .setAuditTypes( List.of( AuditType.DELETE ) ) );
 
         assertAll( () -> assertNotNull( createdAudit ), () -> assertNotNull( updatedAudit ),

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentImportValidationTest.java
@@ -159,7 +159,7 @@ class EnrollmentImportValidationTest extends TrackerTest
 
         assertNoErrors( importReport );
         manager.flush();
-        importProgramStageInstances();
+        importEvents();
         manager.flush();
         params = fromJson( "tracker/validations/enrollments_te_attr-data.json" );
         User user2 = userService.getUser( USER_4 );
@@ -171,7 +171,7 @@ class EnrollmentImportValidationTest extends TrackerTest
         assertHasOnlyErrors( trackerImportDeleteReport, ValidationCode.E1103, ValidationCode.E1091 );
     }
 
-    protected void importProgramStageInstances()
+    protected void importEvents()
         throws IOException
     {
         TrackerImportParams params = fromJson( "tracker/validations/events-with-registration.json" );


### PR DESCRIPTION
After this PR there are a few things left to discuss as noted in https://dhis2.atlassian.net/browse/TECH-1537

Analytics, old tracker (dxf2) still contain `psi` and `programStageInstance`. There are also some endpoints having `psi` and `programStageInstance` in query parameters, paths or response body. We will need to discuss them individually to decide if and how to transition them.