### PR TITLE
fix: add READ access validation for all references in MetadataImportService [DHIS2-11811]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -254,7 +254,7 @@ public enum ErrorCode
     /* Metadata Validation (continued) */
     E4060( "Object could not be deleted: {0}" ),
     E4061(
-        "DashboardItem `{0}` object reference `{1}` with id `{2}` not found or not accessible" ),
+        "DashboardItem `{0}` object reference `{1}` with id `{2}` not found" ),
     E4062( "Start date or end date have to be specified when date period type is set to ABSOLUTE for item `{0}`" ),
     E4063( "Assigned users cannot be empty when assigned user mode is set to PROVIDED" ),
     E4064( "Organisation unit cannot be empty with `{0}` org unit mode" ),
@@ -262,6 +262,8 @@ public enum ErrorCode
     E4066( "No data element found for item: `{0}`" ),
     E4067( "Attribute UID is missing in filter" ),
     E4068( "No tracked entity attribute found for attribute: `{0}`" ),
+    E4069(
+        "DashboardItem `{0}` object reference `{1}` with id `{2}` not accessible" ),
 
     /* SQL views */
     E4300( "SQL query is null" ),
@@ -290,6 +292,7 @@ public enum ErrorCode
     E5005( "Properties `{0}` in objects `{1}` must be unique within the payload" ),
     E5006( "Non-owner reference {0} on object {1} for association `{2}` disallowed for payload for ERRORS_NOT_OWNER" ),
     E5007( "Duplicate reference {0} on object {1} for association `{2}`" ),
+    E5008( "READ access is required for reference {0} on object {1} for association `{2}`" ),
 
     /* Metadata import */
     E6000( "Program `{0}` has more than one Enrollment" ),

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
@@ -157,6 +157,7 @@ public class DefaultPreheatService implements PreheatService
                     {
                         Query query = Query.from( schemaService.getDynamicSchema( klass ) );
                         query.setUser( preheat.getUser() );
+                        query.setSkipSharing( true );
                         query.add( Restrictions.in( "id", ids ) );
                         List<? extends IdentifiableObject> objects = queryService.query( query );
                         preheat.put( PreheatIdentifier.UID, objects );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaCriteriaQueryEngine.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaCriteriaQueryEngine.java
@@ -121,11 +121,12 @@ public class JpaCriteriaQueryEngine<T extends IdentifiableObject>
         if ( query.isEmpty() )
         {
             Predicate predicate = builder.conjunction();
-
-            predicate.getExpressions().addAll( store
-                .getSharingPredicates( builder, query.getUser() ).stream().map( t -> t.apply( root ) )
-                .collect( Collectors.toList() ) );
-
+            if ( !query.isSkipSharing() )
+            {
+                predicate.getExpressions().addAll( store
+                    .getSharingPredicates( builder, query.getUser() ).stream().map( t -> t.apply( root ) )
+                    .collect( Collectors.toList() ) );
+            }
             criteriaQuery.where( predicate );
 
             TypedQuery<T> typedQuery = sessionFactory.getCurrentSession().createQuery( criteriaQuery );
@@ -137,11 +138,12 @@ public class JpaCriteriaQueryEngine<T extends IdentifiableObject>
         }
 
         Predicate predicate = buildPredicates( builder, root, query );
-
-        predicate.getExpressions().addAll( store
-            .getSharingPredicates( builder, query.getUser() ).stream().map( t -> t.apply( root ) )
-            .collect( Collectors.toList() ) );
-
+        if ( !query.isSkipSharing() )
+        {
+            predicate.getExpressions().addAll( store
+                .getSharingPredicates( builder, query.getUser() ).stream().map( t -> t.apply( root ) )
+                .collect( Collectors.toList() ) );
+        }
         criteriaQuery.where( predicate );
 
         if ( !query.getOrders().isEmpty() )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Query.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Query.java
@@ -60,6 +60,8 @@ public class Query extends Criteria
 
     private boolean skipPaging;
 
+    private boolean skipSharing;
+
     private Integer firstResult = 0;
 
     private Integer maxResults = Integer.MAX_VALUE;
@@ -87,6 +89,7 @@ public class Query extends Criteria
     public static Query from( Query query )
     {
         Query clone = Query.from( query.getSchema(), query.getRootJunctionType() );
+        clone.setSkipSharing( query.isSkipSharing() );
         clone.setUser( query.getUser() );
         clone.setLocale( query.getLocale() );
         clone.addOrders( query.getOrders() );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/DefaultQueryPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/DefaultQueryPlanner.java
@@ -217,6 +217,7 @@ public class DefaultQueryPlanner implements QueryPlanner
     private Query getQuery( Query query, boolean persistedOnly )
     {
         Query pQuery = Query.from( query.getSchema(), query.getRootJunctionType() );
+        pQuery.setSkipSharing( query.isSkipSharing() );
         Iterator<Criterion> iterator = query.getCriterions().iterator();
 
         while ( iterator.hasNext() )

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
@@ -77,8 +77,8 @@ class DashboardControllerTest extends DhisControllerIntegrationTest
         JsonMixed response = PUT( "/dashboards/f1OijtLnf8a", Body( "dashboard/update_dashboard.json" ) )
             .content( HttpStatus.CONFLICT );
         assertEquals(
-            "DashboardItem `KnmKNIFiAwC` object reference `VISUALIZATION` with id `gyYXi0rXAIc` not found or not accessible",
-            response.find( JsonErrorReport.class, error -> error.getErrorCode() == ErrorCode.E4061 ).getMessage() );
+            "DashboardItem `KnmKNIFiAwC` object reference `VISUALIZATION` with id `gyYXi0rXAIc` not accessible",
+            response.find( JsonErrorReport.class, error -> error.getErrorCode() == ErrorCode.E4069 ).getMessage() );
     }
 
     @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataSetControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataSetControllerTest.java
@@ -118,9 +118,10 @@ class DataSetControllerTest extends DhisControllerConvenienceTest
         deB.setUid( "fbfJHSPpUQD" );
         manager.save( deA );
         manager.save( deB );
+        String dataSetId = "Tl0gpmhQOmr";
 
-        String dataSetId = assertStatus( HttpStatus.CREATED,
-            POST( "/dataSets/", Body( "dataset/dataset_with_compulsoryDataElementOperand.json" ) ) );
+        assertStatus( HttpStatus.OK,
+            POST( "/metadata/", Body( "dataset/dataset_with_compulsoryDataElementOperand.json" ) ) );
 
         DataSet dataSet = manager.get( DataSet.class, dataSetId );
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportIntegrationTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.metadata;
+
+import static org.hisp.dhis.web.WebClient.Body;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.web.HttpStatus;
+import org.hisp.dhis.webapi.DhisControllerIntegrationTest;
+import org.hisp.dhis.webapi.json.domain.JsonErrorReport;
+import org.hisp.dhis.webapi.json.domain.JsonImportSummary;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MetadataImportIntegrationTest extends DhisControllerIntegrationTest
+{
+    @Test
+    @DisplayName( "Should return error when import program with inaccessible programStage" )
+    void testImportInaccessibleReference()
+    {
+        JsonImportSummary response = POST( "/metadata",
+            Body( "metadata/test_user.json" ) ).content( HttpStatus.OK ).as( JsonImportSummary.class );
+        User user = userService.getUser( "HvbPAQEyXSD" );
+        assertNotNull( user );
+        switchContextToUser( user );
+        response = POST( "/metadata",
+            Body( "metadata/program_with_inaccessible_programStage.json" ) ).content( HttpStatus.CONFLICT )
+            .as( JsonImportSummary.class );
+        JsonErrorReport errorReport = response.find( JsonErrorReport.class,
+            error -> error.getErrorCode() == ErrorCode.E5008 );
+        assertNotNull( errorReport );
+        assertEquals(
+            "READ access is required for reference [LloQNgtkrbt] (ProgramStage) on object test [SkV0iNXNJ2S] (Program) for association `programStage`",
+            errorReport.getMessage() );
+    }
+
+    @Test
+    @DisplayName( "Should return error when import program with inaccessible DataElement which is referenced by a ProgramStageDataElement" )
+    void testImportInaccessibleEmbeddedReference()
+    {
+        POST( "/metadata",
+            Body( "metadata/test_user.json" ) ).content( HttpStatus.OK ).as( JsonImportSummary.class );
+        User user = userService.getUser( "HvbPAQEyXSD" );
+        assertNotNull( user );
+        switchContextToUser( user );
+        JsonImportSummary response = POST( "/metadata",
+            Body( "metadata/program_with_inaccessible_dataelement.json" ) ).content( HttpStatus.CONFLICT )
+            .as( JsonImportSummary.class );
+        JsonErrorReport errorReport = response.find( JsonErrorReport.class,
+            error -> error.getErrorCode() == ErrorCode.E5008 );
+        assertNotNull( errorReport );
+        assertEquals(
+            "READ access is required for reference [rFQNCGMYud2] (DataElement) on object [m69ZMmIJctI] (ProgramStageDataElement) for association `dataElement`",
+            errorReport.getMessage() );
+    }
+
+    @Test
+    @DisplayName( "Should return error when update Program with non-writable ProgramStage" )
+    void testUpdateInaccessibleReference()
+    {
+        JsonImportSummary response = POST( "/metadata",
+            Body( "metadata/test_user.json" ) ).content( HttpStatus.OK ).as( JsonImportSummary.class );
+        User user = userService.getUser( "HvbPAQEyXSD" );
+        assertNotNull( user );
+        switchContextToUser( user );
+        POST( "/metadata",
+            Body( "metadata/program_with_readable_programStage.json" ) ).content( HttpStatus.OK )
+            .as( JsonImportSummary.class );
+
+        response = POST( "/metadata",
+            Body( "metadata/update_program_with_non_writtable_programStage.json" ) ).content( HttpStatus.CONFLICT )
+            .as( JsonImportSummary.class );
+
+        JsonErrorReport errorReport = response.find( JsonErrorReport.class,
+            error -> error.getErrorCode() == ErrorCode.E3001 );
+        assertNotNull( errorReport );
+        assertEquals(
+            "User `test User testuser [HvbPAQEyXSD] (User)` is not allowed to update object `test [LloQNgtkrbt] (ProgramStage)`",
+            errorReport.getMessage() );
+    }
+}

--- a/dhis-2/dhis-test-web-api/src/test/resources/dataset/dataset_with_compulsoryDataElementOperand.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/dataset/dataset_with_compulsoryDataElementOperand.json
@@ -1,54 +1,180 @@
 {
-  "validCompleteOnly": false,
-  "skipOffline": false,
-  "compulsoryFieldsCompleteOnly": false,
-  "id": "Tl0gpmhQOmr",
-  "sharing": {
-    "external": false,
-    "users": {},
-    "userGroups": {},
-    "public": "rw------"
-  },
-  "timelyDays": 15,
-  "name": "test1",
-  "shortName": "test1",
-  "dataElementDecoration": false,
-  "notifyCompletingUser": false,
-  "noValueRequiresComment": false,
-  "fieldCombinationRequired": false,
-  "renderHorizontally": false,
-  "renderAsTabs": false,
-  "mobile": false,
-  "openPeriodsAfterCoEndDate": 0,
-  "periodType": "Monthly",
-  "openFuturePeriods": 0,
-  "expiryDays": 0,
-  "categoryCombo": {
-    "id": "bjDvmb4bfuf"
-  },
-  "lastUpdatedBy": {
-    "id": "GOLswS44mh8"
-  },
-  "dataSetElements": [
+  "categories": [
     {
-      "dataElement": {
-        "id": "cYeuwXTCPkU"
-      }
+      "lastUpdated": "2016-03-17T01:53:56.098+0000",
+      "code": "Gender",
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "dataDimensionType": "DISAGGREGATION",
+      "userGroupAccesses": [],
+      "id": "XFgfIO1qQmd",
+      "name": "Gender",
+      "shortName": "Gender",
+      "created": "2016-03-17T01:53:56.097+0000",
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "categoryOptions": [
+        {
+          "id": "DRs8ZFxNOpW"
+        },
+        {
+          "id": "x3Owjhq9G7K"
+        }
+      ],
+      "dataDimension": true
+    }
+  ],
+  "categoryOptions": [
+    {
+      "userGroupAccesses": [ ],
+      "id": "DRs8ZFxNOpW",
+      "name": "Female",
+      "created": "2016-03-17T01:53:41.459+0000",
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "shortName": "Female",
+      "attributeValues": [ ],
+      "lastUpdated": "2016-03-17T01:53:41.461+0000",
+      "code": "Female",
+      "sharing" : {
+        "public": "rw------",
+        "external": false
+      },
+      "organisationUnits": [ ]
     },
     {
-      "dataElement": {
-        "id": "fbfJHSPpUQD"
+      "code": "Male",
+      "lastUpdated": "2016-03-17T01:53:34.526+0000",
+      "organisationUnits": [ ],
+      "sharing" : {
+        "public": "rw------",
+        "external": false
+      },
+      "name": "Male",
+      "created": "2016-03-17T01:53:34.525+0000",
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "id": "x3Owjhq9G7K",
+      "userGroupAccesses": [ ],
+      "attributeValues": [ ],
+      "shortName": "Male"
+    }
+  ],
+  "categoryOptionCombos": [
+    {
+      "categoryCombo": {
+        "id": "v7n8H4aj8Cg"
+      },
+      "categoryOptions": [
+        {
+          "id": "DRs8ZFxNOpW"
+        }
+      ],
+      "name": "Female",
+      "created": "2016-03-17T01:54:04.952+0000",
+      "lastUpdated": "2016-03-17T01:54:04.952+0000",
+      "ignoreApproval": false,
+      "id": "c8yQa2ZIqhL"
+    },
+    {
+      "name": "Male",
+      "created": "2016-03-17T01:54:04.954+0000",
+      "lastUpdated": "2016-03-17T01:54:04.954+0000",
+      "ignoreApproval": false,
+      "id": "O9ZA0CUVVmL",
+      "categoryOptions": [
+        {
+          "id": "x3Owjhq9G7K"
+        }
+      ],
+      "categoryCombo": {
+        "id": "v7n8H4aj8Cg"
       }
     }
   ],
-  "compulsoryDataElementOperands": [
+  "categoryCombos": [
     {
-      "dataElement": {
-        "id": "fbfJHSPpUQD"
+      "sharing" : {
+        "public": "rw------",
+        "external": false
       },
-      "categoryOptionCombo": {
-        "id": "pq2XI5kz2BY"
+      "lastUpdated": "2016-03-17T01:54:04.956+0000",
+      "code": "Gender",
+      "skipTotal": false,
+      "id": "v7n8H4aj8Cg",
+      "categories": [
+        {
+          "id": "XFgfIO1qQmd"
+        }
+      ],
+      "userGroupAccesses": [ ],
+      "created": "2016-03-17T01:54:04.875+0000",
+      "name": "Gender",
+      "dataDimensionType": "DISAGGREGATION",
+      "user": {
+        "id": "M5zQapPyTZI"
       }
     }
-  ]
+  ],
+  "dataSets": [
+    {
+      "validCompleteOnly": false,
+      "skipOffline": false,
+      "compulsoryFieldsCompleteOnly": false,
+      "id": "Tl0gpmhQOmr",
+      "sharing": {
+        "external": false,
+        "users": {},
+        "userGroups": {},
+        "public": "rw------"
+      },
+      "timelyDays": 15,
+      "name": "test1",
+      "shortName": "test1",
+      "dataElementDecoration": false,
+      "notifyCompletingUser": false,
+      "noValueRequiresComment": false,
+      "fieldCombinationRequired": false,
+      "renderHorizontally": false,
+      "renderAsTabs": false,
+      "mobile": false,
+      "openPeriodsAfterCoEndDate": 0,
+      "periodType": "Monthly",
+      "openFuturePeriods": 0,
+      "expiryDays": 0,
+      "categoryCombo": {
+        "id": "bjDvmb4bfuf"
+      },
+      "lastUpdatedBy": {
+        "id": "GOLswS44mh8"
+      },
+      "dataSetElements": [
+        {
+          "dataElement": {
+            "id": "cYeuwXTCPkU"
+          }
+        },
+        {
+          "dataElement": {
+            "id": "fbfJHSPpUQD"
+          }
+        }
+      ],
+      "compulsoryDataElementOperands": [
+        {
+          "dataElement": {
+            "id": "fbfJHSPpUQD"
+          },
+          "categoryOptionCombo": {
+            "id": "c8yQa2ZIqhL"
+          }
+        }
+      ]
+    }
+    ]
 }

--- a/dhis-2/dhis-test-web-api/src/test/resources/dataset/dataset_with_compulsoryDataElementOperand_update.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/dataset/dataset_with_compulsoryDataElementOperand_update.json
@@ -42,7 +42,7 @@
         "id": "fbfJHSPpUQD"
       },
       "categoryOptionCombo": {
-        "id": "pq2XI5kz2BY"
+        "id": "c8yQa2ZIqhL"
       }
     }
   ]

--- a/dhis-2/dhis-test-web-api/src/test/resources/metadata/program_with_inaccessible_dataelement.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/metadata/program_with_inaccessible_dataelement.json
@@ -1,0 +1,413 @@
+{
+  "categories": [
+    {
+      "code": "default",
+      "name": "default",
+      "created": "2012-11-21T12:15:18.537",
+      "lastUpdated": "2023-05-18T15:04:00.104",
+      "translations": [],
+      "sharing": {
+        "owner": "M5zQapPyTZI",
+        "external": false,
+        "users": {},
+        "userGroups": {},
+        "public": "rw------"
+      },
+      "shortName": "default",
+      "dataDimensionType": "DISAGGREGATION",
+      "dataDimension": false,
+      "categoryOptions": [
+        {
+          "id": "xYerKDKCefk"
+        }
+      ],
+      "id": "GLevLNI9wkl",
+      "attributeValues": []
+    }
+  ],
+  "categoryCombos": [
+    {
+      "code": "default",
+      "name": "default",
+      "created": "2011-12-24T12:24:25.203",
+      "lastUpdated": "2016-04-12T20:37:49.126",
+      "translations": [],
+      "sharing": {
+        "external": false,
+        "users": {},
+        "userGroups": {},
+        "public": "rw------"
+      },
+      "categories": [
+        {
+          "id": "GLevLNI9wkl"
+        }
+      ],
+      "dataDimensionType": "DISAGGREGATION",
+      "skipTotal": false,
+      "id": "bjDvmb4bfuf"
+    }
+  ],
+  "programs": [
+    {
+      "name": "test",
+      "created": "2023-05-18T15:24:15.623",
+      "lastUpdated": "2023-05-18T15:24:15.623",
+      "translations": [],
+      "createdBy": {
+        "id": "M5zQapPyTZI",
+        "code": null,
+        "name": "Tom Wakiki",
+        "displayName": "Tom Wakiki",
+        "username": "system"
+      },
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI",
+        "code": null,
+        "name": "Tom Wakiki",
+        "displayName": "Tom Wakiki",
+        "username": "system"
+      },
+      "sharing": {
+        "owner": "M5zQapPyTZI",
+        "external": false,
+        "users": {},
+        "userGroups": {},
+        "public": "rw------"
+      },
+      "shortName": "test",
+      "version": 0,
+      "programType": "WITH_REGISTRATION",
+      "displayIncidentDate": true,
+      "ignoreOverdueEvents": false,
+      "onlyEnrollOnce": false,
+      "notificationTemplates": [],
+      "selectEnrollmentDatesInFuture": false,
+      "selectIncidentDatesInFuture": false,
+      "trackedEntityType": {
+        "id": "nEenWmSyUEp"
+      },
+      "categoryCombo": {
+        "id": "bjDvmb4bfuf"
+      },
+      "skipOffline": false,
+      "displayFrontPageList": false,
+      "useFirstStageDuringRegistration": false,
+      "expiryDays": 0,
+      "completeEventsExpiryDays": 0,
+      "openDaysAfterCoEndDate": 0,
+      "minAttributesRequiredToSearch": 1,
+      "maxTeiCountToReturn": 0,
+      "accessLevel": "OPEN",
+      "id": "SkV0iNXNJ2S",
+      "attributeValues": [],
+      "organisationUnits": [],
+      "programStages": [
+        {
+          "id": "LloQNgtkrbt"
+        }
+      ],
+      "programSections": [],
+      "programTrackedEntityAttributes": []
+    }
+  ],
+  "trackedEntityTypes": [
+    {
+      "name": "Person",
+      "sharing": {
+        "owner": "M5zQapPyTZI",
+        "external": false,
+        "users": {},
+        "userGroups": {},
+        "public": "rwrw----"
+      },
+      "description": "Person",
+      "trackedEntityTypeAttributes": [
+        {
+          "attributeValues": [],
+          "displayInList": true,
+          "displayName": "Person Given name",
+          "displayShortName": "null Given name",
+          "externalAccess": false,
+          "favorite": false,
+          "favorites": [],
+          "id": "hKZ9AJpnVcG",
+          "name": "Person Given name",
+          "searchable": true,
+          "trackedEntityAttribute": {
+            "id": "sB1IHYu2xQT"
+          },
+          "trackedEntityType": {
+            "id": "NdUUIOhQPcu"
+          },
+          "translations": [],
+          "userAccesses": [],
+          "userGroupAccesses": [],
+          "valueType": "TEXT"
+        }
+      ],
+      "featureType": "NONE",
+      "minAttributesRequiredToSearch": 1,
+      "maxTeiCountToReturn": 0,
+      "allowAuditLog": false,
+      "id": "nEenWmSyUEp"
+    }
+  ],
+  "trackedEntityAttributes": [
+    {
+      "id": "sB1IHYu2xQT",
+      "programScope": false,
+      "displayInListNoProgram": false,
+      "unique": false,
+      "inherit": false,
+      "confidential": false,
+      "shortName": "TrackedEntityAttributeA",
+      "displayOnVisitSchedule": false,
+      "name": "TrackedEntityAttributeA",
+      "attributeValues": [],
+      "valueType": "TEXT",
+      "aggregationType": "NONE",
+      "orgunitScope": false,
+      "sharing": {
+        "public": "rw------",
+        "external": false,
+        "owner": "M5zQapPyTZI",
+        "users": {},
+        "userGroups": {}
+      }
+    }
+  ],
+  "programStages": [
+    {
+      "name": "test",
+      "createdBy": {
+        "id": "M5zQapPyTZI",
+        "code": null,
+        "name": "Tom Wakiki",
+        "displayName": "Tom Wakiki",
+        "username": "system"
+      },
+      "sharing": {
+        "owner": "M5zQapPyTZI",
+        "external": false,
+        "users": {},
+        "userGroups": {},
+        "public": "rw------"
+      },
+      "minDaysFromStart": 0,
+      "program": {
+        "id": "SkV0iNXNJ2S"
+      },
+      "programStageDataElements": [
+        {
+          "created": "2023-05-18T15:24:15.573",
+          "lastUpdated": "2023-05-18T15:24:55.952",
+          "sharing": {
+            "external": false,
+            "users": {},
+            "userGroups": {}
+          },
+          "programStage": {
+            "id": "LloQNgtkrbt"
+          },
+          "dataElement": {
+            "id": "rFQNCGMYud2"
+          },
+          "compulsory": false,
+          "allowProvidedElsewhere": false,
+          "sortOrder": 1,
+          "displayInReports": false,
+          "allowFutureDate": false,
+          "renderOptionsAsRadio": false,
+          "skipSynchronization": false,
+          "skipAnalytics": false,
+          "access": {
+            "manage": true,
+            "externalize": true,
+            "write": true,
+            "read": true,
+            "update": true,
+            "delete": true
+          },
+          "favorite": false,
+          "id": "m69ZMmIJctI",
+          "attributeValues": []
+        },
+        {
+          "created": "2023-05-18T15:24:55.951",
+          "lastUpdated": "2023-05-18T15:24:55.951",
+          "translations": [],
+          "favorites": [],
+          "sharing": {
+            "external": false,
+            "users": {},
+            "userGroups": {}
+          },
+          "programStage": {
+            "id": "LloQNgtkrbt"
+          },
+          "dataElement": {
+            "id": "XLehuM7XIZJ"
+          },
+          "compulsory": false,
+          "allowProvidedElsewhere": false,
+          "sortOrder": 2,
+          "displayInReports": false,
+          "allowFutureDate": false,
+          "renderOptionsAsRadio": false,
+          "skipSynchronization": false,
+          "skipAnalytics": false,
+          "access": {
+            "manage": true,
+            "externalize": true,
+            "write": true,
+            "read": true,
+            "update": true,
+            "delete": true
+          },
+          "favorite": false,
+          "id": "KNgtZNJoQTL",
+          "attributeValues": []
+        }
+      ],
+      "autoGenerateEvent": true,
+      "validationStrategy": "ON_COMPLETE",
+      "displayGenerateEventBox": true,
+      "blockEntryForm": false,
+      "preGenerateUID": false,
+      "remindCompleted": false,
+      "generatedByEnrollmentDate": false,
+      "allowGenerateNextVisit": false,
+      "openAfterEnrollment": false,
+      "sortOrder": 1,
+      "hideDueDate": false,
+      "enableUserAssignment": false,
+      "referral": false,
+      "id": "LloQNgtkrbt",
+      "attributeValues": [],
+      "repeatable": false,
+      "programStageSections": [],
+      "notificationTemplates": []
+    }
+  ],
+  "dataElements": [
+    {
+      "name": "Foci malaria test",
+      "created": "2016-12-13T15:09:22.741",
+      "lastUpdated": "2019-08-21T13:08:42.349",
+      "sharing": {
+        "owner": "M5zQapPyTZI",
+        "external": false,
+        "users": {},
+        "userGroups": {},
+        "public": "--------"
+      },
+      "shortName": "Foci malaria test",
+      "description": "Number of people in foci tested for malaria",
+      "formName": "People in foci tested for malaria",
+      "legendSets": [],
+      "aggregationType": "NONE",
+      "valueType": "INTEGER_POSITIVE",
+      "domainType": "TRACKER",
+      "aggregationLevels": [],
+      "zeroIsSignificant": false,
+      "id": "rFQNCGMYud2",
+      "attributeValues": [],
+      "categoryCombo": {
+        "id": "bjDvmb4bfuf"
+      }
+    },
+    {
+      "name": "test",
+      "created": "2023-05-18T15:09:43.045",
+      "lastUpdated": "2023-05-18T15:24:30.231",
+      "translations": [],
+      "createdBy": {
+        "id": "M5zQapPyTZI",
+        "code": null,
+        "name": "Tom Wakiki",
+        "displayName": "Tom Wakiki",
+        "username": "system"
+      },
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI",
+        "code": null,
+        "name": "Tom Wakiki",
+        "displayName": "Tom Wakiki",
+        "username": "system"
+      },
+      "sharing": {
+        "owner": "M5zQapPyTZI",
+        "external": false,
+        "users": {},
+        "userGroups": {},
+        "public": "rw------"
+      },
+      "shortName": "test",
+      "legendSets": [],
+      "aggregationType": "SUM",
+      "valueType": "NUMBER",
+      "domainType": "TRACKER",
+      "aggregationLevels": [],
+      "zeroIsSignificant": false,
+      "id": "XLehuM7XIZJ",
+      "attributeValues": [],
+      "categoryCombo": {
+        "id": "bjDvmb4bfuf"
+      }
+    }
+  ],
+  "categoryOptions": [
+    {
+      "code": "default",
+      "name": "default",
+      "created": "2011-12-24T12:24:24.149",
+      "lastUpdated": "2016-04-12T20:37:48.414",
+      "translations": [
+        {
+          "locale": "en_GB",
+          "property": "NAME",
+          "value": "default"
+        }
+      ],
+      "createdBy": {
+        "id": "M5zQapPyTZI",
+        "code": null,
+        "name": "Tom Wakiki",
+        "displayName": "Tom Wakiki",
+        "username": "system"
+      },
+      "sharing": {
+        "owner": "M5zQapPyTZI",
+        "external": false,
+        "users": {},
+        "userGroups": {},
+        "public": "rwrw----"
+      },
+      "shortName": "default",
+      "organisationUnits": [],
+      "id": "xYerKDKCefk",
+      "attributeValues": []
+    }
+  ],
+  "categoryOptionCombos": [
+    {
+      "code": "default",
+      "name": "default",
+      "created": "2011-12-24T12:24:25.319",
+      "lastUpdated": "2011-12-24T12:24:25.319",
+      "translations": [],
+      "categoryCombo": {
+        "id": "bjDvmb4bfuf"
+      },
+      "categoryOptions": [
+        {
+          "id": "xYerKDKCefk"
+        }
+      ],
+      "ignoreApproval": false,
+      "id": "HllvX50cXC0",
+      "attributeValues": []
+    }
+  ]
+}

--- a/dhis-2/dhis-test-web-api/src/test/resources/metadata/program_with_inaccessible_programStage.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/metadata/program_with_inaccessible_programStage.json
@@ -1,0 +1,340 @@
+{
+  "categories":
+  [
+    {
+      "code": "default",
+      "name": "default",
+      "created": "2012-11-21T12:15:18.537",
+      "lastUpdated": "2023-05-18T15:04:00.104",
+      "translations":
+      [],
+      "sharing":
+      {
+        "owner": "M5zQapPyTZI",
+        "external": false,
+        "users":
+        {},
+        "userGroups":
+        {},
+        "public": "rw------"
+      },
+      "shortName": "default",
+      "dataDimensionType": "DISAGGREGATION",
+      "dataDimension": false,
+      "categoryOptions":
+      [
+        {
+          "id": "xYerKDKCefk"
+        }
+      ],
+      "id": "GLevLNI9wkl",
+      "attributeValues":
+      []
+    }
+  ],
+  "categoryCombos":
+  [
+    {
+      "code": "default",
+      "name": "default",
+      "created": "2011-12-24T12:24:25.203",
+      "lastUpdated": "2016-04-12T20:37:49.126",
+      "translations":
+      [],
+      "sharing":
+      {
+        "external": false,
+        "users":
+        {},
+        "userGroups":
+        {},
+        "public": "rw------"
+      },
+      "categories":
+      [
+        {
+          "id": "GLevLNI9wkl"
+        }
+      ],
+      "dataDimensionType": "DISAGGREGATION",
+      "skipTotal": false,
+      "id": "bjDvmb4bfuf"
+    }
+  ],
+  "programs":
+  [
+    {
+      "name": "test",
+      "created": "2023-05-18T15:24:15.623",
+      "lastUpdated": "2023-05-18T15:24:15.623",
+      "translations":
+      [],
+      "createdBy":
+      {
+        "id": "M5zQapPyTZI",
+        "code": null,
+        "name": "Tom Wakiki",
+        "displayName": "Tom Wakiki",
+        "username": "system"
+      },
+      "lastUpdatedBy":
+      {
+        "id": "M5zQapPyTZI",
+        "code": null,
+        "name": "Tom Wakiki",
+        "displayName": "Tom Wakiki",
+        "username": "system"
+      },
+      "sharing":
+      {
+        "owner": "M5zQapPyTZI",
+        "external": false,
+        "users":
+        {},
+        "userGroups":
+        {},
+        "public": "rw------"
+      },
+      "shortName": "test",
+      "version": 0,
+      "programType": "WITH_REGISTRATION",
+      "displayIncidentDate": true,
+      "ignoreOverdueEvents": false,
+      "onlyEnrollOnce": false,
+      "notificationTemplates":
+      [],
+      "selectEnrollmentDatesInFuture": false,
+      "selectIncidentDatesInFuture": false,
+      "trackedEntityType":
+      {
+        "id": "nEenWmSyUEp"
+      },
+      "categoryCombo":
+      {
+        "id": "bjDvmb4bfuf"
+      },
+      "skipOffline": false,
+      "displayFrontPageList": false,
+      "useFirstStageDuringRegistration": false,
+      "expiryDays": 0,
+      "completeEventsExpiryDays": 0,
+      "openDaysAfterCoEndDate": 0,
+      "minAttributesRequiredToSearch": 1,
+      "maxTeiCountToReturn": 0,
+      "accessLevel": "OPEN",
+      "id": "SkV0iNXNJ2S",
+      "attributeValues":
+      [],
+      "organisationUnits":
+      [],
+      "programStages":
+      [
+        {
+          "id": "LloQNgtkrbt"
+        }
+      ],
+      "programSections":
+      [],
+      "programTrackedEntityAttributes":
+      []
+    }
+  ],
+  "trackedEntityTypes":
+  [
+    {
+      "name": "Person",
+      "sharing":
+      {
+        "owner": "M5zQapPyTZI",
+        "external": false,
+        "users":
+        {},
+        "userGroups":
+        {},
+        "public": "rwrw----"
+      },
+      "description": "Person",
+      "trackedEntityTypeAttributes": [
+        {
+          "attributeValues": [],
+          "displayInList": true,
+          "displayName": "Person Given name",
+          "displayShortName": "null Given name",
+          "externalAccess": false,
+          "favorite": false,
+          "favorites": [],
+          "id": "hKZ9AJpnVcG",
+          "name": "Person Given name",
+          "searchable": true,
+          "trackedEntityAttribute": {
+            "id": "sB1IHYu2xQT"
+          },
+          "trackedEntityType": {
+            "id": "NdUUIOhQPcu"
+          },
+          "translations": [],
+          "userAccesses": [],
+          "userGroupAccesses": [],
+          "valueType": "TEXT"
+        }
+      ],
+      "featureType": "NONE",
+      "minAttributesRequiredToSearch": 1,
+      "maxTeiCountToReturn": 0,
+      "allowAuditLog": false,
+      "id": "nEenWmSyUEp"
+    }
+  ],
+  "trackedEntityAttributes": [
+    {
+      "id": "sB1IHYu2xQT",
+      "programScope": false,
+      "displayInListNoProgram": false,
+      "unique": false,
+      "inherit": false,
+      "confidential": false,
+      "shortName": "TrackedEntityAttributeA",
+      "displayOnVisitSchedule": false,
+      "name": "TrackedEntityAttributeA",
+      "attributeValues": [],
+      "valueType": "TEXT",
+      "aggregationType": "NONE",
+      "orgunitScope": false,
+      "sharing": {
+        "public": "rw------",
+        "external": false,
+        "owner": "M5zQapPyTZI",
+        "users": {},
+        "userGroups": {}
+      }
+    }
+  ],
+  "programStages":
+  [
+    {
+      "name": "test",
+      "created": "2023-05-18T15:24:15.573",
+      "lastUpdated": "2023-05-18T15:24:55.934",
+      "translations":
+      [],
+      "createdBy":
+      {
+        "id": "M5zQapPyTZI",
+        "code": null,
+        "name": "Tom Wakiki",
+        "displayName": "Tom Wakiki",
+        "username": "system"
+      },
+      "lastUpdatedBy":
+      {
+        "id": "M5zQapPyTZI",
+        "code": null,
+        "name": "Tom Wakiki",
+        "displayName": "Tom Wakiki",
+        "username": "system"
+      },
+      "sharing":
+      {
+        "owner": "M5zQapPyTZI",
+        "external": false,
+        "users":
+        {},
+        "userGroups":
+        {},
+        "public": "--------"
+      },
+      "minDaysFromStart": 0,
+      "program":
+      {
+        "id": "SkV0iNXNJ2S"
+      },
+      "autoGenerateEvent": true,
+      "validationStrategy": "ON_COMPLETE",
+      "displayGenerateEventBox": true,
+      "blockEntryForm": false,
+      "preGenerateUID": false,
+      "remindCompleted": false,
+      "generatedByEnrollmentDate": false,
+      "allowGenerateNextVisit": false,
+      "openAfterEnrollment": false,
+      "sortOrder": 1,
+      "hideDueDate": false,
+      "enableUserAssignment": false,
+      "referral": false,
+      "id": "LloQNgtkrbt",
+      "attributeValues":
+      [],
+      "repeatable": false,
+      "programStageSections":
+      [],
+      "notificationTemplates":
+      []
+    }
+  ],
+  "categoryOptions":
+  [
+    {
+      "code": "default",
+      "name": "default",
+      "created": "2011-12-24T12:24:24.149",
+      "lastUpdated": "2016-04-12T20:37:48.414",
+      "translations":
+      [
+        {
+          "locale": "en_GB",
+          "property": "NAME",
+          "value": "default"
+        }
+      ],
+      "createdBy":
+      {
+        "id": "M5zQapPyTZI",
+        "code": null,
+        "name": "Tom Wakiki",
+        "displayName": "Tom Wakiki",
+        "username": "system"
+      },
+      "sharing":
+      {
+        "owner": "M5zQapPyTZI",
+        "external": false,
+        "users":
+        {},
+        "userGroups":
+        {},
+        "public": "rwrw----"
+      },
+      "shortName": "default",
+      "organisationUnits":
+      [],
+      "id": "xYerKDKCefk",
+      "attributeValues":
+      []
+    }
+  ],
+  "categoryOptionCombos":
+  [
+    {
+      "code": "default",
+      "name": "default",
+      "created": "2011-12-24T12:24:25.319",
+      "lastUpdated": "2011-12-24T12:24:25.319",
+      "translations":
+      [],
+      "categoryCombo":
+      {
+        "id": "bjDvmb4bfuf"
+      },
+      "categoryOptions":
+      [
+        {
+          "id": "xYerKDKCefk"
+        }
+      ],
+      "ignoreApproval": false,
+      "id": "HllvX50cXC0",
+      "attributeValues":
+      []
+    }
+  ]
+}

--- a/dhis-2/dhis-test-web-api/src/test/resources/metadata/program_with_readable_programStage.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/metadata/program_with_readable_programStage.json
@@ -1,0 +1,316 @@
+{
+  "categories":
+  [
+    {
+      "code": "default",
+      "name": "default",
+      "created": "2012-11-21T12:15:18.537",
+      "lastUpdated": "2023-05-18T15:04:00.104",
+      "translations":
+      [],
+      "sharing":
+      {
+        "owner": "M5zQapPyTZI",
+        "external": false,
+        "users":
+        {},
+        "userGroups":
+        {},
+        "public": "rw------"
+      },
+      "shortName": "default",
+      "dataDimensionType": "DISAGGREGATION",
+      "dataDimension": false,
+      "categoryOptions":
+      [
+        {
+          "id": "xYerKDKCefk"
+        }
+      ],
+      "id": "GLevLNI9wkl",
+      "attributeValues":
+      []
+    }
+  ],
+  "categoryCombos":
+  [
+    {
+      "code": "default",
+      "name": "default",
+      "created": "2011-12-24T12:24:25.203",
+      "lastUpdated": "2016-04-12T20:37:49.126",
+      "translations":
+      [],
+      "sharing":
+      {
+        "external": false,
+        "users":
+        {},
+        "userGroups":
+        {},
+        "public": "rw------"
+      },
+      "categories":
+      [
+        {
+          "id": "GLevLNI9wkl"
+        }
+      ],
+      "dataDimensionType": "DISAGGREGATION",
+      "skipTotal": false,
+      "id": "bjDvmb4bfuf"
+    }
+  ],
+  "programs":
+  [
+    {
+      "name": "test",
+      "created": "2023-05-18T15:24:15.623",
+      "lastUpdated": "2023-05-18T15:24:15.623",
+      "translations":
+      [],
+      "createdBy":
+      {
+        "id": "M5zQapPyTZI",
+        "code": null,
+        "name": "Tom Wakiki",
+        "displayName": "Tom Wakiki",
+        "username": "system"
+      },
+      "lastUpdatedBy":
+      {
+        "id": "M5zQapPyTZI",
+        "code": null,
+        "name": "Tom Wakiki",
+        "displayName": "Tom Wakiki",
+        "username": "system"
+      },
+      "sharing":
+      {
+        "owner": "M5zQapPyTZI",
+        "external": false,
+        "users":
+        {},
+        "userGroups":
+        {},
+        "public": "rw------"
+      },
+      "shortName": "test",
+      "version": 0,
+      "programType": "WITH_REGISTRATION",
+      "displayIncidentDate": true,
+      "ignoreOverdueEvents": false,
+      "onlyEnrollOnce": false,
+      "notificationTemplates":
+      [],
+      "selectEnrollmentDatesInFuture": false,
+      "selectIncidentDatesInFuture": false,
+      "trackedEntityType":
+      {
+        "id": "nEenWmSyUEp"
+      },
+      "categoryCombo":
+      {
+        "id": "bjDvmb4bfuf"
+      },
+      "skipOffline": false,
+      "displayFrontPageList": false,
+      "useFirstStageDuringRegistration": false,
+      "expiryDays": 0,
+      "completeEventsExpiryDays": 0,
+      "openDaysAfterCoEndDate": 0,
+      "minAttributesRequiredToSearch": 1,
+      "maxTeiCountToReturn": 0,
+      "accessLevel": "OPEN",
+      "id": "SkV0iNXNJ2S",
+      "attributeValues":
+      [],
+      "organisationUnits":
+      [],
+      "programStages":
+      [
+        {
+          "id": "LloQNgtkrbt"
+        }
+      ],
+      "programSections":
+      [],
+      "programTrackedEntityAttributes":
+      []
+    }
+  ],
+  "trackedEntityTypes":
+  [
+    {
+      "name": "Person",
+      "sharing":
+      {
+        "owner": "M5zQapPyTZI",
+        "external": false,
+        "users":
+        {},
+        "userGroups":
+        {},
+        "public": "rwrw----"
+      },
+      "description": "Person",
+      "featureType": "NONE",
+      "minAttributesRequiredToSearch": 1,
+      "maxTeiCountToReturn": 0,
+      "allowAuditLog": false,
+      "id": "nEenWmSyUEp"
+    }
+  ],
+  "trackedEntityAttributes": [
+    {
+      "id": "sB1IHYu2xQT",
+      "programScope": false,
+      "displayInListNoProgram": false,
+      "unique": false,
+      "inherit": false,
+      "confidential": false,
+      "shortName": "TrackedEntityAttributeA",
+      "displayOnVisitSchedule": false,
+      "name": "TrackedEntityAttributeA",
+      "attributeValues": [],
+      "valueType": "TEXT",
+      "aggregationType": "NONE",
+      "orgunitScope": false,
+      "sharing": {
+        "public": "rw------",
+        "external": false,
+        "owner": "M5zQapPyTZI",
+        "users": {},
+        "userGroups": {}
+      }
+    }
+  ],
+  "programStages":
+  [
+    {
+      "name": "test",
+      "created": "2023-05-18T15:24:15.573",
+      "lastUpdated": "2023-05-18T15:24:55.934",
+      "translations":
+      [],
+      "createdBy":
+      {
+        "id": "M5zQapPyTZI",
+        "code": null,
+        "name": "Tom Wakiki",
+        "displayName": "Tom Wakiki",
+        "username": "system"
+      },
+      "lastUpdatedBy":
+      {
+        "id": "M5zQapPyTZI",
+        "code": null,
+        "name": "Tom Wakiki",
+        "displayName": "Tom Wakiki",
+        "username": "system"
+      },
+      "sharing":
+      {
+        "owner": "M5zQapPyTZI",
+        "external": false,
+        "users":
+        {},
+        "userGroups":
+        {},
+        "public": "r-------"
+      },
+      "minDaysFromStart": 0,
+      "program":
+      {
+        "id": "SkV0iNXNJ2S"
+      },
+      "autoGenerateEvent": true,
+      "validationStrategy": "ON_COMPLETE",
+      "displayGenerateEventBox": true,
+      "blockEntryForm": false,
+      "preGenerateUID": false,
+      "remindCompleted": false,
+      "generatedByEnrollmentDate": false,
+      "allowGenerateNextVisit": false,
+      "openAfterEnrollment": false,
+      "sortOrder": 1,
+      "hideDueDate": false,
+      "enableUserAssignment": false,
+      "referral": false,
+      "id": "LloQNgtkrbt",
+      "attributeValues":
+      [],
+      "repeatable": false,
+      "programStageSections":
+      [],
+      "notificationTemplates":
+      []
+    }
+  ],
+  "categoryOptions":
+  [
+    {
+      "code": "default",
+      "name": "default",
+      "created": "2011-12-24T12:24:24.149",
+      "lastUpdated": "2016-04-12T20:37:48.414",
+      "translations":
+      [
+        {
+          "locale": "en_GB",
+          "property": "NAME",
+          "value": "default"
+        }
+      ],
+      "createdBy":
+      {
+        "id": "M5zQapPyTZI",
+        "code": null,
+        "name": "Tom Wakiki",
+        "displayName": "Tom Wakiki",
+        "username": "system"
+      },
+      "sharing":
+      {
+        "owner": "M5zQapPyTZI",
+        "external": false,
+        "users":
+        {},
+        "userGroups":
+        {},
+        "public": "rwrw----"
+      },
+      "shortName": "default",
+      "organisationUnits":
+      [],
+      "id": "xYerKDKCefk",
+      "attributeValues":
+      []
+    }
+  ],
+  "categoryOptionCombos":
+  [
+    {
+      "code": "default",
+      "name": "default",
+      "created": "2011-12-24T12:24:25.319",
+      "lastUpdated": "2011-12-24T12:24:25.319",
+      "translations":
+      [],
+      "categoryCombo":
+      {
+        "id": "bjDvmb4bfuf"
+      },
+      "categoryOptions":
+      [
+        {
+          "id": "xYerKDKCefk"
+        }
+      ],
+      "ignoreApproval": false,
+      "id": "HllvX50cXC0",
+      "attributeValues":
+      []
+    }
+  ]
+}

--- a/dhis-2/dhis-test-web-api/src/test/resources/metadata/test_user.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/metadata/test_user.json
@@ -1,0 +1,135 @@
+{
+  "userRoles": [
+    {
+      "description": "test UserRole",
+      "name": "testUserRole",
+      "id": "yrB6vc5Ip3r",
+      "programs": [],
+      "code": "testUserRole",
+      "lastUpdated": "2016-03-17T01:51:26.775+0000",
+      "authorities": [
+        "F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS",
+        "F_USERGROUP_MANAGING_RELATIONSHIPS_ADD",
+        "F_DATAELEMENTGROUP_PUBLIC_ADD",
+        "F_USER_GROUPS_READ_ONLY_ADD_MEMBERS",
+        "F_DATAELEMENT_DELETE",
+        "F_CATEGORY_OPTION_GROUP_SET_PRIVATE_ADD",
+        "F_MAP_PUBLIC_ADD",
+        "F_CATEGORY_OPTION_GROUP_SET_DELETE",
+        "F_CATEGORY_PRIVATE_ADD",
+        "F_INDICATORGROUPSET_PUBLIC_ADD",
+        "F_USER_ADD_WITHIN_MANAGED_GROUP",
+        "F_PROGRAM_ENROLLMENT",
+        "F_CATEGORY_OPTION_PRIVATE_ADD",
+        "F_GIS_ADMIN",
+        "F_CATEGORY_OPTION_GROUP_PUBLIC_ADD",
+        "F_REPLICATE_USER",
+        "F_INSERT_CUSTOM_JS_CSS",
+        "F_DATAELEMENTGROUPSET_DELETE",
+        "F_INDICATOR_DELETE",
+        "F_INDICATORTYPE_ADD",
+        "F_VIEW_UNAPPROVED_DATA",
+        "F_INDICATOR_PUBLIC_ADD",
+        "F_INDICATORGROUP_PUBLIC_ADD",
+        "F_USERGROUP_MANAGING_RELATIONSHIPS_VIEW",
+        "F_INDICATOR_PRIVATE_ADD",
+        "F_TRACKED_ENTITY_INSTANCE_ADD",
+        "F_USERGROUP_PUBLIC_ADD",
+        "F_OAUTH2_CLIENT_MANAGE",
+        "F_PROGRAM_DASHBOARD_CONFIG_ADMIN",
+        "F_APPROVE_DATA_LOWER_LEVELS",
+        "F_CATEGORY_OPTION_PUBLIC_ADD",
+        "F_CATEGORY_OPTION_DELETE",
+        "F_CATEGORY_COMBO_PRIVATE_ADD",
+        "F_TRACKED_ENTITY_INSTANCE_DELETE",
+        "F_DATAELEMENT_PUBLIC_ADD",
+        "F_INDICATORGROUP_DELETE",
+        "F_CATEGORY_OPTION_GROUP_DELETE",
+        "F_TRACKED_ENTITY_INSTANCE_SEARCH",
+        "F_SQLVIEW_EXTERNAL",
+        "F_DATAELEMENTGROUPSET_PRIVATE_ADD",
+        "F_CATEGORY_COMBO_DELETE",
+        "F_CATEGORY_OPTION_GROUP_PRIVATE_ADD",
+        "F_DASHBOARD_PUBLIC_ADD",
+        "F_METADATA_IMPORT",
+        "F_INDICATORGROUPSET_PRIVATE_ADD",
+        "F_CATEGORY_PUBLIC_ADD",
+        "F_VISUALIZATION_PUBLIC_ADD",
+        "F_EVENT_VISUALIZATION_PUBLIC_ADD",
+        "F_EVENT_VISUALIZATION_EXTERNAL",
+        "F_CATEGORY_COMBO_PUBLIC_ADD",
+        "F_VISUALIZATION_EXTERNAL",
+        "F_METADATA_EXPORT",
+        "F_PROGRAM_UNENROLLMENT",
+        "F_DATAELEMENTGROUP_PRIVATE_ADD",
+        "F_INDICATORGROUPSET_DELETE",
+        "F_APPROVE_DATA",
+        "F_ACCEPT_DATA_LOWER_LEVELS",
+        "F_CATEGORY_DELETE",
+        "F_TRACKED_ENTITY_DATAVALUE_ADD",
+        "F_INDICATORTYPE_DELETE",
+        "F_CATEGORY_OPTION_GROUP_SET_PUBLIC_ADD",
+        "F_MAP_EXTERNAL",
+        "F_INDICATORGROUP_PRIVATE_ADD",
+        "F_DATAELEMENT_PRIVATE_ADD",
+        "F_TRACKED_ENTITY_DATAVALUE_DELETE",
+        "F_DATAELEMENTGROUP_DELETE",
+        "F_DATAELEMENTGROUPSET_PUBLIC_ADD",
+        "F_PROGRAM_PUBLIC_ADD",
+        "F_TRACKED_ENTITY_ATTRIBUTE_PUBLIC_ADD"
+      ],
+      "dataSets": [],
+      "sharing": {
+        "public": "--------"
+      }
+    }
+  ],
+  "users": [
+    {
+      "firstName": "test User",
+      "userRoles": [
+        {
+          "id": "yrB6vc5Ip3r"
+        }
+      ],
+      "selfRegistered": false,
+      "externalAuth": false,
+      "invitation": false,
+      "catDimensionConstraints": [],
+      "cogsDimensionConstraints": [],
+      "passwordLastUpdated": "2016-03-17T01:51:26.795+0000",
+      "username": "testuser",
+      "disabled": false,
+      "lastLogin": "2016-03-17T01:51:26.794+0000",
+      "organisationUnits": [
+        {
+          "id": "uyHni0GvBpD"
+        }
+      ],
+      "lastUpdated": "2016-03-17T01:51:26.764+0000",
+      "code": "testuser",
+      "teiSearchOrganisationUnits": [],
+      "attributeValues": [],
+      "id": "HvbPAQEyXSD",
+      "surname": "testuser",
+      "dataViewOrganisationUnits": [],
+      "created": "2016-03-17T01:51:26.764+0000"
+    }
+  ],
+  "organisationUnits": [
+    {
+      "path": "/uyHni0GvBpD",
+      "featureType": "NONE",
+      "uuid": "eb380b08-6cc6-4aca-9b67-e1247e02db33",
+      "shortName": "Country",
+      "attributeValues": [ ],
+      "openingDate": "2016-03-17",
+      "id": "uyHni0GvBpD",
+      "description": "",
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "name": "Country"
+    }
+  ]
+}

--- a/dhis-2/dhis-test-web-api/src/test/resources/metadata/update_program_with_non_writtable_programStage.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/metadata/update_program_with_non_writtable_programStage.json
@@ -1,0 +1,142 @@
+{
+  "programs":
+  [
+    {
+      "name": "test",
+      "created": "2023-05-18T15:24:15.623",
+      "lastUpdated": "2023-05-18T15:24:15.623",
+      "translations":
+      [],
+      "createdBy":
+      {
+        "id": "M5zQapPyTZI",
+        "code": null,
+        "name": "Tom Wakiki",
+        "displayName": "Tom Wakiki",
+        "username": "system"
+      },
+      "lastUpdatedBy":
+      {
+        "id": "M5zQapPyTZI",
+        "code": null,
+        "name": "Tom Wakiki",
+        "displayName": "Tom Wakiki",
+        "username": "system"
+      },
+      "sharing":
+      {
+        "owner": "M5zQapPyTZI",
+        "external": false,
+        "users":
+        {},
+        "userGroups":
+        {},
+        "public": "rw------"
+      },
+      "shortName": "test",
+      "version": 0,
+      "programType": "WITH_REGISTRATION",
+      "displayIncidentDate": true,
+      "ignoreOverdueEvents": false,
+      "onlyEnrollOnce": false,
+      "notificationTemplates":
+      [],
+      "selectEnrollmentDatesInFuture": false,
+      "selectIncidentDatesInFuture": false,
+      "trackedEntityType":
+      {
+        "id": "nEenWmSyUEp"
+      },
+      "categoryCombo":
+      {
+        "id": "bjDvmb4bfuf"
+      },
+      "skipOffline": false,
+      "displayFrontPageList": false,
+      "useFirstStageDuringRegistration": false,
+      "expiryDays": 0,
+      "completeEventsExpiryDays": 0,
+      "openDaysAfterCoEndDate": 0,
+      "minAttributesRequiredToSearch": 1,
+      "maxTeiCountToReturn": 0,
+      "accessLevel": "OPEN",
+      "id": "SkV0iNXNJ2S",
+      "attributeValues":
+      [],
+      "organisationUnits":
+      [],
+      "programStages":
+      [
+        {
+          "id": "LloQNgtkrbt"
+        }
+      ],
+      "programSections":
+      [],
+      "programTrackedEntityAttributes":
+      []
+    }
+  ],
+  "programStages":
+  [
+    {
+      "name": "test",
+      "created": "2023-05-18T15:24:15.573",
+      "lastUpdated": "2023-05-18T15:24:55.934",
+      "translations":
+      [],
+      "createdBy":
+      {
+        "id": "M5zQapPyTZI",
+        "code": null,
+        "name": "Tom Wakiki",
+        "displayName": "Tom Wakiki",
+        "username": "system"
+      },
+      "lastUpdatedBy":
+      {
+        "id": "M5zQapPyTZI",
+        "code": null,
+        "name": "Tom Wakiki",
+        "displayName": "Tom Wakiki",
+        "username": "system"
+      },
+      "sharing":
+      {
+        "owner": "M5zQapPyTZI",
+        "external": false,
+        "users":
+        {},
+        "userGroups":
+        {},
+        "public": "rw------"
+      },
+      "minDaysFromStart": 0,
+      "program":
+      {
+        "id": "SkV0iNXNJ2S"
+      },
+      "autoGenerateEvent": true,
+      "validationStrategy": "ON_COMPLETE",
+      "displayGenerateEventBox": true,
+      "blockEntryForm": false,
+      "preGenerateUID": false,
+      "remindCompleted": false,
+      "generatedByEnrollmentDate": false,
+      "allowGenerateNextVisit": false,
+      "openAfterEnrollment": false,
+      "sortOrder": 1,
+      "hideDueDate": false,
+      "enableUserAssignment": false,
+      "referral": false,
+      "id": "LloQNgtkrbt",
+      "attributeValues":
+      [],
+      "repeatable": false,
+      "programStageSections":
+      [],
+      "notificationTemplates":
+      []
+    }
+  ]
+}


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-11811
#### Summary
- User tries to import a metadata payload with some objects that have inaccessible references. For example: a `Program` with an inaccessible `DataElement` and this `DataElement` exists in database.
- 500 Error with message`duplicate key value violates unique constraint` is thrown for the **inaccessible reference objects** which already exist in database.

### Issue
- Currently the Preheat query applies a `METADATA_READ` sharing check for all importing objects and their references. Hence, inaccessible objects won’t be available in the Preheat map in later steps of the importing process.
- There is `ReferenceCheck` which validates if a reference object exists, but it relies on the Preheat map. In order words, error `invalid reference` will be returned if the User doesn’t have `METADATA_READ` access. However, that error is bypassed if the reference object is included in the importing payload. In this case, the import service considers the reference object doesn’t exist in the database and will try to import it. This leads to a `duplicate key value violates unique constraint` error as the object actually exists, just not accessible for currentUser.

### Fix
- Add a `skipSharing=true` flag to Preheat query. So the PreheatMap will contains all importing objects.
- In `ReferenceCheck` add additional logics to check if current User has `METADATA_READ` access to all reference objects.   Including references of `EmbeddedObject`.

### Test
- Added a new test class `MetadataImportIntegrationTest`
- Manual test can be done using same test data in `MetadataImportIntegrationTest`