### PR TITLE
chore: reuse tracker request params in OpenAPI spec TECH-1546

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentFieldsParamMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentFieldsParamMapper.java
@@ -46,7 +46,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class EnrollmentFieldsParamMapper
+class EnrollmentFieldsParamMapper
 {
     private final FieldFilterService fieldFilterService;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
@@ -65,9 +65,8 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component
 @RequiredArgsConstructor
-public class EnrollmentParamsMapper
+class EnrollmentRequestParamsMapper
 {
-
     @Nonnull
     private final CurrentUserService currentUserService;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
@@ -71,13 +71,13 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 @RequestMapping( value = RESOURCE_PATH + "/" + EnrollmentsExportController.ENROLLMENTS )
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
 @RequiredArgsConstructor
-public class EnrollmentsExportController
+class EnrollmentsExportController
 {
     protected static final String ENROLLMENTS = "enrollments";
 
     private static final EnrollmentMapper ENROLLMENT_MAPPER = Mappers.getMapper( EnrollmentMapper.class );
 
-    private final EnrollmentParamsMapper paramsMapper;
+    private final EnrollmentRequestParamsMapper paramsMapper;
 
     private final EnrollmentService enrollmentService;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/RequestParams.java
@@ -51,10 +51,11 @@ import org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity;
 /**
  * Represents query parameters sent to {@link EnrollmentsExportController}.
  */
+@OpenApi.Shared( name = "EnrollmentRequestParams" )
 @OpenApi.Property
 @Data
 @NoArgsConstructor
-public class RequestParams extends PagingAndSortingCriteriaAdapter
+class RequestParams extends PagingAndSortingCriteriaAdapter
 {
     static final String DEFAULT_FIELDS_PARAM = "*,!relationships,!events,!attributes";
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/CategoryOptionComboService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/CategoryOptionComboService.java
@@ -48,7 +48,7 @@ import org.springframework.stereotype.Component;
  * @author Lars Helge Overland
  */
 @Component
-public class CategoryOptionComboService
+class CategoryOptionComboService
 {
     private final Cache<Long> attrOptionComboIdCache;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/CsvEventService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/CsvEventService.java
@@ -58,7 +58,7 @@ import com.fasterxml.jackson.dataformat.csv.CsvSchema;
  * @author Enrico Colasante
  */
 @Service( "org.hisp.dhis.webapi.controller.tracker.export.event.CsvEventService" )
-public class CsvEventService
+class CsvEventService
     implements CsvService<Event>
 {
     private static final CsvMapper CSV_MAPPER = new CsvMapper().enable( CsvParser.Feature.WRAP_AS_ARRAY );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventFieldsParamMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventFieldsParamMapper.java
@@ -44,7 +44,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class EventFieldsParamMapper
+class EventFieldsParamMapper
 {
     private final FieldFilterService fieldFilterService;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
@@ -82,7 +82,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @RequiredArgsConstructor
-class EventParamsMapper
+class EventRequestParamsMapper
 {
     private static final Set<String> SORTABLE_PROPERTIES = JdbcEventStore.QUERY_PARAM_COL_MAP.keySet();
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -82,7 +82,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 @RequestMapping( value = RESOURCE_PATH + "/" + EventsExportController.EVENTS )
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
 @RequiredArgsConstructor
-public class EventsExportController
+class EventsExportController
 {
     protected static final String EVENTS = "events";
 
@@ -92,7 +92,7 @@ public class EventsExportController
     private final org.hisp.dhis.tracker.export.event.EventService eventService;
 
     @Nonnull
-    private final EventParamsMapper requestToSearchParams;
+    private final EventRequestParamsMapper requestToSearchParams;
 
     @Nonnull
     private final CsvService<org.hisp.dhis.webapi.controller.tracker.view.Event> csvEventService;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/RequestParams.java
@@ -60,6 +60,7 @@ import org.hisp.dhis.webapi.controller.tracker.view.User;
  *
  * @author Giuseppe Nespolino <g.nespolino@gmail.com>
  */
+@OpenApi.Shared( name = "EventRequestParams" )
 @OpenApi.Property
 @Data
 @NoArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
@@ -80,7 +80,7 @@ import com.google.common.collect.ImmutableMap;
     + RelationshipsExportController.RELATIONSHIPS )
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
 @RequiredArgsConstructor
-public class RelationshipsExportController
+class RelationshipsExportController
 {
     protected static final String RELATIONSHIPS = "relationships";
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RequestParams.java
@@ -44,6 +44,7 @@ import org.hisp.dhis.webapi.controller.tracker.view.Enrollment;
 import org.hisp.dhis.webapi.controller.tracker.view.Event;
 import org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity;
 
+@OpenApi.Shared( name = "RelationshipRequestParams" )
 @OpenApi.Property
 @NoArgsConstructor
 @EqualsAndHashCode( exclude = { "identifier", "identifierName", "identifierClass" } )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/CsvTrackedEntityService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/CsvTrackedEntityService.java
@@ -46,7 +46,7 @@ import com.fasterxml.jackson.dataformat.csv.CsvParser;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 
 @Service( "org.hisp.dhis.webapi.controller.tracker.export.trackedentity.CsvTrackedEntityService" )
-public class CsvTrackedEntityService implements CsvService<TrackedEntity>
+class CsvTrackedEntityService implements CsvService<TrackedEntity>
 {
     private static final CsvMapper CSV_MAPPER = new CsvMapper().enable( CsvParser.Feature.WRAP_AS_ARRAY );
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParams.java
@@ -56,6 +56,7 @@ import org.hisp.dhis.webapi.controller.tracker.view.User;
  *
  * @author Giuseppe Nespolino
  */
+@OpenApi.Shared( name = "TrackedEntityRequestParams" )
 @OpenApi.Property
 @Data
 @NoArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -85,7 +85,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 @RequestMapping( value = RESOURCE_PATH + "/" + TrackedEntitiesExportController.TRACKED_ENTITIES )
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
 @RequiredArgsConstructor
-public class TrackedEntitiesExportController
+class TrackedEntitiesExportController
 {
     protected static final String TRACKED_ENTITIES = "trackedEntities";
 
@@ -103,7 +103,7 @@ public class TrackedEntitiesExportController
     private static final TrackedEntityMapper TRACKED_ENTITY_MAPPER = Mappers.getMapper( TrackedEntityMapper.class );
 
     @Nonnull
-    private final TrackedEntityParamsMapper paramsMapper;
+    private final TrackedEntityRequestParamsMapper paramsMapper;
 
     @Nonnull
     private final TrackedEntityService trackedEntityService;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityFieldsParamMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityFieldsParamMapper.java
@@ -49,7 +49,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class TrackedEntityFieldsParamMapper
+class TrackedEntityFieldsParamMapper
 {
     private final FieldFilterService fieldFilterService;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
@@ -81,7 +81,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component
 @RequiredArgsConstructor
-public class TrackedEntityParamsMapper
+class TrackedEntityRequestParamsMapper
 {
     @Nonnull
     private final CurrentUserService currentUserService;

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/EnrollmentsExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/EnrollmentsExportController.md
@@ -4,21 +4,27 @@
 
 Get enrollments matching given query parameters.
 
-### `getEnrollments.parameter.enrolledAfter`
+## `getEnrollmentByUid`
+
+Get an enrollment with given UID.
+
+## Common for all endpoints
+
+### `*.parameter.EnrollmentRequestParams.enrolledAfter`
 
 Get enrollments enrolled after given date.
 
-### `getEnrollments.parameter.enrolledBefore`
+### `*.parameter.EnrollmentRequestParams.enrolledBefore`
 
 Get enrollments enrolled before given date.
 
-### `getEnrollments.parameter.enrollments`
+### `*.parameter.EnrollmentRequestParams.enrollments`
 
 `<enrollment1-uid>[,<enrollment2-uid>...]`
 
 Get enrollments with given UID(s).
 
-### `getEnrollments.parameter.enrollment`
+### `*.parameter.EnrollmentRequestParams.enrollment`
 
 **DEPRECATED as of 2.41:** Use parameter `enrollments` instead where UIDs have to be separated by comma!
 
@@ -26,21 +32,21 @@ Get enrollments with given UID(s).
 
 Get enrollments with given UID(s).
 
-### `getEnrollments.parameter.followUp`
+### `*.parameter.EnrollmentRequestParams.followUp`
 
 Get enrollments with given follow-up status of the instance for the given program.
 
-### `getEnrollments.parameter.includeDeleted`
+### `*.parameter.EnrollmentRequestParams.includeDeleted`
 
 Get soft-deleted enrollments by specifying `includeDeleted=true`. Soft-deleted enrollments are excluded by default.
 
-### `getEnrollments.parameter.orgUnits`
+### `*.parameter.EnrollmentRequestParams.orgUnits`
 
 `<orgUnit1-uid>[,<orgUnit2-uid>...]`
 
 Get enrollments owned by given `orgUnit`.
 
-### `getEnrollments.parameter.orgUnit`
+### `*.parameter.EnrollmentRequestParams.orgUnit`
 
 **DEPRECATED as of 2.41:** Use parameter `orgUnits` instead where UIDs have to be separated by comma!
 
@@ -48,34 +54,30 @@ Get enrollments owned by given `orgUnit`.
 
 Get enrollments owned by given `orgUnit`.
 
-### `getEnrollments.parameter.ouMode`
+### `*.parameter.EnrollmentRequestParams.ouMode`
 
 Get enrollments using given organisation unit selection mode.
 
-### `getEnrollments.parameter.program`
+### `*.parameter.EnrollmentRequestParams.program`
 
 Get enrollments enrolled in given program.
 
-### `getEnrollments.parameter.programStatus`
+### `*.parameter.EnrollmentRequestParams.programStatus`
 
 Get enrollments enrolled in a program with given status.
 
-### `getEnrollments.parameter.trackedEntityType`
+### `*.parameter.EnrollmentRequestParams.trackedEntityType`
 
 Get enrollments of tracked entities of given type.
 
-### `getEnrollments.parameter.trackedEntity`
+### `*.parameter.EnrollmentRequestParams.trackedEntity`
 
 Get enrollments of tracked entity with given UID.
 
-### `getEnrollments.parameter.updatedAfter`
+### `*.parameter.EnrollmentRequestParams.updatedAfter`
 
 Get enrollments updated after given date.
 
-### `getEnrollments.parameter.updatedWithin`
+### `*.parameter.EnrollmentRequestParams.updatedWithin`
 
 Get enrollments updated since given ISO-8601 duration.
-
-## `getEnrollmentByUid`
-
-Get an enrollment with given UID.

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/EventsExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/EventsExportController.md
@@ -4,38 +4,44 @@
 
 Get events matching given query parameters.
 
-### `getEvents.parameter.program`
+## `getEventByUid`
 
-### `getEvents.parameter.programStage`
+Get an event with given UID.
 
-### `getEvents.parameter.programStatus`
+## Common for all endpoints
 
-### `getEvents.parameter.followUp`
+### `*.parameter.EventRequestParams.program`
+
+### `*.parameter.EventRequestParams.programStage`
+
+### `*.parameter.EventRequestParams.programStatus`
+
+### `*.parameter.EventRequestParams.followUp`
 
 Get events with given follow-up status of the instance for the given program.
 
-### `getEvents.parameter.trackedEntity`
+### `*.parameter.EventRequestParams.trackedEntity`
 
 Get events of tracked entity with given UID.
 
-### `getEvents.parameter.orgUnit`
+### `*.parameter.EventRequestParams.orgUnit`
 
 Get events owned by given `orgUnit`.
 
-### `getEvents.parameter.ouMode`
+### `*.parameter.EventRequestParams.ouMode`
 
 Get events using given organisation unit selection mode.
 
-### `getEvents.parameter.assignedUserMode`
+### `*.parameter.EventRequestParams.assignedUserMode`
 
-### `getEvents.parameter.assignedUsers`
+### `*.parameter.EventRequestParams.assignedUsers`
 
 `<user1-uid>[,<user2-uid>...]`
 
 Get events that are assigned to the given user(s). Specifying `assignedUsers` is only valid if `assignedUserMode` is
 either `PROVIDED` or not specified.
 
-### `getEvents.parameter.assignedUser`
+### `*.parameter.EventRequestParams.assignedUser`
 
 **DEPRECATED as of 2.41:** Use parameter `assignedUsers` instead where UIDs have to be separated by comma!
 
@@ -44,55 +50,55 @@ either `PROVIDED` or not specified.
 Get events that are assigned to the given user(s). Specifying `assignedUser` is only valid if `assignedUserMode` is
 either `PROVIDED` or not specified.
 
-### `getEvents.parameter.occurredAfter`
+### `*.parameter.EventRequestParams.occurredAfter`
 
 Get events that occurred after given date.
 
-### `getEvents.parameter.occurredBefore`
+### `*.parameter.EventRequestParams.occurredBefore`
 
 Get events that occurred before given date.
 
-### `getEvents.parameter.scheduledAfter`
+### `*.parameter.EventRequestParams.scheduledAfter`
 
 Get events that are scheduled after given date.
 
-### `getEvents.parameter.scheduledBefore`
+### `*.parameter.EventRequestParams.scheduledBefore`
 
 Get events that are scheduled before given date.
 
-### `getEvents.parameter.updatedAfter`
+### `*.parameter.EventRequestParams.updatedAfter`
 
 Get events updated after given date.
 
-### `getEvents.parameter.updatedWithin`
+### `*.parameter.EventRequestParams.updatedWithin`
 
 Get events updated since given ISO-8601 duration.
 
-### `getEvents.parameter.enrollmentEnrolledAfter`
+### `*.parameter.EventRequestParams.enrollmentEnrolledAfter`
 
 Get events with enrollments that were enrolled after given date.
 
-### `getEvents.parameter.enrollmentEnrolledBefore`
+### `*.parameter.EventRequestParams.enrollmentEnrolledBefore`
 
 Get events with enrollments that were enrolled before given date.
 
-### `getEvents.parameter.status`
+### `*.parameter.EventRequestParams.status`
 
-### `getEvents.parameter.attributeCc`
+### `*.parameter.EventRequestParams.attributeCc`
 
-### `getEvents.parameter.attributeCos`
+### `*.parameter.EventRequestParams.attributeCos`
 
-### `getEvents.parameter.includeDeleted`
+### `*.parameter.EventRequestParams.includeDeleted`
 
 Get soft-deleted events by specifying `includeDeleted=true`. Soft-deleted events are excluded by default.
 
-### `getEvents.parameter.events`
+### `*.parameter.EventRequestParams.events`
 
 `<event1-uid>[,<event2-uid>...]`
 
 Get events with given UID(s).
 
-### `getEvents.parameter.event`
+### `*.parameter.EventRequestParams.event`
 
 **DEPRECATED as of 2.41:** Use parameter `events` instead where UIDs have to be separated by comma!
 
@@ -100,9 +106,9 @@ Get events with given UID(s).
 
 Get events with given UID(s).
 
-### `getEvents.parameter.skipEventId`
+### `*.parameter.EventRequestParams.skipEventId`
 
-### `getEvents.parameter.order`
+### `*.parameter.EventRequestParams.order`
 
 `<propertyName1:sortDirection>[,<propertyName2:sortDirection>...]`
 
@@ -113,7 +119,3 @@ Supported properties are `assignedUser`, `assignedUserDisplayName`, `attributeOp
 `completedBy`, `createdAt`, `createdBy`, `deleted`, `enrolledAt`, `enrollment`, `enrollmentStatus`, `event`, `followup`,
 `occurredAt`, `orgUnit`, `orgUnitName`, `program`, `programStage`, `scheduleAt`, `status`, `storedBy`, `trackedEntity`,
 `updatedAt`, `updatedBy`.
-
-## `getEventByUid`
-
-Get an event with given UID.

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/RelationshipsExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/RelationshipsExportController.md
@@ -4,12 +4,14 @@
 
 Get relationships matching given query parameters.
 
-### `getRelationships.parameter.trackedEntity`
-
-### `getRelationships.parameter.enrollment`
-
-### `getRelationships.parameter.event`
-
 ## `getRelationshipByUid`
 
 Get a relationship with given UID.
+
+## Common for all endpoints
+
+### `*.parameter.RelationshipRequestParams.trackedEntity`
+
+### `*.parameter.RelationshipRequestParams.enrollment`
+
+### `*.parameter.RelationshipRequestParams.event`

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
@@ -4,17 +4,25 @@
 
 Get tracked entities matching given query parameters.
 
-### `getTrackedEntities.parameter.query`
+## `getTrackedEntityByUid`
 
-### `getTrackedEntities.parameter.attribute`
+Get a tracked entity with given UID.
 
-### `getTrackedEntities.parameter.orgUnits`
+### `getTrackedEntityByUid.parameter.program`
+
+## Common for all endpoints
+
+### `*.parameter.TrackedEntityRequestParams.query`
+
+### `*.parameter.TrackedEntityRequestParams.attribute`
+
+### `*.parameter.TrackedEntityRequestParams.orgUnits`
 
 `<orgUnit1-uid>[,<orgUnit2-uid>...]`
 
 Get tracked entities owned by given `orgUnit`.
 
-### `getTrackedEntities.parameter.orgUnit`
+### `*.parameter.TrackedEntityRequestParams.orgUnit`
 
 **DEPRECATED as of 2.41:** Use parameter `orgUnits` instead where UIDs have to be separated by comma!
 
@@ -22,39 +30,39 @@ Get tracked entities owned by given `orgUnit`.
 
 Get tracked entities owned by given `orgUnit`.
 
-### `getTrackedEntities.parameter.ouMode`
+### `*.parameter.TrackedEntityRequestParams.ouMode`
 
 Get events using given organisation unit selection mode.
 
-### `getTrackedEntities.parameter.program`
+### `*.parameter.TrackedEntityRequestParams.program`
 
-### `getTrackedEntities.parameter.programStatus`
+### `*.parameter.TrackedEntityRequestParams.programStatus`
 
-### `getTrackedEntities.parameter.followUp`
+### `*.parameter.TrackedEntityRequestParams.followUp`
 
-### `getTrackedEntities.parameter.updatedAfter`
+### `*.parameter.TrackedEntityRequestParams.updatedAfter`
 
-### `getTrackedEntities.parameter.updatedBefore`
+### `*.parameter.TrackedEntityRequestParams.updatedBefore`
 
-### `getTrackedEntities.parameter.updatedWithin`
+### `*.parameter.TrackedEntityRequestParams.updatedWithin`
 
-### `getTrackedEntities.parameter.enrollmentEnrolledAfter`
+### `*.parameter.TrackedEntityRequestParams.enrollmentEnrolledAfter`
 
-### `getTrackedEntities.parameter.enrollmentEnrolledBefore`
+### `*.parameter.TrackedEntityRequestParams.enrollmentEnrolledBefore`
 
-### `getTrackedEntities.parameter.enrollmentOccurredAfter`
+### `*.parameter.TrackedEntityRequestParams.enrollmentOccurredAfter`
 
-### `getTrackedEntities.parameter.enrollmentOccurredBefore`
+### `*.parameter.TrackedEntityRequestParams.enrollmentOccurredBefore`
 
-### `getTrackedEntities.parameter.trackedEntityType`
+### `*.parameter.TrackedEntityRequestParams.trackedEntityType`
 
-### `getTrackedEntities.parameter.trackedEntities`
+### `*.parameter.TrackedEntityRequestParams.trackedEntities`
 
 `<trackedEntity1-uid>[,<trackedEntity2-uid>...]`
 
 Get tracked entities with given UID(s).
 
-### `getTrackedEntities.parameter.trackedEntity`
+### `*.parameter.TrackedEntityRequestParams.trackedEntity`
 
 **DEPRECATED as of 2.41:** Use parameter `trackedEntities` instead where UIDs have to be separated by comma!
 
@@ -62,16 +70,16 @@ Get tracked entities with given UID(s).
 
 Get tracked entities with given UID(s).
 
-### `getTrackedEntities.parameter.assignedUserMode`
+### `*.parameter.TrackedEntityRequestParams.assignedUserMode`
 
-### `getTrackedEntities.parameter.assignedUsers`
+### `*.parameter.TrackedEntityRequestParams.assignedUsers`
 
 `<user1-uid>[,<user2-uid>...]`
 
 Get tracked entities with an event assigned to given user(s). Specifying `assignedUsers` is only valid
 if `assignedUserMode` is either `PROVIDED` or not specified.
 
-### `getTrackedEntities.parameter.assignedUser`
+### `*.parameter.TrackedEntityRequestParams.assignedUser`
 
 **DEPRECATED as of 2.41:** Use parameter `assignedUsers` instead where UIDs have to be separated by comma!
 
@@ -80,24 +88,19 @@ if `assignedUserMode` is either `PROVIDED` or not specified.
 Get tracked entities with an event assigned to given user(s). Specifying `assignedUsers` is only valid
 if `assignedUserMode` is either `PROVIDED` or not specified.
 
-### `getTrackedEntities.parameter.programStage`
+### `*.parameter.TrackedEntityRequestParams.programStage`
 
-### `getTrackedEntities.parameter.eventStatus`
+### `*.parameter.TrackedEntityRequestParams.eventStatus`
 
-### `getTrackedEntities.parameter.eventOccurredAfter`
+### `*.parameter.TrackedEntityRequestParams.eventOccurredAfter`
 
-### `getTrackedEntities.parameter.eventOccurredBefore`
+### `*.parameter.TrackedEntityRequestParams.eventOccurredBefore`
 
-### `getTrackedEntities.parameter.skipMeta`
+### `*.parameter.TrackedEntityRequestParams.skipMeta`
 
-### `getTrackedEntities.parameter.includeDeleted`
+### `*.parameter.TrackedEntityRequestParams.includeDeleted`
 
-### `getTrackedEntities.parameter.includeAllAttributes`
+### `*.parameter.TrackedEntityRequestParams.includeAllAttributes`
 
-### `getTrackedEntities.parameter.potentialDuplicate`
+### `*.parameter.TrackedEntityRequestParams.potentialDuplicate`
 
-## `getTrackedEntityByUid`
-
-Get a tracked entity with given UID.
-
-### `getTrackedEntityByUid.parameter.program`

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deprecated/tracker/EnrollmentCriteriaMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deprecated/tracker/EnrollmentCriteriaMapperTest.java
@@ -58,7 +58,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith( MockitoExtension.class )
-class RequestParamsMapperTest
+class EnrollmentCriteriaMapperTest
 {
 
     @Mock

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapperTest.java
@@ -66,7 +66,7 @@ import org.mockito.quality.Strictness;
 
 @MockitoSettings( strictness = Strictness.LENIENT ) // common setup
 @ExtendWith( MockitoExtension.class )
-class RequestParamsMapperTest
+class EnrollmentRequestParamsMapperTest
 {
 
     private static final String ORG_UNIT_1_UID = "lW0T2U7gZUi";
@@ -98,7 +98,7 @@ class RequestParamsMapperTest
     private TrackerAccessManager trackerAccessManager;
 
     @InjectMocks
-    private EnrollmentParamsMapper mapper;
+    private EnrollmentRequestParamsMapper mapper;
 
     private OrganisationUnit orgUnit1;
 
@@ -147,9 +147,9 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
+        RequestParams requestParams = new RequestParams();
 
-        mapper.map( criteria );
+        mapper.map( requestParams );
 
         verifyNoInteractions( programService );
         verifyNoInteractions( organisationUnitService );
@@ -162,13 +162,13 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setOrgUnit( ORG_UNIT_1_UID + ";" + ORG_UNIT_2_UID );
-        criteria.setProgram( UID.of( program ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setOrgUnit( ORG_UNIT_1_UID + ";" + ORG_UNIT_2_UID );
+        requestParams.setProgram( UID.of( program ) );
         when( trackerAccessManager.canAccess( user, program, orgUnit1 ) ).thenReturn( true );
         when( trackerAccessManager.canAccess( user, program, orgUnit2 ) ).thenReturn( true );
 
-        EnrollmentQueryParams params = mapper.map( criteria );
+        EnrollmentQueryParams params = mapper.map( requestParams );
 
         assertContainsOnly( Set.of( orgUnit1, orgUnit2 ), params.getOrganisationUnits() );
     }
@@ -176,26 +176,26 @@ class RequestParamsMapperTest
     @Test
     void testMappingOrgUnitNotFound()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setOrgUnit( "NeU85luyD4w;" + ORG_UNIT_2_UID );
-        criteria.setProgram( UID.of( program ) );
-        criteria.setProgram( UID.of( program ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setOrgUnit( "NeU85luyD4w;" + ORG_UNIT_2_UID );
+        requestParams.setProgram( UID.of( program ) );
+        requestParams.setProgram( UID.of( program ) );
         when( trackerAccessManager.canAccess( user, program, orgUnit2 ) ).thenReturn( true );
 
         Exception exception = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertEquals( "Organisation unit does not exist: NeU85luyD4w", exception.getMessage() );
     }
 
     @Test
     void shouldThrowExceptionWhenOrgUnitNotInScope()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setOrgUnit( ORG_UNIT_1_UID );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setOrgUnit( ORG_UNIT_1_UID );
         when( trackerAccessManager.canAccess( user, program, orgUnit1 ) ).thenReturn( false );
 
         Exception exception = assertThrows( ForbiddenException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertEquals( "User does not have access to organisation unit: " + ORG_UNIT_1_UID, exception.getMessage() );
     }
 
@@ -204,13 +204,13 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setOrgUnits( Set.of( UID.of( ORG_UNIT_1_UID ), UID.of( ORG_UNIT_2_UID ) ) );
-        criteria.setProgram( UID.of( program ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setOrgUnits( Set.of( UID.of( ORG_UNIT_1_UID ), UID.of( ORG_UNIT_2_UID ) ) );
+        requestParams.setProgram( UID.of( program ) );
         when( trackerAccessManager.canAccess( user, program, orgUnit1 ) ).thenReturn( true );
         when( trackerAccessManager.canAccess( user, program, orgUnit2 ) ).thenReturn( true );
 
-        EnrollmentQueryParams params = mapper.map( criteria );
+        EnrollmentQueryParams params = mapper.map( requestParams );
 
         assertContainsOnly( Set.of( orgUnit1, orgUnit2 ), params.getOrganisationUnits() );
     }
@@ -218,25 +218,25 @@ class RequestParamsMapperTest
     @Test
     void testMappingOrgUnitsNotFound()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setOrgUnits( Set.of( UID.of( "NeU85luyD4w" ), UID.of( ORG_UNIT_2_UID ) ) );
-        criteria.setProgram( UID.of( program ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setOrgUnits( Set.of( UID.of( "NeU85luyD4w" ), UID.of( ORG_UNIT_2_UID ) ) );
+        requestParams.setProgram( UID.of( program ) );
         when( trackerAccessManager.canAccess( user, program, orgUnit2 ) ).thenReturn( true );
 
         Exception exception = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertEquals( "Organisation unit does not exist: NeU85luyD4w", exception.getMessage() );
     }
 
     @Test
     void shouldThrowExceptionWhenOrgUnitsNotInScope()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setOrgUnits( Set.of( UID.of( ORG_UNIT_1_UID ) ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setOrgUnits( Set.of( UID.of( ORG_UNIT_1_UID ) ) );
         when( trackerAccessManager.canAccess( user, program, orgUnit1 ) ).thenReturn( false );
 
         Exception exception = assertThrows( ForbiddenException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertEquals( "User does not have access to organisation unit: " + ORG_UNIT_1_UID, exception.getMessage() );
     }
 
@@ -245,10 +245,10 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setProgram( UID.of( PROGRAM_UID ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setProgram( UID.of( PROGRAM_UID ) );
 
-        EnrollmentQueryParams params = mapper.map( criteria );
+        EnrollmentQueryParams params = mapper.map( requestParams );
 
         assertEquals( program, params.getProgram() );
     }
@@ -256,11 +256,11 @@ class RequestParamsMapperTest
     @Test
     void testMappingProgramNotFound()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setProgram( UID.of( "JW6BrFd0HLu" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setProgram( UID.of( "JW6BrFd0HLu" ) );
 
         Exception exception = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertEquals( "Program is specified but does not exist: JW6BrFd0HLu", exception.getMessage() );
     }
 
@@ -269,10 +269,10 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntityType( UID.of( TRACKED_ENTITY_TYPE_UID ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setTrackedEntityType( UID.of( TRACKED_ENTITY_TYPE_UID ) );
 
-        EnrollmentQueryParams params = mapper.map( criteria );
+        EnrollmentQueryParams params = mapper.map( requestParams );
 
         assertEquals( trackedEntityType, params.getTrackedEntityType() );
     }
@@ -280,11 +280,11 @@ class RequestParamsMapperTest
     @Test
     void testMappingTrackedEntityTypeNotFound()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntityType( UID.of( "JW6BrFd0HLu" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setTrackedEntityType( UID.of( "JW6BrFd0HLu" ) );
 
         Exception exception = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertEquals( "Tracked entity type is specified but does not exist: JW6BrFd0HLu", exception.getMessage() );
     }
 
@@ -293,10 +293,10 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( UID.of( TRACKED_ENTITY_UID ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setTrackedEntity( UID.of( TRACKED_ENTITY_UID ) );
 
-        EnrollmentQueryParams params = mapper.map( criteria );
+        EnrollmentQueryParams params = mapper.map( requestParams );
 
         assertEquals( TRACKED_ENTITY_UID, params.getTrackedEntityUid() );
     }
@@ -304,11 +304,11 @@ class RequestParamsMapperTest
     @Test
     void testMappingTrackedEntityNotFound()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( UID.of( "JW6BrFd0HLu" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setTrackedEntity( UID.of( "JW6BrFd0HLu" ) );
 
         Exception exception = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertEquals( "Tracked entity is specified but does not exist: JW6BrFd0HLu", exception.getMessage() );
     }
 
@@ -317,12 +317,12 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
+        RequestParams requestParams = new RequestParams();
         OrderCriteria order1 = OrderCriteria.of( "field1", SortDirection.ASC );
         OrderCriteria order2 = OrderCriteria.of( "field2", SortDirection.DESC );
-        criteria.setOrder( List.of( order1, order2 ) );
+        requestParams.setOrder( List.of( order1, order2 ) );
 
-        EnrollmentQueryParams params = mapper.map( criteria );
+        EnrollmentQueryParams params = mapper.map( requestParams );
 
         assertEquals( List.of(
             new OrderParam( "field1", SortDirection.ASC ),
@@ -334,9 +334,9 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
+        RequestParams requestParams = new RequestParams();
 
-        EnrollmentQueryParams params = mapper.map( criteria );
+        EnrollmentQueryParams params = mapper.map( requestParams );
 
         assertIsEmpty( params.getOrder() );
     }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
@@ -85,7 +85,7 @@ import org.mockito.quality.Strictness;
 
 @MockitoSettings( strictness = Strictness.LENIENT ) // common setup
 @ExtendWith( MockitoExtension.class )
-class RequestParamsMapperTest
+class EventRequestParamsMapperTest
 {
 
     private static final String DE_1_UID = "OBzmpRP6YUh";
@@ -126,7 +126,7 @@ class RequestParamsMapperTest
     private CategoryOptionComboService categoryOptionComboService;
 
     @InjectMocks
-    private EventParamsMapper mapper;
+    private EventRequestParamsMapper mapper;
 
     private Program program;
 
@@ -180,9 +180,9 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
+        RequestParams requestParams = new RequestParams();
 
-        mapper.map( criteria );
+        mapper.map( requestParams );
 
         verifyNoInteractions( programService );
         verifyNoInteractions( programStageService );
@@ -195,10 +195,10 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setProgram( UID.of( PROGRAM_UID ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setProgram( UID.of( PROGRAM_UID ) );
 
-        EventSearchParams params = mapper.map( criteria );
+        EventSearchParams params = mapper.map( requestParams );
 
         assertEquals( program, params.getProgram() );
     }
@@ -206,11 +206,11 @@ class RequestParamsMapperTest
     @Test
     void testMappingProgramNotFound()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setProgram( UID.of( "NeU85luyD4w" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setProgram( UID.of( "NeU85luyD4w" ) );
 
         Exception exception = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertEquals( "Program is specified but does not exist: NeU85luyD4w", exception.getMessage() );
     }
 
@@ -219,10 +219,10 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setProgramStage( UID.of( "PlZSBEN7iZd" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setProgramStage( UID.of( "PlZSBEN7iZd" ) );
 
-        EventSearchParams params = mapper.map( criteria );
+        EventSearchParams params = mapper.map( requestParams );
 
         assertEquals( programStage, params.getProgramStage() );
     }
@@ -230,11 +230,11 @@ class RequestParamsMapperTest
     @Test
     void shouldFailWithBadRequestExceptionWhenMappingCriteriaWithUnknownProgramStage()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setProgramStage( UID.of( "NeU85luyD4w" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setProgramStage( UID.of( "NeU85luyD4w" ) );
 
         Exception exception = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertEquals( "Program stage is specified but does not exist: NeU85luyD4w", exception.getMessage() );
     }
 
@@ -243,10 +243,10 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setOrgUnit( UID.of( ou.getUid() ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setOrgUnit( UID.of( ou.getUid() ) );
 
-        EventSearchParams params = mapper.map( criteria );
+        EventSearchParams params = mapper.map( requestParams );
 
         assertEquals( ou, params.getOrgUnit() );
     }
@@ -254,12 +254,12 @@ class RequestParamsMapperTest
     @Test
     void shouldFailWithBadRequestExceptionWhenMappingCriteriaWithUnknownOrgUnit()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setOrgUnit( UID.of( "NeU85luyD4w" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setOrgUnit( UID.of( "NeU85luyD4w" ) );
         when( organisationUnitService.getOrganisationUnit( any() ) ).thenReturn( null );
 
         Exception exception = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
 
         assertEquals( "Org unit is specified but does not exist: NeU85luyD4w", exception.getMessage() );
     }
@@ -269,10 +269,10 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( UID.of( "qnR1RK4cTIZ" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setTrackedEntity( UID.of( "qnR1RK4cTIZ" ) );
 
-        EventSearchParams params = mapper.map( criteria );
+        EventSearchParams params = mapper.map( requestParams );
 
         assertEquals( trackedEntity, params.getTrackedEntity() );
     }
@@ -280,14 +280,14 @@ class RequestParamsMapperTest
     @Test
     void shouldFailWithBadRequestExceptionWhenTrackedEntityDoesNotExist()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( UID.of( "qnR1RK4cTIZ" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setTrackedEntity( UID.of( "qnR1RK4cTIZ" ) );
         when( entityInstanceService.getTrackedEntity( "qnR1RK4cTIZ" ) ).thenReturn( null );
 
         Exception exception = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
 
-        assertStartsWith( "Tracked entity is specified but does not exist: " + criteria.getTrackedEntity(),
+        assertStartsWith( "Tracked entity is specified but does not exist: " + requestParams.getTrackedEntity(),
             exception.getMessage() );
     }
 
@@ -296,14 +296,14 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
+        RequestParams requestParams = new RequestParams();
 
         Date occurredAfter = parseDate( "2020-01-01" );
-        criteria.setOccurredAfter( occurredAfter );
+        requestParams.setOccurredAfter( occurredAfter );
         Date occurredBefore = parseDate( "2020-09-12" );
-        criteria.setOccurredBefore( occurredBefore );
+        requestParams.setOccurredBefore( occurredBefore );
 
-        EventSearchParams params = mapper.map( criteria );
+        EventSearchParams params = mapper.map( requestParams );
 
         assertEquals( occurredAfter, params.getStartDate() );
         assertEquals( occurredBefore, params.getEndDate() );
@@ -314,14 +314,14 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
+        RequestParams requestParams = new RequestParams();
 
         Date scheduledAfter = parseDate( "2021-01-01" );
-        criteria.setScheduledAfter( scheduledAfter );
+        requestParams.setScheduledAfter( scheduledAfter );
         Date scheduledBefore = parseDate( "2021-09-12" );
-        criteria.setScheduledBefore( scheduledBefore );
+        requestParams.setScheduledBefore( scheduledBefore );
 
-        EventSearchParams params = mapper.map( criteria );
+        EventSearchParams params = mapper.map( requestParams );
 
         assertEquals( scheduledAfter, params.getScheduleAtStartDate() );
         assertEquals( scheduledBefore, params.getScheduleAtEndDate() );
@@ -332,16 +332,16 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
+        RequestParams requestParams = new RequestParams();
 
         Date updatedAfter = parseDate( "2022-01-01" );
-        criteria.setUpdatedAfter( updatedAfter );
+        requestParams.setUpdatedAfter( updatedAfter );
         Date updatedBefore = parseDate( "2022-09-12" );
-        criteria.setUpdatedBefore( updatedBefore );
+        requestParams.setUpdatedBefore( updatedBefore );
         String updatedWithin = "P6M";
-        criteria.setUpdatedWithin( updatedWithin );
+        requestParams.setUpdatedWithin( updatedWithin );
 
-        EventSearchParams params = mapper.map( criteria );
+        EventSearchParams params = mapper.map( requestParams );
 
         assertEquals( updatedAfter, params.getUpdatedAtStartDate() );
         assertEquals( updatedBefore, params.getUpdatedAtEndDate() );
@@ -353,14 +353,14 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
+        RequestParams requestParams = new RequestParams();
 
         Date enrolledBefore = parseDate( "2022-01-01" );
-        criteria.setEnrollmentEnrolledBefore( enrolledBefore );
+        requestParams.setEnrollmentEnrolledBefore( enrolledBefore );
         Date enrolledAfter = parseDate( "2022-02-01" );
-        criteria.setEnrollmentEnrolledAfter( enrolledAfter );
+        requestParams.setEnrollmentEnrolledAfter( enrolledAfter );
 
-        EventSearchParams params = mapper.map( criteria );
+        EventSearchParams params = mapper.map( requestParams );
 
         assertEquals( enrolledBefore, params.getEnrollmentEnrolledBefore() );
         assertEquals( enrolledAfter, params.getEnrollmentEnrolledAfter() );
@@ -371,14 +371,14 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
+        RequestParams requestParams = new RequestParams();
 
         Date enrolledBefore = parseDate( "2022-01-01" );
-        criteria.setEnrollmentOccurredBefore( enrolledBefore );
+        requestParams.setEnrollmentOccurredBefore( enrolledBefore );
         Date enrolledAfter = parseDate( "2022-02-01" );
-        criteria.setEnrollmentOccurredAfter( enrolledAfter );
+        requestParams.setEnrollmentOccurredAfter( enrolledAfter );
 
-        EventSearchParams params = mapper.map( criteria );
+        EventSearchParams params = mapper.map( requestParams );
 
         assertEquals( enrolledBefore, params.getEnrollmentOccurredBefore() );
         assertEquals( enrolledAfter, params.getEnrollmentOccurredAfter() );
@@ -389,13 +389,13 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
+        RequestParams requestParams = new RequestParams();
 
         OrderCriteria attributeOrder = OrderCriteria.of( TEA_1_UID, SortDirection.ASC );
         OrderCriteria unknownAttributeOrder = OrderCriteria.of( "unknownAtt1", SortDirection.ASC );
-        criteria.setOrder( List.of( attributeOrder, unknownAttributeOrder ) );
+        requestParams.setOrder( List.of( attributeOrder, unknownAttributeOrder ) );
 
-        EventSearchParams params = mapper.map( criteria );
+        EventSearchParams params = mapper.map( requestParams );
 
         assertAll(
             () -> assertContainsOnly( params.getAttributeOrders(),
@@ -408,11 +408,11 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
+        RequestParams requestParams = new RequestParams();
 
-        criteria.setEnrollments( Set.of( UID.of( "NQnuK2kLm6e" ) ) );
+        requestParams.setEnrollments( Set.of( UID.of( "NQnuK2kLm6e" ) ) );
 
-        EventSearchParams params = mapper.map( criteria );
+        EventSearchParams params = mapper.map( requestParams );
 
         assertEquals( Set.of( "NQnuK2kLm6e" ), params.getEnrollments() );
     }
@@ -422,10 +422,10 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setEvent( "XKrcfuM4Hcw;M4pNmLabtXl" );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setEvent( "XKrcfuM4Hcw;M4pNmLabtXl" );
 
-        EventSearchParams params = mapper.map( criteria );
+        EventSearchParams params = mapper.map( requestParams );
 
         assertEquals( Set.of( "XKrcfuM4Hcw", "M4pNmLabtXl" ), params.getEvents() );
     }
@@ -435,10 +435,10 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setEvents( Set.of( UID.of( "XKrcfuM4Hcw" ), UID.of( "M4pNmLabtXl" ) ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setEvents( Set.of( UID.of( "XKrcfuM4Hcw" ), UID.of( "M4pNmLabtXl" ) ) );
 
-        EventSearchParams params = mapper.map( criteria );
+        EventSearchParams params = mapper.map( requestParams );
 
         assertEquals( Set.of( "XKrcfuM4Hcw", "M4pNmLabtXl" ), params.getEvents() );
     }
@@ -448,9 +448,9 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
+        RequestParams requestParams = new RequestParams();
 
-        EventSearchParams params = mapper.map( criteria );
+        EventSearchParams params = mapper.map( requestParams );
 
         assertIsEmpty( params.getEvents() );
     }
@@ -460,11 +460,11 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setAssignedUser( "IsdLBTOBzMi;l5ab8q5skbB" );
-        criteria.setAssignedUserMode( AssignedUserSelectionMode.PROVIDED );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setAssignedUser( "IsdLBTOBzMi;l5ab8q5skbB" );
+        requestParams.setAssignedUserMode( AssignedUserSelectionMode.PROVIDED );
 
-        EventSearchParams params = mapper.map( criteria );
+        EventSearchParams params = mapper.map( requestParams );
 
         assertContainsOnly( Set.of( "IsdLBTOBzMi", "l5ab8q5skbB" ),
             params.getAssignedUserQueryParam().getAssignedUsers() );
@@ -476,11 +476,11 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setAssignedUsers( Set.of( UID.of( "IsdLBTOBzMi" ), UID.of( "l5ab8q5skbB" ) ) );
-        criteria.setAssignedUserMode( AssignedUserSelectionMode.PROVIDED );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setAssignedUsers( Set.of( UID.of( "IsdLBTOBzMi" ), UID.of( "l5ab8q5skbB" ) ) );
+        requestParams.setAssignedUserMode( AssignedUserSelectionMode.PROVIDED );
 
-        EventSearchParams params = mapper.map( criteria );
+        EventSearchParams params = mapper.map( requestParams );
 
         assertContainsOnly( Set.of( "IsdLBTOBzMi", "l5ab8q5skbB" ),
             params.getAssignedUserQueryParam().getAssignedUsers() );
@@ -490,12 +490,12 @@ class RequestParamsMapperTest
     @Test
     void testMutualExclusionOfEventsAndFilter()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setFilter( Set.of( "qrur9Dvnyt5:ge:1:le:2" ) );
-        criteria.setEvent( "XKrcfuM4Hcw;M4pNmLabtXl" );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setFilter( Set.of( "qrur9Dvnyt5:ge:1:le:2" ) );
+        requestParams.setEvent( "XKrcfuM4Hcw;M4pNmLabtXl" );
 
         Exception exception = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertEquals( "Event UIDs and filters can not be specified at the same time", exception.getMessage() );
     }
 
@@ -504,10 +504,10 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setOrder( OrderCriteria.fromOrderString( "createdAt:asc,programStage:desc,scheduledAt:asc" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setOrder( OrderCriteria.fromOrderString( "createdAt:asc,programStage:desc,scheduledAt:asc" ) );
 
-        EventSearchParams params = mapper.map( criteria );
+        EventSearchParams params = mapper.map( requestParams );
 
         assertContainsOnly( List.of(
             new OrderParam( "createdAt", SortDirection.ASC ),
@@ -518,12 +518,12 @@ class RequestParamsMapperTest
     @Test
     void shouldThrowWhenOrderParameterContainsUnsupportedField()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setOrder(
+        RequestParams requestParams = new RequestParams();
+        requestParams.setOrder(
             OrderCriteria.fromOrderString( "unsupportedProperty1:asc,enrolledAt:asc,unsupportedProperty2:desc" ) );
 
         Exception exception = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertAll(
             () -> assertStartsWith( "Order by property `", exception.getMessage() ),
             // order of properties might not always be the same; therefore using
@@ -537,10 +537,10 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setFilter( Set.of( DE_1_UID + ":eq:2", DE_2_UID + ":like:foo" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setFilter( Set.of( DE_1_UID + ":eq:2", DE_2_UID + ":like:foo" ) );
 
-        EventSearchParams params = mapper.map( criteria );
+        EventSearchParams params = mapper.map( requestParams );
 
         List<QueryItem> items = params.getFilters();
         assertNotNull( items );
@@ -572,10 +572,10 @@ class RequestParamsMapperTest
         ForbiddenException
     {
 
-        RequestParams criteria = new RequestParams();
-        criteria.setFilterAttributes( Set.of( TEA_1_UID + ":eq:2", TEA_2_UID + ":like:foo" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setFilterAttributes( Set.of( TEA_1_UID + ":eq:2", TEA_2_UID + ":like:foo" ) );
 
-        EventSearchParams params = mapper.map( criteria );
+        EventSearchParams params = mapper.map( requestParams );
 
         List<QueryItem> items = params.getFilterAttributes();
         assertNotNull( items );
@@ -606,10 +606,10 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setFilter( Set.of( DE_1_UID + ":gt:10:lt:20" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setFilter( Set.of( DE_1_UID + ":gt:10:lt:20" ) );
 
-        EventSearchParams params = mapper.map( criteria );
+        EventSearchParams params = mapper.map( requestParams );
 
         List<QueryItem> items = params.getFilters();
         assertNotNull( items );
@@ -631,10 +631,10 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setFilterAttributes( Set.of( TEA_1_UID + ":gt:10:lt:20" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setFilterAttributes( Set.of( TEA_1_UID + ":gt:10:lt:20" ) );
 
-        EventSearchParams params = mapper.map( criteria );
+        EventSearchParams params = mapper.map( requestParams );
 
         List<QueryItem> items = params.getFilterAttributes();
         assertNotNull( items );
@@ -654,13 +654,13 @@ class RequestParamsMapperTest
     @Test
     void shouldFailWithBadRequestExceptionWhenCriteriaDataElementDoesNotExist()
     {
-        RequestParams criteria = new RequestParams();
+        RequestParams requestParams = new RequestParams();
         String filterName = "filter";
-        criteria.setFilter( Set.of( filterName ) );
+        requestParams.setFilter( Set.of( filterName ) );
         when( dataElementService.getDataElement( filterName ) ).thenReturn( null );
 
         Exception exception = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
 
         assertEquals( "Data element does not exist: " + filterName, exception.getMessage() );
     }
@@ -668,12 +668,12 @@ class RequestParamsMapperTest
     @Test
     void testFilterAttributesWhenTEAUidIsDuplicated()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setFilterAttributes(
+        RequestParams requestParams = new RequestParams();
+        requestParams.setFilterAttributes(
             Set.of( "TvjwTPToKHO:lt:20", "cy2oRh2sNr6:lt:20", "TvjwTPToKHO:gt:30", "cy2oRh2sNr6:gt:30" ) );
 
         Exception exception = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertAll(
             () -> assertStartsWith( "filterAttributes contains duplicate tracked entity attribute",
                 exception.getMessage() ),
@@ -688,10 +688,10 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setFilterAttributes( Set.of( TEA_1_UID ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setFilterAttributes( Set.of( TEA_1_UID ) );
 
-        EventSearchParams params = mapper.map( criteria );
+        EventSearchParams params = mapper.map( requestParams );
 
         assertContainsOnly(
             List.of( new QueryItem( tea1, null, tea1.getValueType(), tea1.getAggregationType(), tea1.getOptionSet(),
@@ -702,14 +702,14 @@ class RequestParamsMapperTest
     @Test
     void shouldFailWithForbiddenExceptionWhenUserHasNoAccessToProgram()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setProgram( UID.of( program ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setProgram( UID.of( program ) );
         User user = new User();
         when( currentUserService.getCurrentUser() ).thenReturn( user );
         when( aclService.canDataRead( user, program ) ).thenReturn( false );
 
         Exception exception = assertThrows( ForbiddenException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
 
         assertEquals( "User has no access to program: " + program.getUid(), exception.getMessage() );
     }
@@ -717,14 +717,14 @@ class RequestParamsMapperTest
     @Test
     void shouldFailWithForbiddenExceptionWhenUserHasNoAccessToProgramStage()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setProgramStage( UID.of( programStage ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setProgramStage( UID.of( programStage ) );
         User user = new User();
         when( currentUserService.getCurrentUser() ).thenReturn( user );
         when( aclService.canDataRead( user, programStage ) ).thenReturn( false );
 
         Exception exception = assertThrows( ForbiddenException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
 
         assertEquals( "User has no access to program stage: " + programStage.getUid(), exception.getMessage() );
     }
@@ -732,18 +732,18 @@ class RequestParamsMapperTest
     @Test
     void shouldFailWithForbiddenExceptionWhenUserHasNoAccessToCategoryCombo()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setAttributeCc( UID.of( "NeU85luyD4w" ) );
-        criteria.setAttributeCos( "Cos" );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setAttributeCc( UID.of( "NeU85luyD4w" ) );
+        requestParams.setAttributeCos( "Cos" );
         CategoryOptionCombo combo = new CategoryOptionCombo();
         combo.setUid( "uid" );
-        when( categoryOptionComboService.getAttributeOptionCombo( "NeU85luyD4w", criteria.getAttributeCos(),
+        when( categoryOptionComboService.getAttributeOptionCombo( "NeU85luyD4w", requestParams.getAttributeCos(),
             true ) )
             .thenReturn( combo );
         when( aclService.canDataRead( any( User.class ), any( CategoryOptionCombo.class ) ) ).thenReturn( false );
 
         Exception exception = assertThrows( ForbiddenException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
 
         assertEquals( "User has no access to attribute category option combo: " + combo.getUid(),
             exception.getMessage() );

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RequestParamsTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RequestParamsTest.java
@@ -43,111 +43,101 @@ class RequestParamsTest
     void getIdentifierParamIfTrackedEntityIsSet()
         throws BadRequestException
     {
+        RequestParams requestParams = new RequestParams();
+        requestParams.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
 
-        RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
-
-        assertEquals( "Hq3Kc6HK4OZ", criteria.getIdentifierParam() );
-        assertEquals( "Hq3Kc6HK4OZ", criteria.getIdentifierParam(), "should return cached identifier" );
+        assertEquals( "Hq3Kc6HK4OZ", requestParams.getIdentifierParam() );
+        assertEquals( "Hq3Kc6HK4OZ", requestParams.getIdentifierParam(), "should return cached identifier" );
     }
 
     @Test
     void getIdentifierParamIfTeiIsSet()
         throws BadRequestException
     {
+        RequestParams requestParams = new RequestParams();
+        requestParams.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
 
-        RequestParams criteria = new RequestParams();
-        criteria.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
-
-        assertEquals( "Hq3Kc6HK4OZ", criteria.getIdentifierParam() );
+        assertEquals( "Hq3Kc6HK4OZ", requestParams.getIdentifierParam() );
     }
 
     @Test
     void getIdentifierNameIfTrackedEntityIsSet()
         throws BadRequestException
     {
+        RequestParams requestParams = new RequestParams();
+        requestParams.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
 
-        RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
-
-        assertEquals( "trackedEntity", criteria.getIdentifierName() );
+        assertEquals( "trackedEntity", requestParams.getIdentifierName() );
     }
 
     @Test
     void getIdentifierNameIfTeiIsSet()
         throws BadRequestException
     {
+        RequestParams requestParams = new RequestParams();
+        requestParams.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
 
-        RequestParams criteria = new RequestParams();
-        criteria.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
-
-        assertEquals( "trackedEntity", criteria.getIdentifierName() );
+        assertEquals( "trackedEntity", requestParams.getIdentifierName() );
     }
 
     @Test
     void getIdentifierClassIfTrackedEntityIsSet()
         throws BadRequestException
     {
+        RequestParams requestParams = new RequestParams();
+        requestParams.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
 
-        RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
-
-        assertEquals( TrackedEntity.class, criteria.getIdentifierClass() );
+        assertEquals( TrackedEntity.class, requestParams.getIdentifierClass() );
     }
 
     @Test
     void getIdentifierClassIfTeiIsSet()
         throws BadRequestException
     {
+        RequestParams requestParams = new RequestParams();
+        requestParams.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
 
-        RequestParams criteria = new RequestParams();
-        criteria.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
-
-        assertEquals( TrackedEntity.class, criteria.getIdentifierClass() );
+        assertEquals( TrackedEntity.class, requestParams.getIdentifierClass() );
     }
 
     @Test
     void getIdentifierParamIfEnrollmentIsSet()
         throws BadRequestException
     {
+        RequestParams requestParams = new RequestParams();
+        requestParams.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
 
-        RequestParams criteria = new RequestParams();
-        criteria.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
-
-        assertEquals( "Hq3Kc6HK4OZ", criteria.getIdentifierParam() );
+        assertEquals( "Hq3Kc6HK4OZ", requestParams.getIdentifierParam() );
     }
 
     @Test
     void getIdentifierNameIfEnrollmentIsSet()
         throws BadRequestException
     {
+        RequestParams requestParams = new RequestParams();
+        requestParams.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
 
-        RequestParams criteria = new RequestParams();
-        criteria.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
-
-        assertEquals( "enrollment", criteria.getIdentifierName() );
+        assertEquals( "enrollment", requestParams.getIdentifierName() );
     }
 
     @Test
     void getIdentifierClassIfEnrollmentIsSet()
         throws BadRequestException
     {
+        RequestParams requestParams = new RequestParams();
+        requestParams.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
 
-        RequestParams criteria = new RequestParams();
-        criteria.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
-
-        assertEquals( Enrollment.class, criteria.getIdentifierClass() );
+        assertEquals( Enrollment.class, requestParams.getIdentifierClass() );
     }
 
     @Test
     void getIdentifierParamIfEventIsSet()
         throws BadRequestException
     {
+        RequestParams requestParams = new RequestParams();
+        requestParams.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
 
-        RequestParams criteria = new RequestParams();
-        criteria.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
-
-        assertEquals( "Hq3Kc6HK4OZ", criteria.getIdentifierParam() );
+        assertEquals( "Hq3Kc6HK4OZ", requestParams.getIdentifierParam() );
     }
 
     @Test
@@ -155,29 +145,28 @@ class RequestParamsTest
         throws BadRequestException
     {
 
-        RequestParams criteria = new RequestParams();
-        criteria.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
 
-        assertEquals( "event", criteria.getIdentifierName() );
+        assertEquals( "event", requestParams.getIdentifierName() );
     }
 
     @Test
     void getIdentifierClassIfEventIsSet()
         throws BadRequestException
     {
+        RequestParams requestParams = new RequestParams();
+        requestParams.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
 
-        RequestParams criteria = new RequestParams();
-        criteria.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
-
-        assertEquals( Event.class, criteria.getIdentifierClass() );
+        assertEquals( Event.class, requestParams.getIdentifierClass() );
     }
 
     @Test
     void getIdentifierParamThrowsIfNoParamsIsSet()
     {
-        RequestParams criteria = new RequestParams();
+        RequestParams requestParams = new RequestParams();
 
-        BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierParam );
+        BadRequestException exception = assertThrows( BadRequestException.class, requestParams::getIdentifierParam );
 
         assertEquals( "Missing required parameter 'trackedEntity', 'enrollment' or 'event'.",
             exception.getMessage() );
@@ -186,9 +175,9 @@ class RequestParamsTest
     @Test
     void getIdentifierNameThrowsIfNoParamsIsSet()
     {
-        RequestParams criteria = new RequestParams();
+        RequestParams requestParams = new RequestParams();
 
-        BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierName );
+        BadRequestException exception = assertThrows( BadRequestException.class, requestParams::getIdentifierName );
 
         assertEquals( "Missing required parameter 'trackedEntity', 'enrollment' or 'event'.",
             exception.getMessage() );
@@ -197,13 +186,13 @@ class RequestParamsTest
     @Test
     void getIdentifierParamThrowsIfAllParamsAreSet()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
-        criteria.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
-        criteria.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
-        criteria.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
+        requestParams.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
+        requestParams.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
+        requestParams.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
 
-        BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierParam );
+        BadRequestException exception = assertThrows( BadRequestException.class, requestParams::getIdentifierParam );
 
         assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
             exception.getMessage() );
@@ -212,13 +201,13 @@ class RequestParamsTest
     @Test
     void getIdentifierNameThrowsIfAllParamsAreSet()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
-        criteria.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
-        criteria.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
-        criteria.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
+        requestParams.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
+        requestParams.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
+        requestParams.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
 
-        BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierName );
+        BadRequestException exception = assertThrows( BadRequestException.class, requestParams::getIdentifierName );
 
         assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
             exception.getMessage() );
@@ -227,13 +216,13 @@ class RequestParamsTest
     @Test
     void getIdentifierClassThrowsIfAllParamsAreSet()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
-        criteria.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
-        criteria.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
-        criteria.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
+        requestParams.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
+        requestParams.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
+        requestParams.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
 
-        BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierClass );
+        BadRequestException exception = assertThrows( BadRequestException.class, requestParams::getIdentifierClass );
 
         assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
             exception.getMessage() );
@@ -242,11 +231,11 @@ class RequestParamsTest
     @Test
     void getIdentifierParamThrowsIfTrackedEntityAndEnrollmentAreSet()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
-        criteria.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
+        requestParams.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
 
-        BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierParam );
+        BadRequestException exception = assertThrows( BadRequestException.class, requestParams::getIdentifierParam );
 
         assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
             exception.getMessage() );
@@ -255,11 +244,11 @@ class RequestParamsTest
     @Test
     void getIdentifierParamThrowsIfTeiAndEnrollmentAreSet()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
-        criteria.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
+        requestParams.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
 
-        BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierParam );
+        BadRequestException exception = assertThrows( BadRequestException.class, requestParams::getIdentifierParam );
 
         assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
             exception.getMessage() );
@@ -268,11 +257,11 @@ class RequestParamsTest
     @Test
     void getIdentifierClassThrowsIfTrackedEntityAndEnrollmentAreSet()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
-        criteria.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
+        requestParams.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
 
-        BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierClass );
+        BadRequestException exception = assertThrows( BadRequestException.class, requestParams::getIdentifierClass );
 
         assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
             exception.getMessage() );
@@ -281,11 +270,11 @@ class RequestParamsTest
     @Test
     void getIdentifierClassThrowsIfTeiAndEnrollmentAreSet()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
-        criteria.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
+        requestParams.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
 
-        BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierClass );
+        BadRequestException exception = assertThrows( BadRequestException.class, requestParams::getIdentifierClass );
 
         assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
             exception.getMessage() );
@@ -294,11 +283,11 @@ class RequestParamsTest
     @Test
     void getIdentifierParamThrowsIfEnrollmentAndEventAreSet()
     {
-        RequestParams criteria = new RequestParams();
-        criteria.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
-        criteria.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
+        RequestParams requestParams = new RequestParams();
+        requestParams.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
+        requestParams.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
 
-        BadRequestException exception = assertThrows( BadRequestException.class, criteria::getIdentifierParam );
+        BadRequestException exception = assertThrows( BadRequestException.class, requestParams::getIdentifierParam );
 
         assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
             exception.getMessage() );

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParamsMapperTest.java
@@ -90,7 +90,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 /**
- * Tests {@link TrackedEntityParamsMapper}.
+ * Tests {@link TrackedEntityRequestParamsMapper}.
  *
  * @author Luciano Fiandesio
  */
@@ -131,7 +131,7 @@ class RequestParamsMapperTest
     private TrackerAccessManager trackerAccessManager;
 
     @InjectMocks
-    private TrackedEntityParamsMapper mapper;
+    private TrackedEntityRequestParamsMapper mapper;
 
     private User user;
 
@@ -145,7 +145,7 @@ class RequestParamsMapperTest
 
     private TrackedEntityType trackedEntityType;
 
-    private RequestParams criteria;
+    private RequestParams requestParams;
 
     @BeforeEach
     public void setUp()
@@ -185,8 +185,8 @@ class RequestParamsMapperTest
         when( trackedEntityTypeService.getTrackedEntityType( TRACKED_ENTITY_TYPE_UID ) )
             .thenReturn( trackedEntityType );
 
-        criteria = new RequestParams();
-        criteria.setAssignedUserMode( AssignedUserSelectionMode.CURRENT );
+        requestParams = new RequestParams();
+        requestParams.setAssignedUserMode( AssignedUserSelectionMode.CURRENT );
     }
 
     @Test
@@ -194,29 +194,29 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        criteria.setQuery( "query-test" );
-        criteria.setOuMode( OrganisationUnitSelectionMode.DESCENDANTS );
-        criteria.setProgramStatus( ProgramStatus.ACTIVE );
-        criteria.setFollowUp( true );
-        criteria.setUpdatedAfter( getDate( 2019, 1, 1 ) );
-        criteria.setUpdatedBefore( getDate( 2020, 1, 1 ) );
-        criteria.setUpdatedWithin( "20" );
-        criteria.setEnrollmentOccurredAfter( getDate( 2019, 5, 5 ) );
-        criteria.setEnrollmentOccurredBefore( getDate( 2020, 5, 5 ) );
-        criteria.setTrackedEntityType( UID.of( TRACKED_ENTITY_TYPE_UID ) );
-        criteria.setEventStatus( EventStatus.COMPLETED );
-        criteria.setEventOccurredAfter( getDate( 2019, 7, 7 ) );
-        criteria.setEventOccurredBefore( getDate( 2020, 7, 7 ) );
-        criteria.setSkipMeta( true );
-        criteria.setPage( 1 );
-        criteria.setPageSize( 50 );
-        criteria.setTotalPages( false );
-        criteria.setSkipPaging( false );
-        criteria.setIncludeDeleted( true );
-        criteria.setIncludeAllAttributes( true );
-        criteria.setOrder( Collections.singletonList( OrderCriteria.of( "created", SortDirection.ASC ) ) );
+        requestParams.setQuery( "query-test" );
+        requestParams.setOuMode( OrganisationUnitSelectionMode.DESCENDANTS );
+        requestParams.setProgramStatus( ProgramStatus.ACTIVE );
+        requestParams.setFollowUp( true );
+        requestParams.setUpdatedAfter( getDate( 2019, 1, 1 ) );
+        requestParams.setUpdatedBefore( getDate( 2020, 1, 1 ) );
+        requestParams.setUpdatedWithin( "20" );
+        requestParams.setEnrollmentOccurredAfter( getDate( 2019, 5, 5 ) );
+        requestParams.setEnrollmentOccurredBefore( getDate( 2020, 5, 5 ) );
+        requestParams.setTrackedEntityType( UID.of( TRACKED_ENTITY_TYPE_UID ) );
+        requestParams.setEventStatus( EventStatus.COMPLETED );
+        requestParams.setEventOccurredAfter( getDate( 2019, 7, 7 ) );
+        requestParams.setEventOccurredBefore( getDate( 2020, 7, 7 ) );
+        requestParams.setSkipMeta( true );
+        requestParams.setPage( 1 );
+        requestParams.setPageSize( 50 );
+        requestParams.setTotalPages( false );
+        requestParams.setSkipPaging( false );
+        requestParams.setIncludeDeleted( true );
+        requestParams.setIncludeAllAttributes( true );
+        requestParams.setOrder( Collections.singletonList( OrderCriteria.of( "created", SortDirection.ASC ) ) );
 
-        final TrackedEntityQueryParams params = mapper.map( criteria );
+        final TrackedEntityQueryParams params = mapper.map( requestParams );
 
         assertThat( params.getQuery().getFilter(), is( "query-test" ) );
         assertThat( params.getQuery().getOperator(), is( QueryOperator.EQ ) );
@@ -227,14 +227,14 @@ class RequestParamsMapperTest
         assertThat( params.isTotalPages(), is( false ) );
         assertThat( params.getProgramStatus(), is( ProgramStatus.ACTIVE ) );
         assertThat( params.getFollowUp(), is( true ) );
-        assertThat( params.getLastUpdatedStartDate(), is( criteria.getUpdatedAfter() ) );
-        assertThat( params.getLastUpdatedEndDate(), is( criteria.getUpdatedBefore() ) );
-        assertThat( params.getProgramIncidentStartDate(), is( criteria.getEnrollmentOccurredAfter() ) );
+        assertThat( params.getLastUpdatedStartDate(), is( requestParams.getUpdatedAfter() ) );
+        assertThat( params.getLastUpdatedEndDate(), is( requestParams.getUpdatedBefore() ) );
+        assertThat( params.getProgramIncidentStartDate(), is( requestParams.getEnrollmentOccurredAfter() ) );
         assertThat( params.getProgramIncidentEndDate(),
-            is( DateUtils.addDays( criteria.getEnrollmentOccurredBefore(), 1 ) ) );
+            is( DateUtils.addDays( requestParams.getEnrollmentOccurredBefore(), 1 ) ) );
         assertThat( params.getEventStatus(), is( EventStatus.COMPLETED ) );
-        assertThat( params.getEventStartDate(), is( criteria.getEventOccurredAfter() ) );
-        assertThat( params.getEventEndDate(), is( criteria.getEventOccurredBefore() ) );
+        assertThat( params.getEventStartDate(), is( requestParams.getEventOccurredAfter() ) );
+        assertThat( params.getEventEndDate(), is( requestParams.getEventOccurredBefore() ) );
         assertThat( params.getAssignedUserQueryParam().getMode(), is( AssignedUserSelectionMode.PROVIDED ) );
         assertThat( params.isIncludeDeleted(), is( true ) );
         assertThat( params.isIncludeAllAttributes(), is( true ) );
@@ -247,7 +247,7 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        mapper.map( criteria );
+        mapper.map( requestParams );
 
         verifyNoInteractions( programService );
         verifyNoInteractions( trackedEntityTypeService );
@@ -259,9 +259,9 @@ class RequestParamsMapperTest
         ForbiddenException
     {
         Date date = parseDate( "2022-12-13" );
-        criteria.setEnrollmentEnrolledAfter( date );
+        requestParams.setEnrollmentEnrolledAfter( date );
 
-        TrackedEntityQueryParams params = mapper.map( criteria );
+        TrackedEntityQueryParams params = mapper.map( requestParams );
 
         assertEquals( date, params.getProgramEnrollmentStartDate() );
     }
@@ -272,9 +272,9 @@ class RequestParamsMapperTest
         ForbiddenException
     {
         Date date = parseDate( "2022-12-13" );
-        criteria.setEnrollmentEnrolledBefore( date );
+        requestParams.setEnrollmentEnrolledBefore( date );
 
-        TrackedEntityQueryParams params = mapper.map( criteria );
+        TrackedEntityQueryParams params = mapper.map( requestParams );
 
         assertEquals( DateUtils.addDays( date, 1 ), params.getProgramEnrollmentEndDate() );
     }
@@ -284,9 +284,9 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        criteria.setFilter( Set.of( TEA_1_UID + ":eq:2", TEA_2_UID + ":like:foo" ) );
+        requestParams.setFilter( Set.of( TEA_1_UID + ":eq:2", TEA_2_UID + ":like:foo" ) );
 
-        TrackedEntityQueryParams params = mapper.map( criteria );
+        TrackedEntityQueryParams params = mapper.map( requestParams );
 
         List<QueryItem> items = params.getFilters();
         assertNotNull( items );
@@ -317,9 +317,9 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        criteria.setFilter( Set.of( TEA_1_UID + ":gt:10:lt:20" ) );
+        requestParams.setFilter( Set.of( TEA_1_UID + ":gt:10:lt:20" ) );
 
-        TrackedEntityQueryParams params = mapper.map( criteria );
+        TrackedEntityQueryParams params = mapper.map( requestParams );
 
         List<QueryItem> items = params.getFilters();
         assertNotNull( items );
@@ -339,10 +339,10 @@ class RequestParamsMapperTest
     @Test
     void shouldFailWithBadExceptionWhenBadFormattedQueryProvided()
     {
-        criteria.setQuery( "wrong-query:" );
+        requestParams.setQuery( "wrong-query:" );
 
         BadRequestException e = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
 
         assertEquals( "Query has invalid format: wrong-query:", e.getMessage() );
     }
@@ -350,9 +350,9 @@ class RequestParamsMapperTest
     @Test
     void testFilterWhenTEAFilterIsRepeated()
     {
-        criteria.setFilter( Set.of( TEA_1_UID + ":gt:10", TEA_1_UID + ":lt:20" ) );
+        requestParams.setFilter( Set.of( TEA_1_UID + ":gt:10", TEA_1_UID + ":lt:20" ) );
 
-        BadRequestException e = assertThrows( BadRequestException.class, () -> mapper.map( criteria ) );
+        BadRequestException e = assertThrows( BadRequestException.class, () -> mapper.map( requestParams ) );
 
         assertStartsWith( "Filter for attribute TvjwTPToKHO was specified more than once.", e.getMessage() );
         assertThat( e.getMessage(), allOf( containsString( "GT:10" ), containsString( "LT:20" ) ) );
@@ -363,10 +363,10 @@ class RequestParamsMapperTest
     @Test
     void testFilterWhenMultipleTEAFiltersAreRepeated()
     {
-        criteria.setFilter( Set.of( TEA_1_UID + ":gt:10", TEA_1_UID + ":lt:20",
+        requestParams.setFilter( Set.of( TEA_1_UID + ":gt:10", TEA_1_UID + ":lt:20",
             TEA_2_UID + ":gt:30", TEA_2_UID + ":lt:40" ) );
 
-        BadRequestException e = assertThrows( BadRequestException.class, () -> mapper.map( criteria ) );
+        BadRequestException e = assertThrows( BadRequestException.class, () -> mapper.map( requestParams ) );
 
         assertThat( e.getMessage(),
             containsString( "Filter for attribute " + TEA_1_UID + " was specified more than once." ) );
@@ -385,9 +385,9 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        criteria.setAttribute( Set.of( TEA_1_UID, TEA_2_UID ) );
+        requestParams.setAttribute( Set.of( TEA_1_UID, TEA_2_UID ) );
 
-        TrackedEntityQueryParams params = mapper.map( criteria );
+        TrackedEntityQueryParams params = mapper.map( requestParams );
 
         List<QueryItem> items = params.getAttributes();
         assertNotNull( items );
@@ -400,20 +400,20 @@ class RequestParamsMapperTest
     @Test
     void testMappingAttributeWhenAttributeDoesNotExist()
     {
-        criteria.setAttribute( Set.of( TEA_1_UID, "unknown" ) );
+        requestParams.setAttribute( Set.of( TEA_1_UID, "unknown" ) );
 
         BadRequestException e = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertEquals( "Attribute does not exist: unknown", e.getMessage() );
     }
 
     @Test
     void testMappingFailsOnMissingAttribute()
     {
-        criteria.setAttribute( Set.of( TEA_1_UID, "unknown" ) );
+        requestParams.setAttribute( Set.of( TEA_1_UID, "unknown" ) );
 
         BadRequestException e = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertEquals( "Attribute does not exist: unknown", e.getMessage() );
     }
 
@@ -422,9 +422,9 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        criteria.setProgram( UID.of( PROGRAM_UID ) );
+        requestParams.setProgram( UID.of( PROGRAM_UID ) );
 
-        TrackedEntityQueryParams params = mapper.map( criteria );
+        TrackedEntityQueryParams params = mapper.map( requestParams );
 
         assertEquals( program, params.getProgram() );
     }
@@ -432,10 +432,10 @@ class RequestParamsMapperTest
     @Test
     void testMappingProgramNotFound()
     {
-        criteria.setProgram( UID.of( "NeU85luyD4w" ) );
+        requestParams.setProgram( UID.of( "NeU85luyD4w" ) );
 
         BadRequestException e = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertEquals( "Program is specified but does not exist: NeU85luyD4w", e.getMessage() );
     }
 
@@ -444,10 +444,10 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        criteria.setProgram( UID.of( PROGRAM_UID ) );
-        criteria.setProgramStage( UID.of( PROGRAM_STAGE_UID ) );
+        requestParams.setProgram( UID.of( PROGRAM_UID ) );
+        requestParams.setProgramStage( UID.of( PROGRAM_STAGE_UID ) );
 
-        TrackedEntityQueryParams params = mapper.map( criteria );
+        TrackedEntityQueryParams params = mapper.map( requestParams );
 
         assertEquals( programStage, params.getProgramStage() );
     }
@@ -455,20 +455,20 @@ class RequestParamsMapperTest
     @Test
     void testMappingProgramStageGivenWithoutProgram()
     {
-        criteria.setProgramStage( UID.of( PROGRAM_STAGE_UID ) );
+        requestParams.setProgramStage( UID.of( PROGRAM_STAGE_UID ) );
 
         BadRequestException e = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertEquals( "Program does not contain the specified programStage: " + PROGRAM_STAGE_UID, e.getMessage() );
     }
 
     @Test
     void testMappingProgramStageNotFound()
     {
-        criteria.setProgramStage( UID.of( "NeU85luyD4w" ) );
+        requestParams.setProgramStage( UID.of( "NeU85luyD4w" ) );
 
         BadRequestException e = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertEquals( "Program does not contain the specified programStage: NeU85luyD4w", e.getMessage() );
     }
 
@@ -477,9 +477,9 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        criteria.setTrackedEntityType( UID.of( TRACKED_ENTITY_TYPE_UID ) );
+        requestParams.setTrackedEntityType( UID.of( TRACKED_ENTITY_TYPE_UID ) );
 
-        TrackedEntityQueryParams params = mapper.map( criteria );
+        TrackedEntityQueryParams params = mapper.map( requestParams );
 
         assertEquals( trackedEntityType, params.getTrackedEntityType() );
     }
@@ -487,10 +487,10 @@ class RequestParamsMapperTest
     @Test
     void testMappingTrackedEntityTypeNotFound()
     {
-        criteria.setTrackedEntityType( UID.of( "NeU85luyD4w" ) );
+        requestParams.setTrackedEntityType( UID.of( "NeU85luyD4w" ) );
 
         BadRequestException e = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertEquals( "Tracked entity type is specified but does not exist: NeU85luyD4w", e.getMessage() );
     }
 
@@ -502,10 +502,10 @@ class RequestParamsMapperTest
     {
         when( trackerAccessManager.canAccess( user, program, orgUnit1 ) ).thenReturn( true );
         when( trackerAccessManager.canAccess( user, program, orgUnit2 ) ).thenReturn( true );
-        criteria.setOrgUnit( ORG_UNIT_1_UID + ";" + ORG_UNIT_2_UID );
-        criteria.setProgram( UID.of( PROGRAM_UID ) );
+        requestParams.setOrgUnit( ORG_UNIT_1_UID + ";" + ORG_UNIT_2_UID );
+        requestParams.setProgram( UID.of( PROGRAM_UID ) );
 
-        TrackedEntityQueryParams params = mapper.map( criteria );
+        TrackedEntityQueryParams params = mapper.map( requestParams );
 
         assertContainsOnly( Set.of( orgUnit1, orgUnit2 ), params.getOrganisationUnits() );
     }
@@ -513,10 +513,10 @@ class RequestParamsMapperTest
     @Test
     void testMappingOrgUnitNotFound()
     {
-        criteria.setOrgUnit( "NeU85luyD4w" );
+        requestParams.setOrgUnit( "NeU85luyD4w" );
 
         BadRequestException e = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertEquals( "Organisation unit does not exist: NeU85luyD4w", e.getMessage() );
     }
 
@@ -528,10 +528,10 @@ class RequestParamsMapperTest
     {
         when( trackerAccessManager.canAccess( user, program, orgUnit1 ) ).thenReturn( true );
         when( trackerAccessManager.canAccess( user, program, orgUnit2 ) ).thenReturn( true );
-        criteria.setOrgUnits( Set.of( UID.of( ORG_UNIT_1_UID ), UID.of( ORG_UNIT_2_UID ) ) );
-        criteria.setProgram( UID.of( PROGRAM_UID ) );
+        requestParams.setOrgUnits( Set.of( UID.of( ORG_UNIT_1_UID ), UID.of( ORG_UNIT_2_UID ) ) );
+        requestParams.setProgram( UID.of( PROGRAM_UID ) );
 
-        TrackedEntityQueryParams params = mapper.map( criteria );
+        TrackedEntityQueryParams params = mapper.map( requestParams );
 
         assertContainsOnly( Set.of( orgUnit1, orgUnit2 ), params.getOrganisationUnits() );
     }
@@ -539,10 +539,10 @@ class RequestParamsMapperTest
     @Test
     void testMappingOrgUnitsNotFound()
     {
-        criteria.setOrgUnits( Set.of( UID.of( "NeU85luyD4w" ) ) );
+        requestParams.setOrgUnits( Set.of( UID.of( "NeU85luyD4w" ) ) );
 
         BadRequestException e = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertEquals( "Organisation unit does not exist: NeU85luyD4w", e.getMessage() );
     }
 
@@ -552,10 +552,10 @@ class RequestParamsMapperTest
         when( organisationUnitService.isInUserHierarchy( orgUnit1.getUid(),
             user.getTeiSearchOrganisationUnitsWithFallback() ) ).thenReturn( false );
 
-        criteria.setOrgUnit( ORG_UNIT_1_UID );
+        requestParams.setOrgUnit( ORG_UNIT_1_UID );
 
         ForbiddenException e = assertThrows( ForbiddenException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertEquals( "User does not have access to organisation unit: " + ORG_UNIT_1_UID, e.getMessage() );
     }
 
@@ -564,10 +564,10 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        criteria.setAssignedUser( "IsdLBTOBzMi;l5ab8q5skbB" );
-        criteria.setAssignedUserMode( AssignedUserSelectionMode.PROVIDED );
+        requestParams.setAssignedUser( "IsdLBTOBzMi;l5ab8q5skbB" );
+        requestParams.setAssignedUserMode( AssignedUserSelectionMode.PROVIDED );
 
-        TrackedEntityQueryParams params = mapper.map( criteria );
+        TrackedEntityQueryParams params = mapper.map( requestParams );
 
         assertContainsOnly( Set.of( "IsdLBTOBzMi", "l5ab8q5skbB" ),
             params.getAssignedUserQueryParam().getAssignedUsers() );
@@ -579,10 +579,10 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        criteria.setAssignedUsers( Set.of( UID.of( "IsdLBTOBzMi" ), UID.of( "l5ab8q5skbB" ) ) );
-        criteria.setAssignedUserMode( AssignedUserSelectionMode.PROVIDED );
+        requestParams.setAssignedUsers( Set.of( UID.of( "IsdLBTOBzMi" ), UID.of( "l5ab8q5skbB" ) ) );
+        requestParams.setAssignedUserMode( AssignedUserSelectionMode.PROVIDED );
 
-        TrackedEntityQueryParams params = mapper.map( criteria );
+        TrackedEntityQueryParams params = mapper.map( requestParams );
 
         assertContainsOnly( Set.of( "IsdLBTOBzMi", "l5ab8q5skbB" ),
             params.getAssignedUserQueryParam().getAssignedUsers() );
@@ -596,9 +596,9 @@ class RequestParamsMapperTest
     {
         OrderCriteria order1 = OrderCriteria.of( "trackedEntity", SortDirection.ASC );
         OrderCriteria order2 = OrderCriteria.of( "createdAt", SortDirection.DESC );
-        criteria.setOrder( List.of( order1, order2 ) );
+        requestParams.setOrder( List.of( order1, order2 ) );
 
-        TrackedEntityQueryParams params = mapper.map( criteria );
+        TrackedEntityQueryParams params = mapper.map( requestParams );
 
         assertEquals( List.of(
             new OrderParam( "trackedEntity", SortDirection.ASC ),
@@ -610,7 +610,7 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        TrackedEntityQueryParams params = mapper.map( criteria );
+        TrackedEntityQueryParams params = mapper.map( requestParams );
 
         assertIsEmpty( params.getOrders() );
     }
@@ -619,10 +619,10 @@ class RequestParamsMapperTest
     void testMappingOrderParamsGivenInvalidField()
     {
         OrderCriteria order1 = OrderCriteria.of( "invalid", SortDirection.DESC );
-        criteria.setOrder( List.of( order1 ) );
+        requestParams.setOrder( List.of( order1 ) );
 
         BadRequestException e = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertEquals( "Invalid order property: invalid", e.getMessage() );
     }
 
@@ -631,8 +631,8 @@ class RequestParamsMapperTest
         throws BadRequestException,
         ForbiddenException
     {
-        criteria.setFilter( Set.of( TEA_2_UID + ":like:project:x:eq:2" ) );
-        TrackedEntityQueryParams params = mapper.map( criteria );
+        requestParams.setFilter( Set.of( TEA_2_UID + ":like:project:x:eq:2" ) );
+        TrackedEntityQueryParams params = mapper.map( requestParams );
 
         List<QueryFilter> actualFilters = params.getFilters().stream().flatMap( f -> f.getFilters().stream() )
             .collect( Collectors.toList() );
@@ -644,9 +644,9 @@ class RequestParamsMapperTest
     @Test
     void shouldThrowBadRequestWhenCriteriaFilterHasOperatorInWrongFormat()
     {
-        criteria.setFilter( Set.of( TEA_1_UID + ":lke:value" ) );
+        requestParams.setFilter( Set.of( TEA_1_UID + ":lke:value" ) );
         BadRequestException exception = assertThrows( BadRequestException.class,
-            () -> mapper.map( criteria ) );
+            () -> mapper.map( requestParams ) );
         assertEquals( "Query item or filter is invalid: " + TEA_1_UID + ":lke:value", exception.getMessage() );
     }
 
@@ -655,9 +655,9 @@ class RequestParamsMapperTest
         throws ForbiddenException,
         BadRequestException
     {
-        criteria.setFilter( Set.of( TEA_1_UID + ":gt:01-01-2000 00:00:01:lt:01-01-2001 00:00:01" ) );
+        requestParams.setFilter( Set.of( TEA_1_UID + ":gt:01-01-2000 00:00:01:lt:01-01-2001 00:00:01" ) );
 
-        List<QueryFilter> actualFilters = mapper.map( criteria ).getFilters().stream()
+        List<QueryFilter> actualFilters = mapper.map( requestParams ).getFilters().stream()
             .flatMap( f -> f.getFilters().stream() )
             .collect( Collectors.toList() );
 
@@ -671,9 +671,9 @@ class RequestParamsMapperTest
         throws ForbiddenException,
         BadRequestException
     {
-        criteria.setFilter( Set.of( TEA_1_UID + ":gt:01-01-2000:lt:01-01-2001" ) );
+        requestParams.setFilter( Set.of( TEA_1_UID + ":gt:01-01-2000:lt:01-01-2001" ) );
 
-        List<QueryFilter> actualFilters = mapper.map( criteria ).getFilters().stream()
+        List<QueryFilter> actualFilters = mapper.map( requestParams ).getFilters().stream()
             .flatMap( f -> f.getFilters().stream() )
             .collect( Collectors.toList() );
 
@@ -687,9 +687,9 @@ class RequestParamsMapperTest
         throws ForbiddenException,
         BadRequestException
     {
-        criteria.setFilter( Set.of( TEA_1_UID + ":gt:2020-01-01T00:00:00 +05:30:lt:2021-01-01T00:00:00 +05:30" ) );
+        requestParams.setFilter( Set.of( TEA_1_UID + ":gt:2020-01-01T00:00:00 +05:30:lt:2021-01-01T00:00:00 +05:30" ) );
 
-        List<QueryFilter> actualFilters = mapper.map( criteria ).getFilters().stream()
+        List<QueryFilter> actualFilters = mapper.map( requestParams ).getFilters().stream()
             .flatMap( f -> f.getFilters().stream() )
             .collect( Collectors.toList() );
 
@@ -703,10 +703,10 @@ class RequestParamsMapperTest
         throws ForbiddenException,
         BadRequestException
     {
-        criteria
+        requestParams
             .setFilter( Set.of( TEA_1_UID + ":ge:2020-01-01T00:00:00.001 +05:30:le:2021-01-01T00:00:00.001 +05:30" ) );
 
-        List<QueryFilter> actualFilters = mapper.map( criteria ).getFilters().stream()
+        List<QueryFilter> actualFilters = mapper.map( requestParams ).getFilters().stream()
             .flatMap( f -> f.getFilters().stream() )
             .collect( Collectors.toList() );
 
@@ -718,18 +718,18 @@ class RequestParamsMapperTest
     @Test
     void shouldFailIfGivenOrgUnitAndOrgUnits()
     {
-        criteria.setOrgUnit( "IsdLBTOBzMi" );
-        criteria.setOrgUnits( Set.of( UID.of( "IsdLBTOBzMi" ) ) );
+        requestParams.setOrgUnit( "IsdLBTOBzMi" );
+        requestParams.setOrgUnits( Set.of( UID.of( "IsdLBTOBzMi" ) ) );
 
-        assertThrows( IllegalArgumentException.class, () -> mapper.map( criteria ) );
+        assertThrows( IllegalArgumentException.class, () -> mapper.map( requestParams ) );
     }
 
     @Test
     void shouldFailIfGivenTrackedEntityAndTrackedEntities()
     {
-        criteria.setTrackedEntity( "IsdLBTOBzMi" );
-        criteria.setTrackedEntities( Set.of( UID.of( "IsdLBTOBzMi" ) ) );
+        requestParams.setTrackedEntity( "IsdLBTOBzMi" );
+        requestParams.setTrackedEntities( Set.of( UID.of( "IsdLBTOBzMi" ) ) );
 
-        assertThrows( IllegalArgumentException.class, () -> mapper.map( criteria ) );
+        assertThrows( IllegalArgumentException.class, () -> mapper.map( requestParams ) );
     }
 }


### PR DESCRIPTION
## Why

Large OpenAPI specs cannot be used easily by tools such as Intellij, sometimes not at all. Since DHIS2 has many APIs we should make sure to create the smallest possible OpenAPI spec. We can achieve that by using references to specs that are only declared once. In DHIS2 we achieve that by annotating with `@OpenAPI.Shared`.

## What

* Annotate with `@OpenAPI.Shared` giving the `RequestParams` a unique name so that we do not have any conflicts in the OpenAPI spec
* Consistently name mappers with the prefix of the params class they are mapping.
* Consistently name tests with the class name and Test suffix so we can jump between implementation and test
* Make classes package-private as our OpenAPI generation and Spring are ok with it

I tried moving the `EnrollmentRequestParams` into the controller as its only used there. For now I find it easier to navigate with them being a separate class as we have the according mapper classes with the same prefix. It might make sense after refactoring our controller -> service boundaries.

This is how the spec then looks like

![image](https://github.com/dhis2/dhis2-core/assets/4661144/597c22e0-1d1c-45fe-8738-3560e15db59a)
