### PR TITLE
fix: getState().builder() -> ().toBuilder()

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/function/FunctionSubExpression.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/function/FunctionSubExpression.java
@@ -147,7 +147,7 @@ public class FunctionSubExpression
      */
     private ExpressionState getSubExpressionState( CommonExpressionVisitor visitor )
     {
-        return visitor.getState().builder().inSubexpression( true ).build();
+        return visitor.getState().toBuilder().inSubexpression( true ).build();
     }
 
     /**


### PR DESCRIPTION
I saw this typo in SubExpression processing as I was reading the code.

It likely doesn't affect anything in practice since there isn't likely to be any expression state that needs to be carried into a SubExpression, but it should be fixed in case there is some day.