### PR TITLE
fix: create new array for org unit parents

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
@@ -318,7 +318,7 @@ public class OrganisationUnitController
         rpLevels = rpLevels != null ? rpLevels : new ArrayList<>();
         rpParents = rpParents != null ? rpParents : new ArrayList<>();
 
-        List<OrganisationUnit> parents = manager.getByUid( OrganisationUnit.class, rpParents );
+        List<OrganisationUnit> parents = new ArrayList<>( manager.getByUid( OrganisationUnit.class, rpParents ) );
 
         if ( rpLevels.isEmpty() )
         {


### PR DESCRIPTION
Fix for a regression in geojson support in 2.40. This happened because some collection have been made immutable but we still have code that mutates them.