### PR TITLE
chore: Harmonize enrollment controller [TECH-1564]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEnrollmentStore.java
@@ -160,7 +160,7 @@ public class HibernateEnrollmentStore
 
         if ( params.hasTrackedEntity() )
         {
-            hql += hlp.whereAnd() + "pi.trackedEntity.uid = '" + params.getTrackedEntityUid() + "'";
+            hql += hlp.whereAnd() + "pi.trackedEntity.uid = '" + params.getTrackedEntity().getUid() + "'";
         }
 
         if ( params.hasTrackedEntityType() )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/enrollment/AbstractEnrollmentService.java
@@ -763,7 +763,7 @@ public abstract class AbstractEnrollmentService
         params.setOrganisationUnitMode( OrganisationUnitSelectionMode.ALL );
         params.setSkipPaging( true );
         params.setProgram( program );
-        params.setTrackedEntityUid( entityInstance.getUid() );
+        params.setTrackedEntity( entityInstance );
 
         // When imported enrollment has status CANCELLED, it is safe to import
         // it, otherwise do additional checks

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -212,11 +212,6 @@ public class DefaultEnrollmentService implements org.hisp.dhis.tracker.export.en
 
         EnrollmentQueryParams queryParams = opeationParamsMapper.map( params );
 
-        if ( !params.isPaging() && !params.isSkipPaging() )
-        {
-            params.setDefaultPaging();
-        }
-
         List<Enrollment> enrollmentList = new ArrayList<>(
             enrollmentService.getEnrollments( queryParams ) );
         if ( !params.isSkipPaging() )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -136,11 +136,11 @@ public class DefaultEnrollmentService implements org.hisp.dhis.tracker.export.en
         result.setComments( enrollment.getComments() );
         if ( params.isIncludeEvents() )
         {
-            result.setEvents( getEvents( user, enrollment, params, includeDeleted ) );
+            result.setEvents( getEvents( user, enrollment, includeDeleted ) );
         }
         if ( params.isIncludeRelationships() )
         {
-            result.setRelationshipItems( getRelationshipItems( user, enrollment, params, includeDeleted ) );
+            result.setRelationshipItems( getRelationshipItems( user, enrollment, includeDeleted ) );
         }
         if ( params.isIncludeAttributes() )
         {
@@ -151,7 +151,7 @@ public class DefaultEnrollmentService implements org.hisp.dhis.tracker.export.en
         return result;
     }
 
-    private Set<Event> getEvents( User user, Enrollment enrollment, EnrollmentParams params, boolean includeDeleted )
+    private Set<Event> getEvents( User user, Enrollment enrollment, boolean includeDeleted )
     {
         Set<Event> events = new HashSet<>();
 
@@ -166,8 +166,7 @@ public class DefaultEnrollmentService implements org.hisp.dhis.tracker.export.en
         return events;
     }
 
-    private Set<RelationshipItem> getRelationshipItems( User user, Enrollment enrollment,
-        EnrollmentParams params, boolean includeDeleted )
+    private Set<RelationshipItem> getRelationshipItems( User user, Enrollment enrollment, boolean includeDeleted )
     {
         Set<RelationshipItem> relationshipItems = new HashSet<>();
 
@@ -231,7 +230,8 @@ public class DefaultEnrollmentService implements org.hisp.dhis.tracker.export.en
             enrollments.setPager( pager );
         }
 
-        enrollments.setEnrollments( getEnrollments( enrollmentList, params.getEnrollmentParams(), params.isIncludeDeleted() ) );
+        enrollments.setEnrollments(
+            getEnrollments( enrollmentList, params.getEnrollmentParams(), params.isIncludeDeleted() ) );
 
         return enrollments;
     }
@@ -272,7 +272,8 @@ public class DefaultEnrollmentService implements org.hisp.dhis.tracker.export.en
         return new SlimPager( originalPage, originalPageSize, isLastPage );
     }
 
-    private List<Enrollment> getEnrollments( Iterable<Enrollment> enrollments, EnrollmentParams params, boolean includeDeleted )
+    private List<Enrollment> getEnrollments( Iterable<Enrollment> enrollments, EnrollmentParams params,
+        boolean includeDeleted )
         throws ForbiddenException
     {
         List<Enrollment> enrollmentList = new ArrayList<>();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParams.java
@@ -27,28 +27,30 @@
  */
 package org.hisp.dhis.tracker.export.enrollment;
 
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.hisp.dhis.common.OrganisationUnitSelectionMode;
+import org.hisp.dhis.common.QueryModifiers;
+import org.hisp.dhis.program.ProgramStatus;
+import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
+
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import lombok.Data;
-import lombok.experimental.Accessors;
-
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.common.OrganisationUnitSelectionMode;
-import org.hisp.dhis.program.ProgramStatus;
-import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
-
-@Data
-@Accessors( chain = true )
+@Getter
+@Builder
 public class EnrollmentOperationParams
 {
     public static final int DEFAULT_PAGE = 1;
 
     public static final int DEFAULT_PAGE_SIZE = 50;
 
+    static final EnrollmentOperationParams EMPTY = EnrollmentOperationParams.builder().build();
+
+    @Builder.Default
     private EnrollmentParams enrollmentParams = EnrollmentParams.FALSE;
 
     /**
@@ -65,6 +67,7 @@ public class EnrollmentOperationParams
      * Organisation units for which instances in the response were registered
      * at. Is related to the specified OrganisationUnitMode.
      */
+    @Builder.Default
     private Set<String> organisationUnitUids = new HashSet<>();
 
     /**
@@ -139,120 +142,6 @@ public class EnrollmentOperationParams
      */
     private List<OrderParam> order;
 
-    // -------------------------------------------------------------------------
-    // Constructors
-    // -------------------------------------------------------------------------
-
-    public EnrollmentOperationParams()
-    {
-    }
-
-    // -------------------------------------------------------------------------
-    // Logic
-    // -------------------------------------------------------------------------
-
-    /**
-     * Adds an organisation unit to the parameters.
-     */
-    public void addOrganisationUnit( String unit )
-    {
-        this.organisationUnitUids.add( unit );
-    }
-
-    public void addOrganisationUnits( Set<String> orgUnits )
-    {
-        this.organisationUnitUids.addAll( orgUnits );
-    }
-
-    /**
-     * Indicates whether this params specifies last updated.
-     */
-    public boolean hasLastUpdated()
-    {
-        return lastUpdated != null;
-    }
-
-    /**
-     * Indicates whether this parameters has a lastUpdatedDuration filter.
-     */
-    public boolean hasLastUpdatedDuration()
-    {
-        return lastUpdatedDuration != null;
-    }
-
-    /**
-     * Indicates whether this params specifies any organisation units.
-     */
-    public boolean hasOrganisationUnits()
-    {
-        return organisationUnitUids != null && !organisationUnitUids.isEmpty();
-    }
-
-    /**
-     * Indicates whether this params specifies a program.
-     */
-    public boolean hasProgram()
-    {
-        return programUid != null;
-    }
-
-    /**
-     * Indicates whether this params specifies a program status.
-     */
-    public boolean hasProgramStatus()
-    {
-        return programStatus != null;
-    }
-
-    /**
-     * Indicates whether this params specifies follow up for the given program.
-     * Follow up can be specified as true or false.
-     */
-    public boolean hasFollowUp()
-    {
-        return followUp != null;
-    }
-
-    /**
-     * Indicates whether this params specifies a program start date.
-     */
-    public boolean hasProgramStartDate()
-    {
-        return programStartDate != null;
-    }
-
-    /**
-     * Indicates whether this params specifies a program end date.
-     */
-    public boolean hasProgramEndDate()
-    {
-        return programEndDate != null;
-    }
-
-    /**
-     * Indicates whether this params specifies a tracked entity.
-     */
-    public boolean hasTrackedEntityType()
-    {
-        return trackedEntityTypeUid != null;
-    }
-
-    /**
-     * Indicates whether this params specifies a tracked entity instance.
-     */
-    public boolean hasTrackedEntity()
-    {
-        return StringUtils.isNotEmpty( this.trackedEntityUid );
-    }
-
-    /**
-     * Indicates whether this params is of the given organisation unit mode.
-     */
-    public boolean isOrganisationUnitMode( OrganisationUnitSelectionMode mode )
-    {
-        return organisationUnitMode != null && organisationUnitMode.equals( mode );
-    }
-
     /**
      * Indicates whether paging is enabled.
      */
@@ -280,14 +169,6 @@ public class EnrollmentOperationParams
     }
 
     /**
-     * Returns the offset based on the page number and page size.
-     */
-    public int getOffset()
-    {
-        return (getPageWithDefault() - 1) * getPageSizeWithDefault();
-    }
-
-    /**
      * Sets paging properties to default values.
      */
     public void setDefaultPaging()
@@ -295,10 +176,5 @@ public class EnrollmentOperationParams
         this.page = DEFAULT_PAGE;
         this.pageSize = DEFAULT_PAGE_SIZE;
         this.skipPaging = false;
-    }
-
-    public boolean isSorting()
-    {
-        return !CollectionUtils.emptyIfNull( order ).isEmpty();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParams.java
@@ -27,18 +27,17 @@
  */
 package org.hisp.dhis.tracker.export.enrollment;
 
-import lombok.Builder;
-import lombok.Data;
-import lombok.Getter;
-import org.hisp.dhis.common.OrganisationUnitSelectionMode;
-import org.hisp.dhis.common.QueryModifiers;
-import org.hisp.dhis.program.ProgramStatus;
-import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
-
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import org.hisp.dhis.common.OrganisationUnitSelectionMode;
+import org.hisp.dhis.program.ProgramStatus;
+import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 
 @Getter
 @Builder

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParams.java
@@ -35,15 +35,15 @@ import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
-
 import lombok.RequiredArgsConstructor;
+
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 
 @Getter
-@Builder(toBuilder = true)
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder( toBuilder = true )
+@RequiredArgsConstructor( access = AccessLevel.PRIVATE )
 public class EnrollmentOperationParams
 {
     public static final int DEFAULT_PAGE = 1;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParams.java
@@ -70,25 +70,25 @@ public class EnrollmentOperationParams
      * at. Is related to the specified OrganisationUnitMode.
      */
     @Builder.Default
-    private final Set<String> organisationUnitUids = new HashSet<>();
+    private final Set<String> orgUnitUids = new HashSet<>();
 
     /**
      * Selection mode for the specified organisation units.
      */
-    private final OrganisationUnitSelectionMode organisationUnitMode;
+    private final OrganisationUnitSelectionMode orgUnitMode;
 
     /**
-     * Program for which instances in the response must be enrolled in.
+     * Enrollments must be enrolled into this program.
      */
     private final String programUid;
 
     /**
-     * Status of the tracked entity instance in the given program.
+     * Status of the tracked entity in the given program.
      */
     private final ProgramStatus programStatus;
 
     /**
-     * Indicates whether tracked entity instance is marked for follow up for the
+     * Indicates whether tracked entity is marked for follow up for the
      * specified program.
      */
     private final Boolean followUp;
@@ -104,12 +104,12 @@ public class EnrollmentOperationParams
     private final Date programEndDate;
 
     /**
-     * Tracked entity of the instances in the response.
+     * Tracked entity type of the tracked entity in the response.
      */
     private final String trackedEntityTypeUid;
 
     /**
-     * Tracked entity instance.
+     * Tracked entity.
      */
     private final String trackedEntityUid;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParams.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.program;
+package org.hisp.dhis.tracker.export.enrollment;
 
 import java.util.Date;
 import java.util.HashSet;
@@ -36,23 +36,20 @@ import lombok.Data;
 import lombok.experimental.Accessors;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.trackedentity.TrackedEntity;
-import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 
-/**
- * @author Morten Olav Hansen <mortenoh@gmail.com>
- */
 @Data
 @Accessors( chain = true )
-public class EnrollmentQueryParams
+public class EnrollmentOperationParams
 {
     public static final int DEFAULT_PAGE = 1;
 
     public static final int DEFAULT_PAGE_SIZE = 50;
+
+    private EnrollmentParams enrollmentParams = EnrollmentParams.FALSE;
 
     /**
      * Last updated for enrollment.
@@ -68,7 +65,7 @@ public class EnrollmentQueryParams
      * Organisation units for which instances in the response were registered
      * at. Is related to the specified OrganisationUnitMode.
      */
-    private Set<OrganisationUnit> organisationUnits = new HashSet<>();
+    private Set<String> organisationUnitUids = new HashSet<>();
 
     /**
      * Selection mode for the specified organisation units.
@@ -78,7 +75,7 @@ public class EnrollmentQueryParams
     /**
      * Program for which instances in the response must be enrolled in.
      */
-    private Program program;
+    private String programUid;
 
     /**
      * Status of the tracked entity instance in the given program.
@@ -104,12 +101,12 @@ public class EnrollmentQueryParams
     /**
      * Tracked entity of the instances in the response.
      */
-    private TrackedEntityType trackedEntityType;
+    private String trackedEntityTypeUid;
 
     /**
      * Tracked entity instance.
      */
-    private TrackedEntity trackedEntity;
+    private String trackedEntityUid;
 
     /**
      * Page number.
@@ -143,19 +140,10 @@ public class EnrollmentQueryParams
     private List<OrderParam> order;
 
     // -------------------------------------------------------------------------
-    // Transient properties
-    // -------------------------------------------------------------------------
-
-    /**
-     * Current user for query.
-     */
-    private transient User user;
-
-    // -------------------------------------------------------------------------
     // Constructors
     // -------------------------------------------------------------------------
 
-    public EnrollmentQueryParams()
+    public EnrollmentOperationParams()
     {
     }
 
@@ -166,14 +154,14 @@ public class EnrollmentQueryParams
     /**
      * Adds an organisation unit to the parameters.
      */
-    public void addOrganisationUnit( OrganisationUnit unit )
+    public void addOrganisationUnit( String unit )
     {
-        this.organisationUnits.add( unit );
+        this.organisationUnitUids.add( unit );
     }
 
-    public void addOrganisationUnits( Set<OrganisationUnit> orgUnits )
+    public void addOrganisationUnits( Set<String> orgUnits )
     {
-        this.organisationUnits.addAll( orgUnits );
+        this.organisationUnitUids.addAll( orgUnits );
     }
 
     /**
@@ -197,7 +185,7 @@ public class EnrollmentQueryParams
      */
     public boolean hasOrganisationUnits()
     {
-        return organisationUnits != null && !organisationUnits.isEmpty();
+        return organisationUnitUids != null && !organisationUnitUids.isEmpty();
     }
 
     /**
@@ -205,7 +193,7 @@ public class EnrollmentQueryParams
      */
     public boolean hasProgram()
     {
-        return program != null;
+        return programUid != null;
     }
 
     /**
@@ -246,7 +234,7 @@ public class EnrollmentQueryParams
      */
     public boolean hasTrackedEntityType()
     {
-        return trackedEntityType != null;
+        return trackedEntityTypeUid != null;
     }
 
     /**
@@ -254,7 +242,7 @@ public class EnrollmentQueryParams
      */
     public boolean hasTrackedEntity()
     {
-        return this.trackedEntity != null;
+        return StringUtils.isNotEmpty( this.trackedEntityUid );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParams.java
@@ -32,15 +32,18 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
+import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 
 @Getter
-@Builder
+@Builder(toBuilder = true)
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class EnrollmentOperationParams
 {
     public static final int DEFAULT_PAGE = 1;
@@ -50,96 +53,96 @@ public class EnrollmentOperationParams
     static final EnrollmentOperationParams EMPTY = EnrollmentOperationParams.builder().build();
 
     @Builder.Default
-    private EnrollmentParams enrollmentParams = EnrollmentParams.FALSE;
+    private final EnrollmentParams enrollmentParams = EnrollmentParams.FALSE;
 
     /**
      * Last updated for enrollment.
      */
-    private Date lastUpdated;
+    private final Date lastUpdated;
 
     /**
      * The last updated duration filter.
      */
-    private String lastUpdatedDuration;
+    private final String lastUpdatedDuration;
 
     /**
      * Organisation units for which instances in the response were registered
      * at. Is related to the specified OrganisationUnitMode.
      */
     @Builder.Default
-    private Set<String> organisationUnitUids = new HashSet<>();
+    private final Set<String> organisationUnitUids = new HashSet<>();
 
     /**
      * Selection mode for the specified organisation units.
      */
-    private OrganisationUnitSelectionMode organisationUnitMode;
+    private final OrganisationUnitSelectionMode organisationUnitMode;
 
     /**
      * Program for which instances in the response must be enrolled in.
      */
-    private String programUid;
+    private final String programUid;
 
     /**
      * Status of the tracked entity instance in the given program.
      */
-    private ProgramStatus programStatus;
+    private final ProgramStatus programStatus;
 
     /**
      * Indicates whether tracked entity instance is marked for follow up for the
      * specified program.
      */
-    private Boolean followUp;
+    private final Boolean followUp;
 
     /**
      * Start date for enrollment in the given program.
      */
-    private Date programStartDate;
+    private final Date programStartDate;
 
     /**
      * End date for enrollment in the given program.
      */
-    private Date programEndDate;
+    private final Date programEndDate;
 
     /**
      * Tracked entity of the instances in the response.
      */
-    private String trackedEntityTypeUid;
+    private final String trackedEntityTypeUid;
 
     /**
      * Tracked entity instance.
      */
-    private String trackedEntityUid;
+    private final String trackedEntityUid;
 
     /**
      * Page number.
      */
-    private Integer page;
+    private final Integer page;
 
     /**
      * Page size.
      */
-    private Integer pageSize;
+    private final Integer pageSize;
 
     /**
      * Indicates whether to include the total number of pages in the paging
      * response.
      */
-    private boolean totalPages;
+    private final boolean totalPages;
 
     /**
      * Indicates whether paging should be skipped.
      */
-    private boolean skipPaging;
+    private final boolean skipPaging;
 
     /**
      * Indicates whether to include soft-deleted enrollments
      */
-    private boolean includeDeleted;
+    private final boolean includeDeleted;
 
     /**
      * List of order params
      */
-    private List<OrderParam> order;
+    private final List<OrderParam> order;
 
     /**
      * Indicates whether paging is enabled.
@@ -165,15 +168,5 @@ public class EnrollmentOperationParams
     public int getPageSizeWithDefault()
     {
         return pageSize != null && pageSize >= 0 ? pageSize : DEFAULT_PAGE_SIZE;
-    }
-
-    /**
-     * Sets paging properties to default values.
-     */
-    public void setDefaultPaging()
-    {
-        this.page = DEFAULT_PAGE;
-        this.pageSize = DEFAULT_PAGE_SIZE;
-        this.skipPaging = false;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapper.java
@@ -53,7 +53,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Maps operation parameters stored in {@link EnrollmentOperationParams} to
+ * Maps {@link EnrollmentOperationParams} to
  * {@link EnrollmentQueryParams} which is used to fetch enrollments from the DB.
  */
 @Component
@@ -82,7 +82,7 @@ class EnrollmentOperationParamsMapper
         TrackedEntity trackedEntity = validateTrackedEntity( operationParams.getTrackedEntityUid() );
 
         User user = currentUserService.getCurrentUser();
-        Set<OrganisationUnit> orgUnits = validateOrgUnits( user, operationParams.getOrganisationUnitUids(), program );
+        Set<OrganisationUnit> orgUnits = validateOrgUnits( user, operationParams.getOrgUnitUids(), program );
 
         EnrollmentQueryParams params = new EnrollmentQueryParams();
         params.setProgram( program );
@@ -95,7 +95,7 @@ class EnrollmentOperationParamsMapper
         params.setTrackedEntityType( trackedEntityType );
         params.setTrackedEntity( trackedEntity );
         params.addOrganisationUnits( orgUnits );
-        params.setOrganisationUnitMode( operationParams.getOrganisationUnitMode() );
+        params.setOrganisationUnitMode( operationParams.getOrgUnitMode() );
         if ( !params.isPaging() && !params.isSkipPaging() )
         {
             params.setPage( DEFAULT_PAGE );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapper.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.export.enrollment;
 
-import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
 import static org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams.DEFAULT_PAGE;
 import static org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams.DEFAULT_PAGE_SIZE;
 
@@ -100,9 +99,11 @@ class EnrollmentOperationParamsMapper
         if ( !params.isPaging() && !params.isSkipPaging() )
         {
             params.setPage( DEFAULT_PAGE );
-            params.setPageSize( DEFAULT_PAGE_SIZE ) ;
+            params.setPageSize( DEFAULT_PAGE_SIZE );
             params.setSkipPaging( false );
-        } else {
+        }
+        else
+        {
             params.setPage( operationParams.getPage() );
             params.setPageSize( operationParams.getPageSize() );
             params.setSkipPaging( operationParams.isSkipPaging() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapper.java
@@ -28,6 +28,8 @@
 package org.hisp.dhis.tracker.export.enrollment;
 
 import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
+import static org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams.DEFAULT_PAGE;
+import static org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams.DEFAULT_PAGE_SIZE;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -95,10 +97,17 @@ class EnrollmentOperationParamsMapper
         params.setTrackedEntity( trackedEntity );
         params.addOrganisationUnits( orgUnits );
         params.setOrganisationUnitMode( operationParams.getOrganisationUnitMode() );
-        params.setPage( operationParams.getPage() );
-        params.setPageSize( operationParams.getPageSize() );
+        if ( !params.isPaging() && !params.isSkipPaging() )
+        {
+            params.setPage( DEFAULT_PAGE );
+            params.setPageSize( DEFAULT_PAGE_SIZE ) ;
+            params.setSkipPaging( false );
+        } else {
+            params.setPage( operationParams.getPage() );
+            params.setPageSize( operationParams.getPageSize() );
+            params.setSkipPaging( operationParams.isSkipPaging() );
+        }
         params.setTotalPages( operationParams.isTotalPages() );
-        params.setSkipPaging( toBooleanDefaultIfNull( operationParams.isSkipPaging(), false ) );
         params.setIncludeDeleted( operationParams.isIncludeDeleted() );
         params.setUser( user );
         params.setOrder( operationParams.getOrder() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapper.java
@@ -53,8 +53,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Maps {@link EnrollmentOperationParams} to
- * {@link EnrollmentQueryParams} which is used to fetch enrollments from the DB.
+ * Maps {@link EnrollmentOperationParams} to {@link EnrollmentQueryParams} which
+ * is used to fetch enrollments from the DB.
  */
 @Component
 @RequiredArgsConstructor

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapper.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.enrollment;
+
+import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import lombok.RequiredArgsConstructor;
+
+import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.EnrollmentQueryParams;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.trackedentity.TrackedEntityService;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
+import org.hisp.dhis.trackedentity.TrackerAccessManager;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Maps operation parameters stored in {@link EnrollmentOperationParams} to
+ * {@link EnrollmentQueryParams} which is used to fetch enrollments from the DB.
+ */
+@Component
+@RequiredArgsConstructor
+class EnrollmentOperationParamsMapper
+{
+    private final CurrentUserService currentUserService;
+
+    private final OrganisationUnitService organisationUnitService;
+
+    private final ProgramService programService;
+
+    private final TrackedEntityTypeService trackedEntityTypeService;
+
+    private final TrackedEntityService trackedEntityService;
+
+    private final TrackerAccessManager trackerAccessManager;
+
+    @Transactional( readOnly = true )
+    public EnrollmentQueryParams map( EnrollmentOperationParams operationParams )
+        throws BadRequestException,
+        ForbiddenException
+    {
+        Program program = validateProgram( operationParams.getProgramUid() );
+        TrackedEntityType trackedEntityType = validateTrackedEntityType( operationParams.getTrackedEntityTypeUid() );
+        TrackedEntity trackedEntity = validateTrackedEntity( operationParams.getTrackedEntityUid() );
+
+        User user = currentUserService.getCurrentUser();
+        Set<OrganisationUnit> orgUnits = validateOrgUnits( user, operationParams.getOrganisationUnitUids(), program );
+
+        EnrollmentQueryParams params = new EnrollmentQueryParams();
+        params.setProgram( program );
+        params.setProgramStatus( operationParams.getProgramStatus() );
+        params.setFollowUp( operationParams.getFollowUp() );
+        params.setLastUpdated( operationParams.getLastUpdated() );
+        params.setLastUpdatedDuration( operationParams.getLastUpdatedDuration() );
+        params.setProgramStartDate( operationParams.getProgramStartDate() );
+        params.setProgramEndDate( operationParams.getProgramEndDate() );
+        params.setTrackedEntityType( trackedEntityType );
+        params.setTrackedEntity( trackedEntity );
+        params.addOrganisationUnits( orgUnits );
+        params.setOrganisationUnitMode( operationParams.getOrganisationUnitMode() );
+        params.setPage( operationParams.getPage() );
+        params.setPageSize( operationParams.getPageSize() );
+        params.setTotalPages( operationParams.isTotalPages() );
+        params.setSkipPaging( toBooleanDefaultIfNull( operationParams.isSkipPaging(), false ) );
+        params.setIncludeDeleted( operationParams.isIncludeDeleted() );
+        params.setUser( user );
+        params.setOrder( operationParams.getOrder() );
+
+        return params;
+    }
+
+    private Program validateProgram( String uid )
+        throws BadRequestException
+    {
+        if ( uid == null )
+        {
+            return null;
+        }
+
+        Program program = programService.getProgram( uid );
+        if ( program == null )
+        {
+            throw new BadRequestException( "Program is specified but does not exist: " + uid );
+        }
+
+        return program;
+    }
+
+    private TrackedEntityType validateTrackedEntityType( String uid )
+        throws BadRequestException
+    {
+        if ( uid == null )
+        {
+            return null;
+        }
+
+        TrackedEntityType trackedEntityType = trackedEntityTypeService.getTrackedEntityType( uid );
+        if ( trackedEntityType == null )
+        {
+            throw new BadRequestException( "Tracked entity type is specified but does not exist: " + uid );
+        }
+
+        return trackedEntityType;
+    }
+
+    private TrackedEntity validateTrackedEntity( String uid )
+        throws BadRequestException
+    {
+        if ( uid == null )
+        {
+            return null;
+        }
+
+        TrackedEntity trackedEntity = trackedEntityService.getTrackedEntity( uid );
+        if ( trackedEntity == null )
+        {
+            throw new BadRequestException( "Tracked entity is specified but does not exist: " + uid );
+        }
+
+        return trackedEntity;
+    }
+
+    private Set<OrganisationUnit> validateOrgUnits( User user, Set<String> orgUnitUids, Program program )
+        throws BadRequestException,
+        ForbiddenException
+    {
+        Set<OrganisationUnit> orgUnits = new HashSet<>();
+        if ( orgUnitUids != null )
+        {
+            for ( String orgUnitUid : orgUnitUids )
+            {
+                OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit(
+                    orgUnitUid );
+
+                if ( orgUnit == null )
+                {
+                    throw new BadRequestException( "Organisation unit does not exist: " + orgUnitUid );
+                }
+
+                if ( !trackerAccessManager.canAccess( user, program, orgUnit ) )
+                {
+                    throw new ForbiddenException(
+                        "User does not have access to organisation unit: " + orgUnit.getUid() );
+                }
+                orgUnits.add( orgUnit );
+            }
+        }
+
+        return orgUnits;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentParams.java
@@ -34,18 +34,15 @@ import lombok.With;
 @Value
 public class EnrollmentParams
 {
-    public static final EnrollmentParams TRUE = new EnrollmentParams( EnrollmentEventsParams.TRUE, true, true, false );
+    public static final EnrollmentParams TRUE = new EnrollmentParams( EnrollmentEventsParams.TRUE, true, true );
 
-    public static final EnrollmentParams FALSE = new EnrollmentParams( EnrollmentEventsParams.FALSE, false, false,
-        false );
+    public static final EnrollmentParams FALSE = new EnrollmentParams( EnrollmentEventsParams.FALSE, false, false );
 
     EnrollmentEventsParams enrollmentEventsParams;
 
     boolean includeRelationships;
 
     boolean includeAttributes;
-
-    boolean includeDeleted;
 
     public boolean isIncludeEvents()
     {
@@ -56,6 +53,6 @@ public class EnrollmentParams
     {
         return this.enrollmentEventsParams.isIncludeEvents() == includeEvents ? this
             : new EnrollmentParams( enrollmentEventsParams.withIncludeEvents( includeEvents ),
-                this.includeRelationships, this.includeAttributes, this.includeDeleted );
+                this.includeRelationships, this.includeAttributes );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
@@ -27,10 +27,10 @@
  */
 package org.hisp.dhis.tracker.export.enrollment;
 
+import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.EnrollmentQueryParams;
 
 public interface EnrollmentService
 {
@@ -41,6 +41,7 @@ public interface EnrollmentService
     Enrollment getEnrollment( Enrollment enrollment, EnrollmentParams params )
         throws ForbiddenException;
 
-    Enrollments getEnrollments( EnrollmentQueryParams params )
-        throws ForbiddenException;
+    Enrollments getEnrollments( EnrollmentOperationParams params )
+        throws ForbiddenException,
+        BadRequestException;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
@@ -34,11 +34,11 @@ import org.hisp.dhis.program.Enrollment;
 
 public interface EnrollmentService
 {
-    Enrollment getEnrollment( String uid, EnrollmentParams params )
+    Enrollment getEnrollment( String uid, EnrollmentParams params, boolean includeDeleted )
         throws NotFoundException,
         ForbiddenException;
 
-    Enrollment getEnrollment( Enrollment enrollment, EnrollmentParams params )
+    Enrollment getEnrollment( Enrollment enrollment, EnrollmentParams params, boolean includeDeleted )
         throws ForbiddenException;
 
     Enrollments getEnrollments( EnrollmentOperationParams params )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -215,7 +215,7 @@ public class DefaultRelationshipService implements RelationshipService
         {
             result.setEnrollment(
                 enrollmentService.getEnrollment( item.getEnrollment(),
-                    EnrollmentParams.TRUE.withIncludeRelationships( false ) ) );
+                    EnrollmentParams.TRUE.withIncludeRelationships( false ), false ) );
         }
         else if ( item.getEvent() != null )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -298,7 +298,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService
         {
             result.setEnrollment(
                 enrollmentService.getEnrollment( item.getEnrollment().getUid(),
-                    EnrollmentParams.TRUE.withIncludeRelationships( false ) ) );
+                    EnrollmentParams.TRUE.withIncludeRelationships( false ), false ) );
         }
         else if ( item.getEvent() != null )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityEnrollmentParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityEnrollmentParams.java
@@ -87,9 +87,4 @@ public class TrackedEntityEnrollmentParams
     {
         return enrollmentParams.isIncludeAttributes();
     }
-
-    public boolean isIncludeDeleted()
-    {
-        return enrollmentParams.isIncludeDeleted();
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapperTest.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.enrollment;
+
+import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.EnrollmentQueryParams;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.trackedentity.TrackedEntityService;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
+import org.hisp.dhis.trackedentity.TrackerAccessManager;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
+import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@MockitoSettings( strictness = Strictness.LENIENT ) // common setup
+@ExtendWith( MockitoExtension.class )
+class EnrollmentRequestParamsMapperTest
+{
+
+    private static final String ORG_UNIT_1_UID = "lW0T2U7gZUi";
+
+    private static final String ORG_UNIT_2_UID = "TK4KA0IIWqa";
+
+    private static final String NOT_PRESENT_ORG_UNIT_UID = "TK4KA0IIWde";
+
+    private static final String PROGRAM_UID = "XhBYIraw7sv";
+
+    private static final String TRACKED_ENTITY_TYPE_UID = "Dp8baZYrLtr";
+
+    private static final String TRACKED_ENTITY_UID = "DGbr8GHG4li";
+
+    @Mock
+    private CurrentUserService currentUserService;
+
+    @Mock
+    private OrganisationUnitService organisationUnitService;
+
+    @Mock
+    private ProgramService programService;
+
+    @Mock
+    private TrackedEntityTypeService trackedEntityTypeService;
+
+    @Mock
+    private TrackedEntityService trackedEntityService;
+
+    @Mock
+    private TrackerAccessManager trackerAccessManager;
+
+    @InjectMocks
+    private EnrollmentOperationParamsMapper mapper;
+
+    private OrganisationUnit orgUnit1;
+
+    private OrganisationUnit orgUnit2;
+
+    private User user;
+
+    private Program program;
+
+    private TrackedEntityType trackedEntityType;
+
+    private TrackedEntity trackedEntity;
+
+    @BeforeEach
+    void setUp()
+    {
+        user = new User();
+        when( currentUserService.getCurrentUser() ).thenReturn( user );
+
+        orgUnit1 = new OrganisationUnit( "orgUnit1" );
+        orgUnit1.setUid( ORG_UNIT_1_UID );
+        when( organisationUnitService.getOrganisationUnit( orgUnit1.getUid() ) ).thenReturn( orgUnit1 );
+        when( organisationUnitService.isInUserHierarchy( orgUnit1.getUid(),
+                user.getTeiSearchOrganisationUnitsWithFallback() ) ).thenReturn( true );
+        orgUnit2 = new OrganisationUnit( "orgUnit2" );
+        orgUnit2.setUid( ORG_UNIT_2_UID );
+        when( organisationUnitService.getOrganisationUnit( orgUnit2.getUid() ) ).thenReturn( orgUnit2 );
+        when( organisationUnitService.isInUserHierarchy( orgUnit2.getUid(),
+                user.getTeiSearchOrganisationUnitsWithFallback() ) ).thenReturn( true );
+
+        program = new Program();
+        program.setUid( PROGRAM_UID );
+        when( programService.getProgram( PROGRAM_UID ) ).thenReturn( program );
+
+        trackedEntityType = new TrackedEntityType();
+        trackedEntityType.setUid( TRACKED_ENTITY_TYPE_UID );
+        when( trackedEntityTypeService.getTrackedEntityType( TRACKED_ENTITY_TYPE_UID ) )
+                .thenReturn( trackedEntityType );
+
+        trackedEntity = new TrackedEntity();
+        trackedEntity.setUid( TRACKED_ENTITY_UID );
+        when( trackedEntityService.getTrackedEntity( TRACKED_ENTITY_UID ) )
+                .thenReturn( trackedEntity );
+    }
+
+    @Test
+    void shouldMapWithoutFetchingNullParamsWhenParamsAreNotSpecified()
+            throws BadRequestException,
+            ForbiddenException
+    {
+        EnrollmentOperationParams operationParams = EnrollmentOperationParams.EMPTY;
+
+        mapper.map( operationParams );
+
+        verifyNoInteractions( programService );
+        verifyNoInteractions( organisationUnitService );
+        verifyNoInteractions( trackedEntityTypeService );
+        verifyNoInteractions( trackedEntityService );
+    }
+
+    @Test
+    void shouldMapOrgUnitsWhenOrgUnitUidsAreSpecified()
+            throws BadRequestException,
+            ForbiddenException
+    {
+        EnrollmentOperationParams operationParams = EnrollmentOperationParams.builder()
+                .organisationUnitUids( Set.of(ORG_UNIT_1_UID, ORG_UNIT_2_UID)  )
+                .programUid( program.getUid() )
+                .build();
+        when( trackerAccessManager.canAccess( user, program, orgUnit1 ) ).thenReturn( true );
+        when( trackerAccessManager.canAccess( user, program, orgUnit2 ) ).thenReturn( true );
+
+        EnrollmentQueryParams params = mapper.map( operationParams );
+
+        assertContainsOnly( Set.of( orgUnit1, orgUnit2 ), params.getOrganisationUnits() );
+    }
+
+    @Test
+    void shouldThrowExceptionWhenOrgUnitNotFound()
+    {
+        EnrollmentOperationParams operationParams = EnrollmentOperationParams.builder()
+                .organisationUnitUids( Set.of("JW6BrFd0HLu", ORG_UNIT_2_UID ) )
+                .programUid( PROGRAM_UID )
+                .build();
+
+        when( trackerAccessManager.canAccess( user, program, orgUnit2 ) ).thenReturn( true );
+
+        Exception exception = assertThrows( BadRequestException.class,
+            () -> mapper.map( operationParams ) );
+        assertEquals( "Organisation unit does not exist: JW6BrFd0HLu", exception.getMessage() );
+    }
+
+    @Test
+    void shouldThrowExceptionWhenOrgUnitNotInScope()
+    {
+        EnrollmentOperationParams operationParams = EnrollmentOperationParams.builder()
+                .organisationUnitUids( Set.of(ORG_UNIT_1_UID) )
+                .build();
+        when( trackerAccessManager.canAccess( user, program, orgUnit1 ) ).thenReturn( false );
+
+        Exception exception = assertThrows( ForbiddenException.class,
+            () -> mapper.map( operationParams ) );
+        assertEquals( "User does not have access to organisation unit: " + ORG_UNIT_1_UID, exception.getMessage() );
+    }
+
+    @Test
+    void shouldMapProgramWhenProgramUidIsSpecified()
+            throws BadRequestException,
+            ForbiddenException
+    {
+        EnrollmentOperationParams requestParams = EnrollmentOperationParams.builder()
+                .programUid( PROGRAM_UID )
+                .build();
+
+        EnrollmentQueryParams params = mapper.map( requestParams );
+
+        assertEquals( program, params.getProgram() );
+    }
+
+    @Test
+    void shouldThrowExceptionWhenProgramNotFound()
+    {
+        EnrollmentOperationParams operationParams = EnrollmentOperationParams.builder()
+                .programUid( "JW6BrFd0HLu" )
+                .build();
+
+        Exception exception = assertThrows( BadRequestException.class,
+            () -> mapper.map( operationParams ) );
+        assertEquals( "Program is specified but does not exist: JW6BrFd0HLu", exception.getMessage() );
+    }
+
+    @Test
+    void shouldMapTrackedEntityTypeWhenTrackedEntityTypeUidIsSpecified()
+            throws BadRequestException,
+            ForbiddenException
+    {
+        EnrollmentOperationParams operationParams = EnrollmentOperationParams.builder()
+                .trackedEntityTypeUid( TRACKED_ENTITY_TYPE_UID )
+                .build();
+
+        EnrollmentQueryParams params = mapper.map( operationParams );
+
+        assertEquals( trackedEntityType, params.getTrackedEntityType() );
+    }
+
+    @Test
+    void shouldThrowExceptionWhenTrackedEntityTypeNotFound()
+    {
+        EnrollmentOperationParams requestParams = EnrollmentOperationParams.builder()
+                .trackedEntityTypeUid( "JW6BrFd0HLu" )
+                .build();
+
+        Exception exception = assertThrows( BadRequestException.class,
+            () -> mapper.map( requestParams ) );
+        assertEquals( "Tracked entity type is specified but does not exist: JW6BrFd0HLu", exception.getMessage() );
+    }
+
+    @Test
+    void shouldMapTrackedEntityWhenTrackedEntityUidIsSpecified()
+            throws BadRequestException,
+            ForbiddenException
+    {
+        EnrollmentOperationParams operationParams = EnrollmentOperationParams.builder()
+                .trackedEntityUid( TRACKED_ENTITY_UID )
+                .build();
+
+        EnrollmentQueryParams params = mapper.map( operationParams );
+
+        assertEquals( trackedEntity, params.getTrackedEntity() );
+    }
+
+    @Test
+    void shouldThrowExceptionTrackedEntityNotFound()
+    {
+        EnrollmentOperationParams operationParams = EnrollmentOperationParams.builder()
+                .trackedEntityUid( "JW6BrFd0HLu" )
+                .build();
+
+        Exception exception = assertThrows( BadRequestException.class,
+            () -> mapper.map( operationParams ) );
+        assertEquals( "Tracked entity is specified but does not exist: JW6BrFd0HLu", exception.getMessage() );
+    }
+
+    @Test
+    void shouldMapOrderingParamsWhenOrderingParamsAreSpecified()
+            throws BadRequestException,
+            ForbiddenException
+    {
+        OrderParam order1 = new OrderParam( "field1", SortDirection.ASC );
+        OrderParam order2 = new OrderParam( "field2", SortDirection.DESC );
+        EnrollmentOperationParams operationParams = EnrollmentOperationParams.builder()
+                .order( List.of( order1, order2 ) )
+                .build();
+
+        EnrollmentQueryParams params = mapper.map( operationParams );
+
+        assertEquals( List.of(
+                new OrderParam( "field1", SortDirection.ASC ),
+                new OrderParam( "field2", SortDirection.DESC ) ), params.getOrder() );
+    }
+
+    @Test
+    void shouldMapNullOrderingParamsWhenNoOrderingParamsAreSpecified()
+            throws BadRequestException,
+            ForbiddenException
+    {
+        EnrollmentOperationParams requestParams = EnrollmentOperationParams.EMPTY;
+
+        EnrollmentQueryParams params = mapper.map( requestParams );
+
+        assertNull( params.getOrder() );
+    }
+}
+

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapperTest.java
@@ -165,7 +165,7 @@ class EnrollmentRequestParamsMapperTest
         ForbiddenException
     {
         EnrollmentOperationParams operationParams = EnrollmentOperationParams.builder()
-            .organisationUnitUids( Set.of( ORG_UNIT_1_UID, ORG_UNIT_2_UID ) )
+            .orgUnitUids( Set.of( ORG_UNIT_1_UID, ORG_UNIT_2_UID ) )
             .programUid( program.getUid() )
             .build();
         when( trackerAccessManager.canAccess( user, program, orgUnit1 ) ).thenReturn( true );
@@ -180,7 +180,7 @@ class EnrollmentRequestParamsMapperTest
     void shouldThrowExceptionWhenOrgUnitNotFound()
     {
         EnrollmentOperationParams operationParams = EnrollmentOperationParams.builder()
-            .organisationUnitUids( Set.of( "JW6BrFd0HLu", ORG_UNIT_2_UID ) )
+            .orgUnitUids( Set.of( "JW6BrFd0HLu", ORG_UNIT_2_UID ) )
             .programUid( PROGRAM_UID )
             .build();
 
@@ -195,7 +195,7 @@ class EnrollmentRequestParamsMapperTest
     void shouldThrowExceptionWhenOrgUnitNotInScope()
     {
         EnrollmentOperationParams operationParams = EnrollmentOperationParams.builder()
-            .organisationUnitUids( Set.of( ORG_UNIT_1_UID ) )
+            .orgUnitUids( Set.of( ORG_UNIT_1_UID ) )
             .build();
         when( trackerAccessManager.canAccess( user, program, orgUnit1 ) ).thenReturn( false );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapperTest.java
@@ -27,6 +27,16 @@
  */
 package org.hisp.dhis.tracker.export.enrollment;
 
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -51,17 +61,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-
-import java.util.List;
-import java.util.Set;
-
-import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
-import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
 @MockitoSettings( strictness = Strictness.LENIENT ) // common setup
 @ExtendWith( MockitoExtension.class )
@@ -123,12 +122,12 @@ class EnrollmentRequestParamsMapperTest
         orgUnit1.setUid( ORG_UNIT_1_UID );
         when( organisationUnitService.getOrganisationUnit( orgUnit1.getUid() ) ).thenReturn( orgUnit1 );
         when( organisationUnitService.isInUserHierarchy( orgUnit1.getUid(),
-                user.getTeiSearchOrganisationUnitsWithFallback() ) ).thenReturn( true );
+            user.getTeiSearchOrganisationUnitsWithFallback() ) ).thenReturn( true );
         orgUnit2 = new OrganisationUnit( "orgUnit2" );
         orgUnit2.setUid( ORG_UNIT_2_UID );
         when( organisationUnitService.getOrganisationUnit( orgUnit2.getUid() ) ).thenReturn( orgUnit2 );
         when( organisationUnitService.isInUserHierarchy( orgUnit2.getUid(),
-                user.getTeiSearchOrganisationUnitsWithFallback() ) ).thenReturn( true );
+            user.getTeiSearchOrganisationUnitsWithFallback() ) ).thenReturn( true );
 
         program = new Program();
         program.setUid( PROGRAM_UID );
@@ -137,18 +136,18 @@ class EnrollmentRequestParamsMapperTest
         trackedEntityType = new TrackedEntityType();
         trackedEntityType.setUid( TRACKED_ENTITY_TYPE_UID );
         when( trackedEntityTypeService.getTrackedEntityType( TRACKED_ENTITY_TYPE_UID ) )
-                .thenReturn( trackedEntityType );
+            .thenReturn( trackedEntityType );
 
         trackedEntity = new TrackedEntity();
         trackedEntity.setUid( TRACKED_ENTITY_UID );
         when( trackedEntityService.getTrackedEntity( TRACKED_ENTITY_UID ) )
-                .thenReturn( trackedEntity );
+            .thenReturn( trackedEntity );
     }
 
     @Test
     void shouldMapWithoutFetchingNullParamsWhenParamsAreNotSpecified()
-            throws BadRequestException,
-            ForbiddenException
+        throws BadRequestException,
+        ForbiddenException
     {
         EnrollmentOperationParams operationParams = EnrollmentOperationParams.EMPTY;
 
@@ -162,13 +161,13 @@ class EnrollmentRequestParamsMapperTest
 
     @Test
     void shouldMapOrgUnitsWhenOrgUnitUidsAreSpecified()
-            throws BadRequestException,
-            ForbiddenException
+        throws BadRequestException,
+        ForbiddenException
     {
         EnrollmentOperationParams operationParams = EnrollmentOperationParams.builder()
-                .organisationUnitUids( Set.of(ORG_UNIT_1_UID, ORG_UNIT_2_UID)  )
-                .programUid( program.getUid() )
-                .build();
+            .organisationUnitUids( Set.of( ORG_UNIT_1_UID, ORG_UNIT_2_UID ) )
+            .programUid( program.getUid() )
+            .build();
         when( trackerAccessManager.canAccess( user, program, orgUnit1 ) ).thenReturn( true );
         when( trackerAccessManager.canAccess( user, program, orgUnit2 ) ).thenReturn( true );
 
@@ -181,9 +180,9 @@ class EnrollmentRequestParamsMapperTest
     void shouldThrowExceptionWhenOrgUnitNotFound()
     {
         EnrollmentOperationParams operationParams = EnrollmentOperationParams.builder()
-                .organisationUnitUids( Set.of("JW6BrFd0HLu", ORG_UNIT_2_UID ) )
-                .programUid( PROGRAM_UID )
-                .build();
+            .organisationUnitUids( Set.of( "JW6BrFd0HLu", ORG_UNIT_2_UID ) )
+            .programUid( PROGRAM_UID )
+            .build();
 
         when( trackerAccessManager.canAccess( user, program, orgUnit2 ) ).thenReturn( true );
 
@@ -196,8 +195,8 @@ class EnrollmentRequestParamsMapperTest
     void shouldThrowExceptionWhenOrgUnitNotInScope()
     {
         EnrollmentOperationParams operationParams = EnrollmentOperationParams.builder()
-                .organisationUnitUids( Set.of(ORG_UNIT_1_UID) )
-                .build();
+            .organisationUnitUids( Set.of( ORG_UNIT_1_UID ) )
+            .build();
         when( trackerAccessManager.canAccess( user, program, orgUnit1 ) ).thenReturn( false );
 
         Exception exception = assertThrows( ForbiddenException.class,
@@ -207,12 +206,12 @@ class EnrollmentRequestParamsMapperTest
 
     @Test
     void shouldMapProgramWhenProgramUidIsSpecified()
-            throws BadRequestException,
-            ForbiddenException
+        throws BadRequestException,
+        ForbiddenException
     {
         EnrollmentOperationParams requestParams = EnrollmentOperationParams.builder()
-                .programUid( PROGRAM_UID )
-                .build();
+            .programUid( PROGRAM_UID )
+            .build();
 
         EnrollmentQueryParams params = mapper.map( requestParams );
 
@@ -223,8 +222,8 @@ class EnrollmentRequestParamsMapperTest
     void shouldThrowExceptionWhenProgramNotFound()
     {
         EnrollmentOperationParams operationParams = EnrollmentOperationParams.builder()
-                .programUid( "JW6BrFd0HLu" )
-                .build();
+            .programUid( "JW6BrFd0HLu" )
+            .build();
 
         Exception exception = assertThrows( BadRequestException.class,
             () -> mapper.map( operationParams ) );
@@ -233,12 +232,12 @@ class EnrollmentRequestParamsMapperTest
 
     @Test
     void shouldMapTrackedEntityTypeWhenTrackedEntityTypeUidIsSpecified()
-            throws BadRequestException,
-            ForbiddenException
+        throws BadRequestException,
+        ForbiddenException
     {
         EnrollmentOperationParams operationParams = EnrollmentOperationParams.builder()
-                .trackedEntityTypeUid( TRACKED_ENTITY_TYPE_UID )
-                .build();
+            .trackedEntityTypeUid( TRACKED_ENTITY_TYPE_UID )
+            .build();
 
         EnrollmentQueryParams params = mapper.map( operationParams );
 
@@ -249,8 +248,8 @@ class EnrollmentRequestParamsMapperTest
     void shouldThrowExceptionWhenTrackedEntityTypeNotFound()
     {
         EnrollmentOperationParams requestParams = EnrollmentOperationParams.builder()
-                .trackedEntityTypeUid( "JW6BrFd0HLu" )
-                .build();
+            .trackedEntityTypeUid( "JW6BrFd0HLu" )
+            .build();
 
         Exception exception = assertThrows( BadRequestException.class,
             () -> mapper.map( requestParams ) );
@@ -259,12 +258,12 @@ class EnrollmentRequestParamsMapperTest
 
     @Test
     void shouldMapTrackedEntityWhenTrackedEntityUidIsSpecified()
-            throws BadRequestException,
-            ForbiddenException
+        throws BadRequestException,
+        ForbiddenException
     {
         EnrollmentOperationParams operationParams = EnrollmentOperationParams.builder()
-                .trackedEntityUid( TRACKED_ENTITY_UID )
-                .build();
+            .trackedEntityUid( TRACKED_ENTITY_UID )
+            .build();
 
         EnrollmentQueryParams params = mapper.map( operationParams );
 
@@ -275,8 +274,8 @@ class EnrollmentRequestParamsMapperTest
     void shouldThrowExceptionTrackedEntityNotFound()
     {
         EnrollmentOperationParams operationParams = EnrollmentOperationParams.builder()
-                .trackedEntityUid( "JW6BrFd0HLu" )
-                .build();
+            .trackedEntityUid( "JW6BrFd0HLu" )
+            .build();
 
         Exception exception = assertThrows( BadRequestException.class,
             () -> mapper.map( operationParams ) );
@@ -285,26 +284,26 @@ class EnrollmentRequestParamsMapperTest
 
     @Test
     void shouldMapOrderingParamsWhenOrderingParamsAreSpecified()
-            throws BadRequestException,
-            ForbiddenException
+        throws BadRequestException,
+        ForbiddenException
     {
         OrderParam order1 = new OrderParam( "field1", SortDirection.ASC );
         OrderParam order2 = new OrderParam( "field2", SortDirection.DESC );
         EnrollmentOperationParams operationParams = EnrollmentOperationParams.builder()
-                .order( List.of( order1, order2 ) )
-                .build();
+            .order( List.of( order1, order2 ) )
+            .build();
 
         EnrollmentQueryParams params = mapper.map( operationParams );
 
         assertEquals( List.of(
-                new OrderParam( "field1", SortDirection.ASC ),
-                new OrderParam( "field2", SortDirection.DESC ) ), params.getOrder() );
+            new OrderParam( "field1", SortDirection.ASC ),
+            new OrderParam( "field2", SortDirection.DESC ) ), params.getOrder() );
     }
 
     @Test
     void shouldMapNullOrderingParamsWhenNoOrderingParamsAreSpecified()
-            throws BadRequestException,
-            ForbiddenException
+        throws BadRequestException,
+        ForbiddenException
     {
         EnrollmentOperationParams requestParams = EnrollmentOperationParams.EMPTY;
 
@@ -313,4 +312,3 @@ class EnrollmentRequestParamsMapperTest
         assertNull( params.getOrder() );
     }
 }
-

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -383,9 +383,10 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
 
         manager.updateNoAcl( programA );
 
-        EnrollmentOperationParams params = EnrollmentOperationParams.EMPTY;
-        params.setProgramUid( programA.getUid() );
-        params.setOrganisationUnitMode( OrganisationUnitSelectionMode.ACCESSIBLE );
+        EnrollmentOperationParams params = EnrollmentOperationParams.builder()
+                .programUid( programA.getUid() )
+                .organisationUnitMode( OrganisationUnitSelectionMode.ACCESSIBLE )
+                .build();
 
         Enrollments enrollments = enrollmentService.getEnrollments( params );
 
@@ -401,9 +402,10 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         programA.getSharing().setPublicAccess( AccessStringHelper.DATA_READ );
         manager.updateNoAcl( programA );
 
-        EnrollmentOperationParams params = EnrollmentOperationParams.EMPTY;
-        params.setOrganisationUnitUids( Set.of( trackedEntityA.getOrganisationUnit().getUid() ) );
-        params.setTrackedEntityUid( trackedEntityA.getUid() );
+        EnrollmentOperationParams params = EnrollmentOperationParams.builder()
+                .organisationUnitUids( Set.of( trackedEntityA.getOrganisationUnit().getUid() ) )
+                .trackedEntityUid( trackedEntityA.getUid() )
+                .build();
 
         Enrollments enrollments = enrollmentService.getEnrollments( params );
 
@@ -421,9 +423,10 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         trackedEntityTypeA.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
         manager.updateNoAcl( trackedEntityTypeA );
 
-        EnrollmentOperationParams params = EnrollmentOperationParams.EMPTY;
-        params.setOrganisationUnitUids( Set.of( trackedEntityA.getOrganisationUnit().getUid() ) );
-        params.setTrackedEntityUid( trackedEntityA.getUid() );
+        EnrollmentOperationParams params = EnrollmentOperationParams.builder()
+                .organisationUnitUids( Set.of( trackedEntityA.getOrganisationUnit().getUid() ) )
+                .trackedEntityUid( trackedEntityA.getUid() )
+                .build();
 
         ForbiddenException exception = assertThrows( ForbiddenException.class,
             () -> enrollmentService.getEnrollments( params ) );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -44,11 +44,11 @@ import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.commons.util.RelationshipUtils;
+import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.EnrollmentQueryParams;
 import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
@@ -376,15 +376,16 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
 
     @Test
     void shouldGetEnrollmentsWhenUserHasReadAccessToProgramAndSearchScopeAccessToOrgUnit()
-        throws ForbiddenException
+        throws ForbiddenException,
+        BadRequestException
     {
-        programA.getSharing().setPublicAccess( AccessStringHelper.DATA_READ );
+        programA.getSharing().setPublicAccess( AccessStringHelper.FULL );
+
         manager.updateNoAcl( programA );
 
-        EnrollmentQueryParams params = new EnrollmentQueryParams();
-        params.setProgram( programA );
+        EnrollmentOperationParams params = new EnrollmentOperationParams();
+        params.setProgramUid( programA.getUid() );
         params.setOrganisationUnitMode( OrganisationUnitSelectionMode.ACCESSIBLE );
-        params.setUser( user );
 
         Enrollments enrollments = enrollmentService.getEnrollments( params );
 
@@ -394,15 +395,15 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
 
     @Test
     void shouldGetEnrollmentsByTrackedEntityWhenUserHasAccessToTrackedEntityType()
-        throws ForbiddenException
+        throws ForbiddenException,
+        BadRequestException
     {
         programA.getSharing().setPublicAccess( AccessStringHelper.DATA_READ );
         manager.updateNoAcl( programA );
 
-        EnrollmentQueryParams params = new EnrollmentQueryParams();
-        params.setOrganisationUnits( Set.of( trackedEntityA.getOrganisationUnit() ) );
+        EnrollmentOperationParams params = new EnrollmentOperationParams();
+        params.setOrganisationUnitUids( Set.of( trackedEntityA.getOrganisationUnit().getUid() ) );
         params.setTrackedEntityUid( trackedEntityA.getUid() );
-        params.setUser( user );
 
         Enrollments enrollments = enrollmentService.getEnrollments( params );
 
@@ -420,10 +421,9 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         trackedEntityTypeA.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
         manager.updateNoAcl( trackedEntityTypeA );
 
-        EnrollmentQueryParams params = new EnrollmentQueryParams();
-        params.setOrganisationUnits( Set.of( trackedEntityA.getOrganisationUnit() ) );
+        EnrollmentOperationParams params = new EnrollmentOperationParams();
+        params.setOrganisationUnitUids( Set.of( trackedEntityA.getOrganisationUnit().getUid() ) );
         params.setTrackedEntityUid( trackedEntityA.getUid() );
-        params.setUser( user );
 
         ForbiddenException exception = assertThrows( ForbiddenException.class,
             () -> enrollmentService.getEnrollments( params ) );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -383,7 +383,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
 
         manager.updateNoAcl( programA );
 
-        EnrollmentOperationParams params = new EnrollmentOperationParams();
+        EnrollmentOperationParams params = EnrollmentOperationParams.EMPTY;
         params.setProgramUid( programA.getUid() );
         params.setOrganisationUnitMode( OrganisationUnitSelectionMode.ACCESSIBLE );
 
@@ -401,7 +401,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         programA.getSharing().setPublicAccess( AccessStringHelper.DATA_READ );
         manager.updateNoAcl( programA );
 
-        EnrollmentOperationParams params = new EnrollmentOperationParams();
+        EnrollmentOperationParams params = EnrollmentOperationParams.EMPTY;
         params.setOrganisationUnitUids( Set.of( trackedEntityA.getOrganisationUnit().getUid() ) );
         params.setTrackedEntityUid( trackedEntityA.getUid() );
 
@@ -421,7 +421,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         trackedEntityTypeA.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
         manager.updateNoAcl( trackedEntityTypeA );
 
-        EnrollmentOperationParams params = new EnrollmentOperationParams();
+        EnrollmentOperationParams params = EnrollmentOperationParams.EMPTY;
         params.setOrganisationUnitUids( Set.of( trackedEntityA.getOrganisationUnit().getUid() ) );
         params.setTrackedEntityUid( trackedEntityA.getUid() );
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -226,7 +226,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         manager.updateNoAcl( programA );
 
         Enrollment enrollment = enrollmentService.getEnrollment( enrollmentA.getUid(),
-            EnrollmentParams.FALSE );
+            EnrollmentParams.FALSE, false );
 
         assertNotNull( enrollment );
         assertEquals( enrollmentA.getUid(), enrollment.getUid() );
@@ -241,7 +241,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         manager.updateNoAcl( programA );
 
         Enrollment enrollment = enrollmentService.getEnrollment( enrollmentA.getUid(),
-            EnrollmentParams.FALSE );
+            EnrollmentParams.FALSE, false );
 
         assertNotNull( enrollment );
         assertEquals( enrollmentA.getUid(), enrollment.getUid() );
@@ -255,7 +255,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         EnrollmentParams params = EnrollmentParams.FALSE;
         params = params.withEnrollmentEventsParams( EnrollmentEventsParams.TRUE );
 
-        Enrollment enrollment = enrollmentService.getEnrollment( enrollmentA.getUid(), params );
+        Enrollment enrollment = enrollmentService.getEnrollment( enrollmentA.getUid(), params, false );
 
         assertNotNull( enrollment );
         assertContainsOnly( List.of( eventA.getUid() ), enrollment.getEvents().stream()
@@ -274,7 +274,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         EnrollmentParams params = EnrollmentParams.FALSE;
         params = params.withIncludeEvents( true );
 
-        Enrollment enrollment = enrollmentService.getEnrollment( enrollmentA.getUid(), params );
+        Enrollment enrollment = enrollmentService.getEnrollment( enrollmentA.getUid(), params, false );
 
         assertNotNull( enrollment );
         assertIsEmpty( enrollment.getEvents() );
@@ -288,7 +288,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         EnrollmentParams params = EnrollmentParams.FALSE;
         params = params.withIncludeRelationships( true );
 
-        Enrollment enrollment = enrollmentService.getEnrollment( enrollmentA.getUid(), params );
+        Enrollment enrollment = enrollmentService.getEnrollment( enrollmentA.getUid(), params, false );
 
         assertNotNull( enrollment );
         assertContainsOnly( Set.of( relationshipA.getUid() ), relationshipUids( enrollment ) );
@@ -305,7 +305,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         EnrollmentParams params = EnrollmentParams.FALSE;
         params = params.withIncludeRelationships( true );
 
-        Enrollment enrollment = enrollmentService.getEnrollment( enrollmentA.getUid(), params );
+        Enrollment enrollment = enrollmentService.getEnrollment( enrollmentA.getUid(), params, false );
 
         assertNotNull( enrollment );
         assertIsEmpty( enrollment.getRelationshipItems() );
@@ -319,7 +319,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         EnrollmentParams params = EnrollmentParams.FALSE;
         params = params.withIncludeAttributes( true );
 
-        Enrollment enrollment = enrollmentService.getEnrollment( enrollmentA.getUid(), params );
+        Enrollment enrollment = enrollmentService.getEnrollment( enrollmentA.getUid(), params, false );
 
         assertNotNull( enrollment );
         assertContainsOnly( List.of( trackedEntityAttributeA.getUid() ), attributeUids( enrollment ) );
@@ -333,7 +333,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         manager.updateNoAcl( trackedEntityTypeA );
 
         ForbiddenException exception = assertThrows( ForbiddenException.class,
-            () -> enrollmentService.getEnrollment( enrollmentA.getUid(), EnrollmentParams.FALSE ) );
+            () -> enrollmentService.getEnrollment( enrollmentA.getUid(), EnrollmentParams.FALSE, false ) );
         assertContains( "access to tracked entity type", exception.getMessage() );
     }
 
@@ -346,7 +346,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         injectSecurityContext( userWithoutOrgUnit );
 
         ForbiddenException exception = assertThrows( ForbiddenException.class,
-            () -> enrollmentService.getEnrollment( enrollmentA.getUid(), EnrollmentParams.FALSE ) );
+            () -> enrollmentService.getEnrollment( enrollmentA.getUid(), EnrollmentParams.FALSE, false ) );
         assertContains( "OWNERSHIP_ACCESS_DENIED", exception.getMessage() );
     }
 
@@ -359,7 +359,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         injectSecurityContext( userWithoutOrgUnit );
 
         ForbiddenException exception = assertThrows( ForbiddenException.class,
-            () -> enrollmentService.getEnrollment( enrollmentA.getUid(), EnrollmentParams.FALSE ) );
+            () -> enrollmentService.getEnrollment( enrollmentA.getUid(), EnrollmentParams.FALSE, false ) );
         assertContains( "OWNERSHIP_ACCESS_DENIED", exception.getMessage() );
     }
 
@@ -370,7 +370,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         manager.updateNoAcl( programA );
 
         ForbiddenException exception = assertThrows( ForbiddenException.class,
-            () -> enrollmentService.getEnrollment( enrollmentA.getUid(), EnrollmentParams.FALSE ) );
+            () -> enrollmentService.getEnrollment( enrollmentA.getUid(), EnrollmentParams.FALSE, false ) );
         assertContains( "access to program", exception.getMessage() );
     }
 
@@ -385,7 +385,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
 
         EnrollmentOperationParams params = EnrollmentOperationParams.builder()
             .programUid( programA.getUid() )
-            .organisationUnitMode( OrganisationUnitSelectionMode.ACCESSIBLE )
+            .orgUnitMode( OrganisationUnitSelectionMode.ACCESSIBLE )
             .build();
 
         Enrollments enrollments = enrollmentService.getEnrollments( params );
@@ -403,7 +403,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         manager.updateNoAcl( programA );
 
         EnrollmentOperationParams params = EnrollmentOperationParams.builder()
-            .organisationUnitUids( Set.of( trackedEntityA.getOrganisationUnit().getUid() ) )
+            .orgUnitUids( Set.of( trackedEntityA.getOrganisationUnit().getUid() ) )
             .trackedEntityUid( trackedEntityA.getUid() )
             .build();
 
@@ -424,7 +424,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         manager.updateNoAcl( trackedEntityTypeA );
 
         EnrollmentOperationParams params = EnrollmentOperationParams.builder()
-            .organisationUnitUids( Set.of( trackedEntityA.getOrganisationUnit().getUid() ) )
+            .orgUnitUids( Set.of( trackedEntityA.getOrganisationUnit().getUid() ) )
             .trackedEntityUid( trackedEntityA.getUid() )
             .build();
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -384,9 +384,9 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         manager.updateNoAcl( programA );
 
         EnrollmentOperationParams params = EnrollmentOperationParams.builder()
-                .programUid( programA.getUid() )
-                .organisationUnitMode( OrganisationUnitSelectionMode.ACCESSIBLE )
-                .build();
+            .programUid( programA.getUid() )
+            .organisationUnitMode( OrganisationUnitSelectionMode.ACCESSIBLE )
+            .build();
 
         Enrollments enrollments = enrollmentService.getEnrollments( params );
 
@@ -403,9 +403,9 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         manager.updateNoAcl( programA );
 
         EnrollmentOperationParams params = EnrollmentOperationParams.builder()
-                .organisationUnitUids( Set.of( trackedEntityA.getOrganisationUnit().getUid() ) )
-                .trackedEntityUid( trackedEntityA.getUid() )
-                .build();
+            .organisationUnitUids( Set.of( trackedEntityA.getOrganisationUnit().getUid() ) )
+            .trackedEntityUid( trackedEntityA.getUid() )
+            .build();
 
         Enrollments enrollments = enrollmentService.getEnrollments( params );
 
@@ -424,9 +424,9 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest
         manager.updateNoAcl( trackedEntityTypeA );
 
         EnrollmentOperationParams params = EnrollmentOperationParams.builder()
-                .organisationUnitUids( Set.of( trackedEntityA.getOrganisationUnit().getUid() ) )
-                .trackedEntityUid( trackedEntityA.getUid() )
-                .build();
+            .organisationUnitUids( Set.of( trackedEntityA.getOrganisationUnit().getUid() ) )
+            .trackedEntityUid( trackedEntityA.getUid() )
+            .build();
 
         ForbiddenException exception = assertThrows( ForbiddenException.class,
             () -> enrollmentService.getEnrollments( params ) );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/EnrollmentCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/EnrollmentCriteriaMapper.java
@@ -31,12 +31,10 @@ import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toO
 
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import lombok.RequiredArgsConstructor;
 
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.feedback.ForbiddenException;
@@ -162,8 +160,7 @@ public class EnrollmentCriteriaMapper
         params.setProgramStartDate( programStartDate );
         params.setProgramEndDate( programEndDate );
         params.setTrackedEntityType( te );
-        params.setTrackedEntityUid(
-            Optional.ofNullable( tei ).map( IdentifiableObject::getUid ).orElse( null ) );
+        params.setTrackedEntity( tei );
         params.setOrganisationUnitMode( ouMode );
         params.setPage( page );
         params.setPageSize( pageSize );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
@@ -68,17 +68,15 @@ class EnrollmentRequestParamsMapper
                 requestParams.getTrackedEntityType() != null ? requestParams.getTrackedEntityType().getValue() : null )
             .trackedEntityUid(
                 requestParams.getTrackedEntity() != null ? requestParams.getTrackedEntity().getValue() : null )
-            .organisationUnitUids( orgUnits.stream().map( UID::getValue ).collect( Collectors.toSet() ) )
-            .organisationUnitMode( requestParams.getOuMode() )
+            .orgUnitUids( UID.toValueSet(orgUnits ) )
+            .orgUnitMode( requestParams.getOuMode() )
             .page( requestParams.getPage() )
             .pageSize( requestParams.getPageSize() )
             .totalPages( requestParams.isTotalPages() )
             .skipPaging( toBooleanDefaultIfNull( requestParams.isSkipPaging(), false ) )
             .includeDeleted( requestParams.isIncludeDeleted() )
             .order( toOrderParams( requestParams.getOrder() ) )
-            .enrollmentParams(
-                fieldsParamMapper.map( requestParams.getFields() )
-                    .withIncludeDeleted( requestParams.isIncludeDeleted() ) )
+            .enrollmentParams( fieldsParamMapper.map( requestParams.getFields() ) )
             .build();
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
@@ -32,7 +32,6 @@ import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toO
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedUidsParameter;
 
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 
@@ -68,7 +67,7 @@ class EnrollmentRequestParamsMapper
                 requestParams.getTrackedEntityType() != null ? requestParams.getTrackedEntityType().getValue() : null )
             .trackedEntityUid(
                 requestParams.getTrackedEntity() != null ? requestParams.getTrackedEntity().getValue() : null )
-            .orgUnitUids( UID.toValueSet(orgUnits ) )
+            .orgUnitUids( UID.toValueSet( orgUnits ) )
             .orgUnitMode( requestParams.getOuMode() )
             .page( requestParams.getPage() )
             .pageSize( requestParams.getPageSize() )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
@@ -27,20 +27,17 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.enrollment;
 
-import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
-import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
-import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedUidsParameter;
+import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
+import org.hisp.dhis.webapi.common.UID;
+import org.springframework.stereotype.Component;
 
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import lombok.RequiredArgsConstructor;
-
-import org.hisp.dhis.feedback.BadRequestException;
-import org.hisp.dhis.feedback.ForbiddenException;
-import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
-import org.hisp.dhis.webapi.common.UID;
-import org.springframework.stereotype.Component;
+import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
+import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedUidsParameter;
 
 /**
  * Maps operation parameters from {@link EnrollmentsExportController} stored in
@@ -54,35 +51,32 @@ class EnrollmentRequestParamsMapper
     private final EnrollmentFieldsParamMapper fieldsParamMapper;
 
     public EnrollmentOperationParams map( RequestParams requestParams )
-        throws BadRequestException,
-        ForbiddenException
     {
         Set<UID> orgUnits = validateDeprecatedUidsParameter( "orgUnit", requestParams.getOrgUnit(), "orgUnits",
             requestParams.getOrgUnits() );
 
-        EnrollmentOperationParams params = new EnrollmentOperationParams();
-        params.setProgramUid( requestParams.getProgram() != null ? requestParams.getProgram().getValue() : null );
-        params.setProgramStatus( requestParams.getProgramStatus() );
-        params.setFollowUp( requestParams.getFollowUp() );
-        params.setLastUpdated( requestParams.getUpdatedAfter() );
-        params.setLastUpdatedDuration( requestParams.getUpdatedWithin() );
-        params.setProgramStartDate( requestParams.getEnrolledAfter() );
-        params.setProgramEndDate( requestParams.getEnrolledBefore() );
-        params.setTrackedEntityTypeUid(
-            requestParams.getTrackedEntityType() != null ? requestParams.getTrackedEntityType().getValue() : null );
-        params.setTrackedEntityUid(
-            requestParams.getTrackedEntity() != null ? requestParams.getTrackedEntity().getValue() : null );
-        params.addOrganisationUnits( orgUnits.stream().map( UID::getValue ).collect( Collectors.toSet() ) );
-        params.setOrganisationUnitMode( requestParams.getOuMode() );
-        params.setPage( requestParams.getPage() );
-        params.setPageSize( requestParams.getPageSize() );
-        params.setTotalPages( requestParams.isTotalPages() );
-        params.setSkipPaging( toBooleanDefaultIfNull( requestParams.isSkipPaging(), false ) );
-        params.setIncludeDeleted( requestParams.isIncludeDeleted() );
-        params.setOrder( toOrderParams( requestParams.getOrder() ) );
-        params.setEnrollmentParams(
-            fieldsParamMapper.map( requestParams.getFields() ).withIncludeDeleted( requestParams.isIncludeDeleted() ) );
-
-        return params;
+        return EnrollmentOperationParams.builder()
+        .programUid( requestParams.getProgram() != null ? requestParams.getProgram().getValue() : null )
+        .programStatus( requestParams.getProgramStatus() )
+        .followUp( requestParams.getFollowUp() )
+        .lastUpdated( requestParams.getUpdatedAfter() )
+        .lastUpdatedDuration( requestParams.getUpdatedWithin() )
+        .programStartDate( requestParams.getEnrolledAfter() )
+        .programEndDate( requestParams.getEnrolledBefore() )
+        .trackedEntityTypeUid(
+            requestParams.getTrackedEntityType() != null ? requestParams.getTrackedEntityType().getValue() : null )
+        .trackedEntityUid(
+            requestParams.getTrackedEntity() != null ? requestParams.getTrackedEntity().getValue() : null )
+        .organisationUnitUids( orgUnits.stream().map( UID::getValue ).collect( Collectors.toSet() ) )
+        .organisationUnitMode( requestParams.getOuMode() )
+        .page( requestParams.getPage() )
+        .pageSize( requestParams.getPageSize() )
+        .totalPages( requestParams.isTotalPages() )
+        .skipPaging( toBooleanDefaultIfNull( requestParams.isSkipPaging(), false ) )
+        .includeDeleted( requestParams.isIncludeDeleted() )
+        .order( toOrderParams( requestParams.getOrder() ) )
+        .enrollmentParams(
+            fieldsParamMapper.map( requestParams.getFields() ).withIncludeDeleted( requestParams.isIncludeDeleted() ) )
+        .build();
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
@@ -31,175 +31,58 @@ import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
 import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedUidsParameter;
 
-import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
-
-import javax.annotation.Nonnull;
+import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.organisationunit.OrganisationUnitService;
-import org.hisp.dhis.program.EnrollmentQueryParams;
-import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.trackedentity.TrackedEntity;
-import org.hisp.dhis.trackedentity.TrackedEntityService;
-import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
-import org.hisp.dhis.trackedentity.TrackerAccessManager;
-import org.hisp.dhis.user.CurrentUserService;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
 import org.hisp.dhis.webapi.common.UID;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Maps query parameters from {@link EnrollmentsExportController} stored in
- * {@link RequestParams} to {@link EnrollmentQueryParams} which is used to fetch
- * enrollments from the DB.
+ * Maps operation parameters from {@link EnrollmentsExportController} stored in
+ * {@link RequestParams} to {@link EnrollmentOperationParams} which is used to
+ * fetch enrollments from the service.
  */
 @Component
 @RequiredArgsConstructor
 class EnrollmentRequestParamsMapper
 {
-    @Nonnull
-    private final CurrentUserService currentUserService;
+    private final EnrollmentFieldsParamMapper fieldsParamMapper;
 
-    @Nonnull
-    private final OrganisationUnitService organisationUnitService;
-
-    @Nonnull
-    private final ProgramService programService;
-
-    @Nonnull
-    private final TrackedEntityTypeService trackedEntityTypeService;
-
-    @Nonnull
-    private final TrackedEntityService trackedEntityService;
-
-    @Nonnull
-    private final TrackerAccessManager trackerAccessManager;
-
-    @Transactional( readOnly = true )
-    public EnrollmentQueryParams map( RequestParams requestParams )
+    public EnrollmentOperationParams map( RequestParams requestParams )
         throws BadRequestException,
         ForbiddenException
     {
-        Program program = validateProgram( requestParams.getProgram() );
-        TrackedEntityType trackedEntityType = validateTrackedEntityType( requestParams.getTrackedEntityType() );
-        TrackedEntity trackedEntity = validateTrackedEntity( requestParams.getTrackedEntity() );
-
-        User user = currentUserService.getCurrentUser();
-        Set<UID> orgUnitUids = validateDeprecatedUidsParameter( "orgUnit", requestParams.getOrgUnit(), "orgUnits",
+        Set<UID> orgUnits = validateDeprecatedUidsParameter( "orgUnit", requestParams.getOrgUnit(), "orgUnits",
             requestParams.getOrgUnits() );
-        Set<OrganisationUnit> orgUnits = validateOrgUnits( user, orgUnitUids, program );
 
-        EnrollmentQueryParams params = new EnrollmentQueryParams();
-        params.setProgram( program );
+        EnrollmentOperationParams params = new EnrollmentOperationParams();
+        params.setProgramUid( requestParams.getProgram() != null ? requestParams.getProgram().getValue() : null );
         params.setProgramStatus( requestParams.getProgramStatus() );
         params.setFollowUp( requestParams.getFollowUp() );
         params.setLastUpdated( requestParams.getUpdatedAfter() );
         params.setLastUpdatedDuration( requestParams.getUpdatedWithin() );
         params.setProgramStartDate( requestParams.getEnrolledAfter() );
         params.setProgramEndDate( requestParams.getEnrolledBefore() );
-        params.setTrackedEntityType( trackedEntityType );
+        params.setTrackedEntityTypeUid(
+            requestParams.getTrackedEntityType() != null ? requestParams.getTrackedEntityType().getValue() : null );
         params.setTrackedEntityUid(
-            Optional.ofNullable( trackedEntity ).map( IdentifiableObject::getUid ).orElse( null ) );
-        params.addOrganisationUnits( orgUnits );
+            requestParams.getTrackedEntity() != null ? requestParams.getTrackedEntity().getValue() : null );
+        params.addOrganisationUnits( orgUnits.stream().map( UID::getValue ).collect( Collectors.toSet() ) );
         params.setOrganisationUnitMode( requestParams.getOuMode() );
         params.setPage( requestParams.getPage() );
         params.setPageSize( requestParams.getPageSize() );
         params.setTotalPages( requestParams.isTotalPages() );
         params.setSkipPaging( toBooleanDefaultIfNull( requestParams.isSkipPaging(), false ) );
         params.setIncludeDeleted( requestParams.isIncludeDeleted() );
-        params.setUser( user );
         params.setOrder( toOrderParams( requestParams.getOrder() ) );
+        params.setEnrollmentParams(
+            fieldsParamMapper.map( requestParams.getFields() ).withIncludeDeleted( requestParams.isIncludeDeleted() ) );
 
         return params;
-    }
-
-    private Program validateProgram( UID uid )
-        throws BadRequestException
-    {
-        if ( uid == null )
-        {
-            return null;
-        }
-
-        Program program = programService.getProgram( uid.getValue() );
-        if ( program == null )
-        {
-            throw new BadRequestException( "Program is specified but does not exist: " + uid );
-        }
-
-        return program;
-    }
-
-    private TrackedEntityType validateTrackedEntityType( UID uid )
-        throws BadRequestException
-    {
-        if ( uid == null )
-        {
-            return null;
-        }
-
-        TrackedEntityType trackedEntityType = trackedEntityTypeService.getTrackedEntityType( uid.getValue() );
-        if ( trackedEntityType == null )
-        {
-            throw new BadRequestException( "Tracked entity type is specified but does not exist: " + uid );
-        }
-
-        return trackedEntityType;
-    }
-
-    private TrackedEntity validateTrackedEntity( UID uid )
-        throws BadRequestException
-    {
-        if ( uid == null )
-        {
-            return null;
-        }
-
-        TrackedEntity trackedEntity = trackedEntityService.getTrackedEntity( uid.getValue() );
-        if ( trackedEntity == null )
-        {
-            throw new BadRequestException( "Tracked entity is specified but does not exist: " + uid );
-        }
-
-        return trackedEntity;
-    }
-
-    private Set<OrganisationUnit> validateOrgUnits( User user, Set<UID> orgUnitUids, Program program )
-        throws BadRequestException,
-        ForbiddenException
-    {
-        Set<OrganisationUnit> orgUnits = new HashSet<>();
-        if ( orgUnitUids != null )
-        {
-            for ( UID orgUnitUid : orgUnitUids )
-            {
-                OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit(
-                    orgUnitUid.getValue() );
-
-                if ( orgUnit == null )
-                {
-                    throw new BadRequestException( "Organisation unit does not exist: " + orgUnitUid.getValue() );
-                }
-
-                if ( !trackerAccessManager.canAccess( user, program, orgUnit ) )
-                {
-                    throw new ForbiddenException(
-                        "User does not have access to organisation unit: " + orgUnit.getUid() );
-                }
-                orgUnits.add( orgUnit );
-            }
-        }
-
-        return orgUnits;
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
@@ -27,17 +27,18 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.enrollment;
 
-import lombok.RequiredArgsConstructor;
-import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
-import org.hisp.dhis.webapi.common.UID;
-import org.springframework.stereotype.Component;
+import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
+import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedUidsParameter;
 
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
-import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
-import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedUidsParameter;
+import lombok.RequiredArgsConstructor;
+
+import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
+import org.hisp.dhis.webapi.common.UID;
+import org.springframework.stereotype.Component;
 
 /**
  * Maps operation parameters from {@link EnrollmentsExportController} stored in
@@ -56,27 +57,28 @@ class EnrollmentRequestParamsMapper
             requestParams.getOrgUnits() );
 
         return EnrollmentOperationParams.builder()
-        .programUid( requestParams.getProgram() != null ? requestParams.getProgram().getValue() : null )
-        .programStatus( requestParams.getProgramStatus() )
-        .followUp( requestParams.getFollowUp() )
-        .lastUpdated( requestParams.getUpdatedAfter() )
-        .lastUpdatedDuration( requestParams.getUpdatedWithin() )
-        .programStartDate( requestParams.getEnrolledAfter() )
-        .programEndDate( requestParams.getEnrolledBefore() )
-        .trackedEntityTypeUid(
-            requestParams.getTrackedEntityType() != null ? requestParams.getTrackedEntityType().getValue() : null )
-        .trackedEntityUid(
-            requestParams.getTrackedEntity() != null ? requestParams.getTrackedEntity().getValue() : null )
-        .organisationUnitUids( orgUnits.stream().map( UID::getValue ).collect( Collectors.toSet() ) )
-        .organisationUnitMode( requestParams.getOuMode() )
-        .page( requestParams.getPage() )
-        .pageSize( requestParams.getPageSize() )
-        .totalPages( requestParams.isTotalPages() )
-        .skipPaging( toBooleanDefaultIfNull( requestParams.isSkipPaging(), false ) )
-        .includeDeleted( requestParams.isIncludeDeleted() )
-        .order( toOrderParams( requestParams.getOrder() ) )
-        .enrollmentParams(
-            fieldsParamMapper.map( requestParams.getFields() ).withIncludeDeleted( requestParams.isIncludeDeleted() ) )
-        .build();
+            .programUid( requestParams.getProgram() != null ? requestParams.getProgram().getValue() : null )
+            .programStatus( requestParams.getProgramStatus() )
+            .followUp( requestParams.getFollowUp() )
+            .lastUpdated( requestParams.getUpdatedAfter() )
+            .lastUpdatedDuration( requestParams.getUpdatedWithin() )
+            .programStartDate( requestParams.getEnrolledAfter() )
+            .programEndDate( requestParams.getEnrolledBefore() )
+            .trackedEntityTypeUid(
+                requestParams.getTrackedEntityType() != null ? requestParams.getTrackedEntityType().getValue() : null )
+            .trackedEntityUid(
+                requestParams.getTrackedEntity() != null ? requestParams.getTrackedEntity().getValue() : null )
+            .organisationUnitUids( orgUnits.stream().map( UID::getValue ).collect( Collectors.toSet() ) )
+            .organisationUnitMode( requestParams.getOuMode() )
+            .page( requestParams.getPage() )
+            .pageSize( requestParams.getPageSize() )
+            .totalPages( requestParams.isTotalPages() )
+            .skipPaging( toBooleanDefaultIfNull( requestParams.isSkipPaging(), false ) )
+            .includeDeleted( requestParams.isIncludeDeleted() )
+            .order( toOrderParams( requestParams.getOrder() ) )
+            .enrollmentParams(
+                fieldsParamMapper.map( requestParams.getFields() )
+                    .withIncludeDeleted( requestParams.isIncludeDeleted() ) )
+            .build();
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
@@ -56,6 +56,7 @@ import org.hisp.dhis.webapi.controller.tracker.export.OpenApiExport;
 import org.hisp.dhis.webapi.controller.tracker.view.Enrollment;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.mapstruct.factory.Mappers;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -75,8 +76,6 @@ class EnrollmentsExportController
     protected static final String ENROLLMENTS = "enrollments";
 
     private static final EnrollmentMapper ENROLLMENT_MAPPER = Mappers.getMapper( EnrollmentMapper.class );
-
-    private final EnrollmentRequestParamsMapper paramsMapper;
 
     private final EnrollmentRequestParamsMapper operationParamsMapper;
 
@@ -119,7 +118,7 @@ class EnrollmentsExportController
             List<org.hisp.dhis.program.Enrollment> list = new ArrayList<>();
             for ( UID uid : enrollmentUids )
             {
-                list.add( enrollmentService.getEnrollment( uid.getValue(), operationParams.getEnrollmentParams() ) );
+                list.add( enrollmentService.getEnrollment( uid.getValue(), operationParams.getEnrollmentParams(), operationParams.isIncludeDeleted() ) );
             }
             enrollmentList = list;
         }
@@ -131,7 +130,7 @@ class EnrollmentsExportController
 
     @OpenApi.Response( OpenApi.EntityType.class )
     @GetMapping( value = "/{uid}" )
-    public ObjectNode getEnrollmentByUid(
+    public ResponseEntity<ObjectNode> getEnrollmentByUid(
         @OpenApi.Param( { UID.class, Enrollment.class } ) @PathVariable UID uid,
         @OpenApi.Param( value = String[].class ) @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
         throws NotFoundException,
@@ -139,7 +138,7 @@ class EnrollmentsExportController
     {
         EnrollmentParams enrollmentParams = fieldsMapper.map( fields );
         Enrollment enrollment = ENROLLMENT_MAPPER
-            .from( enrollmentService.getEnrollment( uid.getValue(), enrollmentParams ) );
-        return fieldFilterService.toObjectNode( enrollment, fields );
+            .from( enrollmentService.getEnrollment( uid.getValue(), enrollmentParams, false ) );
+        return ResponseEntity.ok(fieldFilterService.toObjectNode( enrollment, fields ));
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
@@ -118,7 +118,8 @@ class EnrollmentsExportController
             List<org.hisp.dhis.program.Enrollment> list = new ArrayList<>();
             for ( UID uid : enrollmentUids )
             {
-                list.add( enrollmentService.getEnrollment( uid.getValue(), operationParams.getEnrollmentParams(), operationParams.isIncludeDeleted() ) );
+                list.add( enrollmentService.getEnrollment( uid.getValue(), operationParams.getEnrollmentParams(),
+                    operationParams.isIncludeDeleted() ) );
             }
             enrollmentList = list;
         }
@@ -139,6 +140,6 @@ class EnrollmentsExportController
         EnrollmentParams enrollmentParams = fieldsMapper.map( fields );
         Enrollment enrollment = ENROLLMENT_MAPPER
             .from( enrollmentService.getEnrollment( uid.getValue(), enrollmentParams, false ) );
-        return ResponseEntity.ok(fieldFilterService.toObjectNode( enrollment, fields ));
+        return ResponseEntity.ok( fieldFilterService.toObjectNode( enrollment, fields ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityFieldsParamMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityFieldsParamMapper.java
@@ -73,7 +73,7 @@ class TrackedEntityFieldsParamMapper
             fieldFilterService.filterIncludes( TrackedEntity.class, fields, FIELD_PROGRAM_OWNERS ) );
         params = params.withIncludeAttributes(
             fieldFilterService.filterIncludes( TrackedEntity.class, fields, FIELD_ATTRIBUTES ) );
-        params = params.withIncludeDeleted(includeDeleted);
+        params = params.withIncludeDeleted( includeDeleted );
 
         EventParams eventParams = new EventParams(
             fieldFilterService.filterIncludes( TrackedEntity.class, fields, "enrollments.events.relationships" ) );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityFieldsParamMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityFieldsParamMapper.java
@@ -73,6 +73,7 @@ class TrackedEntityFieldsParamMapper
             fieldFilterService.filterIncludes( TrackedEntity.class, fields, FIELD_PROGRAM_OWNERS ) );
         params = params.withIncludeAttributes(
             fieldFilterService.filterIncludes( TrackedEntity.class, fields, FIELD_ATTRIBUTES ) );
+        params = params.withIncludeDeleted(includeDeleted);
 
         EventParams eventParams = new EventParams(
             fieldFilterService.filterIncludes( TrackedEntity.class, fields, "enrollments.events.relationships" ) );
@@ -82,8 +83,7 @@ class TrackedEntityFieldsParamMapper
         EnrollmentParams enrollmentParams = new EnrollmentParams(
             enrollmentEventsParams,
             fieldFilterService.filterIncludes( TrackedEntity.class, fields, "enrollments.relationships" ),
-            fieldFilterService.filterIncludes( TrackedEntity.class, fields, "enrollments.attributes" ),
-            includeDeleted );
+            fieldFilterService.filterIncludes( TrackedEntity.class, fields, "enrollments.attributes" ) );
         TrackedEntityEnrollmentParams teiEnrollmentParams = new TrackedEntityEnrollmentParams(
             fieldFilterService.filterIncludes( TrackedEntity.class, fields, FIELD_ENROLLMENTS ),
             enrollmentParams );

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapperTest.java
@@ -27,30 +27,9 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.enrollment;
 
-import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
-import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
-
-import java.util.List;
-import java.util.Set;
-
-import org.hisp.dhis.feedback.BadRequestException;
-import org.hisp.dhis.feedback.ForbiddenException;
-import org.hisp.dhis.fieldfiltering.FieldFilterService;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.organisationunit.OrganisationUnitService;
-import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.trackedentity.TrackedEntity;
-import org.hisp.dhis.trackedentity.TrackedEntityService;
-import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
-import org.hisp.dhis.trackedentity.TrackerAccessManager;
+import org.hisp.dhis.fieldfiltering.FieldFilterParser;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
-import org.hisp.dhis.user.CurrentUserService;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.tracker.export.enrollment.EnrollmentParams;
 import org.hisp.dhis.webapi.common.UID;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
@@ -58,10 +37,23 @@ import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
+import static org.hisp.dhis.webapi.controller.tracker.export.enrollment.RequestParams.DEFAULT_FIELDS_PARAM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @MockitoSettings( strictness = Strictness.LENIENT ) // common setup
 @ExtendWith( MockitoExtension.class )
@@ -79,174 +71,53 @@ class EnrollmentRequestParamsMapperTest
     private static final String TRACKED_ENTITY_UID = "DGbr8GHG4li";
 
     @Mock
-    private CurrentUserService currentUserService;
+    private EnrollmentFieldsParamMapper fieldsParamMapper;
 
-    @Mock
-    private OrganisationUnitService organisationUnitService;
-
-    @Mock
-    private ProgramService programService;
-
-    @Mock
-    private TrackedEntityTypeService trackedEntityTypeService;
-
-    @Mock
-    private TrackedEntityService trackedEntityService;
-
-    @Mock
-    private TrackerAccessManager trackerAccessManager;
-
-    @Mock
-    private FieldFilterService fieldFilterService;
-
+    @InjectMocks
     private EnrollmentRequestParamsMapper mapper;
-
-    private OrganisationUnit orgUnit1;
-
-    private OrganisationUnit orgUnit2;
-
-    private User user;
-
-    private Program program;
-
-    private TrackedEntityType trackedEntityType;
 
     @BeforeEach
     void setUp()
     {
-        user = new User();
-        when( currentUserService.getCurrentUser() ).thenReturn( user );
-
-        orgUnit1 = new OrganisationUnit( "orgUnit1" );
-        orgUnit1.setUid( ORG_UNIT_1_UID );
-        when( organisationUnitService.getOrganisationUnit( orgUnit1.getUid() ) ).thenReturn( orgUnit1 );
-        when( organisationUnitService.isInUserHierarchy( orgUnit1.getUid(),
-            user.getTeiSearchOrganisationUnitsWithFallback() ) ).thenReturn( true );
-        orgUnit2 = new OrganisationUnit( "orgUnit2" );
-        orgUnit2.setUid( ORG_UNIT_2_UID );
-        when( organisationUnitService.getOrganisationUnit( orgUnit2.getUid() ) ).thenReturn( orgUnit2 );
-        when( organisationUnitService.isInUserHierarchy( orgUnit2.getUid(),
-            user.getTeiSearchOrganisationUnitsWithFallback() ) ).thenReturn( true );
-
-        program = new Program();
-        program.setUid( PROGRAM_UID );
-        when( programService.getProgram( PROGRAM_UID ) ).thenReturn( program );
-
-        trackedEntityType = new TrackedEntityType();
-        trackedEntityType.setUid( TRACKED_ENTITY_TYPE_UID );
-        when( trackedEntityTypeService.getTrackedEntityType( TRACKED_ENTITY_TYPE_UID ) )
-            .thenReturn( trackedEntityType );
-
-        TrackedEntity trackedEntity = new TrackedEntity();
-        trackedEntity.setUid( TRACKED_ENTITY_UID );
-        when( trackedEntityService.getTrackedEntity( TRACKED_ENTITY_UID ) )
-            .thenReturn( trackedEntity );
-
-        mapper = new EnrollmentRequestParamsMapper( new EnrollmentFieldsParamMapper( fieldFilterService ) );
+        when(fieldsParamMapper.map(anyList())).thenReturn(EnrollmentParams.FALSE);
     }
 
     @Test
     void testMappingDoesNotFetchOptionalEmptyQueryParametersFromDB()
-        throws BadRequestException,
-        ForbiddenException
     {
         RequestParams requestParams = new RequestParams();
 
         mapper.map( requestParams );
 
-        verifyNoInteractions( programService );
-        verifyNoInteractions( organisationUnitService );
-        verifyNoInteractions( trackedEntityTypeService );
-        verifyNoInteractions( trackedEntityService );
+        verify( fieldsParamMapper, times(1) ).map(FieldFilterParser.parse( DEFAULT_FIELDS_PARAM ));
     }
 
     @Test
     void testMappingOrgUnit()
-        throws BadRequestException,
-        ForbiddenException
     {
         RequestParams requestParams = new RequestParams();
         requestParams.setOrgUnit( ORG_UNIT_1_UID + ";" + ORG_UNIT_2_UID );
-        requestParams.setProgram( UID.of( program ) );
-        when( trackerAccessManager.canAccess( user, program, orgUnit1 ) ).thenReturn( true );
-        when( trackerAccessManager.canAccess( user, program, orgUnit2 ) ).thenReturn( true );
+        requestParams.setProgram( UID.of(PROGRAM_UID) );
 
         EnrollmentOperationParams params = mapper.map( requestParams );
 
         assertContainsOnly( Set.of( ORG_UNIT_1_UID, ORG_UNIT_2_UID ), params.getOrganisationUnitUids() );
     }
-
-    //    @Test
-    //    void testMappingOrgUnitNotFound()
-    //    {
-    //        RequestParams requestParams = new RequestParams();
-    //        requestParams.setOrgUnit( "NeU85luyD4w;" + ORG_UNIT_2_UID );
-    //        requestParams.setProgram( UID.of( program ) );
-    //        requestParams.setProgram( UID.of( program ) );
-    //        when( trackerAccessManager.canAccess( user, program, orgUnit2 ) ).thenReturn( true );
-    //
-    //        Exception exception = assertThrows( BadRequestException.class,
-    //            () -> mapper.map( requestParams ) );
-    //        assertEquals( "Organisation unit does not exist: NeU85luyD4w", exception.getMessage() );
-    //    }
-
-    //    @Test
-    //    void shouldThrowExceptionWhenOrgUnitNotInScope()
-    //    {
-    //        RequestParams requestParams = new RequestParams();
-    //        requestParams.setOrgUnit( ORG_UNIT_1_UID );
-    //        when( trackerAccessManager.canAccess( user, program, orgUnit1 ) ).thenReturn( false );
-    //
-    //        Exception exception = assertThrows( ForbiddenException.class,
-    //            () -> mapper.map( requestParams ) );
-    //        assertEquals( "User does not have access to organisation unit: " + ORG_UNIT_1_UID, exception.getMessage() );
-    //    }
 
     @Test
     void testMappingOrgUnits()
-        throws BadRequestException,
-        ForbiddenException
     {
         RequestParams requestParams = new RequestParams();
         requestParams.setOrgUnits( Set.of( UID.of( ORG_UNIT_1_UID ), UID.of( ORG_UNIT_2_UID ) ) );
-        requestParams.setProgram( UID.of( program ) );
-        when( trackerAccessManager.canAccess( user, program, orgUnit1 ) ).thenReturn( true );
-        when( trackerAccessManager.canAccess( user, program, orgUnit2 ) ).thenReturn( true );
+        requestParams.setProgram( UID.of( PROGRAM_UID ) );
 
         EnrollmentOperationParams params = mapper.map( requestParams );
 
         assertContainsOnly( Set.of( ORG_UNIT_1_UID, ORG_UNIT_2_UID ), params.getOrganisationUnitUids() );
     }
 
-    //    @Test
-    //    void testMappingOrgUnitsNotFound()
-    //    {
-    //        RequestParams requestParams = new RequestParams();
-    //        requestParams.setOrgUnits( Set.of( UID.of( "NeU85luyD4w" ), UID.of( ORG_UNIT_2_UID ) ) );
-    //        requestParams.setProgram( UID.of( program ) );
-    //        when( trackerAccessManager.canAccess( user, program, orgUnit2 ) ).thenReturn( true );
-    //
-    //        Exception exception = assertThrows( BadRequestException.class,
-    //            () -> mapper.map( requestParams ) );
-    //        assertEquals( "Organisation unit does not exist: NeU85luyD4w", exception.getMessage() );
-    //    }
-
-    //    @Test
-    //    void shouldThrowExceptionWhenOrgUnitsNotInScope()
-    //    {
-    //        RequestParams requestParams = new RequestParams();
-    //        requestParams.setOrgUnits( Set.of( UID.of( ORG_UNIT_1_UID ) ) );
-    //        when( trackerAccessManager.canAccess( user, program, orgUnit1 ) ).thenReturn( false );
-    //
-    //        Exception exception = assertThrows( ForbiddenException.class,
-    //            () -> mapper.map( requestParams ) );
-    //        assertEquals( "User does not have access to organisation unit: " + ORG_UNIT_1_UID, exception.getMessage() );
-    //    }
-
     @Test
     void testMappingProgram()
-        throws BadRequestException,
-        ForbiddenException
     {
         RequestParams requestParams = new RequestParams();
         requestParams.setProgram( UID.of( PROGRAM_UID ) );
@@ -256,21 +127,8 @@ class EnrollmentRequestParamsMapperTest
         assertEquals( PROGRAM_UID, params.getProgramUid() );
     }
 
-    //    @Test
-    //    void testMappingProgramNotFound()
-    //    {
-    //        RequestParams requestParams = new RequestParams();
-    //        requestParams.setProgram( UID.of( "JW6BrFd0HLu" ) );
-    //
-    //        Exception exception = assertThrows( BadRequestException.class,
-    //            () -> mapper.map( requestParams ) );
-    //        assertEquals( "Program is specified but does not exist: JW6BrFd0HLu", exception.getMessage() );
-    //    }
-
     @Test
     void testMappingTrackedEntityType()
-        throws BadRequestException,
-        ForbiddenException
     {
         RequestParams requestParams = new RequestParams();
         requestParams.setTrackedEntityType( UID.of( TRACKED_ENTITY_TYPE_UID ) );
@@ -280,21 +138,8 @@ class EnrollmentRequestParamsMapperTest
         assertEquals( TRACKED_ENTITY_TYPE_UID, params.getTrackedEntityTypeUid() );
     }
 
-    //    @Test
-    //    void testMappingTrackedEntityTypeNotFound()
-    //    {
-    //        RequestParams requestParams = new RequestParams();
-    //        requestParams.setTrackedEntityType( UID.of( "JW6BrFd0HLu" ) );
-    //
-    //        Exception exception = assertThrows( BadRequestException.class,
-    //            () -> mapper.map( requestParams ) );
-    //        assertEquals( "Tracked entity type is specified but does not exist: JW6BrFd0HLu", exception.getMessage() );
-    //    }
-
     @Test
     void testMappingTrackedEntity()
-        throws BadRequestException,
-        ForbiddenException
     {
         RequestParams requestParams = new RequestParams();
         requestParams.setTrackedEntity( UID.of( TRACKED_ENTITY_UID ) );
@@ -304,21 +149,8 @@ class EnrollmentRequestParamsMapperTest
         assertEquals( TRACKED_ENTITY_UID, params.getTrackedEntityUid() );
     }
 
-    //    @Test
-    //    void testMappingTrackedEntityNotFound()
-    //    {
-    //        RequestParams requestParams = new RequestParams();
-    //        requestParams.setTrackedEntity( UID.of( "JW6BrFd0HLu" ) );
-    //
-    //        Exception exception = assertThrows( BadRequestException.class,
-    //            () -> mapper.map( requestParams ) );
-    //        assertEquals( "Tracked entity is specified but does not exist: JW6BrFd0HLu", exception.getMessage() );
-    //    }
-
     @Test
     void testMappingOrderParams()
-        throws BadRequestException,
-        ForbiddenException
     {
         RequestParams requestParams = new RequestParams();
         OrderCriteria order1 = OrderCriteria.of( "field1", SortDirection.ASC );
@@ -334,8 +166,6 @@ class EnrollmentRequestParamsMapperTest
 
     @Test
     void testMappingOrderParamsNoOrder()
-        throws BadRequestException,
-        ForbiddenException
     {
         RequestParams requestParams = new RequestParams();
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapperTest.java
@@ -101,7 +101,7 @@ class EnrollmentRequestParamsMapperTest
 
         EnrollmentOperationParams params = mapper.map( requestParams );
 
-        assertContainsOnly( Set.of( ORG_UNIT_1_UID, ORG_UNIT_2_UID ), params.getOrganisationUnitUids() );
+        assertContainsOnly( Set.of( ORG_UNIT_1_UID, ORG_UNIT_2_UID ), params.getOrgUnitUids() );
     }
 
     @Test
@@ -113,7 +113,7 @@ class EnrollmentRequestParamsMapperTest
 
         EnrollmentOperationParams params = mapper.map( requestParams );
 
-        assertContainsOnly( Set.of( ORG_UNIT_1_UID, ORG_UNIT_2_UID ), params.getOrganisationUnitUids() );
+        assertContainsOnly( Set.of( ORG_UNIT_1_UID, ORG_UNIT_2_UID ), params.getOrgUnitUids() );
     }
 
     @Test

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapperTest.java
@@ -27,6 +27,18 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.enrollment;
 
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
+import static org.hisp.dhis.webapi.controller.tracker.export.enrollment.RequestParams.DEFAULT_FIELDS_PARAM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+
 import org.hisp.dhis.fieldfiltering.FieldFilterParser;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentParams;
@@ -42,18 +54,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-
-import java.util.List;
-import java.util.Set;
-
-import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
-import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
-import static org.hisp.dhis.webapi.controller.tracker.export.enrollment.RequestParams.DEFAULT_FIELDS_PARAM;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @MockitoSettings( strictness = Strictness.LENIENT ) // common setup
 @ExtendWith( MockitoExtension.class )
@@ -89,7 +89,7 @@ class EnrollmentRequestParamsMapperTest
 
         mapper.map( requestParams );
 
-        verify( fieldsParamMapper, times(1) ).map(FieldFilterParser.parse( DEFAULT_FIELDS_PARAM ));
+        verify( fieldsParamMapper, times( 1 ) ).map( FieldFilterParser.parse( DEFAULT_FIELDS_PARAM ) );
     }
 
     @Test
@@ -97,7 +97,7 @@ class EnrollmentRequestParamsMapperTest
     {
         RequestParams requestParams = new RequestParams();
         requestParams.setOrgUnit( ORG_UNIT_1_UID + ";" + ORG_UNIT_2_UID );
-        requestParams.setProgram( UID.of(PROGRAM_UID) );
+        requestParams.setProgram( UID.of( PROGRAM_UID ) );
 
         EnrollmentOperationParams params = mapper.map( requestParams );
 


### PR DESCRIPTION
Goal of this PR is to create `EnrollmentOperationParams` object for the service layer.

**Detailed changes:**
- Change `trackedEntityUid` field in `EnrollmentQueryParams` to be consistent with other fields.
- Create `EnrollmentOperationParams` object that is meant to contain parameters for the service layer, it is created by converting `RequestParams` and it will be converted to `EnrollmentQueryParams`.
- Separate validations by layer. Move to service layer validations that are accessing DB. (ie. Checking if some metadata exists)

**Next PRs**
- Improving/Rename `EnrollmentParams`
- Pagination 