### PR TITLE
fix: validate uid format for object creation only

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/config/ServiceConfig.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/config/ServiceConfig.java
@@ -105,6 +105,7 @@ import org.hisp.dhis.dxf2.metadata.objectbundle.validation.ReferencesCheck;
 import org.hisp.dhis.dxf2.metadata.objectbundle.validation.SchemaCheck;
 import org.hisp.dhis.dxf2.metadata.objectbundle.validation.SecurityCheck;
 import org.hisp.dhis.dxf2.metadata.objectbundle.validation.TranslationsCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.UidFormatCheck;
 import org.hisp.dhis.dxf2.metadata.objectbundle.validation.UniqueAttributesCheck;
 import org.hisp.dhis.dxf2.metadata.objectbundle.validation.UniqueMultiPropertiesCheck;
 import org.hisp.dhis.dxf2.metadata.objectbundle.validation.UniquenessCheck;
@@ -222,7 +223,8 @@ public class ServiceConfig
                 getValidationCheckByClass( NotOwnerReferencesCheck.class ),
                 getValidationCheckByClass( TranslationsCheck.class ),
                 getValidationCheckByClass( GeoJsonAttributesCheck.class ),
-                getValidationCheckByClass( MetadataAttributeCheck.class ) ),
+                getValidationCheckByClass( MetadataAttributeCheck.class ),
+                getValidationCheckByClass( UidFormatCheck.class ) ),
             CREATE, newArrayList(
                 getValidationCheckByClass( DuplicateIdsCheck.class ),
                 getValidationCheckByClass( ValidationHooksCheck.class ),
@@ -237,7 +239,8 @@ public class ServiceConfig
                 getValidationCheckByClass( NotOwnerReferencesCheck.class ),
                 getValidationCheckByClass( TranslationsCheck.class ),
                 getValidationCheckByClass( GeoJsonAttributesCheck.class ),
-                getValidationCheckByClass( MetadataAttributeCheck.class ) ),
+                getValidationCheckByClass( MetadataAttributeCheck.class ),
+                getValidationCheckByClass( UidFormatCheck.class ) ),
             UPDATE, newArrayList(
                 getValidationCheckByClass( DuplicateIdsCheck.class ),
                 getValidationCheckByClass( ValidationHooksCheck.class ),

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UidFormatCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UidFormatCheck.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.createObjectReport;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.ObjectReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+import org.springframework.stereotype.Component;
+
+/**
+ * Validate UID format for creation of new object only.
+ */
+@Component
+public class UidFormatCheck implements ObjectValidationCheck
+{
+    @Override
+    public <T extends IdentifiableObject> void check( ObjectBundle bundle, Class<T> klass,
+        List<T> persistedObjects, List<T> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext ctx, Consumer<ObjectReport> addReports )
+    {
+        if ( persistedObjects.isEmpty() && nonPersistedObjects.isEmpty() )
+        {
+            return;
+        }
+
+        run( bundle, ctx, nonPersistedObjects, addReports );
+    }
+
+    private void run( ObjectBundle bundle, ValidationContext ctx, Iterable<? extends IdentifiableObject> list,
+        Consumer<ObjectReport> addReports )
+    {
+        list.forEach( object -> {
+            if ( !CodeGenerator.isValidUid( object.getUid() ) )
+            {
+                addReports.accept( createObjectReport( new ErrorReport( object.getClass(), ErrorCode.E4014,
+                    object.getUid(), object.getClass().getSimpleName() ), object, bundle ) );
+                ctx.markForRemoval( object );
+            }
+        } );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/validation/DefaultSchemaValidator.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/validation/DefaultSchemaValidator.java
@@ -39,7 +39,6 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.GenericValidator;
-import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.hibernate.HibernateProxyUtils;
@@ -177,11 +176,7 @@ public class DefaultSchemaValidator implements SchemaValidator
             errorReports.add( createNameMinMaxReport( ErrorCode.E4002, klass, property, value.length() ) );
         }
 
-        if ( isInvalidUid( property, value ) )
-        {
-            errorReports.add( new ErrorReport( klass, ErrorCode.E4014, value, property.getFieldName() ) );
-        }
-        else if ( isInvalidEmail( property, value ) )
+        if ( isInvalidEmail( property, value ) )
         {
             errorReports.add( createNameReport( ErrorCode.E4003, klass, property, value ) );
         }
@@ -212,11 +207,6 @@ public class DefaultSchemaValidator implements SchemaValidator
          */
 
         return errorReports;
-    }
-
-    private boolean isInvalidUid( Property property, String value )
-    {
-        return property.getFieldName().equals( "uid" ) && !CodeGenerator.isValidUid( value );
     }
 
     private boolean isInvalidColor( Property property, String value )

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
@@ -45,11 +45,13 @@ import java.util.Set;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeValue;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonResponse;
+import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.web.HttpStatus;
@@ -821,8 +823,24 @@ class AbstractCrudControllerTest extends DhisControllerConvenienceTest
         JsonImportSummary response = POST( "/dataSets/",
             "{'id':'11111111111','name':'My data set', 'shortName': 'MDS', 'periodType':'Monthly'}" )
                 .content( HttpStatus.CONFLICT ).get( "response" ).as( JsonImportSummary.class );
-        assertEquals( "Invalid UID `11111111111` for property `uid`",
+        assertEquals( "Invalid UID `11111111111` for property `DataSet`",
             response.find( JsonErrorReport.class, error -> error.getErrorCode() == ErrorCode.E4014 ).getMessage() );
+    }
+
+    @Test
+    void testUpdateObjectWithInvalidUid()
+    {
+        DataSet dataSet = createDataSet( 'A' );
+        dataSet.setPeriodType( PeriodType.getPeriodTypeByName( "Monthly" ) );
+        dataSet.setUid( "11111111111" );
+        manager.save( dataSet );
+
+        PUT( "/dataSets/11111111111",
+            "{'id':'11111111111','name':'My data set', 'shortName': 'MDS', 'periodType':'Monthly'}" )
+                .content( HttpStatus.OK );
+
+        JsonIdentifiableObject response = GET( "/dataSets/11111111111" ).content().as( JsonIdentifiableObject.class );
+        assertEquals( "My data set", response.getName() );
     }
 
     private void assertUserGroupHasOnlyUser( String groupId, String userId )


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-14942
- Modified the fix added from https://github.com/dhis2/dhis2-core/pull/13454 so the uid validator will only apply to object creation. This is to avoid issues with existing data.
