### PR TITLE
chore: improve OpenAPI spec for /tracker TECH-1546

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/OpenApiExport.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/OpenApiExport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2023, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,54 +25,36 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.tracker.view;
+package org.hisp.dhis.webapi.controller.tracker.export;
 
-import java.time.Instant;
+import java.util.List;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Value;
 
 import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.common.UID;
-import org.hisp.dhis.dataelement.DataElement;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * OpenAPI specifications used across tracker export endpoints.
  */
-@OpenApi.Shared
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class DataValue
+public class OpenApiExport
 {
-    @JsonProperty
-    private Instant createdAt;
+    private OpenApiExport()
+    {
+        throw new IllegalStateException( "Utility class" );
+    }
 
-    @JsonProperty
-    private Instant updatedAt;
+    @Value
+    @OpenApi.Property
+    @OpenApi.Shared( value = false )
+    public static class ListResponse
+    {
+        Integer page = 1;
 
-    @JsonProperty
-    private String storedBy;
+        Integer pageSize = org.hisp.dhis.common.Pager.DEFAULT_PAGE_SIZE;
 
-    @JsonProperty
-    private boolean providedElsewhere;
+        Long total;
 
-    @OpenApi.Property( { UID.class, DataElement.class } )
-    @JsonProperty
-    @Builder.Default
-    private String dataElement = "";
-
-    @JsonProperty
-    private String value;
-
-    @JsonProperty
-    private User createdBy;
-
-    @JsonProperty
-    private User updatedBy;
+        @OpenApi.Property( value = OpenApi.EntityType[].class )
+        List<Object> instances;
+    }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Set;
 
 import lombok.RequiredArgsConstructor;
-import lombok.Value;
 
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
@@ -53,6 +52,7 @@ import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
 import org.hisp.dhis.tracker.export.enrollment.Enrollments;
 import org.hisp.dhis.webapi.common.UID;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
+import org.hisp.dhis.webapi.controller.tracker.export.OpenApiExport;
 import org.hisp.dhis.webapi.controller.tracker.view.Enrollment;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.mapstruct.factory.Mappers;
@@ -85,23 +85,9 @@ public class EnrollmentsExportController
 
     private final EnrollmentFieldsParamMapper fieldsMapper;
 
-    @Value
-    @OpenApi.Property
-    @OpenApi.Shared( value = false )
-    private static class ObjectListResponse
-    {
-        Integer page = 1;
-
-        Integer pageSize = org.hisp.dhis.common.Pager.DEFAULT_PAGE_SIZE;
-
-        Long total;
-
-        List<Enrollment> instances;
-    }
-
-    @OpenApi.Response( status = Status.OK, value = ObjectListResponse.class )
+    @OpenApi.Response( status = Status.OK, value = OpenApiExport.ListResponse.class )
     @GetMapping( produces = APPLICATION_JSON_VALUE )
-    public PagingWrapper<ObjectNode> getEnrollments( RequestParams requestParams )
+    PagingWrapper<ObjectNode> getEnrollments( RequestParams requestParams )
         throws BadRequestException,
         ForbiddenException,
         NotFoundException

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/RequestParams.java
@@ -44,6 +44,7 @@ import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
 import org.hisp.dhis.webapi.controller.tracker.view.Enrollment;
+import org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity;
 
 /**
  * Represents query parameters sent to {@link EnrollmentsExportController}.
@@ -78,7 +79,7 @@ public class RequestParams extends PagingAndSortingCriteriaAdapter
     @OpenApi.Property( { UID.class, TrackedEntityType.class } )
     private String trackedEntityType;
 
-    @OpenApi.Property( { UID.class, TrackedEntityType.class } )
+    @OpenApi.Property( { UID.class, TrackedEntity.class } )
     private String trackedEntity;
 
     @OpenApi.Property( { UID[].class, Enrollment.class } )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.event;
 
+import static org.hisp.dhis.common.OpenApi.Response.Status;
 import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.RESOURCE_PATH;
 import static org.hisp.dhis.webapi.controller.tracker.export.event.RequestParams.DEFAULT_FIELDS_PARAM;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_CSV;
@@ -60,6 +61,7 @@ import org.hisp.dhis.tracker.export.event.Events;
 import org.hisp.dhis.webapi.common.UID;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
 import org.hisp.dhis.webapi.controller.tracker.export.CsvService;
+import org.hisp.dhis.webapi.controller.tracker.export.OpenApiExport;
 import org.hisp.dhis.webapi.controller.tracker.view.Event;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.ContextUtils;
@@ -74,6 +76,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+@OpenApi.EntityType( Event.class )
 @OpenApi.Tags( "tracker" )
 @RestController
 @RequestMapping( value = RESOURCE_PATH + "/" + EventsExportController.EVENTS )
@@ -99,8 +102,9 @@ public class EventsExportController
 
     private final EventFieldsParamMapper eventsMapper;
 
+    @OpenApi.Response( status = Status.OK, value = OpenApiExport.ListResponse.class )
     @GetMapping( produces = APPLICATION_JSON_VALUE )
-    public PagingWrapper<ObjectNode> getEvents( RequestParams requestParams )
+    PagingWrapper<ObjectNode> getEvents( RequestParams requestParams )
         throws BadRequestException,
         ForbiddenException
     {
@@ -127,7 +131,7 @@ public class EventsExportController
     }
 
     @GetMapping( produces = { CONTENT_TYPE_CSV, CONTENT_TYPE_CSV_GZIP, CONTENT_TYPE_TEXT_CSV } )
-    public void getCsvEvents(
+    void getEventsAsCsv(
         RequestParams requestParams,
         HttpServletResponse response,
         @RequestParam( required = false, defaultValue = "false" ) boolean skipHeader,
@@ -166,10 +170,11 @@ public class EventsExportController
             CollectionUtils.isEmpty( eventSearchParams.getEnrollments() );
     }
 
-    @GetMapping( "{uid}" )
-    public ResponseEntity<ObjectNode> getEvent(
-        @PathVariable UID uid,
-        @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
+    @OpenApi.Response( OpenApi.EntityType.class )
+    @GetMapping( "/{uid}" )
+    ResponseEntity<ObjectNode> getEventByUid(
+        @OpenApi.Param( { org.hisp.dhis.common.UID.class, Event.class } ) @PathVariable UID uid,
+        @OpenApi.Param( name = "fields", value = String[].class ) @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
         throws NotFoundException,
         ForbiddenException
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/RequestParams.java
@@ -35,42 +35,59 @@ import java.util.Set;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.common.AssignedUserSelectionMode;
 import org.hisp.dhis.common.IdSchemes;
+import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.fieldfiltering.FieldFilterParser;
 import org.hisp.dhis.fieldfiltering.FieldPath;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
+import org.hisp.dhis.webapi.controller.tracker.view.Event;
+import org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity;
+import org.hisp.dhis.webapi.controller.tracker.view.User;
 
 /**
  * Represents query parameters sent to {@link EventsExportController}.
  *
  * @author Giuseppe Nespolino <g.nespolino@gmail.com>
  */
+@OpenApi.Property
 @Data
 @NoArgsConstructor
 class RequestParams extends PagingAndSortingCriteriaAdapter
 {
     static final String DEFAULT_FIELDS_PARAM = "*,!relationships";
 
+    @OpenApi.Property( { UID.class, Program.class } )
     private String program;
 
+    @OpenApi.Property( { UID.class, ProgramStage.class } )
     private String programStage;
 
     private ProgramStatus programStatus;
 
     private Boolean followUp;
 
+    @OpenApi.Property( { UID.class, TrackedEntity.class } )
     private String trackedEntity;
 
+    @OpenApi.Property( { UID.class, OrganisationUnit.class } )
     private String orgUnit;
 
     private OrganisationUnitSelectionMode ouMode;
 
     private AssignedUserSelectionMode assignedUserMode;
 
+    @OpenApi.Property( { UID[].class, User.class } )
     private String assignedUser;
 
     private Date occurredAfter;
@@ -97,8 +114,10 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
 
     private EventStatus status;
 
+    @OpenApi.Property( { UID.class, CategoryCombo.class } )
     private String attributeCc;
 
+    @OpenApi.Property( { UID[].class, CategoryOption.class } )
     private String attributeCos;
 
     private boolean skipMeta;
@@ -107,6 +126,7 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
 
     private boolean includeDeleted;
 
+    @OpenApi.Property( { UID[].class, Event.class } )
     private String event;
 
     private Boolean skipEventId;
@@ -115,9 +135,11 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
 
     private Set<String> filterAttributes = new HashSet<>();
 
+    @OpenApi.Property( { UID[].class, Enrollment.class } )
     private Set<String> enrollments = new HashSet<>();
 
     private IdSchemes idSchemes = new IdSchemes();
 
+    @OpenApi.Property( name = "fields", value = String[].class )
     private List<FieldPath> fields = FieldFilterParser.parse( DEFAULT_FIELDS_PARAM );
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.relationship;
 
+import static org.hisp.dhis.common.OpenApi.Response.Status;
 import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.RESOURCE_PATH;
 import static org.hisp.dhis.webapi.controller.tracker.export.relationship.RequestParams.DEFAULT_FIELDS_PARAM;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -58,6 +59,7 @@ import org.hisp.dhis.tracker.export.relationship.RelationshipService;
 import org.hisp.dhis.webapi.common.UID;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
+import org.hisp.dhis.webapi.controller.tracker.export.OpenApiExport;
 import org.hisp.dhis.webapi.controller.tracker.view.Relationship;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.mapstruct.factory.Mappers;
@@ -71,6 +73,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 
+@OpenApi.EntityType( Relationship.class )
 @OpenApi.Tags( "tracker" )
 @RestController
 @RequestMapping( produces = APPLICATION_JSON_VALUE, value = RESOURCE_PATH + "/"
@@ -143,6 +146,7 @@ public class RelationshipsExportController
             criteria );
     }
 
+    @OpenApi.Response( status = Status.OK, value = OpenApiExport.ListResponse.class )
     @GetMapping
     PagingWrapper<ObjectNode> getRelationships( RequestParams requestParams )
         throws NotFoundException,
@@ -167,10 +171,10 @@ public class RelationshipsExportController
         return pagingWrapper.withInstances( objectNodes );
     }
 
-    @GetMapping( "{uid}" )
-    public ResponseEntity<ObjectNode> getRelationship(
-        @PathVariable UID uid,
-        @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
+    @GetMapping( "/{uid}" )
+    ResponseEntity<ObjectNode> getRelationshipByUid(
+        @OpenApi.Param( { org.hisp.dhis.common.UID.class, Relationship.class } ) @PathVariable UID uid,
+        @OpenApi.Param( name = "fields", value = String[].class ) @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
         throws NotFoundException,
         ForbiddenException
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RequestParams.java
@@ -35,25 +35,31 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.fieldfiltering.FieldFilterParser;
 import org.hisp.dhis.fieldfiltering.FieldPath;
-import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.Event;
-import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
+import org.hisp.dhis.webapi.controller.tracker.view.Enrollment;
+import org.hisp.dhis.webapi.controller.tracker.view.Event;
+import org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity;
 
+@OpenApi.Property
 @NoArgsConstructor
 @EqualsAndHashCode( exclude = { "identifier", "identifierName", "identifierClass" } )
 class RequestParams extends PagingAndSortingCriteriaAdapter
 {
     static final String DEFAULT_FIELDS_PARAM = "relationship,relationshipType,from[trackedEntity[trackedEntity],enrollment[enrollment],event[event]],to[trackedEntity[trackedEntity],enrollment[enrollment],event[event]]";
 
+    @OpenApi.Property( { UID.class, TrackedEntity.class } )
     private String trackedEntity;
 
+    @OpenApi.Property( { UID.class, Enrollment.class } )
     @Setter
     private String enrollment;
 
+    @OpenApi.Property( { UID.class, Event.class } )
     @Setter
     private String event;
 
@@ -63,6 +69,7 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
 
     private Class<?> identifierClass;
 
+    @OpenApi.Property( name = "fields", value = String[].class )
     @Getter
     @Setter
     private List<FieldPath> fields = FieldFilterParser.parse( DEFAULT_FIELDS_PARAM );
@@ -80,6 +87,7 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
         this.trackedEntity = trackedEntity;
     }
 
+    @OpenApi.Ignore
     public String getIdentifierParam()
         throws BadRequestException
     {
@@ -93,21 +101,21 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
         {
             this.identifier = this.trackedEntity;
             this.identifierName = "trackedEntity";
-            this.identifierClass = TrackedEntity.class;
+            this.identifierClass = org.hisp.dhis.trackedentity.TrackedEntity.class;
             count++;
         }
         if ( !StringUtils.isBlank( this.enrollment ) )
         {
             this.identifier = this.enrollment;
             this.identifierName = "enrollment";
-            this.identifierClass = Enrollment.class;
+            this.identifierClass = org.hisp.dhis.program.Enrollment.class;
             count++;
         }
         if ( !StringUtils.isBlank( this.event ) )
         {
             this.identifier = this.event;
             this.identifierName = "event";
-            this.identifierClass = Event.class;
+            this.identifierClass = org.hisp.dhis.program.Event.class;
             count++;
         }
 
@@ -123,6 +131,7 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
         return this.identifier;
     }
 
+    @OpenApi.Ignore
     public String getIdentifierName()
         throws BadRequestException
     {
@@ -133,6 +142,7 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
         return this.identifierName;
     }
 
+    @OpenApi.Ignore
     public Class<?> getIdentifierClass()
         throws BadRequestException
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParams.java
@@ -36,18 +36,26 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import org.hisp.dhis.common.AssignedUserSelectionMode;
+import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.fieldfiltering.FieldFilterParser;
 import org.hisp.dhis.fieldfiltering.FieldPath;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStatus;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
+import org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity;
+import org.hisp.dhis.webapi.controller.tracker.view.User;
 
 /**
  * Represents query parameters sent to {@link TrackedEntitiesExportController}.
  *
  * @author Giuseppe Nespolino
  */
+@OpenApi.Property
 @Data
 @NoArgsConstructor
 class RequestParams extends PagingAndSortingCriteriaAdapter
@@ -74,6 +82,7 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
     /**
      * a Program UID for which instances in the response must be enrolled in.
      */
+    @OpenApi.Property( { UID.class, Program.class } )
     private String program;
 
     /**
@@ -126,11 +135,13 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
     /**
      * Only returns Tracked Entity Instances of this type.
      */
+    @OpenApi.Property( { UID.class, TrackedEntityType.class } )
     private String trackedEntityType;
 
     /**
      * Semicolon-delimited list of Tracked Entity Instance UIDs
      */
+    @OpenApi.Property( { UID[].class, TrackedEntity.class } )
     private String trackedEntity;
 
     /**
@@ -142,12 +153,14 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
      * Semicolon-delimited list of user UIDs to filter based on events assigned
      * to the users.
      */
+    @OpenApi.Property( { UID[].class, User.class } )
     private String assignedUser;
 
     /**
      * Program Stage UID, used for filtering TEIs based on the selected Program
      * Stage
      */
+    @OpenApi.Property( { UID.class, ProgramStage.class } )
     private String programStage;
 
     /**

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Attribute.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Attribute.java
@@ -34,6 +34,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -41,12 +43,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@OpenApi.Shared
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Attribute
 {
+    @OpenApi.Property( { UID.class, Attribute.class } )
     @JsonProperty
     private String attribute;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Enrollment.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Enrollment.java
@@ -45,6 +45,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@OpenApi.Shared
 @Data
 @Builder
 @NoArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Event.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Event.java
@@ -48,6 +48,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@OpenApi.Shared
 @Data
 @Builder
 @NoArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Note.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Note.java
@@ -34,6 +34,9 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.common.UID;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -42,12 +45,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@OpenApi.Shared
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Note
 {
+    @OpenApi.Property( { UID.class, Note.class } )
     @JsonProperty
     private String note;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/ProgramOwner.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/ProgramOwner.java
@@ -32,11 +32,15 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.common.UID;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@OpenApi.Shared
 @Data
 @Builder
 @NoArgsConstructor
@@ -46,6 +50,7 @@ public class ProgramOwner
     @JsonProperty
     private String orgUnit;
 
+    @OpenApi.Property( { UID.class, TrackedEntity.class } )
     @JsonProperty
     private String trackedEntity;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Relationship.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Relationship.java
@@ -43,6 +43,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@OpenApi.Shared
 @Data
 @Builder
 @NoArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/RelationshipItem.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/RelationshipItem.java
@@ -38,6 +38,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.event.EventStatus;
 import org.locationtech.jts.geom.Geometry;
 
@@ -46,6 +48,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@OpenApi.Shared
 @Data
 @Builder
 @NoArgsConstructor
@@ -59,6 +62,7 @@ public class RelationshipItem
     public static class TrackedEntity
     {
         @JsonProperty
+        @OpenApi.Property( { UID.class, TrackedEntity.class } )
         private String trackedEntity;
 
         @JsonProperty
@@ -119,6 +123,7 @@ public class RelationshipItem
     @AllArgsConstructor
     public static class Enrollment
     {
+        @OpenApi.Property( { UID.class, Enrollment.class } )
         @JsonProperty
         private String enrollment;
 
@@ -198,6 +203,7 @@ public class RelationshipItem
     @AllArgsConstructor
     public static class Event
     {
+        @OpenApi.Property( { UID.class, Event.class } )
         @JsonProperty
         private String event;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/TrackedEntity.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/TrackedEntity.java
@@ -36,6 +36,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.common.UID;
 import org.locationtech.jts.geom.Geometry;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -43,12 +45,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@OpenApi.Shared
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class TrackedEntity
 {
+    @OpenApi.Property( { UID.class, TrackedEntity.class } )
     @JsonProperty
     private String trackedEntity;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/User.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/User.java
@@ -32,17 +32,22 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.common.UID;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * @author Enrico Colasante
  */
+@OpenApi.Shared
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class User
 {
+    @OpenApi.Property( { UID.class, User.class } )
     @JsonProperty
     private String uid;
 

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/Descriptions.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/Descriptions.md
@@ -1,4 +1,27 @@
 ## Common for all endpoints
 
 ### `*.parameter.PagingAndSortingCriteriaAdapter.page`
-Defines which page number to return.
+
+Get given number of pages. Defaults to `1`.
+
+### `*.parameter.PagingAndSortingCriteriaAdapter.pageSize`
+
+Get given number of entries per page. Defaults to `50`.
+
+### `*.parameter.PagingAndSortingCriteriaAdapter.totalPages`
+
+Get the total number of pages by specifying `totalPages=true`. Defaults to `false`.
+
+### `*.parameter.PagingAndSortingCriteriaAdapter.skipPaging`
+
+Get all entries by specifying `skipPaging=true`. Defaults to `false`, meaning that by default requests are paginated.
+
+**Be aware that the performance is directly related to the amount of data requested. Larger pages will take more time to
+return.**
+
+### `*.parameter.PagingAndSortingCriteriaAdapter.order`
+
+`<propertyName1:sortDirection>[,<propertyName2:sortDirection>...]`
+
+Get entries in given order. Valid `sortDirection`s are `asc` and `desc`. `propName` is case-sensitive, `sortDirection`
+is case-insensitive.

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/EnrollmentsExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/EnrollmentsExportController.md
@@ -58,33 +58,6 @@ Get enrollments updated after given date.
 
 Get enrollments updated since given ISO-8601 duration.
 
-### `getEnrollments.parameter.page`
-
-Get given number of pages. Defaults to `1`.
-
-### `getEnrollments.parameter.pageSize`
-
-Get given number of entries per page. Defaults to `50`.
-
-### `getEnrollments.parameter.totalPages`
-
-Get the total number of pages by specifying `totalPages=true`. Defaults to `false`.
-
-### `getEnrollments.parameter.skipPaging`
-
-Get all enrollments by specifying `skipPaging=true`. Defaults to `false`, meaning that by default requests are
-paginated.
-
-**Be aware that the performance is directly related to the amount of data requested. Larger pages will take more time to
-return.**
-
-### `getEnrollments.parameter.order`
-
-`<propertyName1:sortDirection>[,<propertyName2:sortDirection>...]`
-
-Get entries in given order. Valid `sortDirection`s are `asc` and `desc`. `propName` is case-sensitive, `sortDirection`
-is case-insensitive.
-
 ## `getEnrollmentByUid`
 
 Get an enrollment with given UID.

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/EventsExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/EventsExportController.md
@@ -1,0 +1,102 @@
+# Get Events
+
+## `getEvents`
+
+Get events matching given query parameters.
+
+### `getEvents.parameter.program`
+
+### `getEvents.parameter.programStage`
+
+### `getEvents.parameter.programStatus`
+
+### `getEvents.parameter.followUp`
+
+Get events with given follow-up status of the instance for the given program.
+
+### `getEvents.parameter.trackedEntity`
+
+Get events of tracked entity with given UID.
+
+### `getEvents.parameter.orgUnit`
+
+Get events owned by given `orgUnit`.
+
+### `getEvents.parameter.ouMode`
+
+Get events using given organisation unit selection mode.
+
+### `getEvents.parameter.assignedUserMode`
+
+### `getEvents.parameter.assignedUser`
+
+`<user1-uid>[;<user2-uid>...]`
+
+Get events that are assigned to the given user(s). Specifying `assignedUser` is only valid if `assignedUserMode` is
+either `PROVIDED` or not specified.
+
+### `getEvents.parameter.occurredAfter`
+
+Get events that occurred after given date.
+
+### `getEvents.parameter.occurredBefore`
+
+Get events that occurred before given date.
+
+### `getEvents.parameter.scheduledAfter`
+
+Get events that are scheduled after given date.
+
+### `getEvents.parameter.scheduledBefore`
+
+Get events that are scheduled before given date.
+
+### `getEvents.parameter.updatedAfter`
+
+Get events updated after given date.
+
+### `getEvents.parameter.updatedWithin`
+
+Get events updated since given ISO-8601 duration.
+
+### `getEvents.parameter.enrollmentEnrolledAfter`
+
+Get events with enrollments that were enrolled after given date.
+
+### `getEvents.parameter.enrollmentEnrolledBefore`
+
+Get events with enrollments that were enrolled before given date.
+
+### `getEvents.parameter.status`
+
+### `getEvents.parameter.attributeCc`
+
+### `getEvents.parameter.attributeCos`
+
+### `getEvents.parameter.includeDeleted`
+
+Get soft-deleted events by specifying `includeDeleted=true`. Soft-deleted events are excluded by default.
+
+### `getEvents.parameter.event`
+
+`<event1-uid>[;<event2-uid>...]`
+
+Get events with given UID(s).
+
+### `getEvents.parameter.skipEventId`
+
+### `getEvents.parameter.order`
+
+`<propertyName1:sortDirection>[,<propertyName2:sortDirection>...]`
+
+Get events in given order. Valid `sortDirection`s are `asc` and `desc`. `propName` is case-sensitive, `sortDirection`
+is case-insensitive.
+
+Supported properties are `assignedUser`, `assignedUserDisplayName`, `attributeOptionCombo`, `completedAt`,
+`completedBy`, `createdAt`, `createdBy`, `deleted`, `enrolledAt`, `enrollment`, `enrollmentStatus`, `event`, `followup`,
+`occurredAt`, `orgUnit`, `orgUnitName`, `program`, `programStage`, `scheduleAt`, `status`, `storedBy`, `trackedEntity`,
+`updatedAt`, `updatedBy`.
+
+## `getEventByUid`
+
+Get an event with given UID.

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/RelationshipsExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/RelationshipsExportController.md
@@ -1,0 +1,15 @@
+# Get Relationships
+
+## `getRelationships`
+
+Get relationships matching given query parameters.
+
+### `getRelationships.parameter.trackedEntity`
+
+### `getRelationships.parameter.enrollment`
+
+### `getRelationships.parameter.event`
+
+## `getRelationshipByUid`
+
+Get a relationship with given UID.

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
@@ -1,0 +1,67 @@
+# Get Tracked Entities
+
+## `getTrackedEntities`
+
+Get tracked entities matching given query parameters.
+
+### `getTrackedEntities.parameter.query`
+
+### `getTrackedEntities.parameter.attribute`
+
+### `getTrackedEntities.parameter.orgUnit`
+
+Get tracked entities owned by given `orgUnit`.
+
+### `getTrackedEntities.parameter.ouMode`
+
+Get events using given organisation unit selection mode.
+
+### `getTrackedEntities.parameter.program`
+
+### `getTrackedEntities.parameter.programStatus`
+
+### `getTrackedEntities.parameter.followUp`
+
+### `getTrackedEntities.parameter.updatedAfter`
+
+### `getTrackedEntities.parameter.updatedBefore`
+
+### `getTrackedEntities.parameter.updatedWithin`
+
+### `getTrackedEntities.parameter.enrollmentEnrolledAfter`
+
+### `getTrackedEntities.parameter.enrollmentEnrolledBefore`
+
+### `getTrackedEntities.parameter.enrollmentOccurredAfter`
+
+### `getTrackedEntities.parameter.enrollmentOccurredBefore`
+
+### `getTrackedEntities.parameter.trackedEntityType`
+
+### `getTrackedEntities.parameter.trackedEntity`
+
+### `getTrackedEntities.parameter.assignedUserMode`
+
+### `getTrackedEntities.parameter.assignedUser`
+
+### `getTrackedEntities.parameter.programStage`
+
+### `getTrackedEntities.parameter.eventStatus`
+
+### `getTrackedEntities.parameter.eventOccurredAfter`
+
+### `getTrackedEntities.parameter.eventOccurredBefore`
+
+### `getTrackedEntities.parameter.skipMeta`
+
+### `getTrackedEntities.parameter.includeDeleted`
+
+### `getTrackedEntities.parameter.includeAllAttributes`
+
+### `getTrackedEntities.parameter.potentialDuplicate`
+
+## `getTrackedEntityByUid`
+
+Get a tracked entity with given UID.
+
+### `getTrackedEntityByUid.parameter.program`


### PR DESCRIPTION
# Why

Our docs

https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-240/tracker.html

are often outdated as they are further away from the code. Once we have documented our APIs using OpenAPI specs we can remove the current documentation from the tracker docs. The docs at `docs.dhis2.org` will get a link to our OpenAPI spec and become more high-level than right now.

# What

Describe our `/tracker` APIs using an OpenAPI spec

* Add markdown to add descriptions to the query parameters. Some are just placeholder we will fill in in a later PR.

* Describe query parameters and properties that are UIDs

* Make controller methods consistently package private now that they are discovered by the `ApiAnalyse.analyseController` 🎉 

## Things to improve later on

* Some properties/query params are marked as required even though they have a default. Not sure why that is 🤷🏻 
* Find a way to describe metadata properties which can be one of the supported idSchemes. Like `String Enrollment.program` which can be a UID, NAME, CODE or ATTRIBUTE. At least during import and in theory (according to our docs, at least for /tracker/events 😂) also during export.
* Should we describe all the properties of TrackedEntity, Enrollment, Event, Relationship? I think it would be helpful so we all share the same understanding of what they represent.
* Update query parameters that represent a collection of UIDs that are currently separated by `;` instead of `,`. Once we use `,` and `List<String>` we should annotate with `@OpenApi.Property( { UID[].class, Some.class } )`
* Describe JSON/CSV endpoints separately as they do not always support the same query paramters. We will need to use a workaround as OpenAPI does not take media types into account. Spring also has some limitations which will require another workaround 😅 