### PR TITLE
fix: validate irrelevant object for programRuleAction

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -249,6 +249,8 @@ public enum ErrorCode
     E4053( "Program stage `{0}` must reference a program" ),
     E4057( "The Program Rule name {0} already exist in Program {1}" ),
 
+    E4058( "Program Rule `{0}` with Action Type `{1}` has irrelevant reference objects" ),
+
     /* Metadata Validation (continued) */
     E4060( "Object could not be deleted: {0}" ),
     E4061(

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/action/validation/HideOptionProgramRuleActionValidator.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/action/validation/HideOptionProgramRuleActionValidator.java
@@ -29,11 +29,13 @@ package org.hisp.dhis.programrule.action.validation;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.programrule.ProgramRule;
 import org.hisp.dhis.programrule.ProgramRuleAction;
+import org.hisp.dhis.programrule.ProgramRuleActionType;
 import org.hisp.dhis.programrule.ProgramRuleActionValidationResult;
 import org.springframework.stereotype.Component;
 
@@ -83,6 +85,16 @@ public class HideOptionProgramRuleActionValidator extends BaseProgramRuleActionV
                 .valid( false )
                 .errorReport( new ErrorReport( Option.class, ErrorCode.E4041,
                     programRuleAction.getOption().getUid(), rule.getName() ) )
+                .build();
+        }
+
+        if ( ObjectUtils.anyNotNull( programRuleAction.getDataElement(), programRuleAction.getProgramStage(),
+            programRuleAction.getOptionGroup(), programRuleAction.getProgramStageSection() ) )
+        {
+            return ProgramRuleActionValidationResult.builder()
+                .valid( false )
+                .errorReport( new ErrorReport( Option.class, ErrorCode.E4058,
+                    rule.getName(), ProgramRuleActionType.HIDEOPTION.name() ) )
                 .build();
         }
 

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/action/validation/HideProgramStageProgramRuleActionValidator.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/action/validation/HideProgramStageProgramRuleActionValidator.java
@@ -29,11 +29,14 @@ package org.hisp.dhis.programrule.action.validation;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.option.Option;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.programrule.ProgramRule;
 import org.hisp.dhis.programrule.ProgramRuleAction;
+import org.hisp.dhis.programrule.ProgramRuleActionType;
 import org.hisp.dhis.programrule.ProgramRuleActionValidationResult;
 import org.springframework.stereotype.Component;
 
@@ -82,6 +85,16 @@ public class HideProgramStageProgramRuleActionValidator implements ProgramRuleAc
                 .errorReport(
                     new ErrorReport( ProgramStage.class, ErrorCode.E4039, programRuleAction.getProgramStage().getUid(),
                         rule.getName() ) )
+                .build();
+        }
+
+        if ( ObjectUtils.anyNotNull( programRuleAction.getDataElement(), programRuleAction.getOption(),
+            programRuleAction.getOptionGroup(), programRuleAction.getProgramStageSection() ) )
+        {
+            return ProgramRuleActionValidationResult.builder()
+                .valid( false )
+                .errorReport( new ErrorReport( Option.class, ErrorCode.E4058,
+                    rule.getName(), ProgramRuleActionType.HIDEPROGRAMSTAGE.name() ) )
                 .build();
         }
 

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/action/validation/HideSectionProgramRuleActionValidator.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/action/validation/HideSectionProgramRuleActionValidator.java
@@ -29,11 +29,14 @@ package org.hisp.dhis.programrule.action.validation;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.option.Option;
 import org.hisp.dhis.program.ProgramStageSection;
 import org.hisp.dhis.programrule.ProgramRule;
 import org.hisp.dhis.programrule.ProgramRuleAction;
+import org.hisp.dhis.programrule.ProgramRuleActionType;
 import org.hisp.dhis.programrule.ProgramRuleActionValidationResult;
 import org.springframework.stereotype.Component;
 
@@ -82,6 +85,16 @@ public class HideSectionProgramRuleActionValidator implements ProgramRuleActionV
                 .errorReport( new ErrorReport( ProgramStageSection.class, ErrorCode.E4037,
                     programRuleAction.getProgramStageSection().getUid(),
                     rule.getName() ) )
+                .build();
+        }
+
+        if ( ObjectUtils.anyNotNull( programRuleAction.getDataElement(), programRuleAction.getOption(),
+            programRuleAction.getOptionGroup(), programRuleAction.getProgramStage() ) )
+        {
+            return ProgramRuleActionValidationResult.builder()
+                .valid( false )
+                .errorReport( new ErrorReport( Option.class, ErrorCode.E4058,
+                    rule.getName(), ProgramRuleActionType.HIDESECTION.name() ) )
                 .build();
         }
 

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/action/validation/ShowHideOptionGroupProgramRuleActionValidator.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/action/validation/ShowHideOptionGroupProgramRuleActionValidator.java
@@ -29,12 +29,14 @@ package org.hisp.dhis.programrule.action.validation;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionGroup;
 import org.hisp.dhis.programrule.ProgramRule;
 import org.hisp.dhis.programrule.ProgramRuleAction;
+import org.hisp.dhis.programrule.ProgramRuleActionType;
 import org.hisp.dhis.programrule.ProgramRuleActionValidationResult;
 import org.springframework.stereotype.Component;
 
@@ -92,6 +94,16 @@ public class ShowHideOptionGroupProgramRuleActionValidator extends BaseProgramRu
                 .errorReport(
                     new ErrorReport( Option.class, ErrorCode.E4043, programRuleAction.getOptionGroup().getUid(),
                         rule.getName() ) )
+                .build();
+        }
+
+        if ( ObjectUtils.anyNotNull( programRuleAction.getOption(), programRuleAction.getProgramStage(),
+            programRuleAction.getProgramStageSection() ) )
+        {
+            return ProgramRuleActionValidationResult.builder()
+                .valid( false )
+                .errorReport( new ErrorReport( Option.class, ErrorCode.E4058,
+                    rule.getName(), ProgramRuleActionType.HIDEOPTIONGROUP.name() ) )
                 .build();
         }
 


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-14270
- `ProgramRuleAction` has referenced to metadata objects ( `DataElement`,  `ProgramStage`, etc.. )  according to the `ProgramRuleActionType` value ( `HIDEPROGRAMSTAGE`, `HIDEOPTION`, etc.. ).
- This PR add a validation to existing `ProgramRuleActionValidator` to make sure that no _irrelevant_ object references would be saved to database.
 For example: the validation will throw an error if  `ProgramRuleAction` with type `HIDEPROGRAMSTAGE` has reference to a `DataElement`.

#### Test
- Added a controller test.
- Manual test can be done using web api as the front-end team has fixed the issue so this issue can't be reproduced on the Maintenance app.