### PR TITLE
chore: Rename ProgramInstanceService to EnrollmentService [TECH-1547]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
@@ -40,77 +40,77 @@ import org.hisp.dhis.user.User;
 /**
  * @author Abyot Asalefew
  */
-public interface ProgramInstanceService
+public interface EnrollmentService
 {
     /**
      * Adds an {@link Enrollment}
      *
-     * @param enrollment The to ProgramInstance add.
+     * @param enrollment The to Enrollment add.
      * @return A generated unique id of the added {@link Enrollment}.
      */
-    long addProgramInstance( Enrollment enrollment );
+    long addEnrollment( Enrollment enrollment );
 
     /**
      * Adds an {@link Enrollment}
      *
-     * @param enrollment The to ProgramInstance add.
+     * @param enrollment The to Enrollment add.
      * @param user the current user.
      * @return A generated unique id of the added {@link Enrollment}.
      */
-    long addProgramInstance( Enrollment enrollment, User user );
+    long addEnrollment( Enrollment enrollment, User user );
 
     /**
      * Soft deletes a {@link Enrollment}.
      *
-     * @param enrollment the ProgramInstance to delete.
+     * @param enrollment the Enrollment to delete.
      */
-    void deleteProgramInstance( Enrollment enrollment );
+    void deleteEnrollment( Enrollment enrollment );
 
     /**
      * Hard deletes a {@link Enrollment}.
      *
-     * @param enrollment the ProgramInstance to delete.
+     * @param enrollment the Enrollment to delete.
      */
-    void hardDeleteProgramInstance( Enrollment enrollment );
+    void hardDeleteEnrollment( Enrollment enrollment );
 
     /**
      * Updates an {@link Enrollment}.
      *
-     * @param enrollment the ProgramInstance to update.
+     * @param enrollment the Enrollment to update.
      */
-    void updateProgramInstance( Enrollment enrollment );
+    void updateEnrollment( Enrollment enrollment );
 
     /**
      * Updates an {@link Enrollment}.
      *
-     * @param enrollment the ProgramInstance to update.
+     * @param enrollment the Enrollment to update.
      * @param user the current user.
      */
-    void updateProgramInstance( Enrollment enrollment, User user );
+    void updateEnrollment( Enrollment enrollment, User user );
 
     /**
      * Returns a {@link Enrollment}.
      *
-     * @param id the id of the ProgramInstance to return.
-     * @return the ProgramInstance with the given id
+     * @param id the id of the Enrollment to return.
+     * @return the Enrollment with the given id
      */
-    Enrollment getProgramInstance( long id );
+    Enrollment getEnrollment( long id );
 
     /**
      * Returns the {@link Enrollment} with the given UID.
      *
      * @param uid the UID.
-     * @return the ProgramInstance with the given UID, or null if no match.
+     * @return the Enrollment with the given UID, or null if no match.
      */
-    Enrollment getProgramInstance( String uid );
+    Enrollment getEnrollment( String uid );
 
     /**
-     * Returns a list of existing ProgramInstances from the provided UIDs
+     * Returns a list of existing Enrollments from the provided UIDs
      *
      * @param uids PSI UIDs to check
-     * @return ProgramInstance list
+     * @return Enrollment list
      */
-    List<Enrollment> getProgramInstances( @Nonnull List<String> uids );
+    List<Enrollment> getEnrollments( @Nonnull List<String> uids );
 
     /**
      * Checks for the existence of a PI by UID. Deleted values are not taken
@@ -119,7 +119,7 @@ public interface ProgramInstanceService
      * @param uid PSI UID to check for
      * @return true/false depending on result
      */
-    boolean programInstanceExists( String uid );
+    boolean enrollmentExists( String uid );
 
     /**
      * Checks for the existence of a PI by UID. Takes into account also the
@@ -128,16 +128,16 @@ public interface ProgramInstanceService
      * @param uid PSI UID to check for
      * @return true/false depending on result
      */
-    boolean programInstanceExistsIncludingDeleted( String uid );
+    boolean enrollmentExistsIncludingDeleted( String uid );
 
     /**
-     * Returns UIDs of existing ProgramInstances (including deleted) from the
+     * Returns UIDs of existing Enrollments (including deleted) from the
      * provided UIDs
      *
      * @param uids PSI UIDs to check
      * @return Set containing UIDs of existing PSIs (including deleted)
      */
-    List<String> getProgramInstancesUidsIncludingDeleted( List<String> uids );
+    List<String> getEnrollmentsUidsIncludingDeleted( List<String> uids );
 
     /**
      * Returns a list with program instance values based on the given
@@ -146,7 +146,7 @@ public interface ProgramInstanceService
      * @param params the ProgramInstanceQueryParams.
      * @return List of PIs matching the params
      */
-    List<Enrollment> getProgramInstances( ProgramInstanceQueryParams params );
+    List<Enrollment> getEnrollments( ProgramInstanceQueryParams params );
 
     /**
      * Returns the number of program instance matches based on the given
@@ -155,7 +155,7 @@ public interface ProgramInstanceService
      * @param params the ProgramInstanceQueryParams.
      * @return Number of PIs matching the params
      */
-    int countProgramInstances( ProgramInstanceQueryParams params );
+    int countEnrollments( ProgramInstanceQueryParams params );
 
     /**
      * Decides whether current user is authorized to perform the given query.
@@ -179,9 +179,9 @@ public interface ProgramInstanceService
      * Retrieve program instances on a program
      *
      * @param program Program
-     * @return ProgramInstance list
+     * @return Enrollment list
      */
-    List<Enrollment> getProgramInstances( Program program );
+    List<Enrollment> getEnrollments( Program program );
 
     /**
      * Retrieve program instances on a program by status
@@ -189,9 +189,9 @@ public interface ProgramInstanceService
      * @param program Program
      * @param status Status of program-instance, include STATUS_ACTIVE,
      *        STATUS_COMPLETED and STATUS_CANCELLED
-     * @return ProgramInstance list
+     * @return Enrollment list
      */
-    List<Enrollment> getProgramInstances( Program program, ProgramStatus status );
+    List<Enrollment> getEnrollments( Program program, ProgramStatus status );
 
     /**
      * Retrieve program instances on a TrackedEntityInstance with a status by a
@@ -201,9 +201,9 @@ public interface ProgramInstanceService
      * @param program Program
      * @param status Status of program-instance, include STATUS_ACTIVE,
      *        STATUS_COMPLETED and STATUS_CANCELLED
-     * @return ProgramInstance list
+     * @return Enrollment list
      */
-    List<Enrollment> getProgramInstances( TrackedEntityInstance entityInstance, Program program,
+    List<Enrollment> getEnrollments( TrackedEntityInstance entityInstance, Program program,
         ProgramStatus status );
 
     /**
@@ -216,7 +216,7 @@ public interface ProgramInstanceService
      * @param incidentDate The date of incident
      * @param orgunit Organisation Unit
      * @param uid UID to use for new instance
-     * @return ProgramInstance
+     * @return Enrollment
      */
     Enrollment enrollTrackedEntityInstance( TrackedEntityInstance trackedEntityInstance, Program program,
         Date enrollmentDate, Date incidentDate, OrganisationUnit orgunit, String uid );
@@ -230,7 +230,7 @@ public interface ProgramInstanceService
      * @param enrollmentDate The date of enrollment
      * @param incidentDate The date of incident
      * @param orgunit Organisation Unit
-     * @return ProgramInstance
+     * @return Enrollment
      */
     Enrollment enrollTrackedEntityInstance( TrackedEntityInstance trackedEntityInstance, Program program,
         Date enrollmentDate, Date incidentDate,
@@ -240,27 +240,27 @@ public interface ProgramInstanceService
      * Complete a program instance. Besides, program template messages will be
      * send if it was defined to send when to complete this program
      *
-     * @param enrollment ProgramInstance
+     * @param enrollment Enrollment
      */
-    void completeProgramInstanceStatus( Enrollment enrollment );
+    void completeEnrollmentStatus( Enrollment enrollment );
 
     /**
      * Set status as skipped for overdue events; Remove scheduled events
      *
-     * @param enrollment ProgramInstance
+     * @param enrollment Enrollment
      */
-    void cancelProgramInstanceStatus( Enrollment enrollment );
+    void cancelEnrollmentStatus( Enrollment enrollment );
 
     /**
      * Incomplete a program instance. This is is possible only if there is no
      * other program instance with active status.
      *
-     * @param enrollment ProgramInstance
+     * @param enrollment Enrollment
      */
-    void incompleteProgramInstanceStatus( Enrollment enrollment );
+    void incompleteEnrollmentStatus( Enrollment enrollment );
 
     /**
-     * Prepare a ProgramInstance for storing
+     * Prepare a Enrollment for storing
      *
      * @param trackedEntityInstance TrackedEntityInstance
      * @param program Program
@@ -269,9 +269,9 @@ public interface ProgramInstanceService
      * @param incidentDate The date of incident
      * @param orgUnit Organisation Unit
      * @param uid UID to use for new instance
-     * @return ProgramInstance
+     * @return Enrollment
      */
     @Nonnull
-    Enrollment prepareProgramInstance( TrackedEntityInstance trackedEntityInstance, Program program,
+    Enrollment prepareEnrollment( TrackedEntityInstance trackedEntityInstance, Program program,
         ProgramStatus programStatus, Date enrollmentDate, Date incidentDate, OrganisationUnit orgUnit, String uid );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deduplication/DeduplicationHelper.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deduplication/DeduplicationHelper.java
@@ -40,7 +40,7 @@ import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.commons.collection.ListUtils;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.ProgramInstanceService;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.relationship.RelationshipService;
@@ -65,7 +65,7 @@ public class DeduplicationHelper
 
     private final OrganisationUnitService organisationUnitService;
 
-    private final ProgramInstanceService programInstanceService;
+    private final EnrollmentService enrollmentService;
 
     public String getInvalidReferenceErrors( DeduplicationMergeParams params )
     {
@@ -277,7 +277,7 @@ public class DeduplicationHelper
             return "Missing data write access to one or more Relationship Types.";
         }
 
-        List<Enrollment> enrollments = programInstanceService.getProgramInstances( mergeObject.getEnrollments() );
+        List<Enrollment> enrollments = enrollmentService.getEnrollments( mergeObject.getEnrollments() );
 
         if ( enrollments.stream().anyMatch( e -> !aclService.canDataWrite( user, e.getProgram() ) ) )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
@@ -66,8 +66,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @RequiredArgsConstructor
 @Service( "org.hisp.dhis.program.ProgramInstanceService" )
-public class DefaultProgramInstanceService
-    implements ProgramInstanceService
+public class DefaultEnrollmentService
+    implements EnrollmentService
 {
     private final ProgramInstanceStore programInstanceStore;
 
@@ -89,7 +89,7 @@ public class DefaultProgramInstanceService
 
     @Override
     @Transactional
-    public long addProgramInstance( Enrollment enrollment )
+    public long addEnrollment( Enrollment enrollment )
     {
         programInstanceStore.save( enrollment );
         return enrollment.getId();
@@ -97,7 +97,7 @@ public class DefaultProgramInstanceService
 
     @Override
     @Transactional
-    public long addProgramInstance( Enrollment enrollment, User user )
+    public long addEnrollment( Enrollment enrollment, User user )
     {
         programInstanceStore.save( enrollment, user );
         return enrollment.getId();
@@ -105,7 +105,7 @@ public class DefaultProgramInstanceService
 
     @Override
     @Transactional
-    public void deleteProgramInstance( Enrollment enrollment )
+    public void deleteEnrollment( Enrollment enrollment )
     {
         enrollment.setStatus( ProgramStatus.CANCELLED );
         programInstanceStore.update( enrollment );
@@ -114,14 +114,14 @@ public class DefaultProgramInstanceService
 
     @Override
     @Transactional
-    public void hardDeleteProgramInstance( Enrollment enrollment )
+    public void hardDeleteEnrollment( Enrollment enrollment )
     {
         programInstanceStore.hardDelete( enrollment );
     }
 
     @Override
     @Transactional( readOnly = true )
-    public Enrollment getProgramInstance( long id )
+    public Enrollment getEnrollment( long id )
     {
         Enrollment enrollment = programInstanceStore.get( id );
 
@@ -130,7 +130,7 @@ public class DefaultProgramInstanceService
 
     @Override
     @Transactional( readOnly = true )
-    public Enrollment getProgramInstance( String uid )
+    public Enrollment getEnrollment( String uid )
     {
         Enrollment enrollment = programInstanceStore.getByUid( uid );
 
@@ -139,42 +139,42 @@ public class DefaultProgramInstanceService
 
     @Override
     @Transactional( readOnly = true )
-    public List<Enrollment> getProgramInstances( @Nonnull List<String> uids )
+    public List<Enrollment> getEnrollments( @Nonnull List<String> uids )
     {
         return programInstanceStore.getByUid( uids );
     }
 
     @Override
     @Transactional( readOnly = true )
-    public boolean programInstanceExists( String uid )
+    public boolean enrollmentExists( String uid )
     {
         return programInstanceStore.exists( uid );
     }
 
     @Override
     @Transactional( readOnly = true )
-    public boolean programInstanceExistsIncludingDeleted( String uid )
+    public boolean enrollmentExistsIncludingDeleted( String uid )
     {
         return programInstanceStore.existsIncludingDeleted( uid );
     }
 
     @Override
     @Transactional( readOnly = true )
-    public List<String> getProgramInstancesUidsIncludingDeleted( List<String> uids )
+    public List<String> getEnrollmentsUidsIncludingDeleted( List<String> uids )
     {
         return programInstanceStore.getUidsIncludingDeleted( uids );
     }
 
     @Override
     @Transactional
-    public void updateProgramInstance( Enrollment enrollment )
+    public void updateEnrollment( Enrollment enrollment )
     {
         programInstanceStore.update( enrollment );
     }
 
     @Override
     @Transactional
-    public void updateProgramInstance( Enrollment enrollment, User user )
+    public void updateEnrollment( Enrollment enrollment, User user )
     {
         programInstanceStore.update( enrollment, user );
     }
@@ -182,7 +182,7 @@ public class DefaultProgramInstanceService
     // TODO consider security
     @Override
     @Transactional( readOnly = true )
-    public List<Enrollment> getProgramInstances( ProgramInstanceQueryParams params )
+    public List<Enrollment> getEnrollments( ProgramInstanceQueryParams params )
     {
         decideAccess( params );
         validate( params );
@@ -216,7 +216,7 @@ public class DefaultProgramInstanceService
 
     @Override
     @Transactional( readOnly = true )
-    public int countProgramInstances( ProgramInstanceQueryParams params )
+    public int countEnrollments( ProgramInstanceQueryParams params )
     {
         decideAccess( params );
         validate( params );
@@ -347,21 +347,21 @@ public class DefaultProgramInstanceService
 
     @Override
     @Transactional( readOnly = true )
-    public List<Enrollment> getProgramInstances( Program program )
+    public List<Enrollment> getEnrollments( Program program )
     {
         return programInstanceStore.get( program );
     }
 
     @Override
     @Transactional( readOnly = true )
-    public List<Enrollment> getProgramInstances( Program program, ProgramStatus status )
+    public List<Enrollment> getEnrollments( Program program, ProgramStatus status )
     {
         return programInstanceStore.get( program, status );
     }
 
     @Override
     @Transactional( readOnly = true )
-    public List<Enrollment> getProgramInstances( TrackedEntityInstance entityInstance, Program program,
+    public List<Enrollment> getEnrollments( TrackedEntityInstance entityInstance, Program program,
         ProgramStatus status )
     {
         return programInstanceStore.get( entityInstance, program, status );
@@ -370,7 +370,7 @@ public class DefaultProgramInstanceService
     @Nonnull
     @Override
     @Transactional
-    public Enrollment prepareProgramInstance( TrackedEntityInstance trackedEntityInstance, Program program,
+    public Enrollment prepareEnrollment( TrackedEntityInstance trackedEntityInstance, Program program,
         ProgramStatus programStatus, Date enrollmentDate, Date incidentDate, OrganisationUnit organisationUnit,
         String uid )
     {
@@ -427,10 +427,10 @@ public class DefaultProgramInstanceService
         // Add program instance
         // ---------------------------------------------------------------------
 
-        Enrollment enrollment = prepareProgramInstance( trackedEntityInstance, program, ProgramStatus.ACTIVE,
+        Enrollment enrollment = prepareEnrollment( trackedEntityInstance, program, ProgramStatus.ACTIVE,
             enrollmentDate,
             incidentDate, organisationUnit, uid );
-        addProgramInstance( enrollment );
+        addEnrollment( enrollment );
 
         // ---------------------------------------------------------------------
         // Add program owner and overwrite if already exists.
@@ -450,7 +450,7 @@ public class DefaultProgramInstanceService
         // Update ProgramInstance and TEI
         // -----------------------------------------------------------------
 
-        updateProgramInstance( enrollment );
+        updateEnrollment( enrollment );
         trackedEntityInstanceService.updateTrackedEntityInstance( trackedEntityInstance );
 
         return enrollment;
@@ -458,14 +458,14 @@ public class DefaultProgramInstanceService
 
     @Override
     @Transactional
-    public void completeProgramInstanceStatus( Enrollment enrollment )
+    public void completeEnrollmentStatus( Enrollment enrollment )
     {
         // -----------------------------------------------------------------
         // Update program-instance
         // -----------------------------------------------------------------
 
         enrollment.setStatus( ProgramStatus.COMPLETED );
-        updateProgramInstance( enrollment );
+        updateEnrollment( enrollment );
 
         // ---------------------------------------------------------------------
         // Send sms-message after program completion
@@ -479,13 +479,13 @@ public class DefaultProgramInstanceService
 
     @Override
     @Transactional
-    public void cancelProgramInstanceStatus( Enrollment enrollment )
+    public void cancelEnrollmentStatus( Enrollment enrollment )
     {
         // ---------------------------------------------------------------------
         // Set status of the program-instance
         // ---------------------------------------------------------------------
         enrollment.setStatus( ProgramStatus.CANCELLED );
-        updateProgramInstance( enrollment );
+        updateEnrollment( enrollment );
 
         // ---------------------------------------------------------------------
         // Set statuses of the program-stage-instances
@@ -514,13 +514,13 @@ public class DefaultProgramInstanceService
 
     @Override
     @Transactional
-    public void incompleteProgramInstanceStatus( Enrollment enrollment )
+    public void incompleteEnrollmentStatus( Enrollment enrollment )
     {
         Program program = enrollment.getProgram();
 
         TrackedEntityInstance tei = enrollment.getEntityInstance();
 
-        if ( getProgramInstances( tei, program, ProgramStatus.ACTIVE ).size() > 0 )
+        if ( getEnrollments( tei, program, ProgramStatus.ACTIVE ).size() > 0 )
         {
             log.warn( "Program has another active enrollment going on. Not possible to incomplete" );
 
@@ -535,6 +535,6 @@ public class DefaultProgramInstanceService
         enrollment.setStatus( ProgramStatus.ACTIVE );
         enrollment.setEndDate( null );
 
-        updateProgramInstance( enrollment );
+        updateEnrollment( enrollment );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramInstanceDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramInstanceDeletionHandler.java
@@ -47,7 +47,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ProgramInstanceDeletionHandler extends IdObjectDeletionHandler<Enrollment>
 {
-    private final ProgramInstanceService programInstanceService;
+    private final EnrollmentService enrollmentService;
 
     @Override
     protected void registerHandler()
@@ -61,7 +61,7 @@ public class ProgramInstanceDeletionHandler extends IdObjectDeletionHandler<Enro
     {
         for ( Enrollment enrollment : trackedEntityInstance.getEnrollments() )
         {
-            programInstanceService.deleteProgramInstance( enrollment );
+            enrollmentService.deleteEnrollment( enrollment );
         }
     }
 
@@ -77,7 +77,7 @@ public class ProgramInstanceDeletionHandler extends IdObjectDeletionHandler<Enro
 
     private void deleteProgram( Program program )
     {
-        Collection<Enrollment> enrollments = programInstanceService.getProgramInstances( program );
+        Collection<Enrollment> enrollments = enrollmentService.getEnrollments( program );
 
         if ( enrollments != null )
         {
@@ -86,7 +86,7 @@ public class ProgramInstanceDeletionHandler extends IdObjectDeletionHandler<Enro
             {
                 Enrollment enrollment = iterator.next();
                 iterator.remove();
-                programInstanceService.hardDeleteProgramInstance( enrollment );
+                enrollmentService.hardDeleteEnrollment( enrollment );
             }
         }
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationInstanceService.java
@@ -32,8 +32,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,7 +47,7 @@ public class DefaultProgramNotificationInstanceService
 {
     private final ProgramNotificationInstanceStore notificationInstanceStore;
 
-    private final ProgramInstanceService programInstanceService;
+    private final EnrollmentService enrollmentService;
 
     private final EventService eventService;
 
@@ -71,7 +71,7 @@ public class DefaultProgramNotificationInstanceService
     {
         if ( params.hasProgramInstance() )
         {
-            if ( !programInstanceService.programInstanceExists( params.getEnrollment().getUid() ) )
+            if ( !enrollmentService.enrollmentExists( params.getEnrollment().getUid() ) )
             {
                 throw new IllegalQueryException(
                     String.format( "Program instance %s does not exist", params.getEnrollment().getUid() ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultTrackerNotificationWebHookService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultTrackerNotificationWebHookService.java
@@ -38,9 +38,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.notification.ProgramNotificationMessageRenderer;
 import org.hisp.dhis.notification.ProgramStageNotificationMessageRenderer;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.sms.config.SmsGateway;
 import org.hisp.dhis.system.util.ValidationUtils;
@@ -65,7 +65,7 @@ import com.google.common.collect.Lists;
 @Service( "org.hisp.dhis.program.notification.TrackerNotificationWebHookService" )
 public class DefaultTrackerNotificationWebHookService implements TrackerNotificationWebHookService
 {
-    private final ProgramInstanceService programInstanceService;
+    private final EnrollmentService enrollmentService;
 
     private final EventService eventService;
 
@@ -79,7 +79,7 @@ public class DefaultTrackerNotificationWebHookService implements TrackerNotifica
     @Transactional
     public void handleEnrollment( String pi )
     {
-        Enrollment instance = programInstanceService.getProgramInstance( pi );
+        Enrollment instance = enrollmentService.getEnrollment( pi );
 
         if ( instance == null
             || !templateService.isProgramLinkedToWebHookNotification( instance.getProgram() ) )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CommandSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CommandSMSListener.java
@@ -48,9 +48,9 @@ import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.sms.command.SMSCommand;
@@ -82,7 +82,7 @@ public abstract class CommandSMSListener extends BaseSMSListener
     // Dependencies
     // -------------------------------------------------------------------------
 
-    protected final ProgramInstanceService programInstanceService;
+    protected final EnrollmentService enrollmentService;
 
     protected final CategoryService dataElementCategoryService;
 
@@ -92,20 +92,20 @@ public abstract class CommandSMSListener extends BaseSMSListener
 
     protected final CurrentUserService currentUserService;
 
-    public CommandSMSListener( ProgramInstanceService programInstanceService,
+    public CommandSMSListener( EnrollmentService enrollmentService,
         CategoryService dataElementCategoryService, EventService eventService,
         UserService userService, CurrentUserService currentUserService, IncomingSmsService incomingSmsService,
         MessageSender smsSender )
     {
         super( incomingSmsService, smsSender );
 
-        checkNotNull( programInstanceService );
+        checkNotNull( enrollmentService );
         checkNotNull( dataElementCategoryService );
         checkNotNull( eventService );
         checkNotNull( userService );
         checkNotNull( currentUserService );
 
-        this.programInstanceService = programInstanceService;
+        this.enrollmentService = enrollmentService;
         this.dataElementCategoryService = dataElementCategoryService;
         this.eventService = eventService;
         this.userService = userService;
@@ -227,7 +227,7 @@ public abstract class CommandSMSListener extends BaseSMSListener
             pi.setProgram( smsCommand.getProgram() );
             pi.setStatus( ProgramStatus.ACTIVE );
 
-            programInstanceService.addProgramInstance( pi );
+            enrollmentService.addEnrollment( pi );
 
             enrollments.add( pi );
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DataValueSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DataValueSMSListener.java
@@ -53,8 +53,8 @@ import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.sms.command.CompletenessMethod;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
@@ -96,7 +96,7 @@ public class DataValueSMSListener extends CommandSMSListener
 
     private final DataElementService dataElementService;
 
-    public DataValueSMSListener( ProgramInstanceService programInstanceService,
+    public DataValueSMSListener( EnrollmentService enrollmentService,
         CategoryService dataElementCategoryService, EventService eventService,
         UserService userService, CurrentUserService currentUserService, IncomingSmsService incomingSmsService,
         @Qualifier( "smsMessageSender" ) MessageSender smsSender,
@@ -104,7 +104,7 @@ public class DataValueSMSListener extends CommandSMSListener
         CategoryService dataElementCategoryService1, SMSCommandService smsCommandService, DataSetService dataSetService,
         DataElementService dataElementService )
     {
-        super( programInstanceService, dataElementCategoryService, eventService, userService,
+        super( enrollmentService, dataElementCategoryService, eventService, userService,
             currentUserService, incomingSmsService, smsSender );
 
         this.registrationService = registrationService;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DhisMessageAlertListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DhisMessageAlertListener.java
@@ -43,8 +43,8 @@ import org.hisp.dhis.message.MessageConversationParams;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.message.MessageType;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
@@ -70,13 +70,13 @@ public class DhisMessageAlertListener extends CommandSMSListener
 
     private final MessageService messageService;
 
-    public DhisMessageAlertListener( ProgramInstanceService programInstanceService,
+    public DhisMessageAlertListener( EnrollmentService enrollmentService,
         CategoryService dataElementCategoryService, EventService eventService,
         UserService userService, CurrentUserService currentUserService, IncomingSmsService incomingSmsService,
         @Qualifier( "smsMessageSender" ) MessageSender smsSender, SMSCommandService smsCommandService,
         MessageService messageService )
     {
-        super( programInstanceService, dataElementCategoryService, eventService, userService,
+        super( enrollmentService, dataElementCategoryService, eventService, userService,
             currentUserService, incomingSmsService, smsSender );
 
         checkNotNull( smsCommandService );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/J2MEDataValueSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/J2MEDataValueSMSListener.java
@@ -55,8 +55,8 @@ import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.period.QuarterlyPeriodType;
 import org.hisp.dhis.period.WeeklyPeriodType;
 import org.hisp.dhis.period.YearlyPeriodType;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
 import org.hisp.dhis.sms.command.code.SMSCode;
@@ -90,14 +90,14 @@ public class J2MEDataValueSMSListener extends CommandSMSListener
 
     private final CompleteDataSetRegistrationService registrationService;
 
-    public J2MEDataValueSMSListener( ProgramInstanceService programInstanceService,
+    public J2MEDataValueSMSListener( EnrollmentService enrollmentService,
         CategoryService dataElementCategoryService, EventService eventService,
         UserService userService, CurrentUserService currentUserService, IncomingSmsService incomingSmsService,
         @Qualifier( "smsMessageSender" ) MessageSender smsSender, DataValueService dataValueService,
         CategoryService dataElementCategoryService1, SMSCommandService smsCommandService,
         CompleteDataSetRegistrationService registrationService )
     {
-        super( programInstanceService, dataElementCategoryService, eventService, userService,
+        super( enrollmentService, dataElementCategoryService, eventService, userService,
             currentUserService, incomingSmsService, smsSender );
 
         checkNotNull( dataValueService );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/ProgramStageDataEntrySMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/ProgramStageDataEntrySMSListener.java
@@ -43,9 +43,9 @@ import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
@@ -83,28 +83,28 @@ public class ProgramStageDataEntrySMSListener extends CommandSMSListener
 
     private final SMSCommandService smsCommandService;
 
-    private final ProgramInstanceService programInstanceService;
+    private final EnrollmentService enrollmentService;
 
-    public ProgramStageDataEntrySMSListener( ProgramInstanceService programInstanceService,
+    public ProgramStageDataEntrySMSListener( EnrollmentService enrollmentService,
         CategoryService dataElementCategoryService, EventService eventService,
         UserService userService, CurrentUserService currentUserService, IncomingSmsService incomingSmsService,
         @Qualifier( "smsMessageSender" ) MessageSender smsSender,
         TrackedEntityInstanceService trackedEntityInstanceService,
         TrackedEntityAttributeService trackedEntityAttributeService, SMSCommandService smsCommandService,
-        ProgramInstanceService programInstanceService1 )
+        EnrollmentService enrollmentService1 )
     {
-        super( programInstanceService, dataElementCategoryService, eventService, userService,
+        super( enrollmentService, dataElementCategoryService, eventService, userService,
             currentUserService, incomingSmsService, smsSender );
 
         checkNotNull( trackedEntityAttributeService );
         checkNotNull( trackedEntityInstanceService );
         checkNotNull( smsCommandService );
-        checkNotNull( programInstanceService );
+        checkNotNull( enrollmentService );
 
         this.trackedEntityInstanceService = trackedEntityInstanceService;
         this.trackedEntityAttributeService = trackedEntityAttributeService;
         this.smsCommandService = smsCommandService;
-        this.programInstanceService = programInstanceService1;
+        this.enrollmentService = enrollmentService1;
     }
 
     // -------------------------------------------------------------------------
@@ -137,7 +137,7 @@ public class ProgramStageDataEntrySMSListener extends CommandSMSListener
         Map<String, String> keyValue, Set<OrganisationUnit> ous )
     {
         List<Enrollment> enrollments = new ArrayList<>(
-            programInstanceService.getProgramInstances( tei, smsCommand.getProgram(), ProgramStatus.ACTIVE ) );
+            enrollmentService.getEnrollments( tei, smsCommand.getProgram(), ProgramStatus.ACTIVE ) );
 
         register( enrollments, keyValue, smsCommand, sms, ous );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/ProgramStageDataEntrySMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/ProgramStageDataEntrySMSListener.java
@@ -83,15 +83,12 @@ public class ProgramStageDataEntrySMSListener extends CommandSMSListener
 
     private final SMSCommandService smsCommandService;
 
-    private final EnrollmentService enrollmentService;
-
     public ProgramStageDataEntrySMSListener( EnrollmentService enrollmentService,
         CategoryService dataElementCategoryService, EventService eventService,
         UserService userService, CurrentUserService currentUserService, IncomingSmsService incomingSmsService,
         @Qualifier( "smsMessageSender" ) MessageSender smsSender,
         TrackedEntityInstanceService trackedEntityInstanceService,
-        TrackedEntityAttributeService trackedEntityAttributeService, SMSCommandService smsCommandService,
-        EnrollmentService enrollmentService1 )
+        TrackedEntityAttributeService trackedEntityAttributeService, SMSCommandService smsCommandService )
     {
         super( enrollmentService, dataElementCategoryService, eventService, userService,
             currentUserService, incomingSmsService, smsSender );
@@ -99,12 +96,10 @@ public class ProgramStageDataEntrySMSListener extends CommandSMSListener
         checkNotNull( trackedEntityAttributeService );
         checkNotNull( trackedEntityInstanceService );
         checkNotNull( smsCommandService );
-        checkNotNull( enrollmentService );
 
         this.trackedEntityInstanceService = trackedEntityInstanceService;
         this.trackedEntityAttributeService = trackedEntityAttributeService;
         this.smsCommandService = smsCommandService;
-        this.enrollmentService = enrollmentService1;
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/RelationshipSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/RelationshipSMSListener.java
@@ -35,9 +35,9 @@ import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.relationship.RelationshipEntity;
@@ -77,7 +77,7 @@ public class RelationshipSMSListener extends CompressionSMSListener
 
     private final TrackedEntityInstanceService trackedEntityInstanceService;
 
-    private final ProgramInstanceService programInstanceService;
+    private final EnrollmentService enrollmentService;
 
     public RelationshipSMSListener( IncomingSmsService incomingSmsService,
         @Qualifier( "smsMessageSender" ) MessageSender smsSender, UserService userService,
@@ -85,7 +85,7 @@ public class RelationshipSMSListener extends CompressionSMSListener
         ProgramService programService, OrganisationUnitService organisationUnitService, CategoryService categoryService,
         DataElementService dataElementService, EventService eventService,
         RelationshipService relationshipService, RelationshipTypeService relationshipTypeService,
-        TrackedEntityInstanceService trackedEntityInstanceService, ProgramInstanceService programInstanceService,
+        TrackedEntityInstanceService trackedEntityInstanceService, EnrollmentService enrollmentService,
         IdentifiableObjectManager identifiableObjectManager )
     {
         super( incomingSmsService, smsSender, userService, trackedEntityTypeService, trackedEntityAttributeService,
@@ -95,7 +95,7 @@ public class RelationshipSMSListener extends CompressionSMSListener
         this.relationshipService = relationshipService;
         this.relationshipTypeService = relationshipTypeService;
         this.trackedEntityInstanceService = trackedEntityInstanceService;
-        this.programInstanceService = programInstanceService;
+        this.enrollmentService = enrollmentService;
     }
 
     @Override
@@ -159,7 +159,7 @@ public class RelationshipSMSListener extends CompressionSMSListener
             break;
 
         case PROGRAM_INSTANCE:
-            Enrollment progInst = programInstanceService.getProgramInstance( objId.getUid() );
+            Enrollment progInst = enrollmentService.getEnrollment( objId.getUid() );
             if ( progInst == null )
             {
                 throw new SMSProcessingException( SmsResponse.INVALID_ENROLL.set( objId ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
@@ -40,9 +40,9 @@ import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStatus;
@@ -65,20 +65,20 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class SimpleEventSMSListener extends CompressionSMSListener
 {
-    private final ProgramInstanceService programInstanceService;
+    private final EnrollmentService enrollmentService;
 
     public SimpleEventSMSListener( IncomingSmsService incomingSmsService,
         @Qualifier( "smsMessageSender" ) MessageSender smsSender, UserService userService,
         TrackedEntityTypeService trackedEntityTypeService, TrackedEntityAttributeService trackedEntityAttributeService,
         ProgramService programService, OrganisationUnitService organisationUnitService, CategoryService categoryService,
         DataElementService dataElementService, EventService eventService,
-        ProgramInstanceService programInstanceService, IdentifiableObjectManager identifiableObjectManager )
+        EnrollmentService enrollmentService, IdentifiableObjectManager identifiableObjectManager )
     {
         super( incomingSmsService, smsSender, userService, trackedEntityTypeService, trackedEntityAttributeService,
             programService, organisationUnitService, categoryService, dataElementService, eventService,
             identifiableObjectManager );
 
-        this.programInstanceService = programInstanceService;
+        this.enrollmentService = enrollmentService;
     }
 
     @Override
@@ -114,7 +114,7 @@ public class SimpleEventSMSListener extends CompressionSMSListener
         }
 
         List<Enrollment> enrollments = new ArrayList<>(
-            programInstanceService.getProgramInstances( program, ProgramStatus.ACTIVE ) );
+            enrollmentService.getEnrollments( program, ProgramStatus.ACTIVE ) );
 
         // For Simple Events, the Program should have one Program Instance
         // If it doesn't exist, this is the first event, we can create it here
@@ -126,7 +126,7 @@ public class SimpleEventSMSListener extends CompressionSMSListener
             pi.setProgram( program );
             pi.setStatus( ProgramStatus.ACTIVE );
 
-            programInstanceService.addProgramInstance( pi );
+            enrollmentService.addEnrollment( pi );
 
             enrollments.add( pi );
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SingleEventListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SingleEventListener.java
@@ -62,22 +62,17 @@ public class SingleEventListener extends CommandSMSListener
 {
     private final SMSCommandService smsCommandService;
 
-    private final EnrollmentService enrollmentService;
-
     public SingleEventListener( EnrollmentService enrollmentService,
         CategoryService dataElementCategoryService, EventService eventService,
         UserService userService, CurrentUserService currentUserService, IncomingSmsService incomingSmsService,
-        @Qualifier( "smsMessageSender" ) MessageSender smsSender, SMSCommandService smsCommandService,
-        EnrollmentService enrollmentService1 )
+        @Qualifier( "smsMessageSender" ) MessageSender smsSender, SMSCommandService smsCommandService )
     {
         super( enrollmentService, dataElementCategoryService, eventService, userService,
             currentUserService, incomingSmsService, smsSender );
 
         checkNotNull( smsCommandService );
-        checkNotNull( enrollmentService1 );
 
         this.smsCommandService = smsCommandService;
-        this.enrollmentService = enrollmentService1;
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SingleEventListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SingleEventListener.java
@@ -38,8 +38,8 @@ import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
@@ -62,22 +62,22 @@ public class SingleEventListener extends CommandSMSListener
 {
     private final SMSCommandService smsCommandService;
 
-    private final ProgramInstanceService programInstanceService;
+    private final EnrollmentService enrollmentService;
 
-    public SingleEventListener( ProgramInstanceService programInstanceService,
+    public SingleEventListener( EnrollmentService enrollmentService,
         CategoryService dataElementCategoryService, EventService eventService,
         UserService userService, CurrentUserService currentUserService, IncomingSmsService incomingSmsService,
         @Qualifier( "smsMessageSender" ) MessageSender smsSender, SMSCommandService smsCommandService,
-        ProgramInstanceService programInstanceService1 )
+        EnrollmentService enrollmentService1 )
     {
-        super( programInstanceService, dataElementCategoryService, eventService, userService,
+        super( enrollmentService, dataElementCategoryService, eventService, userService,
             currentUserService, incomingSmsService, smsSender );
 
         checkNotNull( smsCommandService );
-        checkNotNull( programInstanceService1 );
+        checkNotNull( enrollmentService1 );
 
         this.smsCommandService = smsCommandService;
-        this.programInstanceService = programInstanceService1;
+        this.enrollmentService = enrollmentService1;
     }
 
     // -------------------------------------------------------------------------
@@ -107,7 +107,7 @@ public class SingleEventListener extends CommandSMSListener
         Set<OrganisationUnit> ous )
     {
         List<Enrollment> enrollments = new ArrayList<>(
-            programInstanceService.getProgramInstances( smsCommand.getProgram(), ProgramStatus.ACTIVE ) );
+            enrollmentService.getEnrollments( smsCommand.getProgram(), ProgramStatus.ACTIVE ) );
 
         register( enrollments, commandValuePairs, smsCommand, sms, ous );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationSMSListener.java
@@ -39,9 +39,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
@@ -79,29 +79,29 @@ public class TrackedEntityRegistrationSMSListener extends CommandSMSListener
 
     private final TrackedEntityInstanceService trackedEntityInstanceService;
 
-    private final ProgramInstanceService programInstanceService;
+    private final EnrollmentService enrollmentService;
 
     private final ProgramService programService;
 
     public TrackedEntityRegistrationSMSListener( ProgramService programService,
-        ProgramInstanceService programInstanceService,
+        EnrollmentService enrollmentService,
         CategoryService dataElementCategoryService, EventService eventService,
         UserService userService, CurrentUserService currentUserService, IncomingSmsService incomingSmsService,
         @Qualifier( "smsMessageSender" ) MessageSender smsSender, SMSCommandService smsCommandService,
         TrackedEntityTypeService trackedEntityTypeService, TrackedEntityInstanceService trackedEntityInstanceService )
     {
-        super( programInstanceService, dataElementCategoryService, eventService, userService,
+        super( enrollmentService, dataElementCategoryService, eventService, userService,
             currentUserService, incomingSmsService, smsSender );
 
         checkNotNull( smsCommandService );
         checkNotNull( trackedEntityTypeService );
         checkNotNull( trackedEntityInstanceService );
-        checkNotNull( programInstanceService );
+        checkNotNull( enrollmentService );
 
         this.smsCommandService = smsCommandService;
         this.trackedEntityTypeService = trackedEntityTypeService;
         this.trackedEntityInstanceService = trackedEntityInstanceService;
-        this.programInstanceService = programInstanceService;
+        this.enrollmentService = enrollmentService;
         this.programService = programService;
     }
 
@@ -154,7 +154,7 @@ public class TrackedEntityRegistrationSMSListener extends CommandSMSListener
 
         TrackedEntityInstance tei = trackedEntityInstanceService.getTrackedEntityInstance( trackedEntityInstanceId );
 
-        programInstanceService.enrollTrackedEntityInstance( tei, smsCommand.getProgram(), new Date(), date, orgUnit );
+        enrollmentService.enrollTrackedEntityInstance( tei, smsCommand.getProgram(), new Date(), date, orgUnit );
 
         sendFeedback( StringUtils.defaultIfBlank( smsCommand.getSuccessMessage(), SUCCESS_MESSAGE + tei.getUid() ),
             senderPhoneNumber, INFO );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationSMSListener.java
@@ -79,8 +79,6 @@ public class TrackedEntityRegistrationSMSListener extends CommandSMSListener
 
     private final TrackedEntityInstanceService trackedEntityInstanceService;
 
-    private final EnrollmentService enrollmentService;
-
     private final ProgramService programService;
 
     public TrackedEntityRegistrationSMSListener( ProgramService programService,
@@ -96,12 +94,10 @@ public class TrackedEntityRegistrationSMSListener extends CommandSMSListener
         checkNotNull( smsCommandService );
         checkNotNull( trackedEntityTypeService );
         checkNotNull( trackedEntityInstanceService );
-        checkNotNull( enrollmentService );
 
         this.smsCommandService = smsCommandService;
         this.trackedEntityTypeService = trackedEntityTypeService;
         this.trackedEntityInstanceService = trackedEntityInstanceService;
-        this.enrollmentService = enrollmentService;
         this.programService = programService;
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackerEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackerEventSMSListener.java
@@ -37,8 +37,8 @@ import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageService;
@@ -63,14 +63,14 @@ public class TrackerEventSMSListener extends CompressionSMSListener
 {
     private final ProgramStageService programStageService;
 
-    private final ProgramInstanceService programInstanceService;
+    private final EnrollmentService enrollmentService;
 
     public TrackerEventSMSListener( IncomingSmsService incomingSmsService,
         @Qualifier( "smsMessageSender" ) MessageSender smsSender, UserService userService,
         TrackedEntityTypeService trackedEntityTypeService, TrackedEntityAttributeService trackedEntityAttributeService,
         ProgramService programService, OrganisationUnitService organisationUnitService, CategoryService categoryService,
         DataElementService dataElementService, EventService eventService,
-        ProgramStageService programStageService, ProgramInstanceService programInstanceService,
+        ProgramStageService programStageService, EnrollmentService enrollmentService,
         IdentifiableObjectManager identifiableObjectManager )
     {
         super( incomingSmsService, smsSender, userService, trackedEntityTypeService, trackedEntityAttributeService,
@@ -78,7 +78,7 @@ public class TrackerEventSMSListener extends CompressionSMSListener
             identifiableObjectManager );
 
         this.programStageService = programStageService;
-        this.programInstanceService = programInstanceService;
+        this.enrollmentService = enrollmentService;
     }
 
     @Override
@@ -95,7 +95,7 @@ public class TrackerEventSMSListener extends CompressionSMSListener
         OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ouid.getUid() );
         User user = userService.getUser( subm.getUserId().getUid() );
 
-        Enrollment enrollment = programInstanceService.getProgramInstance( enrolmentid.getUid() );
+        Enrollment enrollment = enrollmentService.getEnrollment( enrolmentid.getUid() );
 
         if ( enrollment == null )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/UnregisteredSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/UnregisteredSMSListener.java
@@ -36,8 +36,8 @@ import org.hisp.dhis.message.MessageConversationParams;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.message.MessageType;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
@@ -63,13 +63,13 @@ public class UnregisteredSMSListener extends CommandSMSListener
 
     private final MessageService messageService;
 
-    public UnregisteredSMSListener( ProgramInstanceService programInstanceService,
+    public UnregisteredSMSListener( EnrollmentService enrollmentService,
         CategoryService dataElementCategoryService, EventService eventService,
         UserService userService, CurrentUserService currentUserService, IncomingSmsService incomingSmsService,
         @Qualifier( "smsMessageSender" ) MessageSender smsSender, SMSCommandService smsCommandService,
         UserService userService1, MessageService messageService )
     {
-        super( programInstanceService, dataElementCategoryService, eventService, userService,
+        super( enrollmentService, dataElementCategoryService, eventService, userService,
             currentUserService, incomingSmsService, smsSender );
 
         checkNotNull( smsCommandService );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deduplication/DeduplicationHelperTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deduplication/DeduplicationHelperTest.java
@@ -42,8 +42,8 @@ import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.relationship.RelationshipService;
@@ -86,7 +86,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest
     private OrganisationUnitService organisationUnitService;
 
     @Mock
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     private OrganisationUnit organisationUnitA;
 
@@ -138,7 +138,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, relationshipType ) ).thenReturn( true );
         when( aclService.canDataWrite( user, enrollment.getProgram() ) ).thenReturn( true );
         when( relationshipService.getRelationships( relationshipUids ) ).thenReturn( getRelationships() );
-        when( programInstanceService.getProgramInstances( enrollmentUids ) ).thenReturn( getEnrollments() );
+        when( enrollmentService.getEnrollments( enrollmentUids ) ).thenReturn( getEnrollments() );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnitA ) ).thenReturn( true );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnitB ) ).thenReturn( true );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/TrackerNotificationWebHookServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/TrackerNotificationWebHookServiceTest.java
@@ -48,10 +48,10 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.render.RenderService;
@@ -111,7 +111,7 @@ class TrackerNotificationWebHookServiceTest extends DhisConvenienceTest
     private ResponseEntity<String> responseEntity;
 
     @Mock
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Mock
     private EventService eventService;
@@ -187,7 +187,7 @@ class TrackerNotificationWebHookServiceTest extends DhisConvenienceTest
     @Test
     void testTrackerEnrollmentNotificationWebHook()
     {
-        when( programInstanceService.getProgramInstance( anyString() ) ).thenReturn( enrollment );
+        when( enrollmentService.getEnrollment( anyString() ) ).thenReturn( enrollment );
         when( templateService.isProgramLinkedToWebHookNotification( any( Program.class ) ) ).thenReturn( true );
         when( templateService.getProgramLinkedToWebHookNotifications( any( Program.class ) ) )
             .thenReturn( Lists.newArrayList( programNotification ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/DataValueListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/DataValueListenerTest.java
@@ -62,8 +62,8 @@ import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
 import org.hisp.dhis.period.Period;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
 import org.hisp.dhis.sms.command.SMSSpecialCharacter;
@@ -117,7 +117,7 @@ class DataValueListenerTest extends DhisConvenienceTest
     private static final String MORE_THAN_ONE_OU = "MORE_THAN_ONE_OU";
 
     @Mock
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Mock
     private CategoryService dataElementCategoryService;
@@ -215,7 +215,7 @@ class DataValueListenerTest extends DhisConvenienceTest
     @BeforeEach
     public void initTest()
     {
-        subject = new DataValueSMSListener( programInstanceService, dataElementCategoryService,
+        subject = new DataValueSMSListener( enrollmentService, dataElementCategoryService,
             eventService, userService, currentUserService, incomingSmsService, smsSender,
             registrationService, dataValueService, dataElementCategoryService, smsCommandService, dataSetService,
             dataElementService );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/EnrollmentSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/EnrollmentSMSListenerTest.java
@@ -52,10 +52,10 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageService;
@@ -133,7 +133,7 @@ class EnrollmentSMSListenerTest
     private TrackedEntityInstanceService teiService;
 
     @Mock
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Mock
     private TrackedEntityAttributeValueService attributeValueService;
@@ -195,7 +195,7 @@ class EnrollmentSMSListenerTest
     {
         subject = new EnrollmentSMSListener( incomingSmsService, smsSender, userService, trackedEntityTypeService,
             trackedEntityAttributeService, programService, organisationUnitService, categoryService, dataElementService,
-            programStageService, eventService, attributeValueService, teiService, programInstanceService,
+            programStageService, eventService, attributeValueService, teiService, enrollmentService,
             identifiableObjectManager );
 
         setUpInstances();
@@ -210,7 +210,7 @@ class EnrollmentSMSListenerTest
         when( organisationUnitService.getOrganisationUnit( anyString() ) ).thenReturn( organisationUnit );
         when( programService.getProgram( anyString() ) ).thenReturn( program );
         when( trackedEntityTypeService.getTrackedEntityType( anyString() ) ).thenReturn( trackedEntityType );
-        when( programInstanceService.enrollTrackedEntityInstance( any(), any(), any(), any(), any(), any() ) )
+        when( enrollmentService.enrollTrackedEntityInstance( any(), any(), any(), any(), any(), any() ) )
             .thenReturn( enrollment );
         when( programService.hasOrgUnit( any( Program.class ), any( OrganisationUnit.class ) ) ).thenReturn( true );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/RelationshipSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/RelationshipSMSListenerTest.java
@@ -44,8 +44,8 @@ import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.relationship.RelationshipConstraint;
 import org.hisp.dhis.relationship.RelationshipEntity;
@@ -127,7 +127,7 @@ class RelationshipSMSListenerTest
     private RelationshipTypeService relationshipTypeService;
 
     @Mock
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Mock
     private TrackedEntityInstanceService trackedEntityInstanceService;
@@ -143,7 +143,7 @@ class RelationshipSMSListenerTest
         subject = new RelationshipSMSListener( incomingSmsService, smsSender, userService, trackedEntityTypeService,
             trackedEntityAttributeService, programService, organisationUnitService, categoryService, dataElementService,
             eventService, relationshipService, relationshipTypeService, trackedEntityInstanceService,
-            programInstanceService, identifiableObjectManager );
+            enrollmentService, identifiableObjectManager );
 
         setUpInstances();
 
@@ -155,7 +155,7 @@ class RelationshipSMSListenerTest
         } );
 
         when( relationshipTypeService.getRelationshipType( anyString() ) ).thenReturn( relationshipType );
-        when( programInstanceService.getProgramInstance( anyString() ) ).thenReturn( enrollment );
+        when( enrollmentService.getEnrollment( anyString() ) ).thenReturn( enrollment );
 
         doAnswer( invocation -> {
             updatedIncomingSms = (IncomingSms) invocation.getArguments()[0];

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/SimpleEventSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/SimpleEventSMSListenerTest.java
@@ -51,10 +51,10 @@ import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.sms.incoming.IncomingSms;
@@ -126,7 +126,7 @@ class SimpleEventSMSListenerTest
     // Needed for this test
 
     @Mock
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     private SimpleEventSMSListener subject;
 
@@ -152,7 +152,7 @@ class SimpleEventSMSListenerTest
     {
         subject = new SimpleEventSMSListener( incomingSmsService, smsSender, userService, trackedEntityTypeService,
             trackedEntityAttributeService, programService, organisationUnitService, categoryService, dataElementService,
-            eventService, programInstanceService, identifiableObjectManager );
+            eventService, enrollmentService, identifiableObjectManager );
 
         setUpInstances();
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationListenerTest.java
@@ -46,9 +46,9 @@ import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.sms.command.SMSCommand;
@@ -92,7 +92,7 @@ class TrackedEntityRegistrationListenerTest extends DhisConvenienceTest
     private static final String SUCCESS_MESSAGE = "Command has been processed successfully";
 
     @Mock
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Mock
     private CategoryService dataElementCategoryService;
@@ -157,7 +157,7 @@ class TrackedEntityRegistrationListenerTest extends DhisConvenienceTest
     @BeforeEach
     public void initTest()
     {
-        subject = new TrackedEntityRegistrationSMSListener( programService, programInstanceService,
+        subject = new TrackedEntityRegistrationSMSListener( programService, enrollmentService,
             dataElementCategoryService,
             eventService, userService, currentUserService, incomingSmsService, smsSender,
             smsCommandService,

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackerEventSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackerEventSMSListenerTest.java
@@ -51,10 +51,10 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageService;
@@ -130,7 +130,7 @@ class TrackerEventSMSListenerTest
     // Needed for this test
 
     @Mock
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Mock
     private ProgramStageService programStageService;
@@ -163,7 +163,7 @@ class TrackerEventSMSListenerTest
     {
         subject = new TrackerEventSMSListener( incomingSmsService, smsSender, userService, trackedEntityTypeService,
             trackedEntityAttributeService, programService, organisationUnitService, categoryService, dataElementService,
-            eventService, programStageService, programInstanceService, identifiableObjectManager );
+            eventService, programStageService, enrollmentService, identifiableObjectManager );
 
         setUpInstances();
 
@@ -176,7 +176,7 @@ class TrackerEventSMSListenerTest
 
         when( organisationUnitService.getOrganisationUnit( anyString() ) ).thenReturn( organisationUnit );
         when( programStageService.getProgramStage( anyString() ) ).thenReturn( programStage );
-        when( programInstanceService.getProgramInstance( anyString() ) ).thenReturn( enrollment );
+        when( enrollmentService.getEnrollment( anyString() ) ).thenReturn( enrollment );
         when( dataElementService.getDataElement( anyString() ) ).thenReturn( dataElement );
         when( categoryService.getCategoryOptionCombo( anyString() ) ).thenReturn( categoryOptionCombo );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -78,11 +78,11 @@ import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.organisationunit.FeatureType;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstanceQueryParams;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
@@ -125,7 +125,7 @@ import com.google.common.collect.Maps;
  */
 @Slf4j
 public abstract class AbstractEnrollmentService
-    implements EnrollmentService
+    implements org.hisp.dhis.dxf2.events.enrollment.EnrollmentService
 {
     private static final String ATTRIBUTE_VALUE = "Attribute.value";
 
@@ -135,7 +135,7 @@ public abstract class AbstractEnrollmentService
 
     private static final String ATTRIBUTE_ATTRIBUTE = "Attribute.attribute";
 
-    protected ProgramInstanceService programInstanceService;
+    protected EnrollmentService enrollmentService;
 
     protected EventService programStageInstanceService;
 
@@ -204,7 +204,7 @@ public abstract class AbstractEnrollmentService
             params.setDefaultPaging();
         }
 
-        programInstances.addAll( programInstanceService.getProgramInstances( params ) );
+        programInstances.addAll( enrollmentService.getEnrollments( params ) );
 
         if ( !params.isSkipPaging() )
         {
@@ -212,7 +212,7 @@ public abstract class AbstractEnrollmentService
 
             if ( params.isTotalPages() )
             {
-                int count = programInstanceService.countProgramInstances( params );
+                int count = enrollmentService.countEnrollments( params );
                 pager = new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() );
             }
             else
@@ -285,7 +285,7 @@ public abstract class AbstractEnrollmentService
     @Override
     public org.hisp.dhis.dxf2.events.enrollment.Enrollment getEnrollment( String id, EnrollmentParams params )
     {
-        Enrollment enrollment = programInstanceService.getProgramInstance( id );
+        Enrollment enrollment = enrollmentService.getEnrollment( id );
         return enrollment != null ? getEnrollment( enrollment, params ) : null;
     }
 
@@ -502,7 +502,7 @@ public abstract class AbstractEnrollmentService
         List<org.hisp.dhis.dxf2.events.enrollment.Enrollment> enrollments,
         ImportSummaries importSummaries )
     {
-        List<String> foundEnrollments = programInstanceService.getProgramInstancesUidsIncludingDeleted(
+        List<String> foundEnrollments = enrollmentService.getEnrollmentsUidsIncludingDeleted(
             enrollments.stream().map( org.hisp.dhis.dxf2.events.enrollment.Enrollment::getEnrollment )
                 .collect( toList() ) );
 
@@ -521,7 +521,7 @@ public abstract class AbstractEnrollmentService
     public ImportSummary addEnrollment( org.hisp.dhis.dxf2.events.enrollment.Enrollment enrollment,
         ImportOptions importOptions )
     {
-        if ( programInstanceService.programInstanceExistsIncludingDeleted( enrollment.getEnrollment() ) )
+        if ( enrollmentService.enrollmentExistsIncludingDeleted( enrollment.getEnrollment() ) )
         {
             return new ImportSummary( ImportStatus.ERROR,
                 "Enrollment " + enrollment.getEnrollment() + " already exists or was deleted earlier" )
@@ -587,7 +587,7 @@ public abstract class AbstractEnrollmentService
         ProgramStatus programStatus = enrollment.getStatus() == EnrollmentStatus.ACTIVE ? ProgramStatus.ACTIVE
             : enrollment.getStatus() == EnrollmentStatus.COMPLETED ? ProgramStatus.COMPLETED : ProgramStatus.CANCELLED;
 
-        org.hisp.dhis.program.Enrollment programInstance = programInstanceService.prepareProgramInstance(
+        org.hisp.dhis.program.Enrollment programInstance = enrollmentService.prepareEnrollment(
             daoTrackedEntityInstance,
             program, programStatus,
             enrollment.getEnrollmentDate(), enrollment.getIncidentDate(), organisationUnit,
@@ -616,7 +616,7 @@ public abstract class AbstractEnrollmentService
         programInstance.setCreatedByUserInfo( UserInfoSnapshot.from( importOptions.getUser() ) );
         programInstance.setLastUpdatedByUserInfo( UserInfoSnapshot.from( importOptions.getUser() ) );
 
-        programInstanceService.addProgramInstance( programInstance, importOptions.getUser() );
+        enrollmentService.addEnrollment( programInstance, importOptions.getUser() );
 
         importSummary = validateProgramInstance( program, programInstance, enrollment, importSummary );
 
@@ -641,7 +641,7 @@ public abstract class AbstractEnrollmentService
         programInstance.setFollowup( enrollment.getFollowup() );
         programInstance.setStoredBy( storedBy );
 
-        programInstanceService.updateProgramInstance( programInstance, importOptions.getUser() );
+        enrollmentService.updateEnrollment( programInstance, importOptions.getUser() );
         trackerOwnershipAccessManager.assignOwnership( daoTrackedEntityInstance, program, organisationUnit, true,
             true );
         saveTrackedEntityComment( programInstance, enrollment, importOptions.getUser() );
@@ -762,7 +762,7 @@ public abstract class AbstractEnrollmentService
         if ( enrollment.getStatus() != EnrollmentStatus.CANCELLED )
         {
             List<org.hisp.dhis.dxf2.events.enrollment.Enrollment> enrollments = getEnrollments(
-                programInstanceService.getProgramInstances( params ) );
+                enrollmentService.getEnrollments( params ) );
 
             Set<org.hisp.dhis.dxf2.events.enrollment.Enrollment> activeEnrollments = enrollments.stream()
                 .filter( e -> e.getStatus() == EnrollmentStatus.ACTIVE )
@@ -907,7 +907,7 @@ public abstract class AbstractEnrollmentService
                 .incrementIgnored();
         }
 
-        Enrollment programInstance = programInstanceService.getProgramInstance( enrollment.getEnrollment() );
+        Enrollment programInstance = enrollmentService.getEnrollment( enrollment.getEnrollment() );
         List<String> errors = trackerAccessManager.canUpdate( importOptions.getUser(), programInstance, false );
 
         if ( programInstance == null )
@@ -991,18 +991,18 @@ public abstract class AbstractEnrollmentService
             {
                 programInstance.setEndDate( endDate );
 
-                programInstanceService.cancelProgramInstanceStatus( programInstance );
+                enrollmentService.cancelEnrollmentStatus( programInstance );
             }
             else if ( EnrollmentStatus.COMPLETED == enrollment.getStatus() )
             {
                 programInstance.setEndDate( endDate );
                 programInstance.setCompletedBy( user );
 
-                programInstanceService.completeProgramInstanceStatus( programInstance );
+                enrollmentService.completeEnrollmentStatus( programInstance );
             }
             else if ( EnrollmentStatus.ACTIVE == enrollment.getStatus() )
             {
-                programInstanceService.incompleteProgramInstanceStatus( programInstance );
+                enrollmentService.incompleteEnrollmentStatus( programInstance );
             }
         }
 
@@ -1018,7 +1018,7 @@ public abstract class AbstractEnrollmentService
 
         programInstance.setLastUpdatedByUserInfo( UserInfoSnapshot.from( importOptions.getUser() ) );
 
-        programInstanceService.updateProgramInstance( programInstance, importOptions.getUser() );
+        enrollmentService.updateEnrollment( programInstance, importOptions.getUser() );
         teiService.updateTrackedEntityInstance( programInstance.getEntityInstance(), importOptions.getUser() );
 
         saveTrackedEntityComment( programInstance, enrollment, importOptions.getUser() );
@@ -1054,7 +1054,7 @@ public abstract class AbstractEnrollmentService
 
         ImportSummary importSummary = new ImportSummary( enrollment.getEnrollment() );
 
-        Enrollment programInstance = programInstanceService.getProgramInstance( enrollment.getEnrollment() );
+        Enrollment programInstance = enrollmentService.getEnrollment( enrollment.getEnrollment() );
 
         if ( programInstance == null )
         {
@@ -1086,11 +1086,11 @@ public abstract class AbstractEnrollmentService
         ImportSummary importSummary = new ImportSummary();
         importOptions = updateImportOptions( importOptions );
 
-        boolean existsEnrollment = programInstanceService.programInstanceExists( uid );
+        boolean existsEnrollment = enrollmentService.enrollmentExists( uid );
 
         if ( existsEnrollment )
         {
-            Enrollment programInstance = programInstanceService.getProgramInstance( uid );
+            Enrollment programInstance = enrollmentService.getEnrollment( uid );
 
             if ( enrollment != null )
             {
@@ -1111,7 +1111,7 @@ public abstract class AbstractEnrollmentService
                 }
             }
 
-            programInstanceService.deleteProgramInstance( programInstance );
+            enrollmentService.deleteEnrollment( programInstance );
             teiService.updateTrackedEntityInstance( programInstance.getEntityInstance() );
 
             importSummary.setReference( uid );
@@ -1159,24 +1159,24 @@ public abstract class AbstractEnrollmentService
     @Override
     public void cancelEnrollment( String uid )
     {
-        Enrollment enrollment = programInstanceService.getProgramInstance( uid );
-        programInstanceService.cancelProgramInstanceStatus( enrollment );
+        Enrollment enrollment = enrollmentService.getEnrollment( uid );
+        enrollmentService.cancelEnrollmentStatus( enrollment );
         teiService.updateTrackedEntityInstance( enrollment.getEntityInstance() );
     }
 
     @Override
     public void completeEnrollment( String uid )
     {
-        Enrollment enrollment = programInstanceService.getProgramInstance( uid );
-        programInstanceService.completeProgramInstanceStatus( enrollment );
+        Enrollment enrollment = enrollmentService.getEnrollment( uid );
+        enrollmentService.completeEnrollmentStatus( enrollment );
         teiService.updateTrackedEntityInstance( enrollment.getEntityInstance() );
     }
 
     @Override
     public void incompleteEnrollment( String uid )
     {
-        Enrollment enrollment = programInstanceService.getProgramInstance( uid );
-        programInstanceService.incompleteProgramInstanceStatus( enrollment );
+        Enrollment enrollment = enrollmentService.getEnrollment( uid );
+        enrollmentService.incompleteEnrollmentStatus( enrollment );
         teiService.updateTrackedEntityInstance( enrollment.getEntityInstance() );
     }
 
@@ -1588,7 +1588,7 @@ public abstract class AbstractEnrollmentService
 
                 programInstance.getComments().add( comment );
 
-                programInstanceService.updateProgramInstance( programInstance, user );
+                enrollmentService.updateEnrollment( programInstance, user );
                 teiService.updateTrackedEntityInstance( programInstance.getEntityInstance(), user );
             }
         }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/JacksonEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/JacksonEnrollmentService.java
@@ -46,8 +46,8 @@ import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.dxf2.metadata.feedback.ImportReportMode;
 import org.hisp.dhis.i18n.I18nManager;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.query.QueryService;
 import org.hisp.dhis.schema.SchemaService;
@@ -80,7 +80,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class JacksonEnrollmentService extends AbstractEnrollmentService
 {
     public JacksonEnrollmentService(
-        ProgramInstanceService programInstanceService,
+        EnrollmentService enrollmentService,
         EventService programStageInstanceService,
         ProgramService programService,
         TrackedEntityInstanceService trackedEntityInstanceService,
@@ -104,7 +104,7 @@ public class JacksonEnrollmentService extends AbstractEnrollmentService
         ObjectMapper jsonMapper,
         @Qualifier( "xmlMapper" ) ObjectMapper xmlMapper )
     {
-        checkNotNull( programInstanceService );
+        checkNotNull( enrollmentService );
         checkNotNull( programStageInstanceService );
         checkNotNull( programService );
         checkNotNull( trackedEntityInstanceService );
@@ -128,7 +128,7 @@ public class JacksonEnrollmentService extends AbstractEnrollmentService
         checkNotNull( jsonMapper );
         checkNotNull( xmlMapper );
 
-        this.programInstanceService = programInstanceService;
+        this.enrollmentService = enrollmentService;
         this.programStageInstanceService = programStageInstanceService;
         this.programService = programService;
         this.trackedEntityInstanceService = trackedEntityInstanceService;
@@ -322,7 +322,7 @@ public class JacksonEnrollmentService extends AbstractEnrollmentService
     private void sortCreatesAndUpdates( List<Enrollment> enrollments, List<Enrollment> create, List<Enrollment> update )
     {
         List<String> ids = enrollments.stream().map( Enrollment::getEnrollment ).collect( Collectors.toList() );
-        List<String> existingUids = programInstanceService.getProgramInstancesUidsIncludingDeleted( ids );
+        List<String> existingUids = enrollmentService.getEnrollmentsUidsIncludingDeleted( ids );
 
         for ( Enrollment enrollment : enrollments )
         {
@@ -346,7 +346,7 @@ public class JacksonEnrollmentService extends AbstractEnrollmentService
         }
         else
         {
-            if ( !programInstanceService.programInstanceExists( enrollment.getEnrollment() ) )
+            if ( !enrollmentService.enrollmentExists( enrollment.getEnrollment() ) )
             {
                 create.add( enrollment );
             }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -111,10 +111,10 @@ import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.fileresource.FileResourceService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.program.ProgramType;
@@ -166,7 +166,7 @@ public abstract class AbstractEventService implements org.hisp.dhis.dxf2.events.
 
     protected ProgramService programService;
 
-    protected ProgramInstanceService programInstanceService;
+    protected EnrollmentService enrollmentService;
 
     protected EventService eventService;
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JacksonEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JacksonEventService.java
@@ -48,8 +48,8 @@ import org.hisp.dhis.dxf2.events.relationship.RelationshipService;
 import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
 import org.hisp.dhis.fileresource.FileResourceService;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.query.QueryService;
 import org.hisp.dhis.schema.SchemaService;
@@ -93,7 +93,7 @@ public class JacksonEventService extends AbstractEventService
 
     public JacksonEventService( EventImporter eventImporter, EventManager eventManager,
         WorkContextLoader workContextLoader, EventServiceFacade jacksonEventServiceFacade,
-        ProgramService programService, ProgramInstanceService programInstanceService,
+        ProgramService programService, EnrollmentService enrollmentService,
         EventService eventService, OrganisationUnitService organisationUnitService,
         CurrentUserService currentUserService, TrackedEntityInstanceService entityInstanceService,
         TrackedEntityCommentService commentService, EventStore eventStore, Notifier notifier, DbmsManager dbmsManager,
@@ -109,7 +109,7 @@ public class JacksonEventService extends AbstractEventService
         checkNotNull( workContextLoader );
         checkNotNull( jacksonEventServiceFacade );
         checkNotNull( programService );
-        checkNotNull( programInstanceService );
+        checkNotNull( enrollmentService );
         checkNotNull( eventService );
         checkNotNull( organisationUnitService );
         checkNotNull( currentUserService );
@@ -135,7 +135,7 @@ public class JacksonEventService extends AbstractEventService
         this.workContextLoader = workContextLoader;
         this.jacksonEventServiceFacade = jacksonEventServiceFacade;
         this.programService = programService;
-        this.programInstanceService = programInstanceService;
+        this.enrollmentService = enrollmentService;
         this.eventService = eventService;
         this.organisationUnitService = organisationUnitService;
         this.currentUserService = currentUserService;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -60,7 +60,6 @@ import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.events.RelationshipParams;
 import org.hisp.dhis.dxf2.events.TrackedEntityInstanceParams;
 import org.hisp.dhis.dxf2.events.aggregates.TrackedEntityInstanceAggregate;
-import org.hisp.dhis.dxf2.events.enrollment.EnrollmentService;
 import org.hisp.dhis.dxf2.importsummary.ImportConflicts;
 import org.hisp.dhis.dxf2.importsummary.ImportStatus;
 import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
@@ -72,8 +71,8 @@ import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.organisationunit.FeatureType;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.query.Query;
 import org.hisp.dhis.query.QueryService;
 import org.hisp.dhis.query.Restrictions;
@@ -136,9 +135,9 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
 
     protected DbmsManager dbmsManager;
 
-    protected EnrollmentService enrollmentService;
+    protected org.hisp.dhis.dxf2.events.enrollment.EnrollmentService enrollmentService;
 
-    protected ProgramInstanceService programInstanceService;
+    protected EnrollmentService programInstanceService;
 
     protected TrackedEntityInstanceAuditService trackedEntityInstanceAuditService;
 
@@ -1141,7 +1140,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
             {
                 delete.add( enrollment );
             }
-            else if ( !programInstanceService.programInstanceExists( enrollment.getEnrollment() ) )
+            else if ( !programInstanceService.enrollmentExists( enrollment.getEnrollment() ) )
             {
                 create.add( enrollment );
             }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/JacksonTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/JacksonTrackedEntityInstanceService.java
@@ -40,10 +40,9 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.events.aggregates.TrackedEntityInstanceAggregate;
-import org.hisp.dhis.dxf2.events.enrollment.EnrollmentService;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.fileresource.FileResourceService;
-import org.hisp.dhis.program.ProgramInstanceService;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.query.QueryService;
 import org.hisp.dhis.relationship.RelationshipService;
 import org.hisp.dhis.relationship.RelationshipTypeService;
@@ -90,8 +89,8 @@ public class JacksonTrackedEntityInstanceService extends AbstractTrackedEntityIn
         IdentifiableObjectManager manager,
         UserService userService,
         DbmsManager dbmsManager,
-        EnrollmentService enrollmentService,
-        ProgramInstanceService programInstanceService,
+        org.hisp.dhis.dxf2.events.enrollment.EnrollmentService enrollmentService,
+        EnrollmentService programInstanceService,
         CurrentUserService currentUserService,
         SchemaService schemaService,
         QueryService queryService,

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHook.java
@@ -38,8 +38,8 @@ import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.preheat.PreheatIdentifier;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.program.ProgramStatus;
@@ -56,7 +56,7 @@ import org.springframework.stereotype.Component;
 @AllArgsConstructor
 public class ProgramObjectBundleHook extends AbstractObjectBundleHook<Program>
 {
-    private final ProgramInstanceService programInstanceService;
+    private final EnrollmentService enrollmentService;
 
     private final ProgramStageService programStageService;
 
@@ -131,13 +131,13 @@ public class ProgramObjectBundleHook extends AbstractObjectBundleHook<Program>
             pi.setStatus( ProgramStatus.ACTIVE );
             pi.setStoredBy( "system-process" );
 
-            this.programInstanceService.addProgramInstance( pi );
+            this.enrollmentService.addEnrollment( pi );
         }
     }
 
     private int getProgramInstancesCount( Program program )
     {
-        return programInstanceService.getProgramInstances( program, ProgramStatus.ACTIVE ).size();
+        return enrollmentService.getEnrollments( program, ProgramStatus.ACTIVE ).size();
     }
 
     private void validateAttributeSecurity( Program program, ObjectBundle bundle,

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHookTest.java
@@ -46,9 +46,9 @@ import org.hibernate.SessionFactory;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstanceQueryParams;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageService;
@@ -73,7 +73,7 @@ class ProgramObjectBundleHookTest
     private ProgramObjectBundleHook subject;
 
     @Mock
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Mock
     private ProgramService programService;
@@ -92,7 +92,7 @@ class ProgramObjectBundleHookTest
     @BeforeEach
     public void setUp()
     {
-        this.subject = new ProgramObjectBundleHook( programInstanceService, programStageService,
+        this.subject = new ProgramObjectBundleHook( enrollmentService, programStageService,
             aclService );
 
         programA = createProgram( 'A' );
@@ -104,7 +104,7 @@ class ProgramObjectBundleHookTest
     {
         subject.preCreate( null, null );
 
-        verifyNoInteractions( programInstanceService );
+        verifyNoInteractions( enrollmentService );
     }
 
     @Test
@@ -112,7 +112,7 @@ class ProgramObjectBundleHookTest
     {
         subject.preCreate( programA, null );
 
-        verifyNoInteractions( programInstanceService );
+        verifyNoInteractions( enrollmentService );
     }
 
     @Test
@@ -123,7 +123,7 @@ class ProgramObjectBundleHookTest
         programA.setProgramType( ProgramType.WITHOUT_REGISTRATION );
         subject.postCreate( programA, null );
 
-        verify( programInstanceService ).addProgramInstance( argument.capture() );
+        verify( enrollmentService ).addEnrollment( argument.capture() );
 
         assertThat( argument.getValue().getEnrollmentDate(), is( notNullValue() ) );
         assertThat( argument.getValue().getIncidentDate(), is( notNullValue() ) );
@@ -140,7 +140,7 @@ class ProgramObjectBundleHookTest
         programA.setProgramType( ProgramType.WITH_REGISTRATION );
         subject.postCreate( programA, null );
 
-        verify( programInstanceService, times( 0 ) ).addProgramInstance( argument.capture() );
+        verify( enrollmentService, times( 0 ) ).addEnrollment( argument.capture() );
     }
 
     @Test
@@ -156,7 +156,7 @@ class ProgramObjectBundleHookTest
         programInstanceQueryParams.setProgram( programA );
         programInstanceQueryParams.setProgramStatus( ProgramStatus.ACTIVE );
 
-        when( programInstanceService.getProgramInstances( programA, ProgramStatus.ACTIVE ) )
+        when( enrollmentService.getEnrollments( programA, ProgramStatus.ACTIVE ) )
             .thenReturn( Lists.newArrayList( new Enrollment(), new Enrollment() ) );
 
         List<ErrorReport> errors = subject.validate( programA, null );
@@ -171,7 +171,7 @@ class ProgramObjectBundleHookTest
         Program transientObj = createProgram( 'A' );
         subject.validate( transientObj, null );
 
-        verifyNoInteractions( programInstanceService );
+        verifyNoInteractions( enrollmentService );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEngineService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEngineService.java
@@ -36,10 +36,10 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.programrule.ProgramRule;
 import org.hisp.dhis.rules.models.RuleEffect;
@@ -68,7 +68,7 @@ public class DefaultProgramRuleEngineService
 
     private final List<RuleActionImplementer> ruleActionImplementers;
 
-    private final ProgramInstanceService programInstanceService;
+    private final EnrollmentService enrollmentService;
 
     private final EventService eventService;
 
@@ -85,7 +85,7 @@ public class DefaultProgramRuleEngineService
             return List.of();
         }
 
-        Enrollment programInstance = programInstanceService.getProgramInstance( enrollment );
+        Enrollment programInstance = enrollmentService.getEnrollment( enrollment );
 
         if ( programInstance == null )
         {
@@ -166,8 +166,8 @@ public class DefaultProgramRuleEngineService
         }
         else
         {
-            Enrollment enrollment = programInstanceService
-                .getProgramInstance( event.getEnrollment().getId() );
+            Enrollment enrollment = enrollmentService
+                .getEnrollment( event.getEnrollment().getId() );
 
             ruleEffects = programRuleEngine.evaluate( enrollment, event, enrollment.getEvents(),
                 programRules );

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/NotificationRuleActionImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/NotificationRuleActionImplementer.java
@@ -38,9 +38,9 @@ import org.hisp.dhis.notification.logging.ExternalNotificationLogEntry;
 import org.hisp.dhis.notification.logging.NotificationLoggingService;
 import org.hisp.dhis.notification.logging.NotificationValidationResult;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplateService;
 import org.hisp.dhis.rules.models.RuleAction;
@@ -66,7 +66,7 @@ abstract class NotificationRuleActionImplementer implements RuleActionImplemente
 
     protected final NotificationLoggingService notificationLoggingService;
 
-    protected final ProgramInstanceService programInstanceService;
+    protected final EnrollmentService enrollmentService;
 
     protected final EventService eventService;
 

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionScheduleMessageImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionScheduleMessageImplementer.java
@@ -37,9 +37,9 @@ import org.hisp.dhis.notification.logging.NotificationLoggingService;
 import org.hisp.dhis.notification.logging.NotificationTriggerEvent;
 import org.hisp.dhis.notification.logging.NotificationValidationResult;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.notification.ProgramNotificationInstance;
 import org.hisp.dhis.program.notification.ProgramNotificationInstanceService;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
@@ -71,12 +71,12 @@ public class RuleActionScheduleMessageImplementer extends NotificationRuleAction
 
     public RuleActionScheduleMessageImplementer( ProgramNotificationTemplateService programNotificationTemplateService,
         NotificationLoggingService notificationLoggingService,
-        ProgramInstanceService programInstanceService,
+        EnrollmentService enrollmentService,
         EventService eventService,
         ProgramNotificationInstanceService programNotificationInstanceService,
         NotificationTemplateService notificationTemplateService )
     {
-        super( programNotificationTemplateService, notificationLoggingService, programInstanceService,
+        super( programNotificationTemplateService, notificationLoggingService, enrollmentService,
             eventService );
         this.programNotificationInstanceService = programNotificationInstanceService;
         this.notificationTemplateService = notificationTemplateService;

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionSendMessageImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionSendMessageImplementer.java
@@ -34,9 +34,9 @@ import org.hisp.dhis.notification.logging.NotificationLoggingService;
 import org.hisp.dhis.notification.logging.NotificationTriggerEvent;
 import org.hisp.dhis.notification.logging.NotificationValidationResult;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.notification.*;
 import org.hisp.dhis.program.notification.event.ProgramRuleEnrollmentEvent;
 import org.hisp.dhis.program.notification.event.ProgramRuleStageEvent;
@@ -69,11 +69,11 @@ public class RuleActionSendMessageImplementer extends NotificationRuleActionImpl
 
     public RuleActionSendMessageImplementer( ProgramNotificationTemplateService programNotificationTemplateService,
         NotificationLoggingService notificationLoggingService,
-        ProgramInstanceService programInstanceService,
+        EnrollmentService enrollmentService,
         EventService eventService,
         ApplicationEventPublisher publisher )
     {
-        super( programNotificationTemplateService, notificationLoggingService, programInstanceService,
+        super( programNotificationTemplateService, notificationLoggingService, enrollmentService,
             eventService );
         this.publisher = publisher;
     }

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineServiceTest.java
@@ -50,10 +50,10 @@ import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramType;
@@ -96,7 +96,7 @@ class ProgramRuleEngineServiceTest extends DhisConvenienceTest
     // -------------------------------------------------------------------------
 
     @Mock
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Mock
     private EventService eventService;
@@ -172,7 +172,7 @@ class ProgramRuleEngineServiceTest extends DhisConvenienceTest
         List<RuleEffect> effects = new ArrayList<>();
         effects.add( RuleEffect.create( "", RuleActionSendMessage.create( NOTIFICATION_UID, DATA ) ) );
 
-        when( programInstanceService.getProgramInstance( anyLong() ) ).thenReturn( enrollment );
+        when( enrollmentService.getEnrollment( anyLong() ) ).thenReturn( enrollment );
         when( programRuleEngine.evaluate( any(), any(), any() ) ).thenReturn( effects );
         when( programRuleEngine.getProgramRules( any() ) ).thenReturn( List.of( programRuleA ) );
 
@@ -214,7 +214,7 @@ class ProgramRuleEngineServiceTest extends DhisConvenienceTest
         effects.add( RuleEffect.create( "", RuleActionSendMessage.create( NOTIFICATION_UID, DATA ) ) );
 
         when( eventService.getEvent( anyString() ) ).thenReturn( event );
-        when( programInstanceService.getProgramInstance( anyLong() ) ).thenReturn( enrollment );
+        when( enrollmentService.getEnrollment( anyLong() ) ).thenReturn( enrollment );
 
         when( programRuleEngine.getProgramRules( any(), any() ) ).thenReturn( List.of( programRuleA ) );
         when( programRuleEngine.evaluate( any(), any(), anySet(), anyList() ) ).thenReturn( effects );
@@ -268,7 +268,7 @@ class ProgramRuleEngineServiceTest extends DhisConvenienceTest
         verify( programRuleEngine, times( 1 ) )
             .evaluateProgramEvent( programEvent, program, List.of( programRuleA ) );
 
-        verify( programInstanceService, never() ).getProgramInstance( any() );
+        verify( enrollmentService, never() ).getEnrollment( any() );
 
         verify( ruleActionSendMessage ).accept( ruleEffects.get( 0 ).ruleAction() );
         verify( ruleActionSendMessage ).implement( any( RuleEffect.class ), any( Event.class ) );
@@ -281,7 +281,7 @@ class ProgramRuleEngineServiceTest extends DhisConvenienceTest
     void shouldNotTryToEvaluateWhenThereAreNoRulesToRun()
     {
         when( eventService.getEvent( anyString() ) ).thenReturn( event );
-        when( programInstanceService.getProgramInstance( anyLong() ) ).thenReturn( enrollment );
+        when( enrollmentService.getEnrollment( anyLong() ) ).thenReturn( enrollment );
 
         when( programRuleEngine.getProgramRules( any(), any() ) ).thenReturn( List.of() );
 
@@ -291,7 +291,7 @@ class ProgramRuleEngineServiceTest extends DhisConvenienceTest
 
         verify( programRuleEngine, never() ).evaluateProgramEvent( any(), any(), anyList() );
         verify( programRuleEngine, never() ).evaluate( any(), any(), anyList() );
-        verify( programInstanceService, never() ).getProgramInstance( any() );
+        verify( enrollmentService, never() ).getEnrollment( any() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -45,9 +45,9 @@ import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.SlimPager;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.ProgramInstanceQueryParams;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
@@ -62,9 +62,9 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @RequiredArgsConstructor
 @Service( "org.hisp.dhis.tracker.export.enrollment.EnrollmentService" )
-public class DefaultEnrollmentService implements EnrollmentService
+public class DefaultEnrollmentService implements org.hisp.dhis.tracker.export.enrollment.EnrollmentService
 {
-    private final ProgramInstanceService programInstanceService;
+    private final EnrollmentService enrollmentService;
 
     private final TrackerOwnershipManager trackerOwnershipAccessManager;
 
@@ -77,7 +77,7 @@ public class DefaultEnrollmentService implements EnrollmentService
     @Override
     public Enrollment getEnrollment( String uid, EnrollmentParams params )
     {
-        Enrollment enrollment = programInstanceService.getProgramInstance( uid );
+        Enrollment enrollment = enrollmentService.getEnrollment( uid );
         return enrollment != null ? getEnrollment( enrollment, params ) : null;
     }
 
@@ -202,14 +202,14 @@ public class DefaultEnrollmentService implements EnrollmentService
         }
 
         List<Enrollment> programInstances = new ArrayList<>(
-            programInstanceService.getProgramInstances( params ) );
+            enrollmentService.getEnrollments( params ) );
         if ( !params.isSkipPaging() )
         {
             Pager pager;
 
             if ( params.isTotalPages() )
             {
-                int count = programInstanceService.countProgramInstances( params );
+                int count = enrollmentService.countEnrollments( params );
                 pager = new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() );
             }
             else

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/DefaultTrackerObjectsDeletionService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/DefaultTrackerObjectsDeletionService.java
@@ -34,9 +34,9 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.relationship.RelationshipService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
@@ -60,7 +60,7 @@ import com.google.common.collect.Lists;
 public class DefaultTrackerObjectsDeletionService
     implements TrackerObjectDeletionService
 {
-    private final ProgramInstanceService programInstanceService;
+    private final EnrollmentService enrollmentService;
 
     private final TrackedEntityInstanceService teiService;
 
@@ -85,7 +85,7 @@ public class DefaultTrackerObjectsDeletionService
 
             Entity objectReport = new Entity( TrackerType.ENROLLMENT, uid, idx );
 
-            Enrollment enrollment = programInstanceService.getProgramInstance( uid );
+            Enrollment enrollment = enrollmentService.getEnrollment( uid );
 
             List<org.hisp.dhis.tracker.imports.domain.Event> events = eventTrackerConverterService
                 .to( Lists.newArrayList( enrollment.getEvents()
@@ -100,7 +100,7 @@ public class DefaultTrackerObjectsDeletionService
             TrackedEntityInstance tei = enrollment.getEntityInstance();
             tei.getEnrollments().remove( enrollment );
 
-            programInstanceService.deleteProgramInstance( enrollment );
+            enrollmentService.deleteEnrollment( enrollment );
             teiService.updateTrackedEntityInstance( tei );
 
             typeReport.getStats().incDeleted();
@@ -134,7 +134,7 @@ public class DefaultTrackerObjectsDeletionService
                 teiService.updateTrackedEntityInstance( event.getEnrollment().getEntityInstance() );
 
                 enrollment.getEvents().remove( event );
-                programInstanceService.updateProgramInstance( enrollment );
+                enrollmentService.updateEnrollment( enrollment );
             }
 
             typeReport.getStats().incDeleted();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
@@ -93,10 +93,10 @@ import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.program.AnalyticsType;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramIndicator;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramOwnershipHistory;
 import org.hisp.dhis.program.ProgramOwnershipHistoryService;
 import org.hisp.dhis.program.ProgramStage;
@@ -148,7 +148,7 @@ class EventAnalyticsServiceTest
     private AnalyticsTableGenerator analyticsTableGenerator;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private TrackedEntityAttributeValueService attributeValueService;
@@ -396,15 +396,15 @@ class EventAnalyticsServiceTest
         attributeValueService.addTrackedEntityAttributeValue( atv );
 
         // Program Instances (Enrollments)
-        Enrollment piA = programInstanceService.enrollTrackedEntityInstance( teiA, programA, jan1, jan1, ouE );
+        Enrollment piA = enrollmentService.enrollTrackedEntityInstance( teiA, programA, jan1, jan1, ouE );
         piA.setEnrollmentDate( jan1 );
         piA.setIncidentDate( jan1 );
-        programInstanceService.addProgramInstance( piA );
+        enrollmentService.addEnrollment( piA );
 
-        Enrollment piB = programInstanceService.enrollTrackedEntityInstance( teiA, programB, jan1, jan1, ouE );
+        Enrollment piB = enrollmentService.enrollTrackedEntityInstance( teiA, programB, jan1, jan1, ouE );
         piB.setEnrollmentDate( jan1 );
         piB.setIncidentDate( jan1 );
-        programInstanceService.addProgramInstance( piB );
+        enrollmentService.addEnrollment( piB );
 
         // Change programA / teiA ownership through time:
         // Jan 1 (enrollment) - Jan 15: ouE

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/deduplication/DeduplicationServiceMergeIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/deduplication/DeduplicationServiceMergeIntegrationTest.java
@@ -39,8 +39,8 @@ import java.util.Map;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.security.acl.AccessStringHelper;
 import org.hisp.dhis.test.integration.IntegrationTestBase;
@@ -72,7 +72,7 @@ class DeduplicationServiceMergeIntegrationTest extends IntegrationTestBase
     private TrackedEntityTypeService trackedEntityTypeService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private TrackedEntityInstanceService trackedEntityInstanceService;
@@ -110,8 +110,8 @@ class DeduplicationServiceMergeIntegrationTest extends IntegrationTestBase
         programService.addProgram( program1 );
         Enrollment enrollment1 = createProgramInstance( program, original, ou );
         Enrollment enrollment2 = createProgramInstance( program1, duplicate, ou );
-        programInstanceService.addProgramInstance( enrollment1 );
-        programInstanceService.addProgramInstance( enrollment2 );
+        enrollmentService.addEnrollment( enrollment1 );
+        enrollmentService.addEnrollment( enrollment2 );
         original.getEnrollments().add( enrollment1 );
         duplicate.getEnrollments().add( enrollment2 );
         trackedEntityInstanceService.updateTrackedEntityInstance( original );
@@ -157,10 +157,10 @@ class DeduplicationServiceMergeIntegrationTest extends IntegrationTestBase
         program1.setSharing( sharing );
         Enrollment enrollment1 = createProgramInstance( program, original, ou );
         Enrollment enrollment2 = createProgramInstance( program1, duplicate, ou );
-        programInstanceService.addProgramInstance( enrollment1 );
-        programInstanceService.addProgramInstance( enrollment2 );
-        programInstanceService.updateProgramInstance( enrollment1 );
-        programInstanceService.updateProgramInstance( enrollment2 );
+        enrollmentService.addEnrollment( enrollment1 );
+        enrollmentService.addEnrollment( enrollment2 );
+        enrollmentService.updateEnrollment( enrollment1 );
+        enrollmentService.updateEnrollment( enrollment2 );
         original.getEnrollments().add( enrollment1 );
         duplicate.getEnrollments().add( enrollment2 );
         trackedEntityInstanceService.updateTrackedEntityInstance( original );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/deduplication/hibernate/PotentialDuplicateRemoveTrackedEntityTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/deduplication/hibernate/PotentialDuplicateRemoveTrackedEntityTest.java
@@ -34,8 +34,8 @@ import org.hisp.dhis.deduplication.PotentialDuplicateStore;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.relationship.RelationshipService;
@@ -75,7 +75,7 @@ class PotentialDuplicateRemoveTrackedEntityTest extends TransactionalIntegration
     private TrackedEntityAttributeValueService trackedEntityAttributeValueService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private ProgramService programService;
@@ -163,10 +163,10 @@ class PotentialDuplicateRemoveTrackedEntityTest extends TransactionalIntegration
         Enrollment enrollment2 = createProgramInstance( program, duplicate, ou );
         Enrollment enrollment3 = createProgramInstance( program, control1, ou );
         Enrollment enrollment4 = createProgramInstance( program, control2, ou );
-        programInstanceService.addProgramInstance( enrollment1 );
-        programInstanceService.addProgramInstance( enrollment2 );
-        programInstanceService.addProgramInstance( enrollment3 );
-        programInstanceService.addProgramInstance( enrollment4 );
+        enrollmentService.addEnrollment( enrollment1 );
+        enrollmentService.addEnrollment( enrollment2 );
+        enrollmentService.addEnrollment( enrollment3 );
+        enrollmentService.addEnrollment( enrollment4 );
         original.getEnrollments().add( enrollment1 );
         duplicate.getEnrollments().add( enrollment2 );
         control1.getEnrollments().add( enrollment3 );
@@ -180,10 +180,10 @@ class PotentialDuplicateRemoveTrackedEntityTest extends TransactionalIntegration
         assertNotNull( trackedEntityInstanceService.getTrackedEntityInstance( control1.getUid() ) );
         assertNotNull( trackedEntityInstanceService.getTrackedEntityInstance( control2.getUid() ) );
         removeTrackedEntity( duplicate );
-        assertNull( programInstanceService.getProgramInstance( enrollment2.getUid() ) );
-        assertNotNull( programInstanceService.getProgramInstance( enrollment1.getUid() ) );
-        assertNotNull( programInstanceService.getProgramInstance( enrollment3.getUid() ) );
-        assertNotNull( programInstanceService.getProgramInstance( enrollment4.getUid() ) );
+        assertNull( enrollmentService.getEnrollment( enrollment2.getUid() ) );
+        assertNotNull( enrollmentService.getEnrollment( enrollment1.getUid() ) );
+        assertNotNull( enrollmentService.getEnrollment( enrollment3.getUid() ) );
+        assertNotNull( enrollmentService.getEnrollment( enrollment4.getUid() ) );
         assertNull( trackedEntityInstanceService.getTrackedEntityInstance( duplicate.getUid() ) );
     }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/EventImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/EventImportTest.java
@@ -59,7 +59,6 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dxf2.common.ImportOptions;
-import org.hisp.dhis.dxf2.events.enrollment.EnrollmentService;
 import org.hisp.dhis.dxf2.events.event.DataValue;
 import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstanceService;
@@ -71,10 +70,10 @@ import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.organisationunit.FeatureType;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.program.ProgramStageDataElementService;
@@ -118,13 +117,13 @@ class EventImportTest extends TransactionalIntegrationTest
     private ProgramStageDataElementService programStageDataElementService;
 
     @Autowired
-    private EnrollmentService enrollmentService;
+    private org.hisp.dhis.dxf2.events.enrollment.EnrollmentService enrollmentService;
 
     @Autowired
     private IdentifiableObjectManager manager;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService programInstanceService;
 
     @Autowired
     private EventService programStageInstanceService;
@@ -322,7 +321,7 @@ class EventImportTest extends TransactionalIntegrationTest
         pi.setProgram( programB );
         pi.setStatus( ProgramStatus.ACTIVE );
         pi.setStoredBy( "test" );
-        programInstanceService.addProgramInstance( pi );
+        programInstanceService.addEnrollment( pi );
         InputStream is = createEventJsonInputStream( programB.getUid(), programStageB.getUid(),
             organisationUnitB.getUid(), null, dataElementB, "10" );
         ImportSummaries importSummaries = eventService.addEventsJson( is, null );
@@ -478,7 +477,7 @@ class EventImportTest extends TransactionalIntegrationTest
     @Test
     void testEventDeletion()
     {
-        programInstanceService.addProgramInstance( pi );
+        programInstanceService.addEnrollment( pi );
         ImportOptions importOptions = new ImportOptions();
         ImportSummary importSummary = eventService.addEvent( event, importOptions, false );
         assertEquals( ImportStatus.SUCCESS, importSummary.getStatus() );
@@ -495,7 +494,7 @@ class EventImportTest extends TransactionalIntegrationTest
     @Test
     void testAddAlreadyDeletedEvent()
     {
-        programInstanceService.addProgramInstance( pi );
+        programInstanceService.addEnrollment( pi );
         ImportOptions importOptions = new ImportOptions();
         eventService.addEvent( event, importOptions, false );
         eventService.deleteEvent( event.getUid() );
@@ -511,7 +510,7 @@ class EventImportTest extends TransactionalIntegrationTest
     @Test
     void testAddAlreadyDeletedEventInBulk()
     {
-        programInstanceService.addProgramInstance( pi );
+        programInstanceService.addEnrollment( pi );
         ImportOptions importOptions = new ImportOptions();
         eventService.addEvent( event, importOptions, false );
         eventService.deleteEvent( event.getUid() );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/EventXmlImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/EventXmlImportTest.java
@@ -48,8 +48,8 @@ import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
 import org.hisp.dhis.organisationunit.FeatureType;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.program.ProgramStageDataElementService;
@@ -81,7 +81,7 @@ class EventXmlImportTest extends TransactionalIntegrationTest
     private UserService _userService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     private OrganisationUnit organisationUnitA;
 
@@ -121,7 +121,7 @@ class EventXmlImportTest extends TransactionalIntegrationTest
         enrollment.setEnrollmentDate( new Date() );
         enrollment.setIncidentDate( new Date() );
         enrollment.setStatus( ProgramStatus.ACTIVE );
-        programInstanceService.addProgramInstance( enrollment );
+        enrollmentService.addEnrollment( enrollment );
         programStageA.getProgramStageDataElements().add( programStageDataElement );
         programStageA.setProgram( programA );
         programA.getProgramStages().add( programStageA );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/HandleRelationshipsTrackedEntityInstanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/HandleRelationshipsTrackedEntityInstanceServiceTest.java
@@ -68,7 +68,7 @@ class HandleRelationshipsTrackedEntityInstanceServiceTest extends SingleSetupInt
     private RelationshipTypeService relationshipTypeService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private EventService eventService;
@@ -115,7 +115,7 @@ class HandleRelationshipsTrackedEntityInstanceServiceTest extends SingleSetupInt
         manager.save( programStageA2 );
         programA.getProgramStages().addAll( Set.of( programStageA1, programStageA2 ) );
         manager.update( programA );
-        Enrollment enrollmentA = programInstanceService.enrollTrackedEntityInstance( trackedEntityInstanceA,
+        Enrollment enrollmentA = enrollmentService.enrollTrackedEntityInstance( trackedEntityInstanceA,
             programA, null, null, organisationUnitA );
         eventA = new Event( enrollmentA, programStageA1 );
         eventA.setDueDate( null );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/NoRegistrationSingleEventServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/NoRegistrationSingleEventServiceTest.java
@@ -42,10 +42,10 @@ import org.hisp.dhis.dxf2.importsummary.ImportStatus;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.program.ProgramStageDataElementService;
@@ -68,7 +68,7 @@ class NoRegistrationSingleEventServiceTest extends TransactionalIntegrationTest
     private ProgramStageDataElementService programStageDataElementService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private EventService programStageInstanceService;
@@ -115,7 +115,7 @@ class NoRegistrationSingleEventServiceTest extends TransactionalIntegrationTest
         enrollment.setProgram( programA );
         enrollment.setIncidentDate( new Date() );
         enrollment.setEnrollmentDate( new Date() );
-        programInstanceService.addProgramInstance( enrollment );
+        enrollmentService.addEnrollment( enrollment );
         identifiableObjectManager.update( programA );
         createUserAndInjectSecurityContext( true );
         identifiableObjectManager.flush();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/RelationshipServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/RelationshipServiceTest.java
@@ -48,9 +48,9 @@ import org.hisp.dhis.dxf2.importsummary.ImportStatus;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.relationship.RelationshipEntity;
@@ -63,7 +63,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class RelationshipServiceTest extends TransactionalIntegrationTest
 {
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private RelationshipService relationshipService;
@@ -122,10 +122,10 @@ class RelationshipServiceTest extends TransactionalIntegrationTest
         manager.save( program );
         manager.save( programStage );
 
-        enrollmentA = programInstanceService.enrollTrackedEntityInstance( teiA, program, new Date(), new Date(),
+        enrollmentA = enrollmentService.enrollTrackedEntityInstance( teiA, program, new Date(), new Date(),
             organisationUnit );
 
-        enrollmentB = programInstanceService.enrollTrackedEntityInstance( teiB, program, new Date(), new Date(),
+        enrollmentB = enrollmentService.enrollTrackedEntityInstance( teiB, program, new Date(), new Date(),
             organisationUnit );
 
         eventA = new Event();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/TrackedEntityInstanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/TrackedEntityInstanceServiceTest.java
@@ -64,8 +64,8 @@ import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
@@ -108,7 +108,7 @@ class TrackedEntityInstanceServiceTest extends TransactionalIntegrationTest
     private TrackedEntityAttributeValueService trackedEntityAttributeValueService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private IdentifiableObjectManager manager;
@@ -205,10 +205,10 @@ class TrackedEntityInstanceServiceTest extends TransactionalIntegrationTest
         teiMaleB = trackedEntityInstanceService.getTrackedEntityInstance( maleB );
         teiFemaleA = trackedEntityInstanceService.getTrackedEntityInstance( femaleA );
         trackedEntityAttributeValueService.addTrackedEntityAttributeValue( uniqueId );
-        programInstanceService.enrollTrackedEntityInstance( maleA, programA, null, null, organisationUnitA );
-        programInstanceService.enrollTrackedEntityInstance( femaleA, programA, DateTime.now().plusMonths( 1 ).toDate(),
+        enrollmentService.enrollTrackedEntityInstance( maleA, programA, null, null, organisationUnitA );
+        enrollmentService.enrollTrackedEntityInstance( femaleA, programA, DateTime.now().plusMonths( 1 ).toDate(),
             null, organisationUnitA );
-        programInstanceService.enrollTrackedEntityInstance( dateConflictsMaleA, programA,
+        enrollmentService.enrollTrackedEntityInstance( dateConflictsMaleA, programA,
             DateTime.now().plusMonths( 1 ).toDate(), DateTime.now().plusMonths( 2 ).toDate(), organisationUnitA );
     }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/security/EventSecurityTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/security/EventSecurityTest.java
@@ -49,10 +49,10 @@ import org.hisp.dhis.dxf2.importsummary.ImportStatus;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.program.ProgramStageDataElementService;
@@ -76,7 +76,7 @@ class EventSecurityTest extends TransactionalIntegrationTest
     private org.hisp.dhis.dxf2.events.event.EventService eventService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private EventService programStageInstanceService;
@@ -130,7 +130,7 @@ class EventSecurityTest extends TransactionalIntegrationTest
         enrollment.setProgram( programA );
         enrollment.setIncidentDate( new Date() );
         enrollment.setEnrollmentDate( new Date() );
-        programInstanceService.addProgramInstance( enrollment );
+        enrollmentService.addEnrollment( enrollment );
         manager.update( programA );
         manager.flush();
     }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
@@ -51,10 +51,10 @@ import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageService;
@@ -87,7 +87,7 @@ import com.google.common.collect.Sets;
 class MaintenanceServiceTest extends IntegrationTestBase
 {
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private ProgramMessageService programMessageService;
@@ -203,8 +203,8 @@ class MaintenanceServiceTest extends IntegrationTestBase
         enrollmentWithTeiAssociation.setUid( "UID-B" );
         enrollmentWithTeiAssociation.setOrganisationUnit( organisationUnit );
         trackedEntityInstanceService.addTrackedEntityInstance( entityInstanceWithAssociations );
-        programInstanceService.addProgramInstance( enrollmentWithTeiAssociation );
-        programInstanceService.addProgramInstance( enrollment );
+        enrollmentService.addEnrollment( enrollmentWithTeiAssociation );
+        enrollmentService.addEnrollment( enrollment );
         event = new Event( enrollment, stageA );
         event.setUid( "PSUID-B" );
         event.setOrganisationUnit( organisationUnit );
@@ -265,14 +265,14 @@ class MaintenanceServiceTest extends IntegrationTestBase
         ProgramMessage message = ProgramMessage.builder().subject( "subject" ).text( "text" )
             .recipients( programMessageRecipients ).deliveryChannels( Sets.newHashSet( DeliveryChannel.EMAIL ) )
             .enrollment( enrollment ).build();
-        long idA = programInstanceService.addProgramInstance( enrollment );
+        long idA = enrollmentService.addEnrollment( enrollment );
         programMessageService.saveProgramMessage( message );
-        assertNotNull( programInstanceService.getProgramInstance( idA ) );
-        programInstanceService.deleteProgramInstance( enrollment );
-        assertNull( programInstanceService.getProgramInstance( idA ) );
-        assertTrue( programInstanceService.programInstanceExistsIncludingDeleted( enrollment.getUid() ) );
+        assertNotNull( enrollmentService.getEnrollment( idA ) );
+        enrollmentService.deleteEnrollment( enrollment );
+        assertNull( enrollmentService.getEnrollment( idA ) );
+        assertTrue( enrollmentService.enrollmentExistsIncludingDeleted( enrollment.getUid() ) );
         maintenanceService.deleteSoftDeletedProgramInstances();
-        assertFalse( programInstanceService.programInstanceExistsIncludingDeleted( enrollment.getUid() ) );
+        assertFalse( enrollmentService.enrollmentExistsIncludingDeleted( enrollment.getUid() ) );
     }
 
     @Test
@@ -331,13 +331,13 @@ class MaintenanceServiceTest extends IntegrationTestBase
         TrackedEntityDataValueAudit trackedEntityDataValueAudit = new TrackedEntityDataValueAudit( dataElement,
             eventA, "value", "modifiedBy", false, org.hisp.dhis.common.AuditType.UPDATE );
         trackedEntityDataValueAuditService.addTrackedEntityDataValueAudit( trackedEntityDataValueAudit );
-        long idA = programInstanceService.addProgramInstance( enrollment );
-        assertNotNull( programInstanceService.getProgramInstance( idA ) );
-        programInstanceService.deleteProgramInstance( enrollment );
-        assertNull( programInstanceService.getProgramInstance( idA ) );
-        assertTrue( programInstanceService.programInstanceExistsIncludingDeleted( enrollment.getUid() ) );
+        long idA = enrollmentService.addEnrollment( enrollment );
+        assertNotNull( enrollmentService.getEnrollment( idA ) );
+        enrollmentService.deleteEnrollment( enrollment );
+        assertNull( enrollmentService.getEnrollment( idA ) );
+        assertTrue( enrollmentService.enrollmentExistsIncludingDeleted( enrollment.getUid() ) );
         maintenanceService.deleteSoftDeletedProgramInstances();
-        assertFalse( programInstanceService.programInstanceExistsIncludingDeleted( enrollment.getUid() ) );
+        assertFalse( enrollmentService.enrollmentExistsIncludingDeleted( enrollment.getUid() ) );
     }
 
     @Test
@@ -400,15 +400,15 @@ class MaintenanceServiceTest extends IntegrationTestBase
         r.setKey( RelationshipUtils.generateRelationshipKey( r ) );
         r.setInvertedKey( RelationshipUtils.generateRelationshipInvertedKey( r ) );
         relationshipService.addRelationship( r );
-        assertNotNull( programInstanceService.getProgramInstance( enrollment.getId() ) );
+        assertNotNull( enrollmentService.getEnrollment( enrollment.getId() ) );
         assertNotNull( relationshipService.getRelationship( r.getId() ) );
-        programInstanceService.deleteProgramInstance( enrollment );
-        assertNull( programInstanceService.getProgramInstance( enrollment.getId() ) );
+        enrollmentService.deleteEnrollment( enrollment );
+        assertNull( enrollmentService.getEnrollment( enrollment.getId() ) );
         assertNull( relationshipService.getRelationship( r.getId() ) );
-        assertTrue( programInstanceService.programInstanceExistsIncludingDeleted( enrollment.getUid() ) );
+        assertTrue( enrollmentService.enrollmentExistsIncludingDeleted( enrollment.getUid() ) );
         assertTrue( relationshipService.relationshipExistsIncludingDeleted( r.getUid() ) );
         maintenanceService.deleteSoftDeletedProgramInstances();
-        assertFalse( programInstanceService.programInstanceExistsIncludingDeleted( enrollment.getUid() ) );
+        assertFalse( enrollmentService.enrollmentExistsIncludingDeleted( enrollment.getUid() ) );
         assertFalse( relationshipService.relationshipExistsIncludingDeleted( r.getUid() ) );
     }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/merge/orgunit/handler/TrackerOrgUnitMergeHandlerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/merge/orgunit/handler/TrackerOrgUnitMergeHandlerTest.java
@@ -34,10 +34,10 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.merge.orgunit.OrgUnitMergeRequest;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
@@ -57,7 +57,7 @@ class TrackerOrgUnitMergeHandlerTest extends SingleSetupIntegrationTestBase
     private TrackedEntityInstanceService teiService;
 
     @Autowired
-    private ProgramInstanceService piService;
+    private EnrollmentService piService;
 
     @Autowired
     private EventService eventService;
@@ -121,9 +121,9 @@ class TrackerOrgUnitMergeHandlerTest extends SingleSetupIntegrationTestBase
         piA = createProgramInstance( prA, teiA, ouA );
         piB = createProgramInstance( prA, teiB, ouB );
         piC = createProgramInstance( prA, teiC, ouA );
-        piService.addProgramInstance( piA );
-        piService.addProgramInstance( piB );
-        piService.addProgramInstance( piC );
+        piService.addEnrollment( piA );
+        piService.addEnrollment( piB );
+        piService.addEnrollment( piC );
         eventA = new Event( piA, psA, ouA );
         eventB = new Event( piB, psA, ouB );
         eventC = new Event( piC, psA, ouA );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/notification/ProgramNotificationMessageRendererTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/notification/ProgramNotificationMessageRendererTest.java
@@ -45,10 +45,10 @@ import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
@@ -153,7 +153,7 @@ class ProgramNotificationMessageRendererTest extends TransactionalIntegrationTes
     private TrackedEntityAttributeValueService trackedEntityAttributeValueService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private EventService eventService;
@@ -226,10 +226,10 @@ class ProgramNotificationMessageRendererTest extends TransactionalIntegrationTes
         trackedEntityInstanceA.setTrackedEntityAttributeValues( Sets.newHashSet( trackedEntityAttributeValueA ) );
         entityInstanceService.updateTrackedEntityInstance( trackedEntityInstanceA );
         // ProgramInstance to be provided in message renderer
-        enrollmentA = programInstanceService.enrollTrackedEntityInstance( trackedEntityInstanceA, programA,
+        enrollmentA = enrollmentService.enrollTrackedEntityInstance( trackedEntityInstanceA, programA,
             enrollmentDate, incidentDate, organisationUnitA );
         enrollmentA.setUid( enrollmentUid );
-        programInstanceService.updateProgramInstance( enrollmentA );
+        enrollmentService.updateEnrollment( enrollmentA );
         // Event to be provided in message renderer
         eventA = new Event( enrollmentA, programStageA );
         eventA.setOrganisationUnit( organisationUnitA );
@@ -247,7 +247,7 @@ class ProgramNotificationMessageRendererTest extends TransactionalIntegrationTes
         eventA.setEventDataValues( Sets.newHashSet( eventDataValueA, eventDataValueB ) );
         eventService.addEvent( eventA );
         enrollmentA.getEvents().add( eventA );
-        programInstanceService.updateProgramInstance( enrollmentA );
+        enrollmentService.updateEnrollment( enrollmentA );
         programNotificationTemplate = new ProgramNotificationTemplate();
         programNotificationTemplate.setName( "Test-PNT" );
         programNotificationTemplate.setMessageTemplate( "message_template" );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/EventPredictionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/EventPredictionServiceTest.java
@@ -61,12 +61,12 @@ import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.program.AnalyticsType;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramIndicatorService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageService;
@@ -113,7 +113,7 @@ class EventPredictionServiceTest extends IntegrationTestBase
     private ProgramService programService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private ProgramStageService programStageService;
@@ -273,9 +273,9 @@ class EventPredictionServiceTest extends IntegrationTestBase
         program.getProgramIndicators().add( programIndicatorA );
         program.getProgramIndicators().add( programIndicatorB );
         programService.updateProgram( program );
-        Enrollment enrollment = programInstanceService.enrollTrackedEntityInstance( entityInstance, program,
+        Enrollment enrollment = enrollmentService.enrollTrackedEntityInstance( entityInstance, program,
             dateMar20, dateMar20, orgUnitA );
-        programInstanceService.addProgramInstance( enrollment );
+        enrollmentService.addEnrollment( enrollment );
         Event stageInstanceA = eventService.createEvent( enrollment,
             stageA, dateMar20, dateMar20, orgUnitA );
         Event stageInstanceB = eventService.createEvent( enrollment,

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
@@ -52,11 +52,11 @@ import com.google.common.collect.Sets;
 /**
  * @author Chau Thu Tran
  */
-class ProgramInstanceServiceTest extends TransactionalIntegrationTest
+class EnrollmentServiceTest extends TransactionalIntegrationTest
 {
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private TrackedEntityInstanceService entityInstanceService;
@@ -156,80 +156,80 @@ class ProgramInstanceServiceTest extends TransactionalIntegrationTest
     @Test
     void testAddProgramInstance()
     {
-        long idA = programInstanceService.addProgramInstance( enrollmentA );
-        long idB = programInstanceService.addProgramInstance( enrollmentB );
-        assertNotNull( programInstanceService.getProgramInstance( idA ) );
-        assertNotNull( programInstanceService.getProgramInstance( idB ) );
+        long idA = enrollmentService.addEnrollment( enrollmentA );
+        long idB = enrollmentService.addEnrollment( enrollmentB );
+        assertNotNull( enrollmentService.getEnrollment( idA ) );
+        assertNotNull( enrollmentService.getEnrollment( idB ) );
     }
 
     @Test
     void testDeleteProgramInstance()
     {
-        long idA = programInstanceService.addProgramInstance( enrollmentA );
-        long idB = programInstanceService.addProgramInstance( enrollmentB );
-        assertNotNull( programInstanceService.getProgramInstance( idA ) );
-        assertNotNull( programInstanceService.getProgramInstance( idB ) );
-        programInstanceService.deleteProgramInstance( enrollmentA );
-        assertNull( programInstanceService.getProgramInstance( idA ) );
-        assertNotNull( programInstanceService.getProgramInstance( idB ) );
-        programInstanceService.deleteProgramInstance( enrollmentB );
-        assertNull( programInstanceService.getProgramInstance( idA ) );
-        assertNull( programInstanceService.getProgramInstance( idB ) );
+        long idA = enrollmentService.addEnrollment( enrollmentA );
+        long idB = enrollmentService.addEnrollment( enrollmentB );
+        assertNotNull( enrollmentService.getEnrollment( idA ) );
+        assertNotNull( enrollmentService.getEnrollment( idB ) );
+        enrollmentService.deleteEnrollment( enrollmentA );
+        assertNull( enrollmentService.getEnrollment( idA ) );
+        assertNotNull( enrollmentService.getEnrollment( idB ) );
+        enrollmentService.deleteEnrollment( enrollmentB );
+        assertNull( enrollmentService.getEnrollment( idA ) );
+        assertNull( enrollmentService.getEnrollment( idB ) );
     }
 
     @Test
     void testSoftDeleteProgramInstanceAndLinkedEvent()
     {
-        long idA = programInstanceService.addProgramInstance( enrollmentA );
+        long idA = enrollmentService.addEnrollment( enrollmentA );
         long eventIdA = eventService.addEvent( eventA );
         enrollmentA.setEvents( Sets.newHashSet( eventA ) );
-        programInstanceService.updateProgramInstance( enrollmentA );
-        assertNotNull( programInstanceService.getProgramInstance( idA ) );
+        enrollmentService.updateEnrollment( enrollmentA );
+        assertNotNull( enrollmentService.getEnrollment( idA ) );
         assertNotNull( eventService.getEvent( eventIdA ) );
-        programInstanceService.deleteProgramInstance( enrollmentA );
-        assertNull( programInstanceService.getProgramInstance( idA ) );
+        enrollmentService.deleteEnrollment( enrollmentA );
+        assertNull( enrollmentService.getEnrollment( idA ) );
         assertNull( eventService.getEvent( eventIdA ) );
     }
 
     @Test
     void testUpdateProgramInstance()
     {
-        long idA = programInstanceService.addProgramInstance( enrollmentA );
-        assertNotNull( programInstanceService.getProgramInstance( idA ) );
+        long idA = enrollmentService.addEnrollment( enrollmentA );
+        assertNotNull( enrollmentService.getEnrollment( idA ) );
         enrollmentA.setIncidentDate( enrollmentDate );
-        programInstanceService.updateProgramInstance( enrollmentA );
-        assertEquals( enrollmentDate, programInstanceService.getProgramInstance( idA ).getIncidentDate() );
+        enrollmentService.updateEnrollment( enrollmentA );
+        assertEquals( enrollmentDate, enrollmentService.getEnrollment( idA ).getIncidentDate() );
     }
 
     @Test
     void testGetProgramInstanceById()
     {
-        long idA = programInstanceService.addProgramInstance( enrollmentA );
-        long idB = programInstanceService.addProgramInstance( enrollmentB );
-        assertEquals( enrollmentA, programInstanceService.getProgramInstance( idA ) );
-        assertEquals( enrollmentB, programInstanceService.getProgramInstance( idB ) );
+        long idA = enrollmentService.addEnrollment( enrollmentA );
+        long idB = enrollmentService.addEnrollment( enrollmentB );
+        assertEquals( enrollmentA, enrollmentService.getEnrollment( idA ) );
+        assertEquals( enrollmentB, enrollmentService.getEnrollment( idB ) );
     }
 
     @Test
     void testGetProgramInstanceByUid()
     {
-        programInstanceService.addProgramInstance( enrollmentA );
-        programInstanceService.addProgramInstance( enrollmentB );
-        assertEquals( "UID-A", programInstanceService.getProgramInstance( "UID-A" ).getUid() );
-        assertEquals( "UID-B", programInstanceService.getProgramInstance( "UID-B" ).getUid() );
+        enrollmentService.addEnrollment( enrollmentA );
+        enrollmentService.addEnrollment( enrollmentB );
+        assertEquals( "UID-A", enrollmentService.getEnrollment( "UID-A" ).getUid() );
+        assertEquals( "UID-B", enrollmentService.getEnrollment( "UID-B" ).getUid() );
     }
 
     @Test
     void testGetProgramInstancesByProgram()
     {
-        programInstanceService.addProgramInstance( enrollmentA );
-        programInstanceService.addProgramInstance( enrollmentB );
-        programInstanceService.addProgramInstance( enrollmentD );
-        List<Enrollment> enrollments = programInstanceService.getProgramInstances( programA );
+        enrollmentService.addEnrollment( enrollmentA );
+        enrollmentService.addEnrollment( enrollmentB );
+        enrollmentService.addEnrollment( enrollmentD );
+        List<Enrollment> enrollments = enrollmentService.getEnrollments( programA );
         assertEquals( 2, enrollments.size() );
         assertTrue( enrollments.contains( enrollmentA ) );
         assertTrue( enrollments.contains( enrollmentD ) );
-        enrollments = programInstanceService.getProgramInstances( programB );
+        enrollments = enrollmentService.getEnrollments( programB );
         assertEquals( 1, enrollments.size() );
         assertTrue( enrollments.contains( enrollmentB ) );
     }
@@ -237,21 +237,21 @@ class ProgramInstanceServiceTest extends TransactionalIntegrationTest
     @Test
     void testGetProgramInstancesByEntityInstanceProgramStatus()
     {
-        programInstanceService.addProgramInstance( enrollmentA );
-        Enrollment enrollment1 = programInstanceService.enrollTrackedEntityInstance( entityInstanceA,
+        enrollmentService.addEnrollment( enrollmentA );
+        Enrollment enrollment1 = enrollmentService.enrollTrackedEntityInstance( entityInstanceA,
             programA, enrollmentDate, incidentDate, organisationUnitA );
         enrollment1.setStatus( ProgramStatus.COMPLETED );
-        programInstanceService.updateProgramInstance( enrollment1 );
-        Enrollment enrollment2 = programInstanceService.enrollTrackedEntityInstance( entityInstanceA,
+        enrollmentService.updateEnrollment( enrollment1 );
+        Enrollment enrollment2 = enrollmentService.enrollTrackedEntityInstance( entityInstanceA,
             programA, enrollmentDate, incidentDate, organisationUnitA );
         enrollment2.setStatus( ProgramStatus.COMPLETED );
-        programInstanceService.updateProgramInstance( enrollment2 );
-        List<Enrollment> enrollments = programInstanceService.getProgramInstances( entityInstanceA, programA,
+        enrollmentService.updateEnrollment( enrollment2 );
+        List<Enrollment> enrollments = enrollmentService.getEnrollments( entityInstanceA, programA,
             ProgramStatus.COMPLETED );
         assertEquals( 2, enrollments.size() );
         assertTrue( enrollments.contains( enrollment1 ) );
         assertTrue( enrollments.contains( enrollment2 ) );
-        enrollments = programInstanceService.getProgramInstances( entityInstanceA, programA,
+        enrollments = enrollmentService.getEnrollments( entityInstanceA, programA,
             ProgramStatus.ACTIVE );
         assertEquals( 1, enrollments.size() );
         assertTrue( enrollments.contains( enrollmentA ) );
@@ -260,11 +260,11 @@ class ProgramInstanceServiceTest extends TransactionalIntegrationTest
     @Test
     void testGetProgramInstancesByOuProgram()
     {
-        programInstanceService.addProgramInstance( enrollmentA );
-        programInstanceService.addProgramInstance( enrollmentC );
-        programInstanceService.addProgramInstance( enrollmentD );
-        List<Enrollment> enrollments = programInstanceService
-            .getProgramInstances( new ProgramInstanceQueryParams().setProgram( programA )
+        enrollmentService.addEnrollment( enrollmentA );
+        enrollmentService.addEnrollment( enrollmentC );
+        enrollmentService.addEnrollment( enrollmentD );
+        List<Enrollment> enrollments = enrollmentService
+            .getEnrollments( new ProgramInstanceQueryParams().setProgram( programA )
                 .setOrganisationUnits( Sets.newHashSet( organisationUnitA ) )
                 .setOrganisationUnitMode( OrganisationUnitSelectionMode.SELECTED ) );
         assertEquals( 1, enrollments.size() );
@@ -274,20 +274,20 @@ class ProgramInstanceServiceTest extends TransactionalIntegrationTest
     @Test
     void testEnrollTrackedEntityInstance()
     {
-        Enrollment enrollment = programInstanceService.enrollTrackedEntityInstance( entityInstanceA, programB,
+        Enrollment enrollment = enrollmentService.enrollTrackedEntityInstance( entityInstanceA, programB,
             enrollmentDate, incidentDate, organisationUnitA );
-        assertNotNull( programInstanceService.getProgramInstance( enrollment.getId() ) );
+        assertNotNull( enrollmentService.getEnrollment( enrollment.getId() ) );
     }
 
     @Test
     void testCompleteProgramInstanceStatus()
     {
-        long idA = programInstanceService.addProgramInstance( enrollmentA );
-        long idD = programInstanceService.addProgramInstance( enrollmentD );
-        programInstanceService.completeProgramInstanceStatus( enrollmentA );
-        programInstanceService.completeProgramInstanceStatus( enrollmentD );
-        assertEquals( ProgramStatus.COMPLETED, programInstanceService.getProgramInstance( idA ).getStatus() );
-        assertEquals( ProgramStatus.COMPLETED, programInstanceService.getProgramInstance( idD ).getStatus() );
+        long idA = enrollmentService.addEnrollment( enrollmentA );
+        long idD = enrollmentService.addEnrollment( enrollmentD );
+        enrollmentService.completeEnrollmentStatus( enrollmentA );
+        enrollmentService.completeEnrollmentStatus( enrollmentD );
+        assertEquals( ProgramStatus.COMPLETED, enrollmentService.getEnrollment( idA ).getStatus() );
+        assertEquals( ProgramStatus.COMPLETED, enrollmentService.getEnrollment( idD ).getStatus() );
     }
 
     @Test
@@ -295,22 +295,22 @@ class ProgramInstanceServiceTest extends TransactionalIntegrationTest
     {
         enrollmentA.setStatus( ProgramStatus.COMPLETED );
         enrollmentD.setStatus( ProgramStatus.COMPLETED );
-        long idA = programInstanceService.addProgramInstance( enrollmentA );
-        long idD = programInstanceService.addProgramInstance( enrollmentD );
-        programInstanceService.incompleteProgramInstanceStatus( enrollmentA );
-        programInstanceService.incompleteProgramInstanceStatus( enrollmentD );
-        assertEquals( ProgramStatus.ACTIVE, programInstanceService.getProgramInstance( idA ).getStatus() );
-        assertEquals( ProgramStatus.ACTIVE, programInstanceService.getProgramInstance( idD ).getStatus() );
+        long idA = enrollmentService.addEnrollment( enrollmentA );
+        long idD = enrollmentService.addEnrollment( enrollmentD );
+        enrollmentService.incompleteEnrollmentStatus( enrollmentA );
+        enrollmentService.incompleteEnrollmentStatus( enrollmentD );
+        assertEquals( ProgramStatus.ACTIVE, enrollmentService.getEnrollment( idA ).getStatus() );
+        assertEquals( ProgramStatus.ACTIVE, enrollmentService.getEnrollment( idD ).getStatus() );
     }
 
     @Test
     void testCancelProgramInstanceStatus()
     {
-        long idA = programInstanceService.addProgramInstance( enrollmentA );
-        long idD = programInstanceService.addProgramInstance( enrollmentD );
-        programInstanceService.cancelProgramInstanceStatus( enrollmentA );
-        programInstanceService.cancelProgramInstanceStatus( enrollmentD );
-        assertEquals( ProgramStatus.CANCELLED, programInstanceService.getProgramInstance( idA ).getStatus() );
-        assertEquals( ProgramStatus.CANCELLED, programInstanceService.getProgramInstance( idD ).getStatus() );
+        long idA = enrollmentService.addEnrollment( enrollmentA );
+        long idD = enrollmentService.addEnrollment( enrollmentD );
+        enrollmentService.cancelEnrollmentStatus( enrollmentA );
+        enrollmentService.cancelEnrollmentStatus( enrollmentD );
+        assertEquals( ProgramStatus.CANCELLED, enrollmentService.getEnrollment( idA ).getStatus() );
+        assertEquals( ProgramStatus.CANCELLED, enrollmentService.getEnrollment( idD ).getStatus() );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventServiceTest.java
@@ -81,7 +81,7 @@ class EventServiceTest extends TransactionalIntegrationTest
     private TrackedEntityInstanceService entityInstanceService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private TrackedEntityAttributeService attributeService;
@@ -225,9 +225,9 @@ class EventServiceTest extends TransactionalIntegrationTest
         enrollmentDate = testDate2.toDate();
         enrollmentA = new Enrollment( enrollmentDate, incidenDate, entityInstanceA, programA );
         enrollmentA.setUid( "UID-PIA" );
-        programInstanceService.addProgramInstance( enrollmentA );
+        enrollmentService.addEnrollment( enrollmentA );
         enrollmentB = new Enrollment( enrollmentDate, incidenDate, entityInstanceB, programB );
-        programInstanceService.addProgramInstance( enrollmentB );
+        enrollmentService.addEnrollment( enrollmentB );
         eventA = new Event( enrollmentA, stageA );
         eventA.setDueDate( enrollmentDate );
         eventA.setUid( "UID-A" );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventStoreTest.java
@@ -87,7 +87,7 @@ class EventStoreTest extends TransactionalIntegrationTest
     private DbmsManager dbmsManager;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private IdentifiableObjectManager idObjectManager;
@@ -207,9 +207,9 @@ class EventStoreTest extends TransactionalIntegrationTest
         enrollmentDate = testDate2.toDate();
         enrollmentA = new Enrollment( enrollmentDate, incidenDate, entityInstanceA, programA );
         enrollmentA.setUid( "UID-PIA" );
-        programInstanceService.addProgramInstance( enrollmentA );
+        enrollmentService.addEnrollment( enrollmentA );
         enrollmentB = new Enrollment( enrollmentDate, incidenDate, entityInstanceB, programB );
-        programInstanceService.addProgramInstance( enrollmentB );
+        enrollmentService.addEnrollment( enrollmentB );
         eventA = new Event( enrollmentA, stageA );
         eventA.setDueDate( enrollmentDate );
         eventA.setUid( "UID-A" );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceTest.java
@@ -92,7 +92,7 @@ class ProgramIndicatorServiceTest extends TransactionalIntegrationTest
     private ProgramStageService programStageService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private DataElementService dataElementService;
@@ -248,11 +248,11 @@ class ProgramIndicatorServiceTest extends TransactionalIntegrationTest
         entityInstanceService.addTrackedEntityInstance( entityInstance );
         incidentDate = DateUtils.getMediumDate( "2014-10-22" );
         enrollmentDate = DateUtils.getMediumDate( "2014-12-31" );
-        enrollment = programInstanceService.enrollTrackedEntityInstance( entityInstance, programA, enrollmentDate,
+        enrollment = enrollmentService.enrollTrackedEntityInstance( entityInstance, programA, enrollmentDate,
             incidentDate, organisationUnit );
         incidentDate = DateUtils.getMediumDate( "2014-10-22" );
         enrollmentDate = DateUtils.getMediumDate( "2014-12-31" );
-        enrollment = programInstanceService.enrollTrackedEntityInstance( entityInstance, programA, enrollmentDate,
+        enrollment = enrollmentService.enrollTrackedEntityInstance( entityInstance, programA, enrollmentDate,
             incidentDate, organisationUnit );
         // TODO enroll twice?
         // ---------------------------------------------------------------------

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramMessageServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramMessageServiceTest.java
@@ -118,7 +118,7 @@ class ProgramMessageServiceTest extends TransactionalIntegrationTest
     private TrackedEntityInstanceService teiService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private ProgramService programService;
@@ -150,7 +150,7 @@ class ProgramMessageServiceTest extends TransactionalIntegrationTest
         piA.setName( "programInstanceA" );
         piA.setEnrollmentDate( new Date() );
         piA.setAutoFields();
-        programInstanceService.addProgramInstance( piA );
+        enrollmentService.addEnrollment( piA );
         Set<OrganisationUnit> ouSet = new HashSet<>();
         ouSet.add( ouA );
         Set<String> ouUids = new HashSet<>();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/programrule/engine/ProgramNotificationInstanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/programrule/engine/ProgramNotificationInstanceServiceTest.java
@@ -37,8 +37,8 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.notification.NotificationTrigger;
 import org.hisp.dhis.program.notification.ProgramNotificationInstance;
@@ -79,7 +79,7 @@ class ProgramNotificationInstanceServiceTest extends IntegrationTestBase
     private Enrollment enrollmentB;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private ProgramService programService;
@@ -127,9 +127,9 @@ class ProgramNotificationInstanceServiceTest extends IntegrationTestBase
         programRule.getProgramRuleActions().add( programRuleAction );
         manager.update( programRule );
         enrollment = createProgramInstance( program, trackedEntityInstance, organisationUnit );
-        programInstanceService.addProgramInstance( enrollment );
+        enrollmentService.addEnrollment( enrollment );
         enrollmentB = createProgramInstance( program, trackedEntityInstance, organisationUnit );
-        programInstanceService.addProgramInstance( enrollmentB );
+        enrollmentService.addEnrollment( enrollmentB );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineTest.java
@@ -51,10 +51,10 @@ import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
@@ -194,7 +194,7 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
     private ProgramRuleVariableService programRuleVariableService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private TrackedEntityInstanceService entityInstanceService;
@@ -290,7 +290,7 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
     void testSendMessageForEnrollment()
     {
         ProgramRule programRule = setUpSendMessageForEnrollment();
-        Enrollment enrollment = programInstanceService.getProgramInstance( "UID-P1" );
+        Enrollment enrollment = enrollmentService.getEnrollment( "UID-P1" );
         List<RuleEffect> ruleEffects = programRuleEngine.evaluate( enrollment, Sets.newHashSet(),
             List.of( programRule ) );
         assertEquals( 1, ruleEffects.size() );
@@ -304,7 +304,7 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
     void testSendMessageForEnrollmentAndEvents()
     {
         ProgramRule programRule = setUpSendMessageForEnrollment();
-        Enrollment enrollment = programInstanceService.getProgramInstance( "UID-P1" );
+        Enrollment enrollment = enrollmentService.getEnrollment( "UID-P1" );
         List<RuleEffects> ruleEffects = programRuleEngine.evaluateEnrollmentAndEvents( enrollment,
             Sets.newHashSet(), Lists.newArrayList() );
         assertEquals( 1, ruleEffects.size() );
@@ -321,7 +321,7 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
     void testNotificationWhenUsingD2HasValueWithTEA()
     {
         ProgramRule programRule = setUpNotificationForD2HasValue();
-        Enrollment enrollment = programInstanceService.getProgramInstance( "UID-P2" );
+        Enrollment enrollment = enrollmentService.getEnrollment( "UID-P2" );
         List<RuleEffect> ruleEffects = programRuleEngine.evaluate( enrollment, Sets.newHashSet(),
             List.of( programRule ) );
         assertEquals( 1, ruleEffects.size() );
@@ -340,7 +340,7 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
     void testNotificationWhenUsingD2HasValueWithTEAForEnrollmentAndEvents()
     {
         setUpNotificationForD2HasValue();
-        Enrollment enrollment = programInstanceService.getProgramInstance( "UID-P2" );
+        Enrollment enrollment = enrollmentService.getEnrollment( "UID-P2" );
         List<RuleEffects> ruleEffects = programRuleEngine.evaluateEnrollmentAndEvents( enrollment,
             Sets.newHashSet(), Lists.newArrayList() );
         assertEquals( 1, ruleEffects.size() );
@@ -405,7 +405,7 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
     void testSchedulingByProgramRule()
     {
         setUpScheduleMessage();
-        Enrollment enrollment = programInstanceService.getProgramInstance( "UID-PS" );
+        Enrollment enrollment = enrollmentService.getEnrollment( "UID-PS" );
         List<RuleEffect> ruleEffects = programRuleEngineService
             .evaluateEnrollmentAndRunEffects( enrollment.getId() );
         assertEquals( 1, ruleEffects.size() );
@@ -431,7 +431,7 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
     {
         setUpScheduleMessage();
         pnt.setSendRepeatable( true );
-        Enrollment enrollment = programInstanceService.getProgramInstance( "UID-PS" );
+        Enrollment enrollment = enrollmentService.getEnrollment( "UID-PS" );
         List<RuleEffect> ruleEffects = programRuleEngineService
             .evaluateEnrollmentAndRunEffects( enrollment.getId() );
         assertEquals( 1, ruleEffects.size() );
@@ -629,18 +629,18 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
         DateTime testDate2 = DateTime.now();
         testDate2.withTimeAtStartOfDay();
         Date enrollmentDate = testDate2.toDate();
-        Enrollment enrollmentA = programInstanceService.enrollTrackedEntityInstance( entityInstanceA,
+        Enrollment enrollmentA = enrollmentService.enrollTrackedEntityInstance( entityInstanceA,
             programA, enrollmentDate, incidentDate, organisationUnitA );
         enrollmentA.setUid( "UID-P1" );
-        programInstanceService.updateProgramInstance( enrollmentA );
-        Enrollment enrollmentE = programInstanceService.enrollTrackedEntityInstance( entityInstanceE,
+        enrollmentService.updateEnrollment( enrollmentA );
+        Enrollment enrollmentE = enrollmentService.enrollTrackedEntityInstance( entityInstanceE,
             programB, enrollmentDate, incidentDate, organisationUnitA );
         enrollmentE.setUid( "UID-P2" );
-        programInstanceService.updateProgramInstance( enrollmentE );
-        Enrollment enrollmentS = programInstanceService.enrollTrackedEntityInstance( entityInstanceS,
+        enrollmentService.updateEnrollment( enrollmentE );
+        Enrollment enrollmentS = enrollmentService.enrollTrackedEntityInstance( entityInstanceS,
             programS, enrollmentDate, incidentDate, organisationUnitB );
         enrollmentS.setUid( "UID-PS" );
-        programInstanceService.updateProgramInstance( enrollmentS );
+        enrollmentService.updateEnrollment( enrollmentS );
         Event eventA = new Event( enrollmentA, programStageA );
         eventA.setDueDate( enrollmentDate );
         eventA.setExecutionDate( new Date() );
@@ -685,7 +685,7 @@ class ProgramRuleEngineTest extends TransactionalIntegrationTest
         eventService.addEvent( eventC );
         enrollmentA.getEvents().addAll( Sets.newHashSet( eventA,
             eventB, eventC, eventAge ) );
-        programInstanceService.updateProgramInstance( enrollmentA );
+        enrollmentService.updateEnrollment( enrollmentA );
     }
 
     private void setupProgramRuleEngine()

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/relationship/hibernate/RelationshipStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/relationship/hibernate/RelationshipStoreTest.java
@@ -43,10 +43,10 @@ import org.hisp.dhis.commons.util.RelationshipUtils;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageService;
@@ -83,7 +83,7 @@ class RelationshipStoreTest extends TransactionalIntegrationTest
     private ProgramService programService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private ProgramStageService programStageService;
@@ -297,7 +297,7 @@ class RelationshipStoreTest extends TransactionalIntegrationTest
         enrollment.setEnrollmentDate( new Date() );
         enrollment.setIncidentDate( new Date() );
         enrollment.setStatus( ProgramStatus.ACTIVE );
-        programInstanceService.addProgramInstance( enrollment );
+        enrollmentService.addEnrollment( enrollment );
         return enrollment;
     }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityDataValueAuditStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityDataValueAuditStoreTest.java
@@ -44,10 +44,10 @@ import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageService;
@@ -86,7 +86,7 @@ class TrackedEntityDataValueAuditStoreTest extends SingleSetupIntegrationTestBas
     private ProgramStageService programStageService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private EventService eventService;
@@ -165,7 +165,7 @@ class TrackedEntityDataValueAuditStoreTest extends SingleSetupIntegrationTestBas
         TrackedEntityInstance teiA = createTrackedEntityInstance( ouA );
         entityInstanceService.addTrackedEntityInstance( teiA );
 
-        Enrollment piA = programInstanceService.enrollTrackedEntityInstance(
+        Enrollment piA = enrollmentService.enrollTrackedEntityInstance(
             teiA, pA, new Date(), new Date(), ouA );
 
         dvA = new EventDataValue( deA.getUid(), "A", USER_SNAP_A );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceServiceTest.java
@@ -44,10 +44,10 @@ import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageService;
@@ -85,7 +85,7 @@ class TrackedEntityInstanceServiceTest
     private EventService eventService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private TrackedEntityAttributeService attributeService;
@@ -224,21 +224,21 @@ class TrackedEntityInstanceServiceTest
     void testDeleteTrackedEntityInstanceAndLinkedEnrollmentsAndEvents()
     {
         long idA = entityInstanceService.addTrackedEntityInstance( entityInstanceA1 );
-        long psIdA = programInstanceService.addProgramInstance( enrollment );
+        long psIdA = enrollmentService.addEnrollment( enrollment );
         long eventIdA = eventService.addEvent( event );
         enrollment.setEvents( Set.of( event ) );
         entityInstanceA1.setEnrollments( Set.of( enrollment ) );
-        programInstanceService.updateProgramInstance( enrollment );
+        enrollmentService.updateEnrollment( enrollment );
         entityInstanceService.updateTrackedEntityInstance( entityInstanceA1 );
         TrackedEntityInstance teiA = entityInstanceService.getTrackedEntityInstance( idA );
-        Enrollment psA = programInstanceService.getProgramInstance( psIdA );
+        Enrollment psA = enrollmentService.getEnrollment( psIdA );
         Event eventA = eventService.getEvent( eventIdA );
         assertNotNull( teiA );
         assertNotNull( psA );
         assertNotNull( eventA );
         entityInstanceService.deleteTrackedEntityInstance( entityInstanceA1 );
         assertNull( entityInstanceService.getTrackedEntityInstance( teiA.getUid() ) );
-        assertNull( programInstanceService.getProgramInstance( psIdA ) );
+        assertNull( enrollmentService.getEnrollment( psIdA ) );
         assertNull( eventService.getEvent( eventIdA ) );
     }
 
@@ -437,7 +437,7 @@ class TrackedEntityInstanceServiceTest
         injectSecurityContext( superUser );
 
         addEntityInstances();
-        programInstanceService.addProgramInstance( enrollment );
+        enrollmentService.addEnrollment( enrollment );
         addEnrollment( entityInstanceB1, DateTime.now().plusDays( 2 ).toDate(), 'B' );
         addEnrollment( entityInstanceC1, DateTime.now().minusDays( 2 ).toDate(), 'C' );
         addEnrollment( entityInstanceD1, DateTime.now().plusDays( 1 ).toDate(), 'D' );
@@ -463,7 +463,7 @@ class TrackedEntityInstanceServiceTest
         entityInstanceD1.setInactive( false );
         addEntityInstances();
 
-        programInstanceService.addProgramInstance( enrollment );
+        enrollmentService.addEnrollment( enrollment );
         addEnrollment( entityInstanceB1, DateTime.now().plusDays( 2 ).toDate(), 'B' );
         addEnrollment( entityInstanceC1, DateTime.now().minusDays( 2 ).toDate(), 'C' );
         addEnrollment( entityInstanceD1, DateTime.now().plusDays( 1 ).toDate(), 'D' );
@@ -710,7 +710,7 @@ class TrackedEntityInstanceServiceTest
         enrollment.setUid( "UID-PSI-" + programStage );
         enrollment.setOrganisationUnit( organisationUnit );
 
-        programInstanceService.addProgramInstance( enrollment );
+        enrollmentService.addEnrollment( enrollment );
     }
 
     private void addEntityInstances()

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceStoreTest.java
@@ -50,8 +50,8 @@ import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
@@ -80,7 +80,7 @@ class TrackedEntityInstanceStoreTest extends TransactionalIntegrationTest
     private TrackedEntityTypeService trackedEntityTypeService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private TrackedEntityAttributeService trackedEntityAttributeService;
@@ -214,8 +214,8 @@ class TrackedEntityInstanceStoreTest extends TransactionalIntegrationTest
         attributeValueService.addTrackedEntityAttributeValue( new TrackedEntityAttributeValue( atA, teiD, "Male" ) );
         attributeValueService.addTrackedEntityAttributeValue( new TrackedEntityAttributeValue( atA, teiE, "Male" ) );
         attributeValueService.addTrackedEntityAttributeValue( new TrackedEntityAttributeValue( atA, teiF, "Female" ) );
-        programInstanceService.enrollTrackedEntityInstance( teiB, prA, new Date(), new Date(), ouB );
-        programInstanceService.enrollTrackedEntityInstance( teiE, prA, new Date(), new Date(), ouB );
+        enrollmentService.enrollTrackedEntityInstance( teiB, prA, new Date(), new Date(), ouB );
+        enrollmentService.enrollTrackedEntityInstance( teiE, prA, new Date(), new Date(), ouB );
         // Get all
         TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
         List<TrackedEntityInstance> teis = teiStore.getTrackedEntityInstances( params );
@@ -314,8 +314,8 @@ class TrackedEntityInstanceStoreTest extends TransactionalIntegrationTest
         attributeValueService.addTrackedEntityAttributeValue( new TrackedEntityAttributeValue( atA, teiD, "Male" ) );
         attributeValueService.addTrackedEntityAttributeValue( new TrackedEntityAttributeValue( atA, teiE, "Male" ) );
         attributeValueService.addTrackedEntityAttributeValue( new TrackedEntityAttributeValue( atA, teiF, "Female" ) );
-        programInstanceService.enrollTrackedEntityInstance( teiB, prA, new Date(), new Date(), ouB );
-        programInstanceService.enrollTrackedEntityInstance( teiE, prA, new Date(), new Date(), ouB );
+        enrollmentService.enrollTrackedEntityInstance( teiB, prA, new Date(), new Date(), ouB );
+        enrollmentService.enrollTrackedEntityInstance( teiE, prA, new Date(), new Date(), ouB );
         TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
         List<TrackedEntityInstance> teis = teiStore.getTrackedEntityInstances( params );
         assertEquals( 6, teis.size() );
@@ -351,8 +351,8 @@ class TrackedEntityInstanceStoreTest extends TransactionalIntegrationTest
         attributeValueService.addTrackedEntityAttributeValue( new TrackedEntityAttributeValue( atA, teiD, "Male" ) );
         attributeValueService.addTrackedEntityAttributeValue( new TrackedEntityAttributeValue( atA, teiE, "Male" ) );
         attributeValueService.addTrackedEntityAttributeValue( new TrackedEntityAttributeValue( atA, teiF, "Female" ) );
-        programInstanceService.enrollTrackedEntityInstance( teiB, prA, new Date(), new Date(), ouB );
-        programInstanceService.enrollTrackedEntityInstance( teiE, prA, new Date(), new Date(), ouB );
+        enrollmentService.enrollTrackedEntityInstance( teiB, prA, new Date(), new Date(), ouB );
+        enrollmentService.enrollTrackedEntityInstance( teiE, prA, new Date(), new Date(), ouB );
         TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
         List<TrackedEntityInstance> teis = teiStore.getTrackedEntityInstances( params );
         assertEquals( 6, teis.size() );
@@ -393,7 +393,7 @@ class TrackedEntityInstanceStoreTest extends TransactionalIntegrationTest
         teiB.setCreated( today );
         teiStore.save( teiA );
         teiStore.save( teiB );
-        programInstanceService.enrollTrackedEntityInstance( teiB, prA, new Date(), new Date(), ouB );
+        enrollmentService.enrollTrackedEntityInstance( teiB, prA, new Date(), new Date(), ouB );
         // Get all
         TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
         params.setOrders(
@@ -449,7 +449,7 @@ class TrackedEntityInstanceStoreTest extends TransactionalIntegrationTest
         teiStore.save( teiA );
         attributeValueService
             .addTrackedEntityAttributeValue( new TrackedEntityAttributeValue( atC, teiA, ouC.getUid() ) );
-        programInstanceService.enrollTrackedEntityInstance( teiA, prA, new Date(), new Date(), ouA );
+        enrollmentService.enrollTrackedEntityInstance( teiA, prA, new Date(), new Date(), ouA );
         TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
         params.setTrackedEntityType( trackedEntityTypeA );
         params.setOrganisationUnitMode( OrganisationUnitSelectionMode.ALL );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackerAccessManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackerAccessManagerTest.java
@@ -46,9 +46,9 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.program.ProgramStageDataElementService;
@@ -84,7 +84,7 @@ class TrackerAccessManagerTest extends TransactionalIntegrationTest
     private ProgramStageDataElementService programStageDataElementService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private IdentifiableObjectManager manager;
@@ -168,7 +168,7 @@ class TrackerAccessManagerTest extends TransactionalIntegrationTest
         manager.save( femaleA );
         manager.save( femaleB );
 
-        Enrollment enrollmentA = programInstanceService.enrollTrackedEntityInstance( trackedEntityA, programA,
+        Enrollment enrollmentA = enrollmentService.enrollTrackedEntityInstance( trackedEntityA, programA,
             new Date(),
             new Date(),
             orgUnitA );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentityinstance/TrackedEntityInstanceQueryLimitTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentityinstance/TrackedEntityInstanceQueryLimitTest.java
@@ -39,8 +39,8 @@ import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
@@ -74,7 +74,7 @@ class TrackedEntityInstanceQueryLimitTest extends SingleSetupIntegrationTestBase
     private ProgramService programService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private SystemSettingManager systemSettingManager;
@@ -143,15 +143,15 @@ class TrackedEntityInstanceQueryLimitTest extends SingleSetupIntegrationTestBase
         pi3 = createProgramInstance( program, tei3, orgUnitA );
         pi4 = createProgramInstance( program, tei4, orgUnitA );
 
-        programInstanceService.addProgramInstance( pi1 );
-        programInstanceService.addProgramInstance( pi2 );
-        programInstanceService.addProgramInstance( pi3 );
-        programInstanceService.addProgramInstance( pi4 );
+        enrollmentService.addEnrollment( pi1 );
+        enrollmentService.addEnrollment( pi2 );
+        enrollmentService.addEnrollment( pi3 );
+        enrollmentService.addEnrollment( pi4 );
 
-        programInstanceService.enrollTrackedEntityInstance( tei1, program, new Date(), new Date(), orgUnitA );
-        programInstanceService.enrollTrackedEntityInstance( tei2, program, new Date(), new Date(), orgUnitA );
-        programInstanceService.enrollTrackedEntityInstance( tei3, program, new Date(), new Date(), orgUnitA );
-        programInstanceService.enrollTrackedEntityInstance( tei4, program, new Date(), new Date(), orgUnitA );
+        enrollmentService.enrollTrackedEntityInstance( tei1, program, new Date(), new Date(), orgUnitA );
+        enrollmentService.enrollTrackedEntityInstance( tei2, program, new Date(), new Date(), orgUnitA );
+        enrollmentService.enrollTrackedEntityInstance( tei3, program, new Date(), new Date(), orgUnitA );
+        enrollmentService.enrollTrackedEntityInstance( tei4, program, new Date(), new Date(), orgUnitA );
 
         userService.addUser( user );
     }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -47,10 +47,10 @@ import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.commons.util.RelationshipUtils;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstanceQueryParams;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.relationship.Relationship;
@@ -71,13 +71,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 class EnrollmentServiceTest extends TransactionalIntegrationTest
 {
     @Autowired
-    private EnrollmentService enrollmentService;
+    private org.hisp.dhis.tracker.export.enrollment.EnrollmentService enrollmentService;
 
     @Autowired
     protected UserService _userService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService programInstanceService;
 
     @Autowired
     private IdentifiableObjectManager manager;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipServiceTest.java
@@ -42,9 +42,9 @@ import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.relationship.Relationship;
@@ -68,7 +68,7 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase
     protected UserService _userService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private RelationshipService relationshipService;
@@ -147,7 +147,7 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase
         program.setProgramStages( Set.of( programStage, inaccessibleProgramStage ) );
         manager.save( program, false );
 
-        enrollmentA = programInstanceService.enrollTrackedEntityInstance( teiA, program, new Date(), new Date(),
+        enrollmentA = enrollmentService.enrollTrackedEntityInstance( teiA, program, new Date(), new Date(),
             orgUnit );
         eventA = new Event();
         eventA.setEnrollment( enrollmentA );
@@ -155,7 +155,7 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase
         eventA.setOrganisationUnit( orgUnit );
         manager.save( eventA, false );
 
-        Enrollment enrollmentB = programInstanceService.enrollTrackedEntityInstance( teiB, program, new Date(),
+        Enrollment enrollmentB = enrollmentService.enrollTrackedEntityInstance( teiB, program, new Date(),
             new Date(),
             orgUnit );
         inaccessiblePsi = new Event();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -66,10 +66,10 @@ import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
@@ -108,7 +108,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase
     protected UserService _userService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private EventService eventService;
@@ -253,7 +253,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase
         trackedEntityA.setTrackedEntityType( trackedEntityTypeA );
         manager.save( trackedEntityA, false );
 
-        enrollmentA = programInstanceService.enrollTrackedEntityInstance( trackedEntityA, programA, new Date(),
+        enrollmentA = enrollmentService.enrollTrackedEntityInstance( trackedEntityA, programA, new Date(),
             new Date(), orgUnitA );
         eventA = new Event();
         eventA.setEnrollment( enrollmentA );
@@ -274,7 +274,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase
         enrollmentA.setFollowup( true );
         manager.save( enrollmentA, false );
 
-        enrollmentB = programInstanceService.enrollTrackedEntityInstance( trackedEntityA, programB, new Date(),
+        enrollmentB = enrollmentService.enrollTrackedEntityInstance( trackedEntityA, programB, new Date(),
             new Date(), orgUnitA );
         eventB = new Event();
         eventB.setEnrollment( enrollmentB );
@@ -633,7 +633,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase
             .collect( Collectors.toSet() );
         assertIsEmpty( deletedEvents );
 
-        programInstanceService.deleteProgramInstance( enrollmentA );
+        enrollmentService.deleteEnrollment( enrollmentA );
         eventService.deleteEvent( eventA );
 
         trackedEntities = trackedEntityService.getTrackedEntities( queryParams, TrackedEntityParams.TRUE );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentImportValidationTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
-import org.hisp.dhis.program.ProgramInstanceService;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
@@ -59,7 +59,7 @@ class EnrollmentImportValidationTest extends TrackerTest
 {
 
     @Autowired
-    protected ProgramInstanceService programInstanceService;
+    protected EnrollmentService enrollmentService;
 
     @Autowired
     private TrackerImportService trackerImportService;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventSecurityImportValidationTest.java
@@ -45,10 +45,10 @@ import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
@@ -100,7 +100,7 @@ class EventSecurityImportValidationTest extends TrackerTest
     private TrackedEntityTypeService trackedEntityTypeService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private OrganisationUnitService organisationUnitService;
@@ -207,9 +207,9 @@ class EventSecurityImportValidationTest extends TrackerTest
         int testYear = Calendar.getInstance().get( Calendar.YEAR ) - 1;
         Date dateMar20 = getDate( testYear, 3, 20 );
         Date dateApr10 = getDate( testYear, 4, 10 );
-        Enrollment enrollment = programInstanceService.enrollTrackedEntityInstance( maleA, programA,
+        Enrollment enrollment = enrollmentService.enrollTrackedEntityInstance( maleA, programA,
             dateMar20, dateApr10, organisationUnitA, "MNWZ6hnuhSX" );
-        programInstanceService.addProgramInstance( enrollment );
+        enrollmentService.addEnrollment( enrollment );
         trackedEntityProgramOwnerService.updateTrackedEntityProgramOwner( maleA.getUid(), programA.getUid(),
             organisationUnitA.getUid() );
         manager.update( programA );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/AnalyticsValidationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/AnalyticsValidationServiceTest.java
@@ -71,12 +71,12 @@ import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramIndicatorService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageService;
@@ -116,7 +116,7 @@ class AnalyticsValidationServiceTest extends TransactionalIntegrationTest
     private ProgramService programService;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private ProgramStageService programStageService;
@@ -246,9 +246,9 @@ class AnalyticsValidationServiceTest extends TransactionalIntegrationTest
         program.setProgramStages( Sets.newHashSet( stageA ) );
         program.getProgramIndicators().add( programIndicator );
         programService.updateProgram( program );
-        Enrollment enrollment = programInstanceService.enrollTrackedEntityInstance( entityInstance, program,
+        Enrollment enrollment = enrollmentService.enrollTrackedEntityInstance( entityInstance, program,
             dateMar20, dateMar20, orgUnitA );
-        programInstanceService.addProgramInstance( enrollment );
+        enrollmentService.addEnrollment( enrollment );
         Event stageInstanceA = eventService.createEvent( enrollment,
             stageA, dateMar20, dateMar20, orgUnitA );
         Event stageInstanceB = eventService.createEvent( enrollment,

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/ProgramMessageControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/ProgramMessageControllerTest.java
@@ -35,8 +35,8 @@ import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.web.HttpStatus;
@@ -61,7 +61,7 @@ class ProgramMessageControllerTest extends DhisControllerConvenienceTest
     private TrackedEntityInstanceService teiService;
 
     @Autowired
-    private ProgramInstanceService piService;
+    private EnrollmentService piService;
 
     @Autowired
     private IdentifiableObjectManager idObjectManager;
@@ -78,7 +78,7 @@ class ProgramMessageControllerTest extends DhisControllerConvenienceTest
         TrackedEntityInstance teiA = createTrackedEntityInstance( 'A', ouA );
         teiService.addTrackedEntityInstance( teiA );
         piA = createProgramInstance( prA, teiA, ouA );
-        piService.addProgramInstance( piA );
+        piService.addEnrollment( piA );
     }
 
     @Test

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -50,9 +50,9 @@ import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.relationship.Relationship;
@@ -93,7 +93,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
     private IdentifiableObjectManager manager;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     private OrganisationUnit orgUnit;
 
@@ -251,7 +251,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
         TrackedEntityInstance trackedEntity = trackedEntityInstance();
         trackedEntity.setTrackedEntityAttributeValues(
             Set.of( attributeValue( tea, trackedEntity, "12" ), attributeValue( tea2, trackedEntity, "24" ) ) );
-        programInstanceService.enrollTrackedEntityInstance( trackedEntity, program, new Date(), new Date(), orgUnit );
+        enrollmentService.enrollTrackedEntityInstance( trackedEntity, program, new Date(), new Date(), orgUnit );
 
         JsonList<JsonAttribute> attributes = GET( "/tracker/trackedEntities/{id}?fields=attributes[attribute,value]",
             trackedEntity.getUid() )
@@ -270,7 +270,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
         TrackedEntityInstance trackedEntity = trackedEntityInstance();
         trackedEntity.setTrackedEntityAttributeValues(
             Set.of( attributeValue( tea, trackedEntity, "12" ), attributeValue( tea2, trackedEntity, "24" ) ) );
-        programInstanceService.enrollTrackedEntityInstance( trackedEntity, program, new Date(), new Date(), orgUnit );
+        enrollmentService.enrollTrackedEntityInstance( trackedEntity, program, new Date(), new Date(), orgUnit );
 
         JsonList<JsonAttribute> attributes = GET(
             "/tracker/trackedEntities/{id}?program={id}&fields=attributes[attribute,value]", trackedEntity.getUid(),
@@ -422,7 +422,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
     void shouldGetEnrollmentWhenFieldsHasEnrollments()
     {
         TrackedEntityInstance trackedEntityInstance = trackedEntityInstance();
-        Enrollment programInstance = programInstanceService.enrollTrackedEntityInstance( trackedEntityInstance,
+        Enrollment programInstance = enrollmentService.enrollTrackedEntityInstance( trackedEntityInstance,
             program, new Date(), new Date(), orgUnit );
 
         JsonList<JsonEnrollment> json = GET( "/tracker/trackedEntities/{id}?fields=enrollments",
@@ -441,7 +441,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
     {
         TrackedEntityInstance trackedEntityInstance = trackedEntityInstance();
 
-        Enrollment programInstance = programInstanceService.enrollTrackedEntityInstance( trackedEntityInstance,
+        Enrollment programInstance = enrollmentService.enrollTrackedEntityInstance( trackedEntityInstance,
             program, new Date(), new Date(), orgUnit );
 
         Event event = eventWithDataValue( programInstance );
@@ -467,7 +467,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
     {
         TrackedEntityInstance trackedEntityInstance = trackedEntityInstance();
 
-        Enrollment programInstance = programInstanceService.enrollTrackedEntityInstance( trackedEntityInstance,
+        Enrollment programInstance = enrollmentService.enrollTrackedEntityInstance( trackedEntityInstance,
             program, new Date(), new Date(), orgUnit );
 
         Event event = eventWithDataValue( programInstance );
@@ -498,7 +498,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
     {
         TrackedEntityInstance trackedEntityInstance = trackedEntityInstance();
 
-        Enrollment programInstance = programInstanceService.enrollTrackedEntityInstance( trackedEntityInstance,
+        Enrollment programInstance = enrollmentService.enrollTrackedEntityInstance( trackedEntityInstance,
             program, new Date(), new Date(), orgUnit );
 
         Event event = eventWithDataValue( programInstance );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
@@ -54,7 +54,6 @@ import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.events.EnrollmentParams;
 import org.hisp.dhis.dxf2.events.enrollment.Enrollment;
-import org.hisp.dhis.dxf2.events.enrollment.EnrollmentService;
 import org.hisp.dhis.dxf2.events.enrollment.Enrollments;
 import org.hisp.dhis.dxf2.events.enrollment.ImportEnrollmentsTask;
 import org.hisp.dhis.dxf2.importsummary.ImportStatus;
@@ -68,8 +67,8 @@ import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.node.NodeUtils;
 import org.hisp.dhis.node.types.RootNode;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.ProgramInstanceQueryParams;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.webapi.controller.event.webrequest.EnrollmentCriteria;
@@ -107,13 +106,13 @@ public class EnrollmentController
     private CurrentUserService currentUserService;
 
     @Autowired
-    private EnrollmentService enrollmentService;
+    private org.hisp.dhis.dxf2.events.enrollment.EnrollmentService enrollmentService;
 
     @Autowired
     private AsyncTaskExecutor taskExecutor;
 
     @Autowired
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService programInstanceService;
 
     @Autowired
     protected FieldFilterService fieldFilterService;
@@ -342,7 +341,7 @@ public class EnrollmentController
     @ResponseBody
     public WebMessage cancelEnrollment( @PathVariable String id )
     {
-        if ( !programInstanceService.programInstanceExists( id ) )
+        if ( !programInstanceService.enrollmentExists( id ) )
         {
             return notFound( "Enrollment not found for ID " + id );
         }
@@ -356,7 +355,7 @@ public class EnrollmentController
     @ResponseBody
     public WebMessage completeEnrollment( @PathVariable String id )
     {
-        if ( !programInstanceService.programInstanceExists( id ) )
+        if ( !programInstanceService.enrollmentExists( id ) )
         {
             return notFound( "Enrollment not found for ID " + id );
         }
@@ -370,7 +369,7 @@ public class EnrollmentController
     @ResponseBody
     public WebMessage incompleteEnrollment( @PathVariable String id )
     {
-        if ( !programInstanceService.programInstanceExists( id ) )
+        if ( !programInstanceService.enrollmentExists( id ) )
         {
             return notFound( "Enrollment not found for ID " + id );
         }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceController.java
@@ -32,8 +32,8 @@ import java.util.List;
 
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.program.notification.ProgramNotificationInstance;
 import org.hisp.dhis.program.notification.ProgramNotificationInstanceParam;
 import org.hisp.dhis.program.notification.ProgramNotificationInstanceService;
@@ -58,17 +58,17 @@ public class ProgramNotificationInstanceController
 {
     private final ProgramNotificationInstanceService programNotificationInstanceService;
 
-    private final ProgramInstanceService programInstanceService;
+    private final EnrollmentService enrollmentService;
 
     private final EventService eventService;
 
     public ProgramNotificationInstanceController(
         ProgramNotificationInstanceService programNotificationInstanceService,
-        ProgramInstanceService programInstanceService,
+        EnrollmentService enrollmentService,
         EventService eventService )
     {
         this.programNotificationInstanceService = programNotificationInstanceService;
-        this.programInstanceService = programInstanceService;
+        this.enrollmentService = enrollmentService;
         this.eventService = eventService;
     }
 
@@ -87,7 +87,7 @@ public class ProgramNotificationInstanceController
         @RequestParam( required = false, defaultValue = "50" ) int pageSize )
     {
         ProgramNotificationInstanceParam params = ProgramNotificationInstanceParam.builder()
-            .enrollment( programInstanceService.getProgramInstance( programInstance ) )
+            .enrollment( enrollmentService.getEnrollment( programInstance ) )
             .event( eventService.getEvent( programStageInstance ) )
             .skipPaging( skipPaging )
             .page( page )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/RelationshipController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/RelationshipController.java
@@ -57,8 +57,8 @@ import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.schema.descriptors.RelationshipSchemaDescriptor;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.webapi.controller.event.webrequest.RelationshipCriteria;
@@ -93,7 +93,7 @@ public class RelationshipController
 
     private final TrackedEntityInstanceService trackedEntityInstanceService;
 
-    private final ProgramInstanceService programInstanceService;
+    private final EnrollmentService enrollmentService;
 
     private final EventService eventService;
 
@@ -116,8 +116,8 @@ public class RelationshipController
         }
         else if ( relationshipCriteria.getEnrollment() != null )
         {
-            return Optional.ofNullable( programInstanceService
-                .getProgramInstance( relationshipCriteria.getEnrollment() ) )
+            return Optional.ofNullable( enrollmentService
+                .getEnrollment( relationshipCriteria.getEnrollment() ) )
                 .map(
                     pi -> relationshipService.getRelationshipsByProgramInstance( pi, relationshipCriteria,
                         false ) )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
@@ -48,9 +48,9 @@ import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
@@ -87,7 +87,7 @@ public class RelationshipsExportController
     private final TrackedEntityInstanceService trackedEntityInstanceService;
 
     @Nonnull
-    private final ProgramInstanceService programInstanceService;
+    private final EnrollmentService enrollmentService;
 
     @Nonnull
     private final EventService eventService;
@@ -114,7 +114,7 @@ public class RelationshipsExportController
     {
         objectRetrievers = ImmutableMap.<Class<?>, Function<String, ?>> builder()
             .put( TrackedEntityInstance.class, trackedEntityInstanceService::getTrackedEntityInstance )
-            .put( Enrollment.class, programInstanceService::getProgramInstance )
+            .put( Enrollment.class, enrollmentService::getEnrollment )
             .put( Event.class, eventService::getEvent )
             .build();
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/RelationshipControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/RelationshipControllerTest.java
@@ -40,9 +40,9 @@ import java.util.Optional;
 import org.hisp.dhis.dxf2.events.relationship.RelationshipService;
 import org.hisp.dhis.dxf2.events.trackedentity.Relationship;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.junit.jupiter.api.BeforeEach;
@@ -86,7 +86,7 @@ class RelationshipControllerTest
     private TrackedEntityInstanceService trackedEntityInstanceService;
 
     @Mock
-    private ProgramInstanceService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Mock
     private EventService eventService;
@@ -154,10 +154,10 @@ class RelationshipControllerTest
     void verifyEndpointWithEnrollment()
         throws Exception
     {
-        when( programInstanceService.getProgramInstance( ENROLLMENT_ID ) ).thenReturn( enrollment );
+        when( enrollmentService.getEnrollment( ENROLLMENT_ID ) ).thenReturn( enrollment );
         mockMvc.perform( get( ENDPOINT ).param( "enrollment", ENROLLMENT_ID ) ).andExpect( status().isOk() );
 
-        verify( programInstanceService ).getProgramInstance( ENROLLMENT_ID );
+        verify( enrollmentService ).getEnrollment( ENROLLMENT_ID );
         verify( relationshipService ).getRelationshipsByProgramInstance( eq( enrollment ), any(), eq( false ) );
     }
 


### PR DESCRIPTION
follow up to https://github.com/dhis2/dhis2-core/pull/13794

* replace `programInstance` in `EnrollmentService` method names
* rename `ProgramInstanceService` to `EnrollmentService`

# Next

* rename `ProgramInstanceStore` to `EnrollmentStore`
* rename variables/parameters like `ps`, `pss`, `programInstance`, `programInstances`
* rename the rest like enums
* maybe rename aliases in queries or leave that for https://dhis2.atlassian.net/browse/TECH-1542