### PR TITLE
feat: migrate from speedy-spotless to original spotless

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -17,10 +17,10 @@ jobs:
           distribution: temurin
 
       - name: Check formatting in core
-        run: mvn speedy-spotless:check --threads 2C --batch-mode --no-transfer-progress -q -f ./dhis-2/pom.xml
+        run: mvn spotless:check --threads 2C --batch-mode --no-transfer-progress -q -f ./dhis-2/pom.xml
 
       - name: Check formatting in web
-        run: mvn speedy-spotless:check --threads 2C --batch-mode --no-transfer-progress -q -f ./dhis-2/dhis-web/pom.xml
+        run: mvn spotless:check --threads 2C --batch-mode --no-transfer-progress -q -f ./dhis-2/dhis-web/pom.xml
 
       - name: Check formatting in e2e tests
-        run: mvn speedy-spotless:check --batch-mode --no-transfer-progress -q -f ./dhis-2/dhis-test-e2e/pom.xml
+        run: mvn spotless:check --batch-mode --no-transfer-progress -q -f ./dhis-2/dhis-test-e2e/pom.xml

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/query/NullValueAwareConditionRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/query/NullValueAwareConditionRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2004-2022, University of Oslo
+ * Copyright (c) 2004-2022, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/report/impl/DefaultReportService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/report/impl/DefaultReportService.java
@@ -44,6 +44,7 @@ import javax.sql.DataSource;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import net.sf.jasperreports.engine.JasperCompileManager;
 import net.sf.jasperreports.engine.JasperFillManager;
 import net.sf.jasperreports.engine.JasperPrint;

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/DataSourceConfig.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/DataSourceConfig.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import javax.sql.DataSource;
 
 import lombok.extern.slf4j.Slf4j;
+
 import net.ttddyy.dsproxy.listener.MethodExecutionContext;
 import net.ttddyy.dsproxy.listener.logging.DefaultQueryLogEntryCreator;
 import net.ttddyy.dsproxy.listener.logging.SLF4JLogLevel;

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/DataSourcePoolMetricsConfig.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/DataSourcePoolMetricsConfig.java
@@ -47,6 +47,7 @@ import org.springframework.context.annotation.Configuration;
 
 import com.google.common.collect.Lists;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
+
 import io.micrometer.core.instrument.MeterRegistry;
 
 /**

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/GridUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/GridUtils.java
@@ -52,6 +52,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
+
 import net.sf.jasperreports.engine.JasperCompileManager;
 import net.sf.jasperreports.engine.JasperExportManager;
 import net.sf.jasperreports.engine.JasperFillManager;

--- a/dhis-2/dhis-test-e2e/pom.xml
+++ b/dhis-2/dhis-test-e2e/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <rootDir>..</rootDir>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <speedy-spotless-maven-plugin.version>0.1.3</speedy-spotless-maven-plugin.version>
+    <spotless.version>2.36.0</spotless.version>
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
 
     <junit.version>5.9.3</junit.version>
@@ -225,35 +225,35 @@
           </configuration>
         </plugin>
         <plugin>
-          <groupId>io.committed</groupId>
-          <artifactId>speedy-spotless-maven-plugin</artifactId>
-          <version>${speedy-spotless-maven-plugin.version}</version>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>${spotless.version}</version>
           <executions>
-            <execution>
-              <id>install-formatter-hook</id>
-              <goals>
-                <goal>install-hooks</goal>
-              </goals>
-            </execution>
+              <execution>
+                  <id>install-formatter-hook</id>
+                  <goals>
+                      <goal>install-hooks</goal>
+                  </goals>
+              </execution>
           </executions>
           <configuration>
-            <java>
-              <eclipse>
-                <file>${rootDir}/DHISFormatter.xml</file>
-                <version>4.9.0</version>
-              </eclipse>
-              <trimTrailingWhitespace />
-              <removeUnusedImports />
-              <importOrder>
-                <order>
-                  java,javax,org,com
-                </order>
-              </importOrder>
-              <licenseHeader>
-                <file>${rootDir}/license-header</file>
-              </licenseHeader>
-            </java>
-            <lineEndings>UNIX</lineEndings>
+              <java>
+                  <eclipse>
+                      <file>${rootDir}/DHISFormatter.xml</file>
+                      <version>4.9</version>
+                  </eclipse>
+                  <trimTrailingWhitespace />
+                  <removeUnusedImports />
+                  <importOrder>
+                      <order>
+                          java,javax,lombok,net,org,com
+                      </order>
+                  </importOrder>
+                  <licenseHeader>
+                      <file>${rootDir}/license-header</file>
+                  </licenseHeader>
+              </java>
+              <lineEndings>UNIX</lineEndings>
           </configuration>
         </plugin>
       </plugins>

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/systemsettings/SystemSettingsTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/systemsettings/SystemSettingsTests.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.google.gson.JsonObject;
+
 import io.restassured.http.ContentType;
 
 /**

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/IdSchemeTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/IdSchemeTests.java
@@ -53,6 +53,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import com.google.gson.JsonObject;
+
 import io.restassured.path.json.JsonPath;
 
 /**

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/events/EventsTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/events/EventsTests.java
@@ -62,6 +62,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import com.google.gson.JsonObject;
+
 import io.restassured.http.ContentType;
 
 /**

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -106,6 +106,7 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import com.fasterxml.jackson.core.JsonParseException;
+
 import io.github.classgraph.ClassGraph;
 
 /**

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/interceptor/I18nInterceptor.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/interceptor/I18nInterceptor.java
@@ -31,9 +31,6 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
-import ognl.NoSuchPropertyException;
-import ognl.Ognl;
-
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.i18n.I18nFormat;
 import org.hisp.dhis.i18n.I18nManager;
@@ -42,6 +39,9 @@ import org.hisp.dhis.i18n.locale.LocaleManager;
 import com.opensymphony.xwork2.Action;
 import com.opensymphony.xwork2.ActionInvocation;
 import com.opensymphony.xwork2.interceptor.Interceptor;
+
+import ognl.NoSuchPropertyException;
+import ognl.Ognl;
 
 /**
  * @author Nguyen Dang Quang

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -215,7 +215,7 @@
     <versions-maven-plugin.version>2.15.0</versions-maven-plugin.version>
     <dependency-check-maven.version>8.2.1</dependency-check-maven.version>
     <spotbugs-maven-plugin.version>4.7.3.4</spotbugs-maven-plugin.version>
-    <speedy-spotless-maven-plugin.version>0.1.3</speedy-spotless-maven-plugin.version>
+    <spotless.version>2.36.0</spotless.version>
     <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
     <jrebel-x-maven-plugin.version>1.1.11</jrebel-x-maven-plugin.version>
     <dhis-antlr-expression-parser.version>1.0.34</dhis-antlr-expression-parser.version>
@@ -648,36 +648,35 @@
           <version>${lombok-maven-plugin.version}</version>
         </plugin>
         <plugin>
-          <!-- Note: Remove /.mvn/jvm.config when replacing speedy-spotless -->
-          <groupId>io.committed</groupId>
-          <artifactId>speedy-spotless-maven-plugin</artifactId>
-          <version>${speedy-spotless-maven-plugin.version}</version>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>${spotless.version}</version>
           <executions>
-            <execution>
-              <id>install-formatter-hook</id>
-              <goals>
-                <goal>install-hooks</goal>
-              </goals>
-            </execution>
+              <execution>
+                  <id>install-formatter-hook</id>
+                  <goals>
+                      <goal>install-hooks</goal>
+                  </goals>
+              </execution>
           </executions>
           <configuration>
-            <java>
-              <eclipse>
-                <file>${rootDir}/DHISFormatter.xml</file>
-                <version>4.9.0</version>
-              </eclipse>
-              <trimTrailingWhitespace />
-              <removeUnusedImports />
-              <importOrder>
-                <order>
-                  java,javax,org,com
-                </order>
-              </importOrder>
-              <licenseHeader>
-                <file>${rootDir}/license-header</file>
-              </licenseHeader>
-            </java>
-            <lineEndings>UNIX</lineEndings>
+              <java>
+                  <eclipse>
+                      <file>${rootDir}/DHISFormatter.xml</file>
+                      <version>4.9</version>
+                  </eclipse>
+                  <trimTrailingWhitespace />
+                  <removeUnusedImports />
+                  <importOrder>
+                      <order>
+                          java,javax,lombok,net,org,com
+                      </order>
+                  </importOrder>
+                  <licenseHeader>
+                      <file>${rootDir}/license-header</file>
+                  </licenseHeader>
+              </java>
+              <lineEndings>UNIX</lineEndings>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
### Summary
* Migrate away from the deprecated speedy-spotless Maven plugin to the active spotless plugin.
* Import order is very slightly changed, affects about 9 .java files, affects non defined root package names. 

Deprecated: https://github.com/commitd/speedy-spotless
Active: https://github.com/diffplug/spotless