### PR TITLE
chore: Harmonize get single entity endpoints [TECH-1559]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -38,6 +38,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -92,7 +94,7 @@ public class DefaultEnrollmentService implements org.hisp.dhis.tracker.export.en
     }
 
     @Override
-    public Enrollment getEnrollment( Enrollment enrollment, EnrollmentParams params )
+    public Enrollment getEnrollment( @Nonnull Enrollment enrollment, EnrollmentParams params )
         throws ForbiddenException
     {
         User user = currentUserService.getCurrentUser();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
@@ -27,14 +27,20 @@
  */
 package org.hisp.dhis.tracker.export.enrollment;
 
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentQueryParams;
 
 public interface EnrollmentService
 {
-    Enrollment getEnrollment( String uid, EnrollmentParams params );
+    Enrollment getEnrollment( String uid, EnrollmentParams params )
+        throws NotFoundException,
+        ForbiddenException;
 
-    Enrollment getEnrollment( Enrollment enrollment, EnrollmentParams params );
+    Enrollment getEnrollment( Enrollment enrollment, EnrollmentParams params )
+        throws ForbiddenException;
 
-    Enrollments getEnrollments( EnrollmentQueryParams params );
+    Enrollments getEnrollments( EnrollmentQueryParams params )
+        throws ForbiddenException;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.export.event;
 
+import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.user.User;
@@ -37,9 +38,11 @@ import org.hisp.dhis.user.User;
 public interface EventService
 {
     Event getEvent( String uid, EventParams eventParams )
-        throws NotFoundException;
+        throws NotFoundException,
+        ForbiddenException;
 
-    Event getEvent( Event event, EventParams eventParams );
+    Event getEvent( Event event, EventParams eventParams )
+        throws ForbiddenException;
 
     Events getEvents( EventSearchParams params );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -73,6 +73,51 @@ public class DefaultRelationshipService implements RelationshipService
     private final EventService eventService;
 
     @Override
+    public Relationship getRelationship( String uid )
+        throws ForbiddenException,
+        NotFoundException
+    {
+        Relationship relationship = relationshipStore.getByUid( uid );
+
+        if ( relationship == null )
+        {
+            throw new NotFoundException( Relationship.class, uid );
+        }
+
+        User user = currentUserService.getCurrentUser();
+        List<String> errors = trackerAccessManager.canRead( user, relationship );
+        if ( !errors.isEmpty() )
+        {
+            throw new ForbiddenException( errors.toString() );
+        }
+
+        return map( relationship );
+    }
+
+    @Override
+    public Optional<Relationship> findRelationshipByUid( String uid )
+        throws ForbiddenException,
+        NotFoundException
+    {
+        Relationship relationship = relationshipStore.getByUid( uid );
+
+        if ( relationship == null )
+        {
+            return Optional.empty();
+        }
+
+        User user = currentUserService.getCurrentUser();
+        List<String> errors = trackerAccessManager.canRead( user, relationship );
+
+        if ( !errors.isEmpty() )
+        {
+            return Optional.empty();
+        }
+
+        return Optional.of( map( relationship ) );
+    }
+
+    @Override
     public List<Relationship> getRelationshipsByTrackedEntity(
         TrackedEntity trackedEntity,
         PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter )
@@ -114,52 +159,6 @@ public class DefaultRelationshipService implements RelationshipService
             .filter( r -> trackerAccessManager.canRead( currentUserService.getCurrentUser(), r ).isEmpty() )
             .collect( Collectors.toList() );
         return map( relationships );
-    }
-
-    @Override
-    public Optional<Relationship> findRelationshipByUid( String uid )
-        throws ForbiddenException,
-        NotFoundException
-    {
-        Relationship relationship = relationshipStore.getByUid( uid );
-
-        if ( relationship == null )
-        {
-            return Optional.empty();
-        }
-
-        User user = currentUserService.getCurrentUser();
-        List<String> errors = trackerAccessManager.canRead( user, relationship );
-
-        if ( !errors.isEmpty() )
-        {
-            return Optional.empty();
-        }
-
-        return Optional.of( map( relationship ) );
-    }
-
-    @Override
-    public Relationship getRelationship( String uid )
-        throws ForbiddenException,
-        NotFoundException
-    {
-        Relationship relationship = relationshipStore.getByUid( uid );
-
-        if ( relationship == null )
-        {
-            throw new NotFoundException( Relationship.class, uid );
-        }
-
-        User user = currentUserService.getCurrentUser();
-        List<String> errors = trackerAccessManager.canRead( user, relationship );
-
-        if ( !errors.isEmpty() )
-        {
-            throw new ForbiddenException( errors.toString() );
-        }
-
-        return map( relationship );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -139,6 +139,29 @@ public class DefaultRelationshipService implements RelationshipService
         return Optional.of( map( relationship ) );
     }
 
+    @Override
+    public Relationship getRelationship( String uid )
+        throws ForbiddenException,
+        NotFoundException
+    {
+        Relationship relationship = relationshipStore.getByUid( uid );
+
+        if ( relationship == null )
+        {
+            throw new NotFoundException( Relationship.class, uid );
+        }
+
+        User user = currentUserService.getCurrentUser();
+        List<String> errors = trackerAccessManager.canRead( user, relationship );
+
+        if ( !errors.isEmpty() )
+        {
+            throw new ForbiddenException( errors.toString() );
+        }
+
+        return map( relationship );
+    }
+
     /**
      * Map to a non-proxied Relationship to prevent hibernate exceptions.
      */

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
@@ -58,4 +58,8 @@ public interface RelationshipService
     Optional<Relationship> findRelationshipByUid( String id )
         throws ForbiddenException,
         NotFoundException;
+
+    Relationship getRelationship( String id )
+        throws ForbiddenException,
+        NotFoundException;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
@@ -40,6 +40,14 @@ import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteria
 
 public interface RelationshipService
 {
+    Relationship getRelationship( String id )
+        throws ForbiddenException,
+        NotFoundException;
+
+    Optional<Relationship> findRelationshipByUid( String id )
+        throws ForbiddenException,
+        NotFoundException;
+
     List<Relationship> getRelationshipsByTrackedEntity( TrackedEntity tei,
         PagingAndSortingCriteriaAdapter criteria )
         throws ForbiddenException,
@@ -52,14 +60,6 @@ public interface RelationshipService
 
     List<Relationship> getRelationshipsByEvent( Event event,
         PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter )
-        throws ForbiddenException,
-        NotFoundException;
-
-    Optional<Relationship> findRelationshipByUid( String id )
-        throws ForbiddenException,
-        NotFoundException;
-
-    Relationship getRelationship( String id )
         throws ForbiddenException,
         NotFoundException;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -110,15 +110,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService
             throw new NotFoundException( TrackedEntity.class, uid );
         }
 
-        User user = currentUserService.getCurrentUser();
-        List<String> errors = trackerAccessManager.canRead( user, daoTrackedEntity );
-
-        if ( !errors.isEmpty() )
-        {
-            throw new ForbiddenException( errors.toString() );
-        }
-
-        return getTrackedEntity( daoTrackedEntity, params, user );
+        return getTrackedEntity( daoTrackedEntity, params );
     }
 
     @Override
@@ -182,16 +174,14 @@ public class DefaultTrackedEntityService implements TrackedEntityService
 
     @Override
     public TrackedEntity getTrackedEntity( TrackedEntity trackedEntity, TrackedEntityParams params )
+        throws ForbiddenException
     {
-        return getTrackedEntity( trackedEntity, params, currentUserService.getCurrentUser() );
-    }
+        User user = currentUserService.getCurrentUser();
+        List<String> errors = trackerAccessManager.canRead( user, trackedEntity );
 
-    private TrackedEntity getTrackedEntity( TrackedEntity trackedEntity, TrackedEntityParams params,
-        User user )
-    {
-        if ( trackedEntity == null )
+        if ( !errors.isEmpty() )
         {
-            return null;
+            throw new ForbiddenException( errors.toString() );
         }
 
         TrackedEntity result = new TrackedEntity();
@@ -311,7 +301,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService
         else if ( item.getEvent() != null )
         {
             result.setEvent(
-                eventService.getEvent( item.getEvent(),
+                eventService.getEvent( item.getEvent().getUid(),
                     EventParams.TRUE.withIncludeRelationships( false ) ) );
         }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -36,6 +36,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -173,7 +175,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService
     }
 
     @Override
-    public TrackedEntity getTrackedEntity( TrackedEntity trackedEntity, TrackedEntityParams params )
+    public TrackedEntity getTrackedEntity( @Nonnull TrackedEntity trackedEntity, TrackedEntityParams params )
         throws ForbiddenException
     {
         User user = currentUserService.getCurrentUser();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -42,9 +42,10 @@ import java.util.stream.Collectors;
 
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.commons.util.RelationshipUtils;
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentQueryParams;
@@ -218,6 +219,8 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
 
     @Test
     void shouldGetEnrollmentWhenUserHasReadWriteAccessToProgramAndAccessToOrgUnit()
+        throws ForbiddenException,
+        NotFoundException
     {
         programA.getSharing().setPublicAccess( AccessStringHelper.DATA_READ_WRITE );
         manager.updateNoAcl( programA );
@@ -231,6 +234,8 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
 
     @Test
     void shouldGetEnrollmentWhenUserHasReadAccessToProgramAndAccessToOrgUnit()
+        throws ForbiddenException,
+        NotFoundException
     {
         programA.getSharing().setPublicAccess( AccessStringHelper.DATA_READ );
         manager.updateNoAcl( programA );
@@ -244,6 +249,8 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
 
     @Test
     void shouldGetEnrollmentWithEventsWhenUserHasAccessToEvent()
+        throws ForbiddenException,
+        NotFoundException
     {
         EnrollmentParams params = EnrollmentParams.FALSE;
         params = params.withEnrollmentEventsParams( EnrollmentEventsParams.TRUE );
@@ -257,6 +264,8 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
 
     @Test
     void shouldGetEnrollmentWithoutEventsWhenUserHasNoAccessToProgramStage()
+        throws ForbiddenException,
+        NotFoundException
     {
         programStageA.getSharing().setOwner( admin );
         programStageA.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
@@ -273,6 +282,8 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
 
     @Test
     void shouldGetEnrollmentWithRelationshipsWhenUserHasAccessToThem()
+        throws ForbiddenException,
+        NotFoundException
     {
         EnrollmentParams params = EnrollmentParams.FALSE;
         params = params.withIncludeRelationships( true );
@@ -285,6 +296,8 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
 
     @Test
     void shouldGetEnrollmentWithoutRelationshipsWhenUserHasAccessToThem()
+        throws ForbiddenException,
+        NotFoundException
     {
         relationshipTypeA.getSharing().setOwner( admin );
         relationshipTypeA.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
@@ -300,6 +313,8 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
 
     @Test
     void shouldGetEnrollmentWithAttributesWhenUserHasAccessToThem()
+        throws ForbiddenException,
+        NotFoundException
     {
         EnrollmentParams params = EnrollmentParams.FALSE;
         params = params.withIncludeAttributes( true );
@@ -317,7 +332,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         trackedEntityTypeA.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
         manager.updateNoAcl( trackedEntityTypeA );
 
-        IllegalQueryException exception = assertThrows( IllegalQueryException.class,
+        ForbiddenException exception = assertThrows( ForbiddenException.class,
             () -> enrollmentService.getEnrollment( enrollmentA.getUid(), EnrollmentParams.FALSE ) );
         assertContains( "access to tracked entity type", exception.getMessage() );
     }
@@ -330,7 +345,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
 
         injectSecurityContext( userWithoutOrgUnit );
 
-        IllegalQueryException exception = assertThrows( IllegalQueryException.class,
+        ForbiddenException exception = assertThrows( ForbiddenException.class,
             () -> enrollmentService.getEnrollment( enrollmentA.getUid(), EnrollmentParams.FALSE ) );
         assertContains( "OWNERSHIP_ACCESS_DENIED", exception.getMessage() );
     }
@@ -343,7 +358,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
 
         injectSecurityContext( userWithoutOrgUnit );
 
-        IllegalQueryException exception = assertThrows( IllegalQueryException.class,
+        ForbiddenException exception = assertThrows( ForbiddenException.class,
             () -> enrollmentService.getEnrollment( enrollmentA.getUid(), EnrollmentParams.FALSE ) );
         assertContains( "OWNERSHIP_ACCESS_DENIED", exception.getMessage() );
     }
@@ -354,13 +369,14 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         programA.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
         manager.updateNoAcl( programA );
 
-        IllegalQueryException exception = assertThrows( IllegalQueryException.class,
+        ForbiddenException exception = assertThrows( ForbiddenException.class,
             () -> enrollmentService.getEnrollment( enrollmentA.getUid(), EnrollmentParams.FALSE ) );
         assertContains( "access to program", exception.getMessage() );
     }
 
     @Test
     void shouldGetEnrollmentsWhenUserHasReadAccessToProgramAndSearchScopeAccessToOrgUnit()
+        throws ForbiddenException
     {
         programA.getSharing().setPublicAccess( AccessStringHelper.DATA_READ );
         manager.updateNoAcl( programA );
@@ -378,6 +394,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
 
     @Test
     void shouldGetEnrollmentsByTrackedEntityWhenUserHasAccessToTrackedEntityType()
+        throws ForbiddenException
     {
         programA.getSharing().setPublicAccess( AccessStringHelper.DATA_READ );
         manager.updateNoAcl( programA );
@@ -408,7 +425,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         params.setTrackedEntityUid( trackedEntityA.getUid() );
         params.setUser( user );
 
-        IllegalQueryException exception = assertThrows( IllegalQueryException.class,
+        ForbiddenException exception = assertThrows( ForbiddenException.class,
             () -> enrollmentService.getEnrollments( params ) );
         assertContains( "access to tracked entity type", exception.getMessage() );
     }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
@@ -263,7 +263,7 @@ class EventsExportControllerTest extends DhisControllerConvenienceTest
         this.switchContextToUser( user );
 
         assertTrue( GET( "/tracker/events/{id}", from.getUid() )
-            .error( HttpStatus.CONFLICT ).getMessage()
+            .error( HttpStatus.FORBIDDEN ).getMessage()
             .contains( "OWNERSHIP_ACCESS_DENIED" ) );
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
@@ -31,7 +31,6 @@ import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.RESOURCE
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -114,23 +113,14 @@ public class EnrollmentsExportController
         }
         else
         {
-            Set<String> enrollmentIds = TextUtils.splitToSet( enrollmentCriteria.getEnrollment(),
-                TextUtils.SEMICOLON );
-            if ( enrollmentIds != null )
+            Set<String> enrollmentUids = Set.of( enrollmentCriteria.getEnrollment().split( TextUtils.SEMICOLON ) );
+
+            List<org.hisp.dhis.program.Enrollment> list = new ArrayList<>();
+            for ( String e : enrollmentUids )
             {
-                List<org.hisp.dhis.program.Enrollment> list = new ArrayList<>();
-                for ( String e : enrollmentIds )
-                {
-                    org.hisp.dhis.program.Enrollment enrollment = enrollmentService.getEnrollment( e,
-                        enrollmentParams );
-                    list.add( enrollment );
-                }
-                enrollmentList = list;
+                list.add( enrollmentService.getEnrollment( e, enrollmentParams ) );
             }
-            else
-            {
-                enrollmentList = Collections.emptyList();
-            }
+            enrollmentList = list;
         }
 
         List<ObjectNode> objectNodes = fieldFilterService

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller.tracker.export.enrollment;
 import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.RESOURCE_PATH;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -44,12 +45,12 @@ import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
-import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentQueryParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
 import org.hisp.dhis.tracker.export.enrollment.Enrollments;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
+import org.hisp.dhis.webapi.controller.tracker.view.Enrollment;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.mapstruct.factory.Mappers;
 import org.springframework.http.ResponseEntity;
@@ -87,11 +88,12 @@ public class EnrollmentsExportController
         EnrollmentCriteria enrollmentCriteria,
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
         throws BadRequestException,
-        ForbiddenException
+        ForbiddenException,
+        NotFoundException
     {
         PagingWrapper<ObjectNode> pagingWrapper = new PagingWrapper<>();
 
-        List<Enrollment> enrollmentList;
+        List<org.hisp.dhis.program.Enrollment> enrollmentList;
 
         EnrollmentParams enrollmentParams = fieldsMapper.map( fields )
             .withIncludeDeleted( enrollmentCriteria.isIncludeDeleted() );
@@ -114,10 +116,21 @@ public class EnrollmentsExportController
         {
             Set<String> enrollmentIds = TextUtils.splitToSet( enrollmentCriteria.getEnrollment(),
                 TextUtils.SEMICOLON );
-            enrollmentList = enrollmentIds != null
-                ? enrollmentIds.stream().map( e -> enrollmentService.getEnrollment( e, enrollmentParams ) )
-                    .toList()
-                : Collections.emptyList();
+            if ( enrollmentIds != null )
+            {
+                List<org.hisp.dhis.program.Enrollment> list = new ArrayList<>();
+                for ( String e : enrollmentIds )
+                {
+                    org.hisp.dhis.program.Enrollment enrollment = enrollmentService.getEnrollment( e,
+                        enrollmentParams );
+                    list.add( enrollment );
+                }
+                enrollmentList = list;
+            }
+            else
+            {
+                enrollmentList = Collections.emptyList();
+            }
         }
 
         List<ObjectNode> objectNodes = fieldFilterService
@@ -125,20 +138,16 @@ public class EnrollmentsExportController
         return pagingWrapper.withInstances( objectNodes );
     }
 
-    @GetMapping( value = "{id}" )
-    public ResponseEntity<ObjectNode> getEnrollmentById(
-        @PathVariable String id,
+    @GetMapping( value = "{uid}" )
+    public ResponseEntity<ObjectNode> getEnrollment(
+        @PathVariable String uid,
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
-        throws NotFoundException
+        throws NotFoundException,
+        ForbiddenException
     {
         EnrollmentParams enrollmentParams = fieldsMapper.map( fields );
+        Enrollment enrollment = ENROLLMENT_MAPPER.from( enrollmentService.getEnrollment( uid, enrollmentParams ) );
 
-        org.hisp.dhis.webapi.controller.tracker.view.Enrollment enrollment = ENROLLMENT_MAPPER
-            .from( enrollmentService.getEnrollment( id, enrollmentParams ) );
-        if ( enrollment == null )
-        {
-            throw new NotFoundException( org.hisp.dhis.webapi.controller.tracker.view.Enrollment.class, id );
-        }
         return ResponseEntity.ok( fieldFilterService.toObjectNode( enrollment, fields ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -53,12 +53,12 @@ import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
-import org.hisp.dhis.program.Event;
 import org.hisp.dhis.tracker.export.event.EventParams;
 import org.hisp.dhis.tracker.export.event.EventSearchParams;
 import org.hisp.dhis.tracker.export.event.Events;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
 import org.hisp.dhis.webapi.controller.tracker.export.CsvService;
+import org.hisp.dhis.webapi.controller.tracker.view.Event;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.mapstruct.factory.Mappers;
@@ -172,12 +172,12 @@ public class EventsExportController
     public ResponseEntity<ObjectNode> getEvent(
         @PathVariable String uid,
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
-        throws NotFoundException
+        throws NotFoundException,
+        ForbiddenException
     {
         EventParams eventParams = eventsMapper.map( fields );
-        Event event = eventService.getEvent( uid, eventParams );
+        Event event = EVENTS_MAPPER.from( eventService.getEvent( uid, eventParams ) );
 
-        return ResponseEntity
-            .ok( fieldFilterService.toObjectNode( EVENTS_MAPPER.from( event ), fields ) );
+        return ResponseEntity.ok( fieldFilterService.toObjectNode( event, fields ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -190,17 +190,17 @@ public class TrackedEntitiesExportController
         csvEventService.write( outputStream, trackedEntities, !skipHeader );
     }
 
-    @GetMapping( value = "{id}" )
-    public ResponseEntity<ObjectNode> getTrackedEntityById( @PathVariable String id,
+    @GetMapping( value = "{uid}" )
+    public ResponseEntity<ObjectNode> getTrackedEntity( @PathVariable String uid,
         @RequestParam( required = false ) String program,
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
         throws ForbiddenException,
         NotFoundException
     {
         TrackedEntityParams trackedEntityParams = fieldsMapper.map( fields );
+        TrackedEntity trackedEntity = TRACKED_ENTITY_MAPPER
+            .from( trackedEntityService.getTrackedEntity( uid, program, trackedEntityParams ) );
 
-        TrackedEntity trackedEntity = TRACKED_ENTITY_MAPPER.from(
-            trackedEntityService.getTrackedEntity( id, program, trackedEntityParams ) );
         return ResponseEntity.ok( fieldFilterService.toObjectNode( trackedEntity, fields ) );
     }
 


### PR DESCRIPTION
This is one first step to make all export endpoints in tracker look the same. 
In this PR get[Entity] endpoints are changed to all have the same shape:

- Throw `ForbiddenException` and `NotFoundException`
- Conform with the name `get[Entity]`
- Call the path variable `uid`
- Delegate to the method of the service `get[Entity]` to throw the exceptions

**Not in scope**
Harmonize the services. Every entity service still has its own style and its own way to check access and retrieve objects