### PR TITLE
chore: document deprecated /tracker/relationships?tei parameter TECH-1546

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RequestParams.java
@@ -52,7 +52,16 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
 {
     static final String DEFAULT_FIELDS_PARAM = "relationship,relationshipType,from[trackedEntity[trackedEntity],enrollment[enrollment],event[event]],to[trackedEntity[trackedEntity],enrollment[enrollment],event[event]]";
 
+    /**
+     * @deprecated use {@link #trackedEntity} instead
+     */
+    @Deprecated( since = "2.41" )
     @OpenApi.Property( { UID.class, TrackedEntity.class } )
+    @Setter
+    private UID tei;
+
+    @OpenApi.Property( { UID.class, TrackedEntity.class } )
+    @Setter
     private UID trackedEntity;
 
     @OpenApi.Property( { UID.class, Enrollment.class } )
@@ -74,19 +83,6 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
     @Setter
     private List<FieldPath> fields = FieldFilterParser.parse( DEFAULT_FIELDS_PARAM );
 
-    public void setTei( UID tei )
-    {
-        // this setter is kept for backwards-compatibility
-        // query parameter 'tei' should still be allowed, but 'trackedEntity' is
-        // preferred.
-        this.trackedEntity = tei;
-    }
-
-    public void setTrackedEntity( UID trackedEntity )
-    {
-        this.trackedEntity = trackedEntity;
-    }
-
     @OpenApi.Ignore
     public String getIdentifierParam()
         throws BadRequestException
@@ -96,10 +92,23 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
             return this.identifier;
         }
 
+        if ( this.trackedEntity != null && this.tei != null )
+        {
+            throw new IllegalArgumentException(
+                "Only one parameter of 'tei' and 'trackedEntity' must be specified. Prefer 'trackedEntity' as 'tei' will be removed." );
+        }
+
         int count = 0;
         if ( this.trackedEntity != null )
         {
             this.identifier = this.trackedEntity.getValue();
+            this.identifierName = "trackedEntity";
+            this.identifierClass = org.hisp.dhis.trackedentity.TrackedEntity.class;
+            count++;
+        }
+        if ( this.tei != null )
+        {
+            this.identifier = this.tei.getValue();
             this.identifierName = "trackedEntity";
             this.identifierClass = org.hisp.dhis.trackedentity.TrackedEntity.class;
             count++;

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/RelationshipsExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/RelationshipsExportController.md
@@ -2,16 +2,30 @@
 
 ## `getRelationships`
 
-Get relationships matching given query parameters.
+Get relationships matching the given query parameters.
+
+Exactly one parameter of `trackedEntity` (`tei`), `enrollment` or `event` has to be specified.
 
 ## `getRelationshipByUid`
 
-Get a relationship with given UID.
+Get a relationship with the given UID.
 
 ## Common for all endpoints
 
 ### `*.parameter.RelationshipRequestParams.trackedEntity`
 
+Get relationships of the given trackedEntity.
+
+### `*.parameter.RelationshipRequestParams.tei`
+
+**DEPRECATED as of 2.41:** Use parameter `trackedEntity` instead.
+
+Get relationships of the given trackedEntity.
+
 ### `*.parameter.RelationshipRequestParams.enrollment`
 
+Get the relationships of the given enrollment.
+
 ### `*.parameter.RelationshipRequestParams.event`
+
+Get relationships of the given event.

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RequestParamsTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RequestParamsTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.relationship;
 
+import static org.hisp.dhis.utils.Assertions.assertStartsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -58,6 +59,18 @@ class RequestParamsTest
         requestParams.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
 
         assertEquals( "Hq3Kc6HK4OZ", requestParams.getIdentifierParam() );
+    }
+
+    @Test
+    void getIdentifierParamFailsIfTrackedEntityAndTeiAreSet()
+    {
+        RequestParams requestParams = new RequestParams();
+        requestParams.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
+        requestParams.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
+
+        IllegalArgumentException exception = assertThrows( IllegalArgumentException.class,
+            () -> requestParams.getIdentifierParam() );
+        assertStartsWith( "Only one parameter of 'tei'", exception.getMessage() );
     }
 
     @Test
@@ -188,7 +201,6 @@ class RequestParamsTest
     {
         RequestParams requestParams = new RequestParams();
         requestParams.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
-        requestParams.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
         requestParams.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
         requestParams.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
 
@@ -203,7 +215,6 @@ class RequestParamsTest
     {
         RequestParams requestParams = new RequestParams();
         requestParams.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
-        requestParams.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
         requestParams.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
         requestParams.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
 
@@ -218,7 +229,6 @@ class RequestParamsTest
     {
         RequestParams requestParams = new RequestParams();
         requestParams.setTrackedEntity( UID.of( "Hq3Kc6HK4OZ" ) );
-        requestParams.setTei( UID.of( "Hq3Kc6HK4OZ" ) );
         requestParams.setEnrollment( UID.of( "Hq3Kc6HK4OZ" ) );
         requestParams.setEvent( UID.of( "Hq3Kc6HK4OZ" ) );
 


### PR DESCRIPTION
We renamed the `tei` field to the new name 'trackedEntity' a while ago. 2 setters provided the old `tei` (`setTei`) and new query parameter `trackedEntity` (`setTrackedEntity`). Our OpenAPI generation does not provide the same mechanism as Spring. We therefore need to add the deprecated field so we can document it in our spec. We will be able to remove it in 2.42.