### PR TITLE
fix: handle fixed delay jobs in scheduler list API and startup [DHIS2-15241]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/SchedulerStart.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/SchedulerStart.java
@@ -171,7 +171,7 @@ public class SchedulerStart extends AbstractStartupRoutine
                 {
                     Date expectedFutureExecutionTime = jobConfig.nextExecutionTimeAfter( Clock.fixed(
                         lastExecuted.toInstant().plusSeconds( 1 ), ZoneId.systemDefault() ) );
-                    if ( expectedFutureExecutionTime.before( now ) )
+                    if ( expectedFutureExecutionTime != null && expectedFutureExecutionTime.before( now ) )
                     {
                         unexecutedJobs.add( "\nJob [" + jobConfig.getUid() + ", " + jobConfig.getName()
                             + "] has status failed or was scheduled in server downtime. Actual execution time was supposed to be: "

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobSchedulerController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobSchedulerController.java
@@ -28,6 +28,8 @@
 package org.hisp.dhis.webapi.controller.scheduling;
 
 import static java.util.Comparator.comparing;
+import static java.util.Comparator.naturalOrder;
+import static java.util.Comparator.nullsLast;
 import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
@@ -92,7 +94,7 @@ public class JobSchedulerController
             .stream().collect( groupingBy( JobConfiguration::getQueueIdentifier ) );
         Comparator<SchedulerEntry> sortBy = "name".equals( order )
             ? comparing( SchedulerEntry::getName )
-            : comparing( SchedulerEntry::getNextExecutionTime );
+            : comparing( SchedulerEntry::getNextExecutionTime, nullsLast( naturalOrder() ) );
         return configsByQueueNameOrUid.values().stream()
             .map( SchedulerEntry::of )
             .sorted( sortBy )


### PR DESCRIPTION
Sorting by next execution time caused a NPE for fixed delay jobs.
Similarly during startup then checking if an execution was missed during downtime a fixed delay job does not have a date so again an NPE would occur.