### PR TITLE
chore: remove user type definition for unknown event class TECH-1537

### DIFF
--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/org/hisp/dhis/usertype/UserTypes.hbm.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/org/hisp/dhis/usertype/UserTypes.hbm.xml
@@ -155,10 +155,6 @@
     <param name="clazz">org.hisp.dhis.program.UserInfoSnapshot</param>
   </typedef>
 
-  <typedef class="org.hisp.dhis.hibernate.jsonb.type.SafeJsonBinaryType" name="jbProgramStageInstanceUserInfo">
-    <param name="clazz">org.hisp.dhis.program.ProgramStageInstanceUserInfo</param>
-  </typedef>
-
   <typedef class="org.hisp.dhis.hibernate.jsonb.type.SharingJsonBinaryType" name="jsbObjectSharing">
     <param name="clazz">org.hisp.dhis.user.sharing.Sharing</param>
   </typedef>


### PR DESCRIPTION
ProgramStageInstanceUserInfo does not exist. It might have been replaced by UserInfoSnapshot at some point