### PR TITLE
fix: datastore update skip sharing if namespace ignores it [DHIS2-15087] (2.39)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datastore/DefaultDatastoreService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datastore/DefaultDatastoreService.java
@@ -152,9 +152,13 @@ public class DefaultDatastoreService
     public void updateEntry( DatastoreEntry entry )
     {
         validateEntry( entry );
+        DatastoreNamespaceProtection protection = protectionByNamespace.get( entry.getNamespace() );
+        Runnable update = protection == null || protection.isSharingRespected()
+            ? () -> store.update( entry )
+            : () -> store.updateNoAcl( entry );
         writeProtectedIn( entry.getNamespace(),
             () -> singletonList( entry ),
-            () -> store.update( entry ) );
+            update );
     }
 
     @Override


### PR DESCRIPTION
backport of #13801 