### PR TITLE
fix: error when deleting Dashboard [BETA-66] (2.39)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
@@ -335,7 +335,9 @@ public class DefaultPreheatService implements PreheatService
     {
         if ( dashboardItem.getEmbeddedItem() != null )
         {
-            mapItemObjectIDs.computeIfAbsent( dashboardItem.getEmbeddedItem().getClass(), key -> new HashSet<>() )
+            mapItemObjectIDs
+                .computeIfAbsent( HibernateProxyUtils.unproxy( dashboardItem.getEmbeddedItem() ).getClass(),
+                    key -> new HashSet<>() )
                 .add( dashboardItem.getEmbeddedItem().getUid() );
         }
 

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
@@ -83,4 +83,11 @@ class DashboardControllerTest extends DhisControllerIntegrationTest
         assertTrue( dashboardItem.isPresent() );
         assertEquals( "gyYXi0rXAIc", dashboardItem.get().getVisualization().getUid() );
     }
+
+    @Test
+    void testDeleteDashboard()
+    {
+        POST( "/metadata", Body( "dashboard/create_dashboard.json" ) ).content( HttpStatus.OK );
+        assertWebMessage( "OK", 200, "OK", null, DELETE( "/dashboards/f1OijtLnf8a" ).content( HttpStatus.OK ) );
+    }
 }


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/BETA-66

#### Issue:
- When deleting a Dashboard, `SchemaService.getSchema(class)` returns an error `Input class must not be Hibernate proxy class`.  It is because `DashboardItem.getEmbeddedItem()` returns a Hibernate Proxy class. 
#### Fix:
- Un-proxy `DashboardItem` before putting it in a map.
- This fix does not apply to 2.40+ because the affected code only existed in 2.39 and older versions. 

Test:
- Create a new Dashboard in Dashboard App.
- Add Dashboard Item and add a visualization to it.
- Save Dashboard.
- Delete created Dashboard.
- Expected: Dashboard is deleted successfully.