### PR TITLE
fix: correct android settings app authority and namespace protection [DHIS2-15087] (2.40.0)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/AndroidSettingsApp.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/AndroidSettingsApp.java
@@ -33,20 +33,20 @@ import org.hisp.dhis.datastore.DatastoreService;
 import org.springframework.stereotype.Component;
 
 /**
- * The main purpose (so far) of the {@link AndroidSettingApp} component is to
+ * The main purpose (so far) of the {@link AndroidSettingsApp} component is to
  * establish the protected {@link #NAMESPACE} in the {@link DatastoreService} so
  * that only the app can write to it using a role having the {@link #AUTHORITY}.
  *
  * @author Jan Bernitt
  */
 @Component
-public class AndroidSettingApp
+public class AndroidSettingsApp
 {
-    public static final String NAMESPACE = "ANDROID_SETTING_APP";
+    public static final String NAMESPACE = "ANDROID_SETTINGS_APP";
 
-    public static final String AUTHORITY = "M_Android_Setting";
+    public static final String AUTHORITY = "M_androidsettingsapp";
 
-    public AndroidSettingApp( DatastoreService service )
+    public AndroidSettingsApp( DatastoreService service )
     {
         service.addProtection( new DatastoreNamespaceProtection( NAMESPACE, ProtectionType.NONE,
             ProtectionType.RESTRICTED, false, AUTHORITY ) );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerAndroidSettingsAppTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerAndroidSettingsAppTest.java
@@ -28,8 +28,8 @@
 package org.hisp.dhis.webapi.controller;
 
 import static java.util.Collections.singletonList;
-import static org.hisp.dhis.appmanager.AndroidSettingApp.AUTHORITY;
-import static org.hisp.dhis.appmanager.AndroidSettingApp.NAMESPACE;
+import static org.hisp.dhis.appmanager.AndroidSettingsApp.AUTHORITY;
+import static org.hisp.dhis.appmanager.AndroidSettingsApp.NAMESPACE;
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -41,12 +41,12 @@ import org.junit.jupiter.api.Test;
 
 /**
  * This tests verifies the protection of the
- * {@link org.hisp.dhis.appmanager.AndroidSettingApp#NAMESPACE} in the
+ * {@link org.hisp.dhis.appmanager.AndroidSettingsApp#NAMESPACE} in the
  * {@link DatastoreService} that is installed on startup.
  *
  * @author Jan Bernitt
  */
-class DatastoreControllerAndroidSettingAppTest extends DhisControllerConvenienceTest
+class DatastoreControllerAndroidSettingsAppTest extends DhisControllerConvenienceTest
 {
 
     @BeforeEach
@@ -87,14 +87,14 @@ class DatastoreControllerAndroidSettingAppTest extends DhisControllerConvenience
 
     /**
      * Only user with
-     * {@link org.hisp.dhis.appmanager.AndroidSettingApp#AUTHORITY} can delete
+     * {@link org.hisp.dhis.appmanager.AndroidSettingsApp#AUTHORITY} can delete
      * the NS.
      */
     @Test
     void testDeleteNamespace()
     {
         switchToNewUser( "not-an-android-manager" );
-        assertEquals( "Namespace 'ANDROID_SETTING_APP' is protected, access denied",
+        assertEquals( "Namespace 'ANDROID_SETTINGS_APP' is protected, access denied",
             DELETE( "/dataStore/" + NAMESPACE ).error( HttpStatus.FORBIDDEN ).getMessage() );
         switchToNewUser( "andriod-manager", AUTHORITY );
         assertStatus( HttpStatus.OK, DELETE( "/dataStore/" + NAMESPACE ) );
@@ -102,14 +102,14 @@ class DatastoreControllerAndroidSettingAppTest extends DhisControllerConvenience
 
     /**
      * Only user with
-     * {@link org.hisp.dhis.appmanager.AndroidSettingApp#AUTHORITY} can add to
+     * {@link org.hisp.dhis.appmanager.AndroidSettingsApp#AUTHORITY} can add to
      * the NS.
      */
     @Test
     void testAddKeyJsonValue()
     {
         switchToNewUser( "not-an-android-manager" );
-        assertEquals( "Namespace 'ANDROID_SETTING_APP' is protected, access denied",
+        assertEquals( "Namespace 'ANDROID_SETTINGS_APP' is protected, access denied",
             POST( "/dataStore/" + NAMESPACE + "/new-key", "[]" ).error( HttpStatus.FORBIDDEN ).getMessage() );
         switchToNewUser( "andriod-manager", AUTHORITY );
         assertStatus( HttpStatus.CREATED, POST( "/dataStore/" + NAMESPACE + "/new-key", "[]" ) );
@@ -119,7 +119,7 @@ class DatastoreControllerAndroidSettingAppTest extends DhisControllerConvenience
     void testUpdateKeyJsonValue()
     {
         switchToNewUser( "not-an-android-manager" );
-        assertEquals( "Namespace 'ANDROID_SETTING_APP' is protected, access denied",
+        assertEquals( "Namespace 'ANDROID_SETTINGS_APP' is protected, access denied",
             PUT( "/dataStore/" + NAMESPACE + "/key", "[]" ).error( HttpStatus.FORBIDDEN ).getMessage() );
         switchToNewUser( "andriod-manager", AUTHORITY );
         assertStatus( HttpStatus.OK, PUT( "/dataStore/" + NAMESPACE + "/key", "[]" ) );
@@ -129,7 +129,7 @@ class DatastoreControllerAndroidSettingAppTest extends DhisControllerConvenience
     void testDeleteKeyJsonValue()
     {
         switchToNewUser( "not-an-android-manager" );
-        assertEquals( "Namespace 'ANDROID_SETTING_APP' is protected, access denied",
+        assertEquals( "Namespace 'ANDROID_SETTINGS_APP' is protected, access denied",
             DELETE( "/dataStore/" + NAMESPACE + "/key" ).error( HttpStatus.FORBIDDEN ).getMessage() );
         switchToNewUser( "andriod-manager", AUTHORITY );
         assertStatus( HttpStatus.OK, DELETE( "/dataStore/" + NAMESPACE + "/key" ) );

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/authority/AppsSystemAuthoritiesProvider.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/authority/AppsSystemAuthoritiesProvider.java
@@ -32,7 +32,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.appmanager.AndroidSettingApp;
+import org.hisp.dhis.appmanager.AndroidSettingsApp;
 import org.hisp.dhis.appmanager.AppManager;
 import org.hisp.dhis.security.SystemAuthoritiesProvider;
 
@@ -59,7 +59,7 @@ public class AppsSystemAuthoritiesProvider implements SystemAuthoritiesProvider
                 authorities.add( app.getSeeAppAuthority() );
                 authorities.addAll( app.getAuthorities() );
             } );
-        authorities.add( AndroidSettingApp.AUTHORITY );
+        authorities.add( AndroidSettingsApp.AUTHORITY );
         return authorities;
     }
 }


### PR DESCRIPTION
Backport of #13712 

This is a merge-base branch for both 2.40 and patch/2.40.0, if it is updated to match the head of patch/2.40.0 it will need to be force-pushed again for the 2.40 merge.