### PR TITLE
chore: remove unused Json/Jackson annotations TECH-1552

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Enrollment.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Enrollment.java
@@ -34,6 +34,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import org.hisp.dhis.audit.AuditAttribute;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.Auditable;
@@ -48,6 +51,8 @@ import org.locationtech.jts.geom.Geometry;
 /**
  * @author Abyot Asalefew
  */
+@Getter
+@Setter
 @Auditable( scope = AuditScope.TRACKER )
 public class Enrollment
     extends SoftDeletableObject
@@ -93,10 +98,6 @@ public class Enrollment
 
     private String storedBy;
 
-    // -------------------------------------------------------------------------
-    // Constructors
-    // -------------------------------------------------------------------------
-
     public Enrollment()
     {
     }
@@ -130,10 +131,6 @@ public class Enrollment
         lastUpdatedAtClient = lastUpdated;
     }
 
-    // -------------------------------------------------------------------------
-    // Logic
-    // -------------------------------------------------------------------------
-
     /**
      * Updated the bidirectional associations between this Enrollment and the
      * given tracked entity and program.
@@ -153,10 +150,6 @@ public class Enrollment
     {
         return this.status == ProgramStatus.COMPLETED;
     }
-
-    // -------------------------------------------------------------------------
-    // equals and hashCode
-    // -------------------------------------------------------------------------
 
     @Override
     public int hashCode()
@@ -184,201 +177,6 @@ public class Enrollment
             && Objects.equals( enrollmentDate, other.enrollmentDate )
             && Objects.equals( trackedEntity, other.trackedEntity )
             && Objects.equals( program, other.program );
-    }
-
-    // -------------------------------------------------------------------------
-    // Getters and setters
-    // -------------------------------------------------------------------------
-
-    public Date getCreatedAtClient()
-    {
-        return createdAtClient;
-    }
-
-    public void setCreatedAtClient( Date createdAtClient )
-    {
-        this.createdAtClient = createdAtClient;
-    }
-
-    public Date getLastUpdatedAtClient()
-    {
-        return lastUpdatedAtClient;
-    }
-
-    public void setLastUpdatedAtClient( Date lastUpdatedAtClient )
-    {
-        this.lastUpdatedAtClient = lastUpdatedAtClient;
-    }
-
-    public OrganisationUnit getOrganisationUnit()
-    {
-        return organisationUnit;
-    }
-
-    public Enrollment setOrganisationUnit( OrganisationUnit organisationUnit )
-    {
-        this.organisationUnit = organisationUnit;
-        return this;
-    }
-
-    public Date getIncidentDate()
-    {
-        return incidentDate;
-    }
-
-    public void setIncidentDate( Date incidentDate )
-    {
-        this.incidentDate = incidentDate;
-    }
-
-    public Date getEnrollmentDate()
-    {
-        return enrollmentDate;
-    }
-
-    public void setEnrollmentDate( Date enrollmentDate )
-    {
-        this.enrollmentDate = enrollmentDate;
-    }
-
-    public Date getEndDate()
-    {
-        return endDate;
-    }
-
-    public void setEndDate( Date endDate )
-    {
-        this.endDate = endDate;
-    }
-
-    public UserInfoSnapshot getCreatedByUserInfo()
-    {
-        return createdByUserInfo;
-    }
-
-    public void setCreatedByUserInfo( UserInfoSnapshot createdByUserInfo )
-    {
-        this.createdByUserInfo = createdByUserInfo;
-    }
-
-    public UserInfoSnapshot getLastUpdatedByUserInfo()
-    {
-        return lastUpdatedByUserInfo;
-    }
-
-    public void setLastUpdatedByUserInfo( UserInfoSnapshot lastUpdatedByUserInfo )
-    {
-        this.lastUpdatedByUserInfo = lastUpdatedByUserInfo;
-    }
-
-    public ProgramStatus getStatus()
-    {
-        return status;
-    }
-
-    public void setStatus( ProgramStatus status )
-    {
-        this.status = status;
-    }
-
-    public TrackedEntity getTrackedEntity()
-    {
-        return trackedEntity;
-    }
-
-    public void setTrackedEntity( TrackedEntity trackedEntity )
-    {
-        this.trackedEntity = trackedEntity;
-    }
-
-    public Program getProgram()
-    {
-        return program;
-    }
-
-    public void setProgram( Program program )
-    {
-        this.program = program;
-    }
-
-    public Set<Event> getEvents()
-    {
-        return events;
-    }
-
-    public void setEvents( Set<Event> events )
-    {
-        this.events = events;
-    }
-
-    public Boolean getFollowup()
-    {
-        return followup;
-    }
-
-    public void setFollowup( Boolean followup )
-    {
-        this.followup = followup;
-    }
-
-    public List<MessageConversation> getMessageConversations()
-    {
-        return messageConversations;
-    }
-
-    public void setMessageConversations( List<MessageConversation> messageConversations )
-    {
-        this.messageConversations = messageConversations;
-    }
-
-    public List<TrackedEntityComment> getComments()
-    {
-        return comments;
-    }
-
-    public void setComments( List<TrackedEntityComment> comments )
-    {
-        this.comments = comments;
-    }
-
-    public String getCompletedBy()
-    {
-        return completedBy;
-    }
-
-    public void setCompletedBy( String completedBy )
-    {
-        this.completedBy = completedBy;
-    }
-
-    public Geometry getGeometry()
-    {
-        return geometry;
-    }
-
-    public void setGeometry( Geometry geometry )
-    {
-        this.geometry = geometry;
-    }
-
-    public String getStoredBy()
-    {
-        return storedBy;
-    }
-
-    public void setStoredBy( String storedBy )
-    {
-        this.storedBy = storedBy;
-    }
-
-    public Set<RelationshipItem> getRelationshipItems()
-    {
-        return relationshipItems;
-    }
-
-    public void setRelationshipItems( Set<RelationshipItem> relationshipItems )
-    {
-        this.relationshipItems = relationshipItems;
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Enrollment.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Enrollment.java
@@ -37,8 +37,6 @@ import java.util.Set;
 import org.hisp.dhis.audit.AuditAttribute;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.Auditable;
-import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.SoftDeletableObject;
 import org.hisp.dhis.message.MessageConversation;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -47,17 +45,10 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 import org.locationtech.jts.geom.Geometry;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
-
 /**
  * @author Abyot Asalefew
  */
 @Auditable( scope = AuditScope.TRACKER )
-@JacksonXmlRootElement( localName = "enrollment", namespace = DxfNamespaces.DXF_2_0 )
 public class Enrollment
     extends SoftDeletableObject
 {
@@ -199,8 +190,6 @@ public class Enrollment
     // Getters and setters
     // -------------------------------------------------------------------------
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public Date getCreatedAtClient()
     {
         return createdAtClient;
@@ -211,8 +200,6 @@ public class Enrollment
         this.createdAtClient = createdAtClient;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public Date getLastUpdatedAtClient()
     {
         return lastUpdatedAtClient;
@@ -223,9 +210,6 @@ public class Enrollment
         this.lastUpdatedAtClient = lastUpdatedAtClient;
     }
 
-    @JsonProperty
-    @JsonSerialize( as = BaseIdentifiableObject.class )
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public OrganisationUnit getOrganisationUnit()
     {
         return organisationUnit;
@@ -237,8 +221,6 @@ public class Enrollment
         return this;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public Date getIncidentDate()
     {
         return incidentDate;
@@ -249,8 +231,6 @@ public class Enrollment
         this.incidentDate = incidentDate;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public Date getEnrollmentDate()
     {
         return enrollmentDate;
@@ -261,8 +241,6 @@ public class Enrollment
         this.enrollmentDate = enrollmentDate;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public Date getEndDate()
     {
         return endDate;
@@ -273,8 +251,6 @@ public class Enrollment
         this.endDate = endDate;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public UserInfoSnapshot getCreatedByUserInfo()
     {
         return createdByUserInfo;
@@ -285,8 +261,6 @@ public class Enrollment
         this.createdByUserInfo = createdByUserInfo;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public UserInfoSnapshot getLastUpdatedByUserInfo()
     {
         return lastUpdatedByUserInfo;
@@ -297,8 +271,6 @@ public class Enrollment
         this.lastUpdatedByUserInfo = lastUpdatedByUserInfo;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public ProgramStatus getStatus()
     {
         return status;
@@ -309,9 +281,6 @@ public class Enrollment
         this.status = status;
     }
 
-    @JsonProperty( "trackedEntityInstance" )
-    @JsonSerialize( as = BaseIdentifiableObject.class )
-    @JacksonXmlProperty( localName = "trackedEntityInstance", namespace = DxfNamespaces.DXF_2_0 )
     public TrackedEntity getTrackedEntity()
     {
         return trackedEntity;
@@ -322,9 +291,6 @@ public class Enrollment
         this.trackedEntity = trackedEntity;
     }
 
-    @JsonProperty
-    @JsonSerialize( as = BaseIdentifiableObject.class )
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public Program getProgram()
     {
         return program;
@@ -335,9 +301,6 @@ public class Enrollment
         this.program = program;
     }
 
-    @JsonProperty
-    @JacksonXmlElementWrapper( localName = "events", namespace = DxfNamespaces.DXF_2_0 )
-    @JacksonXmlProperty( localName = "event", namespace = DxfNamespaces.DXF_2_0 )
     public Set<Event> getEvents()
     {
         return events;
@@ -348,8 +311,6 @@ public class Enrollment
         this.events = events;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public Boolean getFollowup()
     {
         return followup;
@@ -360,9 +321,6 @@ public class Enrollment
         this.followup = followup;
     }
 
-    @JsonProperty
-    @JacksonXmlElementWrapper( localName = "messageConversations", namespace = DxfNamespaces.DXF_2_0 )
-    @JacksonXmlProperty( localName = "messageConversation", namespace = DxfNamespaces.DXF_2_0 )
     public List<MessageConversation> getMessageConversations()
     {
         return messageConversations;
@@ -373,9 +331,6 @@ public class Enrollment
         this.messageConversations = messageConversations;
     }
 
-    @JsonProperty( "trackedEntityComments" )
-    @JacksonXmlElementWrapper( localName = "trackedEntityComments", namespace = DxfNamespaces.DXF_2_0 )
-    @JacksonXmlProperty( localName = "trackedEntityComment", namespace = DxfNamespaces.DXF_2_0 )
     public List<TrackedEntityComment> getComments()
     {
         return comments;
@@ -386,8 +341,6 @@ public class Enrollment
         this.comments = comments;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getCompletedBy()
     {
         return completedBy;
@@ -398,8 +351,6 @@ public class Enrollment
         this.completedBy = completedBy;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public Geometry getGeometry()
     {
         return geometry;
@@ -410,8 +361,6 @@ public class Enrollment
         this.geometry = geometry;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getStoredBy()
     {
         return storedBy;
@@ -422,9 +371,6 @@ public class Enrollment
         this.storedBy = storedBy;
     }
 
-    @JsonProperty
-    @JacksonXmlElementWrapper( localName = "relationshipItems", namespace = DxfNamespaces.DXF_2_0 )
-    @JacksonXmlProperty( localName = "relationshipItem", namespace = DxfNamespaces.DXF_2_0 )
     public Set<RelationshipItem> getRelationshipItems()
     {
         return relationshipItems;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Event.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Event.java
@@ -37,8 +37,6 @@ import org.hisp.dhis.audit.AuditAttribute;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.Auditable;
 import org.hisp.dhis.category.CategoryOptionCombo;
-import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.SoftDeletableObject;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
@@ -48,12 +46,6 @@ import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 import org.hisp.dhis.user.User;
 import org.locationtech.jts.geom.Geometry;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 /**
  * @author Abyot Asalefew
@@ -144,12 +136,6 @@ public class Event
         lastUpdatedAtClient = lastUpdated;
     }
 
-    // -------------------------------------------------------------------------
-    // Getters and setters
-    // -------------------------------------------------------------------------
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public Date getCreatedAtClient()
     {
         return createdAtClient;
@@ -160,8 +146,6 @@ public class Event
         this.createdAtClient = createdAtClient;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public Date getLastUpdatedAtClient()
     {
         return lastUpdatedAtClient;
@@ -172,9 +156,6 @@ public class Event
         this.lastUpdatedAtClient = lastUpdatedAtClient;
     }
 
-    @JsonProperty
-    @JsonSerialize( as = BaseIdentifiableObject.class )
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public Enrollment getEnrollment()
     {
         return enrollment;
@@ -185,9 +166,6 @@ public class Event
         this.enrollment = enrollment;
     }
 
-    @JsonProperty
-    @JsonSerialize( as = BaseIdentifiableObject.class )
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public ProgramStage getProgramStage()
     {
         return programStage;
@@ -198,8 +176,6 @@ public class Event
         this.programStage = programStage;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getStoredBy()
     {
         return storedBy;
@@ -210,8 +186,6 @@ public class Event
         this.storedBy = storedBy;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public UserInfoSnapshot getCreatedByUserInfo()
     {
         return createdByUserInfo;
@@ -222,8 +196,6 @@ public class Event
         this.createdByUserInfo = createdByUserInfo;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public UserInfoSnapshot getLastUpdatedByUserInfo()
     {
         return lastUpdatedByUserInfo;
@@ -234,8 +206,6 @@ public class Event
         this.lastUpdatedByUserInfo = lastUpdatedByUserInfo;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getCompletedBy()
     {
         return completedBy;
@@ -246,8 +216,6 @@ public class Event
         this.completedBy = completedBy;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public Date getDueDate()
     {
         return dueDate;
@@ -258,8 +226,6 @@ public class Event
         this.dueDate = dueDate;
     }
 
-    @JsonProperty( "eventDate" )
-    @JacksonXmlProperty( localName = "eventDate", namespace = DxfNamespaces.DXF_2_0 )
     public Date getExecutionDate()
     {
         return executionDate;
@@ -270,16 +236,11 @@ public class Event
         this.executionDate = executionDate;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isCompleted()
     {
         return status == EventStatus.COMPLETED;
     }
 
-    @JsonProperty
-    @JsonSerialize( as = BaseIdentifiableObject.class )
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public OrganisationUnit getOrganisationUnit()
     {
         return organisationUnit;
@@ -291,9 +252,6 @@ public class Event
         return this;
     }
 
-    @JsonProperty
-    @JsonSerialize( as = BaseIdentifiableObject.class )
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public CategoryOptionCombo getAttributeOptionCombo()
     {
         return attributeOptionCombo;
@@ -304,8 +262,6 @@ public class Event
         this.attributeOptionCombo = attributeOptionCombo;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public Date getCompletedDate()
     {
         return completedDate;
@@ -316,9 +272,6 @@ public class Event
         this.completedDate = completedDate;
     }
 
-    @JsonProperty
-    @JsonSerialize( contentAs = BaseIdentifiableObject.class )
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public List<MessageConversation> getMessageConversations()
     {
         return messageConversations;
@@ -329,9 +282,6 @@ public class Event
         this.messageConversations = messageConversations;
     }
 
-    @JsonProperty
-    @JsonSerialize( contentAs = BaseIdentifiableObject.class )
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public List<TrackedEntityComment> getComments()
     {
         return comments;
@@ -342,8 +292,6 @@ public class Event
         this.comments = comments;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public Set<EventDataValue> getEventDataValues()
     {
         return eventDataValues;
@@ -354,8 +302,6 @@ public class Event
         this.eventDataValues = eventDataValues;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public EventStatus getStatus()
     {
         return status;
@@ -367,7 +313,6 @@ public class Event
         return this;
     }
 
-    @JsonIgnore
     public Date getLastSynchronized()
     {
         return lastSynchronized;
@@ -378,9 +323,6 @@ public class Event
         this.lastSynchronized = lastSynchronized;
     }
 
-    @JsonProperty
-    @JacksonXmlElementWrapper( localName = "relationshipItems", namespace = DxfNamespaces.DXF_2_0 )
-    @JacksonXmlProperty( localName = "relationshipItem", namespace = DxfNamespaces.DXF_2_0 )
     public Set<RelationshipItem> getRelationshipItems()
     {
         return relationshipItems;
@@ -391,8 +333,6 @@ public class Event
         this.relationshipItems = relationshipItems;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public Geometry getGeometry()
     {
         return geometry;
@@ -403,9 +343,6 @@ public class Event
         this.geometry = geometry;
     }
 
-    @JsonProperty
-    @JsonSerialize( as = BaseIdentifiableObject.class )
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public User getAssignedUser()
     {
         return assignedUser;
@@ -416,8 +353,6 @@ public class Event
         this.assignedUser = assignedUser;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isCreatableInSearchScope()
     {
         return this.getStatus() == EventStatus.SCHEDULE && this.getEventDataValues().isEmpty()

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Event.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Event.java
@@ -33,6 +33,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import org.hisp.dhis.audit.AuditAttribute;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.Auditable;
@@ -50,6 +53,8 @@ import org.locationtech.jts.geom.Geometry;
 /**
  * @author Abyot Asalefew
  */
+@Getter
+@Setter
 @Auditable( scope = AuditScope.TRACKER )
 public class Event
     extends SoftDeletableObject
@@ -102,10 +107,6 @@ public class Event
 
     private User assignedUser;
 
-    // -------------------------------------------------------------------------
-    // Constructors
-    // -------------------------------------------------------------------------
-
     public Event()
     {
     }
@@ -116,8 +117,7 @@ public class Event
         this.programStage = programStage;
     }
 
-    public Event( Enrollment enrollment, ProgramStage programStage,
-        OrganisationUnit organisationUnit )
+    public Event( Enrollment enrollment, ProgramStage programStage, OrganisationUnit organisationUnit )
     {
         this( enrollment, programStage );
         this.organisationUnit = organisationUnit;
@@ -136,221 +136,9 @@ public class Event
         lastUpdatedAtClient = lastUpdated;
     }
 
-    public Date getCreatedAtClient()
-    {
-        return createdAtClient;
-    }
-
-    public void setCreatedAtClient( Date createdAtClient )
-    {
-        this.createdAtClient = createdAtClient;
-    }
-
-    public Date getLastUpdatedAtClient()
-    {
-        return lastUpdatedAtClient;
-    }
-
-    public void setLastUpdatedAtClient( Date lastUpdatedAtClient )
-    {
-        this.lastUpdatedAtClient = lastUpdatedAtClient;
-    }
-
-    public Enrollment getEnrollment()
-    {
-        return enrollment;
-    }
-
-    public void setEnrollment( Enrollment enrollment )
-    {
-        this.enrollment = enrollment;
-    }
-
-    public ProgramStage getProgramStage()
-    {
-        return programStage;
-    }
-
-    public void setProgramStage( ProgramStage programStage )
-    {
-        this.programStage = programStage;
-    }
-
-    public String getStoredBy()
-    {
-        return storedBy;
-    }
-
-    public void setStoredBy( String storedBy )
-    {
-        this.storedBy = storedBy;
-    }
-
-    public UserInfoSnapshot getCreatedByUserInfo()
-    {
-        return createdByUserInfo;
-    }
-
-    public void setCreatedByUserInfo( UserInfoSnapshot createdByUserInfo )
-    {
-        this.createdByUserInfo = createdByUserInfo;
-    }
-
-    public UserInfoSnapshot getLastUpdatedByUserInfo()
-    {
-        return lastUpdatedByUserInfo;
-    }
-
-    public void setLastUpdatedByUserInfo( UserInfoSnapshot lastUpdatedByUserInfo )
-    {
-        this.lastUpdatedByUserInfo = lastUpdatedByUserInfo;
-    }
-
-    public String getCompletedBy()
-    {
-        return completedBy;
-    }
-
-    public void setCompletedBy( String completedBy )
-    {
-        this.completedBy = completedBy;
-    }
-
-    public Date getDueDate()
-    {
-        return dueDate;
-    }
-
-    public void setDueDate( Date dueDate )
-    {
-        this.dueDate = dueDate;
-    }
-
-    public Date getExecutionDate()
-    {
-        return executionDate;
-    }
-
-    public void setExecutionDate( Date executionDate )
-    {
-        this.executionDate = executionDate;
-    }
-
     public boolean isCompleted()
     {
         return status == EventStatus.COMPLETED;
-    }
-
-    public OrganisationUnit getOrganisationUnit()
-    {
-        return organisationUnit;
-    }
-
-    public Event setOrganisationUnit( OrganisationUnit organisationUnit )
-    {
-        this.organisationUnit = organisationUnit;
-        return this;
-    }
-
-    public CategoryOptionCombo getAttributeOptionCombo()
-    {
-        return attributeOptionCombo;
-    }
-
-    public void setAttributeOptionCombo( CategoryOptionCombo attributeOptionCombo )
-    {
-        this.attributeOptionCombo = attributeOptionCombo;
-    }
-
-    public Date getCompletedDate()
-    {
-        return completedDate;
-    }
-
-    public void setCompletedDate( Date completedDate )
-    {
-        this.completedDate = completedDate;
-    }
-
-    public List<MessageConversation> getMessageConversations()
-    {
-        return messageConversations;
-    }
-
-    public void setMessageConversations( List<MessageConversation> messageConversations )
-    {
-        this.messageConversations = messageConversations;
-    }
-
-    public List<TrackedEntityComment> getComments()
-    {
-        return comments;
-    }
-
-    public void setComments( List<TrackedEntityComment> comments )
-    {
-        this.comments = comments;
-    }
-
-    public Set<EventDataValue> getEventDataValues()
-    {
-        return eventDataValues;
-    }
-
-    public void setEventDataValues( Set<EventDataValue> eventDataValues )
-    {
-        this.eventDataValues = eventDataValues;
-    }
-
-    public EventStatus getStatus()
-    {
-        return status;
-    }
-
-    public Event setStatus( EventStatus status )
-    {
-        this.status = status;
-        return this;
-    }
-
-    public Date getLastSynchronized()
-    {
-        return lastSynchronized;
-    }
-
-    public void setLastSynchronized( Date lastSynchronized )
-    {
-        this.lastSynchronized = lastSynchronized;
-    }
-
-    public Set<RelationshipItem> getRelationshipItems()
-    {
-        return relationshipItems;
-    }
-
-    public void setRelationshipItems( Set<RelationshipItem> relationshipItems )
-    {
-        this.relationshipItems = relationshipItems;
-    }
-
-    public Geometry getGeometry()
-    {
-        return geometry;
-    }
-
-    public void setGeometry( Geometry geometry )
-    {
-        this.geometry = geometry;
-    }
-
-    public User getAssignedUser()
-    {
-        return assignedUser;
-    }
-
-    public void setAssignedUser( User assignedUser )
-    {
-        this.assignedUser = assignedUser;
     }
 
     public boolean isCreatableInSearchScope()

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/Relationship.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/Relationship.java
@@ -32,22 +32,13 @@ import java.io.Serializable;
 import org.hisp.dhis.audit.AuditAttribute;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.Auditable;
-import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.ObjectStyle;
 import org.hisp.dhis.common.SoftDeletableObject;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * @author Abyot Asalefew
  * @author Stian Sandvold
  */
-@JacksonXmlRootElement( localName = "relationship", namespace = DxfNamespaces.DXF_2_0 )
 @Auditable( scope = AuditScope.TRACKER )
 public class Relationship
     extends SoftDeletableObject
@@ -86,24 +77,13 @@ public class Relationship
      */
     private String invertedKey;
 
-    // -------------------------------------------------------------------------
-    // Constructors
-    // -------------------------------------------------------------------------
-
     public Relationship()
     {
     }
 
-    // -------------------------------------------------------------------------
-    // Getters and setters
-    // -------------------------------------------------------------------------
-
     /**
      * @return the relationshipType
      */
-    @JsonProperty
-    @JsonSerialize( as = BaseIdentifiableObject.class )
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public RelationshipType getRelationshipType()
     {
         return relationshipType;
@@ -117,8 +97,6 @@ public class Relationship
         this.relationshipType = relationshipType;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public ObjectStyle getStyle()
     {
         return style;
@@ -129,8 +107,6 @@ public class Relationship
         this.style = style;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getFormName()
     {
         return formName;
@@ -141,8 +117,6 @@ public class Relationship
         this.formName = formName;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getDescription()
     {
         return description;
@@ -153,8 +127,6 @@ public class Relationship
         this.description = description;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public RelationshipItem getFrom()
     {
         return from;
@@ -165,8 +137,6 @@ public class Relationship
         this.from = from;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public RelationshipItem getTo()
     {
         return to;
@@ -177,7 +147,6 @@ public class Relationship
         this.to = to;
     }
 
-    @JsonIgnore
     public String getKey()
     {
         return key;
@@ -188,7 +157,6 @@ public class Relationship
         this.key = key;
     }
 
-    @JsonIgnore
     public String getInvertedKey()
     {
         return invertedKey;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/Relationship.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/Relationship.java
@@ -29,6 +29,9 @@ package org.hisp.dhis.relationship;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import org.hisp.dhis.audit.AuditAttribute;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.Auditable;
@@ -39,6 +42,8 @@ import org.hisp.dhis.common.SoftDeletableObject;
  * @author Abyot Asalefew
  * @author Stian Sandvold
  */
+@Getter
+@Setter
 @Auditable( scope = AuditScope.TRACKER )
 public class Relationship
     extends SoftDeletableObject
@@ -79,92 +84,6 @@ public class Relationship
 
     public Relationship()
     {
-    }
-
-    /**
-     * @return the relationshipType
-     */
-    public RelationshipType getRelationshipType()
-    {
-        return relationshipType;
-    }
-
-    /**
-     * @param relationshipType the relationshipType to set
-     */
-    public void setRelationshipType( RelationshipType relationshipType )
-    {
-        this.relationshipType = relationshipType;
-    }
-
-    public ObjectStyle getStyle()
-    {
-        return style;
-    }
-
-    public void setStyle( ObjectStyle style )
-    {
-        this.style = style;
-    }
-
-    public String getFormName()
-    {
-        return formName;
-    }
-
-    public void setFormName( String formName )
-    {
-        this.formName = formName;
-    }
-
-    public String getDescription()
-    {
-        return description;
-    }
-
-    public void setDescription( String description )
-    {
-        this.description = description;
-    }
-
-    public RelationshipItem getFrom()
-    {
-        return from;
-    }
-
-    public void setFrom( RelationshipItem from )
-    {
-        this.from = from;
-    }
-
-    public RelationshipItem getTo()
-    {
-        return to;
-    }
-
-    public void setTo( RelationshipItem to )
-    {
-        this.to = to;
-    }
-
-    public String getKey()
-    {
-        return key;
-    }
-
-    public void setKey( String key )
-    {
-        this.key = key;
-    }
-
-    public String getInvertedKey()
-    {
-        return invertedKey;
-    }
-
-    public void setInvertedKey( String invertedKey )
-    {
-        this.invertedKey = invertedKey;
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipItem.java
@@ -27,16 +27,10 @@
  */
 package org.hisp.dhis.relationship;
 
-import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.EmbeddedObject;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.trackedentity.TrackedEntity;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 /**
  * @author Stian Sandvold
@@ -68,9 +62,6 @@ public class RelationshipItem implements EmbeddedObject
         this.id = id;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    @JsonSerialize( as = BaseIdentifiableObject.class )
     public Relationship getRelationship()
     {
         return relationship;
@@ -81,9 +72,6 @@ public class RelationshipItem implements EmbeddedObject
         this.relationship = relationship;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    @JsonSerialize( as = BaseIdentifiableObject.class )
     public TrackedEntity getTrackedEntity()
     {
         return trackedEntity;
@@ -94,9 +82,6 @@ public class RelationshipItem implements EmbeddedObject
         this.trackedEntity = trackedEntity;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    @JsonSerialize( as = BaseIdentifiableObject.class )
     public Enrollment getEnrollment()
     {
         return enrollment;
@@ -107,9 +92,6 @@ public class RelationshipItem implements EmbeddedObject
         this.enrollment = enrollment;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    @JsonSerialize( as = BaseIdentifiableObject.class )
     public Event getEvent()
     {
         return event;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntity.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntity.java
@@ -35,8 +35,6 @@ import java.util.Set;
 import org.hisp.dhis.audit.AuditAttribute;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.Auditable;
-import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.SoftDeletableObject;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
@@ -45,17 +43,9 @@ import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.locationtech.jts.geom.Geometry;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
-
 /**
  * @author Abyot Asalefew Gizaw
  */
-@JacksonXmlRootElement( localName = "trackedEntityInstance", namespace = DxfNamespaces.DXF_2_0 )
 @Auditable( scope = AuditScope.TRACKER )
 public class TrackedEntity
     extends SoftDeletableObject
@@ -133,12 +123,6 @@ public class TrackedEntity
         attributeValue.setTrackedEntity( null );
     }
 
-    // -------------------------------------------------------------------------
-    // Getters and setters
-    // -------------------------------------------------------------------------
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public boolean isPotentialDuplicate()
     {
         return potentialDuplicate;
@@ -149,8 +133,6 @@ public class TrackedEntity
         this.potentialDuplicate = potentialDuplicate;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public Date getCreatedAtClient()
     {
         return createdAtClient;
@@ -161,8 +143,6 @@ public class TrackedEntity
         this.createdAtClient = createdAtClient;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public Date getLastUpdatedAtClient()
     {
         return lastUpdatedAtClient;
@@ -173,8 +153,6 @@ public class TrackedEntity
         this.lastUpdatedAtClient = lastUpdatedAtClient;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getStoredBy()
     {
         return storedBy;
@@ -185,9 +163,6 @@ public class TrackedEntity
         this.storedBy = storedBy;
     }
 
-    @JsonProperty
-    @JsonSerialize( as = BaseIdentifiableObject.class )
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public OrganisationUnit getOrganisationUnit()
     {
         return organisationUnit;
@@ -198,9 +173,6 @@ public class TrackedEntity
         this.organisationUnit = organisationUnit;
     }
 
-    @JsonProperty( "trackedEntityAttributeValues" )
-    @JacksonXmlElementWrapper( localName = "trackedEntityAttributeValues", namespace = DxfNamespaces.DXF_2_0 )
-    @JacksonXmlProperty( localName = "trackedEntityAttributeValue", namespace = DxfNamespaces.DXF_2_0 )
     public Set<TrackedEntityAttributeValue> getTrackedEntityAttributeValues()
     {
         return trackedEntityAttributeValues;
@@ -211,9 +183,6 @@ public class TrackedEntity
         this.trackedEntityAttributeValues = trackedEntityAttributeValues;
     }
 
-    @JsonProperty
-    @JacksonXmlElementWrapper( localName = "enrollments", namespace = DxfNamespaces.DXF_2_0 )
-    @JacksonXmlProperty( localName = "enrollment", namespace = DxfNamespaces.DXF_2_0 )
     public Set<Enrollment> getEnrollments()
     {
         return enrollments;
@@ -224,9 +193,6 @@ public class TrackedEntity
         this.enrollments = enrollments;
     }
 
-    @JsonProperty
-    @JacksonXmlElementWrapper( localName = "programOwners", namespace = DxfNamespaces.DXF_2_0 )
-    @JacksonXmlProperty( localName = "programOwners", namespace = DxfNamespaces.DXF_2_0 )
     public Set<TrackedEntityProgramOwner> getProgramOwners()
     {
         return programOwners;
@@ -237,9 +203,6 @@ public class TrackedEntity
         this.programOwners = programOwners;
     }
 
-    @JsonProperty
-    @JacksonXmlElementWrapper( localName = "trackedEntityType", namespace = DxfNamespaces.DXF_2_0 )
-    @JacksonXmlProperty( localName = "trackedEntityType", namespace = DxfNamespaces.DXF_2_0 )
     public TrackedEntityType getTrackedEntityType()
     {
         return trackedEntityType;
@@ -250,8 +213,6 @@ public class TrackedEntity
         this.trackedEntityType = trackedEntityType;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( localName = "inactive", namespace = DxfNamespaces.DXF_2_0 )
     public Boolean isInactive()
     {
         return inactive;
@@ -262,7 +223,6 @@ public class TrackedEntity
         this.inactive = inactive;
     }
 
-    @JsonIgnore
     public Date getLastSynchronized()
     {
         return lastSynchronized;
@@ -273,9 +233,6 @@ public class TrackedEntity
         this.lastSynchronized = lastSynchronized;
     }
 
-    @JsonProperty
-    @JacksonXmlElementWrapper( localName = "relationshipItems", namespace = DxfNamespaces.DXF_2_0 )
-    @JacksonXmlProperty( localName = "relationshipItem", namespace = DxfNamespaces.DXF_2_0 )
     public Set<RelationshipItem> getRelationshipItems()
     {
         return relationshipItems;
@@ -286,8 +243,6 @@ public class TrackedEntity
         this.relationshipItems = relationshipItems;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public Geometry getGeometry()
     {
         return geometry;
@@ -298,8 +253,6 @@ public class TrackedEntity
         this.geometry = geometry;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public UserInfoSnapshot getCreatedByUserInfo()
     {
         return createdByUserInfo;
@@ -310,8 +263,6 @@ public class TrackedEntity
         this.createdByUserInfo = createdByUserInfo;
     }
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public UserInfoSnapshot getLastUpdatedByUserInfo()
     {
         return lastUpdatedByUserInfo;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntity.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntity.java
@@ -32,6 +32,9 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import org.hisp.dhis.audit.AuditAttribute;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.Auditable;
@@ -46,6 +49,8 @@ import org.locationtech.jts.geom.Geometry;
 /**
  * @author Abyot Asalefew Gizaw
  */
+@Getter
+@Setter
 @Auditable( scope = AuditScope.TRACKER )
 public class TrackedEntity
     extends SoftDeletableObject
@@ -70,6 +75,7 @@ public class TrackedEntity
     @AuditAttribute
     private TrackedEntityType trackedEntityType;
 
+    @Getter( )
     @AuditAttribute
     private Boolean inactive = false;
 
@@ -82,10 +88,6 @@ public class TrackedEntity
     private UserInfoSnapshot createdByUserInfo;
 
     private UserInfoSnapshot lastUpdatedByUserInfo;
-
-    // -------------------------------------------------------------------------
-    // Constructors
-    // -------------------------------------------------------------------------
 
     public TrackedEntity()
     {
@@ -107,10 +109,6 @@ public class TrackedEntity
         }
     }
 
-    // -------------------------------------------------------------------------
-    // Logic
-    // -------------------------------------------------------------------------
-
     public void addAttributeValue( TrackedEntityAttributeValue attributeValue )
     {
         trackedEntityAttributeValues.add( attributeValue );
@@ -121,156 +119,6 @@ public class TrackedEntity
     {
         trackedEntityAttributeValues.remove( attributeValue );
         attributeValue.setTrackedEntity( null );
-    }
-
-    public boolean isPotentialDuplicate()
-    {
-        return potentialDuplicate;
-    }
-
-    public void setPotentialDuplicate( boolean potentialDuplicate )
-    {
-        this.potentialDuplicate = potentialDuplicate;
-    }
-
-    public Date getCreatedAtClient()
-    {
-        return createdAtClient;
-    }
-
-    public void setCreatedAtClient( Date createdAtClient )
-    {
-        this.createdAtClient = createdAtClient;
-    }
-
-    public Date getLastUpdatedAtClient()
-    {
-        return lastUpdatedAtClient;
-    }
-
-    public void setLastUpdatedAtClient( Date lastUpdatedAtClient )
-    {
-        this.lastUpdatedAtClient = lastUpdatedAtClient;
-    }
-
-    public String getStoredBy()
-    {
-        return storedBy;
-    }
-
-    public void setStoredBy( String storedBy )
-    {
-        this.storedBy = storedBy;
-    }
-
-    public OrganisationUnit getOrganisationUnit()
-    {
-        return organisationUnit;
-    }
-
-    public void setOrganisationUnit( OrganisationUnit organisationUnit )
-    {
-        this.organisationUnit = organisationUnit;
-    }
-
-    public Set<TrackedEntityAttributeValue> getTrackedEntityAttributeValues()
-    {
-        return trackedEntityAttributeValues;
-    }
-
-    public void setTrackedEntityAttributeValues( Set<TrackedEntityAttributeValue> trackedEntityAttributeValues )
-    {
-        this.trackedEntityAttributeValues = trackedEntityAttributeValues;
-    }
-
-    public Set<Enrollment> getEnrollments()
-    {
-        return enrollments;
-    }
-
-    public void setEnrollments( Set<Enrollment> enrollments )
-    {
-        this.enrollments = enrollments;
-    }
-
-    public Set<TrackedEntityProgramOwner> getProgramOwners()
-    {
-        return programOwners;
-    }
-
-    public void setProgramOwners( Set<TrackedEntityProgramOwner> programOwners )
-    {
-        this.programOwners = programOwners;
-    }
-
-    public TrackedEntityType getTrackedEntityType()
-    {
-        return trackedEntityType;
-    }
-
-    public void setTrackedEntityType( TrackedEntityType trackedEntityType )
-    {
-        this.trackedEntityType = trackedEntityType;
-    }
-
-    public Boolean isInactive()
-    {
-        return inactive;
-    }
-
-    public void setInactive( Boolean inactive )
-    {
-        this.inactive = inactive;
-    }
-
-    public Date getLastSynchronized()
-    {
-        return lastSynchronized;
-    }
-
-    public void setLastSynchronized( Date lastSynchronized )
-    {
-        this.lastSynchronized = lastSynchronized;
-    }
-
-    public Set<RelationshipItem> getRelationshipItems()
-    {
-        return relationshipItems;
-    }
-
-    public void setRelationshipItems( Set<RelationshipItem> relationshipItems )
-    {
-        this.relationshipItems = relationshipItems;
-    }
-
-    public Geometry getGeometry()
-    {
-        return geometry;
-    }
-
-    public void setGeometry( Geometry geometry )
-    {
-        this.geometry = geometry;
-    }
-
-    public UserInfoSnapshot getCreatedByUserInfo()
-    {
-        return createdByUserInfo;
-    }
-
-    public void setCreatedByUserInfo( UserInfoSnapshot createdByUserInfo )
-    {
-        this.createdByUserInfo = createdByUserInfo;
-    }
-
-    public UserInfoSnapshot getLastUpdatedByUserInfo()
-    {
-        return lastUpdatedByUserInfo;
-    }
-
-    public void setLastUpdatedByUserInfo( UserInfoSnapshot lastUpdatedByUserInfo )
-    {
-        this.lastUpdatedByUserInfo = lastUpdatedByUserInfo;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -1608,7 +1608,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
         trackedEntityInstance
             .setLastUpdatedAtClient( DateUtils.getIso8601NoTz( daoTrackedEntity.getLastUpdatedAtClient() ) );
         trackedEntityInstance
-            .setInactive( Optional.ofNullable( daoTrackedEntity.isInactive() ).orElse( false ) );
+            .setInactive( Optional.ofNullable( daoTrackedEntity.getInactive() ).orElse( false ) );
         trackedEntityInstance.setGeometry( daoTrackedEntity.getGeometry() );
         trackedEntityInstance.setDeleted( daoTrackedEntity.isDeleted() );
         trackedEntityInstance.setPotentialDuplicate( daoTrackedEntity.isPotentialDuplicate() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -202,7 +202,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService
         result.setCreatedAtClient( trackedEntity.getCreatedAtClient() );
         result.setLastUpdated( trackedEntity.getLastUpdated() );
         result.setLastUpdatedAtClient( trackedEntity.getLastUpdatedAtClient() );
-        result.setInactive( trackedEntity.isInactive() );
+        result.setInactive( trackedEntity.getInactive() );
         result.setGeometry( trackedEntity.getGeometry() );
         result.setDeleted( trackedEntity.isDeleted() );
         result.setPotentialDuplicate( trackedEntity.isPotentialDuplicate() );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -782,7 +782,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase
             () -> assertEquals( trackedEntityA.getUid(), trackedEntity.getUid() ),
             () -> assertEquals( trackedEntity.getTrackedEntityType().getUid(), trackedEntityTypeA.getUid() ),
             () -> assertEquals( orgUnitA.getUid(), trackedEntity.getOrganisationUnit().getUid() ),
-            () -> assertFalse( trackedEntity.isInactive() ),
+            () -> assertFalse( trackedEntity.getInactive() ),
             () -> assertFalse( trackedEntity.isDeleted() ),
             () -> checkDate( currentTime, trackedEntity.getCreated() ),
             () -> checkDate( currentTime, trackedEntity.getCreatedAtClient() ),


### PR DESCRIPTION
tracker import/export JSON is defined using other types which have the JSON annotations. Remove all JSON related annotations from tracker types in dhis-api instead of renaming them to the names trackedEntity, enrollment and event.

Use lombok Getters/Setters.