### PR TITLE
chore: Create UID type in web [TECH-1565]

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerTest.java
@@ -271,6 +271,16 @@ class EnrollmentsExportControllerTest extends DhisControllerConvenienceTest
                 .getMessage() );
     }
 
+    @Test
+    void shouldReturnABadRequestErrorWhenInvalidUidIsPassedInThePath()
+    {
+        assertEquals(
+            "Value invalidUid is not valid for parameter uid. UID must be an alphanumeric string of 11 characters",
+            GET( "/tracker/enrollments/invalidUid" )
+                .error( HttpStatus.BAD_REQUEST )
+                .getMessage() );
+    }
+
     private Event event()
     {
         Event event = new Event( enrollment, programStage,

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
@@ -328,6 +328,16 @@ class EventsExportControllerTest extends DhisControllerConvenienceTest
                 .getMessage() );
     }
 
+    @Test
+    void shouldReturnABadRequestErrorWhenInvalidUidIsPassedInThePath()
+    {
+        assertEquals(
+            "Value invalidUid is not valid for parameter uid. UID must be an alphanumeric string of 11 characters",
+            GET( "/tracker/events/invalidUid" )
+                .error( HttpStatus.BAD_REQUEST )
+                .getMessage() );
+    }
+
     private TrackedEntityType trackedEntityTypeAccessible()
     {
         TrackedEntityType type = trackedEntityType( 'A' );

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -336,6 +336,16 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
     }
 
     @Test
+    void shouldReturnABadRequestErrorWhenInvalidUidIsPassedInThePath()
+    {
+        assertEquals(
+            "Value invalidUid is not valid for parameter uid. UID must be an alphanumeric string of 11 characters",
+            GET( "/tracker/relationships/invalidUid" )
+                .error( HttpStatus.BAD_REQUEST )
+                .getMessage() );
+    }
+
+    @Test
     void getRelationshipsByEnrollment()
     {
         TrackedEntity to = trackedEntity();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -378,6 +378,16 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
     }
 
     @Test
+    void shouldReturnABadRequestErrorWhenInvalidUidIsPassedInThePath()
+    {
+        assertEquals(
+            "Value invalidUid is not valid for parameter uid. UID must be an alphanumeric string of 11 characters",
+            GET( "/tracker/trackedEntities/invalidUid" )
+                .error( HttpStatus.BAD_REQUEST )
+                .getMessage() );
+    }
+
+    @Test
     void getTrackedEntityReturnsCsvFormat()
     {
         WebClient.HttpResponse response = GET( "/tracker/trackedEntities.csv?program={programId}&orgUnit={orgUnitId}",

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/common/UID.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/common/UID.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.common;
+
+import lombok.Getter;
+
+import org.hisp.dhis.common.CodeGenerator;
+
+/**
+ * UID represents an alphanumeric string of 11 characters.
+ */
+@Getter
+public final class UID
+{
+    private static final String VALID_UID_FORMAT = "UID must be an alphanumeric string of 11 characters";
+
+    private final String value;
+
+    private UID( String value )
+    {
+        if ( !CodeGenerator.isValidUid( value ) )
+        {
+            throw new IllegalArgumentException( VALID_UID_FORMAT );
+        }
+        this.value = value;
+    }
+
+    public static UID of( String value )
+    {
+        return new UID( value );
+    }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/common/UIDParamEditor.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/common/UIDParamEditor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.common;
+
+import java.beans.PropertyEditorSupport;
+
+public class UIDParamEditor extends PropertyEditorSupport
+{
+    @Override
+    public void setAsText( String source )
+    {
+        setValue( UID.of( source ) );
+    }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -74,6 +74,8 @@ import org.hisp.dhis.query.QueryParserException;
 import org.hisp.dhis.schema.SchemaPathException;
 import org.hisp.dhis.tracker.imports.TrackerIdSchemeParam;
 import org.hisp.dhis.util.DateUtils;
+import org.hisp.dhis.webapi.common.UID;
+import org.hisp.dhis.webapi.common.UIDParamEditor;
 import org.hisp.dhis.webapi.controller.exception.MetadataImportConflictException;
 import org.hisp.dhis.webapi.controller.exception.MetadataSyncException;
 import org.hisp.dhis.webapi.controller.exception.MetadataVersionException;
@@ -135,6 +137,7 @@ public class CrudControllerAdvice
         binder.registerCustomEditor( IdentifiableProperty.class, new FromTextPropertyEditor( String::toUpperCase ) );
         this.enumClasses.forEach( c -> binder.registerCustomEditor( c, new ConvertEnum( c ) ) );
         binder.registerCustomEditor( TrackerIdSchemeParam.class, new IdSchemeParamEditor() );
+        binder.registerCustomEditor( UID.class, new UIDParamEditor() );
     }
 
     @ExceptionHandler( org.hisp.dhis.feedback.BadRequestException.class )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
@@ -41,7 +41,6 @@ import lombok.Value;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.OpenApi.Response.Status;
-import org.hisp.dhis.common.UID;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
@@ -52,6 +51,7 @@ import org.hisp.dhis.program.EnrollmentQueryParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
 import org.hisp.dhis.tracker.export.enrollment.Enrollments;
+import org.hisp.dhis.webapi.common.UID;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
 import org.hisp.dhis.webapi.controller.tracker.view.Enrollment;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -147,13 +147,14 @@ public class EnrollmentsExportController
     @OpenApi.Response( OpenApi.EntityType.class )
     @GetMapping( value = "/{uid}" )
     public ResponseEntity<ObjectNode> getEnrollmentByUid(
-        @OpenApi.Param( { UID.class, Enrollment.class } ) @PathVariable String uid,
+        @OpenApi.Param( { Enrollment.class } ) @PathVariable UID uid,
         @OpenApi.Param( name = "fields", value = String[].class ) @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
         throws NotFoundException,
         ForbiddenException
     {
         EnrollmentParams enrollmentParams = fieldsMapper.map( fields );
-        Enrollment enrollment = ENROLLMENT_MAPPER.from( enrollmentService.getEnrollment( uid, enrollmentParams ) );
+        Enrollment enrollment = ENROLLMENT_MAPPER
+            .from( enrollmentService.getEnrollment( uid.getValue(), enrollmentParams ) );
         return ResponseEntity.ok( fieldFilterService.toObjectNode( enrollment, fields ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -57,6 +57,7 @@ import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.tracker.export.event.EventParams;
 import org.hisp.dhis.tracker.export.event.EventSearchParams;
 import org.hisp.dhis.tracker.export.event.Events;
+import org.hisp.dhis.webapi.common.UID;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
 import org.hisp.dhis.webapi.controller.tracker.export.CsvService;
 import org.hisp.dhis.webapi.controller.tracker.view.Event;
@@ -167,13 +168,13 @@ public class EventsExportController
 
     @GetMapping( "{uid}" )
     public ResponseEntity<ObjectNode> getEvent(
-        @PathVariable String uid,
+        @PathVariable UID uid,
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
         throws NotFoundException,
         ForbiddenException
     {
         EventParams eventParams = eventsMapper.map( fields );
-        Event event = EVENTS_MAPPER.from( eventService.getEvent( uid, eventParams ) );
+        Event event = EVENTS_MAPPER.from( eventService.getEvent( uid.getValue(), eventParams ) );
 
         return ResponseEntity.ok( fieldFilterService.toObjectNode( event, fields ) );
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
@@ -55,6 +55,7 @@ import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.tracker.export.relationship.RelationshipService;
+import org.hisp.dhis.webapi.common.UID;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
 import org.hisp.dhis.webapi.controller.tracker.view.Relationship;
@@ -168,12 +169,12 @@ public class RelationshipsExportController
 
     @GetMapping( "{uid}" )
     public ResponseEntity<ObjectNode> getRelationship(
-        @PathVariable String uid,
+        @PathVariable UID uid,
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
         throws NotFoundException,
         ForbiddenException
     {
-        Relationship relationship = RELATIONSHIP_MAPPER.from( relationshipService.getRelationship( uid ) );
+        Relationship relationship = RELATIONSHIP_MAPPER.from( relationshipService.getRelationship( uid.getValue() ) );
 
         return ResponseEntity.ok( fieldFilterService.toObjectNode( relationship, fields ) );
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -59,6 +59,7 @@ import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.trackedentity.TrackedEntityQueryParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityService;
+import org.hisp.dhis.webapi.common.UID;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
 import org.hisp.dhis.webapi.controller.tracker.export.CsvService;
 import org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity;
@@ -190,7 +191,7 @@ public class TrackedEntitiesExportController
     }
 
     @GetMapping( value = "{uid}" )
-    public ResponseEntity<ObjectNode> getTrackedEntity( @PathVariable String uid,
+    public ResponseEntity<ObjectNode> getTrackedEntity( @PathVariable UID uid,
         @RequestParam( required = false ) String program,
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
         throws ForbiddenException,
@@ -198,7 +199,7 @@ public class TrackedEntitiesExportController
     {
         TrackedEntityParams trackedEntityParams = fieldsMapper.map( fields );
         TrackedEntity trackedEntity = TRACKED_ENTITY_MAPPER
-            .from( trackedEntityService.getTrackedEntity( uid, program, trackedEntityParams ) );
+            .from( trackedEntityService.getTrackedEntity( uid.getValue(), program, trackedEntityParams ) );
 
         return ResponseEntity.ok( fieldFilterService.toObjectNode( trackedEntity, fields ) );
     }


### PR DESCRIPTION
This is the first try to create a `UID` type and use it in the web layer.
`UID` type held an alphanumeric string of 11 characters and it is not possible to instantiate and invalid `UID`.
For now, it only lives in web layer. Maybe later we can think of having it as a proper type that is used all across the system.

I didn't use the pre-existent class `org.hisp.dhis.common.UID` as this class is used for OpenAPI purposes and to make it work I should have changed all the uses that are already present in the code. Later we can slowly change all the string fields annotated as `UID` for OpenAPI to `UID` type.