### PR TITLE
chore: upgrade eclipse formatter to 4.27

### DIFF
--- a/dhis-2/DHISFormatter.xml
+++ b/dhis-2/DHISFormatter.xml
@@ -93,8 +93,8 @@
 <setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/calendar/ChronologyBasedCalendar.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/calendar/ChronologyBasedCalendar.java
@@ -88,14 +88,14 @@ public abstract class ChronologyBasedCalendar extends AbstractCalendar
     {
         switch ( type )
         {
-        case ISO8601_YEAR:
-            return toYearIsoInterval( dateTimeUnit, offset, length );
-        case ISO8601_MONTH:
-            return toMonthIsoInterval( dateTimeUnit, offset, length );
-        case ISO8601_WEEK:
-            return toWeekIsoInterval( dateTimeUnit, offset, length );
-        case ISO8601_DAY:
-            return toDayIsoInterval( dateTimeUnit, offset, length );
+            case ISO8601_YEAR:
+                return toYearIsoInterval( dateTimeUnit, offset, length );
+            case ISO8601_MONTH:
+                return toMonthIsoInterval( dateTimeUnit, offset, length );
+            case ISO8601_WEEK:
+                return toWeekIsoInterval( dateTimeUnit, offset, length );
+            case ISO8601_DAY:
+                return toDayIsoInterval( dateTimeUnit, offset, length );
         }
 
         return null;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/calendar/impl/NepaliCalendar.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/calendar/impl/NepaliCalendar.java
@@ -114,14 +114,14 @@ public class NepaliCalendar extends AbstractCalendar
     {
         switch ( type )
         {
-        case ISO8601_YEAR:
-            return toYearIsoInterval( dateTimeUnit, offset, length );
-        case ISO8601_MONTH:
-            return toMonthIsoInterval( dateTimeUnit, offset, length );
-        case ISO8601_WEEK:
-            return toWeekIsoInterval( dateTimeUnit, offset, length );
-        case ISO8601_DAY:
-            return toDayIsoInterval( dateTimeUnit, offset, length );
+            case ISO8601_YEAR:
+                return toYearIsoInterval( dateTimeUnit, offset, length );
+            case ISO8601_MONTH:
+                return toMonthIsoInterval( dateTimeUnit, offset, length );
+            case ISO8601_WEEK:
+                return toWeekIsoInterval( dateTimeUnit, offset, length );
+            case ISO8601_DAY:
+                return toDayIsoInterval( dateTimeUnit, offset, length );
         }
 
         return null;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/calendar/impl/PersianCalendar.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/calendar/impl/PersianCalendar.java
@@ -144,16 +144,16 @@ public class PersianCalendar extends AbstractCalendar
     {
         switch ( type )
         {
-        case ISO8601_YEAR:
-            return toYearIsoInterval( dateTimeUnit, offset, length );
-        case ISO8601_MONTH:
-            return toMonthIsoInterval( dateTimeUnit, offset, length );
-        case ISO8601_WEEK:
-            return toWeekIsoInterval( dateTimeUnit, offset, length );
-        case ISO8601_DAY:
-            return toDayIsoInterval( dateTimeUnit, offset, length );
-        default:
-            return null;
+            case ISO8601_YEAR:
+                return toYearIsoInterval( dateTimeUnit, offset, length );
+            case ISO8601_MONTH:
+                return toMonthIsoInterval( dateTimeUnit, offset, length );
+            case ISO8601_WEEK:
+                return toWeekIsoInterval( dateTimeUnit, offset, length );
+            case ISO8601_DAY:
+                return toDayIsoInterval( dateTimeUnit, offset, length );
+            default:
+                return null;
         }
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
@@ -772,11 +772,11 @@ public abstract class BaseAnalyticalObject
     {
         return getDimensionFromEmbeddedObjects( dimension, DimensionType.DATA_ELEMENT_GROUP_SET,
             dataElementGroupSetDimensions )
-                .or( () -> getDimensionFromEmbeddedObjects( dimension, DimensionType.ORGANISATION_UNIT_GROUP_SET,
-                    organisationUnitGroupSetDimensions ) )
-                .or( () -> getDimensionFromEmbeddedObjects( dimension, DimensionType.CATEGORY, categoryDimensions ) )
-                .or( () -> getDimensionFromEmbeddedObjects( dimension, DimensionType.CATEGORY_OPTION_GROUP_SET,
-                    categoryOptionGroupSetDimensions ) );
+            .or( () -> getDimensionFromEmbeddedObjects( dimension, DimensionType.ORGANISATION_UNIT_GROUP_SET,
+                organisationUnitGroupSetDimensions ) )
+            .or( () -> getDimensionFromEmbeddedObjects( dimension, DimensionType.CATEGORY, categoryDimensions ) )
+            .or( () -> getDimensionFromEmbeddedObjects( dimension, DimensionType.CATEGORY_OPTION_GROUP_SET,
+                categoryOptionGroupSetDimensions ) );
     }
 
     private Optional<DimensionalObject> getTrackedEntityDimension( String dimension )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalItemId.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalItemId.java
@@ -163,13 +163,13 @@ public class DimensionalItemId
     {
         return switch ( dimensionItemType )
         {
-            case DATA_ELEMENT, INDICATOR, PROGRAM_INDICATOR -> id0 != null && id1 == null && id2 == null;
-            case DATA_ELEMENT_OPERAND -> id0 != null && (id1 != null || id2 != null);
-            case REPORTING_RATE -> id0 != null && id1 != null && id2 == null
-                && isValidEnum( ReportingRateMetric.class, id1 );
-            case PROGRAM_DATA_ELEMENT, PROGRAM_ATTRIBUTE -> id0 != null && id1 != null && id2 == null;
-            case SUBEXPRESSION_DIMENSION_ITEM -> subexSql != null && !subexItemIds.isEmpty();
-            default -> false;
+        case DATA_ELEMENT, INDICATOR, PROGRAM_INDICATOR -> id0 != null && id1 == null && id2 == null;
+        case DATA_ELEMENT_OPERAND -> id0 != null && (id1 != null || id2 != null);
+        case REPORTING_RATE -> id0 != null && id1 != null && id2 == null
+            && isValidEnum( ReportingRateMetric.class, id1 );
+        case PROGRAM_DATA_ELEMENT, PROGRAM_ATTRIBUTE -> id0 != null && id1 != null && id2 == null;
+        case SUBEXPRESSION_DIMENSION_ITEM -> subexSql != null && !subexItemIds.isEmpty();
+        default -> false;
         };
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalItemId.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalItemId.java
@@ -163,13 +163,13 @@ public class DimensionalItemId
     {
         return switch ( dimensionItemType )
         {
-        case DATA_ELEMENT, INDICATOR, PROGRAM_INDICATOR -> id0 != null && id1 == null && id2 == null;
-        case DATA_ELEMENT_OPERAND -> id0 != null && (id1 != null || id2 != null);
-        case REPORTING_RATE -> id0 != null && id1 != null && id2 == null
-            && isValidEnum( ReportingRateMetric.class, id1 );
-        case PROGRAM_DATA_ELEMENT, PROGRAM_ATTRIBUTE -> id0 != null && id1 != null && id2 == null;
-        case SUBEXPRESSION_DIMENSION_ITEM -> subexSql != null && !subexItemIds.isEmpty();
-        default -> false;
+            case DATA_ELEMENT, INDICATOR, PROGRAM_INDICATOR -> id0 != null && id1 == null && id2 == null;
+            case DATA_ELEMENT_OPERAND -> id0 != null && (id1 != null || id2 != null);
+            case REPORTING_RATE -> id0 != null && id1 != null && id2 == null
+                && isValidEnum( ReportingRateMetric.class, id1 );
+            case PROGRAM_DATA_ELEMENT, PROGRAM_ATTRIBUTE -> id0 != null && id1 != null && id2 == null;
+            case SUBEXPRESSION_DIMENSION_ITEM -> subexSql != null && !subexItemIds.isEmpty();
+            default -> false;
         };
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/MetadataItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/MetadataItem.java
@@ -249,37 +249,39 @@ public class MetadataItem
         }
         else if ( dimensionalItemObject instanceof DataDimensionItem dataDimensionItem )
         {
-            if( dataDimensionItem.hasDataElement() )
+            if ( dataDimensionItem.hasDataElement() )
             {
                 return dataDimensionItem.getDataElement().getStyle();
             }
 
-            if( dataDimensionItem.hasIndicator() )
+            if ( dataDimensionItem.hasIndicator() )
             {
                 return dataDimensionItem.getIndicator().getStyle();
             }
 
-            if( dataDimensionItem.hasDataElementOperand() && dataDimensionItem.getDataElementOperand().getDataElement() != null )
+            if ( dataDimensionItem.hasDataElementOperand()
+                && dataDimensionItem.getDataElementOperand().getDataElement() != null )
             {
                 return dataDimensionItem.getDataElementOperand().getDataElement().getStyle();
             }
 
-            if( dataDimensionItem.hasProgramIndicator() )
+            if ( dataDimensionItem.hasProgramIndicator() )
             {
                 return dataDimensionItem.getProgramIndicator().getStyle();
             }
 
-            if( dataDimensionItem.hasReportingRate() && dataDimensionItem.getReportingRate().getDataSet() != null )
+            if ( dataDimensionItem.hasReportingRate() && dataDimensionItem.getReportingRate().getDataSet() != null )
             {
                 return dataDimensionItem.getReportingRate().getDataSet().getStyle();
             }
 
-            if( dataDimensionItem.hasProgramTrackedEntityAttributeDimensionItem() && dataDimensionItem.getProgramAttribute().getAttribute() != null )
+            if ( dataDimensionItem.hasProgramTrackedEntityAttributeDimensionItem()
+                && dataDimensionItem.getProgramAttribute().getAttribute() != null )
             {
                 return dataDimensionItem.getProgramAttribute().getAttribute().getStyle();
             }
         }
-        else if ( dimensionalItemObject instanceof  ReportingRate reportingRate && reportingRate.getDataSet() != null )
+        else if ( dimensionalItemObject instanceof ReportingRate reportingRate && reportingRate.getDataSet() != null )
         {
             return reportingRate.getDataSet().getStyle();
         }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Objects.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Objects.java
@@ -92,6 +92,7 @@ public enum Objects
     TRACKEDENTITYINSTANCE( "trackedEntityInstance", TrackedEntity.class ),
     TRACKEDENTITYATTRIBUTE( "trackedEntityAttribute", TrackedEntityAttribute.class ),
     EXPRESSIONDIMENSIONITEM( "expressionDimensionItem", ExpressionDimensionItem.class );
+
     private String value;
 
     private Class<?> clazz;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
@@ -300,25 +300,25 @@ public enum ValueType
     {
         switch ( type )
         {
-        case Types.INTEGER:
-            return ValueType.INTEGER;
-        case Types.DECIMAL:
-        case Types.DOUBLE:
-        case Types.NUMERIC:
-        case Types.BIGINT:
-        case Types.FLOAT:
-            return ValueType.NUMBER;
-        case Types.BOOLEAN:
-            return ValueType.BOOLEAN;
-        case Types.DATE:
-            return ValueType.DATE;
-        case Types.TIMESTAMP_WITH_TIMEZONE:
-            return ValueType.DATETIME;
-        case Types.TIME:
-        case Types.TIME_WITH_TIMEZONE:
-            return ValueType.TIME;
-        default:
-            return ValueType.TEXT;
+            case Types.INTEGER:
+                return ValueType.INTEGER;
+            case Types.DECIMAL:
+            case Types.DOUBLE:
+            case Types.NUMERIC:
+            case Types.BIGINT:
+            case Types.FLOAT:
+                return ValueType.NUMBER;
+            case Types.BOOLEAN:
+                return ValueType.BOOLEAN;
+            case Types.DATE:
+                return ValueType.DATE;
+            case Types.TIMESTAMP_WITH_TIMEZONE:
+                return ValueType.DATETIME;
+            case Types.TIME:
+            case Types.TIME_WITH_TIMEZONE:
+                return ValueType.TIME;
+            default:
+                return ValueType.TEXT;
         }
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/cache/CacheStrategy.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/cache/CacheStrategy.java
@@ -56,27 +56,27 @@ public enum CacheStrategy
     {
         switch ( this )
         {
-        case CACHE_1_MINUTE:
-            return MINUTES.toSeconds( 1 );
-        case CACHE_5_MINUTES:
-            return MINUTES.toSeconds( 5 );
-        case CACHE_10_MINUTES:
-            return MINUTES.toSeconds( 10 );
-        case CACHE_15_MINUTES:
-            return MINUTES.toSeconds( 15 );
-        case CACHE_30_MINUTES:
-            return MINUTES.toSeconds( 30 );
-        case CACHE_1_HOUR:
-            return HOURS.toSeconds( 1 );
-        case CACHE_TWO_WEEKS:
-            return DAYS.toSeconds( 14 );
-        case CACHE_6AM_TOMORROW:
-            return getSecondsUntilTomorrow( 6 );
-        case NO_CACHE:
-            return 0l;
-        case RESPECT_SYSTEM_SETTING:
-        default:
-            throw new UnsupportedOperationException();
+            case CACHE_1_MINUTE:
+                return MINUTES.toSeconds( 1 );
+            case CACHE_5_MINUTES:
+                return MINUTES.toSeconds( 5 );
+            case CACHE_10_MINUTES:
+                return MINUTES.toSeconds( 10 );
+            case CACHE_15_MINUTES:
+                return MINUTES.toSeconds( 15 );
+            case CACHE_30_MINUTES:
+                return MINUTES.toSeconds( 30 );
+            case CACHE_1_HOUR:
+                return HOURS.toSeconds( 1 );
+            case CACHE_TWO_WEEKS:
+                return DAYS.toSeconds( 14 );
+            case CACHE_6AM_TOMORROW:
+                return getSecondsUntilTomorrow( 6 );
+            case NO_CACHE:
+                return 0l;
+            case RESPECT_SYSTEM_SETTING:
+            default:
+                throw new UnsupportedOperationException();
         }
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/FeatureType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/FeatureType.java
@@ -64,14 +64,14 @@ public enum FeatureType
     {
         switch ( type )
         {
-        case "Point":
-            return POINT;
-        case "Polygon":
-            return POLYGON;
-        case "MultiPolygon":
-            return MULTI_POLYGON;
-        default:
-            return NONE;
+            case "Point":
+                return POINT;
+            case "Polygon":
+                return POLYGON;
+            case "MultiPolygon":
+                return MULTI_POLYGON;
+            default:
+                return NONE;
         }
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/Cal.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/Cal.java
@@ -116,18 +116,18 @@ public class Cal
     {
         switch ( field )
         {
-        case Calendar.YEAR:
-            dateTimeUnit = getCalendar().plusYears( dateTimeUnit, amount );
-            break;
-        case Calendar.MONTH:
-            dateTimeUnit = getCalendar().plusMonths( dateTimeUnit, amount );
-            break;
-        case Calendar.DAY_OF_MONTH: // fallthrough
-        case Calendar.DAY_OF_YEAR:
-            dateTimeUnit = getCalendar().plusDays( dateTimeUnit, amount );
-            break;
-        default:
-            throw new UnsupportedOperationException();
+            case Calendar.YEAR:
+                dateTimeUnit = getCalendar().plusYears( dateTimeUnit, amount );
+                break;
+            case Calendar.MONTH:
+                dateTimeUnit = getCalendar().plusMonths( dateTimeUnit, amount );
+                break;
+            case Calendar.DAY_OF_MONTH: // fallthrough
+            case Calendar.DAY_OF_YEAR:
+                dateTimeUnit = getCalendar().plusDays( dateTimeUnit, amount );
+                break;
+            default:
+                throw new UnsupportedOperationException();
         }
 
         return this;
@@ -143,18 +143,18 @@ public class Cal
     {
         switch ( field )
         {
-        case Calendar.YEAR:
-            dateTimeUnit = getCalendar().minusYears( dateTimeUnit, amount );
-            break;
-        case Calendar.MONTH:
-            dateTimeUnit = getCalendar().minusMonths( dateTimeUnit, amount );
-            break;
-        case Calendar.DAY_OF_MONTH: // fallthrough
-        case Calendar.DAY_OF_YEAR:
-            dateTimeUnit = getCalendar().minusDays( dateTimeUnit, amount );
-            break;
-        default:
-            throw new UnsupportedOperationException();
+            case Calendar.YEAR:
+                dateTimeUnit = getCalendar().minusYears( dateTimeUnit, amount );
+                break;
+            case Calendar.MONTH:
+                dateTimeUnit = getCalendar().minusMonths( dateTimeUnit, amount );
+                break;
+            case Calendar.DAY_OF_MONTH: // fallthrough
+            case Calendar.DAY_OF_YEAR:
+                dateTimeUnit = getCalendar().minusDays( dateTimeUnit, amount );
+                break;
+            default:
+                throw new UnsupportedOperationException();
         }
 
         return this;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/QuarterlyNovemberPeriodType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/QuarterlyNovemberPeriodType.java
@@ -101,16 +101,17 @@ public class QuarterlyNovemberPeriodType
 
         switch ( newUnit.getMonth() )
         {
-        case 11:
-            return newUnit.getYear() + 1 + "NovQ1";
-        case 2:
-            return newUnit.getYear() + "NovQ2";
-        case 5:
-            return newUnit.getYear() + "NovQ3";
-        case 8:
-            return newUnit.getYear() + "NovQ4";
-        default:
-            throw new IllegalArgumentException( "Month not valid [11,2,5,8], was given " + dateTimeUnit.getMonth() );
+            case 11:
+                return newUnit.getYear() + 1 + "NovQ1";
+            case 2:
+                return newUnit.getYear() + "NovQ2";
+            case 5:
+                return newUnit.getYear() + "NovQ3";
+            case 8:
+                return newUnit.getYear() + "NovQ4";
+            default:
+                throw new IllegalArgumentException(
+                    "Month not valid [11,2,5,8], was given " + dateTimeUnit.getMonth() );
         }
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/QuarterlyPeriodType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/QuarterlyPeriodType.java
@@ -103,16 +103,17 @@ public class QuarterlyPeriodType
 
         switch ( newUnit.getMonth() )
         {
-        case 1:
-            return newUnit.getYear() + "Q1";
-        case 4:
-            return newUnit.getYear() + "Q2";
-        case 7:
-            return newUnit.getYear() + "Q3";
-        case 10:
-            return newUnit.getYear() + "Q4";
-        default:
-            throw new IllegalArgumentException( "Month not valid [1,4,7,10], was given " + dateTimeUnit.getMonth() );
+            case 1:
+                return newUnit.getYear() + "Q1";
+            case 4:
+                return newUnit.getYear() + "Q2";
+            case 7:
+                return newUnit.getYear() + "Q3";
+            case 10:
+                return newUnit.getYear() + "Q4";
+            default:
+                throw new IllegalArgumentException(
+                    "Month not valid [1,4,7,10], was given " + dateTimeUnit.getMonth() );
         }
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/SixMonthlyAprilPeriodType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/SixMonthlyAprilPeriodType.java
@@ -84,12 +84,12 @@ public class SixMonthlyAprilPeriodType
 
         switch ( month )
         {
-        case 4:
-            return dateTimeUnit.getYear() + "AprilS1";
-        case 10:
-            return dateTimeUnit.getYear() + "AprilS2";
-        default:
-            throw new IllegalArgumentException( "Month not valid [4,10]" );
+            case 4:
+                return dateTimeUnit.getYear() + "AprilS1";
+            case 10:
+                return dateTimeUnit.getYear() + "AprilS2";
+            default:
+                throw new IllegalArgumentException( "Month not valid [4,10]" );
         }
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/SixMonthlyNovemberPeriodType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/SixMonthlyNovemberPeriodType.java
@@ -109,12 +109,12 @@ public class SixMonthlyNovemberPeriodType
 
         switch ( month )
         {
-        case 11:
-            return dateTimeUnit.getYear() + 1 + "NovS1";
-        case 5:
-            return dateTimeUnit.getYear() + "NovS2";
-        default:
-            throw new IllegalArgumentException( "Month not valid [11,5]" );
+            case 11:
+                return dateTimeUnit.getYear() + 1 + "NovS1";
+            case 5:
+                return dateTimeUnit.getYear() + "NovS2";
+            default:
+                throw new IllegalArgumentException( "Month not valid [11,5]" );
         }
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/SixMonthlyPeriodType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/SixMonthlyPeriodType.java
@@ -84,12 +84,12 @@ public class SixMonthlyPeriodType
 
         switch ( month )
         {
-        case 1:
-            return dateTimeUnit.getYear() + "S1";
-        case 7:
-            return dateTimeUnit.getYear() + "S2";
-        default:
-            throw new IllegalArgumentException( String.format( "Month not valid [1,7]: %d", month ) );
+            case 1:
+                return dateTimeUnit.getYear() + "S1";
+            case 7:
+                return dateTimeUnit.getYear() + "S2";
+            default:
+                throw new IllegalArgumentException( String.format( "Month not valid [1,7]: %d", month ) );
         }
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/preheat/PreheatIdentifier.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/preheat/PreheatIdentifier.java
@@ -54,10 +54,10 @@ public enum PreheatIdentifier
     {
         switch ( this )
         {
-        case UID:
-            return object.getUid();
-        case CODE:
-            return object.getCode();
+            case UID:
+                return object.getUid();
+            case CODE:
+                return object.getCode();
         }
         throw new RuntimeException( "Unhandled identifier type." );
     }
@@ -66,10 +66,10 @@ public enum PreheatIdentifier
     {
         switch ( this )
         {
-        case UID:
-            return singletonList( object.getUid() );
-        case CODE:
-            return singletonList( object.getCode() );
+            case UID:
+                return singletonList( object.getUid() );
+            case CODE:
+                return singletonList( object.getCode() );
         }
         return emptyList();
     }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramIndicator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramIndicator.java
@@ -156,13 +156,13 @@ public class ProgramIndicator
 
         switch ( aggregationType )
         {
-        case AVERAGE_SUM_ORG_UNIT, LAST_IN_PERIOD, MAX_SUM_ORG_UNIT, MIN_SUM_ORG_UNIT:
-            return AggregationType.SUM;
-        case LAST_IN_PERIOD_AVERAGE_ORG_UNIT, DEFAULT:
-            return AggregationType.AVERAGE;
-        case FIRST, LAST, FIRST_AVERAGE_ORG_UNIT, LAST_AVERAGE_ORG_UNIT:
-        default:
-            return aggregationType;
+            case AVERAGE_SUM_ORG_UNIT, LAST_IN_PERIOD, MAX_SUM_ORG_UNIT, MIN_SUM_ORG_UNIT:
+                return AggregationType.SUM;
+            case LAST_IN_PERIOD_AVERAGE_ORG_UNIT, DEFAULT:
+                return AggregationType.AVERAGE;
+            case FIRST, LAST, FIRST_AVERAGE_ORG_UNIT, LAST_AVERAGE_ORG_UNIT:
+            default:
+                return aggregationType;
         }
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/ApiTokenType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/ApiTokenType.java
@@ -103,9 +103,9 @@ public enum ApiTokenType
 
         return switch ( tokenChecksumType )
         {
-            case "CRC32" -> validateCrc32Checksum( plaintextToken );
+        case "CRC32" -> validateCrc32Checksum( plaintextToken );
 
-            default -> throw new IllegalArgumentException( "Unsupported checksum type: " + tokenChecksumType );
+        default -> throw new IllegalArgumentException( "Unsupported checksum type: " + tokenChecksumType );
         };
     }
 
@@ -142,10 +142,10 @@ public enum ApiTokenType
 
         return switch ( tokenHashType )
         {
-            case "SHA-256" -> CodeGenerator.hashSHA256( plaintextToken );
-            case "SHA-512" -> CodeGenerator.hashSHA512( plaintextToken );
+        case "SHA-256" -> CodeGenerator.hashSHA256( plaintextToken );
+        case "SHA-512" -> CodeGenerator.hashSHA512( plaintextToken );
 
-            default -> throw new IllegalArgumentException( "Unsupported hash type: " + tokenHashType );
+        default -> throw new IllegalArgumentException( "Unsupported hash type: " + tokenHashType );
         };
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/ApiTokenType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/ApiTokenType.java
@@ -103,9 +103,9 @@ public enum ApiTokenType
 
         return switch ( tokenChecksumType )
         {
-        case "CRC32" -> validateCrc32Checksum( plaintextToken );
+            case "CRC32" -> validateCrc32Checksum( plaintextToken );
 
-        default -> throw new IllegalArgumentException( "Unsupported checksum type: " + tokenChecksumType );
+            default -> throw new IllegalArgumentException( "Unsupported checksum type: " + tokenChecksumType );
         };
     }
 
@@ -142,10 +142,10 @@ public enum ApiTokenType
 
         return switch ( tokenHashType )
         {
-        case "SHA-256" -> CodeGenerator.hashSHA256( plaintextToken );
-        case "SHA-512" -> CodeGenerator.hashSHA512( plaintextToken );
+            case "SHA-256" -> CodeGenerator.hashSHA256( plaintextToken );
+            case "SHA-512" -> CodeGenerator.hashSHA512( plaintextToken );
 
-        default -> throw new IllegalArgumentException( "Unsupported hash type: " + tokenHashType );
+            default -> throw new IllegalArgumentException( "Unsupported hash type: " + tokenHashType );
         };
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/textpattern/TextPatternMethodUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/textpattern/TextPatternMethodUtils.java
@@ -68,18 +68,18 @@ public class TextPatternMethodUtils
         {
             switch ( c )
             {
-            case '*':
-                result.append( all.get( random.nextInt( all.size() ) ) );
-                break;
-            case '#':
-                result.append( digits.get( random.nextInt( digits.size() ) ) );
-                break;
-            case 'X':
-                result.append( uppercase.get( random.nextInt( uppercase.size() ) ) );
-                break;
-            case 'x':
-                result.append( lowercase.get( random.nextInt( lowercase.size() ) ) );
-                break;
+                case '*':
+                    result.append( all.get( random.nextInt( all.size() ) ) );
+                    break;
+                case '#':
+                    result.append( digits.get( random.nextInt( digits.size() ) ) );
+                    break;
+                case 'X':
+                    result.append( uppercase.get( random.nextInt( uppercase.size() ) ) );
+                    break;
+                case 'x':
+                    result.append( lowercase.get( random.nextInt( lowercase.size() ) ) );
+                    break;
             }
         }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/DimensionDescriptor.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/DimensionDescriptor.java
@@ -113,19 +113,19 @@ public class DimensionDescriptor
     {
         switch ( getType() )
         {
-        case ATTRIBUTE_OPTION_COMBO:
-            return ATTRIBUTEOPTIONCOMBO_DIM_ID;
-        case CATEGORY_OPTION_COMBO:
-            return CATEGORYOPTIONCOMBO_DIM_ID;
-        case DATA_X:
-            return DATA_X_DIM_ID;
-        case ORGANISATION_UNIT:
-        case ORGANISATION_UNIT_GROUP_SET:
-            return ORGUNIT_DIM_ID;
-        case PERIOD:
-            return PERIOD_DIM_ID;
-        default:
-            return EMPTY;
+            case ATTRIBUTE_OPTION_COMBO:
+                return ATTRIBUTEOPTIONCOMBO_DIM_ID;
+            case CATEGORY_OPTION_COMBO:
+                return CATEGORYOPTIONCOMBO_DIM_ID;
+            case DATA_X:
+                return DATA_X_DIM_ID;
+            case ORGANISATION_UNIT:
+            case ORGANISATION_UNIT_GROUP_SET:
+                return ORGUNIT_DIM_ID;
+            case PERIOD:
+                return PERIOD_DIM_ID;
+            default:
+                return EMPTY;
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsAggregationType.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsAggregationType.java
@@ -132,43 +132,45 @@ public class AnalyticsAggregationType
 
         switch ( aggregationType )
         {
-        case AVERAGE_SUM_ORG_UNIT:
-            analyticsAggregationType = new AnalyticsAggregationType( AggregationType.SUM, AggregationType.AVERAGE );
-            break;
-        case LAST:
-            analyticsAggregationType = new AnalyticsAggregationType( AggregationType.SUM, AggregationType.LAST );
-            break;
-        case LAST_AVERAGE_ORG_UNIT:
-            analyticsAggregationType = new AnalyticsAggregationType( AggregationType.AVERAGE, AggregationType.LAST );
-            break;
-        case LAST_LAST_ORG_UNIT:
-            analyticsAggregationType = new AnalyticsAggregationType( AggregationType.LAST, AggregationType.LAST );
-            break;
-        case LAST_IN_PERIOD:
-            analyticsAggregationType = new AnalyticsAggregationType( AggregationType.SUM,
-                AggregationType.LAST_IN_PERIOD );
-            break;
-        case LAST_IN_PERIOD_AVERAGE_ORG_UNIT:
-            analyticsAggregationType = new AnalyticsAggregationType( AggregationType.AVERAGE,
-                AggregationType.LAST_IN_PERIOD );
-            break;
-        case FIRST:
-            analyticsAggregationType = new AnalyticsAggregationType( AggregationType.SUM, AggregationType.FIRST );
-            break;
-        case FIRST_AVERAGE_ORG_UNIT:
-            analyticsAggregationType = new AnalyticsAggregationType( AggregationType.AVERAGE, AggregationType.FIRST );
-            break;
-        case FIRST_FIRST_ORG_UNIT:
-            analyticsAggregationType = new AnalyticsAggregationType( AggregationType.FIRST, AggregationType.FIRST );
-            break;
-        case MAX_SUM_ORG_UNIT:
-            analyticsAggregationType = new AnalyticsAggregationType( AggregationType.SUM, AggregationType.MAX );
-            break;
-        case MIN_SUM_ORG_UNIT:
-            analyticsAggregationType = new AnalyticsAggregationType( AggregationType.SUM, AggregationType.MIN );
-            break;
-        default:
-            analyticsAggregationType = new AnalyticsAggregationType( aggregationType, aggregationType );
+            case AVERAGE_SUM_ORG_UNIT:
+                analyticsAggregationType = new AnalyticsAggregationType( AggregationType.SUM, AggregationType.AVERAGE );
+                break;
+            case LAST:
+                analyticsAggregationType = new AnalyticsAggregationType( AggregationType.SUM, AggregationType.LAST );
+                break;
+            case LAST_AVERAGE_ORG_UNIT:
+                analyticsAggregationType = new AnalyticsAggregationType( AggregationType.AVERAGE,
+                    AggregationType.LAST );
+                break;
+            case LAST_LAST_ORG_UNIT:
+                analyticsAggregationType = new AnalyticsAggregationType( AggregationType.LAST, AggregationType.LAST );
+                break;
+            case LAST_IN_PERIOD:
+                analyticsAggregationType = new AnalyticsAggregationType( AggregationType.SUM,
+                    AggregationType.LAST_IN_PERIOD );
+                break;
+            case LAST_IN_PERIOD_AVERAGE_ORG_UNIT:
+                analyticsAggregationType = new AnalyticsAggregationType( AggregationType.AVERAGE,
+                    AggregationType.LAST_IN_PERIOD );
+                break;
+            case FIRST:
+                analyticsAggregationType = new AnalyticsAggregationType( AggregationType.SUM, AggregationType.FIRST );
+                break;
+            case FIRST_AVERAGE_ORG_UNIT:
+                analyticsAggregationType = new AnalyticsAggregationType( AggregationType.AVERAGE,
+                    AggregationType.FIRST );
+                break;
+            case FIRST_FIRST_ORG_UNIT:
+                analyticsAggregationType = new AnalyticsAggregationType( AggregationType.FIRST, AggregationType.FIRST );
+                break;
+            case MAX_SUM_ORG_UNIT:
+                analyticsAggregationType = new AnalyticsAggregationType( AggregationType.SUM, AggregationType.MAX );
+                break;
+            case MIN_SUM_ORG_UNIT:
+                analyticsAggregationType = new AnalyticsAggregationType( AggregationType.SUM, AggregationType.MIN );
+                break;
+            default:
+                analyticsAggregationType = new AnalyticsAggregationType( aggregationType, aggregationType );
         }
 
         return analyticsAggregationType;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/ColumnDataType.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/ColumnDataType.java
@@ -47,6 +47,7 @@ public enum ColumnDataType
     GEOMETRY( "geometry" ),
     GEOMETRY_POINT( "geometry(Point, 4326)" ),
     JSONB( "jsonb" );
+
     String value;
 
     ColumnDataType( String value )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/MeasureFilter.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/MeasureFilter.java
@@ -52,18 +52,18 @@ public enum MeasureFilter
     {
         switch ( this )
         {
-        case EQ:
-            return Double.compare( x, y ) == 0;
-        case GT:
-            return Double.compare( x, y ) > 0;
-        case GE:
-            return Double.compare( x, y ) >= 0;
-        case LT:
-            return Double.compare( x, y ) < 0;
-        case LE:
-            return Double.compare( x, y ) <= 0;
-        default:
-            return false;
+            case EQ:
+                return Double.compare( x, y ) == 0;
+            case GT:
+                return Double.compare( x, y ) > 0;
+            case GE:
+                return Double.compare( x, y ) >= 0;
+            case LT:
+                return Double.compare( x, y ) < 0;
+            case LE:
+                return Double.compare( x, y ) <= 0;
+            default:
+                return false;
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/DimensionIdentifierHelper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/DimensionIdentifierHelper.java
@@ -117,8 +117,8 @@ public class DimensionIdentifierHelper
     {
         return stream(
             split( fullDimensionId, DIMENSION_SEPARATOR ) )
-                .map( DimensionIdentifierHelper::elementWithOffsetByString )
-                .collect( toList() );
+            .map( DimensionIdentifierHelper::elementWithOffsetByString )
+            .collect( toList() );
     }
 
     private static void assertDimensionIdHasNoOffset( ElementWithOffset<StringUid> dimensionIdWithOffset )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
@@ -265,16 +265,16 @@ public class DefaultDataQueryService
         {
             switch ( params.getUserOrgUnitType() )
             {
-            case DATA_CAPTURE:
-                units.addAll( currentUser.getOrganisationUnits().stream().sorted().collect( toList() ) );
-                break;
-            case DATA_OUTPUT:
-                units.addAll(
-                    currentUser.getDataViewOrganisationUnits().stream().sorted().collect( toList() ) );
-                break;
-            case TEI_SEARCH:
-                units.addAll( currentUser.getTeiSearchOrganisationUnits().stream().sorted().collect( toList() ) );
-                break;
+                case DATA_CAPTURE:
+                    units.addAll( currentUser.getOrganisationUnits().stream().sorted().collect( toList() ) );
+                    break;
+                case DATA_OUTPUT:
+                    units.addAll(
+                        currentUser.getDataViewOrganisationUnits().stream().sorted().collect( toList() ) );
+                    break;
+                case TEI_SEARCH:
+                    units.addAll( currentUser.getTeiSearchOrganisationUnits().stream().sorted().collect( toList() ) );
+                    break;
             }
         }
         else if ( currentUser != null )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGenerator.java
@@ -241,9 +241,9 @@ public class JdbcSubexpressionQueryGenerator
      */
     private String getQuotedDataElementUid( DimensionalItemObject item )
     {
-        return "'" + ( (item instanceof DataElementOperand deo)
+        return "'" + ((item instanceof DataElementOperand deo)
             ? deo.getDataElement().getUid()
-            : item.getUid() ) + "'";
+            : item.getUid()) + "'";
     }
 
     /**
@@ -261,7 +261,7 @@ public class JdbcSubexpressionQueryGenerator
         String cocUid = null;
         String aocUid = null;
 
-        if (item instanceof DataElementOperand deo)
+        if ( item instanceof DataElementOperand deo )
         {
             cocUid = (deo.getCategoryOptionCombo() != null) ? deo.getCategoryOptionCombo().getUid() : "";
             aocUid = (deo.getAttributeOptionCombo() != null) ? deo.getAttributeOptionCombo().getUid() : "";
@@ -270,12 +270,13 @@ public class JdbcSubexpressionQueryGenerator
         String fun = getLowLevelAggregateFunction( dataElement );
 
         String conditional = quote( ANALYTICS_TBL_ALIAS, DX ) + "='" + deUid + "'" +
-            ( isEmpty( cocUid )
+            (isEmpty( cocUid )
                 ? ""
-                : " and " + quote( ANALYTICS_TBL_ALIAS, CO ) + "='" + cocUid + "'" ) +
-            ( isEmpty( aocUid )
+                : " and " + quote( ANALYTICS_TBL_ALIAS, CO ) + "='" + cocUid + "'")
+            +
+            (isEmpty( aocUid )
                 ? ""
-                : " and " + quote( ANALYTICS_TBL_ALIAS, AO ) + "='" + aocUid + "'" );
+                : " and " + quote( ANALYTICS_TBL_ALIAS, AO ) + "='" + aocUid + "'");
 
         String value = quote( dataElement.getValueColumn() );
 
@@ -330,10 +331,10 @@ public class JdbcSubexpressionQueryGenerator
     private String aggregateFunctionFromType( AggregationType aggType )
     {
         return switch ( aggType )
-            {
-                case AVERAGE -> "avg";
-                case MAX, MIN, COUNT, STDDEV, VARIANCE -> aggType.name().toLowerCase();
-                default -> "sum";
-            };
+        {
+        case AVERAGE -> "avg";
+        case MAX, MIN, COUNT, STDDEV, VARIANCE -> aggType.name().toLowerCase();
+        default -> "sum";
+        };
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGenerator.java
@@ -332,9 +332,9 @@ public class JdbcSubexpressionQueryGenerator
     {
         return switch ( aggType )
         {
-        case AVERAGE -> "avg";
-        case MAX, MIN, COUNT, STDDEV, VARIANCE -> aggType.name().toLowerCase();
-        default -> "sum";
+            case AVERAGE -> "avg";
+            case MAX, MIN, COUNT, STDDEV, VARIANCE -> aggType.name().toLowerCase();
+            default -> "sum";
         };
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -1164,7 +1164,7 @@ public abstract class AbstractJdbcEventAnalyticsManager
         // Groups repeatable conditions based on PSI.DEID
         Map<String, List<String>> repeatableConditionsByIdentifier = asSqlCollection( itemsByRepeatableFlag.get( true ),
             params )
-                .collect( groupingBy( IdentifiableSql::getIdentifier, mapping( IdentifiableSql::getSql, toList() ) ) );
+            .collect( groupingBy( IdentifiableSql::getIdentifier, mapping( IdentifiableSql::getSql, toList() ) ) );
 
         // Joins each group with OR
         Collection<String> orConditions = repeatableConditionsByIdentifier.values()

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -1309,14 +1309,14 @@ public abstract class AbstractJdbcEventAnalyticsManager
                 // Specific handling for null and empty values
                 switch ( filter.getOperator() )
                 {
-                case NEQ:
-                case NE:
-                case NIEQ:
-                case NLIKE:
-                case NILIKE:
-                    return nullAndEmptyMatcher( item, filter, field );
-                default:
-                    break;
+                    case NEQ:
+                    case NE:
+                    case NIEQ:
+                    case NLIKE:
+                    case NILIKE:
+                        return nullAndEmptyMatcher( item, filter, field );
+                    default:
+                        break;
                 }
             }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryValidator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryValidator.java
@@ -260,11 +260,11 @@ public class DefaultEventQueryValidator
     {
         switch ( valueType )
         {
-        case TIME:
-        case DATETIME:
-            return replaceDateTimeSeparators( filterValue );
-        default:
-            return filterValue;
+            case TIME:
+            case DATETIME:
+                return replaceDateTimeSeparators( filterValue );
+            default:
+                return filterValue;
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/programindicator/RelationshipTypeJoinGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/programindicator/RelationshipTypeJoinGenerator.java
@@ -81,14 +81,14 @@ public class RelationshipTypeJoinGenerator
         String sql = "LEFT JOIN ";
         switch ( relationshipEntity )
         {
-        case TRACKED_ENTITY_INSTANCE:
-            return sql + "trackedentityinstance tei on tei.trackedentityinstanceid = ri2.trackedentityinstanceid";
-        case PROGRAM_STAGE_INSTANCE:
-            return sql + "programstageinstance psi on psi.programstageinstanceid = ri2.programstageinstanceid";
-        case PROGRAM_INSTANCE:
-            return sql + "programinstance pi on pi.programinstanceid = ri2.programinstanceid";
-        default:
-            throw new IllegalQueryException( new ErrorMessage( ErrorCode.E7227, relationshipEntity.name() ) );
+            case TRACKED_ENTITY_INSTANCE:
+                return sql + "trackedentityinstance tei on tei.trackedentityinstanceid = ri2.trackedentityinstanceid";
+            case PROGRAM_STAGE_INSTANCE:
+                return sql + "programstageinstance psi on psi.programstageinstanceid = ri2.programstageinstanceid";
+            case PROGRAM_INSTANCE:
+                return sql + "programinstance pi on pi.programinstanceid = ri2.programinstanceid";
+            default:
+                throw new IllegalQueryException( new ErrorMessage( ErrorCode.E7227, relationshipEntity.name() ) );
         }
     }
 
@@ -97,11 +97,12 @@ public class RelationshipTypeJoinGenerator
     {
         switch ( relationshipEntity )
         {
-        case TRACKED_ENTITY_INSTANCE:
-            return getTei( alias );
-        case PROGRAM_STAGE_INSTANCE:
-        case PROGRAM_INSTANCE:
-            return (programIndicatorType.equals( AnalyticsType.EVENT ) ? getEvent( alias ) : getEnrollment( alias ));
+            case TRACKED_ENTITY_INSTANCE:
+                return getTei( alias );
+            case PROGRAM_STAGE_INSTANCE:
+            case PROGRAM_INSTANCE:
+                return (programIndicatorType.equals( AnalyticsType.EVENT ) ? getEvent( alias )
+                    : getEnrollment( alias ));
         }
         throw new IllegalQueryException( new ErrorMessage( ErrorCode.E7227, relationshipEntity.name() ) );
     }
@@ -133,14 +134,14 @@ public class RelationshipTypeJoinGenerator
 
         switch ( relationshipEntity )
         {
-        case TRACKED_ENTITY_INSTANCE:
-            return sql + "tei.uid = ax.tei ";
-        case PROGRAM_STAGE_INSTANCE:
-            return sql + "psi.uid = ax.psi ";
-        case PROGRAM_INSTANCE:
-            return sql + "pi.uid = ax.pi ";
-        default:
-            throw new IllegalQueryException( new ErrorMessage( ErrorCode.E7227, relationshipEntity.name() ) );
+            case TRACKED_ENTITY_INSTANCE:
+                return sql + "tei.uid = ax.tei ";
+            case PROGRAM_STAGE_INSTANCE:
+                return sql + "psi.uid = ax.psi ";
+            case PROGRAM_INSTANCE:
+                return sql + "pi.uid = ax.pi ";
+            default:
+                throw new IllegalQueryException( new ErrorMessage( ErrorCode.E7227, relationshipEntity.name() ) );
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -556,7 +556,7 @@ public class JdbcEventAnalyticsTableManager
                 "ou.geometry from organisationunit ou where ou.uid = (select value", dataClause );
             columns.add( new AnalyticsTableColumn( quote( attribute.getUid() + OU_GEOMETRY_COL_SUFFIX ),
                 ColumnDataType.GEOMETRY, geoSql )
-                    .withSkipIndex( false ).withIndexType( IndexType.GIST ) );
+                .withSkipIndex( false ).withIndexType( IndexType.GIST ) );
         }
 
         // Add org unit name column
@@ -582,7 +582,7 @@ public class JdbcEventAnalyticsTableManager
 
             columns.add( new AnalyticsTableColumn( quote( dataElement.getUid() + OU_GEOMETRY_COL_SUFFIX ),
                 ColumnDataType.GEOMETRY, geoSql )
-                    .withSkipIndex( false ).withIndexType( IndexType.GIST ) );
+                .withSkipIndex( false ).withIndexType( IndexType.GIST ) );
         }
 
         // Add org unit name column

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/PeriodCondition.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/PeriodCondition.java
@@ -84,7 +84,7 @@ public class PeriodCondition extends BaseRenderable
                 .getDimensionalObject()
                 .getItems()
                 .get( 0 ))
-                    .getDateField() );
+                .getDateField() );
     }
 
     private Date nextDay( Date date )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/TeiFields.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/TeiFields.java
@@ -104,10 +104,10 @@ public class TeiFields
 
         Stream<Field> trackedEntityAttributesFromType = getTrackedEntityAttributes(
             teiQueryParams.getTrackedEntityType() )
-                .filter( programTrackedEntityAttribute -> !programAttributesUids
-                    .contains( programTrackedEntityAttribute.getUid() ) )
-                .map( IdentifiableObject::getUid )
-                .map( attr -> Field.of( TEI_ALIAS, () -> attr, attr ) );
+            .filter( programTrackedEntityAttribute -> !programAttributesUids
+                .contains( programTrackedEntityAttribute.getUid() ) )
+            .map( IdentifiableObject::getUid )
+            .map( attr -> Field.of( TEI_ALIAS, () -> attr, attr ) );
 
         // TET and program attribute uids.
         return Stream.concat( trackedEntityAttributesFromType, programAttributes );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/DisplayNameUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/DisplayNameUtils.java
@@ -107,8 +107,8 @@ public class DisplayNameUtils
             // username
             + " else concat(trim({prefix}.{column} ->> 'surname'), ', ', trim({prefix}.{column} ->> 'firstName'), ' (', trim({prefix}.{column} ->> 'username'), ')') end"
             + " as {alias}").replaceAll( "\\{column}", originColumn )
-                .replaceAll( "\\{prefix}", tablePrefix )
-                .replaceAll( "\\{alias}", columnAlias );
+            .replaceAll( "\\{prefix}", tablePrefix )
+            .replaceAll( "\\{alias}", columnAlias );
     }
 
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/RepeatableStageParamsHelper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/RepeatableStageParamsHelper.java
@@ -111,37 +111,40 @@ public class RepeatableStageParamsHelper
 
         switch ( pattern.toString() )
         {
-        case PS_ASTERISK_REGEX:
+            case PS_ASTERISK_REGEX:
 
-            return getRepeatableStageParams( 0, Integer.MAX_VALUE );
-        case PS_INDEX_COUNT_REGEX:
-            tokens = getMatchedRepeatableStageParamTokens( matcher, 2 );
+                return getRepeatableStageParams( 0, Integer.MAX_VALUE );
+            case PS_INDEX_COUNT_REGEX:
+                tokens = getMatchedRepeatableStageParamTokens( matcher, 2 );
 
-            return getRepeatableStageParams( Integer.parseInt( tokens.get( 0 ) ), Integer.parseInt( tokens.get( 1 ) ) );
-        case PS_INDEX_REGEX:
+                return getRepeatableStageParams( Integer.parseInt( tokens.get( 0 ) ),
+                    Integer.parseInt( tokens.get( 1 ) ) );
+            case PS_INDEX_REGEX:
 
-            return getRepeatableStageParams( Integer.parseInt( getDefaultIndex( matcher ) ), 1 );
-        case PS_INDEX_COUNT_START_DATE_END_DATE_REGEX:
-            tokens = getMatchedRepeatableStageParamTokens( matcher, 4 );
+                return getRepeatableStageParams( Integer.parseInt( getDefaultIndex( matcher ) ), 1 );
+            case PS_INDEX_COUNT_START_DATE_END_DATE_REGEX:
+                tokens = getMatchedRepeatableStageParamTokens( matcher, 4 );
 
-            return getRepeatableStageParams( Integer.parseInt( tokens.get( 0 ) ), Integer.parseInt( tokens.get( 1 ) ),
-                DateUtils.parseDate( tokens.get( 2 ) ), DateUtils.parseDate( tokens.get( 3 ) ) );
-        case PS_INDEX_COUNT_RELATIVE_PERIOD_REGEX:
-            tokens = getMatchedRepeatableStageParamTokens( matcher, 3 );
+                return getRepeatableStageParams( Integer.parseInt( tokens.get( 0 ) ),
+                    Integer.parseInt( tokens.get( 1 ) ),
+                    DateUtils.parseDate( tokens.get( 2 ) ), DateUtils.parseDate( tokens.get( 3 ) ) );
+            case PS_INDEX_COUNT_RELATIVE_PERIOD_REGEX:
+                tokens = getMatchedRepeatableStageParamTokens( matcher, 3 );
 
-            return getRepeatableStageParams( Integer.parseInt( tokens.get( 0 ) ), Integer.parseInt( tokens.get( 1 ) ),
-                getRelativePeriods( tokens.get( 2 ) ) );
-        case PS_START_DATE_END_DATE_REGEX:
-            tokens = getMatchedRepeatableStageParamTokens( matcher, 2 );
+                return getRepeatableStageParams( Integer.parseInt( tokens.get( 0 ) ),
+                    Integer.parseInt( tokens.get( 1 ) ),
+                    getRelativePeriods( tokens.get( 2 ) ) );
+            case PS_START_DATE_END_DATE_REGEX:
+                tokens = getMatchedRepeatableStageParamTokens( matcher, 2 );
 
-            return getRepeatableStageParams( DateUtils.parseDate( tokens.get( 0 ) ),
-                DateUtils.parseDate( tokens.get( 1 ).trim() ) );
-        case PS_RELATIVE_PERIOD_REGEX:
-            tokens = getMatchedRepeatableStageParamTokens( matcher, 1 );
+                return getRepeatableStageParams( DateUtils.parseDate( tokens.get( 0 ) ),
+                    DateUtils.parseDate( tokens.get( 1 ).trim() ) );
+            case PS_RELATIVE_PERIOD_REGEX:
+                tokens = getMatchedRepeatableStageParamTokens( matcher, 1 );
 
-            return getRepeatableStageParams( getRelativePeriods( tokens.get( 0 ) ) );
-        default:
-            return new RepeatableStageParams();
+                return getRepeatableStageParams( getRelativePeriods( tokens.get( 0 ) ) );
+            default:
+                return new RepeatableStageParams();
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/processing/CommonQueryRequestMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/processing/CommonQueryRequestMapperTest.java
@@ -365,7 +365,7 @@ class CommonQueryRequestMapperTest
             aCommonQueryRequest.getDisplayProperty(), UID )) ).thenReturn( null );
         when( eventDataQueryService.getQueryItem( deDimensionIdentifier.getDimension().getUid(),
             deDimensionIdentifier.getProgram().getElement(), TRACKED_ENTITY_INSTANCE ) )
-                .thenReturn( anyQueryItem );
+            .thenReturn( anyQueryItem );
 
         // When
         CommonParams params = new CommonQueryRequestMapper( dataQueryService, eventDataQueryService, programService,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceMetadataTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceMetadataTest.java
@@ -81,7 +81,7 @@ class AnalyticsServiceMetadataTest extends AnalyticsServiceBaseTest
         Map<String, Object> aggregatedValues = new HashMap<>();
         when( analyticsManager.getAggregatedDataValues( any( DataQueryParams.class ),
             eq( AnalyticsTableType.DATA_VALUE ), eq( 0 ) ) )
-                .thenReturn( CompletableFuture.completedFuture( aggregatedValues ) );
+            .thenReturn( CompletableFuture.completedFuture( aggregatedValues ) );
     }
 
     @SuppressWarnings( "unchecked" )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceProgramDataElementTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceProgramDataElementTest.java
@@ -94,7 +94,7 @@ class AnalyticsServiceProgramDataElementTest
 
         when( analyticsManager.getAggregatedDataValues( any( DataQueryParams.class ),
             eq( AnalyticsTableType.DATA_VALUE ), eq( 0 ) ) )
-                .thenReturn( CompletableFuture.completedFuture( emptyData ) );
+            .thenReturn( CompletableFuture.completedFuture( emptyData ) );
 
         when( eventAnalyticsService.getAggregatedEventData( any( EventQueryParams.class ) ) )
             .thenReturn( new ListGrid() );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceReportingRateTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceReportingRateTest.java
@@ -104,14 +104,14 @@ class AnalyticsServiceReportingRateTest extends AnalyticsServiceBaseTest
 
         when( analyticsManager.getAggregatedDataValues( any( DataQueryParams.class ),
             eq( AnalyticsTableType.COMPLETENESS ), eq( 0 ) ) )
-                .thenReturn( CompletableFuture.completedFuture( actualReports ) );
+            .thenReturn( CompletableFuture.completedFuture( actualReports ) );
 
         Map<String, Object> reportingRate = new HashMap<>();
         reportingRate.put( dataSetA.getUid() + "-" + ou.getUid(), expectedReports );
 
         when( analyticsManager.getAggregatedDataValues( any( DataQueryParams.class ),
             eq( AnalyticsTableType.COMPLETENESS_TARGET ), eq( 0 ) ) )
-                .thenReturn( CompletableFuture.completedFuture( reportingRate ) );
+            .thenReturn( CompletableFuture.completedFuture( reportingRate ) );
 
         Grid grid = target.getAggregatedDataValueGrid( params );
 
@@ -160,7 +160,7 @@ class AnalyticsServiceReportingRateTest extends AnalyticsServiceBaseTest
 
         when( analyticsManager.getAggregatedDataValues( any( DataQueryParams.class ),
             eq( AnalyticsTableType.COMPLETENESS_TARGET ), eq( 0 ) ) )
-                .thenReturn( CompletableFuture.completedFuture( reportingRate ) );
+            .thenReturn( CompletableFuture.completedFuture( reportingRate ) );
 
         Grid grid = target.getAggregatedDataValueGrid( params );
 
@@ -194,12 +194,12 @@ class AnalyticsServiceReportingRateTest extends AnalyticsServiceBaseTest
 
         when( analyticsManager.getAggregatedDataValues( any( DataQueryParams.class ),
             eq( AnalyticsTableType.COMPLETENESS ), eq( 0 ) ) )
-                .thenReturn( CompletableFuture.completedFuture( actualReports ) );
+            .thenReturn( CompletableFuture.completedFuture( actualReports ) );
 
         // NO TARGET RETURNED
         when( analyticsManager.getAggregatedDataValues( any( DataQueryParams.class ),
             eq( AnalyticsTableType.COMPLETENESS_TARGET ), eq( 0 ) ) )
-                .thenReturn( CompletableFuture.completedFuture( null ) );
+            .thenReturn( CompletableFuture.completedFuture( null ) );
 
         Grid grid = target.getAggregatedDataValueGrid( params );
 
@@ -243,11 +243,11 @@ class AnalyticsServiceReportingRateTest extends AnalyticsServiceBaseTest
 
         when( analyticsManager.getAggregatedDataValues( any( DataQueryParams.class ),
             eq( AnalyticsTableType.COMPLETENESS_TARGET ), eq( 0 ) ) )
-                .thenReturn( CompletableFuture.completedFuture( targets ) );
+            .thenReturn( CompletableFuture.completedFuture( targets ) );
 
         when( analyticsManager.getAggregatedDataValues( any( DataQueryParams.class ),
             eq( AnalyticsTableType.COMPLETENESS ), eq( 0 ) ) )
-                .thenReturn( CompletableFuture.completedFuture( actuals ) );
+            .thenReturn( CompletableFuture.completedFuture( actuals ) );
 
         Grid grid = target.getAggregatedDataValueGrid( params );
         assertReportingRatesGrid( grid, dataSetA, "201902" );
@@ -290,11 +290,11 @@ class AnalyticsServiceReportingRateTest extends AnalyticsServiceBaseTest
 
         when( analyticsManager.getAggregatedDataValues( any( DataQueryParams.class ),
             eq( AnalyticsTableType.COMPLETENESS_TARGET ), eq( 0 ) ) )
-                .thenReturn( CompletableFuture.completedFuture( targets ) );
+            .thenReturn( CompletableFuture.completedFuture( targets ) );
 
         when( analyticsManager.getAggregatedDataValues( any( DataQueryParams.class ),
             eq( AnalyticsTableType.COMPLETENESS ), eq( 0 ) ) )
-                .thenReturn( CompletableFuture.completedFuture( actuals ) );
+            .thenReturn( CompletableFuture.completedFuture( actuals ) );
 
         Grid grid = target.getAggregatedDataValueGrid( params );
         assertReportingRatesGrid( grid, dataSetA, "201901" );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceDimensionItemKeywordTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceDimensionItemKeywordTest.java
@@ -564,15 +564,15 @@ class DataQueryServiceDimensionItemKeywordTest
 
         switch ( userOrgUnitType )
         {
-        case DATA_CAPTURE:
-            user.setOrganisationUnits( orgUnits );
-            break;
-        case DATA_OUTPUT:
-            user.setDataViewOrganisationUnits( orgUnits );
-            break;
-        case TEI_SEARCH:
-            user.setTeiSearchOrganisationUnits( orgUnits );
-            break;
+            case DATA_CAPTURE:
+                user.setOrganisationUnits( orgUnits );
+                break;
+            case DATA_OUTPUT:
+                user.setDataViewOrganisationUnits( orgUnits );
+                break;
+            case TEI_SEARCH:
+                user.setTeiSearchOrganisationUnits( orgUnits );
+                break;
         }
 
         DataQueryRequest request = DataQueryRequest.newBuilder().userOrgUnitType( userOrgUnitType ).build();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceDimensionItemKeywordTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceDimensionItemKeywordTest.java
@@ -376,7 +376,7 @@ class DataQueryServiceDimensionItemKeywordTest
 
         when( organisationUnitService.getOrganisationUnits( Lists.newArrayList( groupOu ),
             Lists.newArrayList( rootOu ) ) )
-                .thenReturn( Lists.newArrayList( ou1Group, ou2Group ) );
+            .thenReturn( Lists.newArrayList( ou1Group, ou2Group ) );
 
         rb.addOuFilter( "LEVEL-wjP19dkFeIk;OU_GROUP-tDZVQ1WtwpA;ImspTQPwCqd" );
         rb.addDimension( concatenateUuid( DATA_ELEMENT_1, DATA_ELEMENT_2, DATA_ELEMENT_3 ) );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -320,7 +320,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest
 
         when( programIndicatorService.getAnalyticsSql( programIndicator.getExpression(), NUMERIC, programIndicator,
             params.getEarliestStartDate(), params.getLatestEndDate() ) )
-                .thenReturn( "select * from table" );
+            .thenReturn( "select * from table" );
 
         String clause = eventSubject.getAggregateClause( params );
 
@@ -340,7 +340,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest
 
         when( programIndicatorService.getAnalyticsSql( programIndicator.getExpression(), NUMERIC, programIndicator,
             params.getEarliestStartDate(), params.getLatestEndDate() ) )
-                .thenReturn( "select * from table" );
+            .thenReturn( "select * from table" );
 
         String clause = eventSubject.getAggregateClause( params );
 
@@ -358,7 +358,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest
 
         when( programIndicatorService.getAnalyticsSql( programIndicator.getExpression(), NUMERIC, programIndicator,
             params.getEarliestStartDate(), params.getLatestEndDate() ) )
-                .thenReturn( "select * from table" );
+            .thenReturn( "select * from table" );
 
         String clause = eventSubject.getAggregateClause( params );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -417,8 +417,8 @@ class EnrollmentAnalyticsManagerTest
 
         EventQueryParams.Builder params = new EventQueryParams.Builder(
             createRequestParams( programIndicatorA, relationshipTypeA ) )
-                .withStartDate( startDate )
-                .withEndDate( endDate );
+            .withStartDate( startDate )
+            .withEndDate( endDate );
 
         when( programIndicatorService.getAnalyticsSql( "", NUMERIC, programIndicatorA, getDate( 2000, 1, 1 ),
             getDate( 2017, 4, 8 ), "subax" ) ).thenReturn( piSubquery );
@@ -459,8 +459,8 @@ class EnrollmentAnalyticsManagerTest
 
         EventQueryParams.Builder params = new EventQueryParams.Builder(
             createRequestParams( programIndicatorA, relationshipTypeA ) )
-                .withStartDate( startDate )
-                .withEndDate( endDate );
+            .withStartDate( startDate )
+            .withEndDate( endDate );
 
         when( programIndicatorService.getAnalyticsSql( "", NUMERIC, programIndicatorA, getDate( 2000, 1, 1 ),
             getDate( 2017, 4, 8 ), "subax" ) ).thenReturn( piSubquery );
@@ -531,8 +531,8 @@ class EnrollmentAnalyticsManagerTest
 
         EventQueryParams.Builder params = new EventQueryParams.Builder(
             createRequestParams( programIndicatorA, relationshipTypeA ) )
-                .withStartDate( startDate )
-                .withEndDate( endDate );
+            .withStartDate( startDate )
+            .withEndDate( endDate );
 
         when( programIndicatorService.getAnalyticsSql( "", NUMERIC, programIndicatorA, getDate( 2000, 1, 1 ),
             getDate( 2017, 4, 8 ), "subax" ) ).thenReturn( piSubquery );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/RelationshipTypeJoinGeneratorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/RelationshipTypeJoinGeneratorTest.java
@@ -183,11 +183,11 @@ class RelationshipTypeJoinGeneratorTest
     {
         switch ( relationshipEntity )
         {
-        case TRACKED_ENTITY_INSTANCE:
-            return TEI_JOIN_START;
-        case PROGRAM_STAGE_INSTANCE:
-        case PROGRAM_INSTANCE:
-            return (programIndicatorType.equals( AnalyticsType.EVENT ) ? PSI_JOIN_START : PI_JOIN_START);
+            case TRACKED_ENTITY_INSTANCE:
+                return TEI_JOIN_START;
+            case PROGRAM_STAGE_INSTANCE:
+            case PROGRAM_INSTANCE:
+                return (programIndicatorType.equals( AnalyticsType.EVENT ) ? PSI_JOIN_START : PI_JOIN_START);
         }
         return "";
     }
@@ -196,12 +196,12 @@ class RelationshipTypeJoinGeneratorTest
     {
         switch ( relationshipEntity )
         {
-        case TRACKED_ENTITY_INSTANCE:
-            return TEI_RELTO_JOIN;
-        case PROGRAM_STAGE_INSTANCE:
-            return PSI_RELTO_JOIN;
-        case PROGRAM_INSTANCE:
-            return PI_RELTO_JOIN;
+            case TRACKED_ENTITY_INSTANCE:
+                return TEI_RELTO_JOIN;
+            case PROGRAM_STAGE_INSTANCE:
+                return PSI_RELTO_JOIN;
+            case PROGRAM_INSTANCE:
+                return PI_RELTO_JOIN;
         }
         return "";
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
@@ -556,7 +556,7 @@ class JdbcEventAnalyticsTableManagerTest
 
         when( jdbcTemplate.queryForList( getYearQueryForCurrentYear( programA, true, availableDataYears ),
             Integer.class ) )
-                .thenReturn( List.of( 2018, 2019 ) );
+            .thenReturn( List.of( 2018, 2019 ) );
 
         // When
         subject.populateTable( params,
@@ -633,7 +633,7 @@ class JdbcEventAnalyticsTableManagerTest
         AnalyticsTableUpdateParams params = AnalyticsTableUpdateParams.newBuilder().withStartTime( START_TIME ).build();
         when( jdbcTemplate.queryForList( getYearQueryForCurrentYear( programA, false, availableDataYears ),
             Integer.class ) )
-                .thenReturn( List.of( 2018, 2019 ) );
+            .thenReturn( List.of( 2018, 2019 ) );
 
         List<AnalyticsTable> tables = subject.getAnalyticsTables( params );
 
@@ -666,7 +666,7 @@ class JdbcEventAnalyticsTableManagerTest
 
         when( jdbcTemplate.queryForList( getYearQueryForCurrentYear( programA, false, availableDataYears ),
             Integer.class ) )
-                .thenReturn( List.of( 2018, 2019 ) );
+            .thenReturn( List.of( 2018, 2019 ) );
 
         AnalyticsTableUpdateParams params = AnalyticsTableUpdateParams.newBuilder().withStartTime( START_TIME ).build();
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/analytics/hibernate/HibernateAnalyticsTableHookStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/analytics/hibernate/HibernateAnalyticsTableHookStore.java
@@ -76,9 +76,9 @@ public class HibernateAnalyticsTableHookStore
     {
         return getQuery(
             "from AnalyticsTableHook h where h.phase = :phase and h.resourceTableType = :resourceTableType" )
-                .setParameter( "phase", phase )
-                .setParameter( "resourceTableType", resourceTableType )
-                .getResultList();
+            .setParameter( "phase", phase )
+            .setParameter( "resourceTableType", resourceTableType )
+            .getResultList();
     }
 
     @Override
@@ -87,9 +87,9 @@ public class HibernateAnalyticsTableHookStore
     {
         return getQuery(
             "from AnalyticsTableHook h where h.phase = :phase and h.analyticsTableType = :analyticsTableType" )
-                .setParameter( "phase", phase )
-                .setParameter( "analyticsTableType", analyticsTableType )
-                .getResultList();
+            .setParameter( "phase", phase )
+            .setParameter( "analyticsTableType", analyticsTableType )
+            .getResultList();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
@@ -918,15 +918,15 @@ public class DefaultIdentifiableObjectManager implements IdentifiableObjectManag
 
         switch ( property )
         {
-        case UID:
-            return store.getByUid( identifiers );
-        case CODE:
-            return store.getByCode( identifiers );
-        case NAME:
-            return store.getByName( identifiers );
-        default:
-            throw new InvalidIdentifierReferenceException(
-                "Invalid identifiable property / class combination: " + property );
+            case UID:
+                return store.getByUid( identifiers );
+            case CODE:
+                return store.getByCode( identifiers );
+            case NAME:
+                return store.getByName( identifiers );
+            default:
+                throw new InvalidIdentifierReferenceException(
+                    "Invalid identifiable property / class combination: " + property );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DefaultDataSetNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DefaultDataSetNotificationService.java
@@ -466,7 +466,7 @@ public class DefaultDataSetNotificationService implements DataSetNotificationSer
                 new MessageConversationParams.Builder( msg.recipients, null, msg.message.getSubject(),
                     msg.message.getMessage(),
                     MessageType.SYSTEM, null )
-                        .build() ) );
+                    .build() ) );
     }
 
     private void sendProgramMessages( String type, List<ProgramMessage> messages, JobProgress progress )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datastore/hibernate/DatastoreQueryBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datastore/hibernate/DatastoreQueryBuilder.java
@@ -149,19 +149,19 @@ public class DatastoreQueryBuilder
     {
         switch ( filter.getOperator() )
         {
-        case EMPTY:
-        case NOT_EMPTY:
-            return createEmptinessFilterHQL( filter );
-        case NULL:
-        case NOT_NULL:
-            return createNullnessFilterHQL( filter );
-        case IN:
-        case NOT_IN:
-            return createInFilterHQL( filter, id );
-        default:
-            return filter.isNullValue()
-                ? createNullnessFilterHQL( filter )
-                : createBinaryFilterHQL( filter, id );
+            case EMPTY:
+            case NOT_EMPTY:
+                return createEmptinessFilterHQL( filter );
+            case NULL:
+            case NOT_NULL:
+                return createNullnessFilterHQL( filter );
+            case IN:
+            case NOT_IN:
+                return createInFilterHQL( filter, id );
+            default:
+                return filter.isNullValue()
+                    ? createNullnessFilterHQL( filter )
+                    : createBinaryFilterHQL( filter, id );
         }
     }
 
@@ -182,14 +182,14 @@ public class DatastoreQueryBuilder
         }
         switch ( deriveNodeType( filter ) )
         {
-        case "string":
-            return filter.getOperator().isCaseInsensitive()
-                ? "(jsonb_typeof(%1$s) = 'string' and lower(%5$s) %3$s %4$s)"
-                : "(jsonb_typeof(%1$s) = 'string' and %5$s %3$s %4$s)";
-        case "":
-            return "%1$s %3$s to_jsonb(%4$s)";
-        default:
-            return "(jsonb_typeof(%1$s) = '%2$s' and %1$s %3$s to_jsonb(%4$s))";
+            case "string":
+                return filter.getOperator().isCaseInsensitive()
+                    ? "(jsonb_typeof(%1$s) = 'string' and lower(%5$s) %3$s %4$s)"
+                    : "(jsonb_typeof(%1$s) = 'string' and %5$s %3$s %4$s)";
+            case "":
+                return "%1$s %3$s to_jsonb(%4$s)";
+            default:
+                return "(jsonb_typeof(%1$s) = '%2$s' and %1$s %3$s to_jsonb(%4$s))";
         }
     }
 
@@ -224,37 +224,37 @@ public class DatastoreQueryBuilder
     {
         switch ( op )
         {
-        case LESS_THAN:
-            return "<";
-        case LESS_THAN_OR_EQUAL:
-            return "<=";
-        case GREATER_THAN:
-            return ">";
-        case GREATER_THAN_OR_EQUAL:
-            return ">=";
-        case LIKE:
-        case ILIKE:
-        case STARTS_LIKE:
-        case ENDS_LIKE:
-        case STARTS_WITH:
-        case ENDS_WITH:
-            return "like";
-        case NOT_LIKE:
-        case NOT_ILIKE:
-        case NOT_STARTS_LIKE:
-        case NOT_ENDS_LIKE:
-        case NOT_STARTS_WITH:
-        case NOT_ENDS_WITH:
-            return "not like";
-        case IN:
-            return "in";
-        case NOT_IN:
-            return "not in";
-        case NOT_NULL:
-        case NOT_EQUAL:
-            return "!=";
-        default:
-            return "=";
+            case LESS_THAN:
+                return "<";
+            case LESS_THAN_OR_EQUAL:
+                return "<=";
+            case GREATER_THAN:
+                return ">";
+            case GREATER_THAN_OR_EQUAL:
+                return ">=";
+            case LIKE:
+            case ILIKE:
+            case STARTS_LIKE:
+            case ENDS_LIKE:
+            case STARTS_WITH:
+            case ENDS_WITH:
+                return "like";
+            case NOT_LIKE:
+            case NOT_ILIKE:
+            case NOT_STARTS_LIKE:
+            case NOT_ENDS_LIKE:
+            case NOT_STARTS_WITH:
+            case NOT_ENDS_WITH:
+                return "not like";
+            case IN:
+                return "in";
+            case NOT_IN:
+                return "not in";
+            case NOT_NULL:
+            case NOT_EQUAL:
+                return "!=";
+            default:
+                return "=";
         }
     }
 
@@ -263,22 +263,22 @@ public class DatastoreQueryBuilder
         String value = filter.getValue();
         switch ( value )
         {
-        case "true":
-        case "false":
-            return "boolean";
-        case "":
-        case "null":
-            return "";
-        default:
-            if ( value.startsWith( "{" ) && value.endsWith( "}" ) )
-            {
-                return "object";
-            }
-            else if ( value.startsWith( "[" ) && value.endsWith( "]" ) )
-            {
-                return "array";
-            }
-            return value.matches( "[0-9]+(\\.[0-9]*)?" ) ? "number" : "string";
+            case "true":
+            case "false":
+                return "boolean";
+            case "":
+            case "null":
+                return "";
+            default:
+                if ( value.startsWith( "{" ) && value.endsWith( "}" ) )
+                {
+                    return "object";
+                }
+                else if ( value.startsWith( "[" ) && value.endsWith( "]" ) )
+                {
+                    return "array";
+                }
+                return value.matches( "[0-9]+(\\.[0-9]*)?" ) ? "number" : "string";
         }
     }
 
@@ -287,19 +287,19 @@ public class DatastoreQueryBuilder
         String value = filter.getValue();
         switch ( deriveNodeType( filter ) )
         {
-        case "boolean":
-            return parseBoolean( value );
-        case "number":
-            double doubleValue = parseDouble( value );
-            return doubleValue % 1 == 0d ? (int) doubleValue : doubleValue;
-        case "array":
-            return filter.getOperator().isIn()
-                ? asList( value.substring( 1, value.length() - 1 ).split( "," ) )
-                : value;
-        case "object":
-            return value;
-        default:
-            return toTextPatternArgument( filter, value );
+            case "boolean":
+                return parseBoolean( value );
+            case "number":
+                double doubleValue = parseDouble( value );
+                return doubleValue % 1 == 0d ? (int) doubleValue : doubleValue;
+            case "array":
+                return filter.getOperator().isIn()
+                    ? asList( value.substring( 1, value.length() - 1 ).split( "," ) )
+                    : value;
+            case "object":
+                return value;
+            default:
+                return toTextPatternArgument( filter, value );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueStore.java
@@ -230,7 +230,7 @@ public class HibernateDataValueStore extends HibernateGenericStore<DataValue>
         return getCount( builder, newJpaParameters()
             .addPredicates( predicateList )
             .count( builder::countDistinct ) )
-                .intValue();
+            .intValue();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DataDimensionExtractor.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DataDimensionExtractor.java
@@ -100,51 +100,52 @@ public class DataDimensionExtractor
 
             switch ( id.getDimensionItemType() )
             {
-            case DATA_ELEMENT:
-                atomicIds.putValue( DataElement.class, id.getId0() );
-                break;
+                case DATA_ELEMENT:
+                    atomicIds.putValue( DataElement.class, id.getId0() );
+                    break;
 
-            case DATA_ELEMENT_OPERAND:
-                atomicIds.putValue( DataElement.class, id.getId0() );
-                if ( id.getId1() != null )
-                {
-                    atomicIds.putValue( CategoryOptionCombo.class, id.getId1() );
-                }
-                if ( id.getId2() != null )
-                {
-                    atomicIds.putValue( CategoryOptionCombo.class, id.getId2() );
-                }
-                break;
+                case DATA_ELEMENT_OPERAND:
+                    atomicIds.putValue( DataElement.class, id.getId0() );
+                    if ( id.getId1() != null )
+                    {
+                        atomicIds.putValue( CategoryOptionCombo.class, id.getId1() );
+                    }
+                    if ( id.getId2() != null )
+                    {
+                        atomicIds.putValue( CategoryOptionCombo.class, id.getId2() );
+                    }
+                    break;
 
-            case INDICATOR:
-                atomicIds.putValue( Indicator.class, id.getId0() );
-                break;
+                case INDICATOR:
+                    atomicIds.putValue( Indicator.class, id.getId0() );
+                    break;
 
-            case REPORTING_RATE:
-                atomicIds.putValue( DataSet.class, id.getId0() );
-                break;
+                case REPORTING_RATE:
+                    atomicIds.putValue( DataSet.class, id.getId0() );
+                    break;
 
-            case PROGRAM_DATA_ELEMENT:
-                atomicIds.putValue( Program.class, id.getId0() );
-                atomicIds.putValue( DataElement.class, id.getId1() );
-                break;
+                case PROGRAM_DATA_ELEMENT:
+                    atomicIds.putValue( Program.class, id.getId0() );
+                    atomicIds.putValue( DataElement.class, id.getId1() );
+                    break;
 
-            case PROGRAM_ATTRIBUTE:
-                atomicIds.putValue( Program.class, id.getId0() );
-                atomicIds.putValue( TrackedEntityAttribute.class, id.getId1() );
-                break;
+                case PROGRAM_ATTRIBUTE:
+                    atomicIds.putValue( Program.class, id.getId0() );
+                    atomicIds.putValue( TrackedEntityAttribute.class, id.getId1() );
+                    break;
 
-            case PROGRAM_INDICATOR:
-                atomicIds.putValue( ProgramIndicator.class, id.getId0() );
-                break;
+                case PROGRAM_INDICATOR:
+                    atomicIds.putValue( ProgramIndicator.class, id.getId0() );
+                    break;
 
-            case SUBEXPRESSION_DIMENSION_ITEM:
-                atomicIds.putValues( getAtomicIds( id.getSubexItemIds() ) );
-                break;
+                case SUBEXPRESSION_DIMENSION_ITEM:
+                    atomicIds.putValues( getAtomicIds( id.getSubexItemIds() ) );
+                    break;
 
-            default:
-                log.warn( "Unrecognized DimensionItemType " + id.getDimensionItemType().name() + " in getAtomicIds" );
-                break;
+                default:
+                    log.warn(
+                        "Unrecognized DimensionItemType " + id.getDimensionItemType().name() + " in getAtomicIds" );
+                    break;
             }
         }
 
@@ -297,71 +298,75 @@ public class DataDimensionExtractor
 
         switch ( id.getDimensionItemType() )
         {
-        case DATA_ELEMENT:
-            DataElement dataElement = (DataElement) atomicObjects.getValue( DataElement.class, id.getId0() );
-            dimensionalItemObject = withQueryMods( dataElement, id );
-            break;
+            case DATA_ELEMENT:
+                DataElement dataElement = (DataElement) atomicObjects.getValue( DataElement.class, id.getId0() );
+                dimensionalItemObject = withQueryMods( dataElement, id );
+                break;
 
-        case INDICATOR:
-            Indicator indicator = (Indicator) atomicObjects.getValue( Indicator.class, id.getId0() );
-            dimensionalItemObject = withQueryMods( indicator, id );
-            break;
+            case INDICATOR:
+                Indicator indicator = (Indicator) atomicObjects.getValue( Indicator.class, id.getId0() );
+                dimensionalItemObject = withQueryMods( indicator, id );
+                break;
 
-        case DATA_ELEMENT_OPERAND:
-            dataElement = (DataElement) atomicObjects.getValue( DataElement.class, id.getId0() );
-            CategoryOptionCombo categoryOptionCombo = id.getId1() == null ? null
-                : (CategoryOptionCombo) atomicObjects.getValue( CategoryOptionCombo.class, id.getId1() );
-            CategoryOptionCombo attributeOptionCombo = id.getId2() == null ? null
-                : (CategoryOptionCombo) atomicObjects.getValue( CategoryOptionCombo.class, id.getId2() );
-            if ( dataElement != null &&
-                (id.getId1() != null) == (categoryOptionCombo != null) &&
-                (id.getId2() != null) == (attributeOptionCombo != null) )
-            {
-                dimensionalItemObject = new DataElementOperand( (DataElement) withQueryMods( dataElement, id ),
-                    categoryOptionCombo, attributeOptionCombo );
-                dimensionalItemObject.setQueryMods( id.getQueryMods() );
-            }
-            break;
+            case DATA_ELEMENT_OPERAND:
+                dataElement = (DataElement) atomicObjects.getValue( DataElement.class, id.getId0() );
+                CategoryOptionCombo categoryOptionCombo = id.getId1() == null ? null
+                    : (CategoryOptionCombo) atomicObjects.getValue( CategoryOptionCombo.class, id.getId1() );
+                CategoryOptionCombo attributeOptionCombo = id.getId2() == null ? null
+                    : (CategoryOptionCombo) atomicObjects.getValue( CategoryOptionCombo.class, id.getId2() );
+                if ( dataElement != null &&
+                    (id.getId1() != null) == (categoryOptionCombo != null) &&
+                    (id.getId2() != null) == (attributeOptionCombo != null) )
+                {
+                    dimensionalItemObject = new DataElementOperand( (DataElement) withQueryMods( dataElement, id ),
+                        categoryOptionCombo, attributeOptionCombo );
+                    dimensionalItemObject.setQueryMods( id.getQueryMods() );
+                }
+                break;
 
-        case SUBEXPRESSION_DIMENSION_ITEM:
-            Map<DimensionalItemId, DimensionalItemObject> map = getItemObjectMap( id.getSubexItemIds(), atomicObjects );
-            dimensionalItemObject = new SubexpressionDimensionItem( id.getSubexSql(), map.values(), id.getQueryMods() );
-            break;
+            case SUBEXPRESSION_DIMENSION_ITEM:
+                Map<DimensionalItemId, DimensionalItemObject> map = getItemObjectMap( id.getSubexItemIds(),
+                    atomicObjects );
+                dimensionalItemObject = new SubexpressionDimensionItem( id.getSubexSql(), map.values(),
+                    id.getQueryMods() );
+                break;
 
-        case REPORTING_RATE:
-            DataSet dataSet = (DataSet) atomicObjects.getValue( DataSet.class, id.getId0() );
-            if ( dataSet != null )
-            {
-                dimensionalItemObject = new ReportingRate( dataSet, ReportingRateMetric.valueOf( id.getId1() ) );
-            }
-            break;
+            case REPORTING_RATE:
+                DataSet dataSet = (DataSet) atomicObjects.getValue( DataSet.class, id.getId0() );
+                if ( dataSet != null )
+                {
+                    dimensionalItemObject = new ReportingRate( dataSet, ReportingRateMetric.valueOf( id.getId1() ) );
+                }
+                break;
 
-        case PROGRAM_DATA_ELEMENT:
-            Program program = (Program) atomicObjects.getValue( Program.class, id.getId0() );
-            dataElement = (DataElement) atomicObjects.getValue( DataElement.class, id.getId1() );
-            if ( allNotNull( program, dataElement ) )
-            {
-                dimensionalItemObject = new ProgramDataElementDimensionItem( program, dataElement );
-            }
-            break;
+            case PROGRAM_DATA_ELEMENT:
+                Program program = (Program) atomicObjects.getValue( Program.class, id.getId0() );
+                dataElement = (DataElement) atomicObjects.getValue( DataElement.class, id.getId1() );
+                if ( allNotNull( program, dataElement ) )
+                {
+                    dimensionalItemObject = new ProgramDataElementDimensionItem( program, dataElement );
+                }
+                break;
 
-        case PROGRAM_ATTRIBUTE:
-            program = (Program) atomicObjects.getValue( Program.class, id.getId0() );
-            TrackedEntityAttribute attribute = (TrackedEntityAttribute) atomicObjects
-                .getValue( TrackedEntityAttribute.class, id.getId1() );
-            if ( allNotNull( program, attribute ) )
-            {
-                dimensionalItemObject = new ProgramTrackedEntityAttributeDimensionItem( program, attribute );
-            }
-            break;
+            case PROGRAM_ATTRIBUTE:
+                program = (Program) atomicObjects.getValue( Program.class, id.getId0() );
+                TrackedEntityAttribute attribute = (TrackedEntityAttribute) atomicObjects
+                    .getValue( TrackedEntityAttribute.class, id.getId1() );
+                if ( allNotNull( program, attribute ) )
+                {
+                    dimensionalItemObject = new ProgramTrackedEntityAttributeDimensionItem( program, attribute );
+                }
+                break;
 
-        case PROGRAM_INDICATOR:
-            dimensionalItemObject = (ProgramIndicator) atomicObjects.getValue( ProgramIndicator.class, id.getId0() );
-            break;
+            case PROGRAM_INDICATOR:
+                dimensionalItemObject = (ProgramIndicator) atomicObjects.getValue( ProgramIndicator.class,
+                    id.getId0() );
+                break;
 
-        default:
-            log.warn( "Unrecognized DimensionItemType " + id.getDimensionItemType().name() + " in getItemObjectMap" );
-            break;
+            default:
+                log.warn(
+                    "Unrecognized DimensionItemType " + id.getDimensionItemType().name() + " in getItemObjectMap" );
+                break;
         }
 
         return dimensionalItemObject;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -653,36 +653,36 @@ public class DefaultExpressionService
 
         switch ( params.getMissingValueStrategy() )
         {
-        case SKIP_IF_ANY_VALUE_MISSING:
-            if ( itemValuesFound < itemsFound )
-            {
-                return null;
-            }
-            break;
+            case SKIP_IF_ANY_VALUE_MISSING:
+                if ( itemValuesFound < itemsFound )
+                {
+                    return null;
+                }
+                break;
 
-        case SKIP_IF_ALL_VALUES_MISSING:
-            if ( itemsFound != 0 && itemValuesFound == 0 )
-            {
-                return null;
-            }
-            break;
+            case SKIP_IF_ALL_VALUES_MISSING:
+                if ( itemsFound != 0 && itemValuesFound == 0 )
+                {
+                    return null;
+                }
+                break;
 
-        case NEVER_SKIP:
-            break;
+            case NEVER_SKIP:
+                break;
         }
 
         if ( value == null && state.isReplaceNulls() )
         {
             switch ( params.getDataType() )
             {
-            case NUMERIC:
-                return 0d;
+                case NUMERIC:
+                    return 0d;
 
-            case BOOLEAN:
-                return FALSE;
+                case BOOLEAN:
+                    return FALSE;
 
-            case TEXT:
-                return "";
+                case TEXT:
+                    return "";
             }
         }
 
@@ -788,14 +788,14 @@ public class DefaultExpressionService
 
             switch ( dataType )
             {
-            case NUMERIC:
-                return castDouble( result );
+                case NUMERIC:
+                    return castDouble( result );
 
-            case BOOLEAN:
-                return castBoolean( result );
+                case BOOLEAN:
+                    return castBoolean( result );
 
-            case TEXT:
-                return castString( result );
+                case TEXT:
+                    return castString( result );
             }
         }
         catch ( ParserException ex )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/DefaultFileResourceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/DefaultFileResourceService.java
@@ -143,29 +143,30 @@ public class DefaultFileResourceService
         String uid = fr.getUid();
         switch ( fr.getDomain() )
         {
-        case PUSH_ANALYSIS:
-            return List.of();
-        case ORG_UNIT:
-            return fileResourceStore.findOrganisationUnitsByImageFileResource( uid ).stream()
-                .map( id -> new FileResourceOwner( FileResourceDomain.ORG_UNIT, id ) )
-                .collect( toUnmodifiableList() );
-        case DOCUMENT:
-            return fileResourceStore.findDocumentsByFileResource( uid ).stream()
-                .map( id -> new FileResourceOwner( FileResourceDomain.DOCUMENT, id ) )
-                .collect( toUnmodifiableList() );
-        case MESSAGE_ATTACHMENT:
-            return fileResourceStore.findMessagesByFileResource( uid ).stream()
-                .map( id -> new FileResourceOwner( FileResourceDomain.MESSAGE_ATTACHMENT, id ) )
-                .collect( toUnmodifiableList() );
-        case USER_AVATAR:
-            return fileResourceStore.findUsersByAvatarFileResource( uid ).stream()
-                .map( id -> new FileResourceOwner( FileResourceDomain.USER_AVATAR, id ) )
-                .collect( toUnmodifiableList() );
-        case DATA_VALUE:
-            return fileResourceStore.findDataValuesByFileResourceValue( uid ).stream()
-                .map( dv -> new FileResourceOwner( dv.de(), dv.ou(), periodService.getPeriod( dv.pe() ).getIsoDate(),
-                    dv.co() ) )
-                .collect( toUnmodifiableList() );
+            case PUSH_ANALYSIS:
+                return List.of();
+            case ORG_UNIT:
+                return fileResourceStore.findOrganisationUnitsByImageFileResource( uid ).stream()
+                    .map( id -> new FileResourceOwner( FileResourceDomain.ORG_UNIT, id ) )
+                    .collect( toUnmodifiableList() );
+            case DOCUMENT:
+                return fileResourceStore.findDocumentsByFileResource( uid ).stream()
+                    .map( id -> new FileResourceOwner( FileResourceDomain.DOCUMENT, id ) )
+                    .collect( toUnmodifiableList() );
+            case MESSAGE_ATTACHMENT:
+                return fileResourceStore.findMessagesByFileResource( uid ).stream()
+                    .map( id -> new FileResourceOwner( FileResourceDomain.MESSAGE_ATTACHMENT, id ) )
+                    .collect( toUnmodifiableList() );
+            case USER_AVATAR:
+                return fileResourceStore.findUsersByAvatarFileResource( uid ).stream()
+                    .map( id -> new FileResourceOwner( FileResourceDomain.USER_AVATAR, id ) )
+                    .collect( toUnmodifiableList() );
+            case DATA_VALUE:
+                return fileResourceStore.findDataValuesByFileResourceValue( uid ).stream()
+                    .map(
+                        dv -> new FileResourceOwner( dv.de(), dv.ou(), periodService.getPeriod( dv.pe() ).getIsoDate(),
+                            dv.co() ) )
+                    .collect( toUnmodifiableList() );
         }
         return List.of();
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/hibernate/HibernateFileResourceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/hibernate/HibernateFileResourceStore.java
@@ -89,10 +89,10 @@ public class HibernateFileResourceStore
     {
         return getQuery(
             "FROM FileResource fr WHERE fr.domain IN ( :domains ) AND fr.contentType IN ( :contentTypes ) AND hasMultipleStorageFiles = :hasMultipleStorageFiles" )
-                .setParameter( "domains", FileResourceDomain.DOMAIN_FOR_MULTIPLE_IMAGES )
-                .setParameter( "contentTypes", IMAGE_CONTENT_TYPES )
-                .setParameter( "hasMultipleStorageFiles", false )
-                .setMaxResults( 50 ).getResultList();
+            .setParameter( "domains", FileResourceDomain.DOMAIN_FOR_MULTIPLE_IMAGES )
+            .setParameter( "contentTypes", IMAGE_CONTENT_TYPES )
+            .setParameter( "hasMultipleStorageFiles", false )
+            .setMaxResults( 50 ).getResultList();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
@@ -623,27 +623,27 @@ final class GistBuilder
         Transform transform = field.getTransformation();
         switch ( transform )
         {
-        default:
-        case AUTO:
-        case NONE:
-            return HQL_NULL;
-        case SIZE:
-            return createSizeTransformerHQL( index, field, property, "" );
-        case IS_EMPTY:
-            return createSizeTransformerHQL( index, field, property, "=0" );
-        case IS_NOT_EMPTY:
-            return createSizeTransformerHQL( index, field, property, ">0" );
-        case NOT_MEMBER:
-            return createHasMemberTransformerHQL( index, field, property, "=0" );
-        case MEMBER:
-            return createHasMemberTransformerHQL( index, field, property, ">0" );
-        case ID_OBJECTS:
-            addTransformer( row -> row[index] = toIdObjects( row[index] ) );
-            return createIdsTransformerHQL( index, field, property );
-        case IDS:
-            return createIdsTransformerHQL( index, field, property );
-        case PLUCK:
-            return createPluckTransformerHQL( index, field, property );
+            default:
+            case AUTO:
+            case NONE:
+                return HQL_NULL;
+            case SIZE:
+                return createSizeTransformerHQL( index, field, property, "" );
+            case IS_EMPTY:
+                return createSizeTransformerHQL( index, field, property, "=0" );
+            case IS_NOT_EMPTY:
+                return createSizeTransformerHQL( index, field, property, ">0" );
+            case NOT_MEMBER:
+                return createHasMemberTransformerHQL( index, field, property, "=0" );
+            case MEMBER:
+                return createHasMemberTransformerHQL( index, field, property, ">0" );
+            case ID_OBJECTS:
+                addTransformer( row -> row[index] = toIdObjects( row[index] ) );
+                return createIdsTransformerHQL( index, field, property );
+            case IDS:
+                return createIdsTransformerHQL( index, field, property );
+            case PLUCK:
+                return createPluckTransformerHQL( index, field, property );
         }
     }
 
@@ -947,17 +947,17 @@ final class GistBuilder
     {
         switch ( filter.getOperator() )
         {
-        default:
-        case CAN_READ:
-            return AclService.LIKE_READ_METADATA;
-        case CAN_WRITE:
-            return AclService.LIKE_WRITE_METADATA;
-        case CAN_DATA_READ:
-            return AclService.LIKE_READ_DATA;
-        case CAN_DATA_WRITE:
-            return AclService.LIKE_WRITE_DATA;
-        case CAN_ACCESS:
-            return filter.getValue()[1];
+            default:
+            case CAN_READ:
+                return AclService.LIKE_READ_METADATA;
+            case CAN_WRITE:
+                return AclService.LIKE_WRITE_METADATA;
+            case CAN_DATA_READ:
+                return AclService.LIKE_READ_DATA;
+            case CAN_DATA_WRITE:
+                return AclService.LIKE_WRITE_DATA;
+            case CAN_ACCESS:
+                return filter.getValue()[1];
         }
     }
 
@@ -972,47 +972,47 @@ final class GistBuilder
     {
         switch ( operator )
         {
-        case NULL:
-            return "is null";
-        case NOT_NULL:
-            return "is not null";
-        case EQ:
-        case IEQ:
-            return "=";
-        case NE:
-            return "!=";
-        case LT:
-            return "<";
-        case GT:
-            return ">";
-        case LE:
-            return "<=";
-        case GE:
-            return ">=";
-        case IN:
-            return "in (";
-        case NOT_IN:
-            return "not in (";
-        case EMPTY:
-            return "= 0";
-        case NOT_EMPTY:
-            return "> 0";
-        case LIKE:
-        case STARTS_LIKE:
-        case ENDS_LIKE:
-        case ILIKE:
-        case STARTS_WITH:
-        case ENDS_WITH:
-            return "like";
-        case NOT_LIKE:
-        case NOT_STARTS_LIKE:
-        case NOT_ENDS_LIKE:
-        case NOT_ILIKE:
-        case NOT_STARTS_WITH:
-        case NOT_ENDS_WITH:
-            return "not like";
-        default:
-            return "";
+            case NULL:
+                return "is null";
+            case NOT_NULL:
+                return "is not null";
+            case EQ:
+            case IEQ:
+                return "=";
+            case NE:
+                return "!=";
+            case LT:
+                return "<";
+            case GT:
+                return ">";
+            case LE:
+                return "<=";
+            case GE:
+                return ">=";
+            case IN:
+                return "in (";
+            case NOT_IN:
+                return "not in (";
+            case EMPTY:
+                return "= 0";
+            case NOT_EMPTY:
+                return "> 0";
+            case LIKE:
+            case STARTS_LIKE:
+            case ENDS_LIKE:
+            case ILIKE:
+            case STARTS_WITH:
+            case ENDS_WITH:
+                return "like";
+            case NOT_LIKE:
+            case NOT_STARTS_LIKE:
+            case NOT_ENDS_LIKE:
+            case NOT_ILIKE:
+            case NOT_STARTS_WITH:
+            case NOT_ENDS_WITH:
+                return "not like";
+            default:
+                return "";
         }
     }
 
@@ -1020,11 +1020,11 @@ final class GistBuilder
     {
         switch ( operator )
         {
-        case NOT_IN:
-        case IN:
-            return ")";
-        default:
-            return "";
+            case NOT_IN:
+            case IN:
+                return ")";
+            default:
+                return "";
         }
     }
 
@@ -1138,23 +1138,23 @@ final class GistBuilder
     {
         switch ( operator )
         {
-        case LIKE:
-        case ILIKE:
-        case NOT_ILIKE:
-        case NOT_LIKE:
-            return sqlLikeExpressionOf( value );
-        case STARTS_LIKE:
-        case STARTS_WITH:
-        case NOT_STARTS_LIKE:
-        case NOT_STARTS_WITH:
-            return value + "%";
-        case ENDS_LIKE:
-        case ENDS_WITH:
-        case NOT_ENDS_LIKE:
-        case NOT_ENDS_WITH:
-            return "%" + value;
-        default:
-            return value;
+            case LIKE:
+            case ILIKE:
+            case NOT_ILIKE:
+            case NOT_LIKE:
+                return sqlLikeExpressionOf( value );
+            case STARTS_LIKE:
+            case STARTS_WITH:
+            case NOT_STARTS_LIKE:
+            case NOT_STARTS_WITH:
+                return value + "%";
+            case ENDS_LIKE:
+            case ENDS_WITH:
+            case NOT_ENDS_LIKE:
+            case NOT_ENDS_WITH:
+                return "%" + value;
+            default:
+                return value;
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/icon/jdbc/JdbcCustomIconStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/icon/jdbc/JdbcCustomIconStore.java
@@ -64,40 +64,43 @@ public class JdbcCustomIconStore implements CustomIconStore
     };
 
     @Override
-    public CustomIcon getIconByKey(String key) {
+    public CustomIcon getIconByKey( String key )
+    {
         final String sql = """
-                    select c.key as iconkey, c.description as icondescription, c.keywords as keywords, f.uid as fileresourceuid, u.uid as useruid
-                    from customicon c join fileresource f on f.fileresourceid = c.fileresourceid
-                    join userinfo u on u.userinfoid = c.createdby
-                    where key = ?
-                    """;
+            select c.key as iconkey, c.description as icondescription, c.keywords as keywords, f.uid as fileresourceuid, u.uid as useruid
+            from customicon c join fileresource f on f.fileresourceid = c.fileresourceid
+            join userinfo u on u.userinfoid = c.createdby
+            where key = ?
+            """;
 
-        List<CustomIcon> customIcons = jdbcTemplate.query(sql, customIconRowMapper, key);
+        List<CustomIcon> customIcons = jdbcTemplate.query( sql, customIconRowMapper, key );
 
-        return customIcons.isEmpty() ? null : customIcons.get(0);
+        return customIcons.isEmpty() ? null : customIcons.get( 0 );
     }
 
     @Override
-    public List<CustomIcon> getIconsByKeywords(String[] keywords) {
+    public List<CustomIcon> getIconsByKeywords( String[] keywords )
+    {
         final String sql = """
-                    select c.key as iconkey, c.description as icondescription, c.keywords as keywords, f.uid as fileresourceuid, u.uid as useruid
-                    from customicon c join fileresource f on f.fileresourceid = c.fileresourceid
-                    join userinfo u on u.userinfoid = c.createdby
-                    where keywords @> string_to_array(?,',')
-                    """;
+            select c.key as iconkey, c.description as icondescription, c.keywords as keywords, f.uid as fileresourceuid, u.uid as useruid
+            from customicon c join fileresource f on f.fileresourceid = c.fileresourceid
+            join userinfo u on u.userinfoid = c.createdby
+            where keywords @> string_to_array(?,',')
+            """;
 
-        return jdbcTemplate.query(sql, customIconRowMapper, String.join(",", keywords));
+        return jdbcTemplate.query( sql, customIconRowMapper, String.join( ",", keywords ) );
     }
 
     @Override
-    public List<CustomIcon> getAllIcons() {
+    public List<CustomIcon> getAllIcons()
+    {
         final String sql = """
-                    select c.key as iconkey, c.description as icondescription, c.keywords as keywords, f.uid as fileresourceuid, u.uid as useruid
-                    from customicon c join fileresource f on f.fileresourceid = c.fileresourceid
-                    join userinfo u on u.userinfoid = c.createdby
-                    """;
+            select c.key as iconkey, c.description as icondescription, c.keywords as keywords, f.uid as fileresourceuid, u.uid as useruid
+            from customicon c join fileresource f on f.fileresourceid = c.fileresourceid
+            join userinfo u on u.userinfoid = c.createdby
+            """;
 
-        return jdbcTemplate.query(sql, customIconRowMapper);
+        return jdbcTemplate.query( sql, customIconRowMapper );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/interpretation/DefaultInterpretationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/interpretation/DefaultInterpretationService.java
@@ -217,28 +217,28 @@ public class DefaultInterpretationService
 
         switch ( notificationType )
         {
-        case INTERPRETATION_CREATE:
-            actionString = i18n.getString( "notification_interpretation_create" );
-            details = interpretation.getText();
-            break;
-        case INTERPRETATION_UPDATE:
-            actionString = i18n.getString( "notification_interpretation_update" );
-            details = interpretation.getText();
-            break;
-        case INTERPRETATION_LIKE:
-            actionString = i18n.getString( "notification_interpretation_like" );
-            details = "";
-            break;
-        case COMMENT_CREATE:
-            actionString = i18n.getString( "notification_comment_create" );
-            details = comment.getText();
-            break;
-        case COMMENT_UPDATE:
-            actionString = i18n.getString( "notification_comment_update" );
-            details = comment.getText();
-            break;
-        default:
-            throw new IllegalArgumentException( "Unknown notification type: " + notificationType );
+            case INTERPRETATION_CREATE:
+                actionString = i18n.getString( "notification_interpretation_create" );
+                details = interpretation.getText();
+                break;
+            case INTERPRETATION_UPDATE:
+                actionString = i18n.getString( "notification_interpretation_update" );
+                details = interpretation.getText();
+                break;
+            case INTERPRETATION_LIKE:
+                actionString = i18n.getString( "notification_interpretation_like" );
+                details = "";
+                break;
+            case COMMENT_CREATE:
+                actionString = i18n.getString( "notification_comment_create" );
+                details = comment.getText();
+                break;
+            case COMMENT_UPDATE:
+                actionString = i18n.getString( "notification_comment_update" );
+                details = comment.getText();
+                break;
+            default:
+                throw new IllegalArgumentException( "Unknown notification type: " + notificationType );
         }
 
         String subject = String.join( " ", Arrays.asList(
@@ -317,29 +317,30 @@ public class DefaultInterpretationService
 
         switch ( interpretation.getType() )
         {
-        case MAP:
-            path = "/dhis-web-maps/index.html?id=" + interpretation.getMap().getUid() + "&interpretationid="
-                + interpretation.getUid();
-            break;
-        case VISUALIZATION:
-            path = "/dhis-web-data-visualizer/index.html#/" + interpretation.getVisualization().getUid()
-                + "/interpretation/" + interpretation.getUid();
-            break;
-        case EVENT_REPORT:
-            path = "/dhis-web-event-reports/index.html?id=" + interpretation.getEventReport().getUid()
-                + "&interpretationid=" + interpretation.getUid();
-            break;
-        case EVENT_VISUALIZATION:
-            path = "/api/apps/line-listing/#/" + interpretation.getEventVisualization().getUid() + "?interpretationId="
-                + interpretation.getUid();
-            break;
-        case EVENT_CHART:
-            path = "/dhis-web-event-visualizer/index.html?id=" + interpretation.getEventChart().getUid()
-                + "&interpretationid=" + interpretation.getUid();
-            break;
-        default:
-            path = "";
-            break;
+            case MAP:
+                path = "/dhis-web-maps/index.html?id=" + interpretation.getMap().getUid() + "&interpretationid="
+                    + interpretation.getUid();
+                break;
+            case VISUALIZATION:
+                path = "/dhis-web-data-visualizer/index.html#/" + interpretation.getVisualization().getUid()
+                    + "/interpretation/" + interpretation.getUid();
+                break;
+            case EVENT_REPORT:
+                path = "/dhis-web-event-reports/index.html?id=" + interpretation.getEventReport().getUid()
+                    + "&interpretationid=" + interpretation.getUid();
+                break;
+            case EVENT_VISUALIZATION:
+                path = "/api/apps/line-listing/#/" + interpretation.getEventVisualization().getUid()
+                    + "?interpretationId="
+                    + interpretation.getUid();
+                break;
+            case EVENT_CHART:
+                path = "/dhis-web-event-visualizer/index.html?id=" + interpretation.getEventChart().getUid()
+                    + "&interpretationid=" + interpretation.getUid();
+                break;
+            default:
+                path = "";
+                break;
         }
         return configurationProvider.getServerBaseUrl() + path;
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/hibernate/HibernateOrganisationUnitGroupStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/hibernate/HibernateOrganisationUnitGroupStore.java
@@ -74,9 +74,9 @@ public class HibernateOrganisationUnitGroupStore
     {
         return getQuery(
             "select g from OrganisationUnitGroup g inner join g.groupSets gs where gs = :groupSet and g in :groups" )
-                .setParameter( "groupSet", groupSet )
-                .setParameter( "groups", groups )
-                .setMaxResults( 1 )
-                .uniqueResult();
+            .setParameter( "groupSet", groupSet )
+            .setParameter( "groups", groups )
+            .setMaxResults( 1 )
+            .uniqueResult();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/hibernate/HibernateOrganisationUnitStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/hibernate/HibernateOrganisationUnitStore.java
@@ -113,7 +113,7 @@ public class HibernateOrganisationUnitStore
         return getQuery(
             "from OrganisationUnit o where o.parent is null and not exists " +
                 "(select 1 from OrganisationUnit io where io.parent = o.id)" )
-                    .list();
+            .list();
     }
 
     @Override
@@ -132,7 +132,7 @@ public class HibernateOrganisationUnitStore
         return getQuery( "from OrganisationUnit o where size(o.groups) > 1 and exists " +
             "(select 1 from OrganisationUnitGroupSet s where " +
             "(select count(*) from OrganisationUnitGroup g where o in elements(g.members) and s in elements(g.groupSets)) > 1)" )
-                .list();
+            .list();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/patch/DefaultPatchService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/patch/DefaultPatchService.java
@@ -257,28 +257,28 @@ public class DefaultPatchService implements PatchService
 
         switch ( node.getNodeType() )
         {
-        case OBJECT:
-            List<String> fieldNames = Lists.newArrayList( node.fieldNames() );
+            case OBJECT:
+                List<String> fieldNames = Lists.newArrayList( node.fieldNames() );
 
-            for ( String fieldName : fieldNames )
-            {
-                mutations.addAll( calculateMutations( path + "." + fieldName, node.get( fieldName ) ) );
-            }
+                for ( String fieldName : fieldNames )
+                {
+                    mutations.addAll( calculateMutations( path + "." + fieldName, node.get( fieldName ) ) );
+                }
 
-            break;
-        case ARRAY:
-            Collection<Object> identifiers = new ArrayList<>();
+                break;
+            case ARRAY:
+                Collection<Object> identifiers = new ArrayList<>();
 
-            for ( JsonNode jsonNode : node )
-            {
-                identifiers.add( getValue( jsonNode ) );
-            }
+                for ( JsonNode jsonNode : node )
+                {
+                    identifiers.add( getValue( jsonNode ) );
+                }
 
-            mutations.add( new Mutation( path, identifiers ) );
-            break;
-        default:
-            mutations.add( new Mutation( path, getValue( node ) ) );
-            break;
+                mutations.add( new Mutation( path, identifiers ) );
+                break;
+            default:
+                mutations.add( new Mutation( path, getValue( node ) ) );
+                break;
         }
 
         return mutations;
@@ -288,14 +288,14 @@ public class DefaultPatchService implements PatchService
     {
         switch ( node.getNodeType() )
         {
-        case BOOLEAN:
-            return node.booleanValue();
-        case NUMBER:
-            return node.numberValue();
-        case STRING:
-            return node.textValue();
-        case NULL:
-            return null;
+            case BOOLEAN:
+                return node.booleanValue();
+            case NUMBER:
+                return node.numberValue();
+            case STRING:
+                return node.textValue();
+            case NULL:
+                return null;
         }
 
         return null;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramElementsAndAttributesCollecter.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramElementsAndAttributesCollecter.java
@@ -77,33 +77,33 @@ public class ProgramElementsAndAttributesCollecter
 
         switch ( ctx.it.getType() )
         {
-        case HASH_BRACE:
-            assumeStageElementSyntax( ctx );
+            case HASH_BRACE:
+                assumeStageElementSyntax( ctx );
 
-            String programStageId = ctx.uid0.getText();
-            String dataElementId = ctx.uid1.getText();
+                String programStageId = ctx.uid0.getText();
+                String dataElementId = ctx.uid1.getText();
 
-            if ( AnalyticsType.ENROLLMENT.equals( analyticsType ) )
-            {
-                items.add( programStageId + "_" + dataElementId );
-            }
-            else
-            {
-                items.add( dataElementId );
-            }
-            break;
+                if ( AnalyticsType.ENROLLMENT.equals( analyticsType ) )
+                {
+                    items.add( programStageId + "_" + dataElementId );
+                }
+                else
+                {
+                    items.add( dataElementId );
+                }
+                break;
 
-        case A_BRACE:
-            assumeProgramExpressionProgramAttribute( ctx );
+            case A_BRACE:
+                assumeProgramExpressionProgramAttribute( ctx );
 
-            String attributeId = ctx.uid0.getText();
+                String attributeId = ctx.uid0.getText();
 
-            items.add( attributeId );
+                items.add( attributeId );
 
-            break;
+                break;
 
-        default:
-            break;
+            default:
+                break;
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationService.java
@@ -628,8 +628,8 @@ public class DefaultProgramNotificationService
         messages.forEach( m -> messageService.sendMessage(
             new MessageConversationParams.Builder( m.recipients, null, m.message.getSubject(), m.message.getMessage(),
                 MessageType.SYSTEM, null )
-                    .withForceNotification( true )
-                    .build() ) );
+                .withForceNotification( true )
+                .build() ) );
     }
 
     private void sendProgramMessages( Set<ProgramMessage> messages )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultJpaQueryParser.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultJpaQueryParser.java
@@ -135,148 +135,148 @@ public class DefaultJpaQueryParser
 
         switch ( operator )
         {
-        case "eq":
-        {
-            return Restrictions.eq( path, parseValue( valueType, arg ) );
-        }
-        case "!eq":
-        case "neq":
-        case "ne":
-        {
-            return Restrictions.ne( path, parseValue( valueType, arg ) );
-        }
-        case "gt":
-        {
-            return Restrictions.gt( path, parseValue( valueType, arg ) );
-        }
-        case "lt":
-        {
-            return Restrictions.lt( path, parseValue( valueType, arg ) );
-        }
-        case "gte":
-        case "ge":
-        {
-            return Restrictions.ge( path, parseValue( valueType, arg ) );
-        }
-        case "lte":
-        case "le":
-        {
-            return Restrictions.le( path, parseValue( valueType, arg ) );
-        }
-        case "like":
-        {
-            return Restrictions.like( path, parseValue( valueType, arg ), MatchMode.ANYWHERE );
-        }
-        case "!like":
-        {
-            return Restrictions.notLike( path, parseValue( valueType, arg ), MatchMode.ANYWHERE );
-        }
-        case "$like":
-        {
-            return Restrictions.like( path, parseValue( valueType, arg ), MatchMode.START );
-        }
-        case "!$like":
-        {
-            return Restrictions.notLike( path, parseValue( valueType, arg ), MatchMode.START );
-        }
-        case "like$":
-        {
-            return Restrictions.like( path, parseValue( valueType, arg ), MatchMode.END );
-        }
-        case "!like$":
-        {
-            return Restrictions.notLike( path, parseValue( valueType, arg ), MatchMode.END );
-        }
-        case "ilike":
-        {
-            return Restrictions.ilike( path, parseValue( valueType, arg ), MatchMode.ANYWHERE );
-        }
-        case "!ilike":
-        {
-            return Restrictions.notIlike( path, parseValue( valueType, arg ), MatchMode.ANYWHERE );
-        }
-        case "startsWith":
-        case "$ilike":
-        {
-            return Restrictions.ilike( path, parseValue( valueType, arg ), MatchMode.START );
-        }
-        case "!$ilike":
-        {
-            return Restrictions.notIlike( path, parseValue( valueType, arg ), MatchMode.START );
-        }
-        case "token":
-        {
-            return Restrictions.token( path, parseValue( valueType, arg ), MatchMode.START );
-        }
-        case "!token":
-        {
-            return Restrictions.notToken( path, parseValue( valueType, arg ), MatchMode.START );
-        }
-        case "endsWith":
-        case "ilike$":
-        {
-            return Restrictions.ilike( path, parseValue( valueType, arg ), MatchMode.END );
-        }
-        case "!ilike$":
-        {
-            return Restrictions.notIlike( path, parseValue( valueType, arg ), MatchMode.END );
-        }
-        case "in":
-        {
-            Collection values = null;
-
-            if ( property.isCollection() )
+            case "eq":
             {
-                values = parseValue( Collection.class, property.getItemKlass(), arg );
+                return Restrictions.eq( path, parseValue( valueType, arg ) );
             }
-            else
+            case "!eq":
+            case "neq":
+            case "ne":
             {
-                values = parseValue( Collection.class, valueType, arg );
+                return Restrictions.ne( path, parseValue( valueType, arg ) );
             }
-
-            if ( values == null || values.isEmpty() )
+            case "gt":
             {
-                throw new QueryParserException( "Invalid argument `" + arg + "` for in operator." );
+                return Restrictions.gt( path, parseValue( valueType, arg ) );
             }
-
-            return Restrictions.in( path, values );
-        }
-        case "!in":
-        {
-            Collection values = null;
-
-            if ( property.isCollection() )
+            case "lt":
             {
-                values = parseValue( Collection.class, property.getItemKlass(), arg );
+                return Restrictions.lt( path, parseValue( valueType, arg ) );
             }
-            else
+            case "gte":
+            case "ge":
             {
-                values = parseValue( Collection.class, valueType, arg );
+                return Restrictions.ge( path, parseValue( valueType, arg ) );
             }
-
-            if ( values == null || values.isEmpty() )
+            case "lte":
+            case "le":
             {
-                throw new QueryParserException( "Invalid argument `" + arg + "` for in operator." );
+                return Restrictions.le( path, parseValue( valueType, arg ) );
             }
+            case "like":
+            {
+                return Restrictions.like( path, parseValue( valueType, arg ), MatchMode.ANYWHERE );
+            }
+            case "!like":
+            {
+                return Restrictions.notLike( path, parseValue( valueType, arg ), MatchMode.ANYWHERE );
+            }
+            case "$like":
+            {
+                return Restrictions.like( path, parseValue( valueType, arg ), MatchMode.START );
+            }
+            case "!$like":
+            {
+                return Restrictions.notLike( path, parseValue( valueType, arg ), MatchMode.START );
+            }
+            case "like$":
+            {
+                return Restrictions.like( path, parseValue( valueType, arg ), MatchMode.END );
+            }
+            case "!like$":
+            {
+                return Restrictions.notLike( path, parseValue( valueType, arg ), MatchMode.END );
+            }
+            case "ilike":
+            {
+                return Restrictions.ilike( path, parseValue( valueType, arg ), MatchMode.ANYWHERE );
+            }
+            case "!ilike":
+            {
+                return Restrictions.notIlike( path, parseValue( valueType, arg ), MatchMode.ANYWHERE );
+            }
+            case "startsWith":
+            case "$ilike":
+            {
+                return Restrictions.ilike( path, parseValue( valueType, arg ), MatchMode.START );
+            }
+            case "!$ilike":
+            {
+                return Restrictions.notIlike( path, parseValue( valueType, arg ), MatchMode.START );
+            }
+            case "token":
+            {
+                return Restrictions.token( path, parseValue( valueType, arg ), MatchMode.START );
+            }
+            case "!token":
+            {
+                return Restrictions.notToken( path, parseValue( valueType, arg ), MatchMode.START );
+            }
+            case "endsWith":
+            case "ilike$":
+            {
+                return Restrictions.ilike( path, parseValue( valueType, arg ), MatchMode.END );
+            }
+            case "!ilike$":
+            {
+                return Restrictions.notIlike( path, parseValue( valueType, arg ), MatchMode.END );
+            }
+            case "in":
+            {
+                Collection values = null;
 
-            return Restrictions.notIn( path, values );
-        }
-        case "null":
-        {
-            return Restrictions.isNull( path );
-        }
-        case "!null":
-        {
-            return Restrictions.isNotNull( path );
-        }
-        case "empty":
-        {
-            return Restrictions.isEmpty( path );
-        }
-        default:
-        {
-            throw new QueryParserException( "`" + operator + "` is not a valid operator." );
-        }
+                if ( property.isCollection() )
+                {
+                    values = parseValue( Collection.class, property.getItemKlass(), arg );
+                }
+                else
+                {
+                    values = parseValue( Collection.class, valueType, arg );
+                }
+
+                if ( values == null || values.isEmpty() )
+                {
+                    throw new QueryParserException( "Invalid argument `" + arg + "` for in operator." );
+                }
+
+                return Restrictions.in( path, values );
+            }
+            case "!in":
+            {
+                Collection values = null;
+
+                if ( property.isCollection() )
+                {
+                    values = parseValue( Collection.class, property.getItemKlass(), arg );
+                }
+                else
+                {
+                    values = parseValue( Collection.class, valueType, arg );
+                }
+
+                if ( values == null || values.isEmpty() )
+                {
+                    throw new QueryParserException( "Invalid argument `" + arg + "` for in operator." );
+                }
+
+                return Restrictions.notIn( path, values );
+            }
+            case "null":
+            {
+                return Restrictions.isNull( path );
+            }
+            case "!null":
+            {
+                return Restrictions.isNotNull( path );
+            }
+            case "empty":
+            {
+                return Restrictions.isEmpty( path );
+            }
+            default:
+            {
+                throw new QueryParserException( "`" + operator + "` is not a valid operator." );
+            }
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaCriteriaQueryEngine.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaCriteriaQueryEngine.java
@@ -257,10 +257,10 @@ public class JpaCriteriaQueryEngine<T extends IdentifiableObject>
     {
         switch ( type )
         {
-        case AND:
-            return builder.conjunction();
-        case OR:
-            return builder.disjunction();
+            case AND:
+                return builder.conjunction();
+            case OR:
+                return builder.disjunction();
         }
 
         return builder.conjunction();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaQueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaQueryUtils.java
@@ -128,29 +128,29 @@ public class JpaQueryUtils
 
         switch ( searchMode )
         {
-        case EQUALS:
-            return builder.equal( path, attrValue );
-        case NOT_EQUALS:
-            return builder.notEqual( path, attrValue );
-        case ENDING_LIKE:
-            return builder.like( path, "%" + attrValue );
-        case NOT_ENDING_LIKE:
-            return builder.notLike( path, "%" + attrValue );
-        case STARTING_LIKE:
-            return builder.like( path, attrValue + "%" );
-        case NOT_STARTING_LIKE:
-            return builder.notLike( path, attrValue + "%" );
-        case ANYWHERE:
-            return builder.like( path, "%" + attrValue + "%" );
-        case NOT_ANYWHERE:
-            return builder.notLike( path, "%" + attrValue + "%" );
-        case LIKE:
-            // Assumes user provides wildcards
-            return builder.like( path, (String) attrValue );
-        case NOT_LIKE:
-            return builder.notLike( path, (String) attrValue );
-        default:
-            throw new IllegalStateException( "expecting a search mode!" );
+            case EQUALS:
+                return builder.equal( path, attrValue );
+            case NOT_EQUALS:
+                return builder.notEqual( path, attrValue );
+            case ENDING_LIKE:
+                return builder.like( path, "%" + attrValue );
+            case NOT_ENDING_LIKE:
+                return builder.notLike( path, "%" + attrValue );
+            case STARTING_LIKE:
+                return builder.like( path, attrValue + "%" );
+            case NOT_STARTING_LIKE:
+                return builder.notLike( path, attrValue + "%" );
+            case ANYWHERE:
+                return builder.like( path, "%" + attrValue + "%" );
+            case NOT_ANYWHERE:
+                return builder.notLike( path, "%" + attrValue + "%" );
+            case LIKE:
+                // Assumes user provides wildcards
+                return builder.like( path, (String) attrValue );
+            case NOT_LIKE:
+                return builder.notLike( path, (String) attrValue );
+            default:
+                throw new IllegalStateException( "expecting a search mode!" );
         }
     }
 
@@ -205,13 +205,13 @@ public class JpaQueryUtils
     {
         switch ( operator )
         {
-        case "in":
-            return path.in( (Collection<?>) QueryUtils.parseValue( Collection.class, property.getKlass(), value ) );
-        case "eq":
-            return builder.equal( path,
-                property.getKlass().cast( QueryUtils.parseValue( property.getKlass(), value ) ) );
-        default:
-            throw new QueryParserException( "Query operator is not supported : " + operator );
+            case "in":
+                return path.in( (Collection<?>) QueryUtils.parseValue( Collection.class, property.getKlass(), value ) );
+            case "eq":
+                return builder.equal( path,
+                    property.getKlass().cast( QueryUtils.parseValue( property.getKlass(), value ) ) );
+            default:
+                throw new QueryParserException( "Query operator is not supported : " + operator );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Order.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Order.java
@@ -167,16 +167,16 @@ public class Order
     {
         switch ( direction )
         {
-        case "asc":
-            return Order.asc( property );
-        case "iasc":
-            return Order.iasc( property );
-        case "desc":
-            return Order.desc( property );
-        case "idesc":
-            return Order.idesc( property );
-        default:
-            return Order.asc( property );
+            case "asc":
+                return Order.asc( property );
+            case "iasc":
+                return Order.iasc( property );
+            case "desc":
+                return Order.desc( property );
+            case "idesc":
+                return Order.idesc( property );
+            default:
+                return Order.asc( property );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
@@ -307,102 +307,102 @@ public final class QueryUtils
 
         switch ( operator )
         {
-        case "eq":
-        {
-            return "= " + QueryUtils.parseValue( value );
-        }
-        case "!eq":
-        case "ne":
-        case "neq":
-        {
-            return "!= " + QueryUtils.parseValue( value );
-        }
-        case "gt":
-        {
-            return "> " + QueryUtils.parseValue( value );
-        }
-        case "lt":
-        {
-            return "< " + QueryUtils.parseValue( value );
-        }
-        case "gte":
-        case "ge":
-        {
-            return ">= " + QueryUtils.parseValue( value );
-        }
-        case "lte":
-        case "le":
-        {
-            return "<= " + QueryUtils.parseValue( value );
-        }
-        case "like":
-        {
-            return "like '%" + value + "%'";
-        }
-        case "!like":
-        {
-            return "not like '%" + value + "%'";
-        }
-        case "^like":
-        {
-            return " like '" + value + "%'";
-        }
-        case "!^like":
-        {
-            return " not like '" + value + "%'";
-        }
-        case "$like":
-        {
-            return " like '%" + value + "'";
-        }
-        case "!$like":
-        {
-            return " not like '%" + value + "'";
-        }
-        case "ilike":
-        {
-            return " ilike '%" + value + "%'";
-        }
-        case "!ilike":
-        {
-            return " not ilike '%" + value + "%'";
-        }
-        case "^ilike":
-        {
-            return " ilike '" + value + "%'";
-        }
-        case "!^ilike":
-        {
-            return " not ilike '" + value + "%'";
-        }
-        case "$ilike":
-        {
-            return " ilike '%" + value + "'";
-        }
-        case "!$ilike":
-        {
-            return " not ilike '%" + value + "'";
-        }
-        case "in":
-        {
-            return "in " + QueryUtils.convertCollectionValue( value );
-        }
-        case "!in":
-        {
-            return " not in " + QueryUtils.convertCollectionValue( value );
-        }
-        case "null":
-        {
-            return "is null";
-        }
-        case "!null":
-        {
-            return "is not null";
-        }
-        default:
-        {
-            throw new QueryParserException( "`" + operator + "` is not a valid operator." );
-        }
+            case "eq":
+            {
+                return "= " + QueryUtils.parseValue( value );
+            }
+            case "!eq":
+            case "ne":
+            case "neq":
+            {
+                return "!= " + QueryUtils.parseValue( value );
+            }
+            case "gt":
+            {
+                return "> " + QueryUtils.parseValue( value );
+            }
+            case "lt":
+            {
+                return "< " + QueryUtils.parseValue( value );
+            }
+            case "gte":
+            case "ge":
+            {
+                return ">= " + QueryUtils.parseValue( value );
+            }
+            case "lte":
+            case "le":
+            {
+                return "<= " + QueryUtils.parseValue( value );
+            }
+            case "like":
+            {
+                return "like '%" + value + "%'";
+            }
+            case "!like":
+            {
+                return "not like '%" + value + "%'";
+            }
+            case "^like":
+            {
+                return " like '" + value + "%'";
+            }
+            case "!^like":
+            {
+                return " not like '" + value + "%'";
+            }
+            case "$like":
+            {
+                return " like '%" + value + "'";
+            }
+            case "!$like":
+            {
+                return " not like '%" + value + "'";
+            }
+            case "ilike":
+            {
+                return " ilike '%" + value + "%'";
+            }
+            case "!ilike":
+            {
+                return " not ilike '%" + value + "%'";
+            }
+            case "^ilike":
+            {
+                return " ilike '" + value + "%'";
+            }
+            case "!^ilike":
+            {
+                return " not ilike '" + value + "%'";
+            }
+            case "$ilike":
+            {
+                return " ilike '%" + value + "'";
+            }
+            case "!$ilike":
+            {
+                return " not ilike '%" + value + "'";
+            }
+            case "in":
+            {
+                return "in " + QueryUtils.convertCollectionValue( value );
+            }
+            case "!in":
+            {
+                return " not in " + QueryUtils.convertCollectionValue( value );
+            }
+            case "null":
+            {
+                return "is null";
+            }
+            case "!null":
+            {
+                return "is not null";
+            }
+            default:
+            {
+                throw new QueryParserException( "`" + operator + "` is not a valid operator." );
+            }
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/LikeOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/LikeOperator.java
@@ -111,14 +111,14 @@ public class LikeOperator<T extends Comparable<? super T>> extends Operator<T>
 
             switch ( jpaMatchMode )
             {
-            case EQUALS:
-                return s2.equals( s1 );
-            case STARTING_LIKE:
-                return s2.startsWith( s1 );
-            case ENDING_LIKE:
-                return s2.endsWith( s1 );
-            case ANYWHERE:
-                return s2.contains( s1 );
+                case EQUALS:
+                    return s2.equals( s1 );
+                case STARTING_LIKE:
+                    return s2.startsWith( s1 );
+                case ENDING_LIKE:
+                    return s2.endsWith( s1 );
+                case ANYWHERE:
+                    return s2.contains( s1 );
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/NotLikeOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/NotLikeOperator.java
@@ -100,16 +100,16 @@ public class NotLikeOperator<T extends Comparable<? super T>> extends Operator<T
 
             switch ( jpaMatchMode )
             {
-            case NOT_EQUALS:
-                return !s2.equals( s1 );
-            case NOT_STARTING_LIKE:
-                return !s2.startsWith( s1 );
-            case NOT_ENDING_LIKE:
-                return !s2.endsWith( s1 );
-            case NOT_ANYWHERE:
-                return !s2.contains( s1 );
-            default:
-                return false;
+                case NOT_EQUALS:
+                    return !s2.equals( s1 );
+                case NOT_STARTING_LIKE:
+                    return !s2.startsWith( s1 );
+                case NOT_ENDING_LIKE:
+                    return !s2.endsWith( s1 );
+                case NOT_ANYWHERE:
+                    return !s2.contains( s1 );
+                default:
+                    return false;
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/Operator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/Operator.java
@@ -160,16 +160,16 @@ public abstract class Operator<T extends Comparable<? super T>>
     {
         switch ( matchMode )
         {
-        case EXACT:
-            return org.hibernate.criterion.MatchMode.EXACT;
-        case START:
-            return org.hibernate.criterion.MatchMode.START;
-        case END:
-            return org.hibernate.criterion.MatchMode.END;
-        case ANYWHERE:
-            return org.hibernate.criterion.MatchMode.ANYWHERE;
-        default:
-            return null;
+            case EXACT:
+                return org.hibernate.criterion.MatchMode.EXACT;
+            case START:
+                return org.hibernate.criterion.MatchMode.START;
+            case END:
+                return org.hibernate.criterion.MatchMode.END;
+            case ANYWHERE:
+                return org.hibernate.criterion.MatchMode.ANYWHERE;
+            default:
+                return null;
         }
     }
 
@@ -177,16 +177,16 @@ public abstract class Operator<T extends Comparable<? super T>>
     {
         switch ( matchMode )
         {
-        case EXACT:
-            return JpaQueryUtils.StringSearchMode.EQUALS;
-        case START:
-            return JpaQueryUtils.StringSearchMode.STARTING_LIKE;
-        case END:
-            return JpaQueryUtils.StringSearchMode.ENDING_LIKE;
-        case ANYWHERE:
-            return JpaQueryUtils.StringSearchMode.ANYWHERE;
-        default:
-            return null;
+            case EXACT:
+                return JpaQueryUtils.StringSearchMode.EQUALS;
+            case START:
+                return JpaQueryUtils.StringSearchMode.STARTING_LIKE;
+            case END:
+                return JpaQueryUtils.StringSearchMode.ENDING_LIKE;
+            case ANYWHERE:
+                return JpaQueryUtils.StringSearchMode.ANYWHERE;
+            default:
+                return null;
         }
     }
 
@@ -201,16 +201,16 @@ public abstract class Operator<T extends Comparable<? super T>>
     {
         switch ( matchMode )
         {
-        case EXACT:
-            return JpaQueryUtils.StringSearchMode.NOT_EQUALS;
-        case START:
-            return JpaQueryUtils.StringSearchMode.NOT_STARTING_LIKE;
-        case END:
-            return JpaQueryUtils.StringSearchMode.NOT_ENDING_LIKE;
-        case ANYWHERE:
-            return JpaQueryUtils.StringSearchMode.NOT_ANYWHERE;
-        default:
-            return null;
+            case EXACT:
+                return JpaQueryUtils.StringSearchMode.NOT_EQUALS;
+            case START:
+                return JpaQueryUtils.StringSearchMode.NOT_STARTING_LIKE;
+            case END:
+                return JpaQueryUtils.StringSearchMode.NOT_ENDING_LIKE;
+            case ANYWHERE:
+                return JpaQueryUtils.StringSearchMode.NOT_ANYWHERE;
+            default:
+                return null;
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/TokenUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/TokenUtils.java
@@ -83,15 +83,15 @@ public class TokenUtils
     {
         switch ( mode )
         {
-        case EXACT:
-            return valueTokens.stream().anyMatch( token -> token.equals( searchToken ) );
-        case START:
-            return valueTokens.stream().anyMatch( token -> token.startsWith( searchToken ) );
-        case END:
-            return valueTokens.stream().anyMatch( token -> token.endsWith( searchToken ) );
-        default:
-        case ANYWHERE:
-            return valueTokens.stream().anyMatch( token -> token.contains( searchToken ) );
+            case EXACT:
+                return valueTokens.stream().anyMatch( token -> token.equals( searchToken ) );
+            case START:
+                return valueTokens.stream().anyMatch( token -> token.startsWith( searchToken ) );
+            case END:
+                return valueTokens.stream().anyMatch( token -> token.endsWith( searchToken ) );
+            default:
+            case ANYWHERE:
+                return valueTokens.stream().anyMatch( token -> token.contains( searchToken ) );
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/reservedvalue/RandomPatternValueGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/reservedvalue/RandomPatternValueGenerator.java
@@ -91,20 +91,20 @@ public class RandomPatternValueGenerator
                 char c;
                 switch ( p )
                 {
-                case 'x':
-                    c = (char) ('a' + rnd.nextInt( 26 ));
-                    break;
-                case 'X':
-                    c = (char) ('A' + rnd.nextInt( 26 ));
-                    break;
-                case '#':
-                    c = (char) ('0' + rnd.nextInt( 10 ));
-                    break;
-                case '*':
-                    c = STAR.charAt( rnd.nextInt( STAR.length() ) );
-                    break;
-                default:
-                    throw new IllegalArgumentException( "Not a valid pattern symbol: " + p );
+                    case 'x':
+                        c = (char) ('a' + rnd.nextInt( 26 ));
+                        break;
+                    case 'X':
+                        c = (char) ('A' + rnd.nextInt( 26 ));
+                        break;
+                    case '#':
+                        c = (char) ('0' + rnd.nextInt( 10 ));
+                        break;
+                    case '*':
+                        c = STAR.charAt( rnd.nextInt( STAR.length() ) );
+                        break;
+                    default:
+                        throw new IllegalArgumentException( "Not a valid pattern symbol: " + p );
                 }
                 digitsRandom.append( c );
                 if ( multiDigit )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/reservedvalue/ValueGeneratorService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/reservedvalue/ValueGeneratorService.java
@@ -54,12 +54,12 @@ public class ValueGeneratorService
     {
         switch ( segment.getMethod() )
         {
-        case SEQUENTIAL:
-            return generateSequentialValues( segment, textPattern, key, numberOfValues );
-        case RANDOM:
-            return generateRandomValues( segment, numberOfValues );
-        default:
-            return List.of();
+            case SEQUENTIAL:
+                return generateSequentialValues( segment, textPattern, key, numberOfValues );
+            case RANDOM:
+                return generateRandomValues( segment, numberOfValues );
+            default:
+                return List.of();
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/apikey/ApiTokenServiceImpl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/apikey/ApiTokenServiceImpl.java
@@ -179,9 +179,9 @@ public class ApiTokenServiceImpl implements ApiTokenService
 
         return switch ( checksumType )
         {
-            case "CRC32" -> generateCrc32Checksum( secureCode );
+        case "CRC32" -> generateCrc32Checksum( secureCode );
 
-            default -> throw new IllegalArgumentException( "Unknown checksum type: " + checksumType );
+        default -> throw new IllegalArgumentException( "Unknown checksum type: " + checksumType );
         };
 
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/apikey/ApiTokenServiceImpl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/apikey/ApiTokenServiceImpl.java
@@ -179,9 +179,9 @@ public class ApiTokenServiceImpl implements ApiTokenService
 
         return switch ( checksumType )
         {
-        case "CRC32" -> generateCrc32Checksum( secureCode );
+            case "CRC32" -> generateCrc32Checksum( secureCode );
 
-        default -> throw new IllegalArgumentException( "Unknown checksum type: " + checksumType );
+            default -> throw new IllegalArgumentException( "Unknown checksum type: " + checksumType );
         };
 
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
@@ -342,20 +342,20 @@ public abstract class CompressionSMSListener
     {
         switch ( eventStatus )
         {
-        case ACTIVE:
-            return EventStatus.ACTIVE;
-        case COMPLETED:
-            return EventStatus.COMPLETED;
-        case VISITED:
-            return EventStatus.VISITED;
-        case SCHEDULE:
-            return EventStatus.SCHEDULE;
-        case OVERDUE:
-            return EventStatus.OVERDUE;
-        case SKIPPED:
-            return EventStatus.SKIPPED;
-        default:
-            return null;
+            case ACTIVE:
+                return EventStatus.ACTIVE;
+            case COMPLETED:
+                return EventStatus.COMPLETED;
+            case VISITED:
+                return EventStatus.VISITED;
+            case SCHEDULE:
+                return EventStatus.SCHEDULE;
+            case OVERDUE:
+                return EventStatus.OVERDUE;
+            case SKIPPED:
+                return EventStatus.SKIPPED;
+            default:
+                return null;
         }
     }
 
@@ -363,14 +363,14 @@ public abstract class CompressionSMSListener
     {
         switch ( enrollmentStatus )
         {
-        case ACTIVE:
-            return ProgramStatus.ACTIVE;
-        case COMPLETED:
-            return ProgramStatus.COMPLETED;
-        case CANCELLED:
-            return ProgramStatus.CANCELLED;
-        default:
-            return null;
+            case ACTIVE:
+                return ProgramStatus.ACTIVE;
+            case COMPLETED:
+                return ProgramStatus.COMPLETED;
+            case CANCELLED:
+                return ProgramStatus.CANCELLED;
+            default:
+                return null;
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/J2MEDataValueSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/J2MEDataValueSMSListener.java
@@ -400,18 +400,18 @@ public class J2MEDataValueSMSListener extends CommandSMSListener
 
             switch ( periodName.substring( 0, periodName.indexOf( " " ) ) )
             {
-            case "Jan":
-                month = 1;
-                break;
-            case "Apr":
-                month = 4;
-                break;
-            case "Jul":
-                month = 6;
-                break;
-            case "Oct":
-                month = 10;
-                break;
+                case "Jan":
+                    month = 1;
+                    break;
+                case "Apr":
+                    month = 4;
+                    break;
+                case "Jul":
+                    month = 6;
+                    break;
+                case "Oct":
+                    month = 10;
+                    break;
             }
 
             int year = Integer.parseInt( periodName.substring( periodName.lastIndexOf( " " ) + 1 ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/RelationshipSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/RelationshipSMSListener.java
@@ -149,32 +149,32 @@ public class RelationshipSMSListener extends CompressionSMSListener
 
         switch ( relEnt )
         {
-        case TRACKED_ENTITY_INSTANCE:
-            TrackedEntity tei = trackedEntityService.getTrackedEntity( objId.getUid() );
-            if ( tei == null )
-            {
-                throw new SMSProcessingException( SmsResponse.INVALID_TEI.set( objId ) );
-            }
-            relItem.setTrackedEntity( tei );
-            break;
+            case TRACKED_ENTITY_INSTANCE:
+                TrackedEntity tei = trackedEntityService.getTrackedEntity( objId.getUid() );
+                if ( tei == null )
+                {
+                    throw new SMSProcessingException( SmsResponse.INVALID_TEI.set( objId ) );
+                }
+                relItem.setTrackedEntity( tei );
+                break;
 
-        case PROGRAM_INSTANCE:
-            Enrollment progInst = enrollmentService.getEnrollment( objId.getUid() );
-            if ( progInst == null )
-            {
-                throw new SMSProcessingException( SmsResponse.INVALID_ENROLL.set( objId ) );
-            }
-            relItem.setEnrollment( progInst );
-            break;
+            case PROGRAM_INSTANCE:
+                Enrollment progInst = enrollmentService.getEnrollment( objId.getUid() );
+                if ( progInst == null )
+                {
+                    throw new SMSProcessingException( SmsResponse.INVALID_ENROLL.set( objId ) );
+                }
+                relItem.setEnrollment( progInst );
+                break;
 
-        case PROGRAM_STAGE_INSTANCE:
-            Event event = eventService.getEvent( objId.getUid() );
-            if ( event == null )
-            {
-                throw new SMSProcessingException( SmsResponse.INVALID_EVENT.set( objId ) );
-            }
-            relItem.setEvent( event );
-            break;
+            case PROGRAM_STAGE_INSTANCE:
+                Event event = eventService.getEvent( objId.getUid() );
+                if ( event == null )
+                {
+                    throw new SMSProcessingException( SmsResponse.INVALID_EVENT.set( objId ) );
+                }
+                relItem.setEvent( event );
+                break;
 
         }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/textpattern/TextPatternValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/textpattern/TextPatternValidationUtils.java
@@ -71,20 +71,20 @@ public class TextPatternValidationUtils
                 {
                     switch ( c )
                     {
-                    case '*':
-                        res = res * 62;
-                        break;
-                    case '#':
-                        res = res * 10;
-                        break;
-                    case 'X':
-                        res = res * 26;
-                        break;
-                    case 'x':
-                        res = res * 26;
-                        break;
-                    default:
-                        break;
+                        case '*':
+                            res = res * 62;
+                            break;
+                        case '#':
+                            res = res * 10;
+                            break;
+                        case 'X':
+                            res = res * 26;
+                            break;
+                        case 'x':
+                            res = res * 26;
+                            break;
+                        default:
+                            break;
                     }
                 }
             }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/userdatastore/hibernate/HibernateUserDatastoreStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/userdatastore/hibernate/HibernateUserDatastoreStore.java
@@ -77,7 +77,7 @@ public class HibernateUserDatastoreStore
 
         return getList( builder, newJpaParameters()
             .addPredicate( root -> builder.equal( root.get( BaseIdentifiableObject_.CREATED_BY ), user ) ) )
-                .stream().map( UserDatastoreEntry::getNamespace ).distinct().collect( Collectors.toList() );
+            .stream().map( UserDatastoreEntry::getNamespace ).distinct().collect( Collectors.toList() );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
@@ -377,60 +377,60 @@ class ExpressionService2Test extends DhisConvenienceTest
 
         switch ( type )
         {
-        case DATA_ELEMENT:
-            String deItem = "#{" + o.getUid() + "}";
-            return new DimensionalItemId( type, o.getUid(), null, null, deItem );
+            case DATA_ELEMENT:
+                String deItem = "#{" + o.getUid() + "}";
+                return new DimensionalItemId( type, o.getUid(), null, null, deItem );
 
-        case DATA_ELEMENT_OPERAND:
-            DataElementOperand deo = (DataElementOperand) o;
+            case DATA_ELEMENT_OPERAND:
+                DataElementOperand deo = (DataElementOperand) o;
 
-            String deoItem = "#{" + deo.getDataElement().getUid() +
-                ((deo.getCategoryOptionCombo() != null)
-                    ? "." + deo.getCategoryOptionCombo().getUid()
-                    : "")
-                +
-                ((deo.getCategoryOptionCombo() == null && deo.getAttributeOptionCombo() != null)
-                    ? ".*"
-                    : "")
-                +
-                ((deo.getAttributeOptionCombo() != null)
-                    ? "." + deo.getAttributeOptionCombo().getUid()
-                    : "")
-                +
-                "}";
+                String deoItem = "#{" + deo.getDataElement().getUid() +
+                    ((deo.getCategoryOptionCombo() != null)
+                        ? "." + deo.getCategoryOptionCombo().getUid()
+                        : "")
+                    +
+                    ((deo.getCategoryOptionCombo() == null && deo.getAttributeOptionCombo() != null)
+                        ? ".*"
+                        : "")
+                    +
+                    ((deo.getAttributeOptionCombo() != null)
+                        ? "." + deo.getAttributeOptionCombo().getUid()
+                        : "")
+                    +
+                    "}";
 
-            return new DimensionalItemId( type,
-                deo.getDataElement().getUid(),
-                deo.getCategoryOptionCombo() == null ? null : deo.getCategoryOptionCombo().getUid(),
-                deo.getAttributeOptionCombo() == null ? null : deo.getAttributeOptionCombo().getUid(),
-                deoItem );
+                return new DimensionalItemId( type,
+                    deo.getDataElement().getUid(),
+                    deo.getCategoryOptionCombo() == null ? null : deo.getCategoryOptionCombo().getUid(),
+                    deo.getAttributeOptionCombo() == null ? null : deo.getAttributeOptionCombo().getUid(),
+                    deoItem );
 
-        case REPORTING_RATE:
-            ReportingRate rr = (ReportingRate) o;
+            case REPORTING_RATE:
+                ReportingRate rr = (ReportingRate) o;
 
-            return new DimensionalItemId( type,
-                rr.getDataSet().getUid(),
-                rr.getMetric().name() );
+                return new DimensionalItemId( type,
+                    rr.getDataSet().getUid(),
+                    rr.getMetric().name() );
 
-        case PROGRAM_DATA_ELEMENT:
-            ProgramDataElementDimensionItem pde = (ProgramDataElementDimensionItem) o;
+            case PROGRAM_DATA_ELEMENT:
+                ProgramDataElementDimensionItem pde = (ProgramDataElementDimensionItem) o;
 
-            return new DimensionalItemId( type,
-                pde.getProgram().getUid(),
-                pde.getDataElement().getUid() );
+                return new DimensionalItemId( type,
+                    pde.getProgram().getUid(),
+                    pde.getDataElement().getUid() );
 
-        case PROGRAM_ATTRIBUTE:
-            ProgramTrackedEntityAttributeDimensionItem pa = (ProgramTrackedEntityAttributeDimensionItem) o;
+            case PROGRAM_ATTRIBUTE:
+                ProgramTrackedEntityAttributeDimensionItem pa = (ProgramTrackedEntityAttributeDimensionItem) o;
 
-            return new DimensionalItemId( type,
-                pa.getProgram().getUid(),
-                pa.getAttribute().getUid() );
+                return new DimensionalItemId( type,
+                    pa.getProgram().getUid(),
+                    pa.getAttribute().getUid() );
 
-        case PROGRAM_INDICATOR:
-            return new DimensionalItemId( type, o.getUid() );
+            case PROGRAM_INDICATOR:
+                return new DimensionalItemId( type, o.getUid() );
 
-        default:
-            return null;
+            default:
+                return null;
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
@@ -620,23 +620,23 @@ class ExpressionService2Test extends DhisConvenienceTest
 
         when( dimensionService.getNoAclDataDimensionalItemObjectMap( (Set<DimensionalItemId>) argThat(
             containsInAnyOrder( getId( opA ), getId( deB ), getId( reportingRate ), getId( pdeA ) ) ) ) )
-                .thenReturn( Map.of(
-                    getId( opA ), opA,
-                    getId( deB ), deB,
-                    getId( reportingRate ), reportingRate,
-                    getId( pdeA ), pdeA ) );
+            .thenReturn( Map.of(
+                getId( opA ), opA,
+                getId( deB ), deB,
+                getId( reportingRate ), reportingRate,
+                getId( pdeA ), pdeA ) );
 
         when( idObjectManager.getNoAcl( eq( OrganisationUnitGroup.class ), (java.util.Collection<String>) argThat(
             containsInAnyOrder( groupA.getUid(), groupB.getUid() ) ) ) )
-                .thenReturn( List.of( groupA, groupB ) );
+            .thenReturn( List.of( groupA, groupB ) );
 
         when( idObjectManager.getNoAcl( eq( DataSet.class ), (java.util.Collection<String>) argThat(
             containsInAnyOrder( dataSetA.getUid(), dataSetB.getUid() ) ) ) )
-                .thenReturn( List.of( dataSetA, dataSetB ) );
+            .thenReturn( List.of( dataSetA, dataSetB ) );
 
         when( idObjectManager.getNoAcl( eq( Program.class ), (java.util.Collection<String>) argThat(
             containsInAnyOrder( programA.getUid(), programB.getUid() ) ) ) )
-                .thenReturn( List.of( programA, programB ) );
+            .thenReturn( List.of( programA, programB ) );
 
         ExpressionParams baseParams = target.getBaseExpressionParams( info );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/jdbc/JdbcOrgUnitAssociationsStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/jdbc/JdbcOrgUnitAssociationsStoreTest.java
@@ -167,27 +167,27 @@ class JdbcOrgUnitAssociationsStoreTest
 
         when( queryBuilder
             .buildSqlQueryForRawAssociation( new HashSet<>( Collections.singletonList( program ) ) ) )
-                .thenReturn( "query" );
+            .thenReturn( "query" );
 
         when( jdbcTemplate.query(
             anyString(), resultSetExtractorArgumentCaptor.capture() ) )
-                .thenAnswer( ( invocation ) -> {
+            .thenAnswer( ( invocation ) -> {
 
-                    when( orgUnitArray.getArray() ).thenReturn( new String[] { orgUnitA, orgUnitB } );
+                when( orgUnitArray.getArray() ).thenReturn( new String[] { orgUnitA, orgUnitB } );
 
-                    ResultSetExtractor<Map<Integer, String>> resultSetExtractor = invocation
-                        .getArgument( 1 );
+                ResultSetExtractor<Map<Integer, String>> resultSetExtractor = invocation
+                    .getArgument( 1 );
 
-                    when( resultSet.next() ).thenReturn( true, false );
+                when( resultSet.next() ).thenReturn( true, false );
 
-                    Mockito.when( resultSet.getString( 1 ) )
-                        .thenReturn( program );
+                Mockito.when( resultSet.getString( 1 ) )
+                    .thenReturn( program );
 
-                    Mockito.when( resultSet.getArray( 2 ) )
-                        .thenReturn( orgUnitArray );
+                Mockito.when( resultSet.getArray( 2 ) )
+                    .thenReturn( orgUnitArray );
 
-                    return resultSetExtractor.extractData( resultSet );
-                } );
+                return resultSetExtractor.extractData( resultSet );
+            } );
 
         assertTrue( jdbcOrgUnitAssociationsStore.checkOrganisationUnitsAssociations( program, orgUnitB ) );
         verify( jdbcTemplate, times( 1 ) ).query( anyString(), resultSetExtractorArgumentCaptor.capture() );
@@ -200,27 +200,27 @@ class JdbcOrgUnitAssociationsStoreTest
 
         when( queryBuilder
             .buildSqlQueryForRawAssociation( new HashSet<>( Collections.singletonList( program ) ) ) )
-                .thenReturn( "query" );
+            .thenReturn( "query" );
 
         when( jdbcTemplate.query(
             anyString(), resultSetExtractorArgumentCaptor.capture() ) )
-                .thenAnswer( ( invocation ) -> {
+            .thenAnswer( ( invocation ) -> {
 
-                    when( orgUnitArray.getArray() ).thenReturn( new String[] { orgUnitA } );
+                when( orgUnitArray.getArray() ).thenReturn( new String[] { orgUnitA } );
 
-                    ResultSetExtractor<Map<Integer, String>> resultSetExtractor = invocation
-                        .getArgument( 1 );
+                ResultSetExtractor<Map<Integer, String>> resultSetExtractor = invocation
+                    .getArgument( 1 );
 
-                    when( resultSet.next() ).thenReturn( true, false );
+                when( resultSet.next() ).thenReturn( true, false );
 
-                    Mockito.when( resultSet.getString( 1 ) )
-                        .thenReturn( program );
+                Mockito.when( resultSet.getString( 1 ) )
+                    .thenReturn( program );
 
-                    Mockito.when( resultSet.getArray( 2 ) )
-                        .thenReturn( orgUnitArray );
+                Mockito.when( resultSet.getArray( 2 ) )
+                    .thenReturn( orgUnitArray );
 
-                    return resultSetExtractor.extractData( resultSet );
-                } );
+                return resultSetExtractor.extractData( resultSet );
+            } );
 
         assertFalse( jdbcOrgUnitAssociationsStore.checkOrganisationUnitsAssociations( program, orgUnitB ) );
         verify( jdbcTemplate, times( 1 ) ).query( anyString(), resultSetExtractorArgumentCaptor.capture() );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/reservedvalue/RandomPatternValueGeneratorTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/reservedvalue/RandomPatternValueGeneratorTest.java
@@ -136,20 +136,21 @@ class RandomPatternValueGeneratorTest
                 char actual = actualValue.charAt( i );
                 switch ( expected )
                 {
-                case 'x':
-                    assertTrue( isLowerCaseLetter( actual ) );
-                    break;
-                case 'X':
-                    assertTrue( isUpperCaseLetter( actual ) );
-                    break;
-                case '#':
-                    assertTrue( isDigit( actual ) );
-                    break;
-                case '*':
-                    assertTrue( isDigit( actual ) || isLowerCaseLetter( actual ) || isUpperCaseLetter( actual ) );
-                    break;
-                default:
-                    throw new IllegalArgumentException( "expected pattern contains invalid character: " + expected );
+                    case 'x':
+                        assertTrue( isLowerCaseLetter( actual ) );
+                        break;
+                    case 'X':
+                        assertTrue( isUpperCaseLetter( actual ) );
+                        break;
+                    case '#':
+                        assertTrue( isDigit( actual ) );
+                        break;
+                    case '*':
+                        assertTrue( isDigit( actual ) || isLowerCaseLetter( actual ) || isUpperCaseLetter( actual ) );
+                        break;
+                    default:
+                        throw new IllegalArgumentException(
+                            "expected pattern contains invalid character: " + expected );
                 }
             }
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/BulkSmsGatewayTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/BulkSmsGatewayTest.java
@@ -133,7 +133,7 @@ class BulkSmsGatewayTest extends DhisConvenienceTest
 
         when( restTemplate.exchange( any( String.class ), any( HttpMethod.class ), any( HttpEntity.class ),
             eq( String.class ) ) )
-                .thenReturn( successResponse );
+            .thenReturn( successResponse );
 
         OutboundMessageResponse status = bulkSmsGateway.send( SUBJECT, MESSAGE, recipients, smsGatewayConfig );
 
@@ -148,7 +148,7 @@ class BulkSmsGatewayTest extends DhisConvenienceTest
 
         when( restTemplate.exchange( any( String.class ), any( HttpMethod.class ), any( HttpEntity.class ),
             eq( String.class ) ) )
-                .thenReturn( successResponse );
+            .thenReturn( successResponse );
 
         List<OutboundMessageResponse> responses = bulkSmsGateway.sendBatch( batch, smsGatewayConfig );
 
@@ -163,7 +163,7 @@ class BulkSmsGatewayTest extends DhisConvenienceTest
 
         when( restTemplate.exchange( any( String.class ), any( HttpMethod.class ), any( HttpEntity.class ),
             eq( String.class ) ) )
-                .thenReturn( errorResponse );
+            .thenReturn( errorResponse );
 
         OutboundMessageResponse status = bulkSmsGateway.send( SUBJECT, MESSAGE, recipients, smsGatewayConfig );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/GenericSmsGatewayTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/GenericSmsGatewayTest.java
@@ -162,7 +162,7 @@ class GenericSmsGatewayTest
 
         when( restTemplate.exchange( any( URI.class ), any( HttpMethod.class ), any( HttpEntity.class ),
             eq( String.class ) ) )
-                .thenReturn( responseEntity );
+            .thenReturn( responseEntity );
 
         assertThat( subject.send( SUBJECT, TEXT, RECIPIENTS, gatewayConfig ).isOk(), is( true ) );
 
@@ -214,7 +214,7 @@ class GenericSmsGatewayTest
         when( pbeStringEncryptor.decrypt( anyString() ) ).thenReturn( password.getValue() );
         when( restTemplate.exchange( any( URI.class ), any( HttpMethod.class ), any( HttpEntity.class ),
             eq( String.class ) ) )
-                .thenReturn( responseEntity );
+            .thenReturn( responseEntity );
 
         assertThat( subject.send( SUBJECT, TEXT, RECIPIENTS, gatewayConfig ).isOk(), is( true ) );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/adx/AdxPeriod.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/adx/AdxPeriod.java
@@ -106,84 +106,84 @@ public class AdxPeriod
 
             switch ( duration )
             {
-            case P1D:
-                periodType = new DailyPeriodType();
-                break;
-            case P7D:
-                switch ( cal.get( Calendar.DAY_OF_WEEK ) )
-                {
-                case MONDAY:
-                    periodType = new WeeklyPeriodType();
+                case P1D:
+                    periodType = new DailyPeriodType();
                     break;
-                case WEDNESDAY:
-                    periodType = new WeeklyWednesdayPeriodType();
+                case P7D:
+                    switch ( cal.get( Calendar.DAY_OF_WEEK ) )
+                    {
+                        case MONDAY:
+                            periodType = new WeeklyPeriodType();
+                            break;
+                        case WEDNESDAY:
+                            periodType = new WeeklyWednesdayPeriodType();
+                            break;
+                        case THURSDAY:
+                            periodType = new WeeklyThursdayPeriodType();
+                            break;
+                        case SATURDAY:
+                            periodType = new WeeklySaturdayPeriodType();
+                            break;
+                        case SUNDAY:
+                            periodType = new WeeklySundayPeriodType();
+                            break;
+                        default:
+                            throw new AdxException( periodString + " is invalid weekly type" );
+                    }
                     break;
-                case THURSDAY:
-                    periodType = new WeeklyThursdayPeriodType();
+                case P14D:
+                    periodType = new BiWeeklyPeriodType();
                     break;
-                case SATURDAY:
-                    periodType = new WeeklySaturdayPeriodType();
+                case P1M:
+                    periodType = new MonthlyPeriodType();
                     break;
-                case SUNDAY:
-                    periodType = new WeeklySundayPeriodType();
+                case P2M:
+                    periodType = new BiMonthlyPeriodType();
                     break;
-                default:
-                    throw new AdxException( periodString + " is invalid weekly type" );
-                }
-                break;
-            case P14D:
-                periodType = new BiWeeklyPeriodType();
-                break;
-            case P1M:
-                periodType = new MonthlyPeriodType();
-                break;
-            case P2M:
-                periodType = new BiMonthlyPeriodType();
-                break;
-            case P3M:
-                periodType = new QuarterlyPeriodType();
-                break;
-            case P6M:
-                switch ( cal.get( Calendar.MONTH ) )
-                {
-                case JANUARY:
-                case JULY:
-                    periodType = new SixMonthlyPeriodType();
+                case P3M:
+                    periodType = new QuarterlyPeriodType();
                     break;
-                case APRIL:
-                case OCTOBER:
-                    periodType = new SixMonthlyAprilPeriodType();
+                case P6M:
+                    switch ( cal.get( Calendar.MONTH ) )
+                    {
+                        case JANUARY:
+                        case JULY:
+                            periodType = new SixMonthlyPeriodType();
+                            break;
+                        case APRIL:
+                        case OCTOBER:
+                            periodType = new SixMonthlyAprilPeriodType();
+                            break;
+                        case NOVEMBER:
+                        case MAY:
+                            periodType = new SixMonthlyNovemberPeriodType();
+                            break;
+                        default:
+                            throw new AdxException( periodString + " is invalid sixmonthly type" );
+                    }
                     break;
-                case NOVEMBER:
-                case MAY:
-                    periodType = new SixMonthlyNovemberPeriodType();
+                case P1Y:
+                    switch ( cal.get( Calendar.MONTH ) )
+                    {
+                        case JANUARY:
+                            periodType = new YearlyPeriodType();
+                            break;
+                        case APRIL:
+                            periodType = new FinancialAprilPeriodType();
+                            break;
+                        case JULY:
+                            periodType = new FinancialJulyPeriodType();
+                            break;
+                        case OCTOBER:
+                            periodType = new FinancialOctoberPeriodType();
+                            break;
+                        case NOVEMBER:
+                            periodType = new FinancialNovemberPeriodType();
+                            break;
+                        default:
+                            throw new AdxException( periodString + " is invalid yearly type" );
+                    }
                     break;
-                default:
-                    throw new AdxException( periodString + " is invalid sixmonthly type" );
-                }
-                break;
-            case P1Y:
-                switch ( cal.get( Calendar.MONTH ) )
-                {
-                case JANUARY:
-                    periodType = new YearlyPeriodType();
-                    break;
-                case APRIL:
-                    periodType = new FinancialAprilPeriodType();
-                    break;
-                case JULY:
-                    periodType = new FinancialJulyPeriodType();
-                    break;
-                case OCTOBER:
-                    periodType = new FinancialOctoberPeriodType();
-                    break;
-                case NOVEMBER:
-                    periodType = new FinancialNovemberPeriodType();
-                    break;
-                default:
-                    throw new AdxException( periodString + " is invalid yearly type" );
-                }
-                break;
             }
 
             if ( periodType != null )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/csv/DefaultCsvImportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/csv/DefaultCsvImportService.java
@@ -132,59 +132,59 @@ public class DefaultCsvImportService
 
         switch ( options.getImportClass() )
         {
-        case DATA_ELEMENT:
-            metadata.setDataElements( dataElementsFromCsv( reader ) );
-            break;
-        case DATA_ELEMENT_GROUP:
-            metadata.setDataElementGroups( dataElementGroupsFromCsv( reader ) );
-            break;
-        case DATA_ELEMENT_GROUP_MEMBERSHIP:
-            metadata.setDataElementGroups( dataElementGroupMembersFromCsv( reader ) );
-            break;
-        case INDICATOR_GROUP_MEMBERSHIP:
-            metadata.setIndicatorGroups( indicatorGroupMembersFromCsv( reader ) );
-            break;
-        case CATEGORY_OPTION:
-            metadata.setCategoryOptions( categoryOptionsFromCsv( reader ) );
-            break;
-        case CATEGORY:
-            metadata.setCategories( categoriesFromCsv( reader ) );
-            break;
-        case CATEGORY_COMBO:
-            metadata.setCategoryCombos( categoryCombosFromCsv( reader ) );
-            break;
-        case CATEGORY_OPTION_GROUP:
-            metadata.setCategoryOptionGroups( categoryOptionGroupsFromCsv( reader ) );
-            break;
-        case ORGANISATION_UNIT:
-            metadata.setOrganisationUnits( orgUnitsFromCsv( reader ) );
-            break;
-        case ORGANISATION_UNIT_GROUP:
-            metadata.setOrganisationUnitGroups( orgUnitGroupsFromCsv( reader ) );
-            break;
-        case ORGANISATION_UNIT_GROUP_MEMBERSHIP:
-            metadata.setOrganisationUnitGroups( orgUnitGroupMembersFromCsv( reader ) );
-            break;
-        case VALIDATION_RULE:
-            metadata.setValidationRules( validationRulesFromCsv( reader ) );
-            break;
-        case OPTION_SET:
-            setOptionSetsFromCsv( reader, metadata );
-            break;
-        case OPTION_GROUP:
-            setOptionGroupsFromCsv( reader, metadata );
-            break;
-        case OPTION_GROUP_SET:
-            metadata.setOptionGroupSets( setOptionGroupSetFromCsv( reader ) );
-            break;
-        case OPTION_GROUP_SET_MEMBERSHIP:
-            metadata.setOptionGroupSets( optionGroupSetMembersFromCsv( reader ) );
-            break;
-        case INDICATOR:
-            metadata.setIndicators( indicatorsFromCsv( reader ) );
-            break;
-        default:
-            break;
+            case DATA_ELEMENT:
+                metadata.setDataElements( dataElementsFromCsv( reader ) );
+                break;
+            case DATA_ELEMENT_GROUP:
+                metadata.setDataElementGroups( dataElementGroupsFromCsv( reader ) );
+                break;
+            case DATA_ELEMENT_GROUP_MEMBERSHIP:
+                metadata.setDataElementGroups( dataElementGroupMembersFromCsv( reader ) );
+                break;
+            case INDICATOR_GROUP_MEMBERSHIP:
+                metadata.setIndicatorGroups( indicatorGroupMembersFromCsv( reader ) );
+                break;
+            case CATEGORY_OPTION:
+                metadata.setCategoryOptions( categoryOptionsFromCsv( reader ) );
+                break;
+            case CATEGORY:
+                metadata.setCategories( categoriesFromCsv( reader ) );
+                break;
+            case CATEGORY_COMBO:
+                metadata.setCategoryCombos( categoryCombosFromCsv( reader ) );
+                break;
+            case CATEGORY_OPTION_GROUP:
+                metadata.setCategoryOptionGroups( categoryOptionGroupsFromCsv( reader ) );
+                break;
+            case ORGANISATION_UNIT:
+                metadata.setOrganisationUnits( orgUnitsFromCsv( reader ) );
+                break;
+            case ORGANISATION_UNIT_GROUP:
+                metadata.setOrganisationUnitGroups( orgUnitGroupsFromCsv( reader ) );
+                break;
+            case ORGANISATION_UNIT_GROUP_MEMBERSHIP:
+                metadata.setOrganisationUnitGroups( orgUnitGroupMembersFromCsv( reader ) );
+                break;
+            case VALIDATION_RULE:
+                metadata.setValidationRules( validationRulesFromCsv( reader ) );
+                break;
+            case OPTION_SET:
+                setOptionSetsFromCsv( reader, metadata );
+                break;
+            case OPTION_GROUP:
+                setOptionGroupsFromCsv( reader, metadata );
+                break;
+            case OPTION_GROUP_SET:
+                metadata.setOptionGroupSets( setOptionGroupSetFromCsv( reader ) );
+                break;
+            case OPTION_GROUP_SET_MEMBERSHIP:
+                metadata.setOptionGroupSets( optionGroupSetMembersFromCsv( reader ) );
+                break;
+            case INDICATOR:
+                metadata.setIndicators( indicatorsFromCsv( reader ) );
+                break;
+            default:
+                break;
         }
 
         return metadata;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/enrollment/AbstractEnrollmentService.java
@@ -520,7 +520,7 @@ public abstract class AbstractEnrollmentService
         {
             ImportSummary is = new ImportSummary( ImportStatus.ERROR,
                 "Enrollment " + foundEnrollmentUid + " already exists or was deleted earlier" )
-                    .setReference( foundEnrollmentUid ).incrementIgnored();
+                .setReference( foundEnrollmentUid ).incrementIgnored();
             importSummaries.addImportSummary( is );
         }
 
@@ -535,7 +535,7 @@ public abstract class AbstractEnrollmentService
         {
             return new ImportSummary( ImportStatus.ERROR,
                 "Enrollment " + enrollment.getEnrollment() + " already exists or was deleted earlier" )
-                    .setReference( enrollment.getEnrollment() ).incrementIgnored();
+                .setReference( enrollment.getEnrollment() ).incrementIgnored();
         }
 
         return addEnrollment( enrollment, importOptions, null );
@@ -927,7 +927,7 @@ public abstract class AbstractEnrollmentService
         {
             return new ImportSummary( ImportStatus.ERROR,
                 "ID " + enrollment.getEnrollment() + " doesn't point to a valid enrollment." )
-                    .incrementIgnored();
+                .incrementIgnored();
         }
 
         if ( !errors.isEmpty() )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/enrollment/EnrollmentStatus.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/enrollment/EnrollmentStatus.java
@@ -69,12 +69,12 @@ public enum EnrollmentStatus
     {
         switch ( programStatus )
         {
-        case ACTIVE:
-            return ACTIVE;
-        case CANCELLED:
-            return CANCELLED;
-        case COMPLETED:
-            return COMPLETED;
+            case ACTIVE:
+                return ACTIVE;
+            case CANCELLED:
+                return CANCELLED;
+            case COMPLETED:
+                return COMPLETED;
         }
 
         throw new IllegalArgumentException( "Enum value not found: " + programStatus );
@@ -84,14 +84,14 @@ public enum EnrollmentStatus
     {
         switch ( status )
         {
-        case "ACTIVE":
-            return ACTIVE;
-        case "CANCELLED":
-            return CANCELLED;
-        case "COMPLETED":
-            return COMPLETED;
-        default:
-            // Do nothing and fail
+            case "ACTIVE":
+                return ACTIVE;
+            case "CANCELLED":
+                return CANCELLED;
+            case "COMPLETED":
+                return COMPLETED;
+            default:
+                // Do nothing and fail
         }
         throw new IllegalArgumentException( "Enum value not found for string: " + status );
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/AbstractEventService.java
@@ -1013,26 +1013,26 @@ public abstract class AbstractEventService implements org.hisp.dhis.dxf2.depreca
 
         switch ( selectedOuMode )
         {
-        case ALL:
-            violation = userCanSearchOuModeALL( user ) ? null
-                : "Current user is not authorized to query across all organisation units";
-            break;
-        case ACCESSIBLE:
-            violation = getAccessibleScopeValidation( user, params );
-            break;
-        case CAPTURE:
-            violation = getCaptureScopeValidation( user );
-            break;
-        case CHILDREN:
-        case SELECTED:
-        case DESCENDANTS:
-            violation = params.getOrgUnit() == null
-                ? "Organisation unit is required for ouMode: " + params.getOrgUnitSelectionMode()
-                : null;
-            break;
-        default:
-            violation = "Invalid ouMode:  " + params.getOrgUnitSelectionMode();
-            break;
+            case ALL:
+                violation = userCanSearchOuModeALL( user ) ? null
+                    : "Current user is not authorized to query across all organisation units";
+                break;
+            case ACCESSIBLE:
+                violation = getAccessibleScopeValidation( user, params );
+                break;
+            case CAPTURE:
+                violation = getCaptureScopeValidation( user );
+                break;
+            case CHILDREN:
+            case SELECTED:
+            case DESCENDANTS:
+                violation = params.getOrgUnit() == null
+                    ? "Organisation unit is required for ouMode: " + params.getOrgUnitSelectionMode()
+                    : null;
+                break;
+            default:
+                violation = "Invalid ouMode:  " + params.getOrgUnitSelectionMode();
+                break;
         }
 
         return violation;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/JdbcEventStore.java
@@ -2252,24 +2252,24 @@ public class JdbcEventStore implements EventStore
 
         switch ( orgUnitSelectionMode )
         {
-        case ALL:
-            orgUnitSql = null;
-            break;
-        case CHILDREN:
-            orgUnitSql = getChildrenOrgUnitsPath( params, ouTable );
-            break;
-        case DESCENDANTS:
-            orgUnitSql = getDescendantOrgUnitsPath( params, ouTable );
-            break;
-        case CAPTURE:
-            orgUnitSql = getCaptureOrgUnitsPath( user, ouTable );
-            break;
-        case SELECTED:
-            orgUnitSql = getSelectedOrgUnitsPath( params, ouTable );
-            break;
-        default:
-            orgUnitSql = getAccessibleOrgUnitsPath( params, user, ouTable );
-            break;
+            case ALL:
+                orgUnitSql = null;
+                break;
+            case CHILDREN:
+                orgUnitSql = getChildrenOrgUnitsPath( params, ouTable );
+                break;
+            case DESCENDANTS:
+                orgUnitSql = getDescendantOrgUnitsPath( params, ouTable );
+                break;
+            case CAPTURE:
+                orgUnitSql = getCaptureOrgUnitsPath( user, ouTable );
+                break;
+            case SELECTED:
+                orgUnitSql = getSelectedOrgUnitsPath( params, ouTable );
+                break;
+            default:
+                orgUnitSql = getAccessibleOrgUnitsPath( params, user, ouTable );
+                break;
         }
 
         return orgUnitSql;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/EventManager.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/EventManager.java
@@ -460,7 +460,7 @@ public class EventManager
             {
                 final ImportSummary is = new ImportSummary( ERROR,
                     "Event " + eventToImport.getUid() + " already exists or was deleted earlier" )
-                        .setReference( eventToImport.getUid() ).incrementIgnored();
+                    .setReference( eventToImport.getUid() ).incrementIgnored();
 
                 importSummaries.addImportSummary( is );
 
@@ -480,7 +480,7 @@ public class EventManager
                     final ImportSummary is = new ImportSummary( ERROR,
                         "ProgramStage " + eventToImport.getProgramStage()
                             + " is not repeatable. Current payload contains duplicate event" )
-                                .setReference( eventToImport.getUid() ).incrementIgnored();
+                        .setReference( eventToImport.getUid() ).incrementIgnored();
 
                     importSummaries.addImportSummary( is );
                 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/EventManager.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/EventManager.java
@@ -403,21 +403,21 @@ public class EventManager
 
                 switch ( importStrategy )
                 {
-                case CREATE:
-                    is.incrementImported();
-                    break;
+                    case CREATE:
+                        is.incrementImported();
+                        break;
 
-                case UPDATE:
-                    is.incrementUpdated();
-                    break;
+                    case UPDATE:
+                        is.incrementUpdated();
+                        break;
 
-                case DELETE:
-                    is.incrementDeleted();
-                    is.setDescription( "Deletion of event " + event.getUid() + " was successful" );
-                    break;
+                    case DELETE:
+                        is.incrementDeleted();
+                        is.setDescription( "Deletion of event " + event.getUid() + " was successful" );
+                        break;
 
-                default:
-                    log.warn( "Invalid Import Strategy during summary increment, ignoring" );
+                    default:
+                        log.warn( "Invalid Import Strategy during summary increment, ignoring" );
                 }
 
                 importSummaries.addImportSummary( is );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/context/ProgramSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/context/ProgramSupplier.java
@@ -179,11 +179,11 @@ public class ProgramSupplier extends AbstractSupplier<Map<String, Program>>
                 {
                     Stream<ProgramStageDataElement> compulsoryProgramStageDataElementsStream = getOrEmpty(
                         dataElementSets.getCompulsoryDataElements() )
-                            .map( de -> new ProgramStageDataElement( programStage, de, true ) );
+                        .map( de -> new ProgramStageDataElement( programStage, de, true ) );
 
                     Stream<ProgramStageDataElement> nonCompulsoryProgramStageDataElementsStream = getOrEmpty(
                         dataElementSets.getNonCompulsoryDataElements() )
-                            .map( de -> new ProgramStageDataElement( programStage, de, false ) );
+                        .map( de -> new ProgramStageDataElement( programStage, de, false ) );
 
                     Set<ProgramStageDataElement> allProgramStageDataElements = Stream
                         .concat( compulsoryProgramStageDataElementsStream, nonCompulsoryProgramStageDataElementsStream )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/insert/validation/TrackedEntityInstanceCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/insert/validation/TrackedEntityInstanceCheck.java
@@ -56,7 +56,8 @@ public class TrackedEntityInstanceCheck implements Checker
         {
             return new ImportSummary( ImportStatus.ERROR,
                 "Event.trackedEntityInstance does not point to a valid tracked entity instance: "
-                    + event.getTrackedEntityInstance() ).setReference( event.getEvent() ).incrementIgnored();
+                    + event.getTrackedEntityInstance() )
+                .setReference( event.getEvent() ).incrementIgnored();
         }
 
         return success();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/shared/validation/EventGeometryCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/shared/validation/EventGeometryCheck.java
@@ -59,7 +59,8 @@ public class EventGeometryCheck implements Checker
             return new ImportSummary( ImportStatus.ERROR,
                 "Geometry (" + event.getGeometry().getGeometryType() + ") does not conform to the feature type ("
                     + programStage.getFeatureType().value() + ") specified for the program stage: "
-                    + programStage.getUid() ).setReference( event.getEvent() ).incrementIgnored();
+                    + programStage.getUid() )
+                .setReference( event.getEvent() ).incrementIgnored();
         }
 
         return success();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/shared/validation/FilteredDataValueCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/shared/validation/FilteredDataValueCheck.java
@@ -70,8 +70,8 @@ public class FilteredDataValueCheck implements Checker
 
             Set<String> filteredEventDataValuesUids = getFilteredDataValues( event.getDataValues(),
                 getDataElementUidsFromProgramStage( event.getProgramStage(), ctx ) ).stream()
-                    .map( DataValue::getDataElement )
-                    .collect( Collectors.toSet() );
+                .map( DataValue::getDataElement )
+                .collect( Collectors.toSet() );
 
             Set<String> ignoredDataValues = eventDataValuesUids.stream()
                 .filter( uid -> !filteredEventDataValuesUids.contains( uid ) )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/update/validation/ProgramStageInstanceBasicCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/update/validation/ProgramStageInstanceBasicCheck.java
@@ -60,7 +60,7 @@ public class ProgramStageInstanceBasicCheck implements Checker
         {
             return error(
                 "Event ID " + event.getEvent() + " was already used and/or deleted. This event can not be modified." )
-                    .setReference( event.getEvent() );
+                .setReference( event.getEvent() );
         }
 
         return success();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -608,7 +608,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
         {
             ImportSummary is = new ImportSummary( ImportStatus.ERROR,
                 "Tracked entity instance " + foundTeiUid + " already exists or was deleted earlier" )
-                    .setReference( foundTeiUid ).incrementIgnored();
+                .setReference( foundTeiUid ).incrementIgnored();
 
             importSummaries.addImportSummary( is );
         }
@@ -633,7 +633,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
             return new ImportSummary( ImportStatus.ERROR,
                 "Tracked entity instance " + dtoEntityInstance.getTrackedEntityInstance()
                     + " already exists or was deleted earlier" )
-                        .setReference( dtoEntityInstance.getTrackedEntityInstance() ).incrementIgnored();
+                .setReference( dtoEntityInstance.getTrackedEntityInstance() ).incrementIgnored();
         }
 
         importOptions = updateImportOptions( importOptions );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/trackedentity/store/mapper/RelationshipRowCallbackHandler.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/trackedentity/store/mapper/RelationshipRowCallbackHandler.java
@@ -133,27 +133,27 @@ public class RelationshipRowCallbackHandler extends AbstractMapper<Relationship>
 
         switch ( type )
         {
-        case "tei":
+            case "tei":
 
-            TrackedEntityInstance tei = new TrackedEntityInstance();
-            tei.clear();
-            tei.setTrackedEntityInstance( uid );
-            ri.setTrackedEntityInstance( tei );
-            break;
-        case "pi":
+                TrackedEntityInstance tei = new TrackedEntityInstance();
+                tei.clear();
+                tei.setTrackedEntityInstance( uid );
+                ri.setTrackedEntityInstance( tei );
+                break;
+            case "pi":
 
-            Enrollment enrollment = new Enrollment();
-            enrollment.setEnrollment( uid );
-            ri.setEnrollment( enrollment );
-            break;
-        case "psi":
+                Enrollment enrollment = new Enrollment();
+                enrollment.setEnrollment( uid );
+                ri.setEnrollment( enrollment );
+                break;
+            case "psi":
 
-            Event psi = new Event();
-            psi.setEvent( uid );
-            ri.setEvent( psi );
-            break;
-        default:
-            log.warn( "Expecting tei|psi|pi as type when fetching a relationship, got: " + type );
+                Event psi = new Event();
+                psi.setEvent( uid );
+                ri.setEvent( psi );
+                break;
+            default:
+                log.warn( "Expecting tei|psi|pi as type when fetching a relationship, got: " + type );
         }
 
         return ri;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/CoordinatesUtils.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/CoordinatesUtils.java
@@ -141,20 +141,20 @@ public final class CoordinatesUtils
         StringBuilder asPairs = new StringBuilder();
         switch ( dimensions )
         {
-        case 1:
-            coordinatesAsPairsDim1( coordinates, asPairs );
-            break;
-        case 2:
-            coordinatesAsPairsDim2( coordinates, asPairs );
-            break;
-        case 3:
-            coordinatesAsPairsDim3( coordinates, asPairs );
-            break;
-        case 4:
-            coordinatesAsPairsDim4( coordinates, asPairs );
-            break;
-        default:
-            throw new UnsupportedOperationException( "Coordinates format not supported" );
+            case 1:
+                coordinatesAsPairsDim1( coordinates, asPairs );
+                break;
+            case 2:
+                coordinatesAsPairsDim2( coordinates, asPairs );
+                break;
+            case 3:
+                coordinatesAsPairsDim3( coordinates, asPairs );
+                break;
+            case 4:
+                coordinatesAsPairsDim4( coordinates, asPairs );
+                break;
+            default:
+                throw new UnsupportedOperationException( "Coordinates format not supported" );
         }
         return asPairs.toString();
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/DefaultGeoJsonService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/DefaultGeoJsonService.java
@@ -193,12 +193,12 @@ public class DefaultGeoJsonService implements GeoJsonService
     {
         switch ( params.getIdType() )
         {
-        case CODE:
-            return OrganisationUnit::getCode;
-        case NAME:
-            return OrganisationUnit::getName;
-        default:
-            return OrganisationUnit::getUid;
+            case CODE:
+                return OrganisationUnit::getCode;
+            case NAME:
+                return OrganisationUnit::getName;
+            default:
+                return OrganisationUnit::getUid;
         }
     }
 
@@ -207,12 +207,12 @@ public class DefaultGeoJsonService implements GeoJsonService
     {
         switch ( params.getIdType() )
         {
-        case CODE:
-            return organisationUnitStore.getByCode( ouIdentifiers, params.getUser() );
-        case NAME:
-            return organisationUnitStore.getByName( ouIdentifiers, params.getUser() );
-        default:
-            return organisationUnitStore.getByUid( ouIdentifiers, params.getUser() );
+            case CODE:
+                return organisationUnitStore.getByCode( ouIdentifiers, params.getUser() );
+            case NAME:
+                return organisationUnitStore.getByName( ouIdentifiers, params.getUser() );
+            default:
+                return organisationUnitStore.getByUid( ouIdentifiers, params.getUser() );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/RelationshipTypeObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/RelationshipTypeObjectBundleHook.java
@@ -176,15 +176,15 @@ public class RelationshipTypeObjectBundleHook
     {
         switch ( constraint.getRelationshipEntity() )
         {
-        case TRACKED_ENTITY_INSTANCE:
-            validateTrackedEntityInstance( constraint, addReports, constraint.getTrackerDataView() );
-            break;
-        case PROGRAM_INSTANCE:
-            validateProgramInstance( constraint, addReports, constraint.getTrackerDataView() );
-            break;
-        case PROGRAM_STAGE_INSTANCE:
-            validateProgramStageInstance( constraint, addReports, constraint.getTrackerDataView() );
-            break;
+            case TRACKED_ENTITY_INSTANCE:
+                validateTrackedEntityInstance( constraint, addReports, constraint.getTrackerDataView() );
+                break;
+            case PROGRAM_INSTANCE:
+                validateProgramInstance( constraint, addReports, constraint.getTrackerDataView() );
+                break;
+            case PROGRAM_STAGE_INSTANCE:
+                validateProgramStageInstance( constraint, addReports, constraint.getTrackerDataView() );
+                break;
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/TrackedEntityTypeObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/TrackedEntityTypeObjectBundleHook.java
@@ -63,7 +63,7 @@ public class TrackedEntityTypeObjectBundleHook extends AbstractObjectBundleHook<
                     addReports.accept(
                         new ErrorReport( TrackedEntityAttribute.class, ErrorCode.E5001, preheatIdentifier,
                             preheatIdentifier.getIdentifiersWithName( tea ) ).setErrorProperty( "id" )
-                                .setMainId( tea.getUid() ) );
+                            .setMainId( tea.getUid() ) );
                 }
             } );
         }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/CreationCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/CreationCheck.java
@@ -64,7 +64,7 @@ public class CreationCheck implements ObjectValidationCheck
             {
                 ErrorReport errorReport = new ErrorReport( klass, ErrorCode.E5000, bundle.getPreheatIdentifier(),
                     bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) )
-                        .setMainId( identifiableObject.getUid() );
+                    .setMainId( identifiableObject.getUid() );
 
                 addReports.accept( createObjectReport( errorReport, object, bundle ) );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DeletionCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DeletionCheck.java
@@ -64,7 +64,7 @@ public class DeletionCheck implements ObjectValidationCheck
             {
                 ErrorReport errorReport = new ErrorReport( klass, ErrorCode.E5001, bundle.getPreheatIdentifier(),
                     bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) )
-                        .setMainId( object != null ? object.getUid() : null );
+                    .setMainId( object != null ? object.getUid() : null );
                 addReports.accept( createObjectReport( errorReport, object, bundle ) );
                 ctx.markForRemoval( object );
             }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/MetadataAttributeCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/MetadataAttributeCheck.java
@@ -94,8 +94,8 @@ public class MetadataAttributeCheck implements ObjectValidationCheck
             object.getAttributeValues()
                 .forEach( av -> getValueType( av.getAttribute().getUid(), attributesMap, klass.getSimpleName(),
                     errorReports::add )
-                        .ifPresent( type -> attributeValidator.validate( type, av.getValue(),
-                            errorReports::add ) ) );
+                    .ifPresent( type -> attributeValidator.validate( type, av.getValue(),
+                        errorReports::add ) ) );
 
             if ( !errorReports.isEmpty() )
             {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/TranslationsCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/TranslationsCheck.java
@@ -103,7 +103,7 @@ public class TranslationsCheck implements ObjectValidationCheck
                 objectReport.addErrorReport(
                     new ErrorReport( Translation.class, ErrorCode.E1106, translation.getProperty(),
                         translation.getLocale() )
-                            .setErrorKlass( klass ) );
+                        .setErrorKlass( klass ) );
             }
             else
             {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniqueAttributesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UniqueAttributesCheck.java
@@ -115,7 +115,7 @@ public class UniqueAttributesCheck implements ObjectValidationCheck
                 {
                     errorReports.add( new ErrorReport( Attribute.class, ErrorCode.E4009,
                         IdentifiableObjectUtils.getDisplayName( attribute ), attributeValue.getValue() )
-                            .setMainId( attribute.getUid() ).setErrorProperty( "value" ) );
+                        .setMainId( attribute.getUid() ).setErrorProperty( "value" ) );
                 }
                 else
                 {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UpdateCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/UpdateCheck.java
@@ -64,7 +64,7 @@ public class UpdateCheck implements ObjectValidationCheck
             {
                 ErrorReport errorReport = new ErrorReport( klass, ErrorCode.E5001, bundle.getPreheatIdentifier(),
                     bundle.getPreheatIdentifier().getIdentifiersWithName( identifiableObject ) )
-                        .setErrorProperty( "id" ).setMainId( identifiableObject.getUid() );
+                    .setErrorProperty( "id" ).setMainId( identifiableObject.getUid() );
 
                 addReports.accept( createObjectReport( errorReport, object, bundle ) );
                 ctx.markForRemoval( object );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/attribute/EntityCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/attribute/EntityCheck.java
@@ -57,7 +57,9 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
  * Example:
  *
  * <pre>
- * {@code EntityCheck.isOrganisationUnitExist.apply( value, klass -> manager.get( klass, value ) != null ) }
+ * {@code
+ * EntityCheck.isOrganisationUnitExist.apply( value, klass -> manager.get( klass, value ) != null )
+ * }
  * </pre>
  *
  * @author viet

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/attribute/UserCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/attribute/UserCheck.java
@@ -52,7 +52,9 @@ import org.hisp.dhis.user.UserService;
  * Example:
  *
  * <pre>
- * {@code UserCheck.isUserNameExist.apply( value, klass -> userService.getUserByUsername( value ) != null ) }
+ * {@code
+ * UserCheck.isUserNameExist.apply( value, klass -> userService.getUserByUsername( value ) != null )
+ * }
  * </pre>
  *
  * @author viet

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPostProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPostProcessor.java
@@ -107,9 +107,9 @@ public class MetadataSyncPostProcessor
         ImportReport importReport = metadataSyncSummary.getImportReport();
         StringBuilder text = new StringBuilder(
             "Successful Import Report for the scheduler run for Metadata synchronization \n\n" )
-                .append( "Imported Version Details \n " )
-                .append( "Version Name: " + metadataSyncSummary.getMetadataVersion().getName() + "\n" )
-                .append( "Version Type: " + metadataSyncSummary.getMetadataVersion().getType() + "\n" );
+            .append( "Imported Version Details \n " )
+            .append( "Version Name: " + metadataSyncSummary.getMetadataVersion().getName() + "\n" )
+            .append( "Version Type: " + metadataSyncSummary.getMetadataVersion().getType() + "\n" );
 
         if ( importReport.getTypeReportCount() == 0 )
         {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/pdfform/PdfDataEntryFormUtil.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/pdfform/PdfDataEntryFormUtil.java
@@ -163,17 +163,17 @@ public class PdfDataEntryFormUtil
 
         switch ( cellContentType )
         {
-        case CELL_COLUMN_TYPE_HEADER: // fallthrough
-        case CELL_COLUMN_TYPE_ENTRYFIELD:
-            cell.setHorizontalAlignment( Element.ALIGN_CENTER );
-            cell.setVerticalAlignment( Element.ALIGN_MIDDLE );
-            break;
-        case CELL_COLUMN_TYPE_LABEL:
-            cell.setHorizontalAlignment( Element.ALIGN_RIGHT );
-            cell.setVerticalAlignment( Element.ALIGN_TOP );
-            break;
-        default:
-            break;
+            case CELL_COLUMN_TYPE_HEADER: // fallthrough
+            case CELL_COLUMN_TYPE_ENTRYFIELD:
+                cell.setHorizontalAlignment( Element.ALIGN_CENTER );
+                cell.setVerticalAlignment( Element.ALIGN_MIDDLE );
+                break;
+            case CELL_COLUMN_TYPE_LABEL:
+                cell.setHorizontalAlignment( Element.ALIGN_RIGHT );
+                cell.setVerticalAlignment( Element.ALIGN_TOP );
+                break;
+            default:
+                break;
         }
 
         return cell;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/pdfform/PdfFormFontSettings.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/pdfform/PdfFormFontSettings.java
@@ -89,30 +89,30 @@ public class PdfFormFontSettings
 
         switch ( fontType )
         {
-        case FONTTYPE_BODY:
-            font.setSize( FONTSIZE_BODY );
-            font.setColor( Color.BLACK );
-            break;
-        case FONTTYPE_TITLE:
-            font.setSize( FONTSIZE_TITLE );
-            font.setStyle( java.awt.Font.BOLD );
-            font.setColor( new Color( 0, 0, 128 ) ); // Navy Color
-            break;
-        case FONTTYPE_DESCRIPTION:
-            font.setSize( FONTSIZE_DESCRIPTION );
-            font.setColor( Color.DARK_GRAY );
-            break;
-        case FONTTYPE_SECTIONHEADER:
-            font.setSize( FONTSIZE_SECTIONHEADER );
-            font.setStyle( java.awt.Font.BOLD );
-            font.setColor( new Color( 70, 130, 180 ) ); // Steel Blue Color
-            break;
-        case FONTTYPE_FOOTER:
-            font.setSize( FONTSIZE_FOOTER );
-            break;
-        default:
-            font.setSize( FONTSIZE_BODY );
-            break;
+            case FONTTYPE_BODY:
+                font.setSize( FONTSIZE_BODY );
+                font.setColor( Color.BLACK );
+                break;
+            case FONTTYPE_TITLE:
+                font.setSize( FONTSIZE_TITLE );
+                font.setStyle( java.awt.Font.BOLD );
+                font.setColor( new Color( 0, 0, 128 ) ); // Navy Color
+                break;
+            case FONTTYPE_DESCRIPTION:
+                font.setSize( FONTSIZE_DESCRIPTION );
+                font.setColor( Color.DARK_GRAY );
+                break;
+            case FONTTYPE_SECTIONHEADER:
+                font.setSize( FONTSIZE_SECTIONHEADER );
+                font.setStyle( java.awt.Font.BOLD );
+                font.setColor( new Color( 70, 130, 180 ) ); // Steel Blue Color
+                break;
+            case FONTTYPE_FOOTER:
+                font.setSize( FONTSIZE_FOOTER );
+                break;
+            default:
+                font.setSize( FONTSIZE_BODY );
+                break;
         }
 
         return font;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeServiceTest.java
@@ -258,7 +258,7 @@ class DefaultCompleteDataSetRegistrationExchangeServiceTest
             when( orgUnitInHierarchyCache.get( eq( organisationUnit.getUid() ), any() ) ).thenReturn( Boolean.TRUE );
             when(
                 attrOptComboOrgUnitCache.get( eq( categoryOptionCombo.getUid() + organisationUnit.getUid() ), any() ) )
-                    .thenReturn( Boolean.TRUE );
+                .thenReturn( Boolean.TRUE );
             when( categoryService.getCategoryOptionCombo( categoryOptionCombo.getUid() ) )
                 .thenReturn( categoryOptionCombo );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportValidatorTest.java
@@ -636,7 +636,7 @@ class DataValueSetImportValidatorTest
             .strategy( ImportStrategy.DELETE ).build();
         when( dataValueService.getDataValue( any( DataElement.class ), any( Period.class ),
             any( OrganisationUnit.class ), any( CategoryOptionCombo.class ), any( CategoryOptionCombo.class ) ) )
-                .thenReturn( null );
+            .thenReturn( null );
         assertTrue( validator.skipDataValue( dataValue, context, dataSetContext, valueContext ) );
         assertConflict( ErrorCode.E7645,
             "No data value for file resource exist for the given combination for data element: `<object1>`", context,

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/relationship/JacksonRelationshipServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/relationship/JacksonRelationshipServiceTest.java
@@ -154,7 +154,7 @@ class JacksonRelationshipServiceTest
 
         when(
             relationshipService.getRelationshipByRelationship( any( org.hisp.dhis.relationship.Relationship.class ) ) )
-                .thenReturn( Optional.of( daoRelationship ) );
+            .thenReturn( Optional.of( daoRelationship ) );
 
         ImportSummary importSummary = subject.addRelationship( relationship, rnd.nextObject( ImportOptions.class ) );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobParametersTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobParametersTest.java
@@ -187,7 +187,7 @@ class MetadataSyncJobParametersTest
             .thenReturn( metadataVersion );
         when(
             metadataSyncPreProcessor.handleMetadataVersionsList( metadataRetryContext, metadataVersion, JOB_PROGRESS ) )
-                .thenReturn( metadataVersions );
+            .thenReturn( metadataVersions );
         when( metadataSyncService.doMetadataSync( any( MetadataSyncParams.class ) ) )
             .thenThrow( new DhisVersionMismatchException( "" ) );
         when( metadataSyncService.isSyncRequired( any( MetadataSyncParams.class ) ) ).thenReturn( true );
@@ -219,7 +219,7 @@ class MetadataSyncJobParametersTest
             .thenReturn( metadataVersion );
         when(
             metadataSyncPreProcessor.handleMetadataVersionsList( metadataRetryContext, metadataVersion, JOB_PROGRESS ) )
-                .thenReturn( metadataVersions );
+            .thenReturn( metadataVersions );
         when( metadataSyncService.doMetadataSync( any( MetadataSyncParams.class ) ) ).thenReturn( metadataSyncSummary );
         when( metadataSyncPostProcessor.handleSyncNotificationsAndAbortStatus( metadataSyncSummary,
             metadataRetryContext, metadataVersion ) ).thenReturn( true );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DummyCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DummyCheck.java
@@ -56,7 +56,7 @@ public class DummyCheck implements ObjectValidationCheck
             {
                 ErrorReport errorReport = new ErrorReport( klass, ErrorCode.E5000, bundle.getPreheatIdentifier(),
                     bundle.getPreheatIdentifier().getIdentifiersWithName( nonPersistedObject ) )
-                        .setMainId( nonPersistedObject.getUid() );
+                    .setMainId( nonPersistedObject.getUid() );
                 addReports.accept( createObjectReport( errorReport, nonPersistedObject, bundle ) );
 
                 context.markForRemoval( nonPersistedObject );

--- a/dhis-2/dhis-services/dhis-service-event-hook/src/main/java/org/hisp/dhis/eventhook/EventHookSecretManager.java
+++ b/dhis-2/dhis-services/dhis-service-event-hook/src/main/java/org/hisp/dhis/eventhook/EventHookSecretManager.java
@@ -94,24 +94,24 @@ public class EventHookSecretManager
 
         switch ( auth.getType() )
         {
-        case HttpBasicAuth.TYPE:
-            HttpBasicAuth httpBasicAuth = (HttpBasicAuth) auth;
+            case HttpBasicAuth.TYPE:
+                HttpBasicAuth httpBasicAuth = (HttpBasicAuth) auth;
 
-            if ( StringUtils.hasText( httpBasicAuth.getPassword() ) )
-            {
-                httpBasicAuth.setPassword( callback.apply( httpBasicAuth.getPassword() ) );
-            }
-            break;
-        case ApiTokenAuth.TYPE:
-            ApiTokenAuth apiTokenAuth = (ApiTokenAuth) auth;
+                if ( StringUtils.hasText( httpBasicAuth.getPassword() ) )
+                {
+                    httpBasicAuth.setPassword( callback.apply( httpBasicAuth.getPassword() ) );
+                }
+                break;
+            case ApiTokenAuth.TYPE:
+                ApiTokenAuth apiTokenAuth = (ApiTokenAuth) auth;
 
-            if ( StringUtils.hasText( apiTokenAuth.getToken() ) )
-            {
-                apiTokenAuth.setToken( callback.apply( apiTokenAuth.getToken() ) );
-            }
-            break;
-        default:
-            break;
+                if ( StringUtils.hasText( apiTokenAuth.getToken() ) )
+                {
+                    apiTokenAuth.setToken( callback.apply( apiTokenAuth.getToken() ) );
+                }
+                break;
+            default:
+                break;
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
@@ -470,7 +470,7 @@ public class FieldFilterService
         applyFieldPathVisitor( object, fieldPaths, isSkipSharing,
             s -> s.equals( "attributeValues.attribute" ) || s.endsWith( ".attributeValues.attribute" ),
             o -> {
-                if ( o instanceof AttributeValue a)
+                if ( o instanceof AttributeValue a )
                 {
                     a.setAttribute(
                         attributeService.getAttribute( ((AttributeValue) o).getAttribute().getUid() ) );

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
@@ -446,16 +446,16 @@ public class FieldFilterService
             {
                 switch ( fieldPathTransformer.getName() )
                 {
-                case "rename" -> fieldTransformers.add( new RenameFieldTransformer( fieldPathTransformer ) );
-                case "size" -> fieldTransformers.add( SizeFieldTransformer.INSTANCE );
-                case "isEmpty" -> fieldTransformers.add( IsEmptyFieldTransformer.INSTANCE );
-                case "isNotEmpty" -> fieldTransformers.add( IsNotEmptyFieldTransformer.INSTANCE );
-                case "pluck" -> fieldTransformers.add( new PluckFieldTransformer( fieldPathTransformer ) );
-                case "keyBy" -> fieldTransformers.add( new KeyByFieldTransformer( fieldPathTransformer ) );
-                default ->
-                {
-                    // invalid transformer
-                }
+                    case "rename" -> fieldTransformers.add( new RenameFieldTransformer( fieldPathTransformer ) );
+                    case "size" -> fieldTransformers.add( SizeFieldTransformer.INSTANCE );
+                    case "isEmpty" -> fieldTransformers.add( IsEmptyFieldTransformer.INSTANCE );
+                    case "isNotEmpty" -> fieldTransformers.add( IsNotEmptyFieldTransformer.INSTANCE );
+                    case "pluck" -> fieldTransformers.add( new PluckFieldTransformer( fieldPathTransformer ) );
+                    case "keyBy" -> fieldTransformers.add( new KeyByFieldTransformer( fieldPathTransformer ) );
+                    default ->
+                    {
+                        // invalid transformer
+                    }
                 }
             }
 

--- a/dhis-2/dhis-services/dhis-service-metadata-workflow/src/main/java/org/hisp/dhis/metadata/DefaultMetadataWorkflowService.java
+++ b/dhis-2/dhis-services/dhis-service-metadata-workflow/src/main/java/org/hisp/dhis/metadata/DefaultMetadataWorkflowService.java
@@ -174,13 +174,13 @@ public class DefaultMetadataWorkflowService implements MetadataWorkflowService
         }
         switch ( type )
         {
-        default:
-        case ADD:
-            return acceptAdd( proposal, mode );
-        case REMOVE:
-            return acceptRemove( proposal, mode );
-        case UPDATE:
-            return acceptUpdate( proposal, mode );
+            default:
+            case ADD:
+                return acceptAdd( proposal, mode );
+            case REMOVE:
+                return acceptRemove( proposal, mode );
+            case UPDATE:
+                return acceptUpdate( proposal, mode );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/AbstractNodeSerializer.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/AbstractNodeSerializer.java
@@ -165,15 +165,15 @@ public abstract class AbstractNodeSerializer implements NodeSerializer
     {
         switch ( node.getType() )
         {
-        case SIMPLE:
-            writeSimpleNode( (SimpleNode) node );
-            break;
-        case COMPLEX:
-            writeComplexNode( (ComplexNode) node );
-            break;
-        case COLLECTION:
-            writeCollectionNode( (CollectionNode) node );
-            break;
+            case SIMPLE:
+                writeSimpleNode( (SimpleNode) node );
+                break;
+            case COMPLEX:
+                writeComplexNode( (ComplexNode) node );
+                break;
+            case COLLECTION:
+                writeCollectionNode( (CollectionNode) node );
+                break;
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngine.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngine.java
@@ -159,9 +159,9 @@ public class ProgramRuleEngine
 
         RuleEngine.Builder builder = getRuleEngineContext( program,
             programRules )
-                .toEngineBuilder()
-                .triggerEnvironment( TriggerEnvironment.SERVER )
-                .events( ruleEvents );
+            .toEngineBuilder()
+            .triggerEnvironment( TriggerEnvironment.SERVER )
+            .events( ruleEvents );
 
         if ( ruleEnrollment != null )
         {

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/hibernate/HibernateProgramRuleActionStore.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/hibernate/HibernateProgramRuleActionStore.java
@@ -79,8 +79,8 @@ public class HibernateProgramRuleActionStore
     {
         return getQuery(
             "FROM ProgramRuleAction pra WHERE pra.programRuleActionType IN (:dataTypes ) AND pra.dataElement IS NULL AND pra.attribute IS NULL" )
-                .setParameter( "dataTypes", ProgramRuleActionType.DATA_LINKED_TYPES )
-                .getResultList();
+            .setParameter( "dataTypes", ProgramRuleActionType.DATA_LINKED_TYPES )
+            .getResultList();
     }
 
     @Override
@@ -88,8 +88,8 @@ public class HibernateProgramRuleActionStore
     {
         return getQuery(
             "FROM ProgramRuleAction pra WHERE pra.programRuleActionType IN ( :notificationTypes ) AND pra.templateUid IS NULL" )
-                .setParameter( "notificationTypes", ProgramRuleActionType.NOTIFICATION_LINKED_TYPES )
-                .getResultList();
+            .setParameter( "notificationTypes", ProgramRuleActionType.NOTIFICATION_LINKED_TYPES )
+            .getResultList();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/hibernate/HibernateProgramRuleVariableStore.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/hibernate/HibernateProgramRuleVariableStore.java
@@ -83,8 +83,8 @@ public class HibernateProgramRuleVariableStore
     {
         return getQuery(
             "FROM ProgramRuleVariable prv WHERE prv.sourceType IN ( :dataTypes ) AND prv.dataElement IS NULL" )
-                .setParameter( "dataTypes", ProgramRuleVariableSourceType.getDataTypes() )
-                .getResultList();
+            .setParameter( "dataTypes", ProgramRuleVariableSourceType.getDataTypes() )
+            .getResultList();
     }
 
     @Override
@@ -92,7 +92,7 @@ public class HibernateProgramRuleVariableStore
     {
         return getQuery(
             "FROM ProgramRuleVariable prv WHERE prv.sourceType IN ( :attributeTypes ) AND prv.attribute IS NULL" )
-                .setParameter( "attributeTypes", ProgramRuleVariableSourceType.getAttributeTypes() )
-                .getResultList();
+            .setParameter( "attributeTypes", ProgramRuleVariableSourceType.getAttributeTypes() )
+            .getResultList();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/dashboard/impl/DefaultCascadeSharingService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/dashboard/impl/DefaultCascadeSharingService.java
@@ -105,28 +105,28 @@ public class DefaultCascadeSharingService
 
             switch ( dashboardItem.getType() )
             {
-            case MAP:
-                handleMapObject( dashboard.getSharing(), dashboardItem.getMap(), itemCanMergeObjects, parameters );
-                break;
-            case VISUALIZATION:
-                handleVisualization( dashboard.getSharing(), dashboardItem.getVisualization(), itemCanMergeObjects,
-                    parameters );
-                break;
-            case EVENT_REPORT:
-                handleEventReport( dashboard.getSharing(), dashboardItem.getEventReport(), itemCanMergeObjects,
-                    parameters );
-                break;
-            case EVENT_CHART:
-                handleEventChart( dashboard.getSharing(), dashboardItem.getEventChart(), itemCanMergeObjects,
-                    parameters );
-                break;
-            case EVENT_VISUALIZATION:
-                handleEventVisualization( dashboard.getSharing(), dashboardItem.getEventVisualization(),
-                    itemCanMergeObjects,
-                    parameters );
-                break;
-            default:
-                break;
+                case MAP:
+                    handleMapObject( dashboard.getSharing(), dashboardItem.getMap(), itemCanMergeObjects, parameters );
+                    break;
+                case VISUALIZATION:
+                    handleVisualization( dashboard.getSharing(), dashboardItem.getVisualization(), itemCanMergeObjects,
+                        parameters );
+                    break;
+                case EVENT_REPORT:
+                    handleEventReport( dashboard.getSharing(), dashboardItem.getEventReport(), itemCanMergeObjects,
+                        parameters );
+                    break;
+                case EVENT_CHART:
+                    handleEventChart( dashboard.getSharing(), dashboardItem.getEventChart(), itemCanMergeObjects,
+                        parameters );
+                    break;
+                case EVENT_VISUALIZATION:
+                    handleEventVisualization( dashboard.getSharing(), dashboardItem.getEventVisualization(),
+                        itemCanMergeObjects,
+                        parameters );
+                    break;
+                default:
+                    break;
             }
 
             if ( !CollectionUtils.isEmpty( itemCanMergeObjects ) )

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java
@@ -304,15 +304,15 @@ public class DefaultPushAnalysisService
     {
         switch ( item.getType() )
         {
-        case MAP:
-            return generateMapHtml( item.getMap(), user );
-        case VISUALIZATION:
-            return generateVisualizationHtml( item.getVisualization(), user );
-        default:
-            // TODO: Add support for EventCharts
-            // TODO: Add support for EventReports
-            log.warn( "Dashboard item of type '" + item.getType() + "' not supported. Skipping." );
-            return "";
+            case MAP:
+                return generateMapHtml( item.getMap(), user );
+            case VISUALIZATION:
+                return generateVisualizationHtml( item.getVisualization(), user );
+            default:
+                // TODO: Add support for EventCharts
+                // TODO: Add support for EventReports
+                log.warn( "Dashboard item of type '" + item.getType() + "' not supported. Skipping." );
+                return "";
         }
     }
 
@@ -322,14 +322,14 @@ public class DefaultPushAnalysisService
 
         switch ( item.getType() )
         {
-        case MAP:
-            result += "/dhis-web-maps/index.html?id=" + item.getMap().getUid();
-            break;
-        case VISUALIZATION:
-            result += "/dhis-web-data-visualizer/index.html?id=" + item.getVisualization().getUid();
-            break;
-        default:
-            break;
+            case MAP:
+                result += "/dhis-web-maps/index.html?id=" + item.getMap().getUid();
+                break;
+            case VISUALIZATION:
+                result += "/dhis-web-data-visualizer/index.html?id=" + item.getVisualization().getUid();
+                break;
+            default:
+                break;
         }
 
         return result;
@@ -371,10 +371,10 @@ public class DefaultPushAnalysisService
     {
         switch ( visualization.getType() )
         {
-        case PIVOT_TABLE:
-            return generateReportTableHtml( visualization, user );
-        default:
-            return generateChartHtml( visualization, user );
+            case PIVOT_TABLE:
+                return generateReportTableHtml( visualization, user );
+            default:
+                return generateChartHtml( visualization, user );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/DataValidationRunnerTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/DataValidationRunnerTest.java
@@ -181,7 +181,7 @@ class DataValidationRunnerTest
 
         when( expressionService.getExpressionValue( ExpressionParams.builder()
             .expression( "8.4!=-10.0" ).parseType( SIMPLE_TEST ).build() ) )
-                .thenReturn( true );
+            .thenReturn( true );
 
         subject.run( organisationUnits, ctx );
 

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultMergeService.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultMergeService.java
@@ -137,7 +137,7 @@ public class DefaultMergeService implements MergeService
         {
             return merge( new MergeParams<>( source,
                 (T) HibernateProxyUtils.getRealClass( source ).getDeclaredConstructor().newInstance() )
-                    .setMergeMode( MergeMode.REPLACE ) );
+                .setMergeMode( MergeMode.REPLACE ) );
         }
         catch ( InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -298,26 +298,26 @@ public class DefaultEventService implements EventService
 
         switch ( selectedOuMode )
         {
-        case ALL:
-            violation = userCanSearchOuModeALL( user ) ? null
-                : "Current user is not authorized to query across all organisation units";
-            break;
-        case ACCESSIBLE:
-            violation = getAccessibleScopeValidation( user, params );
-            break;
-        case CAPTURE:
-            violation = getCaptureScopeValidation( user );
-            break;
-        case CHILDREN:
-        case SELECTED:
-        case DESCENDANTS:
-            violation = params.getOrgUnit() == null
-                ? "Organisation unit is required for ouMode: " + params.getOrgUnitSelectionMode()
-                : null;
-            break;
-        default:
-            violation = "Invalid ouMode:  " + params.getOrgUnitSelectionMode();
-            break;
+            case ALL:
+                violation = userCanSearchOuModeALL( user ) ? null
+                    : "Current user is not authorized to query across all organisation units";
+                break;
+            case ACCESSIBLE:
+                violation = getAccessibleScopeValidation( user, params );
+                break;
+            case CAPTURE:
+                violation = getCaptureScopeValidation( user );
+                break;
+            case CHILDREN:
+            case SELECTED:
+            case DESCENDANTS:
+                violation = params.getOrgUnit() == null
+                    ? "Organisation unit is required for ouMode: " + params.getOrgUnitSelectionMode()
+                    : null;
+                break;
+            default:
+                violation = "Invalid ouMode:  " + params.getOrgUnitSelectionMode();
+                break;
         }
 
         return violation;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -1666,12 +1666,12 @@ public class JdbcEventStore implements EventStore
 
         return switch ( orgUnitSelectionMode )
         {
-        case ALL -> null;
-        case CHILDREN -> getChildrenOrgUnitsPath( params, ouTable );
-        case DESCENDANTS -> getDescendantOrgUnitsPath( params, ouTable );
-        case CAPTURE -> getCaptureOrgUnitsPath( user, ouTable );
-        case SELECTED -> getSelectedOrgUnitsPath( params, ouTable );
-        default -> getAccessibleOrgUnitsPath( params, user, ouTable );
+            case ALL -> null;
+            case CHILDREN -> getChildrenOrgUnitsPath( params, ouTable );
+            case DESCENDANTS -> getDescendantOrgUnitsPath( params, ouTable );
+            case CAPTURE -> getCaptureOrgUnitsPath( user, ouTable );
+            case SELECTED -> getSelectedOrgUnitsPath( params, ouTable );
+            default -> getAccessibleOrgUnitsPath( params, user, ouTable );
         };
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -1664,13 +1664,14 @@ public class JdbcEventStore implements EventStore
             return getAccessibleOrgUnitsPath( params, user, ouTable );
         }
 
-        return switch (orgUnitSelectionMode) {
-            case ALL -> null;
-            case CHILDREN -> getChildrenOrgUnitsPath(params, ouTable);
-            case DESCENDANTS -> getDescendantOrgUnitsPath(params, ouTable);
-            case CAPTURE -> getCaptureOrgUnitsPath(user, ouTable);
-            case SELECTED -> getSelectedOrgUnitsPath(params, ouTable);
-            default -> getAccessibleOrgUnitsPath(params, user, ouTable);
+        return switch ( orgUnitSelectionMode )
+        {
+        case ALL -> null;
+        case CHILDREN -> getChildrenOrgUnitsPath( params, ouTable );
+        case DESCENDANTS -> getDescendantOrgUnitsPath( params, ouTable );
+        case CAPTURE -> getCaptureOrgUnitsPath( user, ouTable );
+        case SELECTED -> getSelectedOrgUnitsPath( params, ouTable );
+        default -> getAccessibleOrgUnitsPath( params, user, ouTable );
         };
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/mapper/RelationshipRowCallbackHandler.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/mapper/RelationshipRowCallbackHandler.java
@@ -140,23 +140,23 @@ public class RelationshipRowCallbackHandler extends AbstractMapper<RelationshipI
 
         switch ( type )
         {
-        case "tei":
-            TrackedEntity tei = new TrackedEntity();
-            tei.setUid( uid );
-            ri.setTrackedEntity( tei );
-            break;
-        case "pi":
-            Enrollment enrollment = new Enrollment();
-            enrollment.setUid( uid );
-            ri.setEnrollment( enrollment );
-            break;
-        case "psi":
-            Event event = new Event();
-            event.setUid( uid );
-            ri.setEvent( event );
-            break;
-        default:
-            log.warn( "Expecting tei|psi|pi as type when fetching a relationship, got: " + type );
+            case "tei":
+                TrackedEntity tei = new TrackedEntity();
+                tei.setUid( uid );
+                ri.setTrackedEntity( tei );
+                break;
+            case "pi":
+                Enrollment enrollment = new Enrollment();
+                enrollment.setUid( uid );
+                ri.setEnrollment( enrollment );
+                break;
+            case "psi":
+                Event event = new Event();
+                event.setUid( uid );
+                ri.setEvent( event );
+                break;
+            default:
+                log.warn( "Expecting tei|psi|pi as type when fetching a relationship, got: " + type );
         }
 
         return ri;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/TrackerIdSchemeParam.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/TrackerIdSchemeParam.java
@@ -75,19 +75,19 @@ public class TrackerIdSchemeParam
     {
         switch ( idScheme )
         {
-        case UID:
-            return object.getUid();
-        case CODE:
-            return object.getCode();
-        case NAME:
-            return object.getName();
-        case ATTRIBUTE:
-            return object.getAttributeValues()
-                .stream()
-                .filter( av -> av.getAttribute().getUid().equals( attributeUid ) )
-                .map( AttributeValue::getValue )
-                .findFirst()
-                .orElse( null );
+            case UID:
+                return object.getUid();
+            case CODE:
+                return object.getCode();
+            case NAME:
+                return object.getName();
+            case ATTRIBUTE:
+                return object.getAttributeValues()
+                    .stream()
+                    .filter( av -> av.getAttribute().getUid().equals( attributeUid ) )
+                    .map( AttributeValue::getValue )
+                    .findFirst()
+                    .orElse( null );
         }
 
         throw new RuntimeException( "Unhandled identifier type." );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/TrackerIdSchemeParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/TrackerIdSchemeParams.java
@@ -109,20 +109,20 @@ public class TrackerIdSchemeParams
     {
         switch ( klazz.getSimpleName() )
         {
-        case "CategoryOptionCombo":
-            return categoryOptionComboIdScheme;
-        case "OrganisationUnit":
-            return orgUnitIdScheme;
-        case "CategoryOption":
-            return categoryOptionIdScheme;
-        case "DataElement":
-            return dataElementIdScheme;
-        case "Program":
-            return programIdScheme;
-        case "ProgramStage":
-            return programStageIdScheme;
-        default:
-            return idScheme;
+            case "CategoryOptionCombo":
+                return categoryOptionComboIdScheme;
+            case "OrganisationUnit":
+                return orgUnitIdScheme;
+            case "CategoryOption":
+                return categoryOptionIdScheme;
+            case "DataElement":
+                return dataElementIdScheme;
+            case "Program":
+                return programIdScheme;
+            case "ProgramStage":
+                return programStageIdScheme;
+            default:
+                return idScheme;
         }
 
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundle.java
@@ -300,17 +300,17 @@ public class TrackerBundle
 
         switch ( type )
         {
-        case TRACKED_ENTITY:
-            return findTrackedEntityByUid( uid ).isPresent();
-        case ENROLLMENT:
-            return findEnrollmentByUid( uid ).isPresent();
-        case EVENT:
-            return findEventByUid( uid ).isPresent();
-        case RELATIONSHIP:
-            return findRelationshipByUid( uid ).isPresent();
-        default:
-            // only reached if a new TrackerDto implementation is added
-            throw new IllegalStateException( "TrackerType " + type.getName() + " not yet supported." );
+            case TRACKED_ENTITY:
+                return findTrackedEntityByUid( uid ).isPresent();
+            case ENROLLMENT:
+                return findEnrollmentByUid( uid ).isPresent();
+            case EVENT:
+                return findEventByUid( uid ).isPresent();
+            case RELATIONSHIP:
+                return findRelationshipByUid( uid ).isPresent();
+            default:
+                // only reached if a new TrackerDto implementation is added
+                throw new IllegalStateException( "TrackerType " + type.getName() + " not yet supported." );
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/EnrollmentStatus.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/EnrollmentStatus.java
@@ -62,12 +62,12 @@ public enum EnrollmentStatus
     {
         switch ( programStatus )
         {
-        case ACTIVE:
-            return ACTIVE;
-        case CANCELLED:
-            return CANCELLED;
-        case COMPLETED:
-            return COMPLETED;
+            case ACTIVE:
+                return ACTIVE;
+            case CANCELLED:
+                return CANCELLED;
+            case COMPLETED:
+                return COMPLETED;
         }
 
         throw new IllegalArgumentException( "Enum value not found: " + programStatus );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/MetadataIdentifier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/MetadataIdentifier.java
@@ -236,19 +236,19 @@ public class MetadataIdentifier
     {
         switch ( idScheme )
         {
-        case UID:
-            return metadata.getUid();
-        case CODE:
-            return metadata.getCode();
-        case NAME:
-            return metadata.getName();
-        case ATTRIBUTE:
-            return metadata.getAttributeValues()
-                .stream()
-                .filter( av -> av.getAttribute().getUid().equals( this.identifier ) )
-                .map( AttributeValue::getValue )
-                .findFirst()
-                .orElse( null );
+            case UID:
+                return metadata.getUid();
+            case CODE:
+                return metadata.getCode();
+            case NAME:
+                return metadata.getName();
+            case ATTRIBUTE:
+                return metadata.getAttributeValues()
+                    .stream()
+                    .filter( av -> av.getAttribute().getUid().equals( this.identifier ) )
+                    .map( AttributeValue::getValue )
+                    .findFirst()
+                    .orElse( null );
         }
 
         throw new RuntimeException( "Unhandled identifier type." );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheat.java
@@ -777,17 +777,17 @@ public class TrackerPreheat
 
         switch ( type )
         {
-        case TRACKED_ENTITY:
-            return getTrackedEntity( uid ) != null;
-        case ENROLLMENT:
-            return getEnrollment( uid ) != null;
-        case EVENT:
-            return getEvent( uid ) != null;
-        case RELATIONSHIP:
-            return getRelationship( uid ) != null;
-        default:
-            // only reached if a new TrackerDto implementation is added
-            throw new IllegalStateException( "TrackerType " + type.getName() + " not yet supported." );
+            case TRACKED_ENTITY:
+                return getTrackedEntity( uid ) != null;
+            case ENROLLMENT:
+                return getEnrollment( uid ) != null;
+            case EVENT:
+                return getEvent( uid ) != null;
+            case RELATIONSHIP:
+                return getRelationship( uid ) != null;
+            default:
+                // only reached if a new TrackerDto implementation is added
+                throw new IllegalStateException( "TrackerType " + type.getName() + " not yet supported." );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/executor/ValidationExecutor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/programrule/executor/ValidationExecutor.java
@@ -75,14 +75,14 @@ public interface ValidationExecutor<T> extends RuleActionExecutor<T>
 
         switch ( getIssueType() )
         {
-        case WARNING:
-            return Optional.of( warning( ruleAction.getRuleUid(), ValidationCode.E1300,
-                validationMessage.toString() ) );
-        case ERROR:
-            return Optional.of(
-                error( ruleAction.getRuleUid(), ValidationCode.E1300, validationMessage.toString() ) );
-        default:
-            return Optional.empty();
+            case WARNING:
+                return Optional.of( warning( ruleAction.getRuleUid(), ValidationCode.E1300,
+                    validationMessage.toString() ) );
+            case ERROR:
+                return Optional.of(
+                    error( ruleAction.getRuleUid(), ValidationCode.E1300, validationMessage.toString() ) );
+            default:
+                return Optional.empty();
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/Each.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/Each.java
@@ -66,7 +66,9 @@ public class Each<T, R> implements Validator<T>
      * You would then write
      *
      * <pre>
-     * {@code each(Enrollment::getNotes, noteValidator)}
+     * {@code
+     * each( Enrollment::getNotes, noteValidator )
+     * }
      * </pre>
      *
      * @param map function taking type T to Collection of R

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/relationship/ConstraintValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/relationship/ConstraintValidator.java
@@ -70,17 +70,17 @@ public class ConstraintValidator implements Validator<Relationship>
     {
         switch ( constraint.getRelationshipEntity() )
         {
-        case TRACKED_ENTITY_INSTANCE:
-            validateTrackedEntityRelationship( reporter, bundle, relationship, item, relSide, constraint );
-            break;
-        case PROGRAM_INSTANCE:
-            validateEnrollmentRelationship( reporter, bundle, relationship, item, relSide );
-            break;
-        case PROGRAM_STAGE_INSTANCE:
-            validateEventRelationship( reporter, bundle, relationship, item, relSide );
-            break;
-        default:
-            break;
+            case TRACKED_ENTITY_INSTANCE:
+                validateTrackedEntityRelationship( reporter, bundle, relationship, item, relSide, constraint );
+                break;
+            case PROGRAM_INSTANCE:
+                validateEnrollmentRelationship( reporter, bundle, relationship, item, relSide );
+                break;
+            case PROGRAM_STAGE_INSTANCE:
+                validateEventRelationship( reporter, bundle, relationship, item, relSide );
+                break;
+            default:
+                break;
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/dataanalysis/MinMaxOutlierAnalysisService.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/dataanalysis/MinMaxOutlierAnalysisService.java
@@ -128,13 +128,13 @@ public class MinMaxOutlierAnalysisService
 
                     switch ( dataElement.getValueType() )
                     {
-                    case INTEGER_POSITIVE:
-                    case INTEGER_ZERO_OR_POSITIVE:
-                        min = Math.max( 0, min ); // Cannot be < 0
-                        break;
-                    case INTEGER_NEGATIVE:
-                        max = Math.min( 0, max ); // Cannot be > 0
-                        break;
+                        case INTEGER_POSITIVE:
+                        case INTEGER_ZERO_OR_POSITIVE:
+                            min = Math.max( 0, min ); // Cannot be < 0
+                            break;
+                        case INTEGER_NEGATIVE:
+                            max = Math.min( 0, max ); // Cannot be > 0
+                            break;
                     }
 
                     OrganisationUnit orgUnit = new OrganisationUnit();

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/minmax/hibernate/HibernateMinMaxDataElementStore.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/minmax/hibernate/HibernateMinMaxDataElementStore.java
@@ -145,7 +145,7 @@ public class HibernateMinMaxDataElementStore
         return getCount( builder, newJpaParameters()
             .addPredicate( root -> parseFilter( builder, root, query.getFilters() ) )
             .setUseDistinct( true ) )
-                .intValue();
+            .intValue();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/outlierdetection/service/DefaultOutlierDetectionService.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/outlierdetection/service/DefaultOutlierDetectionService.java
@@ -228,14 +228,14 @@ public class DefaultOutlierDetectionService
     {
         switch ( request.getAlgorithm() )
         {
-        case Z_SCORE:
-        case MOD_Z_SCORE:
-            return zScoreOutlierDetection.getOutlierValues( request );
-        case MIN_MAX:
-            return minMaxOutlierDetection.getOutlierValues( request );
-        default:
-            throw new IllegalStateException( String.format(
-                "Outlier detection algorithm not supported: %s", request.getAlgorithm() ) );
+            case Z_SCORE:
+            case MOD_Z_SCORE:
+                return zScoreOutlierDetection.getOutlierValues( request );
+            case MIN_MAX:
+                return minMaxOutlierDetection.getOutlierValues( request );
+            default:
+                throw new IllegalStateException( String.format(
+                    "Outlier detection algorithm not supported: %s", request.getAlgorithm() ) );
         }
     }
 }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/legacy/DefaultAuditObjectFactory.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/legacy/DefaultAuditObjectFactory.java
@@ -59,12 +59,12 @@ public class DefaultAuditObjectFactory implements AuditObjectFactory
     {
         switch ( auditScope )
         {
-        case METADATA:
-            return handleMetadataAudit( object );
-        case TRACKER:
-            return handleTracker( object );
-        case AGGREGATE:
-            return handleAggregate( object );
+            case METADATA:
+                return handleMetadataAudit( object );
+            case TRACKER:
+                return handleTracker( object );
+            case AGGREGATE:
+                return handleAggregate( object );
         }
         return null;
     }

--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/util/TextUtils.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/util/TextUtils.java
@@ -730,20 +730,20 @@ public class TextUtils
             final char c = glob.charAt( i );
             switch ( c )
             {
-            case '*':
-                out.append( ".*" );
-                break;
-            case '?':
-                out.append( '.' );
-                break;
-            case '.':
-                out.append( "\\." );
-                break;
-            case '\\':
-                out.append( "\\\\" );
-                break;
-            default:
-                out.append( c );
+                case '*':
+                    out.append( ".*" );
+                    break;
+                case '?':
+                    out.append( '.' );
+                    break;
+                case '.':
+                    out.append( "\\." );
+                    break;
+                case '\\':
+                    out.append( "\\\\" );
+                    break;
+                default:
+                    out.append( c );
             }
         }
 

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/util/LogOnceLogger.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/util/LogOnceLogger.java
@@ -59,21 +59,21 @@ public abstract class LogOnceLogger
         {
             switch ( level )
             {
-            case ERROR:
-                log.error( logString );
-                break;
-            case WARN:
-                log.warn( logString );
-                break;
-            case INFO:
-                log.info( logString );
-                break;
-            case DEBUG:
-                log.debug( logString );
-                break;
-            case TRACE:
-                log.trace( logString );
-                break;
+                case ERROR:
+                    log.error( logString );
+                    break;
+                case WARN:
+                    log.warn( logString );
+                    break;
+                case INFO:
+                    log.info( logString );
+                    break;
+                case DEBUG:
+                    log.debug( logString );
+                    break;
+                case TRACE:
+                    log.trace( logString );
+                    break;
             }
             logged.add( logString );
         }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/NotificationLoggerUtil.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/NotificationLoggerUtil.java
@@ -40,21 +40,21 @@ public class NotificationLoggerUtil
     {
         switch ( level )
         {
-        case LOOP:
-        case DEBUG:
-            logger.debug( message );
-            break;
-        case INFO:
-            logger.info( message );
-            break;
-        case WARN:
-            logger.warn( message );
-            break;
-        case ERROR:
-            logger.error( message );
-            break;
-        case OFF:
-            break;
+            case LOOP:
+            case DEBUG:
+                logger.debug( message );
+                break;
+            case INFO:
+                logger.info( message );
+                break;
+            case WARN:
+                logger.warn( message );
+                break;
+            case ERROR:
+                logger.error( message );
+                break;
+            case OFF:
+                break;
         }
     }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
@@ -536,39 +536,39 @@ public class ValidationUtils
         // Value type checks
         switch ( valueType )
         {
-        case LETTER:
-            return !isValidLetter( value ) ? "value_not_valid_letter" : null;
-        case NUMBER:
-            return !isNumeric( value ) ? "value_not_numeric" : null;
-        case UNIT_INTERVAL:
-            return !isUnitInterval( value ) ? "value_not_unit_interval" : null;
-        case PERCENTAGE:
-            return !isPercentage( value ) ? "value_not_percentage" : null;
-        case INTEGER:
-            return !isInteger( value ) ? "value_not_integer" : null;
-        case INTEGER_POSITIVE:
-            return !isPositiveInteger( value ) ? "value_not_positive_integer" : null;
-        case INTEGER_NEGATIVE:
-            return !isNegativeInteger( value ) ? "value_not_negative_integer" : null;
-        case INTEGER_ZERO_OR_POSITIVE:
-            return !isZeroOrPositiveInteger( value ) ? "value_not_zero_or_positive_integer" : null;
-        case BOOLEAN:
-            return !isBool( value.toLowerCase() ) ? "value_not_bool" : null;
-        case TRUE_ONLY:
-            return !TRUE.equalsIgnoreCase( value ) ? "value_not_true_only" : null;
-        case DATE:
-            return !dateIsValid( value ) ? "value_not_valid_date" : null;
-        case DATETIME:
-            return !dateTimeIsValid( value ) ? "value_not_valid_datetime" : null;
-        case COORDINATE:
-            return !isCoordinate( value ) ? "value_not_coordinate" : null;
-        case URL:
-            return !urlIsValid( value ) ? "value_not_url" : null;
-        case FILE_RESOURCE:
-        case IMAGE:
-            return !isValidUid( value ) ? "value_not_valid_file_resource_uid" : null;
-        default:
-            return null;
+            case LETTER:
+                return !isValidLetter( value ) ? "value_not_valid_letter" : null;
+            case NUMBER:
+                return !isNumeric( value ) ? "value_not_numeric" : null;
+            case UNIT_INTERVAL:
+                return !isUnitInterval( value ) ? "value_not_unit_interval" : null;
+            case PERCENTAGE:
+                return !isPercentage( value ) ? "value_not_percentage" : null;
+            case INTEGER:
+                return !isInteger( value ) ? "value_not_integer" : null;
+            case INTEGER_POSITIVE:
+                return !isPositiveInteger( value ) ? "value_not_positive_integer" : null;
+            case INTEGER_NEGATIVE:
+                return !isNegativeInteger( value ) ? "value_not_negative_integer" : null;
+            case INTEGER_ZERO_OR_POSITIVE:
+                return !isZeroOrPositiveInteger( value ) ? "value_not_zero_or_positive_integer" : null;
+            case BOOLEAN:
+                return !isBool( value.toLowerCase() ) ? "value_not_bool" : null;
+            case TRUE_ONLY:
+                return !TRUE.equalsIgnoreCase( value ) ? "value_not_true_only" : null;
+            case DATE:
+                return !dateIsValid( value ) ? "value_not_valid_date" : null;
+            case DATETIME:
+                return !dateTimeIsValid( value ) ? "value_not_valid_datetime" : null;
+            case COORDINATE:
+                return !isCoordinate( value ) ? "value_not_coordinate" : null;
+            case URL:
+                return !urlIsValid( value ) ? "value_not_url" : null;
+            case FILE_RESOURCE:
+            case IMAGE:
+                return !isValidUid( value ) ? "value_not_valid_file_resource_uid" : null;
+            default:
+                return null;
         }
     }
 
@@ -592,38 +592,38 @@ public class ValidationUtils
         // Value type grouped checks.
         switch ( valueType )
         {
-        case INTEGER:
-        case INTEGER_POSITIVE:
-        case INTEGER_NEGATIVE:
-        case INTEGER_ZERO_OR_POSITIVE:
-            return isInteger( trim( value ) );
-        case NUMBER:
-        case UNIT_INTERVAL:
-        case PERCENTAGE:
-            return isValidDouble( parseDouble( trim( value ) ) );
-        case BOOLEAN:
-        case TRUE_ONLY:
-            return isBool( defaultIfBlank( BOOLEAN_VALUES.get( lowerCase( trim( value ) ) ), EMPTY ) );
-        case DATE:
-            return dateIsValid( trim( value ) );
-        case TIME:
-            return timeIsValid( trim( value ) );
-        case DATETIME:
-            return dateTimeIsValid( trim( value ) );
-        case LONG_TEXT:
-        case MULTI_TEXT:
-        case PHONE_NUMBER:
-        case EMAIL:
-        case TEXT:
-        case LETTER:
-        case COORDINATE:
-        case URL:
-        case FILE_RESOURCE:
-        case IMAGE:
-        case USERNAME:
-        case GEOJSON:
-        default:
-            return true;
+            case INTEGER:
+            case INTEGER_POSITIVE:
+            case INTEGER_NEGATIVE:
+            case INTEGER_ZERO_OR_POSITIVE:
+                return isInteger( trim( value ) );
+            case NUMBER:
+            case UNIT_INTERVAL:
+            case PERCENTAGE:
+                return isValidDouble( parseDouble( trim( value ) ) );
+            case BOOLEAN:
+            case TRUE_ONLY:
+                return isBool( defaultIfBlank( BOOLEAN_VALUES.get( lowerCase( trim( value ) ) ), EMPTY ) );
+            case DATE:
+                return dateIsValid( trim( value ) );
+            case TIME:
+                return timeIsValid( trim( value ) );
+            case DATETIME:
+                return dateTimeIsValid( trim( value ) );
+            case LONG_TEXT:
+            case MULTI_TEXT:
+            case PHONE_NUMBER:
+            case EMAIL:
+            case TEXT:
+            case LETTER:
+            case COORDINATE:
+            case URL:
+            case FILE_RESOURCE:
+            case IMAGE:
+            case USERNAME:
+            case GEOJSON:
+            default:
+                return true;
         }
     }
 

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonGenerator.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonGenerator.java
@@ -132,55 +132,55 @@ public class JsonGenerator
     {
         switch ( property.getPropertyType() )
         {
-        case COMPLEX:
-            JsonSchema schema = schemasByKlass.get( property.getString( "klass" ).string() );
-            if ( schema == null )
-            {
-                json.append( "null" );
-            }
-            else
-            {
-                json.append( createObject( schema, false, emptyMap() ) );
-            }
-            break;
-        case TEXT:
-            json.append( '"' ).append( generateString( property ) ).append( '"' );
-            break;
-        case DATE:
-            json.append( '"' ).append( generateDateString() ).append( '"' );
-            break;
-        case CONSTANT:
-            json.append( '"' ).append( property.getConstants().get( 0 ) ).append( '"' );
-            break;
-        case BOOLEAN:
-            json.append( "true" );
-            break;
-        case INTEGER:
-        case NUMBER:
-            json.append( getSmallestPositiveValue( property ) );
-            break;
-        case IDENTIFIER:
-            json.append( '"' ).append( generateId( property ) ).append( '"' );
-            break;
-        case REFERENCE:
-            String object = objects.get( property.getRelativeApiEndpoint() );
-            if ( object == null )
-            {
-                schema = schemasByEndpoint.get( property.getRelativeApiEndpoint() );
-                object = addObject( schema, true, objects );
-            }
-            if ( object.isEmpty() )
-            {
-                // we are already trying to compute an object of this type
-                json.append( "null" );
-                return;
-            }
-            int idStart = object.indexOf( "\"id\":" ) + 6;
-            int idEnd = object.indexOf( '"', idStart );
-            json.append( "{\"id\":\"" ).append( object, idStart, idEnd ).append( "\"}" );
-            break;
-        default:
-            throw new IllegalArgumentException( property.getName() + " " + property.getPropertyType() );
+            case COMPLEX:
+                JsonSchema schema = schemasByKlass.get( property.getString( "klass" ).string() );
+                if ( schema == null )
+                {
+                    json.append( "null" );
+                }
+                else
+                {
+                    json.append( createObject( schema, false, emptyMap() ) );
+                }
+                break;
+            case TEXT:
+                json.append( '"' ).append( generateString( property ) ).append( '"' );
+                break;
+            case DATE:
+                json.append( '"' ).append( generateDateString() ).append( '"' );
+                break;
+            case CONSTANT:
+                json.append( '"' ).append( property.getConstants().get( 0 ) ).append( '"' );
+                break;
+            case BOOLEAN:
+                json.append( "true" );
+                break;
+            case INTEGER:
+            case NUMBER:
+                json.append( getSmallestPositiveValue( property ) );
+                break;
+            case IDENTIFIER:
+                json.append( '"' ).append( generateId( property ) ).append( '"' );
+                break;
+            case REFERENCE:
+                String object = objects.get( property.getRelativeApiEndpoint() );
+                if ( object == null )
+                {
+                    schema = schemasByEndpoint.get( property.getRelativeApiEndpoint() );
+                    object = addObject( schema, true, objects );
+                }
+                if ( object.isEmpty() )
+                {
+                    // we are already trying to compute an object of this type
+                    json.append( "null" );
+                    return;
+                }
+                int idStart = object.indexOf( "\"id\":" ) + 6;
+                int idEnd = object.indexOf( '"', idStart );
+                json.append( "{\"id\":\"" ).append( object, idStart, idEnd ).append( "\"}" );
+                break;
+            default:
+                throw new IllegalArgumentException( property.getName() + " " + property.getPropertyType() );
         }
     }
 
@@ -188,13 +188,13 @@ public class JsonGenerator
     {
         switch ( property.getName() )
         {
-        case "id":
-        case "uid":
-        case "code":
-        case "cid":
-            return CodeGenerator.generateUid();
-        default:
-            throw new UnsupportedOperationException( "id type not supported: " + property.getName() );
+            case "id":
+            case "uid":
+            case "code":
+            case "cid":
+                return CodeGenerator.generateUid();
+            default:
+                throw new UnsupportedOperationException( "id type not supported: " + property.getName() );
         }
     }
 
@@ -207,20 +207,20 @@ public class JsonGenerator
     {
         switch ( property.getName() )
         {
-        case "url":
-            return "http://example.com";
-        case "cronExpression":
-            return "* * * * * *";
-        case "periodType":
-            return PeriodType.PERIOD_TYPES.get( 0 ).getName();
+            case "url":
+                return "http://example.com";
+            case "cronExpression":
+                return "* * * * * *";
+            case "periodType":
+                return PeriodType.PERIOD_TYPES.get( 0 ).getName();
 
-        case "name":
-        case "shortName":
-            // there are often unique constrains on TEXT attributes called name,
-            // so...
-            return getUniqueString( property );
-        default:
-            return getRandomString( property );
+            case "name":
+            case "shortName":
+                // there are often unique constrains on TEXT attributes called name,
+                // so...
+                return getUniqueString( property );
+            default:
+                return getRandomString( property );
         }
     }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/security/CategorySecurityUtilsTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/security/CategorySecurityUtilsTest.java
@@ -129,9 +129,9 @@ class CategorySecurityUtilsTest
                 params.getDimensions().stream(),
                 params.getFilters().stream() )
                 .collect( Collectors.toList() ) )
-                    .stream()
-                    .map( IdentifiableObject::getUid )
-                    .collect( Collectors.toList() );
+            .stream()
+            .map( IdentifiableObject::getUid )
+            .collect( Collectors.toList() );
 
         assertThat( expected, containsInAnyOrder( actual.toArray() ) );
         assertThat( actual, hasSize( expected.size() ) );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -696,14 +696,14 @@ class ExpressionServiceTest extends SingleSetupIntegrationTestBase
 
     private String itemNameOrSubexpression( DimensionalItemObject item )
     {
-        String name = (item instanceof SubexpressionDimensionItem subex )
+        String name = (item instanceof SubexpressionDimensionItem subex)
             ? getItemNames( subex.getItems() ) + " [" + subex.getSubexSql() + "]::"
                 + subex.getQueryMods().getValueType().name()
             : item.getName();
 
         String typeOverride = (item.getQueryMods() != null && item.getQueryMods().getAggregationType() != null)
-        ? ".aggregationType(" + item.getQueryMods().getAggregationType().name() + ")"
-        : "";
+            ? ".aggregationType(" + item.getQueryMods().getAggregationType().name() + ")"
+            : "";
 
         return name + typeOverride;
     }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
@@ -175,7 +175,7 @@ class AbstractCrudControllerTest extends DhisControllerConvenienceTest
             "One or more errors occurred, please see full details in import report.",
             PUT( "/users/" + id + "/translations",
                 "{'translations': [{'locale':'sv', 'property':'name', 'value':'namn'}]}" )
-                    .content( HttpStatus.CONFLICT ) );
+                .content( HttpStatus.CONFLICT ) );
         JsonErrorReport error = message.find( JsonErrorReport.class,
             report -> report.getErrorCode() == ErrorCode.E1107 );
         assertEquals( "Object type `User` is not translatable", error.getMessage() );
@@ -193,7 +193,7 @@ class AbstractCrudControllerTest extends DhisControllerConvenienceTest
 
         PUT( "/dataSets/" + id + "/translations",
             "{'translations': [{'locale':'sv', 'property':'name', 'value':'name sv'}]}" )
-                .content( HttpStatus.NO_CONTENT );
+            .content( HttpStatus.NO_CONTENT );
 
         GET( "/dataSets/{id}", id ).content();
 
@@ -219,7 +219,7 @@ class AbstractCrudControllerTest extends DhisControllerConvenienceTest
             "One or more errors occurred, please see full details in import report.",
             PUT( "/dataSets/" + id + "/translations",
                 "{'translations': [{'locale':'sv', 'property':'name', 'value':'namn 1'},{'locale':'sv', 'property':'name', 'value':'namn2'}]}" )
-                    .content( HttpStatus.CONFLICT ) );
+                .content( HttpStatus.CONFLICT ) );
 
         JsonErrorReport error = message.find( JsonErrorReport.class,
             report -> report.getErrorCode() == ErrorCode.E1106 );
@@ -246,7 +246,7 @@ class AbstractCrudControllerTest extends DhisControllerConvenienceTest
             "One or more errors occurred, please see full details in import report.",
             PUT( "/dataSets/" + id + "/translations",
                 "{'translations': [{'locale':'en', 'property':'name'}]}" )
-                    .content( HttpStatus.CONFLICT ) );
+                .content( HttpStatus.CONFLICT ) );
 
         JsonErrorReport error = message.find( JsonErrorReport.class,
             report -> report.getErrorCode() == ErrorCode.E4000 );
@@ -265,7 +265,7 @@ class AbstractCrudControllerTest extends DhisControllerConvenienceTest
             "One or more errors occurred, please see full details in import report.",
             PUT( "/dataSets/" + id + "/translations",
                 "{'translations': [{'locale':'en', 'value':'namn 1'}]}" )
-                    .content( HttpStatus.CONFLICT ) );
+                .content( HttpStatus.CONFLICT ) );
 
         JsonErrorReport error = message.find( JsonErrorReport.class,
             report -> report.getErrorCode() == ErrorCode.E4000 );
@@ -284,7 +284,7 @@ class AbstractCrudControllerTest extends DhisControllerConvenienceTest
             "One or more errors occurred, please see full details in import report.",
             PUT( "/dataSets/" + id + "/translations",
                 "{'translations': [{'property':'name', 'value':'namn 1'}]}" )
-                    .content( HttpStatus.CONFLICT ) );
+                .content( HttpStatus.CONFLICT ) );
 
         JsonErrorReport error = message.find( JsonErrorReport.class,
             report -> report.getErrorCode() == ErrorCode.E4000 );
@@ -640,7 +640,7 @@ class AbstractCrudControllerTest extends DhisControllerConvenienceTest
 
         JsonWebMessage message = PUT( "/userGroups/" + groupId + "/users",
             "{'identifiableObjects':[{'id':'" + peterUserId + "'}]}" )
-                .content( HttpStatus.OK ).as( JsonWebMessage.class );
+            .content( HttpStatus.OK ).as( JsonWebMessage.class );
         JsonStats stats = message.getResponse().as( JsonTypeReport.class ).getStats();
         assertEquals( 1, stats.getUpdated() );
         assertEquals( 1, stats.getDeleted() );
@@ -808,12 +808,12 @@ class AbstractCrudControllerTest extends DhisControllerConvenienceTest
 
         JsonList<JsonIdentifiableObject> response = GET(
             "/attributes?fields=id,name&filter=dataElementAttribute:eq:true" )
-                .content().getList( "attributes", JsonIdentifiableObject.class );
+            .content().getList( "attributes", JsonIdentifiableObject.class );
         assertEquals( attribute.getUid(), response.get( 0 ).getId() );
 
         response = GET(
             "/attributes?fields=id,name&filter=userAttribute:eq:true" )
-                .content().getList( "attributes", JsonIdentifiableObject.class );
+            .content().getList( "attributes", JsonIdentifiableObject.class );
         assertEquals( 0, response.size() );
     }
 
@@ -822,7 +822,7 @@ class AbstractCrudControllerTest extends DhisControllerConvenienceTest
     {
         JsonImportSummary response = POST( "/dataSets/",
             "{'id':'11111111111','name':'My data set', 'shortName': 'MDS', 'periodType':'Monthly'}" )
-                .content( HttpStatus.CONFLICT ).get( "response" ).as( JsonImportSummary.class );
+            .content( HttpStatus.CONFLICT ).get( "response" ).as( JsonImportSummary.class );
         assertEquals( "Invalid UID `11111111111` for property `DataSet`",
             response.find( JsonErrorReport.class, error -> error.getErrorCode() == ErrorCode.E4014 ).getMessage() );
     }
@@ -837,7 +837,7 @@ class AbstractCrudControllerTest extends DhisControllerConvenienceTest
 
         PUT( "/dataSets/11111111111",
             "{'id':'11111111111','name':'My data set', 'shortName': 'MDS', 'periodType':'Monthly'}" )
-                .content( HttpStatus.OK );
+            .content( HttpStatus.OK );
 
         JsonIdentifiableObject response = GET( "/dataSets/11111111111" ).content().as( JsonIdentifiableObject.class );
         assertEquals( "My data set", response.getName() );

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractDataValueControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractDataValueControllerTest.java
@@ -66,7 +66,7 @@ abstract class AbstractDataValueControllerTest
             Body( "{'additions':[{'id':'" + orgUnitId + "'}]}" ) ) );
         JsonObject ccDefault = GET(
             "/categoryCombos/gist?fields=id,categoryOptionCombos::ids&pageSize=1&headless=true&filter=name:eq:default" )
-                .content().getObject( 0 );
+            .content().getObject( 0 );
         categoryComboId = ccDefault.getString( "id" ).string();
         categoryOptionComboId = ccDefault.getArray( "categoryOptionCombos" ).getString( 0 ).string();
         dataElementId = addDataElement( "My data element", "DE1", ValueType.INTEGER, null, categoryComboId );

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
@@ -73,7 +73,7 @@ class AccountControllerTest extends DhisControllerConvenienceTest
         systemSettingManager.saveSystemSetting( SettingKey.SELF_REGISTRATION_NO_RECAPTCHA, Boolean.TRUE );
         assertWebMessage( "Bad Request", 400, "ERROR", "User self registration is not allowed", POST(
             "/account?username=test&firstName=fn&surname=sn&password=Pass%23%23%23123663&email=test@example.com&phoneNumber=0123456789&employer=em" )
-                .content( HttpStatus.BAD_REQUEST ) );
+            .content( HttpStatus.BAD_REQUEST ) );
     }
 
     @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CrudControllerPagingTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CrudControllerPagingTest.java
@@ -89,8 +89,8 @@ class CrudControllerPagingTest extends DhisControllerConvenienceTest
     {
         JsonList<JsonOrganisationUnit> ous = GET(
             "/organisationUnits?order=displayName&paging=true&pageSize=2&page=" + page )
-                .content( HttpStatus.OK )
-                .getList( "organisationUnits", JsonOrganisationUnit.class );
+            .content( HttpStatus.OK )
+            .getList( "organisationUnits", JsonOrganisationUnit.class );
         assertEquals( size, ous.size() );
         assertEquals( firstItem, ous.get( 0 ).getDisplayName() );
         assertEquals( secondItem, ous.get( 1 ).getDisplayName() );
@@ -105,8 +105,8 @@ class CrudControllerPagingTest extends DhisControllerConvenienceTest
     {
         JsonList<JsonOrganisationUnit> ous = GET(
             "/organisationUnits?order=displayName:desc&paging=true&pageSize=2&page=" + page )
-                .content( HttpStatus.OK )
-                .getList( "organisationUnits", JsonOrganisationUnit.class );
+            .content( HttpStatus.OK )
+            .getList( "organisationUnits", JsonOrganisationUnit.class );
         assertEquals( size, ous.size() );
         assertEquals( firstItem, ous.get( 0 ).getDisplayName() );
         assertEquals( secondItem, ous.get( 1 ).getDisplayName() );
@@ -117,7 +117,7 @@ class CrudControllerPagingTest extends DhisControllerConvenienceTest
     {
         JsonList<JsonOrganisationUnit> ous = GET(
             "/organisationUnits?filter=displayName:in:[A,B,C]&paging=true&pageSize=2&page=2" ).content( HttpStatus.OK )
-                .getList( "organisationUnits", JsonOrganisationUnit.class );
+            .getList( "organisationUnits", JsonOrganisationUnit.class );
         assertEquals( 1, ous.size() );
         assertEquals( "C", ous.get( 0 ).getDisplayName() );
     }
@@ -138,7 +138,7 @@ class CrudControllerPagingTest extends DhisControllerConvenienceTest
     {
         JsonList<JsonOrganisationUnit> ous = GET(
             "/organisationUnits?filter=name:in:[A,B,C]&paging=true&pageSize=2&page=2" ).content( HttpStatus.OK )
-                .getList( "organisationUnits", JsonOrganisationUnit.class );
+            .getList( "organisationUnits", JsonOrganisationUnit.class );
         assertEquals( 1, ous.size() );
         assertEquals( "C", ous.get( 0 ).getDisplayName() );
     }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityChecksControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityChecksControllerTest.java
@@ -118,7 +118,7 @@ class DataIntegrityChecksControllerTest extends AbstractDataIntegrityControllerT
     {
         JsonList<JsonDataIntegrityCheck> checks = GET(
             "/dataIntegrity?checks=program_rule_variables_without_attribute" ).content()
-                .asList( JsonDataIntegrityCheck.class );
+            .asList( JsonDataIntegrityCheck.class );
         assertEquals( 1, checks.size() );
         JsonDataIntegrityCheck check = checks.get( 0 );
         assertEquals( "program_rule_variables_without_attribute", check.getName() );

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataValueControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataValueControllerTest.java
@@ -74,7 +74,7 @@ class DataValueControllerTest extends AbstractDataValueControllerTest
         assertEquals( ErrorCode.E2032,
             PUT( "/dataValues/followups",
                 Body( format( "{'values':[%s]}", dataValueKeyJSON( "2021-02", true ) ) ) )
-                    .error( HttpStatus.CONFLICT ).getErrorCode() );
+                .error( HttpStatus.CONFLICT ).getErrorCode() );
     }
 
     @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataValueFileResourceControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataValueFileResourceControllerTest.java
@@ -65,7 +65,7 @@ class DataValueFileResourceControllerTest extends DhisControllerIntegrationTest
         pe = "2021-01";
         JsonObject ccDefault = GET(
             "/categoryCombos/gist?fields=id,categoryOptionCombos::ids&pageSize=1&headless=true&filter=name:eq:default" )
-                .content().getObject( 0 );
+            .content().getObject( 0 );
         String cc = ccDefault.getString( "id" ).string();
         coc = ccDefault.getArray( "categoryOptionCombos" ).getString( 0 ).string();
         de = addDataElement( "file data", "FDE1", ValueType.FILE_RESOURCE, null, cc );

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataValueSetControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataValueSetControllerTest.java
@@ -163,7 +163,7 @@ class DataValueSetControllerTest extends DhisControllerConvenienceTest
         JsonWebMessage response = GET(
             "/dataValueSets/?inputOrgUnitIdScheme=code&idScheme=name&orgUnit={ou}&period=2022-01&dataSet={ds}", "OU1",
             dsId )
-                .content( HttpStatus.CONFLICT ).as( JsonWebMessage.class );
+            .content( HttpStatus.CONFLICT ).as( JsonWebMessage.class );
         assertEquals( String.format( "User is not allowed to view org unit: `%s`", ouId ), response.getMessage() );
     }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/EmailControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/EmailControllerTest.java
@@ -50,7 +50,7 @@ class EmailControllerTest extends DhisControllerConvenienceTest
         assertWebMessage( "Conflict", 409, "ERROR", "SMTP server not configured",
             POST( "/email/notification", "{" + "'subject':'Subject'," + "'text':'Text'," + "'sender':{'id':'"
                 + getCurrentUser().getUid() + "'}," + "'recipients':[{'id':'" + getSuperuserUid() + "'}]" + "}" )
-                    .content( HttpStatus.CONFLICT ) );
+                .content( HttpStatus.CONFLICT ) );
     }
 
     @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GeoFeatureControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GeoFeatureControllerTest.java
@@ -54,7 +54,7 @@ public class GeoFeatureControllerTest extends DhisControllerConvenienceTest
 
                 + "],"
                 + "\"attributes\":[{\"id\":\"RRH9IFiZZYN\",\"valueType\":\"GEOJSON\",\"organisationUnitAttribute\":true,\"name\":\"testgeojson\"}]}" )
-                    .content( HttpStatus.OK );
+            .content( HttpStatus.OK );
 
         JsonResponse response = GET( "/geoFeatures?ou=ou:LEVEL-1&&coordinateField=RRH9IFiZZYN" )
             .content( HttpStatus.OK );

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GeoJsonImportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GeoJsonImportControllerTest.java
@@ -227,7 +227,7 @@ class GeoJsonImportControllerTest extends DhisControllerConvenienceTest
         JsonWebMessage msg = assertWebMessage( "OK", 200, "ERROR", "Import failed.",
             POST( "/organisationUnits/geometry",
                 "{'features':[{'geometry': {'type':'MultiPolygon', 'coordinates': [ [ [ [ -12, 9 ], [ -13, 10 ], [ -11, 8 ] ] ] ] }}]}" )
-                    .content( HttpStatus.OK ) );
+                .content( HttpStatus.OK ) );
         assertReportError( msg, ErrorCode.E7705, List.of( 0 ) );
     }
 
@@ -250,7 +250,7 @@ class GeoJsonImportControllerTest extends DhisControllerConvenienceTest
         JsonWebMessage msg = assertWebMessage( "OK", 200, "ERROR", "Import failed.",
             POST( "/organisationUnits/geometry",
                 "{'features':[{'id':'Kare5678901', 'geometry': {'type':'Invalid', 'coordinates':[1,2]} }]}" )
-                    .content( HttpStatus.OK ) );
+                .content( HttpStatus.OK ) );
         assertReportError( msg, ErrorCode.E7707, List.of( 0 ) );
     }
 
@@ -262,7 +262,7 @@ class GeoJsonImportControllerTest extends DhisControllerConvenienceTest
         JsonWebMessage msg = assertWebMessage( "OK", 200, "ERROR", "Import failed.",
             POST( "/organisationUnits/geometry",
                 "{'features':[{'id':'Kare5678901', 'geometry': {'type':'Polygon', 'coordinates':[]} }]}" )
-                    .content( HttpStatus.OK ) );
+                .content( HttpStatus.OK ) );
         assertReportError( msg, ErrorCode.E7712, List.of( 0 ) );
     }
 
@@ -272,7 +272,7 @@ class GeoJsonImportControllerTest extends DhisControllerConvenienceTest
         JsonWebMessage msg = assertWebMessage( "OK", 200, "ERROR", "Import failed.",
             POST( "/organisationUnits/geometry",
                 "{'features':[{'id':'foo', 'geometry': {'type':'MultiPolygon', 'coordinates': [ [ [ [ -12, 9 ], [ -13, 10 ], [ -11, 8 ] ] ] ]}}]}" )
-                    .content( HttpStatus.OK ) );
+                .content( HttpStatus.OK ) );
         assertReportError( msg, ErrorCode.E7708, List.of( 0 ) );
     }
 
@@ -288,7 +288,7 @@ class GeoJsonImportControllerTest extends DhisControllerConvenienceTest
                     + "'properties': { 'name': 'Alpha'}, "
                     + "'geometry': {'type':'MultiPolygon', 'coordinates': [ [ [ [ 1,1 ], [ 2,2 ], [ 1,3 ], [1,1] ] ] ] }"
                     + "}]}" )
-                        .content( HttpStatus.OK ) );
+                .content( HttpStatus.OK ) );
         assertReportError( msg, ErrorCode.E7711, List.of( 0 ) );
     }
 
@@ -301,7 +301,7 @@ class GeoJsonImportControllerTest extends DhisControllerConvenienceTest
         JsonWebMessage msg = assertWebMessage( "OK", 200, "OK", "Import successful.",
             POST( "/organisationUnits/" + ouId + "/geometry",
                 "{'type':'MultiPolygon', 'coordinates': [ [ [ [ 1,1 ], [ 2,2 ], [ 1,3 ], [1,1] ] ] ] }" )
-                    .content( HttpStatus.OK ) );
+                .content( HttpStatus.OK ) );
 
         assertImportedAndIgnored( msg, 1, 0 );
         assertGeometryIsNotNull( ouId );
@@ -317,7 +317,7 @@ class GeoJsonImportControllerTest extends DhisControllerConvenienceTest
         JsonWebMessage msg = assertWebMessage( "OK", 200, "OK", "Import successful.",
             POST( "/organisationUnits/" + ouId + "/geometry?attributeId=" + attrId,
                 "{'type':'MultiPolygon', 'coordinates': [ [ [ [ 1,1 ], [ 2,2 ], [ 1,3 ], [1,1] ] ] ] }" )
-                    .content( HttpStatus.OK ) );
+                .content( HttpStatus.OK ) );
 
         assertImportedAndIgnored( msg, 1, 0 );
         assertGeometryAttributeIsNotNull( attrId, ouId );
@@ -332,7 +332,7 @@ class GeoJsonImportControllerTest extends DhisControllerConvenienceTest
         JsonWebMessage msg = assertWebMessage( "OK", 200, "OK", "Import successful.",
             POST( "/organisationUnits/" + ouId + "/geometry",
                 "{'type':'MultiPolygon', 'coordinates': [ [ [ [ 1,1 ], [ 2,2 ], [ 1,3 ], [1,1] ] ] ] }" )
-                    .content( HttpStatus.OK ) );
+                .content( HttpStatus.OK ) );
 
         assertImportedAndIgnored( msg, 1, 0 );
         assertGeometryIsNotNull( ouId );
@@ -354,7 +354,7 @@ class GeoJsonImportControllerTest extends DhisControllerConvenienceTest
         JsonWebMessage msg = assertWebMessage( "OK", 200, "OK", "Import successful.",
             POST( "/organisationUnits/" + ouId + "/geometry?attributeId=" + attrId,
                 "{'type':'MultiPolygon', 'coordinates': [ [ [ [ 1,1 ], [ 2,2 ], [ 1,3 ], [1,1] ] ] ] }" )
-                    .content( HttpStatus.OK ) );
+                .content( HttpStatus.OK ) );
 
         assertImportedAndIgnored( msg, 1, 0 );
         assertGeometryAttributeIsNotNull( attrId, ouId );

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistAttributeControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistAttributeControllerTest.java
@@ -184,7 +184,7 @@ class GistAttributeControllerTest extends AbstractGistControllerTest
         String geoGroupId = postNewUserGroupWithAttributeValue( "gg", geoAttrId, geoJsonValue.replace( "'", "\\\"" ) );
         JsonObject group = GET( "/userGroups/{uid}/gist?fields=id,name,{attr}::rename(geo)::pluck", geoGroupId,
             geoAttrId )
-                .content();
+            .content();
         assertTrue( group.get( "geo" ).isObject() );
         assertEquals( "MultiPolygon", group.getString( "geo.type" ).string() );
     }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistValidationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistValidationControllerTest.java
@@ -89,7 +89,7 @@ class GistValidationControllerTest extends AbstractGistControllerTest
             "Filter `surname:canaccess:[" + getSuperuserUid() + "]` requires a user ID and an access pattern argument.",
             GET(
                 "/users/gist?filter=username:like:admin&filter=surname:canAccess" ).error( HttpStatus.BAD_REQUEST )
-                    .getMessage() );
+                .getMessage() );
     }
 
     @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobSchedulerControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobSchedulerControllerTest.java
@@ -97,7 +97,7 @@ class JobSchedulerControllerTest extends DhisControllerConvenienceTest
             "JobConfiguration with id no-uid could not be found.",
             POST( "/scheduler/queues/testQueue",
                 format( "{'cronExpression':'0 0 1 ? * *','sequence':['%s','%s','%s']}", jobIdA, "no-uid", jobIdC ) )
-                    .content( HttpStatus.NOT_FOUND ) );
+                .content( HttpStatus.NOT_FOUND ) );
     }
 
     @Test
@@ -107,7 +107,7 @@ class JobSchedulerControllerTest extends DhisControllerConvenienceTest
             "Job queue must have at least two jobs.",
             POST( "/scheduler/queues/testQueue",
                 format( "{'cronExpression':'0 0 1 ? * *','sequence':['%s']}", jobIdA ) )
-                    .content( HttpStatus.CONFLICT ) );
+                .content( HttpStatus.CONFLICT ) );
     }
 
     @Test
@@ -131,7 +131,7 @@ class JobSchedulerControllerTest extends DhisControllerConvenienceTest
             "Cron expression is invalid: `Cron expression must consist of 6 fields (found 5 in \"0 1 ? * *\")`",
             POST( "/scheduler/queues/testQueue",
                 format( "{'cronExpression':'0 1 ? * *','sequence':['%s','%s']}", jobIdA, jobIdB ) )
-                    .content( HttpStatus.CONFLICT ) );
+                .content( HttpStatus.CONFLICT ) );
     }
 
     @Test
@@ -203,7 +203,7 @@ class JobSchedulerControllerTest extends DhisControllerConvenienceTest
             "Cron expression is invalid: `Cron expression must consist of 6 fields (found 5 in \"0 1 ? * *\")`",
             PUT( "/scheduler/queues/testQueue",
                 format( "{'cronExpression':'0 1 ? * *','sequence':['%s','%s']}", jobIdA, jobIdB ) )
-                    .content( HttpStatus.CONFLICT ) );
+                .content( HttpStatus.CONFLICT ) );
     }
 
     @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MaintenanceControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MaintenanceControllerTest.java
@@ -73,7 +73,7 @@ class MaintenanceControllerTest extends DhisControllerConvenienceTest
     {
         String ccId = GET(
             "/categoryCombos/gist?fields=id,categoryOptionCombos::ids&pageSize=1&headless=true&filter=name:eq:default" )
-                .content().getObject( 0 ).getString( "id" ).string();
+            .content().getObject( 0 ).getString( "id" ).string();
         String deId = assertStatus( HttpStatus.CREATED,
             POST( "/dataElements/",
                 "{'name':'My data element', 'shortName':'DE1', 'code':'DE1', 'valueType':'INTEGER', "
@@ -117,7 +117,7 @@ class MaintenanceControllerTest extends DhisControllerConvenienceTest
     {
         String ccId = GET(
             "/categoryCombos/gist?fields=id,categoryOptionCombos::ids&pageSize=1&headless=true&filter=name:eq:default" )
-                .content().getObject( 0 ).getString( "id" ).string();
+            .content().getObject( 0 ).getString( "id" ).string();
         assertWebMessage( "OK", 200, "OK", "Import was successful.",
             POST( "/maintenance/categoryOptionComboUpdate/categoryCombo/" + ccId ).content() );
     }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MessageConversationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MessageConversationControllerTest.java
@@ -47,7 +47,7 @@ class MessageConversationControllerTest extends DhisControllerConvenienceTest
         assertWebMessage( "Created", 201, "OK", "Message conversation created",
             POST( "/messageConversations/",
                 "{'subject':'Subject','text':'Text','users':[{'id':'" + getSuperuserUid() + "'}]}" )
-                    .content( HttpStatus.CREATED ) );
+                .content( HttpStatus.CREATED ) );
     }
 
     @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
@@ -66,7 +66,7 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest
         assertWebMessage( "OK", 200, "OK", null,
             POST( "/38/metadata",
                 "{'organisationUnits':[{'name':'My Unit', 'shortName':'OU1', 'openingDate': '2020-01-01'}]}" )
-                    .content( HttpStatus.OK ) );
+                .content( HttpStatus.OK ) );
     }
 
     @Test
@@ -81,7 +81,7 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest
         assertWebMessage( "OK", 200, "OK", "Initiated metadataImport",
             POST( "/metadata?async=true",
                 "{'organisationUnits':[{'name':'My Unit', 'shortName':'OU1', 'openingDate': '2020-01-01'}]}" )
-                    .content( HttpStatus.OK ) );
+                .content( HttpStatus.OK ) );
     }
 
     @Test
@@ -89,7 +89,7 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest
     {
         JsonObject report = POST( "/37/metadata",
             "{'organisationUnits':[{'name':'My Unit', 'shortName':'OU1', 'openingDate': '2020-01-01'}]}" )
-                .content( HttpStatus.OK );
+            .content( HttpStatus.OK );
         assertEquals( "OK", report.getString( "status" ).string() );
     }
 
@@ -158,7 +158,7 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest
     {
         POST( "/metadata/",
             "{'programs':[{'name':'test program', 'id':'VoZMWi7rBgj', 'shortName':'test program','programType':'WITH_REGISTRATION','programStages':[{'id':'VoZMWi7rBgf'}] }],'programStages':[{'id':'VoZMWi7rBgf','name':'test programStage'}]}" )
-                .content( HttpStatus.OK );
+            .content( HttpStatus.OK );
         assertEquals( "VoZMWi7rBgj",
             GET( "/programStages/{id}", "VoZMWi7rBgf" ).content().getString( "program.id" ).string() );
         assertEquals( "VoZMWi7rBgf",
@@ -175,7 +175,7 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest
                 + "\\\"coordinates\\\":  [[[100,0],[101,0],[101,1],[100,1],[100,0]]] }\","
                 + "\"attribute\": {\"id\": \"RRH9IFiZZYN\"}}]}],"
                 + "\"attributes\":[{\"id\":\"RRH9IFiZZYN\",\"valueType\":\"GEOJSON\",\"organisationUnitAttribute\":true,\"name\":\"testgeojson\"}]}" )
-                    .content( HttpStatus.OK );
+            .content( HttpStatus.OK );
 
         JsonIdentifiableObject organisationUnit = GET( "/organisationUnits/{id}", "rXnqqH2Pu6N" ).content()
             .asObject( JsonIdentifiableObject.class );
@@ -197,7 +197,7 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest
                 + "\"attributeValues\": [{\"value\":  \"{\\\"type\\\": \\\"Polygon\\\"}\","
                 + "\"attribute\": {\"id\": \"RRH9IFiZZYN\"}}]}],"
                 + "\"attributes\":[{\"id\":\"RRH9IFiZZYN\",\"valueType\":\"GEOJSON\",\"organisationUnitAttribute\":true,\"name\":\"testgeojson\"}]}" )
-                    .content( HttpStatus.CONFLICT ).as( JsonWebMessage.class );
+            .content( HttpStatus.CONFLICT ).as( JsonWebMessage.class );
         assertNotNull( message.find( JsonErrorReport.class, report -> report.getErrorCode() == ErrorCode.E6004 ) );
     }
 
@@ -214,7 +214,7 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest
             "    [{\"code\": \"Vaccine freezer\",\"name\": \"Vaccine freezer\",\"id\": \"BQMei56UBl6\",\"sortOrder\": 2,\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}},\n"
             +
             "    {\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"id\": \"Uh4HvjK6zg3\",\"sortOrder\": 3,\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}" )
-                .content( HttpStatus.OK );
+            .content( HttpStatus.OK );
 
         JsonResponse response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
 
@@ -237,7 +237,7 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest
             "    [{\"code\": \"Vaccine freezer\",\"name\": \"Vaccine freezer\",\"id\": \"BQMei56UBl6\",\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}},\n"
             +
             "    {\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"id\": \"Uh4HvjK6zg3\",\"sortOrder\": 3,\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}" )
-                .content( HttpStatus.OK );
+            .content( HttpStatus.OK );
 
         JsonResponse response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
 
@@ -259,7 +259,7 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest
             "    [{\"code\": \"Vaccine freezer\",\"name\": \"Vaccine freezer\",\"id\": \"BQMei56UBl6\",\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}},\n"
             +
             "    {\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"id\": \"Uh4HvjK6zg3\",\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}" )
-                .content( HttpStatus.OK );
+            .content( HttpStatus.OK );
 
         JsonResponse response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
 
@@ -281,7 +281,7 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest
             "    [{\"code\": \"Vaccine freezer\",\"name\": \"Vaccine freezer\",\"sortOrder\": 2,\"id\": \"BQMei56UBl6\",\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}},\n"
             +
             "    {\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"sortOrder\": 2,\"id\": \"Uh4HvjK6zg3\",\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}" )
-                .content( HttpStatus.OK );
+            .content( HttpStatus.OK );
 
         JsonResponse response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
 
@@ -300,7 +300,7 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest
             "    [{\"code\": \"Vaccine freezer\",\"name\": \"Vaccine freezer\",\"sortOrder\": 2,\"id\": \"BQMei56UBl6\",\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}},\n"
             +
             "    {\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"sortOrder\": 3,\"id\": \"Uh4HvjK6zg3\",\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}" )
-                .content( HttpStatus.OK );
+            .content( HttpStatus.OK );
 
         JsonResponse response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataWorkflowControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataWorkflowControllerTest.java
@@ -129,7 +129,7 @@ class MetadataWorkflowControllerTest extends DhisControllerConvenienceTest
             "One or more errors occurred, please see full details in import report.",
             POST( "/metadata/proposals/", "{" + "'type':'ADD'," + "'target':'ORGANISATION_UNIT',"
                 + "'change':{'name':'hasNoShortName', " + "'openingDate': '2020-01-01'" + "}" + "}" )
-                    .content( HttpStatus.CONFLICT ) );
+                .content( HttpStatus.CONFLICT ) );
         JsonErrorReport error = message.find( JsonErrorReport.class,
             report -> report.getErrorCode() == ErrorCode.E4000 );
         assertEquals( "Missing required property `shortName`", error.getMessage() );
@@ -162,7 +162,7 @@ class MetadataWorkflowControllerTest extends DhisControllerConvenienceTest
             POST( "/metadata/proposals/",
                 "{" + "'type':'UPDATE'," + "'target':'ORGANISATION_UNIT',"
                     + "'change':[{'op':'replace', 'path':'/name', 'value':'New name'}]" + "}" )
-                        .content( HttpStatus.BAD_REQUEST ) );
+                .content( HttpStatus.BAD_REQUEST ) );
     }
 
     @Test
@@ -180,7 +180,7 @@ class MetadataWorkflowControllerTest extends DhisControllerConvenienceTest
             "One or more errors occurred, please see full details in import report.",
             POST( "/metadata/proposals/", "{" + "'type':'UPDATE'," + "'target':'ORGANISATION_UNIT'," + "'targetId': '"
                 + defaultTargetId + "'," + "'change':[{'op':'not-json-patch-op'}]" + "}" )
-                    .content( HttpStatus.CONFLICT ) );
+                .content( HttpStatus.CONFLICT ) );
         JsonErrorReport error = message.find( JsonErrorReport.class,
             report -> report.getErrorCode() == ErrorCode.E4031 );
         assertEquals( "Property `change` requires a valid JSON payload, was given `[{\"op\":\"not-json-patch-op\"}]`",

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MinMaxDataElementControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MinMaxDataElementControllerTest.java
@@ -47,7 +47,7 @@ class MinMaxDataElementControllerTest extends AbstractDataValueControllerTest
             POST( "/minMaxDataElements/",
                 "{" + "'source':{'id':'" + orgUnitId + "'}," + "'dataElement':{'id':'" + dataElementId + "'},"
                     + "'optionCombo':{'id':'" + categoryOptionComboId + "'}," + "'min':1," + "'max':42" + "}" )
-                        .content( HttpStatus.CREATED ) );
+                .content( HttpStatus.CREATED ) );
     }
 
     @Test
@@ -60,7 +60,7 @@ class MinMaxDataElementControllerTest extends AbstractDataValueControllerTest
         assertWebMessage( "OK", 200, "OK", "MinMaxDataElement deleted.",
             DELETE( "/minMaxDataElements/", "{" + "'source':{'id':'" + orgUnitId + "'}," + "'dataElement':{'id':'"
                 + dataElementId + "'}," + "'optionCombo':{'id':'" + categoryOptionComboId + "'}" + "}" )
-                    .content( HttpStatus.OK ) );
+                .content( HttpStatus.OK ) );
     }
 
     @Test
@@ -69,6 +69,6 @@ class MinMaxDataElementControllerTest extends AbstractDataValueControllerTest
         assertWebMessage( "Not Found", 404, "ERROR", "Can not find MinMaxDataElement.",
             DELETE( "/minMaxDataElements/", "{" + "'source':{'id':'" + orgUnitId + "'}," + "'dataElement':{'id':'"
                 + dataElementId + "'}," + "'optionCombo':{'id':'" + categoryOptionComboId + "'}" + "}" )
-                    .content( HttpStatus.NOT_FOUND ) );
+                .content( HttpStatus.NOT_FOUND ) );
     }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OptionControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OptionControllerTest.java
@@ -52,7 +52,7 @@ class OptionControllerTest extends DhisControllerConvenienceTest
             "    [{\"code\": \"Vaccine freezer\",\"name\": \"Vaccine freezer\",\"id\": \"BQMei56UBl6\",\"sortOrder\": 1,\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}},\n"
             +
             "    {\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"id\": \"Uh4HvjK6zg3\",\"sortOrder\": 2,\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}" )
-                .content( HttpStatus.OK );
+            .content( HttpStatus.OK );
 
         JsonResponse response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
 
@@ -64,7 +64,7 @@ class OptionControllerTest extends DhisControllerConvenienceTest
         // Update option sortOrder 2 to 20
         POST( "/metadata", "{\"options\":\n" +
             "[{\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"id\": \"Uh4HvjK6zg3\",\"sortOrder\": 20,\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}" )
-                .content( HttpStatus.OK );
+            .content( HttpStatus.OK );
 
         response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
         assertEquals( 2, response.getObject( "options" ).size() );

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/PredictorControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/PredictorControllerTest.java
@@ -97,7 +97,7 @@ class PredictorControllerTest extends DhisControllerConvenienceTest
     {
         String ccId = GET(
             "/categoryCombos/gist?fields=id,categoryOptionCombos::ids&pageSize=1&headless=true&filter=name:eq:default" )
-                .content().getObject( 0 ).getString( "id" ).string();
+            .content().getObject( 0 ).getString( "id" ).string();
         String deId = assertStatus( HttpStatus.CREATED,
             POST( "/dataElements/",
                 "{'name':'My data element', 'shortName':'DE1', 'code':'DE1', 'valueType':'INTEGER', "

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramRuleControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramRuleControllerTest.java
@@ -74,7 +74,7 @@ class ProgramRuleControllerTest extends DhisControllerConvenienceTest
 
         JsonImportSummary response = POST( "/metadata/",
             "{'programRules':[{'name':'test', 'program':{ 'id':'" + program.getUid() + "'}}]}" )
-                .content( HttpStatus.CONFLICT ).get( "response" ).as( JsonImportSummary.class );
+            .content( HttpStatus.CONFLICT ).get( "response" ).as( JsonImportSummary.class );
         assertEquals( "The Program Rule name test already exist in Program ProgramA",
             response.find( JsonErrorReport.class, error -> error.getErrorCode() == ErrorCode.E4057 ).getMessage() );
     }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramStageControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramStageControllerTest.java
@@ -59,7 +59,7 @@ class ProgramStageControllerTest extends DhisControllerConvenienceTest
     {
         POST( "/programs/",
             "{'name':'test program', 'id':'VoZMWi7rBgj', 'shortName':'test program','programType':'WITH_REGISTRATION' }" )
-                .content( HttpStatus.CREATED );
+            .content( HttpStatus.CREATED );
         String programStageId = assertStatus( HttpStatus.CREATED,
             POST( "/programStages/", "{'name':'test programStage', 'program':{'id':'VoZMWi7rBgj'}}" ) );
         JsonResponse programStage = GET( "/programStages/{id}", programStageId ).content();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/RelationshipTypeControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/RelationshipTypeControllerTest.java
@@ -101,7 +101,7 @@ class RelationshipTypeControllerTest extends DhisControllerIntegrationTest
 
         JsonList<JsonString> attributes = GET(
             "/relationshipTypes/" + relationshipTypeId + "?fields=toConstraint[trackerDataView[attributes]]" ).content()
-                .getList( "toConstraint.trackerDataView.attributes", JsonString.class );
+            .getList( "toConstraint.trackerDataView.attributes", JsonString.class );
 
         assertEquals( 3, attributes.size() );
         assertEquals( List.of( attrA, attrB, attrC ), attributes.toList( JsonString::string ) );

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SmsOutboundControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SmsOutboundControllerTest.java
@@ -74,7 +74,7 @@ class SmsOutboundControllerTest extends DhisControllerConvenienceTest
         assertWebMessage( "Internal Server Error", 500, "ERROR", "No default gateway configured",
             POST( "/sms/outbound",
                 "{" + "'recipients':[{'id':'" + getSuperuserUid() + "'}]," + "'message':'text'" + "}" )
-                    .content( HttpStatus.INTERNAL_SERVER_ERROR ) );
+                .content( HttpStatus.INTERNAL_SERVER_ERROR ) );
     }
 
     @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -364,7 +364,7 @@ class UserControllerTest extends DhisControllerConvenienceTest
         assertWebMessage( "Created", 201, "OK", null,
             POST( "/users/",
                 "{'surname':'S.','firstName':'Harry', 'username':'harrys', 'userRoles': [{'id': 'yrB6vc5Ip3r'}]}" )
-                    .content( HttpStatus.CREATED ) );
+                .content( HttpStatus.CREATED ) );
     }
 
     @Test
@@ -374,7 +374,7 @@ class UserControllerTest extends DhisControllerConvenienceTest
             "One or more errors occurred, please see full details in import report.",
             POST( "/users/",
                 "{'id': 'yrB6vc5Ip¤¤', 'surname':'S.','firstName':'Harry', 'username':'harrys', 'userRoles': [{'id': 'yrB6vc5Ip3r'}]}" )
-                    .content( HttpStatus.CONFLICT ) );
+                .content( HttpStatus.CONFLICT ) );
     }
 
     @Test
@@ -499,7 +499,7 @@ class UserControllerTest extends DhisControllerConvenienceTest
         assertWebMessage( "Created", 201, "OK", null, POST( "/users/invite",
             "{'surname':'S.','firstName':'Harry', 'email':'test@example.com', 'username':'harrys', 'userRoles': [{'id': '"
                 + roleUid + "'}]}" )
-                    .content( HttpStatus.CREATED ) );
+            .content( HttpStatus.CREATED ) );
     }
 
     @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/AbstractDataIntegrityIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/AbstractDataIntegrityIntegrationTest.java
@@ -267,7 +267,7 @@ class AbstractDataIntegrityIntegrationTest extends DhisControllerIntegrationTest
     {
         JsonObject ccDefault = GET(
             "/categoryCombos/gist?fields=id,categoryOptionCombos::ids&pageSize=1&headless=true&filter=name:eq:default" )
-                .content().getObject( 0 );
+            .content().getObject( 0 );
         return ccDefault.getString( "id" ).string();
     }
 
@@ -275,7 +275,7 @@ class AbstractDataIntegrityIntegrationTest extends DhisControllerIntegrationTest
     {
         JsonObject ccDefault = GET(
             "/categoryCombos/gist?fields=id,categoryOptionCombos::ids&pageSize=1&headless=true&filter=name:eq:default" )
-                .content().getObject( 0 );
+            .content().getObject( 0 );
         return ccDefault.getArray( "categoryOptionCombos" ).getString( 0 ).string();
 
     }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/deprecated/tracker/TrackedEntityControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/deprecated/tracker/TrackedEntityControllerTest.java
@@ -77,7 +77,7 @@ class TrackedEntityControllerTest extends DhisControllerConvenienceTest
         assertWebMessage( "OK", 200, "OK", "Import was successful.",
             POST( "/trackedEntityInstances",
                 "{'name':'A', 'trackedEntityType':'" + tetId + "', 'orgUnit':'" + ouId + "'}" )
-                    .content( HttpStatus.OK ) );
+                .content( HttpStatus.OK ) );
     }
 
     @Test
@@ -86,7 +86,7 @@ class TrackedEntityControllerTest extends DhisControllerConvenienceTest
         assertWebMessage( "OK", 200, "OK", "Initiated inMemoryEventImport",
             POST( "/trackedEntityInstances?async=true",
                 "{'name':'A', 'trackedEntityType':'" + tetId + "', 'orgUnit':'" + ouId + "'}" )
-                    .content( HttpStatus.OK ) );
+                .content( HttpStatus.OK ) );
     }
 
     @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/icon/IconControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/icon/IconControllerTest.java
@@ -63,7 +63,7 @@ class IconControllerTest extends DhisControllerIntegrationTest
         JsonWebMessage message = POST( "/icons/",
             "{'key':'" + iconKey + "', 'description':'" + description + "', 'fileResourceUid':'" + createFileResource()
                 + "', 'keywords':" + keywords + "}" )
-                    .content( HttpStatus.CREATED ).as( JsonWebMessage.class );
+            .content( HttpStatus.CREATED ).as( JsonWebMessage.class );
 
         assertEquals( String.format( "Icon %s created", iconKey ), message.getMessage() );
     }
@@ -116,7 +116,7 @@ class IconControllerTest extends DhisControllerIntegrationTest
         JsonWebMessage message = POST( "/icons/",
             "{'key':'" + iconKey + "', 'description':'" + description + "', 'fileResourceUid':'" + fileResourceId
                 + "', 'keywords':" + keywords + "}" )
-                    .content( HttpStatus.CREATED ).as( JsonWebMessage.class );
+            .content( HttpStatus.CREATED ).as( JsonWebMessage.class );
         return message.getMessage();
     }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerTest.java
@@ -212,7 +212,7 @@ class EnrollmentsExportControllerTest extends DhisControllerConvenienceTest
     {
         JsonList<JsonRelationship> relationships = GET( "/tracker/enrollments/{id}?fields=relationships",
             enrollment.getUid() )
-                .content( HttpStatus.OK ).getList( "relationships", JsonRelationship.class );
+            .content( HttpStatus.OK ).getList( "relationships", JsonRelationship.class );
 
         JsonRelationship jsonRelationship = relationships.get( 0 );
         assertEquals( relationship.getUid(), jsonRelationship.getRelationship() );

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -204,7 +204,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
 
         JsonRelationship relationship = GET( "/tracker/relationships/{uid}?fields=relationship,from[event]",
             r.getUid() )
-                .content( HttpStatus.OK ).as( JsonRelationship.class );
+            .content( HttpStatus.OK ).as( JsonRelationship.class );
 
         assertHasOnlyMembers( relationship, "relationship", "from" );
         assertEquals( r.getUid(), relationship.getRelationship(), "relationship UID" );
@@ -264,7 +264,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
 
         JsonList<JsonRelationship> relationships = GET(
             "/tracker/relationships?event={uid}&fields=relationship,from[event]", from.getUid() )
-                .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
+            .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
 
         assertEquals( 1, relationships.size(), "one relationship expected" );
         JsonRelationship relationship = relationships.get( 0 ).as( JsonRelationship.class );
@@ -285,7 +285,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
         JsonList<JsonRelationship> relationships = GET(
             "/tracker/relationships?event={uid}&fields=from[event[assignedUser]]",
             from.getUid() )
-                .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
+            .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
 
         JsonUser user = relationships.get( 0 ).getFrom().getEvent().getAssignedUser();
         assertEquals( owner.getUid(), user.getUid() );
@@ -303,7 +303,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
         JsonList<JsonRelationship> relationships = GET(
             "/tracker/relationships?event={uid}&fields=from[event[dataValues[dataElement,value]]]",
             from.getUid() )
-                .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
+            .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
 
         JsonDataValue dataValue = relationships.get( 0 ).getFrom().getEvent().getDataValues().get( 0 );
         assertEquals( dataElement.getUid(), dataValue.getDataElement() );
@@ -320,7 +320,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
 
         JsonList<JsonRelationship> relationships = GET( "/tracker/relationships?event={uid}&fields=from[event[notes]]",
             from.getUid() )
-                .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
+            .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
 
         JsonNote note = relationships.get( 0 ).getFrom().getEvent().getNotes().get( 0 );
         assertEquals( "oqXG28h988k", note.getNote() );
@@ -360,7 +360,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
 
         JsonList<JsonRelationship> relationships = GET( "/tracker/relationships?enrollment={uid}&fields=*",
             from.getUid() )
-                .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
+            .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
 
         JsonRelationship relationship = assertFirstRelationship( r, relationships );
         assertEnrollmentWithinRelationship( from, relationship.getFrom() );
@@ -376,7 +376,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
 
         JsonList<JsonRelationship> relationships = GET(
             "/tracker/relationships?enrollment={uid}&fields=from[enrollment[events[enrollment,event]]]", from.getUid() )
-                .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
+            .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
 
         JsonRelationshipItem.JsonEvent event = relationships.get( 0 ).getFrom().getEnrollment().getEvents().get( 0 );
         assertEquals( from.getUid(), event.getEnrollment() );
@@ -396,7 +396,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
         JsonList<JsonRelationship> relationships = GET(
             "/tracker/relationships?enrollment={uid}&fields=from[enrollment[attributes[attribute,value]]]",
             from.getUid() )
-                .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
+            .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
 
         JsonAttribute attribute = relationships.get( 0 ).getFrom().getEnrollment().getAttributes().get( 0 );
         assertEquals( tea.getUid(), attribute.getAttribute() );
@@ -413,7 +413,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
 
         JsonList<JsonRelationship> relationships = GET(
             "/tracker/relationships?enrollment={uid}&fields=from[enrollment[notes]]", from.getUid() )
-                .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
+            .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
 
         JsonNote note = relationships.get( 0 ).getFrom().getEnrollment().getNotes().get( 0 );
         assertEquals( "oqXG28h988k", note.getNote() );
@@ -470,7 +470,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
         JsonList<JsonRelationship> relationships = GET(
             "/tracker/relationships?trackedEntity={tei}&fields=to[trackedEntity[enrollments[enrollment,trackedEntity]]",
             to.getUid() )
-                .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
+            .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
 
         JsonRelationshipItem.JsonEnrollment enrollment = relationships.get( 0 ).getTo().getTrackedEntity()
             .getEnrollments().get( 0 );
@@ -491,7 +491,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
         JsonList<JsonRelationship> relationships = GET(
             "/tracker/relationships?trackedEntity={tei}&fields=from[enrollment[attributes[attribute,value]]],to[trackedEntity[attributes[attribute,value]]]",
             to.getUid() )
-                .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
+            .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
 
         JsonList<JsonAttribute> enrollmentAttr = relationships.get( 0 ).getFrom().getEnrollment().getAttributes();
         assertContainsAll( List.of( tea2.getUid() ), enrollmentAttr, JsonAttribute::getAttribute );
@@ -512,7 +512,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest
         JsonList<JsonRelationship> relationships = GET(
             "/tracker/relationships?trackedEntity={tei}&fields=to[trackedEntity[programOwners]",
             to.getUid() )
-                .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
+            .content( HttpStatus.OK ).getList( "instances", JsonRelationship.class );
 
         JsonProgramOwner jsonProgramOwner = relationships.get( 0 ).getTo().getTrackedEntity().getProgramOwners()
             .get( 0 );

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -255,7 +255,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
 
         JsonList<JsonAttribute> attributes = GET( "/tracker/trackedEntities/{id}?fields=attributes[attribute,value]",
             trackedEntity.getUid() )
-                .content( HttpStatus.OK ).getList( "attributes", JsonAttribute.class );
+            .content( HttpStatus.OK ).getList( "attributes", JsonAttribute.class );
 
         assertAll( "include tracked entity type attributes only if no program query param is given",
             () -> assertEquals( 1, attributes.size(),
@@ -275,7 +275,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
         JsonList<JsonAttribute> attributes = GET(
             "/tracker/trackedEntities/{id}?program={id}&fields=attributes[attribute,value]", trackedEntity.getUid(),
             program.getUid() )
-                .content( HttpStatus.OK ).getList( "attributes", JsonAttribute.class );
+            .content( HttpStatus.OK ).getList( "attributes", JsonAttribute.class );
 
         assertContainsAll( List.of( tea.getUid(), tea2.getUid() ), attributes, JsonAttribute::getAttribute );
         assertContainsAll( List.of( "12", "24" ), attributes, JsonAttribute::getValue );
@@ -308,7 +308,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
 
         JsonList<JsonRelationship> relationships = GET( "/tracker/trackedEntities/{id}?fields=relationships",
             from.getUid() )
-                .content( HttpStatus.OK ).getList( "relationships", JsonRelationship.class );
+            .content( HttpStatus.OK ).getList( "relationships", JsonRelationship.class );
 
         assertEquals( 0, relationships.size(), "user needs access to relationship type to access the relationship" );
     }
@@ -323,7 +323,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
 
         JsonList<JsonRelationship> relationships = GET( "/tracker/trackedEntities/{id}?fields=relationships",
             from.getUid() )
-                .content( HttpStatus.OK ).getList( "relationships", JsonRelationship.class );
+            .content( HttpStatus.OK ).getList( "relationships", JsonRelationship.class );
 
         assertEquals( 0, relationships.size(), "user needs access to from and to items to access the relationship" );
     }
@@ -427,7 +427,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
 
         JsonList<JsonEnrollment> json = GET( "/tracker/trackedEntities/{id}?fields=enrollments",
             trackedEntity.getUid() )
-                .content( HttpStatus.OK ).getList( "enrollments", JsonEnrollment.class );
+            .content( HttpStatus.OK ).getList( "enrollments", JsonEnrollment.class );
 
         JsonEnrollment jsonEnrollment = assertDefaultEnrollmentResponse( json, enrollment );
 
@@ -451,7 +451,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
 
         JsonList<JsonEnrollment> json = GET( "/tracker/trackedEntities/{id}?fields=enrollments",
             trackedEntity.getUid() )
-                .content( HttpStatus.OK ).getList( "enrollments", JsonEnrollment.class );
+            .content( HttpStatus.OK ).getList( "enrollments", JsonEnrollment.class );
 
         JsonEnrollment jsonEnrollment = assertDefaultEnrollmentResponse( json, enrollment );
         assertTrue( jsonEnrollment.getArray( "relationships" ).isEmpty() );
@@ -478,7 +478,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
 
         JsonList<JsonEnrollment> json = GET( "/tracker/trackedEntities/{id}?fields=enrollments",
             trackedEntity.getUid() )
-                .content( HttpStatus.OK ).getList( "enrollments", JsonEnrollment.class );
+            .content( HttpStatus.OK ).getList( "enrollments", JsonEnrollment.class );
 
         JsonEnrollment jsonEnrollment = assertDefaultEnrollmentResponse( json, enrollment );
         assertTrue( jsonEnrollment.getAttributes().isEmpty() );
@@ -511,7 +511,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest
         JsonList<JsonEnrollment> json = GET(
             "/tracker/trackedEntities/{id}?fields=enrollments[*,events[!relationships]]",
             trackedEntity.getUid() )
-                .content( HttpStatus.OK ).getList( "enrollments", JsonEnrollment.class );
+            .content( HttpStatus.OK ).getList( "enrollments", JsonEnrollment.class );
 
         JsonEnrollment jsonEnrollment = assertDefaultEnrollmentResponse( json, enrollment );
         assertTrue( jsonEnrollment.getAttributes().isEmpty() );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
@@ -422,7 +422,7 @@ public abstract class AbstractFullReadOnlyController<T extends IdentifiableObjec
 
             throw new ConflictException(
                 "Invalid property selected. Make sure all properties are either simple or collections of refs / simple." )
-                    .setDevMessage( ex.getMessage() );
+                .setDevMessage( ex.getMessage() );
         }
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AuditController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AuditController.java
@@ -156,7 +156,7 @@ public class AuditController
             throw new WebMessageException( conflict(
                 "The content is being processed and is not available yet. Try again later.",
                 "The content requested is in transit to the file store and will be available at a later time." )
-                    .setResponse( new FileResourceWebMessageResponse( fileResource ) ) );
+                .setResponse( new FileResourceWebMessageResponse( fileResource ) ) );
         }
 
         response.setContentType( fileResource.getContentType() );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -283,7 +283,8 @@ public class CrudControllerAdvice
         {
             return MessageFormat.format( "{0} cannot be empty.", field );
         }
-        if (isPathVariable){
+        if ( isPathVariable )
+        {
             return String.format( "Value '%s' is not valid for path parameter %s.", value, field );
         }
         return String.format( "Value '%s' is not valid for parameter %s.", value, field );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
@@ -127,17 +127,17 @@ public class DataValueSetController
     {
         switch ( format )
         {
-        case "xml":
-            getDataValueSetXml( params, attachment, compression, response );
-            break;
-        case "adx+xml":
-            getDataValueSetXmlAdx( params, attachment, compression, response );
-            break;
-        case "csv":
-            getDataValueSetCsv( params, attachment, compression, response );
-            break;
-        default:
-            getDataValueSetJson( params, attachment, compression, response );
+            case "xml":
+                getDataValueSetXml( params, attachment, compression, response );
+                break;
+            case "adx+xml":
+                getDataValueSetXmlAdx( params, attachment, compression, response );
+                break;
+            case "csv":
+                getDataValueSetCsv( params, attachment, compression, response );
+                break;
+            default:
+                getDataValueSetJson( params, attachment, compression, response );
         }
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
@@ -182,14 +182,14 @@ public class InterpretationController extends AbstractCrudController<Interpretat
          */
         switch ( eventVisualization.getType() )
         {
-        case LINE_LIST:
-        case PIVOT_TABLE:
-            final EventReport eventReport = idObjectManager.get( EventReport.class,
-                eventVisualization.getUid() );
-            return createInterpretation( new Interpretation( eventVisualization, eventReport, orgUnit, text ) );
-        default:
-            final EventChart eventChart = idObjectManager.get( EventChart.class, eventVisualization.getUid() );
-            return createInterpretation( new Interpretation( eventVisualization, eventChart, orgUnit, text ) );
+            case LINE_LIST:
+            case PIVOT_TABLE:
+                final EventReport eventReport = idObjectManager.get( EventReport.class,
+                    eventVisualization.getUid() );
+                return createInterpretation( new Interpretation( eventVisualization, eventReport, orgUnit, text ) );
+            default:
+                final EventChart eventChart = idObjectManager.get( EventChart.class, eventVisualization.getUid() );
+                return createInterpretation( new Interpretation( eventVisualization, eventChart, orgUnit, text ) );
         }
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationController.java
@@ -172,17 +172,17 @@ public class VisualizationController
 
                     switch ( ei.getDimensionItemType() )
                     {
-                    case DATA_ELEMENT:
-                        dataDimensionItem.setDataElement( (DataElement) ei );
-                        dataDimensionItems.add( dataDimensionItem );
-                        break;
-                    case DATA_ELEMENT_OPERAND:
-                        dataDimensionItem.setDataElementOperand( (DataElementOperand) ei );
-                        dataDimensionItems.add( dataDimensionItem );
-                        break;
-                    default:
-                        //ignore
-                        break;
+                        case DATA_ELEMENT:
+                            dataDimensionItem.setDataElement( (DataElement) ei );
+                            dataDimensionItems.add( dataDimensionItem );
+                            break;
+                        case DATA_ELEMENT_OPERAND:
+                            dataDimensionItem.setDataElementOperand( (DataElementOperand) ei );
+                            dataDimensionItems.add( dataDimensionItem );
+                            break;
+                        default:
+                            //ignore
+                            break;
                     }
                 } );
             } );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
@@ -682,7 +682,7 @@ public class DataValueController
             throw new WebMessageException( conflict(
                 "The content is being processed and is not available yet. Try again later.",
                 "The content requested is in transit to the file store and will be available at a later time." )
-                    .setResponse( new FileResourceWebMessageResponse( fileResource ) ) );
+                .setResponse( new FileResourceWebMessageResponse( fileResource ) ) );
         }
 
         response.setContentType( fileResource.getContentType() );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/EventController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/EventController.java
@@ -809,7 +809,7 @@ public class EventController
             throw new WebMessageException( conflict(
                 "The content is being processed and is not available yet. Try again later.",
                 "The content requested is in transit to the file store and will be available at a later time." )
-                    .setResponse( new FileResourceWebMessageResponse( fileResource ) ) );
+                .setResponse( new FileResourceWebMessageResponse( fileResource ) ) );
         }
 
         FileResourceUtils.setImageFileDimensions( fileResource,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/icon/IconMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/icon/IconMapper.java
@@ -56,12 +56,17 @@ public class IconMapper
 
     private ContextService contextService;
 
-    public IconResponse from(Icon icon) {
-        if (icon instanceof CustomIcon ci) {
-            return new IconResponse(icon.getKey(), icon.getDescription(), icon.getKeywords(),
-                    ci.getFileResourceUid(), ci.getCreatedByUserUid(), getCustomIconReference(ci.getFileResourceUid()));
-        } else {
-            return new IconResponse(icon.getKey(), icon.getDescription(), icon.getKeywords(), getDefaultIconReference(icon.getKey()));
+    public IconResponse from( Icon icon )
+    {
+        if ( icon instanceof CustomIcon ci )
+        {
+            return new IconResponse( icon.getKey(), icon.getDescription(), icon.getKeywords(),
+                ci.getFileResourceUid(), ci.getCreatedByUserUid(), getCustomIconReference( ci.getFileResourceUid() ) );
+        }
+        else
+        {
+            return new IconResponse( icon.getKey(), icon.getDescription(), icon.getKeywords(),
+                getDefaultIconReference( icon.getKey() ) );
         }
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/IdSchemeParamEditor.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/IdSchemeParamEditor.java
@@ -72,20 +72,20 @@ public class IdSchemeParamEditor extends PropertyEditorSupport
 
         switch ( idScheme )
         {
-        case UID:
-            setValue( TrackerIdSchemeParam.UID );
-            break;
-        case NAME:
-            setValue( TrackerIdSchemeParam.NAME );
-            break;
-        case CODE:
-            setValue( TrackerIdSchemeParam.CODE );
-            break;
-        case ATTRIBUTE:
-            setValue( TrackerIdSchemeParam.ofAttribute( attributeUid ) );
-            break;
-        default:
-            throw new IllegalArgumentException( VALID_VALUES );
+            case UID:
+                setValue( TrackerIdSchemeParam.UID );
+                break;
+            case NAME:
+                setValue( TrackerIdSchemeParam.NAME );
+                break;
+            case CODE:
+                setValue( TrackerIdSchemeParam.CODE );
+                break;
+            case ATTRIBUTE:
+                setValue( TrackerIdSchemeParam.ofAttribute( attributeUid ) );
+                break;
+            default:
+                throw new IllegalArgumentException( VALID_VALUES );
         }
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/EnrollmentStatus.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/EnrollmentStatus.java
@@ -62,12 +62,12 @@ public enum EnrollmentStatus
     {
         switch ( programStatus )
         {
-        case ACTIVE:
-            return ACTIVE;
-        case CANCELLED:
-            return CANCELLED;
-        case COMPLETED:
-            return COMPLETED;
+            case ACTIVE:
+                return ACTIVE;
+            case CANCELLED:
+                return CANCELLED;
+            case COMPLETED:
+                return COMPLETED;
         }
 
         throw new IllegalArgumentException( "Enum value not found: " + programStatus );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/dimension/DimensionFilteringAndPagingService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/dimension/DimensionFilteringAndPagingService.java
@@ -84,7 +84,7 @@ public class DimensionFilteringAndPagingService
 
         List<DimensionResponse> filteredDimensions = filterStream( dimensionResponses.stream(),
             dimensionsCriteria )
-                .collect( Collectors.toList() );
+            .collect( Collectors.toList() );
 
         FieldFilterParams<DimensionResponse> filterParams = FieldFilterParams
             .of( sortedAndPagedStream( filteredDimensions.stream(), dimensionsCriteria )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/CsvMessageConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/CsvMessageConverter.java
@@ -85,14 +85,14 @@ public class CsvMessageConverter extends AbstractRootNodeMessageConverter
         super( nodeService, "text/csv", "csv", compression );
         switch ( getCompression() )
         {
-        case NONE:
-            setSupportedMediaTypes( SUPPORTED_MEDIA_TYPES );
-            break;
-        case GZIP:
-            setSupportedMediaTypes( GZIP_SUPPORTED_MEDIA_TYPES );
-            break;
-        case ZIP:
-            setSupportedMediaTypes( ZIP_SUPPORTED_MEDIA_TYPES );
+            case NONE:
+                setSupportedMediaTypes( SUPPORTED_MEDIA_TYPES );
+                break;
+            case GZIP:
+                setSupportedMediaTypes( GZIP_SUPPORTED_MEDIA_TYPES );
+                break;
+            case ZIP:
+                setSupportedMediaTypes( ZIP_SUPPORTED_MEDIA_TYPES );
         }
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/JsonMessageConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/JsonMessageConverter.java
@@ -48,14 +48,14 @@ public class JsonMessageConverter extends AbstractRootNodeMessageConverter
 
         switch ( getCompression() )
         {
-        case NONE:
-            setSupportedMediaTypes( JSON_SUPPORTED_MEDIA_TYPES );
-            break;
-        case GZIP:
-            setSupportedMediaTypes( JSON_GZIP_SUPPORTED_MEDIA_TYPES );
-            break;
-        case ZIP:
-            setSupportedMediaTypes( JSON_ZIP_SUPPORTED_MEDIA_TYPES );
+            case NONE:
+                setSupportedMediaTypes( JSON_SUPPORTED_MEDIA_TYPES );
+                break;
+            case GZIP:
+                setSupportedMediaTypes( JSON_GZIP_SUPPORTED_MEDIA_TYPES );
+                break;
+            case ZIP:
+                setSupportedMediaTypes( JSON_ZIP_SUPPORTED_MEDIA_TYPES );
         }
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/MetadataExportParamsMessageConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/MetadataExportParamsMessageConverter.java
@@ -68,14 +68,14 @@ public class MetadataExportParamsMessageConverter extends AbstractHttpMessageCon
 
         switch ( compression )
         {
-        case NONE:
-            setSupportedMediaTypes( JSON_SUPPORTED_MEDIA_TYPES );
-            break;
-        case GZIP:
-            setSupportedMediaTypes( JSON_GZIP_SUPPORTED_MEDIA_TYPES );
-            break;
-        case ZIP:
-            setSupportedMediaTypes( JSON_ZIP_SUPPORTED_MEDIA_TYPES );
+            case NONE:
+                setSupportedMediaTypes( JSON_SUPPORTED_MEDIA_TYPES );
+                break;
+            case GZIP:
+                setSupportedMediaTypes( JSON_GZIP_SUPPORTED_MEDIA_TYPES );
+                break;
+            case ZIP:
+                setSupportedMediaTypes( JSON_ZIP_SUPPORTED_MEDIA_TYPES );
         }
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/StreamingJsonRootMessageConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/StreamingJsonRootMessageConverter.java
@@ -73,14 +73,14 @@ public class StreamingJsonRootMessageConverter extends AbstractHttpMessageConver
 
         switch ( compression )
         {
-        case NONE:
-            setSupportedMediaTypes( JSON_SUPPORTED_MEDIA_TYPES );
-            break;
-        case GZIP:
-            setSupportedMediaTypes( JSON_GZIP_SUPPORTED_MEDIA_TYPES );
-            break;
-        case ZIP:
-            setSupportedMediaTypes( JSON_ZIP_SUPPORTED_MEDIA_TYPES );
+            case NONE:
+                setSupportedMediaTypes( JSON_SUPPORTED_MEDIA_TYPES );
+                break;
+            case GZIP:
+                setSupportedMediaTypes( JSON_GZIP_SUPPORTED_MEDIA_TYPES );
+                break;
+            case ZIP:
+                setSupportedMediaTypes( JSON_ZIP_SUPPORTED_MEDIA_TYPES );
         }
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/XmlMessageConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/XmlMessageConverter.java
@@ -74,14 +74,14 @@ public class XmlMessageConverter extends AbstractRootNodeMessageConverter
 
         switch ( getCompression() )
         {
-        case NONE:
-            setSupportedMediaTypes( XML_SUPPORTED_MEDIA_TYPES );
-            break;
-        case GZIP:
-            setSupportedMediaTypes( XML_GZIP_SUPPORTED_MEDIA_TYPES );
-            break;
-        case ZIP:
-            setSupportedMediaTypes( XML_ZIP_SUPPORTED_MEDIA_TYPES );
+            case NONE:
+                setSupportedMediaTypes( XML_SUPPORTED_MEDIA_TYPES );
+                break;
+            case GZIP:
+                setSupportedMediaTypes( XML_GZIP_SUPPORTED_MEDIA_TYPES );
+                break;
+            case ZIP:
+                setSupportedMediaTypes( XML_ZIP_SUPPORTED_MEDIA_TYPES );
         }
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiTool.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiTool.java
@@ -112,11 +112,11 @@ public class OpenApiTool implements ToolProvider
             {
                 switch ( arg )
                 {
-                case "--group":
-                    group = true;
-                    break;
-                default:
-                    err.println( "Unknown option: " + arg );
+                    case "--group":
+                        group = true;
+                        break;
+                    default:
+                        err.println( "Unknown option: " + arg );
                 }
             }
             else if ( arg.startsWith( "/" ) )

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/AnalyticsControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/AnalyticsControllerTest.java
@@ -116,7 +116,7 @@ class AnalyticsControllerTest
             .thenReturn( new DataElement( "beta" ) );
         when( analyticsService.getAggregatedDataValues( Mockito.any( DataQueryParams.class ), Mockito.any(),
             Mockito.any() ) )
-                .thenReturn( buildMockGrid() );
+            .thenReturn( buildMockGrid() );
     }
 
     @Test

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandControllerTest.java
@@ -186,7 +186,7 @@ class DataElementOperandControllerTest
 
         when( fieldFilterService.toCollectionNode( eq( DataElementOperand.class ),
             filterParamsArgumentCaptor.capture() ) )
-                .thenReturn( buildResponse( first50elements ) );
+            .thenReturn( buildResponse( first50elements ) );
 
         doReturn( totalSize ).when( queryService ).count( any( Query.class ) );
 
@@ -240,7 +240,7 @@ class DataElementOperandControllerTest
 
         when( fieldFilterService.toCollectionNode( eq( DataElementOperand.class ),
             filterParamsArgumentCaptor.capture() ) )
-                .thenReturn( buildResponse( thirdPageElements ) );
+            .thenReturn( buildResponse( thirdPageElements ) );
 
         doReturn( totalSize ).when( queryService ).count( any( Query.class ) );
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/RequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/RequestParamsMapperTest.java
@@ -745,7 +745,7 @@ class RequestParamsMapperTest
         combo.setUid( "uid" );
         when( categoryOptionComboService.getAttributeOptionCombo( criteria.getAttributeCc(), criteria.getAttributeCos(),
             true ) )
-                .thenReturn( combo );
+            .thenReturn( combo );
         when( aclService.canDataRead( any( User.class ), any( CategoryOptionCombo.class ) ) ).thenReturn( false );
 
         Exception exception = assertThrows( ForbiddenException.class,

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -663,7 +663,7 @@
               <java>
                   <eclipse>
                       <file>${rootDir}/DHISFormatter.xml</file>
-                      <version>4.9</version>
+                      <version>4.27</version>
                   </eclipse>
                   <trimTrailingWhitespace />
                   <removeUnusedImports />

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -651,14 +651,6 @@
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
           <version>${spotless.version}</version>
-          <executions>
-              <execution>
-                  <id>install-formatter-hook</id>
-                  <goals>
-                      <goal>install-hooks</goal>
-                  </goals>
-              </execution>
-          </executions>
           <configuration>
               <java>
                   <eclipse>


### PR DESCRIPTION
### Summary
* Upgrades the Eclipse CDT formatter used by the Maven spotless plugin, from 4.9 to 4.27
* This is needed to support JDK17+ features like multiline strings.
* The upgrade triggers quite a bit of cleaning up, most fixes seems related to the previous formatter version not applying the rules correctly everywhere.