### PR TITLE
chore: Rename most programInstance occurrences [TECH-1547]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -290,7 +290,7 @@ public enum ErrorCode
     E5007( "Duplicate reference {0} on object {1} for association `{2}`" ),
 
     /* Metadata import */
-    E6000( "Program `{0}` has more than one program instance" ),
+    E6000( "Program `{0}` has more than one Enrollment" ),
     E6001( "Program stage `{0}` has invalid next event scheduling property `{1}`" +
         "This property need to be data element of value type date and belong the program stage" ),
     E6002( "Class name {0} is not supported" ),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/maintenance/MaintenanceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/maintenance/MaintenanceService.java
@@ -71,12 +71,12 @@ public interface MaintenanceService
     int deleteSoftDeletedRelationships();
 
     /**
-     * Permanently deletes program instances which have been soft deleted, i.e.
-     * program instances where the deleted property is true.
+     * Permanently deletes Enrollments which have been soft deleted, i.e.
+     * Enrollments where the deleted property is true.
      *
-     * @return the number of deleted program instances.
+     * @return the number of deleted Enrollments.
      */
-    int deleteSoftDeletedProgramInstances();
+    int deleteSoftDeletedEnrollments();
 
     /**
      * Permanently deletes tracked entity instances which have been soft

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/maintenance/MaintenanceStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/maintenance/MaintenanceStore.java
@@ -65,12 +65,12 @@ public interface MaintenanceStore
     int deleteSoftDeletedRelationships();
 
     /**
-     * Permanently deletes program instances which have been soft deleted, i.e.
-     * program instances where the deleted property is true.
+     * Permanently deletes Enrollments which have been soft deleted, i.e.
+     * Enrollments where the deleted property is true.
      *
-     * @return the number of deleted program instances
+     * @return the number of deleted Enrollments
      */
-    int deleteSoftDeletedProgramInstances();
+    int deleteSoftDeletedEnrollments();
 
     /**
      * Permanently deletes tracked entity instances which have been soft

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Enrollment.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Enrollment.java
@@ -40,7 +40,6 @@ import org.hisp.dhis.audit.Auditable;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.SoftDeletableObject;
-import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.message.MessageConversation;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.relationship.RelationshipItem;
@@ -145,8 +144,8 @@ public class Enrollment
     // -------------------------------------------------------------------------
 
     /**
-     * Updated the bi-directional associations between this program instance and
-     * the given entity instance and program.
+     * Updated the bi-directional associations between this Enrollment and the
+     * given entity instance and program.
      *
      * @param entityInstance the entity instance to enroll.
      * @param program the program to enroll the entity instance to.
@@ -162,64 +161,6 @@ public class Enrollment
     public boolean isCompleted()
     {
         return this.status == ProgramStatus.COMPLETED;
-    }
-
-    public Event getEventByStage( int stage )
-    {
-        int count = 1;
-
-        for ( Event programInstanceStage : events )
-        {
-            if ( count == stage )
-            {
-                return programInstanceStage;
-            }
-
-            count++;
-        }
-
-        return null;
-    }
-
-    public Event getActiveEvent()
-    {
-        for ( Event event : events )
-        {
-            if ( event.getProgramStage().getOpenAfterEnrollment()
-                && !event.isCompleted()
-                && (event.getStatus() != null
-                    && event.getStatus() != EventStatus.SKIPPED) )
-            {
-                return event;
-            }
-        }
-
-        for ( Event event : events )
-        {
-            if ( !event.isCompleted()
-                && (event.getStatus() != null
-                    && event.getStatus() != EventStatus.SKIPPED) )
-            {
-                return event;
-            }
-        }
-
-        return null;
-    }
-
-    public boolean hasActiveEvent( ProgramStage programStage )
-    {
-        for ( Event event : events )
-        {
-            if ( !event.isDeleted()
-                && event.getProgramStage().getUid().equalsIgnoreCase( programStage.getUid() )
-                && event.getStatus() == EventStatus.ACTIVE )
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
@@ -140,19 +140,19 @@ public interface EnrollmentService
     List<String> getEnrollmentsUidsIncludingDeleted( List<String> uids );
 
     /**
-     * Returns a list with program instance values based on the given
-     * ProgramInstanceQueryParams.
+     * Returns a list with Enrollment values based on the given
+     * EnrollmentQueryParams.
      *
-     * @param params the ProgramInstanceQueryParams.
+     * @param params the EnrollmentQueryParams.
      * @return List of PIs matching the params
      */
     List<Enrollment> getEnrollments( EnrollmentQueryParams params );
 
     /**
-     * Returns the number of program instance matches based on the given
-     * ProgramInstanceQueryParams.
+     * Returns the number of Enrollment matches based on the given
+     * EnrollmentQueryParams.
      *
-     * @param params the ProgramInstanceQueryParams.
+     * @param params the EnrollmentQueryParams.
      * @return Number of PIs matching the params
      */
     int countEnrollments( EnrollmentQueryParams params );
@@ -161,22 +161,22 @@ public interface EnrollmentService
      * Decides whether current user is authorized to perform the given query.
      * IllegalQueryException is thrown if not.
      *
-     * @param params the ProgramInstanceQueryParams.
+     * @param params the EnrollmentQueryParams.
      */
     void decideAccess( EnrollmentQueryParams params );
 
     /**
-     * Validates the given ProgramInstanceQueryParams. The params is considered
-     * valid if no exception are thrown and the method returns normally.
+     * Validates the given EnrollmentQueryParams. The params is considered valid
+     * if no exception are thrown and the method returns normally.
      *
-     * @param params the ProgramInstanceQueryParams.
+     * @param params the EnrollmentQueryParams.
      * @throws IllegalQueryException if the given params is invalid.
      */
     void validate( EnrollmentQueryParams params )
         throws IllegalQueryException;
 
     /**
-     * Retrieve program instances on a program
+     * Retrieve Enrollments on a program
      *
      * @param program Program
      * @return Enrollment list
@@ -184,7 +184,7 @@ public interface EnrollmentService
     List<Enrollment> getEnrollments( Program program );
 
     /**
-     * Retrieve program instances on a program by status
+     * Retrieve enrollments on a program by status
      *
      * @param program Program
      * @param status Status of program-instance, include STATUS_ACTIVE,
@@ -194,7 +194,7 @@ public interface EnrollmentService
     List<Enrollment> getEnrollments( Program program, ProgramStatus status );
 
     /**
-     * Retrieve program instances on a TrackedEntityInstance with a status by a
+     * Retrieve enrollments on a TrackedEntityInstance with a status by a
      * program
      *
      * @param entityInstance TrackedEntityInstance
@@ -237,8 +237,8 @@ public interface EnrollmentService
         OrganisationUnit orgunit );
 
     /**
-     * Complete a program instance. Besides, program template messages will be
-     * send if it was defined to send when to complete this program
+     * Complete a enrollment. Besides, program template messages will be send if
+     * it was defined to send when to complete this program
      *
      * @param enrollment Enrollment
      */
@@ -252,8 +252,8 @@ public interface EnrollmentService
     void cancelEnrollmentStatus( Enrollment enrollment );
 
     /**
-     * Incomplete a program instance. This is is possible only if there is no
-     * other program instance with active status.
+     * Incomplete a enrollment. This is is possible only if there is no other
+     * enrollment with active status.
      *
      * @param enrollment Enrollment
      */

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentStore.java
@@ -44,23 +44,23 @@ public interface EnrollmentStore
     String ID = EnrollmentStore.class.getName();
 
     /**
-     * Count all program instances by PI query params.
+     * Count all enrollments by PI query params.
      *
-     * @param params ProgramInstanceQueryParams to use
+     * @param params EnrollmentQueryParams to use
      * @return Count of matching PIs
      */
     int countEnrollments( EnrollmentQueryParams params );
 
     /**
-     * Get all program instances by PI query params.
+     * Get all enrollments by PI query params.
      *
-     * @param params ProgramInstanceQueryParams to use
+     * @param params EnrollmentQueryParams to use
      * @return PIs matching params
      */
     List<Enrollment> getEnrollments( EnrollmentQueryParams params );
 
     /**
-     * Retrieve program instances on a program
+     * Retrieve enrollments on a program
      *
      * @param program Program
      * @return Enrollment list
@@ -68,7 +68,7 @@ public interface EnrollmentStore
     List<Enrollment> get( Program program );
 
     /**
-     * Retrieve program instances on a program by status
+     * Retrieve enrollments on a program by status
      *
      * @param program Program
      * @param status Status of program-instance, include STATUS_ACTIVE,
@@ -78,7 +78,7 @@ public interface EnrollmentStore
     List<Enrollment> get( Program program, ProgramStatus status );
 
     /**
-     * Retrieve program instances on a TrackedEntityInstance with a status by a
+     * Retrieve enrollments on a TrackedEntityInstance with a status by a
      * program
      *
      * @param entityInstance TrackedEntityInstance
@@ -136,7 +136,7 @@ public interface EnrollmentStore
     List<Enrollment> getWithScheduledNotifications( ProgramNotificationTemplate template, Date notificationDate );
 
     /**
-     * Return all program instance linked to programs.
+     * Return all enrollment linked to programs.
      *
      * @param programs Programs to fetch by
      * @return List of all PIs that that are linked to programs
@@ -144,7 +144,7 @@ public interface EnrollmentStore
     List<Enrollment> getByPrograms( List<Program> programs );
 
     /**
-     * Return all program instance by type.
+     * Return all enrollment by type.
      * <p>
      * Warning: this is meant to be used for WITHOUT_REGISTRATION programs only,
      * be careful if you need it for other uses.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventStore.java
@@ -43,7 +43,7 @@ public interface EventStore
     extends IdentifiableObjectStore<Event>
 {
     /**
-     * Retrieve an event list on program instance list with a certain status
+     * Retrieve an event list on enrollment list with a certain status
      *
      * @param enrollments Enrollment list
      * @param status EventStatus

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramTempOwnershipAuditService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramTempOwnershipAuditService.java
@@ -46,7 +46,7 @@ public interface ProgramTempOwnershipAuditService
     void addProgramTempOwnershipAudit( ProgramTempOwnershipAudit programTempOwnershipAudit );
 
     /**
-     * Deletes program temp ownership audit for the given program instance
+     * Deletes program temp ownership audit for the given enrollment
      *
      * @param program the program
      */

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramTempOwnershipAuditStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramTempOwnershipAuditStore.java
@@ -48,7 +48,7 @@ public interface ProgramTempOwnershipAuditStore
     /**
      * Deletes audit for the given program
      *
-     * @param program the program instance
+     * @param program the enrollment
      */
     void deleteProgramTempOwnershipAudit( Program program );
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/message/ProgramMessage.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/message/ProgramMessage.java
@@ -101,7 +101,7 @@ public class ProgramMessage
     // Logic
     // -------------------------------------------------------------------------
 
-    public boolean hasProgramInstance()
+    public boolean hasEnrollment()
     {
         return this.enrollment != null;
     }
@@ -122,7 +122,7 @@ public class ProgramMessage
         return MoreObjects.toStringHelper( this )
             .add( "uid", uid )
             .add( "event", event )
-            .add( "program instance", enrollment )
+            .add( "enrollment", enrollment )
             .add( "recipients", recipients )
             .add( "delivery channels", deliveryChannels )
             .add( "subject", subject )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/message/ProgramMessageQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/message/ProgramMessageQueryParams.java
@@ -87,7 +87,7 @@ public class ProgramMessageQueryParams
         return organisationUnit != null;
     }
 
-    public boolean hasProgramInstance()
+    public boolean hasEnrollment()
     {
         return enrollment != null;
     }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationInstance.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationInstance.java
@@ -83,7 +83,7 @@ public class ProgramNotificationInstance extends BaseIdentifiableObject
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private Date scheduledAt;
 
-    public boolean hasProgramInstance()
+    public boolean hasEnrollment()
     {
         return enrollment != null;
     }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationInstanceParam.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationInstanceParam.java
@@ -63,7 +63,7 @@ public class ProgramNotificationInstanceParam extends BaseNotificationParam
 
     private Date scheduledAt;
 
-    public boolean hasProgramInstance()
+    public boolean hasEnrollment()
     {
         return enrollment != null;
     }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipService.java
@@ -112,12 +112,12 @@ public interface RelationshipService
         PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
         boolean skipAccessValidation );
 
-    default List<Relationship> getRelationshipsByProgramInstance( Enrollment pi, boolean skipAccessValidation )
+    default List<Relationship> getRelationshipsByEnrollment( Enrollment pi, boolean skipAccessValidation )
     {
-        return getRelationshipsByProgramInstance( pi, null, skipAccessValidation );
+        return getRelationshipsByEnrollment( pi, null, skipAccessValidation );
     }
 
-    List<Relationship> getRelationshipsByProgramInstance( Enrollment pi,
+    List<Relationship> getRelationshipsByEnrollment( Enrollment pi,
         PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter, boolean skipAccessValidation );
 
     default List<Relationship> getRelationshipsByEvent( Event event, boolean skipAccessValidation )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipStore.java
@@ -51,12 +51,12 @@ public interface RelationshipStore
     List<Relationship> getByTrackedEntityInstance( TrackedEntityInstance tei,
         PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter );
 
-    default List<Relationship> getByProgramInstance( Enrollment pi )
+    default List<Relationship> getByEnrollment( Enrollment pi )
     {
-        return getByProgramInstance( pi, null );
+        return getByEnrollment( pi, null );
     }
 
-    List<Relationship> getByProgramInstance( Enrollment pi,
+    List<Relationship> getByEnrollment( Enrollment pi,
         PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter );
 
     default List<Relationship> getByEvent( Event event )

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/maintenance/DefaultMaintenanceService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/maintenance/DefaultMaintenanceService.java
@@ -134,9 +134,9 @@ public class DefaultMaintenanceService
     }
 
     @Override
-    public int deleteSoftDeletedProgramInstances()
+    public int deleteSoftDeletedEnrollments()
     {
-        int result = maintenanceStore.deleteSoftDeletedProgramInstances();
+        int result = maintenanceStore.deleteSoftDeletedEnrollments();
 
         log.info( "Permanently deleted soft deleted enrollments: " + result );
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/maintenance/jdbc/JdbcMaintenanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/maintenance/jdbc/JdbcMaintenanceStore.java
@@ -162,7 +162,7 @@ public class JdbcMaintenanceStore implements MaintenanceStore
     }
 
     @Override
-    public int deleteSoftDeletedProgramInstances()
+    public int deleteSoftDeletedEnrollments()
     {
         String piSelect = "(select programinstanceid from programinstance where deleted is true)";
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/orgunit/DefaultOrgUnitMergeService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/orgunit/DefaultOrgUnitMergeService.java
@@ -142,7 +142,7 @@ public class DefaultOrgUnitMergeService
             .add( ( r ) -> dataHandler.mergeMinMaxDataElements( r ) )
             .add( ( r ) -> dataHandler.mergeInterpretations( r ) )
             .add( ( r ) -> trackerHandler.mergeProgramMessages( r ) )
-            .add( ( r ) -> trackerHandler.mergeProgramInstances( r ) )
+            .add( ( r ) -> trackerHandler.mergeEnrollments( r ) )
             .add( ( r ) -> trackerHandler.mergeTrackedEntityInstances( r ) )
             .build();
     }

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/orgunit/handler/TrackerOrgUnitMergeHandler.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/orgunit/handler/TrackerOrgUnitMergeHandler.java
@@ -55,7 +55,7 @@ public class TrackerOrgUnitMergeHandler
     }
 
     @Transactional
-    public void mergeProgramInstances( OrgUnitMergeRequest request )
+    public void mergeEnrollments( OrgUnitMergeRequest request )
     {
         migrate( "update Event psi " +
             "set psi.organisationUnit = :target " +

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
@@ -424,7 +424,7 @@ public class DefaultEnrollmentService
         Date enrollmentDate, Date incidentDate, OrganisationUnit organisationUnit, String uid )
     {
         // ---------------------------------------------------------------------
-        // Add program instance
+        // Add enrollment
         // ---------------------------------------------------------------------
 
         Enrollment enrollment = prepareEnrollment( trackedEntityInstance, program, ProgramStatus.ACTIVE,

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/EventDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/EventDeletionHandler.java
@@ -49,7 +49,7 @@ public class EventDeletionHandler extends IdObjectDeletionHandler<Event>
     protected void registerHandler()
     {
         whenVetoing( ProgramStage.class, this::allowDeleteProgramStage );
-        whenDeleting( Enrollment.class, this::deleteProgramInstance );
+        whenDeleting( Enrollment.class, this::deleteEnrollment );
         whenVetoing( Program.class, this::allowDeleteProgram );
         whenVetoing( DataElement.class, this::allowDeleteDataElement );
     }
@@ -61,7 +61,7 @@ public class EventDeletionHandler extends IdObjectDeletionHandler<Event>
             Map.of( "id", programStage.getId() ) );
     }
 
-    private void deleteProgramInstance( Enrollment enrollment )
+    private void deleteEnrollment( Enrollment enrollment )
     {
         for ( Event event : enrollment.getEvents() )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramNotificationInstanceDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramNotificationInstanceDeletionHandler.java
@@ -53,13 +53,13 @@ public class ProgramNotificationInstanceDeletionHandler extends IdObjectDeletion
     @Override
     protected void registerHandler()
     {
-        whenDeleting( Enrollment.class, this::deleteProgramInstance );
+        whenDeleting( Enrollment.class, this::deleteEnrollment );
         whenDeleting( Event.class, this::deleteEvent );
-        whenVetoing( Enrollment.class, this::allowDeleteProgramInstance );
+        whenVetoing( Enrollment.class, this::allowDeleteEnrollment );
         whenVetoing( Event.class, this::allowDeleteEvent );
     }
 
-    private void deleteProgramInstance( Enrollment enrollment )
+    private void deleteEnrollment( Enrollment enrollment )
     {
         List<ProgramNotificationInstance> notificationInstances = programNotificationInstanceService
             .getProgramNotificationInstances(
@@ -77,7 +77,7 @@ public class ProgramNotificationInstanceDeletionHandler extends IdObjectDeletion
         notificationInstances.forEach( programNotificationInstanceService::delete );
     }
 
-    private DeletionVeto allowDeleteProgramInstance( Enrollment enrollment )
+    private DeletionVeto allowDeleteEnrollment( Enrollment enrollment )
     {
         List<ProgramNotificationInstance> instances = programNotificationInstanceService
             .getProgramNotificationInstances(

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramMessageStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramMessageStore.java
@@ -108,7 +108,7 @@ public class HibernateProgramMessageStore
 
         String hql = " select distinct pm from ProgramMessage pm ";
 
-        if ( params.hasProgramInstance() )
+        if ( params.hasEnrollment() )
         {
             hql += helper.whereAnd() + "pm.enrollment = :enrollment";
         }
@@ -130,7 +130,7 @@ public class HibernateProgramMessageStore
 
         Query<ProgramMessage> query = getQuery( hql );
 
-        if ( params.hasProgramInstance() )
+        if ( params.hasEnrollment() )
         {
             query.setParameter( "enrollment", params.getEnrollment() );
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/message/DefaultProgramMessageService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/message/DefaultProgramMessageService.java
@@ -241,7 +241,7 @@ public class DefaultProgramMessageService
 
         Set<Program> programs;
 
-        if ( params.hasProgramInstance() )
+        if ( params.hasEnrollment() )
         {
             enrollment = params.getEnrollment();
         }
@@ -270,9 +270,9 @@ public class DefaultProgramMessageService
     {
         String violation = null;
 
-        if ( !params.hasProgramInstance() && !params.hasEvent() )
+        if ( !params.hasEnrollment() && !params.hasEvent() )
         {
-            violation = "Program instance or program stage instance must be provided";
+            violation = "Enrollment or program stage instance must be provided";
         }
 
         if ( violation != null )
@@ -303,7 +303,7 @@ public class DefaultProgramMessageService
 
         if ( message.getEnrollment() == null && message.getEvent() == null )
         {
-            violation = "Program instance or program stage instance must be specified";
+            violation = "Enrollment or program stage instance must be specified";
         }
 
         if ( recipients.getTrackedEntityInstance() != null && trackedEntityInstanceService
@@ -337,7 +337,7 @@ public class DefaultProgramMessageService
 
         boolean isAuthorized;
 
-        if ( message.hasProgramInstance() )
+        if ( message.hasEnrollment() )
         {
             object = message.getEnrollment().getProgram();
         }
@@ -371,7 +371,7 @@ public class DefaultProgramMessageService
 
     private ProgramMessage setParameters( ProgramMessage message, BatchResponseStatus status )
     {
-        message.setEnrollment( getProgramInstance( message ) );
+        message.setEnrollment( getEnrollment( message ) );
         message.setEvent( getEvent( message ) );
         message.setProcessedDate( new Date() );
         message.setMessageStatus( status.isOk() ? ProgramMessageStatus.SENT : ProgramMessageStatus.FAILED );
@@ -387,7 +387,7 @@ public class DefaultProgramMessageService
             .collect( Collectors.toList() );
     }
 
-    private Enrollment getProgramInstance( ProgramMessage programMessage )
+    private Enrollment getEnrollment( ProgramMessage programMessage )
     {
         if ( programMessage.getEnrollment() != null )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationInstanceService.java
@@ -69,12 +69,12 @@ public class DefaultProgramNotificationInstanceService
     @Transactional( readOnly = true )
     public void validateQueryParameters( ProgramNotificationInstanceParam params )
     {
-        if ( params.hasProgramInstance() )
+        if ( params.hasEnrollment() )
         {
             if ( !enrollmentService.enrollmentExists( params.getEnrollment().getUid() ) )
             {
                 throw new IllegalQueryException(
-                    String.format( "Program instance %s does not exist", params.getEnrollment().getUid() ) );
+                    String.format( "Enrollment %s does not exist", params.getEnrollment().getUid() ) );
             }
 
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationService.java
@@ -175,9 +175,9 @@ public class DefaultProgramNotificationService
         }
 
         List<MessageBatch> batches = progress.runStage( List.of(), () -> {
-            Stream<MessageBatch> programInstanceBatches = instancesWithTemplates.stream()
-                .filter( this::hasProgramInstance )
-                .map( iwt -> createProgramInstanceMessageBatch(
+            Stream<MessageBatch> enrollmentBatches = instancesWithTemplates.stream()
+                .filter( this::hasEnrollment )
+                .map( iwt -> createEnrollmentMessageBatch(
                     iwt.getProgramNotificationTemplate(),
                     List.of( iwt.getProgramNotificationInstance().getEnrollment() ) ) );
 
@@ -187,7 +187,7 @@ public class DefaultProgramNotificationService
                     iwt.getProgramNotificationTemplate(),
                     List.of( iwt.getProgramNotificationInstance().getEvent() ) ) );
 
-            return Stream.concat( programInstanceBatches, eventBatches ).collect( toList() );
+            return Stream.concat( enrollmentBatches, eventBatches ).collect( toList() );
         } );
 
         progress.startingStage( "Sending message batches", batches.size(), SKIP_ITEM_OUTLIER );
@@ -207,11 +207,11 @@ public class DefaultProgramNotificationService
             .isPresent();
     }
 
-    private boolean hasProgramInstance( NotificationInstanceWithTemplate instanceWithTemplate )
+    private boolean hasEnrollment( NotificationInstanceWithTemplate instanceWithTemplate )
     {
         return Optional.of( instanceWithTemplate )
             .map( NotificationInstanceWithTemplate::getProgramNotificationInstance )
-            .filter( ProgramNotificationInstance::hasProgramInstance )
+            .filter( ProgramNotificationInstance::hasEnrollment )
             .isPresent();
     }
 
@@ -273,21 +273,21 @@ public class DefaultProgramNotificationService
     @Transactional
     public void sendEnrollmentCompletionNotifications( long enrollment )
     {
-        sendProgramInstanceNotifications( enrollmentStore.get( enrollment ), NotificationTrigger.COMPLETION );
+        sendEnrollmentNotifications( enrollmentStore.get( enrollment ), NotificationTrigger.COMPLETION );
     }
 
     @Override
     @Transactional
     public void sendEnrollmentNotifications( long enrollment )
     {
-        sendProgramInstanceNotifications( enrollmentStore.get( enrollment ), NotificationTrigger.ENROLLMENT );
+        sendEnrollmentNotifications( enrollmentStore.get( enrollment ), NotificationTrigger.ENROLLMENT );
     }
 
     @Override
     @Transactional
     public void sendProgramRuleTriggeredNotifications( long pnt, long enrollment )
     {
-        MessageBatch messageBatch = createProgramInstanceMessageBatch( notificationTemplateService.get( pnt ),
+        MessageBatch messageBatch = createEnrollmentMessageBatch( notificationTemplateService.get( pnt ),
             Collections.singletonList( enrollmentStore.get( enrollment ) ) );
         sendAll( messageBatch );
     }
@@ -296,7 +296,7 @@ public class DefaultProgramNotificationService
     @Transactional
     public void sendProgramRuleTriggeredNotifications( long pnt, Enrollment enrollment )
     {
-        MessageBatch messageBatch = createProgramInstanceMessageBatch( notificationTemplateService.get( pnt ),
+        MessageBatch messageBatch = createEnrollmentMessageBatch( notificationTemplateService.get( pnt ),
             Collections.singletonList( enrollment ) );
         sendAll( messageBatch );
     }
@@ -331,7 +331,7 @@ public class DefaultProgramNotificationService
         List<Enrollment> enrollments = enrollmentStore.getWithScheduledNotifications( template, day );
 
         MessageBatch eventBatch = createEventMessageBatch( template, events );
-        MessageBatch psBatch = createProgramInstanceMessageBatch( template, enrollments );
+        MessageBatch psBatch = createEnrollmentMessageBatch( template, enrollments );
 
         return new MessageBatch( eventBatch, psBatch );
     }
@@ -365,7 +365,7 @@ public class DefaultProgramNotificationService
         }
     }
 
-    private void sendProgramInstanceNotifications( Enrollment enrollment, NotificationTrigger trigger )
+    private void sendEnrollmentNotifications( Enrollment enrollment, NotificationTrigger trigger )
     {
         if ( enrollment == null )
         {
@@ -376,7 +376,7 @@ public class DefaultProgramNotificationService
 
         for ( ProgramNotificationTemplate template : templates )
         {
-            MessageBatch batch = createProgramInstanceMessageBatch( template, Lists.newArrayList( enrollment ) );
+            MessageBatch batch = createEnrollmentMessageBatch( template, Lists.newArrayList( enrollment ) );
             sendAll( batch );
         }
     }
@@ -403,7 +403,7 @@ public class DefaultProgramNotificationService
         return batch;
     }
 
-    private MessageBatch createProgramInstanceMessageBatch( ProgramNotificationTemplate template,
+    private MessageBatch createEnrollmentMessageBatch( ProgramNotificationTemplate template,
         List<Enrollment> enrollments )
     {
         MessageBatch batch = new MessageBatch();
@@ -460,7 +460,7 @@ public class DefaultProgramNotificationService
         if ( enrollment == null && event == null )
         {
             throw new IllegalArgumentException(
-                "Either of the arguments [programInstance, event] must be non-null" );
+                "Either of the arguments [enrollment, event] must be non-null" );
         }
 
         Set<User> recipients = Sets.newHashSet();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/HibernateProgramNotificationInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/HibernateProgramNotificationInstanceStore.java
@@ -104,7 +104,7 @@ public class HibernateProgramNotificationInstanceStore
                 params.getEvent() ) );
         }
 
-        if ( params.hasProgramInstance() )
+        if ( params.hasEnrollment() )
         {
             predicates.add( root -> builder.equal( root.get( "enrollment" ),
                 params.getEnrollment() ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationListener.java
@@ -61,7 +61,7 @@ public class ProgramNotificationListener
     @TransactionalEventListener( fallbackExecution = true )
     public void onCompletion( ProgramEnrollmentCompletionNotificationEvent event )
     {
-        programNotificationService.sendEnrollmentCompletionNotifications( event.getEnrollment() );
+        programNotificationService.sendEnrollmentCompletionNotifications( event.getEnrollmentId() );
     }
 
     @TransactionalEventListener( fallbackExecution = true )
@@ -75,7 +75,7 @@ public class ProgramNotificationListener
     public void onProgramRuleEnrollment( ProgramRuleEnrollmentEvent event )
     {
         programNotificationService.sendProgramRuleTriggeredNotifications( event.getTemplate(),
-            event.getProgramInstance() );
+            event.getEnrollment() );
     }
 
     @TransactionalEventListener( fallbackExecution = true )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/event/ProgramEnrollmentCompletionNotificationEvent.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/event/ProgramEnrollmentCompletionNotificationEvent.java
@@ -34,16 +34,16 @@ import org.springframework.context.ApplicationEvent;
  */
 public class ProgramEnrollmentCompletionNotificationEvent extends ApplicationEvent
 {
-    private long enrollment;
+    private final long enrollmentId;
 
-    public ProgramEnrollmentCompletionNotificationEvent( Object source, long programInstance )
+    public ProgramEnrollmentCompletionNotificationEvent( Object source, long enrollmentId )
     {
         super( source );
-        this.enrollment = programInstance;
+        this.enrollmentId = enrollmentId;
     }
 
-    public long getEnrollment()
+    public long getEnrollmentId()
     {
-        return enrollment;
+        return enrollmentId;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/event/ProgramRuleEnrollmentEvent.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/event/ProgramRuleEnrollmentEvent.java
@@ -51,7 +51,7 @@ public class ProgramRuleEnrollmentEvent extends ApplicationEvent
         return template;
     }
 
-    public Enrollment getProgramInstance()
+    public Enrollment getEnrollment()
     {
         return enrollment;
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/DefaultRelationshipService.java
@@ -138,11 +138,11 @@ public class DefaultRelationshipService
 
     @Override
     @Transactional( readOnly = true )
-    public List<Relationship> getRelationshipsByProgramInstance( Enrollment pi,
+    public List<Relationship> getRelationshipsByEnrollment( Enrollment pi,
         PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
         boolean skipAccessValidation )
     {
-        return relationshipStore.getByProgramInstance( pi, pagingAndSortingCriteriaAdapter );
+        return relationshipStore.getByEnrollment( pi, pagingAndSortingCriteriaAdapter );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/RelationshipDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/RelationshipDeletionHandler.java
@@ -56,7 +56,7 @@ public class RelationshipDeletionHandler extends DeletionHandler
     {
         whenDeleting( TrackedEntityInstance.class, this::deleteTrackedEntityInstance );
         whenDeleting( Event.class, this::deleteEvent );
-        whenDeleting( Enrollment.class, this::deleteProgramInstance );
+        whenDeleting( Enrollment.class, this::deleteEnrollment );
         whenVetoing( RelationshipType.class, this::allowDeleteRelationshipType );
     }
 
@@ -88,10 +88,10 @@ public class RelationshipDeletionHandler extends DeletionHandler
         }
     }
 
-    private void deleteProgramInstance( Enrollment enrollment )
+    private void deleteEnrollment( Enrollment enrollment )
     {
         Collection<Relationship> relationships = relationshipService
-            .getRelationshipsByProgramInstance( enrollment, false );
+            .getRelationshipsByEnrollment( enrollment, false );
 
         if ( relationships != null )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/hibernate/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/hibernate/HibernateRelationshipStore.java
@@ -92,7 +92,7 @@ public class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<R
     }
 
     @Override
-    public List<Relationship> getByProgramInstance( Enrollment pi,
+    public List<Relationship> getByEnrollment( Enrollment pi,
         PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter )
     {
         TypedQuery<Relationship> relationshipTypedQuery = getRelationshipTypedQuery( pi,

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CommandSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CommandSMSListener.java
@@ -235,7 +235,7 @@ public abstract class CommandSMSListener extends BaseSMSListener
         {
             update( sms, SmsMessageStatus.FAILED, false );
 
-            sendFeedback( "Multiple active program instances exists for program: " + smsCommand.getProgram().getUid(),
+            sendFeedback( "Multiple active Enrollments exists for program: " + smsCommand.getProgram().getUid(),
                 sms.getOriginator(), ERROR );
 
             return;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
@@ -116,7 +116,7 @@ public class SimpleEventSMSListener extends CompressionSMSListener
         List<Enrollment> enrollments = new ArrayList<>(
             enrollmentService.getEnrollments( program, ProgramStatus.ACTIVE ) );
 
-        // For Simple Events, the Program should have one Program Instance
+        // For Simple Events, the Program should have one Enrollment
         // If it doesn't exist, this is the first event, we can create it here
         if ( enrollments.isEmpty() )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -936,12 +936,12 @@ public class HibernateTrackedEntityInstanceStore
     }
 
     /**
-     * Generates an INNER JOIN for program instances. If the param we need to
-     * order by is enrolledAt, we need to join the program instance table to be
-     * able to select and order by this value
+     * Generates an INNER JOIN for enrollments. If the param we need to order by
+     * is enrolledAt, we need to join the enrollment table to be able to select
+     * and order by this value
      *
      * @param params
-     * @return a SQL INNER JOIN for program instances
+     * @return a SQL INNER JOIN for enrollments
      */
     private String getFromSubQueryJoinProgramInstanceConditions( TrackedEntityInstanceQueryParams params )
     {
@@ -956,10 +956,9 @@ public class HibernateTrackedEntityInstanceStore
     }
 
     /**
-     * Generates an EXISTS condition for program instance (and program stage
-     * instance if specified). The EXIST will allow us to filter by enrollments
-     * with a low overhead. This condition only applies when a program is
-     * specified.
+     * Generates an EXISTS condition for enrollment (and program stage instance
+     * if specified). The EXIST will allow us to filter by enrollments with a
+     * low overhead. This condition only applies when a program is specified.
      *
      * @param whereAnd indicator tracking whether WHERE has been invoked or not
      * @param params
@@ -1052,7 +1051,7 @@ public class HibernateTrackedEntityInstanceStore
     }
 
     /**
-     * Generates an INNER JOIN with the program instances if event-filters are
+     * Generates an INNER JOIN with the enrollments if event-filters are
      * specified. In the case of user assignment is part of the filter, we join
      * with the userinfo table as well.
      *

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitycomment/TrackedEntityCommentDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitycomment/TrackedEntityCommentDeletionHandler.java
@@ -44,11 +44,11 @@ public class TrackedEntityCommentDeletionHandler extends IdObjectDeletionHandler
     @Override
     protected void registerHandler()
     {
-        whenDeleting( Enrollment.class, this::deleteProgramInstance );
+        whenDeleting( Enrollment.class, this::deleteEnrollment );
         whenDeleting( Event.class, this::deleteEvent );
     }
 
-    private void deleteProgramInstance( Enrollment enrollment )
+    private void deleteEnrollment( Enrollment enrollment )
     {
         for ( TrackedEntityComment comment : enrollment.getComments() )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deduplication/DeduplicationHelperTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deduplication/DeduplicationHelperTest.java
@@ -122,7 +122,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest
         relationshipType = createRelationshipType( 'A' );
         relationshipTypeBidirectional = createRelationshipType( 'B' );
         attribute = createTrackedEntityAttribute( 'A' );
-        enrollment = createProgramInstance( createProgram( 'A' ), getTeiA(), organisationUnitA );
+        enrollment = createEnrollment( createProgram( 'A' ), getTeiA(), organisationUnitA );
         mergeObject = MergeObject.builder()
             .relationships( relationshipUids )
             .trackedEntityAttributes( attributeUids )
@@ -219,7 +219,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest
     }
 
     @Test
-    void shouldNotHasUserAccessWhenUserHasNoAccessToProgramInstance()
+    void shouldNotHasUserAccessWhenUserHasNoAccessToEnrollment()
     {
         when( aclService.canDataWrite( user, enrollment.getProgram() ) ).thenReturn( false );
 
@@ -372,19 +372,19 @@ class DeduplicationHelperTest extends DhisConvenienceTest
     {
         TrackedEntityInstance original = getTeiA();
         Program programA = createProgram( 'A' );
-        Enrollment enrollmentA = createProgramInstance( programA, original, organisationUnitA );
-        enrollmentA.setUid( "programInstanceA" );
+        Enrollment enrollmentA = createEnrollment( programA, original, organisationUnitA );
+        enrollmentA.setUid( "enrollmentA" );
         original.getEnrollments().add( enrollmentA );
 
         TrackedEntityInstance duplicate = getTeiA();
         Program programB = createProgram( 'B' );
-        Enrollment enrollmentB = createProgramInstance( programB, duplicate, organisationUnitA );
-        enrollmentB.setUid( "programInstanceB" );
+        Enrollment enrollmentB = createEnrollment( programB, duplicate, organisationUnitA );
+        enrollmentB.setUid( "enrollmentB" );
         duplicate.getEnrollments().add( enrollmentB );
 
         MergeObject generatedMergeObject = deduplicationHelper.generateMergeObject( original, duplicate );
 
-        assertEquals( "programInstanceB", generatedMergeObject.getEnrollments().get( 0 ) );
+        assertEquals( "enrollmentB", generatedMergeObject.getEnrollments().get( 0 ) );
     }
 
     @Test
@@ -393,11 +393,11 @@ class DeduplicationHelperTest extends DhisConvenienceTest
         TrackedEntityInstance original = getTeiA();
 
         Program program = createProgram( 'A' );
-        Enrollment enrollmentA = createProgramInstance( program, original, organisationUnitA );
+        Enrollment enrollmentA = createEnrollment( program, original, organisationUnitA );
         original.getEnrollments().add( enrollmentA );
 
         TrackedEntityInstance duplicate = getTeiA();
-        Enrollment enrollmentB = createProgramInstance( program, duplicate, organisationUnitA );
+        Enrollment enrollmentB = createEnrollment( program, duplicate, organisationUnitA );
         duplicate.getEnrollments().add( enrollmentB );
 
         assertThrows( PotentialDuplicateConflictException.class,

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deduplication/DeduplicationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deduplication/DeduplicationServiceTest.java
@@ -194,7 +194,7 @@ class DeduplicationServiceTest
     }
 
     @Test
-    void shouldNotBeAutoMergeableSameProgramInstance()
+    void shouldNotBeAutoMergeableSameEnrollment()
         throws PotentialDuplicateConflictException,
         PotentialDuplicateForbiddenException
     {

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/ProgramNotificationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/ProgramNotificationServiceTest.java
@@ -218,7 +218,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest
     // -------------------------------------------------------------------------
 
     @Test
-    void testIfProgramInstanceIsNull()
+    void testIfEnrollmentIsNull()
     {
         when( enrollmentStore.get( anyLong() ) ).thenReturn( null );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/EventAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/EventAggregate.java
@@ -68,8 +68,8 @@ public class EventAggregate
      *
      * @param ids a List of {@see Enrollment} Primary Keys
      * @param ctx the {@see AggregateContext}
-     * @return a Map where the key is a Program Instance Primary Key, and the
-     *         value is a List of {@see Event}
+     * @return a Map where the key is a Enrollment Primary Key, and the value is
+     *         a List of {@see Event}
      */
     Multimap<String, Event> findByEnrollmentIds( List<Long> ids, AggregateContext ctx )
     {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventSearchParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventSearchParams.java
@@ -819,7 +819,7 @@ public class EventSearchParams
         return programInstances;
     }
 
-    public EventSearchParams setProgramInstances( Set<String> programInstances )
+    public EventSearchParams setEnrollments( Set<String> programInstances )
     {
         this.programInstances = programInstances;
         return this;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/EnrollmentSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/EnrollmentSupplier.java
@@ -78,7 +78,7 @@ public class EnrollmentSupplier extends AbstractSupplier<Map<String, Enrollment>
             return new HashMap<>();
         }
 
-        // Collect all the program instance UIDs to pass as SQL query argument
+        // Collect all the enrollment UIDs to pass as SQL query argument
         Set<String> programInstanceUids = events.stream()
             .map( Event::getEnrollment )
             .filter( StringUtils::isNotEmpty ).collect( Collectors.toSet() );
@@ -110,7 +110,7 @@ public class EnrollmentSupplier extends AbstractSupplier<Map<String, Enrollment>
 
     /**
      * Loop through the events and check if there is any event left without a
-     * Program Instance: for each Event without a PI, try to fetch the Program
+     * Enrollment: for each Event without a PI, try to fetch the Program
      * Instance by Program and Tracked Entity Instance
      */
     private void mapEventsToProgramInstanceByTei( ImportOptions importOptions, List<Event> events,
@@ -141,14 +141,14 @@ public class EnrollmentSupplier extends AbstractSupplier<Map<String, Enrollment>
     /**
      * This method is only used if the Event already exist in the db (update) If
      * the Event does not have the "enrollment" property set OR enrollment is
-     * pointing to an invalid UID, use the Program Instance already connected to
-     * the Event.
+     * pointing to an invalid UID, use the Enrollment already connected to the
+     * Event.
      *
      */
     private void mapExistingEventsToProgramInstances( ImportOptions importOptions, List<Event> events,
         Map<String, Enrollment> programInstances )
     {
-        // Collect all the Program Instances by event uid
+        // Collect all the Enrollments by event uid
         final Map<String, Enrollment> programInstancesByEvent = getProgramInstanceByEvent( importOptions, events );
 
         if ( !programInstancesByEvent.isEmpty() )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/insert/preprocess/EnrollmentPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/insert/preprocess/EnrollmentPreProcessor.java
@@ -44,9 +44,9 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 /**
- * The goal of this Pre-processor is to assign a Program Instance (Enrollment)
- * to the Event getting processed. If the Program Instance can not be assigned,
- * the Event will not pass validation.
+ * The goal of this Pre-processor is to assign a Enrollment (Enrollment) to the
+ * Event getting processed. If the Enrollment can not be assigned, the Event
+ * will not pass validation.
  *
  * @author Luciano Fiandesio
  */
@@ -85,7 +85,7 @@ public class EnrollmentPreProcessor implements Processor
             List<Enrollment> enrollments = getProgramInstances( ctx.getServiceDelegator().getJdbcTemplate(),
                 program, ProgramStatus.ACTIVE );
 
-            // the "original" event import code creates a Program Instance, if
+            // the "original" event import code creates a Enrollment, if
             // none is found
             // but this is no longer needed, since a Program POST-CREATION hook
             // takes care of that
@@ -94,7 +94,7 @@ public class EnrollmentPreProcessor implements Processor
                 event.setEnrollment( enrollments.get( 0 ).getUid() );
                 ctx.getProgramInstanceMap().put( event.getUid(), enrollments.get( 0 ) );
             }
-            // If more than one Program Instance is present, the validation will
+            // If more than one Enrollment is present, the validation will
             // detect it later
         }
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/mapper/ProgramStageInstanceMapper.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/mapper/ProgramStageInstanceMapper.java
@@ -105,7 +105,7 @@ public class ProgramStageInstanceMapper extends AbstractMapper<org.hisp.dhis.dxf
 
     private Event mapForUpdate( org.hisp.dhis.dxf2.events.event.Event event, Event psi )
     {
-        // Program Instance
+        // Enrollment
         workContext.getProgramInstance( event.getUid() ).ifPresent( psi::setEnrollment );
 
         // Program Stage
@@ -169,7 +169,7 @@ public class ProgramStageInstanceMapper extends AbstractMapper<org.hisp.dhis.dxf
             psi.setUid( event.getUid() );
         }
 
-        // Program Instance
+        // Enrollment
         psi.setEnrollment( this.workContext.getProgramInstanceMap().get( event.getUid() ) );
 
         // Program Stage

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/shared/validation/EnrollmentCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/shared/validation/EnrollmentCheck.java
@@ -65,7 +65,7 @@ public class EnrollmentCheck implements Checker
 
         List<Enrollment> enrollments;
 
-        if ( enrollment == null ) // Program Instance should be NOT null,
+        if ( enrollment == null ) // Enrollment should be NOT null,
                                  // after the pre-processing stage
         {
             if ( program.isRegistration() )
@@ -93,7 +93,7 @@ public class EnrollmentCheck implements Checker
 
                 if ( enrollments.size() > 1 )
                 {
-                    return error( "Multiple active program instances exists for program: " + program.getUid(),
+                    return error( "Multiple active enrollments exists for program: " + program.getUid(),
                         event.getEvent() );
                 }
             }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/shared/validation/EventBaseCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/shared/validation/EventBaseCheck.java
@@ -111,7 +111,7 @@ public class EventBaseCheck implements Checker
 
         if ( enrollment == null )
         {
-            errors.add( "No program instance found for event: " + event.getEvent() );
+            errors.add( "No enrollment found for event: " + event.getEvent() );
 
         }
         else if ( COMPLETED.equals( enrollment.getStatus() ) )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/relationship/AbstractRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/relationship/AbstractRelationshipService.java
@@ -143,7 +143,7 @@ public abstract class AbstractRelationshipService
         User user = currentUserService.getCurrentUser();
 
         return relationshipService
-            .getRelationshipsByProgramInstance( pi, pagingAndSortingCriteriaAdapter, skipAccessValidation ).stream()
+            .getRelationshipsByEnrollment( pi, pagingAndSortingCriteriaAdapter, skipAccessValidation ).stream()
             .filter( ( r ) -> !skipAccessValidation && trackerAccessManager.canRead( user, r ).isEmpty() )
             .map( r -> getRelationship( r, user ) )
             .filter( Optional::isPresent )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/relationship/AbstractRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/relationship/AbstractRelationshipService.java
@@ -136,7 +136,7 @@ public abstract class AbstractRelationshipService
 
     @Override
     @Transactional( readOnly = true )
-    public List<Relationship> getRelationshipsByProgramInstance( Enrollment pi,
+    public List<Relationship> getRelationshipsByEnrollment( Enrollment pi,
         PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
         boolean skipAccessValidation )
     {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/relationship/RelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/relationship/RelationshipService.java
@@ -59,7 +59,7 @@ public interface RelationshipService
         PagingAndSortingCriteriaAdapter criteria,
         boolean skipAccessValidation );
 
-    List<Relationship> getRelationshipsByProgramInstance( Enrollment pi,
+    List<Relationship> getRelationshipsByEnrollment( Enrollment pi,
         PagingAndSortingCriteriaAdapter criteria,
         boolean skipAccessValidation );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -137,7 +137,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
 
     protected org.hisp.dhis.dxf2.events.enrollment.EnrollmentService enrollmentService;
 
-    protected EnrollmentService enrollmentService;
+    protected EnrollmentService programInstanceService;
 
     protected TrackedEntityInstanceAuditService trackedEntityInstanceAuditService;
 
@@ -1140,7 +1140,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
             {
                 delete.add( enrollment );
             }
-            else if ( !enrollmentService.enrollmentExists( enrollment.getEnrollment() ) )
+            else if ( !programInstanceService.enrollmentExists( enrollment.getEnrollment() ) )
             {
                 create.add( enrollment );
             }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -137,7 +137,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
 
     protected org.hisp.dhis.dxf2.events.enrollment.EnrollmentService enrollmentService;
 
-    protected EnrollmentService programInstanceService;
+    protected EnrollmentService enrollmentService;
 
     protected TrackedEntityInstanceAuditService trackedEntityInstanceAuditService;
 
@@ -1140,7 +1140,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
             {
                 delete.add( enrollment );
             }
-            else if ( !programInstanceService.enrollmentExists( enrollment.getEnrollment() ) )
+            else if ( !enrollmentService.enrollmentExists( enrollment.getEnrollment() ) )
             {
                 create.add( enrollment );
             }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/JacksonTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/JacksonTrackedEntityInstanceService.java
@@ -90,7 +90,7 @@ public class JacksonTrackedEntityInstanceService extends AbstractTrackedEntityIn
         UserService userService,
         DbmsManager dbmsManager,
         org.hisp.dhis.dxf2.events.enrollment.EnrollmentService enrollmentService,
-        EnrollmentService enrollmentService,
+        EnrollmentService programInstanceService,
         CurrentUserService currentUserService,
         SchemaService schemaService,
         QueryService queryService,
@@ -116,7 +116,7 @@ public class JacksonTrackedEntityInstanceService extends AbstractTrackedEntityIn
         checkNotNull( userService );
         checkNotNull( dbmsManager );
         checkNotNull( enrollmentService );
-        checkNotNull( enrollmentService );
+        checkNotNull( programInstanceService );
         checkNotNull( currentUserService );
         checkNotNull( schemaService );
         checkNotNull( queryService );
@@ -141,7 +141,7 @@ public class JacksonTrackedEntityInstanceService extends AbstractTrackedEntityIn
         this.userService = userService;
         this.dbmsManager = dbmsManager;
         this.enrollmentService = enrollmentService;
-        this.enrollmentService = enrollmentService;
+        this.programInstanceService = programInstanceService;
         this.currentUserService = currentUserService;
         this.schemaService = schemaService;
         this.queryService = queryService;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/JacksonTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/JacksonTrackedEntityInstanceService.java
@@ -90,7 +90,7 @@ public class JacksonTrackedEntityInstanceService extends AbstractTrackedEntityIn
         UserService userService,
         DbmsManager dbmsManager,
         org.hisp.dhis.dxf2.events.enrollment.EnrollmentService enrollmentService,
-        EnrollmentService programInstanceService,
+        EnrollmentService enrollmentService,
         CurrentUserService currentUserService,
         SchemaService schemaService,
         QueryService queryService,
@@ -116,7 +116,7 @@ public class JacksonTrackedEntityInstanceService extends AbstractTrackedEntityIn
         checkNotNull( userService );
         checkNotNull( dbmsManager );
         checkNotNull( enrollmentService );
-        checkNotNull( programInstanceService );
+        checkNotNull( enrollmentService );
         checkNotNull( currentUserService );
         checkNotNull( schemaService );
         checkNotNull( queryService );
@@ -141,7 +141,7 @@ public class JacksonTrackedEntityInstanceService extends AbstractTrackedEntityIn
         this.userService = userService;
         this.dbmsManager = dbmsManager;
         this.enrollmentService = enrollmentService;
-        this.programInstanceService = programInstanceService;
+        this.enrollmentService = enrollmentService;
         this.currentUserService = currentUserService;
         this.schemaService = schemaService;
         this.queryService = queryService;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/EnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/EnrollmentStore.java
@@ -59,8 +59,8 @@ public interface EnrollmentStore
     Multimap<String, Note> getNotes( List<Long> ids );
 
     /**
-     * Fetches all the relationships having the Program Instance id specified in
-     * the arg as "left" or "right" relationship
+     * Fetches all the relationships having the Enrollment id specified in the
+     * arg as "left" or "right" relationship
      *
      * @param ids a list of {@see Enrollment} Primary Keys
      * @return a MultiMap where key is a {@see Enrollment} uid and the key a

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/EventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/EventStore.java
@@ -47,10 +47,10 @@ public interface EventStore
     /**
      * Key: enrollment uid -> Value: Event
      *
-     * @param enrollmentsId a List of Program Instance Primary Keys
+     * @param enrollmentsId a List of Enrollment Primary Keys
      * @param ctx the {@see AggregateContext}
-     * @return A Map, where the key is a Program Instance Primary Key, and the
-     *         value is a List of {@see Event}
+     * @return A Map, where the key is a Enrollment Primary Key, and the value
+     *         is a List of {@see Event}
      */
     Multimap<String, Event> getEventsByEnrollmentIds( List<Long> enrollmentsId, AggregateContext ctx );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/mapper/RelationshipRowCallbackHandler.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/mapper/RelationshipRowCallbackHandler.java
@@ -104,11 +104,11 @@ public class RelationshipRowCallbackHandler extends AbstractMapper<Relationship>
     /**
      * The SQL query that generates the ResultSet used by this
      * {@see RowCallbackHandler} fetches both sides of a relationship: since
-     * each side can be a Tracked Entity Instance, a Program Instance or a
-     * Program Stage Instance, the query adds an "hint" to the final result to
-     * help this Handler to correctly associate the type to the left or right
-     * side of the relationship. The "typeWithUid" variable contains the UID of
-     * the object and a string representing the type. E.g.
+     * each side can be a Tracked Entity Instance, a Enrollment or a Program
+     * Stage Instance, the query adds an "hint" to the final result to help this
+     * Handler to correctly associate the type to the left or right side of the
+     * relationship. The "typeWithUid" variable contains the UID of the object
+     * and a string representing the type. E.g.
      *
      * tei|dj3382832 psi|332983893
      *

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/insert/preprocess/EnrollmentPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/insert/preprocess/EnrollmentPreProcessorTest.java
@@ -92,7 +92,7 @@ class EnrollmentPreProcessorTest extends BasePreProcessTest
     {
         this.subject = new EnrollmentPreProcessor();
         //
-        // empty Program Instance Map
+        // empty Enrollment Map
         //
         when( workContext.getProgramInstanceMap() ).thenReturn( programInstanceMap );
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/shared/validation/EnrollmentCheckTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/shared/validation/EnrollmentCheckTest.java
@@ -81,7 +81,7 @@ class EnrollmentCheckTest extends BaseValidationTest
     {
         // Data preparation
         //
-        // Program Instance
+        // Enrollment
         //
         when( workContext.getProgramInstanceMap() ).thenReturn( new HashMap<>() );
         //
@@ -103,7 +103,7 @@ class EnrollmentCheckTest extends BaseValidationTest
     {
         // Data preparation
         //
-        // Program Instance
+        // Enrollment
         //
         when( workContext.getProgramInstanceMap() ).thenReturn( new HashMap<>() );
         //
@@ -134,7 +134,7 @@ class EnrollmentCheckTest extends BaseValidationTest
         programMap.put( programNoReg.getUid(), programNoReg );
         when( workContext.getProgramsMap() ).thenReturn( programMap );
         //
-        // Program Instance
+        // Enrollment
         //
         when( workContext.getProgramInstanceMap() ).thenReturn( new HashMap<>() );
         //
@@ -154,6 +154,6 @@ class EnrollmentCheckTest extends BaseValidationTest
         //
         ImportSummary summary = rule.check( new ImmutableEvent( event ), workContext );
         assertHasError( summary, event,
-            "Multiple active program instances exists for program: " + programNoReg.getUid() );
+            "Multiple active enrollments exists for program: " + programNoReg.getUid() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/shared/validation/EventBaseCheckTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/shared/validation/EventBaseCheckTest.java
@@ -109,7 +109,7 @@ class EventBaseCheckTest extends BaseValidationTest
         event.setEvent( event.getUid() );
         ImportSummary importSummary = rule.check( new ImmutableEvent( event ), workContext );
         assertHasError( importSummary, event, null );
-        assertHasConflict( importSummary, event, "No program instance found for event: " + event.getEvent() );
+        assertHasConflict( importSummary, event, "No enrollment found for event: " + event.getEvent() );
     }
 
     @Test
@@ -134,7 +134,7 @@ class EventBaseCheckTest extends BaseValidationTest
         Map<String, Enrollment> programInstanceMap = new HashMap<>();
         Enrollment enrollment = new Enrollment();
         enrollment.setStatus( ProgramStatus.COMPLETED );
-        // Set program instance end date to NOW - one month
+        // Set enrollment end date to NOW - one month
         enrollment.setEndDate( Date.from( ZonedDateTime.now().minusMonths( 1 ).toInstant() ) );
         programInstanceMap.put( event.getUid(), enrollment );
         when( workContext.getProgramInstanceMap() ).thenReturn( programInstanceMap );

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEngineService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEngineService.java
@@ -78,36 +78,36 @@ public class DefaultProgramRuleEngineService
 
     @Override
     @Transactional
-    public List<RuleEffect> evaluateEnrollmentAndRunEffects( long enrollment )
+    public List<RuleEffect> evaluateEnrollmentAndRunEffects( long enrollmentId )
     {
         if ( config.isDisabled( SYSTEM_PROGRAM_RULE_SERVER_EXECUTION ) )
         {
             return List.of();
         }
 
-        Enrollment programInstance = enrollmentService.getEnrollment( enrollment );
+        Enrollment enrollment = enrollmentService.getEnrollment( enrollmentId );
 
-        if ( programInstance == null )
+        if ( enrollment == null )
         {
             return List.of();
         }
 
-        List<ProgramRule> programRules = programRuleEngine.getProgramRules( programInstance.getProgram() );
+        List<ProgramRule> programRules = programRuleEngine.getProgramRules( enrollment.getProgram() );
 
         if ( programRules.isEmpty() )
         {
             return List.of();
         }
 
-        List<RuleEffect> ruleEffects = programRuleEngine.evaluate( programInstance,
-            programInstance.getEvents(), programRules );
+        List<RuleEffect> ruleEffects = programRuleEngine.evaluate( enrollment,
+            enrollment.getEvents(), programRules );
 
         for ( RuleEffect effect : ruleEffects )
         {
             ruleActionImplementers.stream().filter( i -> i.accept( effect.ruleAction() ) ).forEach( i -> {
                 log.debug( String.format( "Invoking action implementer: %s", i.getClass().getSimpleName() ) );
 
-                i.implement( effect, programInstance );
+                i.implement( effect, enrollment );
             } );
         }
 

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/NotificationRuleActionImplementerTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/NotificationRuleActionImplementerTest.java
@@ -135,7 +135,7 @@ class NotificationRuleActionImplementerTest extends DhisConvenienceTest
     }
 
     @Test
-    void test_implementWithProgramInstanceWithTemplate()
+    void test_implementWithEnrollmentWithTemplate()
     {
 
         when( templateStore.getByUid( anyString() ) ).thenReturn( template );
@@ -161,7 +161,7 @@ class NotificationRuleActionImplementerTest extends DhisConvenienceTest
 
         verify( publisher ).publishEvent( argumentEventCaptor.capture() );
         assertEquals( eventType, argumentEventCaptor.getValue() );
-        assertEquals( enrollment.getId(), ((ProgramRuleEnrollmentEvent) eventType).getProgramInstance().getId() );
+        assertEquals( enrollment.getId(), ((ProgramRuleEnrollmentEvent) eventType).getEnrollment().getId() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineServiceTest.java
@@ -153,7 +153,7 @@ class ProgramRuleEngineServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    void testWhenNoImplementableActionExist_programInstance()
+    void testWhenNoImplementableActionExist_enrollment()
     {
         setProgramRuleActionType_ShowError();
 
@@ -162,7 +162,7 @@ class ProgramRuleEngineServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    void testWithImplementableActionExist_programInstance()
+    void testWithImplementableActionExist_enrollment()
     {
         doAnswer( invocationOnMock -> {
             ruleEffects.add( (RuleEffect) invocationOnMock.getArguments()[0] );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -202,7 +202,7 @@ public class DefaultEnrollmentService implements org.hisp.dhis.tracker.export.en
             params.setDefaultPaging();
         }
 
-        List<Enrollment> programInstances = new ArrayList<>(
+        List<Enrollment> enrollmentList = new ArrayList<>(
             enrollmentService.getEnrollments( params ) );
         if ( !params.isSkipPaging() )
         {
@@ -215,13 +215,13 @@ public class DefaultEnrollmentService implements org.hisp.dhis.tracker.export.en
             }
             else
             {
-                pager = handleLastPageFlag( params, programInstances );
+                pager = handleLastPageFlag( params, enrollmentList );
             }
 
             enrollments.setPager( pager );
         }
 
-        enrollments.setEnrollments( getEnrollments( programInstances ) );
+        enrollments.setEnrollments( getEnrollments( enrollmentList ) );
 
         return enrollments;
     }
@@ -262,20 +262,20 @@ public class DefaultEnrollmentService implements org.hisp.dhis.tracker.export.en
         return new SlimPager( originalPage, originalPageSize, isLastPage );
     }
 
-    private List<Enrollment> getEnrollments( Iterable<Enrollment> programInstances )
+    private List<Enrollment> getEnrollments( Iterable<Enrollment> enrollments )
     {
-        List<Enrollment> enrollments = new ArrayList<>();
+        List<Enrollment> enrollmentList = new ArrayList<>();
         User user = currentUserService.getCurrentUser();
 
-        for ( Enrollment enrollment : programInstances )
+        for ( Enrollment enrollment : enrollments )
         {
             if ( enrollment != null && trackerOwnershipAccessManager
                 .hasAccess( user, enrollment.getEntityInstance(), enrollment.getProgram() ) )
             {
-                enrollments.add( getEnrollment( user, enrollment, EnrollmentParams.FALSE ) );
+                enrollmentList.add( getEnrollment( user, enrollment, EnrollmentParams.FALSE ) );
             }
         }
 
-        return enrollments;
+        return enrollmentList;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/Events.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/Events.java
@@ -49,7 +49,7 @@ public class Events
 {
     private String program;
 
-    private String programInstance;
+    private String enrollment;
 
     private List<Event> events = new ArrayList<>();
 
@@ -75,14 +75,14 @@ public class Events
 
     @JsonProperty
     @JacksonXmlProperty( isAttribute = true )
-    public String getProgramInstance()
+    public String getEnrollment()
     {
-        return programInstance;
+        return enrollment;
     }
 
-    public void setProgramInstance( String programInstance )
+    public void setEnrollment( String enrollment )
     {
-        this.programInstance = programInstance;
+        this.enrollment = enrollment;
     }
 
     @JsonProperty
@@ -129,7 +129,7 @@ public class Events
     {
         return "Events{" +
             "program='" + program + '\'' +
-            ", programInstance='" + programInstance + '\'' +
+            ", enrollment='" + enrollment + '\'' +
             ", events=" + events +
             '}';
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -89,14 +89,14 @@ public class DefaultRelationshipService implements RelationshipService
     }
 
     @Override
-    public List<Relationship> getRelationshipsByProgramInstance( Enrollment pi,
+    public List<Relationship> getRelationshipsByEnrollment( Enrollment enrollment,
         PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter )
         throws ForbiddenException,
         NotFoundException
     {
 
         List<Relationship> relationships = relationshipStore
-            .getByProgramInstance( pi, pagingAndSortingCriteriaAdapter ).stream()
+            .getByEnrollment( enrollment, pagingAndSortingCriteriaAdapter ).stream()
             .filter( r -> trackerAccessManager.canRead( currentUserService.getCurrentUser(), r ).isEmpty() )
             .collect( Collectors.toList() );
         return map( relationships );
@@ -180,7 +180,7 @@ public class DefaultRelationshipService implements RelationshipService
         RelationshipItem result = new RelationshipItem();
 
         // the call to the individual services is to detach and apply some logic like filtering out attribute values
-        // for tracked entity type attributes from programInstance.entityInstance. Enrollment attributes are actually
+        // for tracked entity type attributes from enrollment.entityInstance. Enrollment attributes are actually
         // owned by the TEI and cannot be set on the Enrollment. When returning enrollments in our API an enrollment
         // should only have the program tracked entity attributes.
         if ( item.getTrackedEntityInstance() != null )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
@@ -45,7 +45,7 @@ public interface RelationshipService
         throws ForbiddenException,
         NotFoundException;
 
-    List<Relationship> getRelationshipsByProgramInstance( Enrollment pi,
+    List<Relationship> getRelationshipsByEnrollment( Enrollment pi,
         PagingAndSortingCriteriaAdapter criteria )
         throws ForbiddenException,
         NotFoundException;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -216,7 +216,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService
         }
         if ( params.isIncludeEnrollments() )
         {
-            result.setEnrollments( getProgramInstances( trackedEntity, params, user ) );
+            result.setEnrollments( getEnrollments( trackedEntity, params, user ) );
         }
         if ( params.isIncludeProgramOwners() )
         {
@@ -245,7 +245,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService
         return items;
     }
 
-    private Set<Enrollment> getProgramInstances( TrackedEntityInstance trackedEntity, TrackedEntityParams params,
+    private Set<Enrollment> getEnrollments( TrackedEntityInstance trackedEntity, TrackedEntityParams params,
         User user )
     {
         Set<Enrollment> enrollments = new HashSet<>();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/EnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/EnrollmentStore.java
@@ -58,8 +58,8 @@ public interface EnrollmentStore
     Multimap<String, TrackedEntityComment> getNotes( List<Long> ids );
 
     /**
-     * Fetches all the relationships having the Program Instance id specified in
-     * the arg as "left" or "right" relationship
+     * Fetches all the relationships having the Enrollment id specified in the
+     * arg as "left" or "right" relationship
      *
      * @param ids a list of {@see Enrollment} Primary Keys
      * @return a MultiMap where key is a {@see Enrollment} uid and the key a

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/EventAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/EventAggregate.java
@@ -69,8 +69,8 @@ public class EventAggregate
      *
      * @param ids a List of {@see Enrollment} Primary Keys
      * @param ctx the {@see Context}
-     * @return a Map where the key is a Program Instance Primary Key, and the
-     *         value is a List of {@see Event}
+     * @return a Map where the key is a Enrollment Primary Key, and the value is
+     *         a List of {@see Event}
      */
     Multimap<String, Event> findByEnrollmentIds( List<Long> ids, Context ctx )
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/EventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/EventStore.java
@@ -45,10 +45,10 @@ public interface EventStore
     /**
      * Key: enrollment uid -> Value: Event
      *
-     * @param enrollmentsId a List of Program Instance Primary Keys
+     * @param enrollmentsId a List of Enrollment Primary Keys
      * @param ctx the {@see Context}
-     * @return A Map, where the key is a Program Instance Primary Key, and the
-     *         value is a List of {@see Event}
+     * @return A Map, where the key is a Enrollment Primary Key, and the value
+     *         is a List of {@see Event}
      */
     Multimap<String, Event> getEventsByEnrollmentIds( List<Long> enrollmentsId, Context ctx );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/mapper/RelationshipRowCallbackHandler.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/mapper/RelationshipRowCallbackHandler.java
@@ -111,11 +111,11 @@ public class RelationshipRowCallbackHandler extends AbstractMapper<RelationshipI
     /**
      * The SQL query that generates the ResultSet used by this
      * {@see RowCallbackHandler} fetches both sides of a relationship: since
-     * each side can be a Tracked Entity Instance, a Program Instance or a
-     * Program Stage Instance, the query adds a "hint" to the final result to
-     * help this Handler to correctly associate the type to the left or right
-     * side of the relationship. The "typeWithUid" variable contains the UID of
-     * the object and a string representing the type. E.g.
+     * each side can be a Tracked Entity Instance, a Enrollment or a Program
+     * Stage Instance, the query adds a "hint" to the final result to help this
+     * Handler to correctly associate the type to the left or right side of the
+     * relationship. The "typeWithUid" variable contains the UID of the object
+     * and a string representing the type. E.g.
      *
      * tei|dj3382832 psi|332983893
      *

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/DefaultTrackerObjectsDeletionService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/DefaultTrackerObjectsDeletionService.java
@@ -160,10 +160,10 @@ public class DefaultTrackerObjectsDeletionService
             org.hisp.dhis.trackedentity.TrackedEntityInstance daoEntityInstance = teiService
                 .getTrackedEntityInstance( uid );
 
-            Set<Enrollment> programInstances = daoEntityInstance.getEnrollments();
+            Set<Enrollment> daoEnrollments = daoEntityInstance.getEnrollments();
 
             List<org.hisp.dhis.tracker.imports.domain.Enrollment> enrollments = enrollmentTrackerConverterService
-                .to( Lists.newArrayList( programInstances.stream()
+                .to( Lists.newArrayList( daoEnrollments.stream()
                     .filter( pi -> !pi.isDeleted() )
                     .collect( Collectors.toList() ) ) );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/EnrollmentPersister.java
@@ -78,15 +78,15 @@ public class EnrollmentPersister
 
     @Override
     protected void updateAttributes( Session session, TrackerPreheat preheat,
-        org.hisp.dhis.tracker.imports.domain.Enrollment enrollment, Enrollment programInstance )
+        org.hisp.dhis.tracker.imports.domain.Enrollment enrollment, Enrollment enrollmentToPersist )
     {
         handleTrackedEntityAttributeValues( session, preheat, enrollment.getAttributes(),
-            preheat.getTrackedEntity( programInstance.getEntityInstance().getUid() ) );
+            preheat.getTrackedEntity( enrollmentToPersist.getEntityInstance().getUid() ) );
     }
 
     @Override
     protected void updateDataValues( Session session, TrackerPreheat preheat,
-        org.hisp.dhis.tracker.imports.domain.Enrollment enrollment, Enrollment programInstance )
+        org.hisp.dhis.tracker.imports.domain.Enrollment enrollment, Enrollment enrollmentToPersist )
     {
         // DO NOTHING - TEI HAVE NO DATA VALUES
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/EnrollmentTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/EnrollmentTrackerConverterService.java
@@ -78,11 +78,11 @@ public class EnrollmentTrackerConverterService
     }
 
     @Override
-    public List<org.hisp.dhis.tracker.imports.domain.Enrollment> to( List<Enrollment> programInstances )
+    public List<org.hisp.dhis.tracker.imports.domain.Enrollment> to( List<Enrollment> preheatEnrollments )
     {
         List<org.hisp.dhis.tracker.imports.domain.Enrollment> enrollments = new ArrayList<>();
 
-        programInstances.forEach( tei -> {
+        preheatEnrollments.forEach( tei -> {
             // TODO: Add implementation
         } );
 
@@ -92,8 +92,8 @@ public class EnrollmentTrackerConverterService
     @Override
     public Enrollment from( TrackerPreheat preheat, org.hisp.dhis.tracker.imports.domain.Enrollment enrollment )
     {
-        Enrollment programInstance = preheat.getEnrollment( enrollment.getEnrollment() );
-        return from( preheat, enrollment, programInstance );
+        Enrollment preheatEnrollment = preheat.getEnrollment( enrollment.getEnrollment() );
+        return from( preheat, enrollment, preheatEnrollment );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/EnrollmentTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/EnrollmentTrackerConverterService.java
@@ -114,7 +114,7 @@ public class EnrollmentTrackerConverterService
     }
 
     private Enrollment from( TrackerPreheat preheat, org.hisp.dhis.tracker.imports.domain.Enrollment enrollment,
-        Enrollment programInstance )
+        Enrollment dbEnrollment )
     {
         OrganisationUnit organisationUnit = preheat.getOrganisationUnit( enrollment.getOrgUnit() );
 
@@ -128,59 +128,59 @@ public class EnrollmentTrackerConverterService
 
         Date now = new Date();
 
-        if ( isNewEntity( programInstance ) )
+        if ( isNewEntity( dbEnrollment ) )
         {
-            programInstance = new Enrollment();
-            programInstance.setUid(
+            dbEnrollment = new Enrollment();
+            dbEnrollment.setUid(
                 !StringUtils.isEmpty( enrollment.getEnrollment() ) ? enrollment.getEnrollment() : enrollment.getUid() );
-            programInstance.setCreated( now );
-            programInstance.setStoredBy( enrollment.getStoredBy() );
-            programInstance.setCreatedByUserInfo( UserInfoSnapshot.from( preheat.getUser() ) );
+            dbEnrollment.setCreated( now );
+            dbEnrollment.setStoredBy( enrollment.getStoredBy() );
+            dbEnrollment.setCreatedByUserInfo( UserInfoSnapshot.from( preheat.getUser() ) );
         }
 
-        programInstance.setLastUpdated( now );
-        programInstance.setLastUpdatedByUserInfo( UserInfoSnapshot.from( preheat.getUser() ) );
-        programInstance.setDeleted( false );
-        programInstance.setCreatedAtClient( DateUtils.fromInstant( enrollment.getCreatedAtClient() ) );
-        programInstance.setLastUpdatedAtClient( DateUtils.fromInstant( enrollment.getUpdatedAtClient() ) );
+        dbEnrollment.setLastUpdated( now );
+        dbEnrollment.setLastUpdatedByUserInfo( UserInfoSnapshot.from( preheat.getUser() ) );
+        dbEnrollment.setDeleted( false );
+        dbEnrollment.setCreatedAtClient( DateUtils.fromInstant( enrollment.getCreatedAtClient() ) );
+        dbEnrollment.setLastUpdatedAtClient( DateUtils.fromInstant( enrollment.getUpdatedAtClient() ) );
 
         Date enrollmentDate = DateUtils.fromInstant( enrollment.getEnrolledAt() );
         Date incidentDate = DateUtils.fromInstant( enrollment.getOccurredAt() );
 
-        programInstance.setEnrollmentDate( enrollmentDate );
-        programInstance.setIncidentDate( incidentDate != null ? incidentDate : enrollmentDate );
-        programInstance.setOrganisationUnit( organisationUnit );
-        programInstance.setProgram( program );
-        programInstance.setEntityInstance( trackedEntityInstance );
-        programInstance.setFollowup( enrollment.isFollowUp() );
-        programInstance.setGeometry( enrollment.getGeometry() );
+        dbEnrollment.setEnrollmentDate( enrollmentDate );
+        dbEnrollment.setIncidentDate( incidentDate != null ? incidentDate : enrollmentDate );
+        dbEnrollment.setOrganisationUnit( organisationUnit );
+        dbEnrollment.setProgram( program );
+        dbEnrollment.setEntityInstance( trackedEntityInstance );
+        dbEnrollment.setFollowup( enrollment.isFollowUp() );
+        dbEnrollment.setGeometry( enrollment.getGeometry() );
 
         if ( enrollment.getStatus() == null )
         {
             enrollment.setStatus( EnrollmentStatus.ACTIVE );
         }
 
-        ProgramStatus previousStatus = programInstance.getStatus();
-        programInstance.setStatus( enrollment.getStatus().getProgramStatus() );
+        ProgramStatus previousStatus = dbEnrollment.getStatus();
+        dbEnrollment.setStatus( enrollment.getStatus().getProgramStatus() );
 
-        if ( !Objects.equal( previousStatus, programInstance.getStatus() ) )
+        if ( !Objects.equal( previousStatus, dbEnrollment.getStatus() ) )
         {
-            if ( programInstance.isCompleted() )
+            if ( dbEnrollment.isCompleted() )
             {
-                programInstance.setEndDate( new Date() );
-                programInstance.setCompletedBy( preheat.getUsername() );
+                dbEnrollment.setEndDate( new Date() );
+                dbEnrollment.setCompletedBy( preheat.getUsername() );
             }
-            else if ( programInstance.getStatus().equals( ProgramStatus.CANCELLED ) )
+            else if ( dbEnrollment.getStatus().equals( ProgramStatus.CANCELLED ) )
             {
-                programInstance.setEndDate( new Date() );
+                dbEnrollment.setEndDate( new Date() );
             }
         }
 
         if ( isNotEmpty( enrollment.getNotes() ) )
         {
-            programInstance.getComments()
+            dbEnrollment.getComments()
                 .addAll( notesConverterService.from( preheat, enrollment.getNotes() ) );
         }
-        return programInstance;
+        return dbEnrollment;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheat.java
@@ -275,7 +275,7 @@ public class TrackerPreheat
     private final Map<String, Map<String, TrackedEntityProgramOwnerOrgUnit>> programOwner = new HashMap<>();
 
     /**
-     * A Map of trackedEntity uid connected to Program Instances
+     * A Map of trackedEntity uid connected to Enrollments
      */
     @Getter
     @Setter
@@ -305,7 +305,7 @@ public class TrackerPreheat
     private List<UniqueAttributeValue> uniqueAttributeValues = Lists.newArrayList();
 
     /**
-     * A list of all Program Instance UID having at least one Event that is not
+     * A list of all Enrollment UID having at least one Event that is not
      * deleted.
      */
     @Getter

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/EnrollmentsWithAtLeastOneEventSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/EnrollmentsWithAtLeastOneEventSupplier.java
@@ -41,8 +41,8 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.stereotype.Component;
 
 /**
- * This supplier adds to the pre-heat object a List of all Program Instance UIDs
- * that have at least ONE Program Stage Instance that is not logically deleted
+ * This supplier adds to the pre-heat object a List of all Enrollment UIDs that
+ * have at least ONE Program Stage Instance that is not logically deleted
  * ('deleted = true').
  *
  * @author Luciano Fiandesio

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/EventProgramStageMapSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/EventProgramStageMapSupplier.java
@@ -54,7 +54,7 @@ public class EventProgramStageMapSupplier
 {
     private static final String PS_UID = "programStageUid";
 
-    private static final String PI_UID = "programInstanceUid";
+    private static final String PI_UID = "enrollmentUid";
 
     private static final String SQL = "select distinct ps.uid as " + PS_UID + ", pi.uid as " + PI_UID + " " +
         " from programinstance as pi " +
@@ -64,7 +64,7 @@ public class EventProgramStageMapSupplier
         " and psi.status != 'SKIPPED' " +
         " and ps.programstageid = psi.programstageid " +
         " and ps.uid in (:programStageUids) " +
-        " and pi.uid in (:programInstanceUids) ";
+        " and pi.uid in (:enrollmentUids) ";
 
     protected EventProgramStageMapSupplier( JdbcTemplate jdbcTemplate )
     {
@@ -89,17 +89,17 @@ public class EventProgramStageMapSupplier
             .distinct()
             .collect( Collectors.toList() );
 
-        List<String> programInstanceUids = params.getEvents().stream()
+        List<String> enrollmentUids = params.getEvents().stream()
             .map( Event::getEnrollment )
             .filter( Objects::nonNull )
             .distinct()
             .collect( Collectors.toList() );
 
-        if ( !notRepeatableProgramStageUids.isEmpty() && !programInstanceUids.isEmpty() )
+        if ( !notRepeatableProgramStageUids.isEmpty() && !enrollmentUids.isEmpty() )
         {
             MapSqlParameterSource parameters = new MapSqlParameterSource();
             parameters.addValue( "programStageUids", notRepeatableProgramStageUids );
-            parameters.addValue( "programInstanceUids", programInstanceUids );
+            parameters.addValue( "enrollmentUids", enrollmentUids );
             jdbcTemplate.query( SQL, parameters, (RowCallbackHandler) rs -> preheat
                 .addProgramStageWithEvents( rs.getString( PS_UID ), rs.getString( PI_UID ) ) );
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/TrackedEntityEnrollmentSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/TrackedEntityEnrollmentSupplier.java
@@ -103,20 +103,20 @@ public class TrackedEntityEnrollmentSupplier extends JdbcAbstractPreheatSupplier
         if ( programList.isEmpty() || teiList.isEmpty() )
             return;
 
-        Map<String, List<Enrollment>> trackedEntityToProgramInstanceMap = new HashMap<>();
+        Map<String, List<Enrollment>> trackedEntityToEnrollmentMap = new HashMap<>();
 
         if ( params.getEnrollments().isEmpty() )
             return;
 
         for ( List<String> trackedEntityListSubList : teiList )
         {
-            queryTeiAndAddToMap( trackedEntityToProgramInstanceMap, trackedEntityListSubList, programList );
+            queryTeiAndAddToMap( trackedEntityToEnrollmentMap, trackedEntityListSubList, programList );
         }
 
-        preheat.setTrackedEntityToEnrollmentMap( trackedEntityToProgramInstanceMap );
+        preheat.setTrackedEntityToEnrollmentMap( trackedEntityToEnrollmentMap );
     }
 
-    private void queryTeiAndAddToMap( Map<String, List<Enrollment>> trackedEntityToProgramInstanceMap,
+    private void queryTeiAndAddToMap( Map<String, List<Enrollment>> trackedEntityToEnrollmentMap,
         List<String> trackedEntityListSubList, List<String> programList )
     {
         MapSqlParameterSource parameters = new MapSqlParameterSource();
@@ -134,12 +134,12 @@ public class TrackedEntityEnrollmentSupplier extends JdbcAbstractPreheatSupplier
             program.setUid( resultSet.getString( PR_UID_COLUMN_ALIAS ) );
             newPi.setProgram( program );
 
-            List<Enrollment> piList = trackedEntityToProgramInstanceMap.getOrDefault( tei,
+            List<Enrollment> piList = trackedEntityToEnrollmentMap.getOrDefault( tei,
                 new ArrayList<>() );
 
             piList.add( newPi );
 
-            trackedEntityToProgramInstanceMap.put( tei, piList );
+            trackedEntityToEnrollmentMap.put( tei, piList );
         } );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/ExistingEnrollmentValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/ExistingEnrollmentValidator.java
@@ -102,7 +102,7 @@ class ExistingEnrollmentValidator
             .filter( pi -> pi.getProgram().getUid().equals( program.getUid() )
                 && !pi.getUid().equals( enrollment.getEnrollment() ) )
             .filter( pi -> ProgramStatus.ACTIVE == pi.getStatus() || ProgramStatus.COMPLETED == pi.getStatus() )
-            .distinct().map( this::getEnrollmentFromProgramInstance )
+            .distinct().map( this::getEnrollmentFromDbEnrollment )
             .collect( Collectors.toSet() );
 
         // Priority to payload
@@ -134,12 +134,12 @@ class ExistingEnrollmentValidator
         }
     }
 
-    public org.hisp.dhis.tracker.imports.domain.Enrollment getEnrollmentFromProgramInstance(
-        Enrollment programInstance )
+    public org.hisp.dhis.tracker.imports.domain.Enrollment getEnrollmentFromDbEnrollment(
+        Enrollment dbEnrollment )
     {
         org.hisp.dhis.tracker.imports.domain.Enrollment enrollment = new org.hisp.dhis.tracker.imports.domain.Enrollment();
-        enrollment.setEnrollment( programInstance.getUid() );
-        enrollment.setStatus( EnrollmentStatus.fromProgramStatus( programInstance.getStatus() ) );
+        enrollment.setEnrollment( dbEnrollment.getUid() );
+        enrollment.setStatus( EnrollmentStatus.fromProgramStatus( dbEnrollment.getStatus() ) );
 
         return enrollment;
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/SecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/SecurityOwnershipValidator.java
@@ -103,7 +103,7 @@ class SecurityOwnershipValidator
 
         if ( strategy.isDelete() )
         {
-            boolean hasNonDeletedEvents = programInstanceHasEvents( preheat, enrollment.getEnrollment() );
+            boolean hasNonDeletedEvents = enrollmentHasEvents( preheat, enrollment.getEnrollment() );
             boolean hasNotCascadeDeleteAuthority = !user
                 .isAuthorized( Authorities.F_ENROLLMENT_CASCADE_DELETE.getAuthority() );
 
@@ -130,9 +130,9 @@ class SecurityOwnershipValidator
         }
     }
 
-    private boolean programInstanceHasEvents( TrackerPreheat preheat, String programInstanceUid )
+    private boolean enrollmentHasEvents( TrackerPreheat preheat, String enrollmentUid )
     {
-        return preheat.getEnrollmentsWithOneOrMoreNonDeletedEvent().contains( programInstanceUid );
+        return preheat.getEnrollmentsWithOneOrMoreNonDeletedEvent().contains( enrollmentUid );
     }
 
     private void checkEnrollmentOrgUnit( Reporter reporter, TrackerBundle bundle,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataRelationsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataRelationsValidator.java
@@ -348,10 +348,10 @@ class DataRelationsValidator
 
     private Program getEnrollmentProgramFromEvent( TrackerBundle bundle, Event event )
     {
-        Enrollment programInstance = bundle.getPreheat().getEnrollment( event.getEnrollment() );
-        if ( programInstance != null )
+        Enrollment preheatEnrollment = bundle.getPreheat().getEnrollment( event.getEnrollment() );
+        if ( preheatEnrollment != null )
         {
-            return programInstance.getProgram();
+            return preheatEnrollment.getProgram();
         }
         else
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/relationship/ConstraintValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/relationship/ConstraintValidator.java
@@ -75,7 +75,7 @@ public class ConstraintValidator implements Validator<Relationship>
             validateTrackedEntityInstanceRelationship( reporter, bundle, relationship, item, relSide, constraint );
             break;
         case PROGRAM_INSTANCE:
-            validateProgramInstanceRelationship( reporter, bundle, relationship, item, relSide );
+            validateEnrollmentRelationship( reporter, bundle, relationship, item, relSide );
             break;
         case PROGRAM_STAGE_INSTANCE:
             validateEventRelationship( reporter, bundle, relationship, item, relSide );
@@ -103,7 +103,7 @@ public class ConstraintValidator implements Validator<Relationship>
         }
     }
 
-    private void validateProgramInstanceRelationship( Reporter reporter, TrackerBundle bundle,
+    private void validateEnrollmentRelationship( Reporter reporter, TrackerBundle bundle,
         Relationship relationship, RelationshipItem item, String relSide )
     {
         if ( item.getEnrollment() == null )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/converter/EventTrackerConverterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/converter/EventTrackerConverterServiceTest.java
@@ -69,7 +69,7 @@ import com.google.common.collect.Sets;
 class EventTrackerConverterServiceTest extends DhisConvenienceTest
 {
 
-    private final static String PROGRAM_INSTANCE_UID = "programInstanceUid";
+    private final static String ENROLLMENT_UID = "enrollmentUid";
 
     private final static String PROGRAM_STAGE_UID = "ProgramStageUid";
 
@@ -114,8 +114,8 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
         program.setUid( PROGRAM_UID );
         program.setProgramType( ProgramType.WITHOUT_REGISTRATION );
         TrackedEntityInstance tei = createTrackedEntityInstance( organisationUnit );
-        Enrollment enrollment = createProgramInstance( program, tei, organisationUnit );
-        enrollment.setUid( PROGRAM_INSTANCE_UID );
+        Enrollment enrollment = createEnrollment( program, tei, organisationUnit );
+        enrollment.setUid( ENROLLMENT_UID );
         event = new Event();
         event.setAutoFields();
         event.setAttributeOptionCombo( createCategoryOptionCombo( 'C' ) );
@@ -311,7 +311,7 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
 
         org.hisp.dhis.tracker.imports.domain.Event event = converter.to( this.event );
 
-        assertEquals( PROGRAM_INSTANCE_UID, event.getEnrollment() );
+        assertEquals( ENROLLMENT_UID, event.getEnrollment() );
         assertEquals( event.getStoredBy(), user.getUsername() );
         event.getDataValues().forEach( e -> {
             assertEquals( DateUtils.fromInstant( e.getCreatedAt() ), this.event.getCreated() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/converter/RelationshipTrackerConverterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/converter/RelationshipTrackerConverterServiceTest.java
@@ -104,7 +104,7 @@ class RelationshipTrackerConverterServiceTest extends DhisConvenienceTest
         tei = createTrackedEntityInstance( organisationUnit );
         tei.setTrackedEntityType( teiType );
         tei.setUid( TEI );
-        pi = createProgramInstance( program, tei, organisationUnit );
+        pi = createEnrollment( program, tei, organisationUnit );
         pi.setUid( ENROLLMENT );
         event = createEvent( createProgramStage( 'A', program ), pi, organisationUnit );
         event.setUid( EVENT );
@@ -198,7 +198,7 @@ class RelationshipTrackerConverterServiceTest extends DhisConvenienceTest
 
     private org.hisp.dhis.relationship.Relationship relationshipAFromDB()
     {
-        return createTeiToProgramInstanceRelationship( tei, pi, teiToEnrollment );
+        return createTeiToEnrollmentRelationship( tei, pi, teiToEnrollment );
     }
 
     private org.hisp.dhis.relationship.Relationship relationshipBFromDB()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/job/TrackerSideEffectDataBundleTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/job/TrackerSideEffectDataBundleTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.hisp.dhis.artemis.MessageType;
+import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
@@ -56,13 +57,12 @@ class TrackerSideEffectDataBundleTest
         enrollment.setEnrollment( "test-enrollment" );
         Map<String, List<TrackerRuleEngineSideEffect>> enrollmentRuleEffects = new HashMap<>();
         enrollmentRuleEffects.put( enrollment.getEnrollment(), Lists.newArrayList() );
-        Enrollment programInstance = new Enrollment();
-        programInstance.setAutoFields();
+        String enrollmentUid = CodeGenerator.generateUid();
         TrackerSideEffectDataBundle bundle = TrackerSideEffectDataBundle.builder()
             .enrollmentRuleEffects( enrollmentRuleEffects ).accessedBy( "testUser" )
-            .importStrategy( TrackerImportStrategy.CREATE ).object( programInstance.getUid() )
+            .importStrategy( TrackerImportStrategy.CREATE ).object( enrollmentUid )
             .klass( Enrollment.class ).build();
-        assertEquals( programInstance.getUid(), bundle.getObject() );
+        assertEquals( enrollmentUid, bundle.getObject() );
         assertEquals( Enrollment.class, bundle.getKlass() );
         assertTrue( bundle.getEnrollmentRuleEffects().containsKey( "test-enrollment" ) );
         assertTrue( bundle.getEventRuleEffects().isEmpty() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/EnrollmentSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/EnrollmentSupplierTest.java
@@ -142,7 +142,7 @@ class EnrollmentSupplierTest extends DhisConvenienceTest
 
         this.supplier.preheatAdd( params, preheat );
 
-        assertProgramInstanceInPreheat( enrollment,
+        assertEnrollmentInPreheat( enrollment,
             preheat.getEnrollmentsWithoutRegistration( programWithoutRegistration.getUid() ) );
     }
 
@@ -154,11 +154,11 @@ class EnrollmentSupplierTest extends DhisConvenienceTest
 
         this.supplier.preheatAdd( params, preheat );
 
-        assertProgramInstanceInPreheat( enrollmentWithoutRegistration,
+        assertEnrollmentInPreheat( enrollmentWithoutRegistration,
             preheat.getEnrollmentsWithoutRegistration( programWithoutRegistration.getUid() ) );
     }
 
-    private void assertProgramInstanceInPreheat( Enrollment expected, Enrollment actual )
+    private void assertEnrollmentInPreheat( Enrollment expected, Enrollment actual )
     {
         assertEquals( expected.getUid(), actual.getUid() );
         assertEquals( expected.getProgram().getUid(), actual.getProgram().getUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/UniqueAttributeSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/UniqueAttributeSupplierTest.java
@@ -108,7 +108,7 @@ class UniqueAttributeSupplierTest extends DhisConvenienceTest
         tei = createTrackedEntityInstance( 'A', orgUnit );
         tei.setUid( TEI_UID );
         tei.setAttributeValues( Collections.singleton( attributeValue ) );
-        enrollment = createProgramInstance( program, tei, orgUnit );
+        enrollment = createEnrollment( program, tei, orgUnit );
         enrollment.setAttributeValues( Collections.singleton( attributeValue ) );
         trackedEntityAttributeValue = createTrackedEntityAttributeValue( 'A', tei, uniqueAttribute );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/EventStatusPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/EventStatusPreProcessorTest.java
@@ -65,7 +65,7 @@ class EventStatusPreProcessorTest
         event.setProgramStage( MetadataIdentifier.ofUid( "programStageUid" ) );
         TrackerBundle bundle = TrackerBundle.builder().events( Collections.singletonList( event ) ).build();
         Enrollment enrollment = new Enrollment();
-        enrollment.setUid( "programInstanceUid" );
+        enrollment.setUid( "enrollmentUid" );
         Program program = new Program();
         program.setUid( "programUid" );
         ProgramStage programStage = new ProgramStage();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/EventWithoutRegistrationPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/EventWithoutRegistrationPreProcessorTest.java
@@ -64,7 +64,7 @@ class EventWithoutRegistrationPreProcessorTest
         event.setProgramStage( MetadataIdentifier.ofUid( "programStageUid" ) );
         TrackerBundle bundle = TrackerBundle.builder().events( Collections.singletonList( event ) ).build();
         Enrollment enrollment = new Enrollment();
-        enrollment.setUid( "programInstanceUid" );
+        enrollment.setUid( "enrollmentUid" );
         Program program = new Program();
         program.setUid( "programUid" );
         ProgramStage programStage = new ProgramStage();
@@ -77,7 +77,7 @@ class EventWithoutRegistrationPreProcessorTest
         // When
         preProcessorToTest.process( bundle );
         // Then
-        assertEquals( "programInstanceUid", bundle.getEvents().get( 0 ).getEnrollment() );
+        assertEquals( "enrollmentUid", bundle.getEvents().get( 0 ).getEnrollment() );
     }
 
     @Test
@@ -88,7 +88,7 @@ class EventWithoutRegistrationPreProcessorTest
         event.setProgramStage( MetadataIdentifier.ofUid( "programStageUid" ) );
         TrackerBundle bundle = TrackerBundle.builder().events( Collections.singletonList( event ) ).build();
         Enrollment enrollment = new Enrollment();
-        enrollment.setUid( "programInstanceUid" );
+        enrollment.setUid( "enrollmentUid" );
         Program program = new Program();
         program.setUid( "programUid" );
         ProgramStage programStage = new ProgramStage();
@@ -100,6 +100,6 @@ class EventWithoutRegistrationPreProcessorTest
         // When
         preProcessorToTest.process( bundle );
         // Then
-        assertNull( bundle.getEvents().get( 0 ).getEnrollment(), "programInstanceUid" );
+        assertNull( bundle.getEvents().get( 0 ).getEnrollment(), "enrollmentUid" );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/SecurityOwnershipValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/SecurityOwnershipValidatorTest.java
@@ -142,7 +142,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest
     }
 
     @Test
-    void verifyValidationSuccessForEnrollmentWhenProgramInstanceHasNoOrgUnitAssigned()
+    void verifyValidationSuccessForEnrollmentWhenEnrollmentHasNoOrgUnitAssigned()
     {
         org.hisp.dhis.tracker.imports.domain.Enrollment enrollment = org.hisp.dhis.tracker.imports.domain.Enrollment
             .builder()
@@ -155,11 +155,11 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.UPDATE );
 
-        Enrollment programInstance = getEnrollment( enrollment.getEnrollment() );
-        programInstance.setOrganisationUnit( null );
+        Enrollment preheatEnrollment = getEnrollment( enrollment.getEnrollment() );
+        preheatEnrollment.setOrganisationUnit( null );
 
         when( preheat.getEnrollment( enrollment.getEnrollment() ) )
-            .thenReturn( programInstance );
+            .thenReturn( preheatEnrollment );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
 
@@ -434,7 +434,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest
         assertHasError( reporter, enrollment, E1104 );
     }
 
-    private TrackedEntityInstance getTEIWithNoProgramInstances()
+    private TrackedEntityInstance getTEIWithNoEnrollments()
     {
         TrackedEntityInstance trackedEntityInstance = createTrackedEntityInstance( organisationUnit );
         trackedEntityInstance.setUid( TEI_ID );
@@ -453,7 +453,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest
         Enrollment enrollment = new Enrollment();
         enrollment.setUid( enrollmentUid );
         enrollment.setOrganisationUnit( organisationUnit );
-        enrollment.setEntityInstance( getTEIWithNoProgramInstances() );
+        enrollment.setEntityInstance( getTEIWithNoEnrollments() );
         enrollment.setProgram( program );
         enrollment.setStatus( ProgramStatus.ACTIVE );
         return enrollment;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataRelationsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataRelationsValidatorTest.java
@@ -117,7 +117,7 @@ class DataRelationsValidatorTest extends DhisConvenienceTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) ) )
             .thenReturn( programStage( PROGRAM_STAGE_ID, program ) );
         when( preheat.getEnrollment( ENROLLMENT_ID ) )
-            .thenReturn( programInstance( ENROLLMENT_ID, program ) );
+            .thenReturn( enrollment( ENROLLMENT_ID, program ) );
 
         CategoryCombo defaultCC = defaultCategoryCombo();
         program.setCategoryCombo( defaultCC );
@@ -215,7 +215,7 @@ class DataRelationsValidatorTest extends DhisConvenienceTest
             .thenReturn( programStage( PROGRAM_STAGE_ID, program ) );
         when( preheat.getEnrollment( ENROLLMENT_ID ) )
             .thenReturn(
-                programInstance( ENROLLMENT_ID, programWithRegistration( CodeGenerator.generateUid(), orgUnit ) ) );
+                enrollment( ENROLLMENT_ID, programWithRegistration( CodeGenerator.generateUid(), orgUnit ) ) );
 
         CategoryCombo defaultCC = defaultCategoryCombo();
         program.setCategoryCombo( defaultCC );
@@ -251,7 +251,7 @@ class DataRelationsValidatorTest extends DhisConvenienceTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) ) )
             .thenReturn( programStage( PROGRAM_STAGE_ID, program ) );
         when( preheat.getEnrollment( ENROLLMENT_ID ) )
-            .thenReturn( programInstance( ENROLLMENT_ID, program ) );
+            .thenReturn( enrollment( ENROLLMENT_ID, program ) );
 
         CategoryCombo defaultCC = defaultCategoryCombo();
         program.setCategoryCombo( defaultCC );
@@ -802,7 +802,7 @@ class DataRelationsValidatorTest extends DhisConvenienceTest
         return programStage;
     }
 
-    private Enrollment programInstance( String uid, Program program )
+    private Enrollment enrollment( String uid, Program program )
     {
         Enrollment enrollment = new Enrollment();
         enrollment.setUid( uid );
@@ -820,7 +820,7 @@ class DataRelationsValidatorTest extends DhisConvenienceTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) ) )
             .thenReturn( programStage( PROGRAM_STAGE_ID, program ) );
         when( preheat.getEnrollment( ENROLLMENT_ID ) )
-            .thenReturn( programInstance( ENROLLMENT_ID, program ) );
+            .thenReturn( enrollment( ENROLLMENT_ID, program ) );
         return program;
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecurityOwnershipValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecurityOwnershipValidatorTest.java
@@ -484,7 +484,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest
         assertIsEmpty( reporter.getErrors() );
     }
 
-    private TrackedEntityInstance getTEIWithNoProgramInstances()
+    private TrackedEntityInstance getTEIWithNoEnrollments()
     {
         TrackedEntityInstance trackedEntityInstance = createTrackedEntityInstance( organisationUnit );
         trackedEntityInstance.setUid( TEI_ID );
@@ -503,7 +503,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest
         Enrollment enrollment = new Enrollment();
         enrollment.setUid( enrollmentUid );
         enrollment.setOrganisationUnit( organisationUnit );
-        enrollment.setEntityInstance( getTEIWithNoProgramInstances() );
+        enrollment.setEntityInstance( getTEIWithNoEnrollments() );
         enrollment.setProgram( program );
         enrollment.setStatus( ProgramStatus.ACTIVE );
         return enrollment;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/relationship/ConstraintValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/relationship/ConstraintValidatorTest.java
@@ -205,7 +205,7 @@ class ConstraintValidatorTest
     }
 
     @Test
-    void shouldFailWhenRelationshipEntityIsProgramInstanceAndEnrollmentDoesNotExist()
+    void shouldFailWhenRelationshipEntityIsEnrollmentAndEnrollmentDoesNotExist()
     {
         RelationshipType relType = createRelTypeConstraint( PROGRAM_INSTANCE, PROGRAM_STAGE_INSTANCE );
 
@@ -225,7 +225,7 @@ class ConstraintValidatorTest
     }
 
     @Test
-    void shouldFailWhenRelationshipEntityIsProgramInstanceAndFromConstraintIsSetToEvent()
+    void shouldFailWhenRelationshipEntityIsEnrollmentAndFromConstraintIsSetToEvent()
     {
         RelationshipType relType = createRelTypeConstraint( PROGRAM_INSTANCE, TRACKED_ENTITY_INSTANCE );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidatorTest.java
@@ -153,7 +153,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest
     }
 
     @Test
-    void verifyValidationSuccessForTrackedEntityWithNoProgramInstancesUsingDeleteStrategy()
+    void verifyValidationSuccessForTrackedEntityWithNoEnrollmentsUsingDeleteStrategy()
     {
         TrackedEntity trackedEntity = TrackedEntity.builder()
             .trackedEntity( TEI_ID )
@@ -162,7 +162,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest
             .build();
 
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( preheat.getTrackedEntity( TEI_ID ) ).thenReturn( getTEIWithNoProgramInstances() );
+        when( preheat.getTrackedEntity( TEI_ID ) ).thenReturn( getTEIWithNoEnrollments() );
 
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
@@ -227,7 +227,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest
             .build();
 
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( preheat.getTrackedEntity( TEI_ID ) ).thenReturn( getTEIWithNoProgramInstances() );
+        when( preheat.getTrackedEntity( TEI_ID ) ).thenReturn( getTEIWithNoEnrollments() );
 
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
@@ -239,7 +239,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest
     }
 
     @Test
-    void verifyValidationSuccessForTrackedEntityWithDeletedProgramInstancesUsingDeleteStrategy()
+    void verifyValidationSuccessForTrackedEntityWithDeletedEnrollmentsUsingDeleteStrategy()
     {
         TrackedEntity trackedEntity = TrackedEntity.builder()
             .trackedEntity( TEI_ID )
@@ -248,7 +248,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest
             .build();
 
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( preheat.getTrackedEntity( TEI_ID ) ).thenReturn( getTEIWithDeleteProgramInstances() );
+        when( preheat.getTrackedEntity( TEI_ID ) ).thenReturn( getTEIWithDeleteEnrollments() );
 
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
@@ -270,7 +270,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest
 
         when( bundle.getUser() ).thenReturn( deleteTeiAuthorisedUser() );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( preheat.getTrackedEntity( TEI_ID ) ).thenReturn( getTEIWithProgramInstances() );
+        when( preheat.getTrackedEntity( TEI_ID ) ).thenReturn( getTEIWithEnrollments() );
 
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
@@ -291,7 +291,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest
             .build();
 
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( preheat.getTrackedEntity( TEI_ID ) ).thenReturn( getTEIWithProgramInstances() );
+        when( preheat.getTrackedEntity( TEI_ID ) ).thenReturn( getTEIWithEnrollments() );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
@@ -367,7 +367,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest
         assertHasError( reporter, trackedEntity, E1001 );
     }
 
-    private TrackedEntityInstance getTEIWithNoProgramInstances()
+    private TrackedEntityInstance getTEIWithNoEnrollments()
     {
         TrackedEntityInstance trackedEntityInstance = createTrackedEntityInstance( organisationUnit );
         trackedEntityInstance.setUid( TEI_ID );
@@ -377,7 +377,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest
         return trackedEntityInstance;
     }
 
-    private TrackedEntityInstance getTEIWithDeleteProgramInstances()
+    private TrackedEntityInstance getTEIWithDeleteEnrollments()
     {
         Enrollment enrollment = new Enrollment();
         enrollment.setDeleted( true );
@@ -390,7 +390,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest
         return trackedEntityInstance;
     }
 
-    private TrackedEntityInstance getTEIWithProgramInstances()
+    private TrackedEntityInstance getTEIWithEnrollments()
     {
         TrackedEntityInstance trackedEntityInstance = createTrackedEntityInstance( organisationUnit );
         trackedEntityInstance.setUid( TEI_ID );

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -1683,7 +1683,7 @@ public abstract class DhisConvenienceTest
         return program;
     }
 
-    public static Enrollment createProgramInstance( Program program, TrackedEntityInstance tei,
+    public static Enrollment createEnrollment( Program program, TrackedEntityInstance tei,
         OrganisationUnit organisationUnit )
     {
         Enrollment enrollment = new Enrollment( program, tei, organisationUnit );
@@ -2000,7 +2000,7 @@ public abstract class DhisConvenienceTest
         return relationship;
     }
 
-    public static Relationship createTeiToProgramInstanceRelationship( TrackedEntityInstance from, Enrollment to,
+    public static Relationship createTeiToEnrollmentRelationship( TrackedEntityInstance from, Enrollment to,
         RelationshipType relationshipType )
     {
         Relationship relationship = new Relationship();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
@@ -395,7 +395,7 @@ class EventAnalyticsServiceTest
         atv.setValue( ouF.getUid() );
         attributeValueService.addTrackedEntityAttributeValue( atv );
 
-        // Program Instances (Enrollments)
+        // Enrollments (Enrollments)
         Enrollment piA = enrollmentService.enrollTrackedEntityInstance( teiA, programA, jan1, jan1, ouE );
         piA.setEnrollmentDate( jan1 );
         piA.setIncidentDate( jan1 );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/deduplication/DeduplicationServiceMergeIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/deduplication/DeduplicationServiceMergeIntegrationTest.java
@@ -108,8 +108,8 @@ class DeduplicationServiceMergeIntegrationTest extends IntegrationTestBase
         Program program1 = createProgram( 'B' );
         programService.addProgram( program );
         programService.addProgram( program1 );
-        Enrollment enrollment1 = createProgramInstance( program, original, ou );
-        Enrollment enrollment2 = createProgramInstance( program1, duplicate, ou );
+        Enrollment enrollment1 = createEnrollment( program, original, ou );
+        Enrollment enrollment2 = createEnrollment( program1, duplicate, ou );
         enrollmentService.addEnrollment( enrollment1 );
         enrollmentService.addEnrollment( enrollment2 );
         original.getEnrollments().add( enrollment1 );
@@ -155,8 +155,8 @@ class DeduplicationServiceMergeIntegrationTest extends IntegrationTestBase
         programService.addProgram( program1 );
         program.setSharing( sharing );
         program1.setSharing( sharing );
-        Enrollment enrollment1 = createProgramInstance( program, original, ou );
-        Enrollment enrollment2 = createProgramInstance( program1, duplicate, ou );
+        Enrollment enrollment1 = createEnrollment( program, original, ou );
+        Enrollment enrollment2 = createEnrollment( program1, duplicate, ou );
         enrollmentService.addEnrollment( enrollment1 );
         enrollmentService.addEnrollment( enrollment2 );
         enrollmentService.updateEnrollment( enrollment1 );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/deduplication/hibernate/PotentialDuplicateRemoveTrackedEntityTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/deduplication/hibernate/PotentialDuplicateRemoveTrackedEntityTest.java
@@ -159,10 +159,10 @@ class PotentialDuplicateRemoveTrackedEntityTest extends TransactionalIntegration
         trackedEntityInstanceService.addTrackedEntityInstance( control2 );
         Program program = createProgram( 'A' );
         programService.addProgram( program );
-        Enrollment enrollment1 = createProgramInstance( program, original, ou );
-        Enrollment enrollment2 = createProgramInstance( program, duplicate, ou );
-        Enrollment enrollment3 = createProgramInstance( program, control1, ou );
-        Enrollment enrollment4 = createProgramInstance( program, control2, ou );
+        Enrollment enrollment1 = createEnrollment( program, original, ou );
+        Enrollment enrollment2 = createEnrollment( program, duplicate, ou );
+        Enrollment enrollment3 = createEnrollment( program, control1, ou );
+        Enrollment enrollment4 = createEnrollment( program, control2, ou );
         enrollmentService.addEnrollment( enrollment1 );
         enrollmentService.addEnrollment( enrollment2 );
         enrollmentService.addEnrollment( enrollment3 );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/EventImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/EventImportTest.java
@@ -123,7 +123,7 @@ class EventImportTest extends TransactionalIntegrationTest
     private IdentifiableObjectManager manager;
 
     @Autowired
-    private EnrollmentService enrollmentService;
+    private EnrollmentService programInstanceService;
 
     @Autowired
     private EventService programStageInstanceService;
@@ -321,7 +321,7 @@ class EventImportTest extends TransactionalIntegrationTest
         pi.setProgram( programB );
         pi.setStatus( ProgramStatus.ACTIVE );
         pi.setStoredBy( "test" );
-        enrollmentService.addEnrollment( pi );
+        programInstanceService.addEnrollment( pi );
         InputStream is = createEventJsonInputStream( programB.getUid(), programStageB.getUid(),
             organisationUnitB.getUid(), null, dataElementB, "10" );
         ImportSummaries importSummaries = eventService.addEventsJson( is, null );
@@ -477,7 +477,7 @@ class EventImportTest extends TransactionalIntegrationTest
     @Test
     void testEventDeletion()
     {
-        enrollmentService.addEnrollment( pi );
+        programInstanceService.addEnrollment( pi );
         ImportOptions importOptions = new ImportOptions();
         ImportSummary importSummary = eventService.addEvent( event, importOptions, false );
         assertEquals( ImportStatus.SUCCESS, importSummary.getStatus() );
@@ -494,7 +494,7 @@ class EventImportTest extends TransactionalIntegrationTest
     @Test
     void testAddAlreadyDeletedEvent()
     {
-        enrollmentService.addEnrollment( pi );
+        programInstanceService.addEnrollment( pi );
         ImportOptions importOptions = new ImportOptions();
         eventService.addEvent( event, importOptions, false );
         eventService.deleteEvent( event.getUid() );
@@ -510,7 +510,7 @@ class EventImportTest extends TransactionalIntegrationTest
     @Test
     void testAddAlreadyDeletedEventInBulk()
     {
-        enrollmentService.addEnrollment( pi );
+        programInstanceService.addEnrollment( pi );
         ImportOptions importOptions = new ImportOptions();
         eventService.addEvent( event, importOptions, false );
         eventService.deleteEvent( event.getUid() );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/EventImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/EventImportTest.java
@@ -123,7 +123,7 @@ class EventImportTest extends TransactionalIntegrationTest
     private IdentifiableObjectManager manager;
 
     @Autowired
-    private EnrollmentService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private EventService programStageInstanceService;
@@ -308,11 +308,11 @@ class EventImportTest extends TransactionalIntegrationTest
 
     /**
      * TODO: LUCIANO: this test has been ignored because the Importer should not
-     * import an event linked to a Program with 2 or more Program Instances
+     * import an event linked to a Program with 2 or more Enrollments
      */
     @Test
     @Disabled
-    void testAddEventOnProgramWithoutRegistrationAndExistingProgramInstance()
+    void testAddEventOnProgramWithoutRegistrationAndExistingEnrollment()
         throws IOException
     {
         Enrollment pi = new Enrollment();
@@ -321,7 +321,7 @@ class EventImportTest extends TransactionalIntegrationTest
         pi.setProgram( programB );
         pi.setStatus( ProgramStatus.ACTIVE );
         pi.setStoredBy( "test" );
-        programInstanceService.addEnrollment( pi );
+        enrollmentService.addEnrollment( pi );
         InputStream is = createEventJsonInputStream( programB.getUid(), programStageB.getUid(),
             organisationUnitB.getUid(), null, dataElementB, "10" );
         ImportSummaries importSummaries = eventService.addEventsJson( is, null );
@@ -477,7 +477,7 @@ class EventImportTest extends TransactionalIntegrationTest
     @Test
     void testEventDeletion()
     {
-        programInstanceService.addEnrollment( pi );
+        enrollmentService.addEnrollment( pi );
         ImportOptions importOptions = new ImportOptions();
         ImportSummary importSummary = eventService.addEvent( event, importOptions, false );
         assertEquals( ImportStatus.SUCCESS, importSummary.getStatus() );
@@ -494,7 +494,7 @@ class EventImportTest extends TransactionalIntegrationTest
     @Test
     void testAddAlreadyDeletedEvent()
     {
-        programInstanceService.addEnrollment( pi );
+        enrollmentService.addEnrollment( pi );
         ImportOptions importOptions = new ImportOptions();
         eventService.addEvent( event, importOptions, false );
         eventService.deleteEvent( event.getUid() );
@@ -510,7 +510,7 @@ class EventImportTest extends TransactionalIntegrationTest
     @Test
     void testAddAlreadyDeletedEventInBulk()
     {
-        programInstanceService.addEnrollment( pi );
+        enrollmentService.addEnrollment( pi );
         ImportOptions importOptions = new ImportOptions();
         eventService.addEvent( event, importOptions, false );
         eventService.deleteEvent( event.getUid() );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
@@ -255,7 +255,7 @@ class MaintenanceServiceTest extends IntegrationTestBase
     }
 
     @Test
-    void testDeleteSoftDeletedProgramInstanceWithAProgramMessage()
+    void testDeleteSoftDeletedEnrollmentWithAProgramMessage()
     {
         ProgramMessageRecipients programMessageRecipients = new ProgramMessageRecipients();
         programMessageRecipients.setEmailAddresses( Sets.newHashSet( "testemail" ) );
@@ -271,7 +271,7 @@ class MaintenanceServiceTest extends IntegrationTestBase
         enrollmentService.deleteEnrollment( enrollment );
         assertNull( enrollmentService.getEnrollment( idA ) );
         assertTrue( enrollmentService.enrollmentExistsIncludingDeleted( enrollment.getUid() ) );
-        maintenanceService.deleteSoftDeletedProgramInstances();
+        maintenanceService.deleteSoftDeletedEnrollments();
         assertFalse( enrollmentService.enrollmentExistsIncludingDeleted( enrollment.getUid() ) );
     }
 
@@ -319,7 +319,7 @@ class MaintenanceServiceTest extends IntegrationTestBase
     }
 
     @Test
-    void testDeleteSoftDeletedProgramInstanceLinkedToATrackedEntityDataValueAudit()
+    void testDeleteSoftDeletedEnrollmentLinkedToATrackedEntityDataValueAudit()
     {
         DataElement dataElement = createDataElement( 'A' );
         dataElementService.addDataElement( dataElement );
@@ -336,7 +336,7 @@ class MaintenanceServiceTest extends IntegrationTestBase
         enrollmentService.deleteEnrollment( enrollment );
         assertNull( enrollmentService.getEnrollment( idA ) );
         assertTrue( enrollmentService.enrollmentExistsIncludingDeleted( enrollment.getUid() ) );
-        maintenanceService.deleteSoftDeletedProgramInstances();
+        maintenanceService.deleteSoftDeletedEnrollments();
         assertFalse( enrollmentService.enrollmentExistsIncludingDeleted( enrollment.getUid() ) );
     }
 
@@ -381,7 +381,7 @@ class MaintenanceServiceTest extends IntegrationTestBase
     }
 
     @Test
-    void testDeleteSoftDeletedProgramInstanceLinkedToARelationshipItem()
+    void testDeleteSoftDeletedEnrollmentLinkedToARelationshipItem()
     {
         RelationshipType rType = createRelationshipType( 'A' );
         rType.getFromConstraint().setRelationshipEntity( RelationshipEntity.PROGRAM_INSTANCE );
@@ -407,7 +407,7 @@ class MaintenanceServiceTest extends IntegrationTestBase
         assertNull( relationshipService.getRelationship( r.getId() ) );
         assertTrue( enrollmentService.enrollmentExistsIncludingDeleted( enrollment.getUid() ) );
         assertTrue( relationshipService.relationshipExistsIncludingDeleted( r.getUid() ) );
-        maintenanceService.deleteSoftDeletedProgramInstances();
+        maintenanceService.deleteSoftDeletedEnrollments();
         assertFalse( enrollmentService.enrollmentExistsIncludingDeleted( enrollment.getUid() ) );
         assertFalse( relationshipService.relationshipExistsIncludingDeleted( r.getUid() ) );
     }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/merge/orgunit/handler/TrackerOrgUnitMergeHandlerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/merge/orgunit/handler/TrackerOrgUnitMergeHandlerTest.java
@@ -118,9 +118,9 @@ class TrackerOrgUnitMergeHandlerTest extends SingleSetupIntegrationTestBase
         teiService.addTrackedEntityInstance( teiA );
         teiService.addTrackedEntityInstance( teiB );
         teiService.addTrackedEntityInstance( teiC );
-        piA = createProgramInstance( prA, teiA, ouA );
-        piB = createProgramInstance( prA, teiB, ouB );
-        piC = createProgramInstance( prA, teiC, ouA );
+        piA = createEnrollment( prA, teiA, ouA );
+        piB = createEnrollment( prA, teiB, ouB );
+        piC = createEnrollment( prA, teiC, ouA );
         piService.addEnrollment( piA );
         piService.addEnrollment( piB );
         piService.addEnrollment( piC );
@@ -133,17 +133,17 @@ class TrackerOrgUnitMergeHandlerTest extends SingleSetupIntegrationTestBase
     }
 
     @Test
-    void testMigrateProgramInstances()
+    void testMigrateEnrollments()
     {
-        assertEquals( 2, getProgramInstanceCount( ouA ) );
-        assertEquals( 1, getProgramInstanceCount( ouB ) );
-        assertEquals( 0, getProgramInstanceCount( ouC ) );
+        assertEquals( 2, getEnrollmentCount( ouA ) );
+        assertEquals( 1, getEnrollmentCount( ouB ) );
+        assertEquals( 0, getEnrollmentCount( ouC ) );
         OrgUnitMergeRequest request = new OrgUnitMergeRequest.Builder().addSource( ouA ).addSource( ouB )
             .withTarget( ouC ).build();
-        mergeHandler.mergeProgramInstances( request );
-        assertEquals( 0, getProgramInstanceCount( ouA ) );
-        assertEquals( 0, getProgramInstanceCount( ouB ) );
-        assertEquals( 3, getProgramInstanceCount( ouC ) );
+        mergeHandler.mergeEnrollments( request );
+        assertEquals( 0, getEnrollmentCount( ouA ) );
+        assertEquals( 0, getEnrollmentCount( ouB ) );
+        assertEquals( 3, getEnrollmentCount( ouC ) );
     }
 
     /**
@@ -153,7 +153,7 @@ class TrackerOrgUnitMergeHandlerTest extends SingleSetupIntegrationTestBase
      * @param target the {@link OrganisationUnit}
      * @return the count of interpretations.
      */
-    private long getProgramInstanceCount( OrganisationUnit target )
+    private long getEnrollmentCount( OrganisationUnit target )
     {
         return (Long) sessionFactory.getCurrentSession()
             .createQuery( "select count(*) from Enrollment pi where pi.organisationUnit = :target" )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
@@ -154,7 +154,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testAddProgramInstance()
+    void testAddEnrollment()
     {
         long idA = enrollmentService.addEnrollment( enrollmentA );
         long idB = enrollmentService.addEnrollment( enrollmentB );
@@ -163,7 +163,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testDeleteProgramInstance()
+    void testDeleteEnrollment()
     {
         long idA = enrollmentService.addEnrollment( enrollmentA );
         long idB = enrollmentService.addEnrollment( enrollmentB );
@@ -178,7 +178,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testSoftDeleteProgramInstanceAndLinkedEvent()
+    void testSoftDeleteEnrollmentAndLinkedEvent()
     {
         long idA = enrollmentService.addEnrollment( enrollmentA );
         long eventIdA = eventService.addEvent( eventA );
@@ -192,7 +192,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testUpdateProgramInstance()
+    void testUpdateEnrollment()
     {
         long idA = enrollmentService.addEnrollment( enrollmentA );
         assertNotNull( enrollmentService.getEnrollment( idA ) );
@@ -202,7 +202,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testGetProgramInstanceById()
+    void testGetEnrollmentById()
     {
         long idA = enrollmentService.addEnrollment( enrollmentA );
         long idB = enrollmentService.addEnrollment( enrollmentB );
@@ -211,7 +211,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testGetProgramInstanceByUid()
+    void testGetEnrollmentByUid()
     {
         enrollmentService.addEnrollment( enrollmentA );
         enrollmentService.addEnrollment( enrollmentB );
@@ -220,7 +220,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testGetProgramInstancesByProgram()
+    void testGetEnrollmentsByProgram()
     {
         enrollmentService.addEnrollment( enrollmentA );
         enrollmentService.addEnrollment( enrollmentB );
@@ -235,7 +235,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testGetProgramInstancesByEntityInstanceProgramStatus()
+    void testGetEnrollmentsByEntityInstanceProgramStatus()
     {
         enrollmentService.addEnrollment( enrollmentA );
         Enrollment enrollment1 = enrollmentService.enrollTrackedEntityInstance( entityInstanceA,
@@ -258,7 +258,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testGetProgramInstancesByOuProgram()
+    void testGetEnrollmentsByOuProgram()
     {
         enrollmentService.addEnrollment( enrollmentA );
         enrollmentService.addEnrollment( enrollmentC );
@@ -280,7 +280,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testCompleteProgramInstanceStatus()
+    void testCompleteEnrollmentStatus()
     {
         long idA = enrollmentService.addEnrollment( enrollmentA );
         long idD = enrollmentService.addEnrollment( enrollmentD );
@@ -291,7 +291,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testIncompleteProgramInstanceStatus()
+    void testIncompleteEnrollmentStatus()
     {
         enrollmentA.setStatus( ProgramStatus.COMPLETED );
         enrollmentD.setStatus( ProgramStatus.COMPLETED );
@@ -304,7 +304,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testCancelProgramInstanceStatus()
+    void testCancelEnrollmentStatus()
     {
         long idA = enrollmentService.addEnrollment( enrollmentA );
         long idD = enrollmentService.addEnrollment( enrollmentD );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentStoreTest.java
@@ -180,7 +180,7 @@ class EnrollmentStoreTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testGetProgramInstancesByProgram()
+    void testGetEnrollmentsByProgram()
     {
         enrollmentStore.save( enrollmentA );
         enrollmentStore.save( enrollmentB );
@@ -195,7 +195,7 @@ class EnrollmentStoreTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testGetProgramInstancesByEntityInstanceProgramStatus()
+    void testGetEnrollmentsByEntityInstanceProgramStatus()
     {
         enrollmentStore.save( enrollmentA );
         enrollmentStore.save( enrollmentB );
@@ -262,7 +262,7 @@ class EnrollmentStoreTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testGetExcludeDeletedProgramInstance()
+    void testGetExcludeDeletedEnrollment()
     {
         enrollmentStore.save( enrollmentA );
         enrollmentStore.save( enrollmentB );
@@ -273,8 +273,8 @@ class EnrollmentStoreTest extends TransactionalIntegrationTest
     @Test
     void testGetByProgramAndTrackedEntityInstance()
     {
-        // Create a second Program Instance with identical Program and TEI as
-        // programInstanceA.
+        // Create a second enrollment with identical Program and TEI as
+        // enrollmentA.
         // This should really never happen in production
         // Doing it here to test that the query can return both instances
         Enrollment enrollmentZ = new Enrollment( enrollmentDate, incidentDate, entityInstanceA,

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventServiceTest.java
@@ -214,7 +214,7 @@ class EventServiceTest extends TransactionalIntegrationTest
         programB.setProgramStages( programStages );
         programService.updateProgram( programB );
         /**
-         * Program Instance and Program Stage Instance
+         * Enrollment and Program Stage Instance
          */
         DateTime testDate1 = DateTime.now();
         testDate1.withTimeAtStartOfDay();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventStoreTest.java
@@ -196,7 +196,7 @@ class EventStoreTest extends TransactionalIntegrationTest
         programB.getProgramStages().addAll( programStages );
         programService.updateProgram( programB );
         /**
-         * Program Instance and Program Stage Instance
+         * Enrollment and Program Stage Instance
          */
         DateTime testDate1 = DateTime.now();
         testDate1.withTimeAtStartOfDay();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramMessageServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramMessageServiceTest.java
@@ -147,7 +147,7 @@ class ProgramMessageServiceTest extends TransactionalIntegrationTest
         piA = new Enrollment();
         piA.setProgram( program );
         piA.setOrganisationUnit( ouA );
-        piA.setName( "programInstanceA" );
+        piA.setName( "enrollmentA" );
         piA.setEnrollmentDate( new Date() );
         piA.setAutoFields();
         enrollmentService.addEnrollment( piA );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramMessageStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramMessageStoreTest.java
@@ -258,7 +258,7 @@ class ProgramMessageStoreTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testGetProgramMessageByProgramInstance()
+    void testGetProgramMessageByEnrollment()
     {
         enrollmentStore.save( enrollmentA );
         pmsgA.setEnrollment( enrollmentA );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/programrule/engine/ProgramNotificationInstanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/programrule/engine/ProgramNotificationInstanceServiceTest.java
@@ -126,9 +126,9 @@ class ProgramNotificationInstanceServiceTest extends IntegrationTestBase
         manager.save( programRuleAction );
         programRule.getProgramRuleActions().add( programRuleAction );
         manager.update( programRule );
-        enrollment = createProgramInstance( program, trackedEntityInstance, organisationUnit );
+        enrollment = createEnrollment( program, trackedEntityInstance, organisationUnit );
         enrollmentService.addEnrollment( enrollment );
-        enrollmentB = createProgramInstance( program, trackedEntityInstance, organisationUnit );
+        enrollmentB = createEnrollment( program, trackedEntityInstance, organisationUnit );
         enrollmentService.addEnrollment( enrollmentB );
     }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/relationship/hibernate/RelationshipStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/relationship/hibernate/RelationshipStoreTest.java
@@ -125,7 +125,7 @@ class RelationshipStoreTest extends TransactionalIntegrationTest
     {
         Program programA = addProgram();
 
-        Enrollment enrollment = addProgramInstance( programA );
+        Enrollment enrollment = addEnrollment( programA );
 
         ProgramStage programStageA = addProgramStage( programA );
 
@@ -147,20 +147,20 @@ class RelationshipStoreTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testGetByProgramInstance()
+    void testGetByEnrollment()
     {
         trackedEntityInstanceA = createTrackedEntityInstance( organisationUnit );
         trackedEntityInstanceService.addTrackedEntityInstance( trackedEntityInstanceA );
 
         Program programA = addProgram();
 
-        Enrollment enrollment = addProgramInstance( programA );
+        Enrollment enrollment = addEnrollment( programA );
 
-        Relationship relationshipA = addTeiToProgramInstanceRelationship( trackedEntityInstanceA,
+        Relationship relationshipA = addTeiToEnrollmentRelationship( trackedEntityInstanceA,
             enrollment );
 
         List<Relationship> relationshipList = relationshipService
-            .getRelationshipsByProgramInstance( enrollment, true );
+            .getRelationshipsByEnrollment( enrollment, true );
 
         assertEquals( 1, relationshipList.size() );
         assertTrue( relationshipList.contains( relationshipA ) );
@@ -249,7 +249,7 @@ class RelationshipStoreTest extends TransactionalIntegrationTest
         return relationshipA;
     }
 
-    private Relationship addTeiToProgramInstanceRelationship( TrackedEntityInstance entityInstance,
+    private Relationship addTeiToEnrollmentRelationship( TrackedEntityInstance entityInstance,
         Enrollment enrollment )
     {
         RelationshipItem relationshipItemFrom = new RelationshipItem();
@@ -289,7 +289,7 @@ class RelationshipStoreTest extends TransactionalIntegrationTest
         return programStageA;
     }
 
-    private Enrollment addProgramInstance( Program programA )
+    private Enrollment addEnrollment( Program programA )
     {
         Enrollment enrollment = new Enrollment();
         enrollment.setProgram( programA );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentityinstance/TrackedEntityInstanceQueryLimitTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentityinstance/TrackedEntityInstanceQueryLimitTest.java
@@ -138,10 +138,10 @@ class TrackedEntityInstanceQueryLimitTest extends SingleSetupIntegrationTestBase
         trackedEntityInstanceService.addTrackedEntityInstance( tei3 );
         trackedEntityInstanceService.addTrackedEntityInstance( tei4 );
 
-        pi1 = createProgramInstance( program, tei1, orgUnitA );
-        pi2 = createProgramInstance( program, tei2, orgUnitA );
-        pi3 = createProgramInstance( program, tei3, orgUnitA );
-        pi4 = createProgramInstance( program, tei4, orgUnitA );
+        pi1 = createEnrollment( program, tei1, orgUnitA );
+        pi2 = createEnrollment( program, tei2, orgUnitA );
+        pi3 = createEnrollment( program, tei3, orgUnitA );
+        pi4 = createEnrollment( program, tei4, orgUnitA );
 
         enrollmentService.addEnrollment( pi1 );
         enrollmentService.addEnrollment( pi2 );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -77,7 +77,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
     protected UserService _userService;
 
     @Autowired
-    private EnrollmentService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     private IdentifiableObjectManager manager;
@@ -197,7 +197,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         relationshipA.setInvertedKey( RelationshipUtils.generateRelationshipInvertedKey( relationshipA ) );
         manager.save( relationshipA, false );
 
-        enrollmentA = programInstanceService.enrollTrackedEntityInstance( trackedEntityA, programA, new Date(),
+        enrollmentA = enrollmentService.enrollTrackedEntityInstance( trackedEntityA, programA, new Date(),
             new Date(),
             orgUnitA );
         eventA = new Event();
@@ -209,7 +209,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         enrollmentA.setRelationshipItems( Set.of( from, to ) );
         manager.save( enrollmentA, false );
 
-        enrollmentB = programInstanceService.enrollTrackedEntityInstance( trackedEntityB, programA, new Date(),
+        enrollmentB = enrollmentService.enrollTrackedEntityInstance( trackedEntityB, programA, new Date(),
             new Date(),
             orgUnitB );
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -77,7 +77,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
     protected UserService _userService;
 
     @Autowired
-    private EnrollmentService enrollmentService;
+    private EnrollmentService programInstanceService;
 
     @Autowired
     private IdentifiableObjectManager manager;
@@ -197,7 +197,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         relationshipA.setInvertedKey( RelationshipUtils.generateRelationshipInvertedKey( relationshipA ) );
         manager.save( relationshipA, false );
 
-        enrollmentA = enrollmentService.enrollTrackedEntityInstance( trackedEntityA, programA, new Date(),
+        enrollmentA = programInstanceService.enrollTrackedEntityInstance( trackedEntityA, programA, new Date(),
             new Date(),
             orgUnitA );
         eventA = new Event();
@@ -209,7 +209,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         enrollmentA.setRelationshipItems( Set.of( from, to ) );
         manager.save( enrollmentA, false );
 
-        enrollmentB = enrollmentService.enrollTrackedEntityInstance( trackedEntityB, programA, new Date(),
+        enrollmentB = programInstanceService.enrollTrackedEntityInstance( trackedEntityB, programA, new Date(),
             new Date(),
             orgUnitB );
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipServiceTest.java
@@ -238,14 +238,14 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase
     }
 
     @Test
-    void shouldNotReturnRelationshipByProgramInstanceIfUserHasNoAccessToRelationshipType()
+    void shouldNotReturnRelationshipByEnrollmentIfUserHasNoAccessToRelationshipType()
         throws ForbiddenException,
         NotFoundException
     {
         Relationship accessible = relationship( teiA, enrollmentA );
         relationship( teiB, enrollmentA, teiToPiInaccessibleType );
 
-        List<Relationship> relationships = relationshipService.getRelationshipsByProgramInstance( enrollmentA,
+        List<Relationship> relationships = relationshipService.getRelationshipsByEnrollment( enrollmentA,
             new Paging() );
 
         assertContainsOnly( List.of( accessible.getUid() ),

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -627,7 +627,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase
             .filter( Enrollment::isDeleted ).map( BaseIdentifiableObject::getUid ).collect( Collectors.toSet() );
         assertIsEmpty( deletedEnrollments );
         Set<String> deletedEvents = trackedEntity.getEnrollments().stream()
-            .flatMap( programInstance -> programInstance.getEvents().stream() )
+            .flatMap( enrollment -> enrollment.getEvents().stream() )
             .filter( Event::isDeleted )
             .map( BaseIdentifiableObject::getUid )
             .collect( Collectors.toSet() );
@@ -648,7 +648,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase
         assertContainsOnly( Set.of( enrollmentA.getUid() ), deletedEnrollments );
 
         Set<Event> events = trackedEntity.getEnrollments().stream()
-            .flatMap( programInstance -> programInstance.getEvents().stream() )
+            .flatMap( e -> e.getEvents().stream() )
             .collect( Collectors.toSet() );
         assertContainsOnly( Set.of( eventA.getUid(), eventB.getUid() ), uids( events ) );
         deletedEvents = events.stream()
@@ -664,7 +664,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase
         trackedEntity = trackedEntities.get( 0 );
         assertContainsOnly( Set.of( enrollmentB.getUid() ), uids( trackedEntity.getEnrollments() ) );
         events = trackedEntity.getEnrollments().stream()
-            .flatMap( programInstance -> programInstance.getEvents().stream() )
+            .flatMap( e -> e.getEvents().stream() )
             .collect( Collectors.toSet() );
         assertContainsOnly( Set.of( eventB.getUid() ), uids( events ) );
     }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentImportValidationTest.java
@@ -150,7 +150,7 @@ class EnrollmentImportValidationTest extends TrackerTest
     }
 
     @Test
-    void testDeleteCascadeProgramInstances()
+    void testDeleteCascadeEnrollments()
         throws IOException
     {
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TrackedEntityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TrackedEntityImportValidationTest.java
@@ -220,12 +220,12 @@ class TrackedEntityImportValidationTest extends TrackerTest
     }
 
     @Test
-    void testDeleteCascadeProgramInstances()
+    void testDeleteCascadeEnrollments()
         throws IOException
     {
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_te-data.json" );
         assertNoErrors( trackerImportService.importTracker( params ) );
-        importProgramInstances();
+        importEnrollments();
         manager.flush();
         manager.clear();
         params = fromJson( "tracker/validations/enrollments_te_te-data.json" );
@@ -258,7 +258,7 @@ class TrackedEntityImportValidationTest extends TrackerTest
         assertEquals( 1, importReportDelete.getStats().getDeleted() );
     }
 
-    protected void importProgramInstances()
+    protected void importEnrollments()
         throws IOException
     {
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_enrollments-data.json" );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/ProgramMessageControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/ProgramMessageControllerTest.java
@@ -77,7 +77,7 @@ class ProgramMessageControllerTest extends DhisControllerConvenienceTest
         idObjectManager.save( prA );
         TrackedEntityInstance teiA = createTrackedEntityInstance( 'A', ouA );
         teiService.addTrackedEntityInstance( teiA );
-        piA = createProgramInstance( prA, teiA, ouA );
+        piA = createEnrollment( prA, teiA, ouA );
         piService.addEnrollment( piA );
     }
 

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAssertions.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAssertions.java
@@ -86,7 +86,7 @@ public class JsonAssertions
 
         assertEquals( expected.getStatus().toString(), jsonEvent.getStatus(), "event status" );
         assertEquals( expected.getProgramStage().getUid(), jsonEvent.getProgramStage(), "event programStage UID" );
-        assertEquals( expected.getEnrollment().getUid(), jsonEvent.getEnrollment(), "event programInstance UID" );
+        assertEquals( expected.getEnrollment().getUid(), jsonEvent.getEnrollment(), "event enrollment UID" );
         assertFalse( jsonEvent.has( "relationships" ), "relationships is not returned within relationship items" );
     }
 

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerTest.java
@@ -146,7 +146,7 @@ class EnrollmentsExportControllerTest extends DhisControllerConvenienceTest
         programStage = createProgramStage( 'A', program );
         manager.save( programStage );
 
-        enrollment = programInstance( tei );
+        enrollment = enrollment( tei );
         event = event();
         enrollment.setEvents( Set.of( event ) );
         manager.update( enrollment );
@@ -342,7 +342,7 @@ class EnrollmentsExportControllerTest extends DhisControllerConvenienceTest
         assertHasNoMember( enrollment, "attributes" );
     }
 
-    private Enrollment programInstance( TrackedEntityInstance tei )
+    private Enrollment enrollment( TrackedEntityInstance tei )
     {
         Enrollment enrollment = new Enrollment( program, tei, orgUnit );
         enrollment.setAutoFields();

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
@@ -141,7 +141,7 @@ class EventsExportControllerTest extends DhisControllerConvenienceTest
     @Test
     void getEventById()
     {
-        Event event = event( programInstance( trackedEntityInstance() ) );
+        Event event = event( enrollment( trackedEntityInstance() ) );
 
         JsonEvent json = GET( "/tracker/events/{id}", event.getUid() )
             .content( HttpStatus.OK ).as( JsonEvent.class );
@@ -152,7 +152,7 @@ class EventsExportControllerTest extends DhisControllerConvenienceTest
     @Test
     void getEventByIdWithFields()
     {
-        Event event = event( programInstance( trackedEntityInstance() ) );
+        Event event = event( enrollment( trackedEntityInstance() ) );
 
         JsonEvent jsonEvent = GET( "/tracker/events/{id}?fields=orgUnit,status", event.getUid() )
             .content( HttpStatus.OK ).as( JsonEvent.class );
@@ -165,7 +165,7 @@ class EventsExportControllerTest extends DhisControllerConvenienceTest
     @Test
     void getEventByIdWithNotes()
     {
-        Event event = event( programInstance( trackedEntityInstance() ) );
+        Event event = event( enrollment( trackedEntityInstance() ) );
         event.setComments( List.of( note( "oqXG28h988k", "my notes", owner.getUid() ) ) );
         manager.update( event );
 
@@ -181,7 +181,7 @@ class EventsExportControllerTest extends DhisControllerConvenienceTest
     @Test
     void getEventByIdWithDataValues()
     {
-        Event event = event( programInstance( trackedEntityInstance() ) );
+        Event event = event( enrollment( trackedEntityInstance() ) );
         event.getEventDataValues().add( dv );
         manager.update( event );
 
@@ -201,7 +201,7 @@ class EventsExportControllerTest extends DhisControllerConvenienceTest
     void getEventByIdWithFieldsRelationships()
     {
         TrackedEntityInstance to = trackedEntityInstance();
-        Event from = event( programInstance( to ) );
+        Event from = event( enrollment( to ) );
         Relationship relationship = relationship( from, to );
 
         JsonList<JsonRelationship> relationships = GET( "/tracker/events/{id}?fields=relationships", from.getUid() )
@@ -229,7 +229,7 @@ class EventsExportControllerTest extends DhisControllerConvenienceTest
     void getEventByIdRelationshipsNoAccessToRelationshipType()
     {
         TrackedEntityInstance to = trackedEntityInstance();
-        Event from = event( programInstance( to ) );
+        Event from = event( enrollment( to ) );
         relationship( relationshipTypeNotAccessible(), from, to );
         this.switchContextToUser( user );
 
@@ -244,7 +244,7 @@ class EventsExportControllerTest extends DhisControllerConvenienceTest
     {
         TrackedEntityType type = trackedEntityTypeNotAccessible();
         TrackedEntityInstance to = trackedEntityInstance( type );
-        Event from = event( programInstance( to ) );
+        Event from = event( enrollment( to ) );
         relationship( from, to );
         this.switchContextToUser( user );
 
@@ -258,7 +258,7 @@ class EventsExportControllerTest extends DhisControllerConvenienceTest
     void getEventByIdRelationshipsNoAccessToBothRelationshipItems()
     {
         TrackedEntityInstance to = trackedEntityInstanceNotInSearchScope();
-        Event from = event( programInstance( to ) );
+        Event from = event( enrollment( to ) );
         relationship( from, to );
         this.switchContextToUser( user );
 
@@ -272,7 +272,7 @@ class EventsExportControllerTest extends DhisControllerConvenienceTest
     {
         TrackedEntityType type = trackedEntityTypeNotAccessible();
         TrackedEntityInstance from = trackedEntityInstance( type );
-        Event to = event( programInstance( from ) );
+        Event to = event( enrollment( from ) );
         relationship( from, to );
         this.switchContextToUser( user );
 
@@ -287,7 +287,7 @@ class EventsExportControllerTest extends DhisControllerConvenienceTest
     {
 
         TrackedEntityInstance tei = trackedEntityInstance();
-        Enrollment enrollment = programInstance( tei );
+        Enrollment enrollment = enrollment( tei );
         Event programStageInstance = event( enrollment );
         programStageInstance.setCreatedByUserInfo( UserInfoSnapshot.from( user ) );
         programStageInstance.setLastUpdatedByUserInfo( UserInfoSnapshot.from( user ) );
@@ -386,7 +386,7 @@ class EventsExportControllerTest extends DhisControllerConvenienceTest
         return tei;
     }
 
-    private Enrollment programInstance( TrackedEntityInstance tei )
+    private Enrollment enrollment( TrackedEntityInstance tei )
     {
         Enrollment enrollment = new Enrollment( program, tei, tei.getOrganisationUnit() );
         enrollment.setAutoFields();

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -168,7 +168,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
     void getRelationshipsById()
     {
         TrackedEntityInstance to = trackedEntityInstance();
-        Event from = event( programInstance( to ) );
+        Event from = event( enrollment( to ) );
         Relationship r = relationship( from, to );
 
         JsonRelationship relationship = GET( "/tracker/relationships/{uid}", r.getUid() )
@@ -184,7 +184,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
     void getRelationshipsByIdWithFieldsAll()
     {
         TrackedEntityInstance to = trackedEntityInstance();
-        Event from = event( programInstance( to ) );
+        Event from = event( enrollment( to ) );
         Relationship r = relationship( from, to );
 
         JsonRelationship relationship = GET( "/tracker/relationships/{uid}?fields=*", r.getUid() )
@@ -199,7 +199,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
     void getRelationshipsByIdWithFields()
     {
         TrackedEntityInstance to = trackedEntityInstance();
-        Event from = event( programInstance( to ) );
+        Event from = event( enrollment( to ) );
         Relationship r = relationship( from, to );
 
         JsonRelationship relationship = GET( "/tracker/relationships/{uid}?fields=relationship,from[event]",
@@ -243,7 +243,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
     void getRelationshipsByEvent()
     {
         TrackedEntityInstance to = trackedEntityInstance();
-        Event from = event( programInstance( to ) );
+        Event from = event( enrollment( to ) );
         Relationship r = relationship( from, to );
 
         JsonList<JsonRelationship> relationships = GET( "/tracker/relationships?event={uid}", from.getUid() )
@@ -259,7 +259,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
     void getRelationshipsByEventWithFields()
     {
         TrackedEntityInstance to = trackedEntityInstance();
-        Event from = event( programInstance( to ) );
+        Event from = event( enrollment( to ) );
         Relationship r = relationship( from, to );
 
         JsonList<JsonRelationship> relationships = GET(
@@ -278,7 +278,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
     void getRelationshipsByEventWithAssignedUser()
     {
         TrackedEntityInstance to = trackedEntityInstance();
-        Event from = event( programInstance( to ) );
+        Event from = event( enrollment( to ) );
         from.setAssignedUser( owner );
         relationship( from, to );
 
@@ -296,7 +296,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
     void getRelationshipsByEventWithDataValues()
     {
         TrackedEntityInstance to = trackedEntityInstance();
-        Event from = event( programInstance( to ) );
+        Event from = event( enrollment( to ) );
         from.setEventDataValues( Set.of( new EventDataValue( dataElement.getUid(), "12" ) ) );
         relationship( from, to );
 
@@ -314,7 +314,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
     void getRelationshipsByEventWithNotes()
     {
         TrackedEntityInstance to = trackedEntityInstance();
-        Event from = event( programInstance( to ) );
+        Event from = event( enrollment( to ) );
         from.setComments( List.of( note( "oqXG28h988k", "my notes", owner.getUid() ) ) );
         relationship( from, to );
 
@@ -339,7 +339,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
     void getRelationshipsByEnrollment()
     {
         TrackedEntityInstance to = trackedEntityInstance();
-        Enrollment from = programInstance( to );
+        Enrollment from = enrollment( to );
         Relationship r = relationship( from, to );
 
         JsonList<JsonRelationship> relationships = GET( "/tracker/relationships?enrollment=" + from.getUid() )
@@ -355,7 +355,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
     void getRelationshipsByEnrollmentWithFieldsAll()
     {
         TrackedEntityInstance to = trackedEntityInstance();
-        Enrollment from = programInstance( to );
+        Enrollment from = enrollment( to );
         Relationship r = relationship( from, to );
 
         JsonList<JsonRelationship> relationships = GET( "/tracker/relationships?enrollment={uid}&fields=*",
@@ -370,7 +370,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
     @Test
     void getRelationshipsByEnrollmentWithEvents()
     {
-        Enrollment from = programInstance( trackedEntityInstance() );
+        Enrollment from = enrollment( trackedEntityInstance() );
         Event to = event( from );
         relationship( from, to );
 
@@ -390,7 +390,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
         to.setTrackedEntityAttributeValues( Set.of( attributeValue( tea, to, "12" ) ) );
         program.setProgramAttributes( List.of( createProgramTrackedEntityAttribute( program, tea ) ) );
 
-        Enrollment from = programInstance( to );
+        Enrollment from = enrollment( to );
         relationship( from, to );
 
         JsonList<JsonRelationship> relationships = GET(
@@ -407,7 +407,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
     void getRelationshipsByEnrollmentWithNotes()
     {
         TrackedEntityInstance to = trackedEntityInstance();
-        Enrollment from = programInstance( to );
+        Enrollment from = enrollment( to );
         from.setComments( List.of( note( "oqXG28h988k", "my notes", owner.getUid() ) ) );
         relationship( from, to );
 
@@ -432,7 +432,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
     void getRelationshipsByTrackedEntity()
     {
         TrackedEntityInstance to = trackedEntityInstance();
-        Enrollment from = programInstance( to );
+        Enrollment from = enrollment( to );
         Relationship r = relationship( from, to );
 
         JsonList<JsonRelationship> relationships = GET( "/tracker/relationships?trackedEntity={tei}", to.getUid() )
@@ -448,7 +448,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
     void getRelationshipsByTei()
     {
         TrackedEntityInstance to = trackedEntityInstance();
-        Enrollment from = programInstance( to );
+        Enrollment from = enrollment( to );
         Relationship r = relationship( from, to );
 
         JsonList<JsonRelationship> relationships = GET( "/tracker/relationships?tei=" + to.getUid() )
@@ -464,7 +464,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
     void getRelationshipsByTrackedEntityWithEnrollments()
     {
         TrackedEntityInstance to = trackedEntityInstance();
-        Enrollment from = programInstance( to );
+        Enrollment from = enrollment( to );
         relationship( from, to );
 
         JsonList<JsonRelationship> relationships = GET(
@@ -485,7 +485,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
         to.setTrackedEntityAttributeValues(
             Set.of( attributeValue( tea, to, "12" ), attributeValue( tea2, to, "24" ) ) );
         program.setProgramAttributes( List.of( createProgramTrackedEntityAttribute( program, tea2 ) ) );
-        Enrollment from = programInstance( to );
+        Enrollment from = enrollment( to );
         relationship( from, to );
 
         JsonList<JsonRelationship> relationships = GET(
@@ -505,7 +505,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
     void getRelationshipsByTrackedEntityWithProgramOwners()
     {
         TrackedEntityInstance to = trackedEntityInstance( orgUnit );
-        Enrollment from = programInstance( to );
+        Enrollment from = enrollment( to );
         to.setProgramOwners( Set.of( new TrackedEntityProgramOwner( to, from.getProgram(), orgUnit ) ) );
         relationship( from, to );
 
@@ -665,7 +665,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
         return tei;
     }
 
-    private Enrollment programInstance( TrackedEntityInstance tei )
+    private Enrollment enrollment( TrackedEntityInstance tei )
     {
         Enrollment enrollment = new Enrollment( program, tei, orgUnit );
         enrollment.setAutoFields();

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -422,18 +422,18 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
     void shouldGetEnrollmentWhenFieldsHasEnrollments()
     {
         TrackedEntityInstance trackedEntityInstance = trackedEntityInstance();
-        Enrollment programInstance = enrollmentService.enrollTrackedEntityInstance( trackedEntityInstance,
+        Enrollment enrollment = enrollmentService.enrollTrackedEntityInstance( trackedEntityInstance,
             program, new Date(), new Date(), orgUnit );
 
         JsonList<JsonEnrollment> json = GET( "/tracker/trackedEntities/{id}?fields=enrollments",
             trackedEntityInstance.getUid() )
                 .content( HttpStatus.OK ).getList( "enrollments", JsonEnrollment.class );
 
-        JsonEnrollment enrollment = assertDefaultEnrollmentResponse( json, programInstance );
+        JsonEnrollment jsonEnrollment = assertDefaultEnrollmentResponse( json, enrollment );
 
-        assertTrue( enrollment.getArray( "relationships" ).isEmpty() );
-        assertTrue( enrollment.getAttributes().isEmpty() );
-        assertTrue( enrollment.getEvents().isEmpty() );
+        assertTrue( jsonEnrollment.getArray( "relationships" ).isEmpty() );
+        assertTrue( jsonEnrollment.getAttributes().isEmpty() );
+        assertTrue( jsonEnrollment.getEvents().isEmpty() );
     }
 
     @Test
@@ -441,23 +441,23 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
     {
         TrackedEntityInstance trackedEntityInstance = trackedEntityInstance();
 
-        Enrollment programInstance = enrollmentService.enrollTrackedEntityInstance( trackedEntityInstance,
+        Enrollment enrollment = enrollmentService.enrollTrackedEntityInstance( trackedEntityInstance,
             program, new Date(), new Date(), orgUnit );
 
-        Event event = eventWithDataValue( programInstance );
+        Event event = eventWithDataValue( enrollment );
 
-        programInstance.getEvents().add( event );
-        manager.update( programInstance );
+        enrollment.getEvents().add( event );
+        manager.update( enrollment );
 
         JsonList<JsonEnrollment> json = GET( "/tracker/trackedEntities/{id}?fields=enrollments",
             trackedEntityInstance.getUid() )
                 .content( HttpStatus.OK ).getList( "enrollments", JsonEnrollment.class );
 
-        JsonEnrollment enrollment = assertDefaultEnrollmentResponse( json, programInstance );
-        assertTrue( enrollment.getArray( "relationships" ).isEmpty() );
-        assertTrue( enrollment.getAttributes().isEmpty() );
+        JsonEnrollment jsonEnrollment = assertDefaultEnrollmentResponse( json, enrollment );
+        assertTrue( jsonEnrollment.getArray( "relationships" ).isEmpty() );
+        assertTrue( jsonEnrollment.getAttributes().isEmpty() );
 
-        JsonEvent jsonEvent = assertDefaultEventResponse( enrollment, event );
+        JsonEvent jsonEvent = assertDefaultEventResponse( jsonEnrollment, event );
 
         assertTrue( jsonEvent.getRelationships().isEmpty() );
     }
@@ -467,12 +467,12 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
     {
         TrackedEntityInstance trackedEntityInstance = trackedEntityInstance();
 
-        Enrollment programInstance = enrollmentService.enrollTrackedEntityInstance( trackedEntityInstance,
+        Enrollment enrollment = enrollmentService.enrollTrackedEntityInstance( trackedEntityInstance,
             program, new Date(), new Date(), orgUnit );
 
-        Event event = eventWithDataValue( programInstance );
-        programInstance.getEvents().add( event );
-        manager.update( programInstance );
+        Event event = eventWithDataValue( enrollment );
+        enrollment.getEvents().add( event );
+        manager.update( enrollment );
 
         Relationship teiToEventRelationship = relationship( trackedEntityInstance, event );
 
@@ -480,11 +480,11 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
             trackedEntityInstance.getUid() )
                 .content( HttpStatus.OK ).getList( "enrollments", JsonEnrollment.class );
 
-        JsonEnrollment enrollment = assertDefaultEnrollmentResponse( json, programInstance );
-        assertTrue( enrollment.getAttributes().isEmpty() );
-        assertTrue( enrollment.getArray( "relationships" ).isEmpty() );
+        JsonEnrollment jsonEnrollment = assertDefaultEnrollmentResponse( json, enrollment );
+        assertTrue( jsonEnrollment.getAttributes().isEmpty() );
+        assertTrue( jsonEnrollment.getArray( "relationships" ).isEmpty() );
 
-        JsonEvent jsonEvent = assertDefaultEventResponse( enrollment, event );
+        JsonEvent jsonEvent = assertDefaultEventResponse( jsonEnrollment, event );
 
         JsonRelationship relationship = jsonEvent.getRelationships().get( 0 );
 
@@ -498,13 +498,13 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
     {
         TrackedEntityInstance trackedEntityInstance = trackedEntityInstance();
 
-        Enrollment programInstance = enrollmentService.enrollTrackedEntityInstance( trackedEntityInstance,
+        Enrollment enrollment = enrollmentService.enrollTrackedEntityInstance( trackedEntityInstance,
             program, new Date(), new Date(), orgUnit );
 
-        Event event = eventWithDataValue( programInstance );
+        Event event = eventWithDataValue( enrollment );
 
-        programInstance.getEvents().add( event );
-        manager.update( programInstance );
+        enrollment.getEvents().add( event );
+        manager.update( enrollment );
 
         relationship( trackedEntityInstance, event );
 
@@ -513,11 +513,11 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
             trackedEntityInstance.getUid() )
                 .content( HttpStatus.OK ).getList( "enrollments", JsonEnrollment.class );
 
-        JsonEnrollment enrollment = assertDefaultEnrollmentResponse( json, programInstance );
-        assertTrue( enrollment.getAttributes().isEmpty() );
-        assertTrue( enrollment.getArray( "relationships" ).isEmpty() );
+        JsonEnrollment jsonEnrollment = assertDefaultEnrollmentResponse( json, enrollment );
+        assertTrue( jsonEnrollment.getAttributes().isEmpty() );
+        assertTrue( jsonEnrollment.getArray( "relationships" ).isEmpty() );
 
-        JsonEvent jsonEvent = assertDefaultEventResponse( enrollment, event );
+        JsonEvent jsonEvent = assertDefaultEventResponse( jsonEnrollment, event );
 
         assertHasNoMember( jsonEvent, "relationships" );
     }
@@ -546,29 +546,29 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
     }
 
     private JsonEnrollment assertDefaultEnrollmentResponse( JsonList<JsonEnrollment> enrollments,
-        Enrollment programInstance )
+        Enrollment enrollment )
     {
         assertFalse( enrollments.isEmpty() );
-        JsonEnrollment enrollment = enrollments.get( 0 );
+        JsonEnrollment jsonEnrollment = enrollments.get( 0 );
 
-        assertHasMember( enrollment, "enrollment" );
+        assertHasMember( jsonEnrollment, "enrollment" );
 
-        assertEquals( programInstance.getUid(), enrollment.getEnrollment() );
-        assertEquals( programInstance.getEntityInstance().getUid(), enrollment.getTrackedEntity() );
-        assertEquals( program.getUid(), enrollment.getProgram() );
-        assertEquals( "ACTIVE", enrollment.getStatus() );
-        assertEquals( orgUnit.getUid(), enrollment.getOrgUnit() );
-        assertEquals( orgUnit.getName(), enrollment.getOrgUnitName() );
-        assertFalse( enrollment.getBoolean( "deleted" ).booleanValue() );
-        assertHasMember( enrollment, "enrolledAt" );
-        assertHasMember( enrollment, "occurredAt" );
-        assertHasMember( enrollment, "createdAt" );
-        assertHasMember( enrollment, "createdAtClient" );
-        assertHasMember( enrollment, "updatedAt" );
-        assertHasMember( enrollment, "notes" );
-        assertHasMember( enrollment, "followUp" );
+        assertEquals( enrollment.getUid(), jsonEnrollment.getEnrollment() );
+        assertEquals( enrollment.getEntityInstance().getUid(), jsonEnrollment.getTrackedEntity() );
+        assertEquals( program.getUid(), jsonEnrollment.getProgram() );
+        assertEquals( "ACTIVE", jsonEnrollment.getStatus() );
+        assertEquals( orgUnit.getUid(), jsonEnrollment.getOrgUnit() );
+        assertEquals( orgUnit.getName(), jsonEnrollment.getOrgUnitName() );
+        assertFalse( jsonEnrollment.getBoolean( "deleted" ).booleanValue() );
+        assertHasMember( jsonEnrollment, "enrolledAt" );
+        assertHasMember( jsonEnrollment, "occurredAt" );
+        assertHasMember( jsonEnrollment, "createdAt" );
+        assertHasMember( jsonEnrollment, "createdAtClient" );
+        assertHasMember( jsonEnrollment, "updatedAt" );
+        assertHasMember( jsonEnrollment, "notes" );
+        assertHasMember( jsonEnrollment, "followUp" );
 
-        return enrollment;
+        return jsonEnrollment;
     }
 
     private JsonEvent assertDefaultEventResponse( JsonEnrollment enrollment, Event event )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MaintenanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MaintenanceController.java
@@ -181,9 +181,9 @@ public class MaintenanceController
     @RequestMapping( value = "/softDeletedProgramInstanceRemoval", method = { RequestMethod.PUT, RequestMethod.POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
-    public void deleteSoftDeletedProgramInstances()
+    public void deleteSoftDeletedEnrollments()
     {
-        maintenanceService.deleteSoftDeletedProgramInstances();
+        maintenanceService.deleteSoftDeletedEnrollments();
     }
 
     @RequestMapping( value = "/softDeletedTrackedEntityInstanceRemoval", method = { RequestMethod.PUT,
@@ -356,7 +356,7 @@ public class MaintenanceController
 
         if ( softDeletedEnrollmentRemoval )
         {
-            deleteSoftDeletedProgramInstances();
+            deleteSoftDeletedEnrollments();
         }
 
         if ( softDeletedTrackedEntityInstanceRemoval )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
@@ -112,7 +112,7 @@ public class EnrollmentController
     private AsyncTaskExecutor taskExecutor;
 
     @Autowired
-    private EnrollmentService programInstanceService;
+    private EnrollmentService enrollmentService;
 
     @Autowired
     protected FieldFilterService fieldFilterService;
@@ -341,7 +341,7 @@ public class EnrollmentController
     @ResponseBody
     public WebMessage cancelEnrollment( @PathVariable String id )
     {
-        if ( !programInstanceService.enrollmentExists( id ) )
+        if ( !enrollmentService.enrollmentExists( id ) )
         {
             return notFound( "Enrollment not found for ID " + id );
         }
@@ -355,7 +355,7 @@ public class EnrollmentController
     @ResponseBody
     public WebMessage completeEnrollment( @PathVariable String id )
     {
-        if ( !programInstanceService.enrollmentExists( id ) )
+        if ( !enrollmentService.enrollmentExists( id ) )
         {
             return notFound( "Enrollment not found for ID " + id );
         }
@@ -369,7 +369,7 @@ public class EnrollmentController
     @ResponseBody
     public WebMessage incompleteEnrollment( @PathVariable String id )
     {
-        if ( !programInstanceService.enrollmentExists( id ) )
+        if ( !enrollmentService.enrollmentExists( id ) )
         {
             return notFound( "Enrollment not found for ID " + id );
         }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
@@ -112,7 +112,7 @@ public class EnrollmentController
     private AsyncTaskExecutor taskExecutor;
 
     @Autowired
-    private EnrollmentService enrollmentService;
+    private EnrollmentService programInstanceService;
 
     @Autowired
     protected FieldFilterService fieldFilterService;
@@ -341,7 +341,7 @@ public class EnrollmentController
     @ResponseBody
     public WebMessage cancelEnrollment( @PathVariable String id )
     {
-        if ( !enrollmentService.enrollmentExists( id ) )
+        if ( !programInstanceService.enrollmentExists( id ) )
         {
             return notFound( "Enrollment not found for ID " + id );
         }
@@ -355,7 +355,7 @@ public class EnrollmentController
     @ResponseBody
     public WebMessage completeEnrollment( @PathVariable String id )
     {
-        if ( !enrollmentService.enrollmentExists( id ) )
+        if ( !programInstanceService.enrollmentExists( id ) )
         {
             return notFound( "Enrollment not found for ID " + id );
         }
@@ -369,7 +369,7 @@ public class EnrollmentController
     @ResponseBody
     public WebMessage incompleteEnrollment( @PathVariable String id )
     {
-        if ( !enrollmentService.enrollmentExists( id ) )
+        if ( !programInstanceService.enrollmentExists( id ) )
         {
             return notFound( "Enrollment not found for ID " + id );
         }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentCriteriaMapper.java
@@ -75,7 +75,7 @@ public class EnrollmentCriteriaMapper
     private final TrackerAccessManager trackerAccessManager;
 
     /**
-     * Returns a ProgramInstanceQueryParams based on the given input.
+     * Returns a EnrollmentQueryParams based on the given input.
      *
      * @param ou the set of organisation unit identifiers.
      * @param ouMode the OrganisationUnitSelectionMode.
@@ -94,7 +94,7 @@ public class EnrollmentCriteriaMapper
      * @param totalPages indicates whether to include the total number of pages.
      * @param skipPaging whether to skip paging.
      * @param includeDeleted whether to include soft deleted ones
-     * @return a ProgramInstanceQueryParams.
+     * @return a EnrollmentQueryParams.
      */
     @Transactional( readOnly = true )
     public EnrollmentQueryParams getFromUrl( Set<String> ou, OrganisationUnitSelectionMode ouMode,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventRequestToSearchParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventRequestToSearchParamsMapper.java
@@ -144,7 +144,7 @@ class EventRequestToSearchParamsMapper
         CategoryOptionCombo attributeOptionCombo, IdSchemes idSchemes, Integer page, Integer pageSize,
         boolean totalPages, boolean skipPaging, List<OrderParam> orders, List<OrderParam> gridOrders,
         boolean includeAttributes,
-        Set<String> events, Set<String> programInstances, Boolean skipEventId,
+        Set<String> events, Set<String> enrollments, Boolean skipEventId,
         AssignedUserSelectionMode assignedUserSelectionMode,
         Set<String> assignedUsers, Set<String> filters, Set<String> dataElements, boolean includeAllDataElements,
         boolean includeDeleted )
@@ -239,9 +239,9 @@ class EventRequestToSearchParamsMapper
                 .collect( Collectors.toSet() );
         }
 
-        if ( programInstances != null )
+        if ( enrollments != null )
         {
-            programInstances = programInstances.stream()
+            enrollments = enrollments.stream()
                 .filter( CodeGenerator::isValidUid )
                 .collect( Collectors.toSet() );
         }
@@ -256,7 +256,7 @@ class EventRequestToSearchParamsMapper
             .setPageSize( pageSize ).setTotalPages( totalPages ).setSkipPaging( skipPaging )
             .setSkipEventId( skipEventId ).setIncludeAttributes( includeAttributes )
             .setIncludeAllDataElements( includeAllDataElements ).addOrders( orders ).addGridOrders( gridOrders )
-            .setEvents( events ).setProgramInstances( programInstances ).setIncludeDeleted( includeDeleted );
+            .setEvents( events ).setEnrollments( enrollments ).setIncludeDeleted( includeDeleted );
     }
 
     private QueryItem getQueryItem( String item )
@@ -332,7 +332,7 @@ class EventRequestToSearchParamsMapper
             getGridOrderParams( eventCriteria.getOrder(), dataElementOrders ),
             false,
             eventIds,
-            eventCriteria.getProgramInstances(),
+            eventCriteria.getEnrollments(),
             eventCriteria.getSkipEventId(),
             eventCriteria.getAssignedUserMode(),
             assignedUserIds,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/RelationshipController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/RelationshipController.java
@@ -119,7 +119,7 @@ public class RelationshipController
             return Optional.ofNullable( enrollmentService
                 .getEnrollment( relationshipCriteria.getEnrollment() ) )
                 .map(
-                    pi -> relationshipService.getRelationshipsByProgramInstance( pi, relationshipCriteria,
+                    pi -> relationshipService.getRelationshipsByEnrollment( pi, relationshipCriteria,
                         false ) )
                 .orElseThrow( () -> new WebMessageException(
                     notFound( "No enrollment '" + relationshipCriteria.getEnrollment() + "' found." ) ) );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/EventCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/EventCriteria.java
@@ -105,7 +105,7 @@ public class EventCriteria extends PagingAndSortingCriteriaAdapter
 
     private Set<String> filter;
 
-    private Set<String> programInstances;
+    private Set<String> enrollments;
 
     private IdSchemes idSchemes = new IdSchemes();
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventCriteriaMapper.java
@@ -162,7 +162,7 @@ class EventCriteriaMapper
             filters.add( parseQueryItem( eventCriteria, this::dataElementToQueryItem ) );
         }
 
-        Set<String> programInstances = criteria.getEnrollments().stream()
+        Set<String> enrollments = criteria.getEnrollments().stream()
             .filter( CodeGenerator::isValidUid )
             .collect( Collectors.toSet() );
 
@@ -194,7 +194,7 @@ class EventCriteriaMapper
             .addOrders( getOrderParams( criteria.getOrder() ) )
             .addGridOrders( dataElementOrderParams )
             .addAttributeOrders( attributeOrderParams )
-            .setEvents( eventIds ).setEnrollments( programInstances )
+            .setEvents( eventIds ).setEnrollments( enrollments )
             .setIncludeDeleted( criteria.isIncludeDeleted() );
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
@@ -134,7 +134,7 @@ public class RelationshipsExportController
 
     private CheckedBiFunction<Object, PagingAndSortingCriteriaAdapter, List<Relationship>> getRelationshipsByEnrollment()
     {
-        return ( o, criteria ) -> relationshipService.getRelationshipsByProgramInstance( (Enrollment) o,
+        return ( o, criteria ) -> relationshipService.getRelationshipsByEnrollment( (Enrollment) o,
             criteria );
     }
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/RelationshipControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/RelationshipControllerTest.java
@@ -158,7 +158,7 @@ class RelationshipControllerTest
         mockMvc.perform( get( ENDPOINT ).param( "enrollment", ENROLLMENT_ID ) ).andExpect( status().isOk() );
 
         verify( enrollmentService ).getEnrollment( ENROLLMENT_ID );
-        verify( relationshipService ).getRelationshipsByProgramInstance( eq( enrollment ), any(), eq( false ) );
+        verify( relationshipService ).getRelationshipsByEnrollment( eq( enrollment ), any(), eq( false ) );
     }
 
     @Test


### PR DESCRIPTION
What is missing after this PR:
- Checking out enums
- Rename `pi` occurrences (not easy as also `ProgramIndicator` uses the same alias)