### PR TITLE
chore: use new UID type instead of String in tracker request params TECH-1565

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/common/UID.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/common/UID.java
@@ -37,6 +37,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.UidObject;
 
 /**
  * UID represents an alphanumeric string of 11 characters starting with a
@@ -59,9 +60,20 @@ public final class UID
         this.value = value;
     }
 
+    @Override
+    public String toString()
+    {
+        return value;
+    }
+
     public static UID of( String value )
     {
         return new UID( value );
+    }
+
+    public static UID of( UidObject object )
+    {
+        return new UID( object.getUid() );
     }
 
     public static Set<String> toValueSet( Collection<UID> uids )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/RequestParams.java
@@ -74,7 +74,7 @@ public class RequestParams extends PagingAndSortingCriteriaAdapter
     private OrganisationUnitSelectionMode ouMode;
 
     @OpenApi.Property( { UID.class, Program.class } )
-    private String program;
+    private UID program;
 
     private ProgramStatus programStatus;
 
@@ -89,10 +89,10 @@ public class RequestParams extends PagingAndSortingCriteriaAdapter
     private Date enrolledBefore;
 
     @OpenApi.Property( { UID.class, TrackedEntityType.class } )
-    private String trackedEntityType;
+    private UID trackedEntityType;
 
     @OpenApi.Property( { UID.class, TrackedEntity.class } )
-    private String trackedEntity;
+    private UID trackedEntity;
 
     /**
      * Semicolon-delimited list of enrollment UIDs.

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/RequestParams.java
@@ -68,20 +68,20 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
     static final String DEFAULT_FIELDS_PARAM = "*,!relationships";
 
     @OpenApi.Property( { UID.class, Program.class } )
-    private String program;
+    private UID program;
 
     @OpenApi.Property( { UID.class, ProgramStage.class } )
-    private String programStage;
+    private UID programStage;
 
     private ProgramStatus programStatus;
 
     private Boolean followUp;
 
     @OpenApi.Property( { UID.class, TrackedEntity.class } )
-    private String trackedEntity;
+    private UID trackedEntity;
 
     @OpenApi.Property( { UID.class, OrganisationUnit.class } )
-    private String orgUnit;
+    private UID orgUnit;
 
     private OrganisationUnitSelectionMode ouMode;
 
@@ -126,7 +126,7 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
     private EventStatus status;
 
     @OpenApi.Property( { UID.class, CategoryCombo.class } )
-    private String attributeCc;
+    private UID attributeCc;
 
     @OpenApi.Property( { UID[].class, CategoryOption.class } )
     private String attributeCos;
@@ -157,7 +157,7 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
     private Set<String> filterAttributes = new HashSet<>();
 
     @OpenApi.Property( { UID[].class, Enrollment.class } )
-    private Set<String> enrollments = new HashSet<>();
+    private Set<UID> enrollments = new HashSet<>();
 
     private IdSchemes idSchemes = new IdSchemes();
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RequestParams.java
@@ -34,7 +34,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.fieldfiltering.FieldFilterParser;
@@ -53,15 +52,15 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
     static final String DEFAULT_FIELDS_PARAM = "relationship,relationshipType,from[trackedEntity[trackedEntity],enrollment[enrollment],event[event]],to[trackedEntity[trackedEntity],enrollment[enrollment],event[event]]";
 
     @OpenApi.Property( { UID.class, TrackedEntity.class } )
-    private String trackedEntity;
+    private UID trackedEntity;
 
     @OpenApi.Property( { UID.class, Enrollment.class } )
     @Setter
-    private String enrollment;
+    private UID enrollment;
 
     @OpenApi.Property( { UID.class, Event.class } )
     @Setter
-    private String event;
+    private UID event;
 
     private String identifier;
 
@@ -74,7 +73,7 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
     @Setter
     private List<FieldPath> fields = FieldFilterParser.parse( DEFAULT_FIELDS_PARAM );
 
-    public void setTei( String tei )
+    public void setTei( UID tei )
     {
         // this setter is kept for backwards-compatibility
         // query parameter 'tei' should still be allowed, but 'trackedEntity' is
@@ -82,7 +81,7 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
         this.trackedEntity = tei;
     }
 
-    public void setTrackedEntity( String trackedEntity )
+    public void setTrackedEntity( UID trackedEntity )
     {
         this.trackedEntity = trackedEntity;
     }
@@ -97,23 +96,23 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
         }
 
         int count = 0;
-        if ( !StringUtils.isBlank( this.trackedEntity ) )
+        if ( this.trackedEntity != null )
         {
-            this.identifier = this.trackedEntity;
+            this.identifier = this.trackedEntity.getValue();
             this.identifierName = "trackedEntity";
             this.identifierClass = org.hisp.dhis.trackedentity.TrackedEntity.class;
             count++;
         }
-        if ( !StringUtils.isBlank( this.enrollment ) )
+        if ( this.enrollment != null )
         {
-            this.identifier = this.enrollment;
+            this.identifier = this.enrollment.getValue();
             this.identifierName = "enrollment";
             this.identifierClass = org.hisp.dhis.program.Enrollment.class;
             count++;
         }
-        if ( !StringUtils.isBlank( this.event ) )
+        if ( this.event != null )
         {
-            this.identifier = this.event;
+            this.identifier = this.event.getValue();
             this.identifierName = "event";
             this.identifierClass = org.hisp.dhis.program.Event.class;
             count++;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParams.java
@@ -92,7 +92,7 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
      * a Program UID for which instances in the response must be enrolled in.
      */
     @OpenApi.Property( { UID.class, Program.class } )
-    private String program;
+    private UID program;
 
     /**
      * The {@see ProgramStatus} of the Tracked Entity Instance in the given
@@ -145,7 +145,7 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
      * Only returns Tracked Entity Instances of this type.
      */
     @OpenApi.Property( { UID.class, TrackedEntityType.class } )
-    private String trackedEntityType;
+    private UID trackedEntityType;
 
     /**
      * Semicolon-delimited list of Tracked Entity Instance UIDs
@@ -184,7 +184,7 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
      * Stage
      */
     @OpenApi.Property( { UID.class, ProgramStage.class } )
-    private String programStage;
+    private UID programStage;
 
     /**
      * Status of any events in the specified program.

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/RequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/RequestParamsMapperTest.java
@@ -164,7 +164,7 @@ class RequestParamsMapperTest
     {
         RequestParams criteria = new RequestParams();
         criteria.setOrgUnit( ORG_UNIT_1_UID + ";" + ORG_UNIT_2_UID );
-        criteria.setProgram( program.getUid() );
+        criteria.setProgram( UID.of( program ) );
         when( trackerAccessManager.canAccess( user, program, orgUnit1 ) ).thenReturn( true );
         when( trackerAccessManager.canAccess( user, program, orgUnit2 ) ).thenReturn( true );
 
@@ -178,7 +178,8 @@ class RequestParamsMapperTest
     {
         RequestParams criteria = new RequestParams();
         criteria.setOrgUnit( "NeU85luyD4w;" + ORG_UNIT_2_UID );
-        criteria.setProgram( program.getUid() );
+        criteria.setProgram( UID.of( program ) );
+        criteria.setProgram( UID.of( program ) );
         when( trackerAccessManager.canAccess( user, program, orgUnit2 ) ).thenReturn( true );
 
         Exception exception = assertThrows( BadRequestException.class,
@@ -205,7 +206,7 @@ class RequestParamsMapperTest
     {
         RequestParams criteria = new RequestParams();
         criteria.setOrgUnits( Set.of( UID.of( ORG_UNIT_1_UID ), UID.of( ORG_UNIT_2_UID ) ) );
-        criteria.setProgram( program.getUid() );
+        criteria.setProgram( UID.of( program ) );
         when( trackerAccessManager.canAccess( user, program, orgUnit1 ) ).thenReturn( true );
         when( trackerAccessManager.canAccess( user, program, orgUnit2 ) ).thenReturn( true );
 
@@ -219,7 +220,7 @@ class RequestParamsMapperTest
     {
         RequestParams criteria = new RequestParams();
         criteria.setOrgUnits( Set.of( UID.of( "NeU85luyD4w" ), UID.of( ORG_UNIT_2_UID ) ) );
-        criteria.setProgram( program.getUid() );
+        criteria.setProgram( UID.of( program ) );
         when( trackerAccessManager.canAccess( user, program, orgUnit2 ) ).thenReturn( true );
 
         Exception exception = assertThrows( BadRequestException.class,
@@ -245,7 +246,7 @@ class RequestParamsMapperTest
         ForbiddenException
     {
         RequestParams criteria = new RequestParams();
-        criteria.setProgram( PROGRAM_UID );
+        criteria.setProgram( UID.of( PROGRAM_UID ) );
 
         EnrollmentQueryParams params = mapper.map( criteria );
 
@@ -256,11 +257,11 @@ class RequestParamsMapperTest
     void testMappingProgramNotFound()
     {
         RequestParams criteria = new RequestParams();
-        criteria.setProgram( "unknown" );
+        criteria.setProgram( UID.of( "JW6BrFd0HLu" ) );
 
         Exception exception = assertThrows( BadRequestException.class,
             () -> mapper.map( criteria ) );
-        assertEquals( "Program is specified but does not exist: unknown", exception.getMessage() );
+        assertEquals( "Program is specified but does not exist: JW6BrFd0HLu", exception.getMessage() );
     }
 
     @Test
@@ -269,7 +270,7 @@ class RequestParamsMapperTest
         ForbiddenException
     {
         RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntityType( TRACKED_ENTITY_TYPE_UID );
+        criteria.setTrackedEntityType( UID.of( TRACKED_ENTITY_TYPE_UID ) );
 
         EnrollmentQueryParams params = mapper.map( criteria );
 
@@ -280,11 +281,11 @@ class RequestParamsMapperTest
     void testMappingTrackedEntityTypeNotFound()
     {
         RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntityType( "unknown" );
+        criteria.setTrackedEntityType( UID.of( "JW6BrFd0HLu" ) );
 
         Exception exception = assertThrows( BadRequestException.class,
             () -> mapper.map( criteria ) );
-        assertEquals( "Tracked entity type is specified but does not exist: unknown", exception.getMessage() );
+        assertEquals( "Tracked entity type is specified but does not exist: JW6BrFd0HLu", exception.getMessage() );
     }
 
     @Test
@@ -293,7 +294,7 @@ class RequestParamsMapperTest
         ForbiddenException
     {
         RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( TRACKED_ENTITY_UID );
+        criteria.setTrackedEntity( UID.of( TRACKED_ENTITY_UID ) );
 
         EnrollmentQueryParams params = mapper.map( criteria );
 
@@ -304,11 +305,11 @@ class RequestParamsMapperTest
     void testMappingTrackedEntityNotFound()
     {
         RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( "unknown" );
+        criteria.setTrackedEntity( UID.of( "JW6BrFd0HLu" ) );
 
         Exception exception = assertThrows( BadRequestException.class,
             () -> mapper.map( criteria ) );
-        assertEquals( "Tracked entity instance is specified but does not exist: unknown", exception.getMessage() );
+        assertEquals( "Tracked entity is specified but does not exist: JW6BrFd0HLu", exception.getMessage() );
     }
 
     @Test

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/RequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/RequestParamsMapperTest.java
@@ -96,7 +96,7 @@ class RequestParamsMapperTest
 
     private static final String TEA_2_UID = "cy2oRh2sNr6";
 
-    private static final String PROGRAM_UID = "programuid";
+    private static final String PROGRAM_UID = "PlZSBEN7iZd";
 
     @Mock
     private CurrentUserService currentUserService;
@@ -150,8 +150,8 @@ class RequestParamsMapperTest
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
 
         programStage = new ProgramStage();
-        programStage.setUid( "programstageuid" );
-        when( programStageService.getProgramStage( "programstageuid" ) ).thenReturn( programStage );
+        programStage.setUid( "PlZSBEN7iZd" );
+        when( programStageService.getProgramStage( "PlZSBEN7iZd" ) ).thenReturn( programStage );
         when( aclService.canDataRead( user, programStage ) ).thenReturn( true );
 
         ou = new OrganisationUnit();
@@ -159,7 +159,7 @@ class RequestParamsMapperTest
         when( organisationUnitService.isInUserHierarchy( ou ) ).thenReturn( true );
 
         trackedEntity = new TrackedEntity();
-        when( entityInstanceService.getTrackedEntity( "teiuid" ) ).thenReturn( trackedEntity );
+        when( entityInstanceService.getTrackedEntity( "qnR1RK4cTIZ" ) ).thenReturn( trackedEntity );
         tea1 = new TrackedEntityAttribute();
         tea1.setUid( TEA_1_UID );
         TrackedEntityAttribute tea2 = new TrackedEntityAttribute();
@@ -196,7 +196,7 @@ class RequestParamsMapperTest
         ForbiddenException
     {
         RequestParams criteria = new RequestParams();
-        criteria.setProgram( PROGRAM_UID );
+        criteria.setProgram( UID.of( PROGRAM_UID ) );
 
         EventSearchParams params = mapper.map( criteria );
 
@@ -207,11 +207,11 @@ class RequestParamsMapperTest
     void testMappingProgramNotFound()
     {
         RequestParams criteria = new RequestParams();
-        criteria.setProgram( "unknown" );
+        criteria.setProgram( UID.of( "NeU85luyD4w" ) );
 
         Exception exception = assertThrows( BadRequestException.class,
             () -> mapper.map( criteria ) );
-        assertEquals( "Program is specified but does not exist: unknown", exception.getMessage() );
+        assertEquals( "Program is specified but does not exist: NeU85luyD4w", exception.getMessage() );
     }
 
     @Test
@@ -220,7 +220,7 @@ class RequestParamsMapperTest
         ForbiddenException
     {
         RequestParams criteria = new RequestParams();
-        criteria.setProgramStage( "programstageuid" );
+        criteria.setProgramStage( UID.of( "PlZSBEN7iZd" ) );
 
         EventSearchParams params = mapper.map( criteria );
 
@@ -231,11 +231,11 @@ class RequestParamsMapperTest
     void shouldFailWithBadRequestExceptionWhenMappingCriteriaWithUnknownProgramStage()
     {
         RequestParams criteria = new RequestParams();
-        criteria.setProgramStage( "unknown" );
+        criteria.setProgramStage( UID.of( "NeU85luyD4w" ) );
 
         Exception exception = assertThrows( BadRequestException.class,
             () -> mapper.map( criteria ) );
-        assertEquals( "Program stage is specified but does not exist: unknown", exception.getMessage() );
+        assertEquals( "Program stage is specified but does not exist: NeU85luyD4w", exception.getMessage() );
     }
 
     @Test
@@ -244,7 +244,7 @@ class RequestParamsMapperTest
         ForbiddenException
     {
         RequestParams criteria = new RequestParams();
-        criteria.setOrgUnit( ou.getUid() );
+        criteria.setOrgUnit( UID.of( ou.getUid() ) );
 
         EventSearchParams params = mapper.map( criteria );
 
@@ -255,13 +255,13 @@ class RequestParamsMapperTest
     void shouldFailWithBadRequestExceptionWhenMappingCriteriaWithUnknownOrgUnit()
     {
         RequestParams criteria = new RequestParams();
-        criteria.setOrgUnit( "unknown" );
+        criteria.setOrgUnit( UID.of( "NeU85luyD4w" ) );
         when( organisationUnitService.getOrganisationUnit( any() ) ).thenReturn( null );
 
         Exception exception = assertThrows( BadRequestException.class,
             () -> mapper.map( criteria ) );
 
-        assertEquals( "Org unit is specified but does not exist: unknown", exception.getMessage() );
+        assertEquals( "Org unit is specified but does not exist: NeU85luyD4w", exception.getMessage() );
     }
 
     @Test
@@ -270,7 +270,7 @@ class RequestParamsMapperTest
         ForbiddenException
     {
         RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( "teiuid" );
+        criteria.setTrackedEntity( UID.of( "qnR1RK4cTIZ" ) );
 
         EventSearchParams params = mapper.map( criteria );
 
@@ -281,13 +281,13 @@ class RequestParamsMapperTest
     void shouldFailWithBadRequestExceptionWhenTrackedEntityDoesNotExist()
     {
         RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( "teiuid" );
-        when( entityInstanceService.getTrackedEntity( "teiuid" ) ).thenReturn( null );
+        criteria.setTrackedEntity( UID.of( "qnR1RK4cTIZ" ) );
+        when( entityInstanceService.getTrackedEntity( "qnR1RK4cTIZ" ) ).thenReturn( null );
 
         Exception exception = assertThrows( BadRequestException.class,
             () -> mapper.map( criteria ) );
 
-        assertStartsWith( "Tracked entity instance is specified but does not exist: " + criteria.getTrackedEntity(),
+        assertStartsWith( "Tracked entity is specified but does not exist: " + criteria.getTrackedEntity(),
             exception.getMessage() );
     }
 
@@ -410,12 +410,11 @@ class RequestParamsMapperTest
     {
         RequestParams criteria = new RequestParams();
 
-        Set<String> enrollments = Set.of( "NQnuK2kLm6e" );
-        criteria.setEnrollments( enrollments );
+        criteria.setEnrollments( Set.of( UID.of( "NQnuK2kLm6e" ) ) );
 
         EventSearchParams params = mapper.map( criteria );
 
-        assertEquals( enrollments, params.getEnrollments() );
+        assertEquals( Set.of( "NQnuK2kLm6e" ), params.getEnrollments() );
     }
 
     @Test
@@ -704,7 +703,7 @@ class RequestParamsMapperTest
     void shouldFailWithForbiddenExceptionWhenUserHasNoAccessToProgram()
     {
         RequestParams criteria = new RequestParams();
-        criteria.setProgram( program.getUid() );
+        criteria.setProgram( UID.of( program ) );
         User user = new User();
         when( currentUserService.getCurrentUser() ).thenReturn( user );
         when( aclService.canDataRead( user, program ) ).thenReturn( false );
@@ -719,7 +718,7 @@ class RequestParamsMapperTest
     void shouldFailWithForbiddenExceptionWhenUserHasNoAccessToProgramStage()
     {
         RequestParams criteria = new RequestParams();
-        criteria.setProgramStage( programStage.getUid() );
+        criteria.setProgramStage( UID.of( programStage ) );
         User user = new User();
         when( currentUserService.getCurrentUser() ).thenReturn( user );
         when( aclService.canDataRead( user, programStage ) ).thenReturn( false );
@@ -734,11 +733,11 @@ class RequestParamsMapperTest
     void shouldFailWithForbiddenExceptionWhenUserHasNoAccessToCategoryCombo()
     {
         RequestParams criteria = new RequestParams();
-        criteria.setAttributeCc( "Cc" );
+        criteria.setAttributeCc( UID.of( "NeU85luyD4w" ) );
         criteria.setAttributeCos( "Cos" );
         CategoryOptionCombo combo = new CategoryOptionCombo();
         combo.setUid( "uid" );
-        when( categoryOptionComboService.getAttributeOptionCombo( criteria.getAttributeCc(), criteria.getAttributeCos(),
+        when( categoryOptionComboService.getAttributeOptionCombo( "NeU85luyD4w", criteria.getAttributeCos(),
             true ) )
             .thenReturn( combo );
         when( aclService.canDataRead( any( User.class ), any( CategoryOptionCombo.class ) ) ).thenReturn( false );

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RequestParamsTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RequestParamsTest.java
@@ -34,6 +34,7 @@ import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.webapi.common.UID;
 import org.junit.jupiter.api.Test;
 
 class RequestParamsTest
@@ -44,7 +45,7 @@ class RequestParamsTest
     {
 
         RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( "Hq3Kc6HK4OZ" );
+        criteria.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
 
         assertEquals( "Hq3Kc6HK4OZ", criteria.getIdentifierParam() );
         assertEquals( "Hq3Kc6HK4OZ", criteria.getIdentifierParam(), "should return cached identifier" );
@@ -56,7 +57,7 @@ class RequestParamsTest
     {
 
         RequestParams criteria = new RequestParams();
-        criteria.setTei( "Hq3Kc6HK4OZ" );
+        criteria.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
 
         assertEquals( "Hq3Kc6HK4OZ", criteria.getIdentifierParam() );
     }
@@ -67,7 +68,7 @@ class RequestParamsTest
     {
 
         RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( "Hq3Kc6HK4OZ" );
+        criteria.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
 
         assertEquals( "trackedEntity", criteria.getIdentifierName() );
     }
@@ -78,7 +79,7 @@ class RequestParamsTest
     {
 
         RequestParams criteria = new RequestParams();
-        criteria.setTei( "Hq3Kc6HK4OZ" );
+        criteria.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
 
         assertEquals( "trackedEntity", criteria.getIdentifierName() );
     }
@@ -89,7 +90,7 @@ class RequestParamsTest
     {
 
         RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( "Hq3Kc6HK4OZ" );
+        criteria.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
 
         assertEquals( TrackedEntity.class, criteria.getIdentifierClass() );
     }
@@ -100,7 +101,7 @@ class RequestParamsTest
     {
 
         RequestParams criteria = new RequestParams();
-        criteria.setTei( "Hq3Kc6HK4OZ" );
+        criteria.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
 
         assertEquals( TrackedEntity.class, criteria.getIdentifierClass() );
     }
@@ -111,7 +112,7 @@ class RequestParamsTest
     {
 
         RequestParams criteria = new RequestParams();
-        criteria.setEnrollment( "Hq3Kc6HK4OZ" );
+        criteria.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
 
         assertEquals( "Hq3Kc6HK4OZ", criteria.getIdentifierParam() );
     }
@@ -122,7 +123,7 @@ class RequestParamsTest
     {
 
         RequestParams criteria = new RequestParams();
-        criteria.setEnrollment( "Hq3Kc6HK4OZ" );
+        criteria.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
 
         assertEquals( "enrollment", criteria.getIdentifierName() );
     }
@@ -133,7 +134,7 @@ class RequestParamsTest
     {
 
         RequestParams criteria = new RequestParams();
-        criteria.setEnrollment( "Hq3Kc6HK4OZ" );
+        criteria.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
 
         assertEquals( Enrollment.class, criteria.getIdentifierClass() );
     }
@@ -144,7 +145,7 @@ class RequestParamsTest
     {
 
         RequestParams criteria = new RequestParams();
-        criteria.setEvent( "Hq3Kc6HK4OZ" );
+        criteria.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
 
         assertEquals( "Hq3Kc6HK4OZ", criteria.getIdentifierParam() );
     }
@@ -155,7 +156,7 @@ class RequestParamsTest
     {
 
         RequestParams criteria = new RequestParams();
-        criteria.setEvent( "Hq3Kc6HK4OZ" );
+        criteria.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
 
         assertEquals( "event", criteria.getIdentifierName() );
     }
@@ -166,7 +167,7 @@ class RequestParamsTest
     {
 
         RequestParams criteria = new RequestParams();
-        criteria.setEvent( "Hq3Kc6HK4OZ" );
+        criteria.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
 
         assertEquals( Event.class, criteria.getIdentifierClass() );
     }
@@ -197,10 +198,10 @@ class RequestParamsTest
     void getIdentifierParamThrowsIfAllParamsAreSet()
     {
         RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( "Hq3Kc6HK4OZ" );
-        criteria.setTei( "Hq3Kc6HK4OZ" );
-        criteria.setEnrollment( "Hq3Kc6HK4OZ" );
-        criteria.setEvent( "Hq3Kc6HK4OZ" );
+        criteria.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
+        criteria.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
+        criteria.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
+        criteria.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
 
         BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierParam );
 
@@ -212,10 +213,10 @@ class RequestParamsTest
     void getIdentifierNameThrowsIfAllParamsAreSet()
     {
         RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( "Hq3Kc6HK4OZ" );
-        criteria.setTei( "Hq3Kc6HK4OZ" );
-        criteria.setEnrollment( "Hq3Kc6HK4OZ" );
-        criteria.setEvent( "Hq3Kc6HK4OZ" );
+        criteria.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
+        criteria.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
+        criteria.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
+        criteria.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
 
         BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierName );
 
@@ -227,10 +228,10 @@ class RequestParamsTest
     void getIdentifierClassThrowsIfAllParamsAreSet()
     {
         RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( "Hq3Kc6HK4OZ" );
-        criteria.setTei( "Hq3Kc6HK4OZ" );
-        criteria.setEnrollment( "Hq3Kc6HK4OZ" );
-        criteria.setEvent( "Hq3Kc6HK4OZ" );
+        criteria.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
+        criteria.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
+        criteria.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
+        criteria.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
 
         BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierClass );
 
@@ -242,8 +243,8 @@ class RequestParamsTest
     void getIdentifierParamThrowsIfTrackedEntityAndEnrollmentAreSet()
     {
         RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( "Hq3Kc6HK4OZ" );
-        criteria.setEnrollment( "Hq3Kc6HK4OZ" );
+        criteria.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
+        criteria.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
 
         BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierParam );
 
@@ -255,8 +256,8 @@ class RequestParamsTest
     void getIdentifierParamThrowsIfTeiAndEnrollmentAreSet()
     {
         RequestParams criteria = new RequestParams();
-        criteria.setTei( "Hq3Kc6HK4OZ" );
-        criteria.setEnrollment( "Hq3Kc6HK4OZ" );
+        criteria.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
+        criteria.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
 
         BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierParam );
 
@@ -268,8 +269,8 @@ class RequestParamsTest
     void getIdentifierClassThrowsIfTrackedEntityAndEnrollmentAreSet()
     {
         RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( "Hq3Kc6HK4OZ" );
-        criteria.setEnrollment( "Hq3Kc6HK4OZ" );
+        criteria.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
+        criteria.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
 
         BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierClass );
 
@@ -281,8 +282,8 @@ class RequestParamsTest
     void getIdentifierClassThrowsIfTeiAndEnrollmentAreSet()
     {
         RequestParams criteria = new RequestParams();
-        criteria.setTei( "Hq3Kc6HK4OZ" );
-        criteria.setEnrollment( "Hq3Kc6HK4OZ" );
+        criteria.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
+        criteria.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
 
         BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierClass );
 
@@ -294,8 +295,8 @@ class RequestParamsTest
     void getIdentifierParamThrowsIfEnrollmentAndEventAreSet()
     {
         RequestParams criteria = new RequestParams();
-        criteria.setEnrollment( "Hq3Kc6HK4OZ" );
-        criteria.setEvent( "Hq3Kc6HK4OZ" );
+        criteria.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
+        criteria.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
 
         BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierParam );
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParamsMapperTest.java
@@ -203,7 +203,7 @@ class RequestParamsMapperTest
         criteria.setUpdatedWithin( "20" );
         criteria.setEnrollmentOccurredAfter( getDate( 2019, 5, 5 ) );
         criteria.setEnrollmentOccurredBefore( getDate( 2020, 5, 5 ) );
-        criteria.setTrackedEntityType( TRACKED_ENTITY_TYPE_UID );
+        criteria.setTrackedEntityType( UID.of( TRACKED_ENTITY_TYPE_UID ) );
         criteria.setEventStatus( EventStatus.COMPLETED );
         criteria.setEventOccurredAfter( getDate( 2019, 7, 7 ) );
         criteria.setEventOccurredBefore( getDate( 2020, 7, 7 ) );
@@ -422,7 +422,7 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        criteria.setProgram( PROGRAM_UID );
+        criteria.setProgram( UID.of( PROGRAM_UID ) );
 
         TrackedEntityQueryParams params = mapper.map( criteria );
 
@@ -432,11 +432,11 @@ class RequestParamsMapperTest
     @Test
     void testMappingProgramNotFound()
     {
-        criteria.setProgram( "unknown" );
+        criteria.setProgram( UID.of( "NeU85luyD4w" ) );
 
         BadRequestException e = assertThrows( BadRequestException.class,
             () -> mapper.map( criteria ) );
-        assertEquals( "Program is specified but does not exist: unknown", e.getMessage() );
+        assertEquals( "Program is specified but does not exist: NeU85luyD4w", e.getMessage() );
     }
 
     @Test
@@ -444,8 +444,8 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        criteria.setProgram( PROGRAM_UID );
-        criteria.setProgramStage( PROGRAM_STAGE_UID );
+        criteria.setProgram( UID.of( PROGRAM_UID ) );
+        criteria.setProgramStage( UID.of( PROGRAM_STAGE_UID ) );
 
         TrackedEntityQueryParams params = mapper.map( criteria );
 
@@ -455,7 +455,7 @@ class RequestParamsMapperTest
     @Test
     void testMappingProgramStageGivenWithoutProgram()
     {
-        criteria.setProgramStage( PROGRAM_STAGE_UID );
+        criteria.setProgramStage( UID.of( PROGRAM_STAGE_UID ) );
 
         BadRequestException e = assertThrows( BadRequestException.class,
             () -> mapper.map( criteria ) );
@@ -465,11 +465,11 @@ class RequestParamsMapperTest
     @Test
     void testMappingProgramStageNotFound()
     {
-        criteria.setProgramStage( "unknown" );
+        criteria.setProgramStage( UID.of( "NeU85luyD4w" ) );
 
         BadRequestException e = assertThrows( BadRequestException.class,
             () -> mapper.map( criteria ) );
-        assertEquals( "Program does not contain the specified programStage: unknown", e.getMessage() );
+        assertEquals( "Program does not contain the specified programStage: NeU85luyD4w", e.getMessage() );
     }
 
     @Test
@@ -477,7 +477,7 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        criteria.setTrackedEntityType( TRACKED_ENTITY_TYPE_UID );
+        criteria.setTrackedEntityType( UID.of( TRACKED_ENTITY_TYPE_UID ) );
 
         TrackedEntityQueryParams params = mapper.map( criteria );
 
@@ -487,22 +487,23 @@ class RequestParamsMapperTest
     @Test
     void testMappingTrackedEntityTypeNotFound()
     {
-        criteria.setTrackedEntityType( "unknown" );
+        criteria.setTrackedEntityType( UID.of( "NeU85luyD4w" ) );
 
         BadRequestException e = assertThrows( BadRequestException.class,
             () -> mapper.map( criteria ) );
-        assertEquals( "Tracked entity type does not exist: unknown", e.getMessage() );
+        assertEquals( "Tracked entity type is specified but does not exist: NeU85luyD4w", e.getMessage() );
     }
 
     @Test
     void testMappingOrgUnit()
-        throws BadRequestException,
+        throws
+        BadRequestException,
         ForbiddenException
     {
         when( trackerAccessManager.canAccess( user, program, orgUnit1 ) ).thenReturn( true );
         when( trackerAccessManager.canAccess( user, program, orgUnit2 ) ).thenReturn( true );
         criteria.setOrgUnit( ORG_UNIT_1_UID + ";" + ORG_UNIT_2_UID );
-        criteria.setProgram( PROGRAM_UID );
+        criteria.setProgram( UID.of( PROGRAM_UID ) );
 
         TrackedEntityQueryParams params = mapper.map( criteria );
 
@@ -521,13 +522,14 @@ class RequestParamsMapperTest
 
     @Test
     void testMappingOrgUnits()
-        throws BadRequestException,
+        throws
+        BadRequestException,
         ForbiddenException
     {
         when( trackerAccessManager.canAccess( user, program, orgUnit1 ) ).thenReturn( true );
         when( trackerAccessManager.canAccess( user, program, orgUnit2 ) ).thenReturn( true );
         criteria.setOrgUnits( Set.of( UID.of( ORG_UNIT_1_UID ), UID.of( ORG_UNIT_2_UID ) ) );
-        criteria.setProgram( PROGRAM_UID );
+        criteria.setProgram( UID.of( PROGRAM_UID ) );
 
         TrackedEntityQueryParams params = mapper.map( criteria );
 


### PR DESCRIPTION
to make use of the validation we now have for UIDs 🤩 

* added `toString` to UID so we simply print the UID value
* create factory for UID from anything that has a UID (UidObject)

NOTE: the mappers will be tackled soon in https://dhis2.atlassian.net/browse/TECH-1534 The code that had to change now `validation` methods will move into services. We can then figure out a way to remove the duplication/integrate better with the new UID type.
