### PR TITLE
chore: 2.40.0 analytics apps to bundle

### DIFF
--- a/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
+++ b/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
@@ -6,7 +6,7 @@
     "https://github.com/d2-ci/capture-app#v100.29.0",
     "https://github.com/d2-ci/dashboard-app#patch/2.40.0",
     "https://github.com/d2-ci/data-administration-app#patch/2.40.0",
-    "https://github.com/d2-ci/data-visualizer-app#v100.0.2",
+    "https://github.com/d2-ci/data-visualizer-app#v100.0.3",
     "https://github.com/d2-ci/data-quality-app#patch/2.40.0",
     "https://github.com/d2-ci/datastore-app#patch/2.40.0",
     "https://github.com/d2-ci/event-reports-app#patch/2.40.0",


### PR DESCRIPTION
Analytics apps (non-classic):

DV
- bundling d2-ci v100.0.3
- 2.40 features available on hub before 2.40 core release (as v100.1.0)

LL
- not bundled
- 2.40 features available on hub before 2.40 core release (as v100.6.0)

Maps
- bundling the patch/2.40.0 branch
- on app hub, but no new features yet

Dashboard
- bundling the patch/2.40.0 branch
- not on app hub yet, but should be soon