### PR TITLE
ci: --illegal-access=permit was removed in Java 17

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -55,7 +55,7 @@
     <snippetsDirectory>${project.build.directory}/generated-snippets</snippetsDirectory>
     <sonar.organization>dhis2</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-    <surefireArgLine>-Xmx2024m --illegal-access=permit</surefireArgLine>
+    <surefireArgLine>-Xmx2024m</surefireArgLine>
 
     <!-- Needed so we can disable running tests when the default profile 
       is used (activated by default). It does not honor -DskipTests otherwise https://maven.apache.org/surefire/maven-surefire-plugin/examples/skipping-tests.html -->
@@ -559,9 +559,6 @@
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>${maven-failsafe-plugin.version}</version>
           <configuration>
-            <argLine>
-              --illegal-access=permit
-            </argLine>
             <encoding>${project.build.sourceEncoding}</encoding>
           </configuration>
         </plugin>


### PR DESCRIPTION
this fixes warning

OpenJDK 64-Bit Server VM warning: Ignoring option --illegal-access=permit; support was removed in 17.0

printed when executing tests.