### PR TITLE
fix: use json-tree v0.8

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/common/ImportSummariesResponseExtractor.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/common/ImportSummariesResponseExtractor.java
@@ -32,9 +32,8 @@ import java.nio.charset.StandardCharsets;
 
 import org.hisp.dhis.commons.jackson.config.JacksonObjectMapperConfig;
 import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
+import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.jsontree.JsonObject;
-import org.hisp.dhis.jsontree.JsonResponse;
-import org.hisp.dhis.jsontree.JsonTypedAccess;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.web.client.ResponseExtractor;
 
@@ -51,8 +50,7 @@ public class ImportSummariesResponseExtractor implements ResponseExtractor<Impor
     public ImportSummaries extractData( ClientHttpResponse response )
         throws IOException
     {
-        JsonObject body = new JsonResponse( new String( response.getBody().readAllBytes(), StandardCharsets.UTF_8 ),
-            JsonTypedAccess.GLOBAL );
+        JsonObject body = JsonMixed.of( new String( response.getBody().readAllBytes(), StandardCharsets.UTF_8 ) );
         // auto-detect if it is wrapped in a WebMessage envelope
         if ( body.has( "httpStatus", "response" ) ) // is a WebMessage wrapper
         {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/common/ImportSummaryResponseExtractor.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/common/ImportSummaryResponseExtractor.java
@@ -32,9 +32,8 @@ import java.nio.charset.StandardCharsets;
 
 import org.hisp.dhis.commons.jackson.config.JacksonObjectMapperConfig;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
+import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.jsontree.JsonObject;
-import org.hisp.dhis.jsontree.JsonResponse;
-import org.hisp.dhis.jsontree.JsonTypedAccess;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.web.client.ResponseExtractor;
 
@@ -59,8 +58,7 @@ public class ImportSummaryResponseExtractor implements ResponseExtractor<ImportS
     public ImportSummary extractData( ClientHttpResponse response )
         throws IOException
     {
-        JsonObject body = new JsonResponse( new String( response.getBody().readAllBytes(), StandardCharsets.UTF_8 ),
-            JsonTypedAccess.GLOBAL );
+        JsonObject body = JsonMixed.of( new String( response.getBody().readAllBytes(), StandardCharsets.UTF_8 ) );
         // auto-detect if it is wrapped in a WebMessage envelope
         if ( body.has( "httpStatus", "response" ) ) // is a WebMessage wrapper
         {

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/h2/H2SqlFunction.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/h2/H2SqlFunction.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.h2;
 
-import static org.hisp.dhis.jsontree.JsonTypedAccess.GLOBAL;
-
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -39,8 +37,8 @@ import javax.sql.DataSource;
 
 import lombok.extern.slf4j.Slf4j;
 
-import org.hisp.dhis.jsontree.JsonDocument.JsonNodeType;
-import org.hisp.dhis.jsontree.JsonResponse;
+import org.hisp.dhis.jsontree.JsonMixed;
+import org.hisp.dhis.jsontree.JsonNodeType;
 import org.hisp.dhis.jsontree.JsonString;
 import org.hisp.dhis.jsontree.JsonValue;
 import org.postgresql.util.PGobject;
@@ -107,7 +105,7 @@ public class H2SqlFunction
             {
                 return null;
             }
-            JsonValue value = new JsonResponse( content, GLOBAL ).get( toJsonPath( paths ) );
+            JsonValue value = JsonMixed.of( content ).get( toJsonPath( paths ) );
             if ( !value.exists() )
             {
                 return null;
@@ -136,7 +134,7 @@ public class H2SqlFunction
             {
                 return null;
             }
-            JsonValue value = new JsonResponse( content, GLOBAL ).get( toJsonPath( paths ) );
+            JsonValue value = JsonMixed.of( content ).get( toJsonPath( paths ) );
             if ( !value.exists() )
             {
                 return null;

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/web/WebClient.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/web/WebClient.java
@@ -46,8 +46,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.hisp.dhis.jsontree.JsonResponse;
-import org.hisp.dhis.jsontree.JsonTypedAccess;
+import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.jsontree.JsonValue;
 import org.hisp.dhis.webapi.json.domain.JsonError;
 
@@ -306,18 +305,18 @@ public interface WebClient
             return failOnException( response::getContent );
         }
 
-        public JsonResponse content()
+        public JsonMixed content()
         {
             return content( HttpStatus.Series.SUCCESSFUL );
         }
 
-        public JsonResponse content( HttpStatus.Series expected )
+        public JsonMixed content( HttpStatus.Series expected )
         {
             assertSeries( expected, this );
             return contentUnchecked();
         }
 
-        public JsonResponse content( HttpStatus expected )
+        public JsonMixed content( HttpStatus expected )
         {
             assertStatus( expected, this );
             return contentUnchecked();
@@ -364,9 +363,9 @@ public interface WebClient
             return !response.getContent().isEmpty();
         }
 
-        public JsonResponse contentUnchecked()
+        public JsonMixed contentUnchecked()
         {
-            return failOnException( () -> new JsonResponse( response.getContent(), JsonTypedAccess.GLOBAL ) );
+            return failOnException( () -> JsonMixed.of( response.getContent() ) );
         }
 
         public String location()

--- a/dhis-2/dhis-support/dhis-support-test/src/test/java/org/hisp/dhis/webapi/json/domain/DomainJsonResponseTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/test/java/org/hisp/dhis/webapi/json/domain/DomainJsonResponseTest.java
@@ -34,14 +34,13 @@ import java.time.LocalDateTime;
 
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonMap;
+import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.jsontree.JsonObject;
-import org.hisp.dhis.jsontree.JsonResponse;
-import org.hisp.dhis.jsontree.JsonTypedAccess;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests the {@link JsonResponse} with domain specific cases.
+ * Tests the {@link JsonMixed} with domain specific cases.
  *
  * @author Jan Bernitt
  */
@@ -117,8 +116,8 @@ class DomainJsonResponseTest
             response.as( JsonError.class ).summary() );
     }
 
-    private JsonResponse createJSON( String content )
+    private JsonMixed createJSON( String content )
     {
-        return new JsonResponse( content.replace( '\'', '"' ), JsonTypedAccess.GLOBAL );
+        return JsonMixed.of( content.replace( '\'', '"' ) );
     }
 }

--- a/dhis-2/dhis-test-e2e/pom.xml
+++ b/dhis-2/dhis-test-e2e/pom.xml
@@ -20,7 +20,7 @@
     <rest-assured.version>5.3.0</rest-assured.version>
     <jackson.version>2.15.1</jackson.version>
     <guava.version>31.1-jre</guava.version>
-    <json-tree.version>0.6.0</json-tree.version>
+    <json-tree.version>0.8.0</json-tree.version>
     <epam-reportportal.version>5.1.6</epam-reportportal.version>
     <javafaker.version>1.0.2</javafaker.version>
     <opencsv.version>4.5</opencsv.version>

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/dto/ApiResponse.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/dto/ApiResponse.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.helpers.JsonObjectBuilder;
-import org.hisp.dhis.jsontree.JsonResponse;
+import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.jsontree.JsonTypedAccess;
 
 import com.google.gson.JsonObject;
@@ -150,9 +150,9 @@ public class ApiResponse
         return new JsonObjectBuilder( getBody() );
     }
 
-    public JsonResponse getBodyAsJson()
+    public JsonMixed getBodyAsJson()
     {
-        return new JsonResponse( raw.asString(), JsonTypedAccess.GLOBAL );
+        return JsonMixed.of( raw.asString(), JsonTypedAccess.GLOBAL );
     }
 
     public boolean isEntityCreated()

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/DhisControllerConvenienceTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/DhisControllerConvenienceTest.java
@@ -33,7 +33,6 @@ import org.hisp.dhis.IntegrationH2Test;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.config.ConfigProviderConfiguration;
 import org.hisp.dhis.dbms.DbmsManager;
-import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
@@ -52,7 +51,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 /**
  * Base class for convenient testing of the web API on basis of
- * {@link JsonResponse}.
+ * {@link org.hisp.dhis.jsontree.JsonMixed} responses.
  *
  * @author Jan Bernitt
  */

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/DhisControllerWithApiTokenAuthTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/DhisControllerWithApiTokenAuthTest.java
@@ -31,7 +31,6 @@ import static org.hisp.dhis.web.WebClientUtils.failOnException;
 
 import org.hisp.dhis.IntegrationH2Test;
 import org.hisp.dhis.config.ConfigProviderConfiguration;
-import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.utils.TestUtils;
@@ -53,10 +52,11 @@ import org.springframework.web.context.WebApplicationContext;
 
 /**
  * Base class for convenient testing of the web API on basis of
- * {@link JsonResponse}, with API tokens. This class differs from
- * {@link DhisControllerConvenienceTest} in that this base class also includes
- * the {@link FilterChainProxy} so that we can authenticate the request like it
- * would in a normal running server.
+ * {@link org.hisp.dhis.jsontree.JsonMixed} responses, with API tokens.
+ * <p>
+ * This class differs from {@link DhisControllerConvenienceTest} in that this
+ * base class also includes the {@link FilterChainProxy} so that we can
+ * authenticate the request like it would in a normal running server.
  *
  * @author Morten Svanæs
  */

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/DhisControllerWithJwtTokenAuthTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/DhisControllerWithJwtTokenAuthTest.java
@@ -33,7 +33,6 @@ import javax.sql.DataSource;
 
 import org.hisp.dhis.IntegrationH2Test;
 import org.hisp.dhis.h2.H2SqlFunction;
-import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.utils.TestUtils;
@@ -55,7 +54,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 /**
  * Base class for convenient testing of the web API on basis of
- * {@link JsonResponse}, with JWT token
+ * {@link org.hisp.dhis.jsontree.JsonMixed} responses, with JWT token
  *
  * @author Morten Svanæs
  */

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
@@ -50,7 +50,6 @@ import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
-import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
@@ -144,7 +143,7 @@ class AbstractCrudControllerTest extends DhisControllerConvenienceTest
             POST( "/dataSets/", "{'name':'My data set', 'shortName':'MDS', 'periodType':'Monthly',"
                 + "'organisationUnits':[{'id':'" + ou1 + "'},{'id':'" + ou2 + "'}]}" ) );
 
-        JsonResponse dataSet = GET( "/dataSets/{id}", dsId ).content();
+        JsonObject dataSet = GET( "/dataSets/{id}", dsId ).content();
         assertEquals( 2, dataSet.getArray( "organisationUnits" ).size() );
 
         assertStatus( HttpStatus.OK, PATCH( "/dataSets/" + dsId,
@@ -321,7 +320,7 @@ class AbstractCrudControllerTest extends DhisControllerConvenienceTest
         assertStatus( HttpStatus.OK, PATCH( "/dataSets/" + dsId,
             "[{'op': 'add', 'path': '/sharing/userGroups/ZoHNWQajIoe', 'value': { 'access': 'rw------', 'id': 'ZoHNWQajIoe' } }]" ) );
 
-        JsonResponse dataSet = GET( "/dataSets/{id}", dsId ).content();
+        JsonObject dataSet = GET( "/dataSets/{id}", dsId ).content();
         assertNotNull( dataSet.getObject( "sharing" ).getObject( "userGroups" ).getObject( "th4S6ovwcr8" ) );
         assertNotNull( dataSet.getObject( "sharing" ).getObject( "userGroups" ).getObject( "ZoHNWQajIoe" ) );
     }
@@ -331,7 +330,7 @@ class AbstractCrudControllerTest extends DhisControllerConvenienceTest
     {
         String peter = "{'name': 'Peter', 'firstName':'Peter', 'surname':'Pan', 'username':'peter47', 'userRoles': [{'id': 'yrB6vc5Ip3r'}]}";
         String peterUserId = assertStatus( HttpStatus.CREATED, POST( "/users", peter ) );
-        JsonResponse roles = GET( "/userRoles?fields=id" ).content();
+        JsonObject roles = GET( "/userRoles?fields=id" ).content();
         String roleId = roles.getArray( "userRoles" ).getObject( 0 ).getString( "id" ).string();
         assertStatus( HttpStatus.NO_CONTENT, POST( "/userRoles/" + roleId + "/users/" + peterUserId ) );
         JsonUser oldPeter = GET( "/users/{id}", peterUserId ).content().as( JsonUser.class );
@@ -353,7 +352,7 @@ class AbstractCrudControllerTest extends DhisControllerConvenienceTest
     {
         String peter = "{'name': 'Peter', 'firstName':'Peter', 'surname':'Pan', 'username':'peter47', 'userRoles': [{'id': 'yrB6vc5Ip3r'}]}";
         String peterUserId = assertStatus( HttpStatus.CREATED, POST( "/users", peter ) );
-        JsonResponse roles = GET( "/userRoles?fields=id" ).content();
+        JsonObject roles = GET( "/userRoles?fields=id" ).content();
         String roleId = roles.getArray( "userRoles" ).getObject( 0 ).getString( "id" ).string();
         assertStatus( HttpStatus.NO_CONTENT, POST( "/userRoles/" + roleId + "/users/" + peterUserId ) );
         JsonUser oldPeter = GET( "/users/{id}", peterUserId ).content().as( JsonUser.class );

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Set;
 
-import org.hisp.dhis.jsontree.JsonResponse;
+import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.user.User;
@@ -138,9 +138,9 @@ class AccountControllerTest extends DhisControllerConvenienceTest
             POST( "/account/validatePassword?password=xyz" ).content( HttpStatus.OK ) );
     }
 
-    private static void assertMessage( String key, String value, String message, JsonResponse response )
+    private static void assertMessage( String key, String value, String message, JsonMixed response )
     {
-        assertContainsOnly( Set.of( key, "message" ), response.node().members().keySet() );
+        assertContainsOnly( Set.of( key, "message" ), response.names() );
         assertEquals( value, response.getString( key ).string() );
         assertEquals( message, response.getString( "message" ).string() );
     }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
@@ -38,7 +38,7 @@ import java.util.Optional;
 import org.hisp.dhis.dashboard.Dashboard;
 import org.hisp.dhis.dashboard.DashboardItem;
 import org.hisp.dhis.feedback.ErrorCode;
-import org.hisp.dhis.jsontree.JsonResponse;
+import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.visualization.Visualization;
@@ -74,7 +74,7 @@ class DashboardControllerTest extends DhisControllerIntegrationTest
         assertFalse( aclService.canRead( userA, visualization ) );
 
         // Add one more DashboardItem to the created Dashboard
-        JsonResponse response = PUT( "/dashboards/f1OijtLnf8a", Body( "dashboard/update_dashboard.json" ) )
+        JsonMixed response = PUT( "/dashboards/f1OijtLnf8a", Body( "dashboard/update_dashboard.json" ) )
             .content( HttpStatus.CONFLICT );
         assertEquals(
             "DashboardItem `KnmKNIFiAwC` object reference `VISUALIZATION` with id `gyYXi0rXAIc` not found or not accessible",

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityReportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityReportControllerTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
-import org.hisp.dhis.jsontree.JsonDocument.JsonNodeType;
+import org.hisp.dhis.jsontree.JsonNodeType;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonString;
 import org.hisp.dhis.organisationunit.OrganisationUnit;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/EventChartControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/EventChartControllerTest.java
@@ -28,17 +28,13 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
 import static org.hisp.dhis.web.HttpStatus.CREATED;
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
-
-import java.util.Map;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.jsontree.JsonNode;
-import org.hisp.dhis.jsontree.JsonResponse;
+import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -77,13 +73,10 @@ class EventChartControllerTest extends DhisControllerConvenienceTest
         final String uid = assertStatus( CREATED, POST( "/eventCharts/", body ) );
 
         // Then
-        final JsonResponse response = GET( "/eventVisualizations/" + uid ).content();
+        final JsonObject response = GET( "/eventVisualizations/" + uid ).content();
 
-        @SuppressWarnings( "unchecked" )
-        final Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
-
-        assertThat( nodeMap.get( "name" ).toString(), containsString( "Name Test" ) );
-        assertThat( nodeMap.get( "type" ).toString(), containsString( "GAUGE" ) );
+        assertThat( response.get( "name" ).toString(), containsString( "Name Test" ) );
+        assertThat( response.get( "type" ).toString(), containsString( "GAUGE" ) );
     }
 
     @Test
@@ -97,11 +90,6 @@ class EventChartControllerTest extends DhisControllerConvenienceTest
         final String uid = assertStatus( CREATED, POST( "/eventVisualizations/", body ) );
 
         // Then
-        final JsonResponse response = GET( "/eventCharts/" + uid ).content();
-
-        @SuppressWarnings( "unchecked" )
-        final Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
-
-        assertThat( nodeMap.values(), is( empty() ) );
+        assertTrue( GET( "/eventCharts/" + uid ).content().isEmpty() );
     }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/EventReportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/EventReportControllerTest.java
@@ -28,20 +28,16 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
 import static org.hisp.dhis.web.HttpStatus.BAD_REQUEST;
 import static org.hisp.dhis.web.HttpStatus.CREATED;
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.util.Map;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.jsontree.JsonNode;
-import org.hisp.dhis.jsontree.JsonResponse;
+import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -70,7 +66,6 @@ class EventReportControllerTest extends DhisControllerConvenienceTest
     }
 
     @Test
-    @SuppressWarnings( "unchecked" )
     void testPostForSingleEventDate()
     {
         // Given
@@ -85,19 +80,17 @@ class EventReportControllerTest extends DhisControllerConvenienceTest
         final String uid = assertStatus( CREATED, POST( "/eventReports/", body ) );
 
         // Then
-        final JsonResponse response = GET( "/eventVisualizations/" + uid ).content();
-        final Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
+        final JsonObject response = GET( "/eventVisualizations/" + uid ).content();
 
-        assertThat( nodeMap.get( "simpleDimensions" ).toString(), containsString( "COLUMN" ) );
-        assertThat( nodeMap.get( "simpleDimensions" ).toString(), containsString( eventDateDimension ) );
-        assertThat( nodeMap.get( "simpleDimensions" ).toString(), containsString( eventDate ) );
-        assertThat( nodeMap.get( "columns" ).toString(), containsString( eventDateDimension ) );
-        assertThat( nodeMap.get( "rows" ).toString(), not( containsString( eventDateDimension ) ) );
-        assertThat( nodeMap.get( "filters" ).toString(), not( containsString( eventDateDimension ) ) );
+        assertThat( response.get( "simpleDimensions" ).toString(), containsString( "COLUMN" ) );
+        assertThat( response.get( "simpleDimensions" ).toString(), containsString( eventDateDimension ) );
+        assertThat( response.get( "simpleDimensions" ).toString(), containsString( eventDate ) );
+        assertThat( response.get( "columns" ).toString(), containsString( eventDateDimension ) );
+        assertThat( response.get( "rows" ).toString(), not( containsString( eventDateDimension ) ) );
+        assertThat( response.get( "filters" ).toString(), not( containsString( eventDateDimension ) ) );
     }
 
     @Test
-    @SuppressWarnings( "unchecked" )
     void testPostForMultiEventDates()
     {
         // Given
@@ -117,18 +110,17 @@ class EventReportControllerTest extends DhisControllerConvenienceTest
         final String uid = assertStatus( CREATED, POST( "/eventReports/", body ) );
 
         // Then
-        final JsonResponse response = GET( "/eventReports/" + uid ).content();
-        final Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
+        final JsonObject response = GET( "/eventReports/" + uid ).content();
 
-        assertThat( nodeMap.get( "simpleDimensions" ).toString(), containsString( "ROW" ) );
-        assertThat( nodeMap.get( "simpleDimensions" ).toString(), containsString( eventDate ) );
-        assertThat( nodeMap.get( "simpleDimensions" ).toString(), containsString( incidentDate ) );
-        assertThat( nodeMap.get( "rows" ).toString(), containsString( eventDateDimension ) );
-        assertThat( nodeMap.get( "rows" ).toString(), containsString( incidentDateDimension ) );
-        assertThat( nodeMap.get( "columns" ).toString(), not( containsString( eventDateDimension ) ) );
-        assertThat( nodeMap.get( "columns" ).toString(), not( containsString( incidentDateDimension ) ) );
-        assertThat( nodeMap.get( "filters" ).toString(), not( containsString( eventDateDimension ) ) );
-        assertThat( nodeMap.get( "filters" ).toString(), not( containsString( incidentDateDimension ) ) );
+        assertThat( response.get( "simpleDimensions" ).toString(), containsString( "ROW" ) );
+        assertThat( response.get( "simpleDimensions" ).toString(), containsString( eventDate ) );
+        assertThat( response.get( "simpleDimensions" ).toString(), containsString( incidentDate ) );
+        assertThat( response.get( "rows" ).toString(), containsString( eventDateDimension ) );
+        assertThat( response.get( "rows" ).toString(), containsString( incidentDateDimension ) );
+        assertThat( response.get( "columns" ).toString(), not( containsString( eventDateDimension ) ) );
+        assertThat( response.get( "columns" ).toString(), not( containsString( incidentDateDimension ) ) );
+        assertThat( response.get( "filters" ).toString(), not( containsString( eventDateDimension ) ) );
+        assertThat( response.get( "filters" ).toString(), not( containsString( incidentDateDimension ) ) );
     }
 
     @Test
@@ -151,7 +143,6 @@ class EventReportControllerTest extends DhisControllerConvenienceTest
     }
 
     @Test
-    @SuppressWarnings( "unchecked" )
     void testThatGetEventVisualizationsContainsLegacyEventReports()
     {
         // Given
@@ -162,15 +153,13 @@ class EventReportControllerTest extends DhisControllerConvenienceTest
         final String uid = assertStatus( CREATED, POST( "/eventReports/", body ) );
 
         // Then
-        final JsonResponse response = GET( "/eventVisualizations/" + uid ).content();
-        final Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
+        final JsonObject response = GET( "/eventVisualizations/" + uid ).content();
 
-        assertThat( nodeMap.get( "name" ).toString(), containsString( "Name Test" ) );
-        assertThat( nodeMap.get( "type" ).toString(), containsString( "LINE_LIST" ) );
+        assertThat( response.get( "name" ).toString(), containsString( "Name Test" ) );
+        assertThat( response.get( "type" ).toString(), containsString( "LINE_LIST" ) );
     }
 
     @Test
-    @SuppressWarnings( "unchecked" )
     void testThatGetEventReportsDoesNotContainNewEventVisualizations()
     {
         // Given
@@ -181,9 +170,6 @@ class EventReportControllerTest extends DhisControllerConvenienceTest
         final String uid = assertStatus( CREATED, POST( "/eventVisualizations/", body ) );
 
         // Then
-        final JsonResponse response = GET( "/eventReports/" + uid ).content();
-        final Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
-
-        assertThat( nodeMap.values(), is( empty() ) );
+        assertTrue( GET( "/eventReports/" + uid ).content().isEmpty() );
     }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/EventVisualizationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/EventVisualizationControllerTest.java
@@ -35,11 +35,8 @@ import static org.hisp.dhis.web.HttpStatus.CREATED;
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Map;
-
 import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.jsontree.JsonNode;
-import org.hisp.dhis.jsontree.JsonResponse;
+import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -67,7 +64,6 @@ class EventVisualizationControllerTest extends DhisControllerConvenienceTest
     }
 
     @Test
-    @SuppressWarnings( "unchecked" )
     void testPostForSingleEventDate()
     {
         // Given
@@ -82,19 +78,17 @@ class EventVisualizationControllerTest extends DhisControllerConvenienceTest
         final String uid = assertStatus( CREATED, POST( "/eventVisualizations/", body ) );
 
         // Then
-        final JsonResponse response = GET( "/eventVisualizations/" + uid ).content();
-        final Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
+        final JsonObject response = GET( "/eventVisualizations/" + uid ).content();
 
-        assertThat( nodeMap.get( "simpleDimensions" ).toString(), containsString( "COLUMN" ) );
-        assertThat( nodeMap.get( "simpleDimensions" ).toString(), containsString( eventDateDimension ) );
-        assertThat( nodeMap.get( "simpleDimensions" ).toString(), containsString( eventDate ) );
-        assertThat( nodeMap.get( "columns" ).toString(), containsString( eventDateDimension ) );
-        assertThat( nodeMap.get( "rows" ).toString(), not( containsString( eventDateDimension ) ) );
-        assertThat( nodeMap.get( "filters" ).toString(), not( containsString( eventDateDimension ) ) );
+        assertThat( response.get( "simpleDimensions" ).toString(), containsString( "COLUMN" ) );
+        assertThat( response.get( "simpleDimensions" ).toString(), containsString( eventDateDimension ) );
+        assertThat( response.get( "simpleDimensions" ).toString(), containsString( eventDate ) );
+        assertThat( response.get( "columns" ).toString(), containsString( eventDateDimension ) );
+        assertThat( response.get( "rows" ).toString(), not( containsString( eventDateDimension ) ) );
+        assertThat( response.get( "filters" ).toString(), not( containsString( eventDateDimension ) ) );
     }
 
     @Test
-    @SuppressWarnings( "unchecked" )
     void testPostForMultiEventDates()
     {
         // Given
@@ -114,18 +108,17 @@ class EventVisualizationControllerTest extends DhisControllerConvenienceTest
         final String uid = assertStatus( CREATED, POST( "/eventVisualizations/", body ) );
 
         // Then
-        final JsonResponse response = GET( "/eventVisualizations/" + uid ).content();
-        final Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
+        final JsonObject response = GET( "/eventVisualizations/" + uid ).content();
 
-        assertThat( nodeMap.get( "simpleDimensions" ).toString(), containsString( "ROW" ) );
-        assertThat( nodeMap.get( "simpleDimensions" ).toString(), containsString( eventDate ) );
-        assertThat( nodeMap.get( "simpleDimensions" ).toString(), containsString( incidentDate ) );
-        assertThat( nodeMap.get( "rows" ).toString(), containsString( eventDateDimension ) );
-        assertThat( nodeMap.get( "rows" ).toString(), containsString( incidentDateDimension ) );
-        assertThat( nodeMap.get( "columns" ).toString(), not( containsString( eventDateDimension ) ) );
-        assertThat( nodeMap.get( "columns" ).toString(), not( containsString( incidentDateDimension ) ) );
-        assertThat( nodeMap.get( "filters" ).toString(), not( containsString( eventDateDimension ) ) );
-        assertThat( nodeMap.get( "filters" ).toString(), not( containsString( incidentDateDimension ) ) );
+        assertThat( response.get( "simpleDimensions" ).toString(), containsString( "ROW" ) );
+        assertThat( response.get( "simpleDimensions" ).toString(), containsString( eventDate ) );
+        assertThat( response.get( "simpleDimensions" ).toString(), containsString( incidentDate ) );
+        assertThat( response.get( "rows" ).toString(), containsString( eventDateDimension ) );
+        assertThat( response.get( "rows" ).toString(), containsString( incidentDateDimension ) );
+        assertThat( response.get( "columns" ).toString(), not( containsString( eventDateDimension ) ) );
+        assertThat( response.get( "columns" ).toString(), not( containsString( incidentDateDimension ) ) );
+        assertThat( response.get( "filters" ).toString(), not( containsString( eventDateDimension ) ) );
+        assertThat( response.get( "filters" ).toString(), not( containsString( incidentDateDimension ) ) );
     }
 
     @Test
@@ -148,7 +141,6 @@ class EventVisualizationControllerTest extends DhisControllerConvenienceTest
     }
 
     @Test
-    @SuppressWarnings( "unchecked" )
     void testPostRepetitionForFilter()
     {
         // Given
@@ -163,19 +155,17 @@ class EventVisualizationControllerTest extends DhisControllerConvenienceTest
 
         // Then
         final String getParams = "?fields=:all,filters[:all,items,repetitions]";
-        final JsonResponse response = GET( "/eventVisualizations/" + uid + getParams ).content();
-        final Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
+        final JsonObject response = GET( "/eventVisualizations/" + uid + getParams ).content();
 
-        assertThat( nodeMap.get( "repetitions" ).toString(), containsString( "FILTER" ) );
-        assertThat( nodeMap.get( "repetitions" ).toString(), containsString( indexes ) );
-        assertThat( nodeMap.get( "repetitions" ).toString(), containsString( dimension ) );
-        assertThat( nodeMap.get( "filters" ).toString(), containsString( indexes ) );
-        assertThat( nodeMap.get( "columns" ).toString(), not( containsString( indexes ) ) );
-        assertThat( nodeMap.get( "rows" ).toString(), not( containsString( indexes ) ) );
+        assertThat( response.get( "repetitions" ).toString(), containsString( "FILTER" ) );
+        assertThat( response.get( "repetitions" ).toString(), containsString( indexes ) );
+        assertThat( response.get( "repetitions" ).toString(), containsString( dimension ) );
+        assertThat( response.get( "filters" ).toString(), containsString( indexes ) );
+        assertThat( response.get( "columns" ).toString(), not( containsString( indexes ) ) );
+        assertThat( response.get( "rows" ).toString(), not( containsString( indexes ) ) );
     }
 
     @Test
-    @SuppressWarnings( "unchecked" )
     void testPostRepetitionForRow()
     {
         // Given
@@ -190,19 +180,17 @@ class EventVisualizationControllerTest extends DhisControllerConvenienceTest
 
         // Then
         final String getParams = "?fields=:all,rows[:all,items,repetitions]";
-        final JsonResponse response = GET( "/eventVisualizations/" + uid + getParams ).content();
-        final Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
+        final JsonObject response = GET( "/eventVisualizations/" + uid + getParams ).content();
 
-        assertThat( nodeMap.get( "repetitions" ).toString(), containsString( "ROW" ) );
-        assertThat( nodeMap.get( "repetitions" ).toString(), containsString( indexes ) );
-        assertThat( nodeMap.get( "repetitions" ).toString(), containsString( dimension ) );
-        assertThat( nodeMap.get( "rows" ).toString(), containsString( indexes ) );
-        assertThat( nodeMap.get( "columns" ).toString(), not( containsString( indexes ) ) );
-        assertThat( nodeMap.get( "filters" ).toString(), not( containsString( indexes ) ) );
+        assertThat( response.get( "repetitions" ).toString(), containsString( "ROW" ) );
+        assertThat( response.get( "repetitions" ).toString(), containsString( indexes ) );
+        assertThat( response.get( "repetitions" ).toString(), containsString( dimension ) );
+        assertThat( response.get( "rows" ).toString(), containsString( indexes ) );
+        assertThat( response.get( "columns" ).toString(), not( containsString( indexes ) ) );
+        assertThat( response.get( "filters" ).toString(), not( containsString( indexes ) ) );
     }
 
     @Test
-    @SuppressWarnings( "unchecked" )
     void testPostRepetitionForColumn()
     {
         // Given
@@ -217,14 +205,13 @@ class EventVisualizationControllerTest extends DhisControllerConvenienceTest
 
         // Then
         final String getParams = "?fields=:all,columns[:all,items,repetitions]";
-        final JsonResponse response = GET( "/eventVisualizations/" + uid + getParams ).content();
-        final Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
+        final JsonObject response = GET( "/eventVisualizations/" + uid + getParams ).content();
 
-        assertThat( nodeMap.get( "repetitions" ).toString(), containsString( "COLUMN" ) );
-        assertThat( nodeMap.get( "repetitions" ).toString(), containsString( indexes ) );
-        assertThat( nodeMap.get( "repetitions" ).toString(), containsString( dimension ) );
-        assertThat( nodeMap.get( "columns" ).toString(), containsString( indexes ) );
-        assertThat( nodeMap.get( "rows" ).toString(), not( containsString( indexes ) ) );
-        assertThat( nodeMap.get( "filters" ).toString(), not( containsString( indexes ) ) );
+        assertThat( response.get( "repetitions" ).toString(), containsString( "COLUMN" ) );
+        assertThat( response.get( "repetitions" ).toString(), containsString( indexes ) );
+        assertThat( response.get( "repetitions" ).toString(), containsString( dimension ) );
+        assertThat( response.get( "columns" ).toString(), containsString( indexes ) );
+        assertThat( response.get( "rows" ).toString(), not( containsString( indexes ) ) );
+        assertThat( response.get( "filters" ).toString(), not( containsString( indexes ) ) );
     }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/FollowupAnalysisControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/FollowupAnalysisControllerTest.java
@@ -42,7 +42,6 @@ import org.hisp.dhis.dataanalysis.FollowupAnalysisRequest;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
-import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.json.domain.JsonError;
 import org.hisp.dhis.webapi.json.domain.JsonFollowupValue;
@@ -215,7 +214,7 @@ class FollowupAnalysisControllerTest extends AbstractDataValueControllerTest
 
     private void assertFollowupValues( HttpResponse response, String... expectedComments )
     {
-        JsonResponse body = response.content();
+        JsonObject body = response.content();
         JsonList<JsonFollowupValue> values = body.getList( "followupValues", JsonFollowupValue.class );
         assertEquals( expectedComments.length, values.size() );
         assertEquals( Arrays.stream( expectedComments ).collect( toSet() ),

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GeoFeatureControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GeoFeatureControllerTest.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.webapi.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.hisp.dhis.jsontree.JsonResponse;
+import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.junit.jupiter.api.Test;
@@ -37,10 +37,10 @@ import org.junit.jupiter.api.Test;
 /**
  * @author viet@dhis2.org
  */
-public class GeoFeatureControllerTest extends DhisControllerConvenienceTest
+class GeoFeatureControllerTest extends DhisControllerConvenienceTest
 {
     @Test
-    public void testGetWithCoordinateField()
+    void testGetWithCoordinateField()
     {
         POST( "/metadata",
             "{\"organisationUnits\": ["
@@ -56,7 +56,7 @@ public class GeoFeatureControllerTest extends DhisControllerConvenienceTest
                 + "\"attributes\":[{\"id\":\"RRH9IFiZZYN\",\"valueType\":\"GEOJSON\",\"organisationUnitAttribute\":true,\"name\":\"testgeojson\"}]}" )
             .content( HttpStatus.OK );
 
-        JsonResponse response = GET( "/geoFeatures?ou=ou:LEVEL-1&&coordinateField=RRH9IFiZZYN" )
+        JsonArray response = GET( "/geoFeatures?ou=ou:LEVEL-1&&coordinateField=RRH9IFiZZYN" )
             .content( HttpStatus.OK );
         assertEquals( 1, response.size() );
         assertEquals( "[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]",

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
@@ -104,11 +104,11 @@ class GistFieldsControllerTest extends AbstractGistControllerTest
         JsonArray users = GET( "/users/gist?headless=true" ).content();
         JsonObject user0 = users.getObject( 0 );
         assertContainsOnly( Set.of( "id", "code", "surname", "firstName", "username" ),
-            user0.node().members().keySet() );
+            user0.names() );
         switchToSuperuser();
         users = GET( "/users/gist?headless=true" ).content();
         user0 = users.getObject( 0 );
-        assertTrue( user0.node().members().keySet().size() > 4 );
+        assertTrue( user0.size() > 4 );
     }
 
     /*

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistValidationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistValidationControllerTest.java
@@ -177,7 +177,7 @@ class GistValidationControllerTest extends AbstractGistControllerTest
     void testValidation_Access_CollectionOwnerSharing()
     {
         JsonObject group = GET( "/userGroups/{id}", userGroupId ).content();
-        String sharing = group.getObject( "sharing" ).node().extract().members().get( "public" )
+        String sharing = group.getObject( "sharing" ).node().extract().member( "public" )
             .replaceWith( "\"--------\"" ).toString();
         assertStatus( HttpStatus.NO_CONTENT, PUT( "/userGroups/" + userGroupId + "/sharing", sharing ) );
         switchToGuestUser();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MapControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MapControllerTest.java
@@ -32,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.hisp.dhis.jsontree.JsonObject;
-import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.junit.jupiter.api.Test;
@@ -50,7 +49,7 @@ class MapControllerTest extends DhisControllerConvenienceTest
     {
         String mapId = assertStatus( HttpStatus.CREATED, POST( "/maps/", "{'name':'My map'}" ) );
 
-        JsonResponse map = GET( "/maps/{uid}", mapId ).content();
+        JsonObject map = GET( "/maps/{uid}", mapId ).content();
 
         // The default merge method is REPLACE, so we must set the mandatory attributes from the created object.
         String mandatoryProperties = "'lastUpdated':'" + map.get( "lastUpdated" ).node().value() + "', 'created':'"
@@ -81,7 +80,7 @@ class MapControllerTest extends DhisControllerConvenienceTest
             "{\"name\":\"My map\", \"mapViews\":[ { \"orgUnitField\": \"" + attrId + "\", " +
                 "\"layer\": \"thematic1\",\"renderingStrategy\": \"SINGLE\" } ]}" ) );
 
-        JsonResponse map = GET( "/maps/{uid}", mapId ).content();
+        JsonObject map = GET( "/maps/{uid}", mapId ).content();
         assertNotNull( map.getArray( "mapViews" ) );
         assertEquals( 1, map.getArray( "mapViews" ).size() );
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MeControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MeControllerTest.java
@@ -37,7 +37,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonObject;
-import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.jsontree.JsonValue;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.web.HttpStatus;
@@ -229,7 +228,7 @@ class MeControllerTest extends DhisControllerConvenienceTest
     @Test
     void testLegacyUserCredentialsIdPresent()
     {
-        JsonResponse response = GET( "/me?fields=id,userCredentials" ).content();
+        JsonObject response = GET( "/me?fields=id,userCredentials" ).content();
         JsonObject userCredentials = response.getObject( "userCredentials" );
         JsonValue id = userCredentials.get( "id" );
         assertTrue( id.exists() );

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
@@ -39,7 +39,6 @@ import org.geojson.GeoJsonObject;
 import org.geojson.Polygon;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.jsontree.JsonObject;
-import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.webapi.json.domain.JsonAttributeValue;
@@ -216,7 +215,7 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest
             "    {\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"id\": \"Uh4HvjK6zg3\",\"sortOrder\": 3,\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}" )
             .content( HttpStatus.OK );
 
-        JsonResponse response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
+        JsonObject response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
 
         assertEquals( 2, response.getObject( "options" ).size() );
         assertNotNull( response.get( "options[0].sortOrder" ) );
@@ -239,7 +238,7 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest
             "    {\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"id\": \"Uh4HvjK6zg3\",\"sortOrder\": 3,\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}" )
             .content( HttpStatus.OK );
 
-        JsonResponse response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
+        JsonObject response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
 
         assertEquals( 2, response.getObject( "options" ).size() );
         assertNotNull( response.get( "options[0].sortOrder" ) );
@@ -261,7 +260,7 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest
             "    {\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"id\": \"Uh4HvjK6zg3\",\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}" )
             .content( HttpStatus.OK );
 
-        JsonResponse response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
+        JsonObject response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
 
         assertEquals( 2, response.getObject( "options" ).size() );
         assertNotNull( response.get( "options[0].sortOrder" ) );
@@ -283,7 +282,7 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest
             "    {\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"sortOrder\": 2,\"id\": \"Uh4HvjK6zg3\",\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}" )
             .content( HttpStatus.OK );
 
-        JsonResponse response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
+        JsonObject response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
 
         assertEquals( 2, response.getObject( "options" ).size() );
         assertNotNull( response.get( "options[0].sortOrder" ) );
@@ -302,7 +301,7 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest
             "    {\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"sortOrder\": 3,\"id\": \"Uh4HvjK6zg3\",\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}" )
             .content( HttpStatus.OK );
 
-        JsonResponse response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
+        JsonObject response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
 
         assertEquals( 2, response.getObject( "options" ).size() );
         assertNotNull( response.get( "options[0].sortOrder" ) );

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OptionControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OptionControllerTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
-import org.hisp.dhis.jsontree.JsonResponse;
+import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.webapi.json.domain.JsonIdentifiableObject;
@@ -54,7 +54,7 @@ class OptionControllerTest extends DhisControllerConvenienceTest
             "    {\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"id\": \"Uh4HvjK6zg3\",\"sortOrder\": 2,\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}" )
             .content( HttpStatus.OK );
 
-        JsonResponse response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
+        JsonObject response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
 
         // sortOrder is 1 and 2
         assertEquals( 2, response.getObject( "options" ).size() );

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OrganisationUnitLocationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OrganisationUnitLocationControllerTest.java
@@ -28,13 +28,11 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonBoolean;
-import org.hisp.dhis.jsontree.JsonDocument.JsonNodeType;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.junit.jupiter.api.Test;
@@ -66,7 +64,6 @@ class OrganisationUnitLocationControllerTest extends DhisControllerConvenienceTe
         JsonBoolean isWithin = GET(
             "/organisationUnitLocations/locationWithinOrgUnitBoundary?longitude=23.1&latitude=56.2&orgUnitUid={ou}",
             ouId ).content( HttpStatus.OK );
-        assertEquals( JsonNodeType.BOOLEAN, isWithin.node().getType() );
         assertFalse( isWithin.booleanValue() );
     }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramStageControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramStageControllerTest.java
@@ -31,7 +31,7 @@ import static org.hisp.dhis.web.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.hisp.dhis.feedback.ErrorCode;
-import org.hisp.dhis.jsontree.JsonResponse;
+import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.webapi.json.domain.JsonTypeReport;
@@ -62,9 +62,9 @@ class ProgramStageControllerTest extends DhisControllerConvenienceTest
             .content( HttpStatus.CREATED );
         String programStageId = assertStatus( HttpStatus.CREATED,
             POST( "/programStages/", "{'name':'test programStage', 'program':{'id':'VoZMWi7rBgj'}}" ) );
-        JsonResponse programStage = GET( "/programStages/{id}", programStageId ).content();
+        JsonObject programStage = GET( "/programStages/{id}", programStageId ).content();
         assertEquals( "VoZMWi7rBgj", programStage.getString( "program.id" ).string() );
-        JsonResponse program = GET( "/programs/{id}", "VoZMWi7rBgj" ).content();
+        JsonObject program = GET( "/programs/{id}", "VoZMWi7rBgj" ).content();
         assertEquals( programStageId, program.getString( "programStages[0].id" ).string() );
     }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/RequestInfoControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/RequestInfoControllerTest.java
@@ -32,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.jsontree.JsonObject;
-import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.junit.jupiter.api.Test;
 
@@ -43,7 +42,6 @@ import org.junit.jupiter.api.Test;
  */
 class RequestInfoControllerTest extends DhisControllerConvenienceTest
 {
-
     @Test
     void testGetCurrentInfo_NoHeader()
     {
@@ -55,7 +53,7 @@ class RequestInfoControllerTest extends DhisControllerConvenienceTest
     @Test
     void testGetCurrentInfo_XRequestIdHeader()
     {
-        JsonResponse info = GET( "/request", Header( "X-Request-ID", "abc" ) ).content();
+        JsonObject info = GET( "/request", Header( "X-Request-ID", "abc" ) ).content();
         assertTrue( info.isObject() );
         assertEquals( "abc", info.getString( "headerXRequestID" ).string() );
     }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SqlViewControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SqlViewControllerTest.java
@@ -33,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.List;
 
 import org.hisp.dhis.jsontree.JsonObject;
-import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.junit.jupiter.api.Test;
@@ -84,7 +83,7 @@ class SqlViewControllerTest extends DhisControllerConvenienceTest
         String uid = assertStatus( HttpStatus.CREATED,
             POST( "/sqlViews/", "{'name':'My SQL View','sqlQuery':'select 1 from userinfo'}" ) );
 
-        JsonResponse sqlView = GET( "/sqlViews/{uid}", uid ).content();
+        JsonObject sqlView = GET( "/sqlViews/{uid}", uid ).content();
         assertEquals( "VIEW", sqlView.getString( "type" ).string() );
         assertEquals( "RESPECT_SYSTEM_SETTING", sqlView.getString( "cacheStrategy" ).string() );
     }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -47,7 +47,6 @@ import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonBoolean;
 import org.hisp.dhis.jsontree.JsonObject;
-import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.jsontree.JsonValue;
 import org.hisp.dhis.message.FakeMessageSender;
 import org.hisp.dhis.message.MessageSender;
@@ -291,7 +290,7 @@ class UserControllerTest extends DhisControllerConvenienceTest
     @Test
     void testGetUserLegacyUserCredentialsIdPresent()
     {
-        JsonResponse response = GET( "/users/{id}", peter.getUid() ).content();
+        JsonObject response = GET( "/users/{id}", peter.getUid() ).content();
         JsonObject userCredentials = response.getObject( "userCredentials" );
         JsonValue id = userCredentials.get( "id" );
         assertTrue( id.exists() );
@@ -300,7 +299,7 @@ class UserControllerTest extends DhisControllerConvenienceTest
     @Test
     void testNewTwoFAStatusExistsInUserCredentials()
     {
-        JsonResponse response = GET( "/users/{id}", peter.getUid() ).content();
+        JsonObject response = GET( "/users/{id}", peter.getUid() ).content();
         JsonObject userCredentials = response.getObject( "userCredentials" );
         Boolean twoFA = userCredentials.get( "twoFA" ).as( JsonBoolean.class ).bool();
         assertFalse( twoFA );
@@ -517,7 +516,7 @@ class UserControllerTest extends DhisControllerConvenienceTest
             Body(
                 "[{'op': 'add', 'path': '/userGroups', 'value': [ { 'id': 'GZSvMCVowAx' }, { 'id': 'B6JNeAQ6akX' } ] } ]" ) ) );
 
-        JsonResponse response = GET( "/users/{id}?fields=userGroups", peter.getUid() ).content( HttpStatus.OK );
+        JsonObject response = GET( "/users/{id}?fields=userGroups", peter.getUid() ).content( HttpStatus.OK );
         assertEquals( 2, response.getArray( "userGroups" ).size() );
 
         assertStatus( HttpStatus.OK, PATCH( "/users/{id}", peter.getUid() + "?importReportMode=ERRORS",

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/AbstractDataIntegrityIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/AbstractDataIntegrityIntegrationTest.java
@@ -201,7 +201,7 @@ class AbstractDataIntegrityIntegrationTest extends DhisControllerIntegrationTest
 
     final void assertNamedMetadataObjectExists( String endpoint, String name )
     {
-        JsonResponse response = GET( "/" + endpoint + "/?filter=name:eq:" + name ).content();
+        JsonObject response = GET( "/" + endpoint + "/?filter=name:eq:" + name ).content();
         JsonArray dimensions = response.getArray( endpoint );
         assertEquals( 1, dimensions.size() );
     }
@@ -210,7 +210,7 @@ class AbstractDataIntegrityIntegrationTest extends DhisControllerIntegrationTest
     {
         GET( "/" + endpoint + "/gist?fields=id&headless=true" ).content().stringValues()
             .forEach( id -> DELETE( "/" + endpoint + "/" + id ) );
-        JsonResponse response = GET( "/" + endpoint ).content();
+        JsonObject response = GET( "/" + endpoint ).content();
         JsonArray dimensions = response.getArray( endpoint );
         assertEquals( 0, dimensions.size() );
     }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityCategoryOptionComboDisjointControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityCategoryOptionComboDisjointControllerTest.java
@@ -31,7 +31,7 @@ import static org.hisp.dhis.web.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.hisp.dhis.jsontree.JsonList;
-import org.hisp.dhis.jsontree.JsonResponse;
+import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.json.domain.JsonCategoryOptionCombo;
 import org.junit.jupiter.api.Test;
@@ -67,7 +67,7 @@ class DataIntegrityCategoryOptionComboDisjointControllerTest extends AbstractDat
 
         setupTest();
         //We should have three cat option combos now. The two we created and default.
-        JsonResponse response = GET( "/categoryOptionCombos?fields=id,name" ).content();
+        JsonObject response = GET( "/categoryOptionCombos?fields=id,name" ).content();
         JsonList<JsonCategoryOptionCombo> catOptionCombos = response.getList( "categoryOptionCombos",
             JsonCategoryOptionCombo.class );
         assertEquals( 3, catOptionCombos.size() );

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityOrganisationUnitsTrailingSpacesControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityOrganisationUnitsTrailingSpacesControllerTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Set;
 
-import org.hisp.dhis.jsontree.JsonResponse;
+import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.web.HttpStatus;
@@ -83,7 +83,7 @@ class DataIntegrityOrganisationUnitsTrailingSpacesControllerTest extends Abstrac
         orgUnitService.addOrganisationUnit( unitC );
         dbmsManager.clearSession();
 
-        JsonResponse json_unitA = GET( "/organisationUnits/" + unitA.getUid() ).content().as( JsonResponse.class );
+        JsonObject json_unitA = GET( "/organisationUnits/" + unitA.getUid() ).content();
         assertEquals( unitAName, json_unitA.getString( "name" ).string() );
 
         Set<String> orgUnitUIDs = Set.of( unitA.getUid(), unitB.getUid() );

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/deprecated/tracker/EventControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/deprecated/tracker/EventControllerIntegrationTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.hisp.dhis.jsontree.JsonResponse;
+import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
@@ -114,7 +114,7 @@ class EventControllerIntegrationTest extends DhisControllerIntegrationTest
     @Test
     void testSkipPaging()
     {
-        JsonResponse res = GET( "/events.json?ouMode=ALL&skipPaging=true" ).content( HttpStatus.OK );
+        JsonObject res = GET( "/events.json?ouMode=ALL&skipPaging=true" ).content( HttpStatus.OK );
         assertFalse( res.get( "pager" ).exists() );
 
         res = GET( "/events.json?ouMode=ALL&skipPaging=false" ).content( HttpStatus.OK );

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/utils/DhisMockMvcControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/utils/DhisMockMvcControllerTest.java
@@ -35,7 +35,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.hisp.dhis.DhisConvenienceTest;
-import org.hisp.dhis.jsontree.JsonResponse;
+import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.web.HttpMethod;
 import org.hisp.dhis.web.WebClient;
 import org.hisp.dhis.webapi.json.domain.JsonWebMessage;
@@ -52,7 +52,7 @@ public abstract class DhisMockMvcControllerTest extends DhisConvenienceTest impl
 {
 
     public static JsonWebMessage assertWebMessage( String httpStatus, int httpStatusCode, String status, String message,
-        JsonResponse actual )
+        JsonMixed actual )
     {
         return assertWebMessage( httpStatus, httpStatusCode, status, message, actual.as( JsonWebMessage.class ) );
     }

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -69,7 +69,7 @@
     <!-- HISP Quick and Staxwax -->
     <dhis-hisp-quick.version>1.4.1</dhis-hisp-quick.version>
     <dhis-hisp-staxwax.version>2.0.0</dhis-hisp-staxwax.version>
-    <dhis-json-tree.version>0.5.0</dhis-json-tree.version>
+    <dhis-json-tree.version>0.8.0</dhis-json-tree.version>
 
     <!-- Security -->
     <spring-security.version>5.8.3</spring-security.version>


### PR DESCRIPTION
Updates `json-tree` dependency to `0.8.0` version.

There were a couple of breaking changes where implementation details got hidden which needed to be addressed.

Main API changes are:
* `JsonResponse` got hidden behind `JsonMixed` interface
* `JsonNodeType` got moved to a top level type
* `JsonNode#members()` and `JsonNode#elements()` now return `Iterable` instead of `List`/`Map`