### PR TITLE
fix: Use search scope if no program provided [DHIS2-15021]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
@@ -800,7 +800,7 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager
             return true;
         }
 
-        if ( program.isClosed() || program.isProtected() )
+        if ( program != null && (program.isClosed() || program.isProtected()) )
         {
             return organisationUnitService.isInUserHierarchy( user, orgUnit );
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
@@ -800,7 +800,7 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager
             return true;
         }
 
-        if ( program == null || program.isClosed() || program.isProtected() )
+        if ( program.isClosed() || program.isProtected() )
         {
             return organisationUnitService.isInUserHierarchy( user, orgUnit );
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManagerTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.trackedentity;
+
+import static org.hisp.dhis.common.AccessLevel.CLOSED;
+import static org.hisp.dhis.common.AccessLevel.OPEN;
+import static org.hisp.dhis.common.AccessLevel.PROTECTED;
+import static org.mockito.Mockito.when;
+
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.user.User;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith( MockitoExtension.class )
+class DefaultTrackerAccessManagerTest
+{
+
+    @Mock
+    private OrganisationUnitService organisationUnitService;
+
+    @InjectMocks
+    private DefaultTrackerAccessManager trackerAccessManager;
+
+    @Test
+    void shouldHaveAccessWhenProgramOpenAndSearchAccessAvailable()
+    {
+        User user = new User();
+        Program program = new Program();
+        program.setAccessLevel( OPEN );
+        OrganisationUnit orgUnit = new OrganisationUnit();
+        when( organisationUnitService.isInUserSearchHierarchy( user, orgUnit ) ).thenReturn( true );
+
+        Assertions.assertTrue( trackerAccessManager.canAccess( user, program, orgUnit ) );
+    }
+
+    @Test
+    void shouldNotHaveAccessWhenProgramNullAndSearchAccessNotAvailable()
+    {
+        User user = new User();
+        OrganisationUnit orgUnit = new OrganisationUnit();
+        when( organisationUnitService.isInUserSearchHierarchy( user, orgUnit ) ).thenReturn( false );
+
+        Assertions.assertFalse( trackerAccessManager.canAccess( user, null, orgUnit ) );
+    }
+
+    @Test
+    void shouldHaveAccessWhenProgramClosedAndCaptureAccessAvailable()
+    {
+        User user = new User();
+        Program program = new Program();
+        program.setAccessLevel( CLOSED );
+        OrganisationUnit orgUnit = new OrganisationUnit();
+        when( organisationUnitService.isInUserHierarchy( user, orgUnit ) ).thenReturn( true );
+
+        Assertions.assertTrue( trackerAccessManager.canAccess( user, program, orgUnit ) );
+    }
+
+    @Test
+    void shouldNotHaveAccessWhenProgramProtectedAndCaptureAccessNotAvailable()
+    {
+        User user = new User();
+        Program program = new Program();
+        program.setAccessLevel( PROTECTED );
+        OrganisationUnit orgUnit = new OrganisationUnit();
+        when( organisationUnitService.isInUserHierarchy( user, orgUnit ) ).thenReturn( false );
+
+        Assertions.assertFalse( trackerAccessManager.canAccess( user, program, orgUnit ) );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManagerTest.java
@@ -30,13 +30,14 @@ package org.hisp.dhis.trackedentity;
 import static org.hisp.dhis.common.AccessLevel.CLOSED;
 import static org.hisp.dhis.common.AccessLevel.OPEN;
 import static org.hisp.dhis.common.AccessLevel.PROTECTED;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.user.User;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -60,9 +61,37 @@ class DefaultTrackerAccessManagerTest
         Program program = new Program();
         program.setAccessLevel( OPEN );
         OrganisationUnit orgUnit = new OrganisationUnit();
+
         when( organisationUnitService.isInUserSearchHierarchy( user, orgUnit ) ).thenReturn( true );
 
-        Assertions.assertTrue( trackerAccessManager.canAccess( user, program, orgUnit ) );
+        assertTrue( trackerAccessManager.canAccess( user, program, orgUnit ),
+            "User should have access to open program" );
+    }
+
+    @Test
+    void shouldNotHaveAccessWhenProgramOpenAndSearchAccessNotAvailable()
+    {
+        User user = new User();
+        Program program = new Program();
+        program.setAccessLevel( OPEN );
+        OrganisationUnit orgUnit = new OrganisationUnit();
+
+        when( organisationUnitService.isInUserSearchHierarchy( user, orgUnit ) ).thenReturn( false );
+
+        assertFalse( trackerAccessManager.canAccess( user, program, orgUnit ),
+            "User should not have access to open program" );
+    }
+
+    @Test
+    void shouldHaveAccessWhenProgramNullAndSearchAccessAvailable()
+    {
+        User user = new User();
+        OrganisationUnit orgUnit = new OrganisationUnit();
+
+        when( organisationUnitService.isInUserSearchHierarchy( user, orgUnit ) ).thenReturn( true );
+
+        assertTrue( trackerAccessManager.canAccess( user, null, orgUnit ),
+            "User should have access to unspecified program" );
     }
 
     @Test
@@ -70,9 +99,11 @@ class DefaultTrackerAccessManagerTest
     {
         User user = new User();
         OrganisationUnit orgUnit = new OrganisationUnit();
+
         when( organisationUnitService.isInUserSearchHierarchy( user, orgUnit ) ).thenReturn( false );
 
-        Assertions.assertFalse( trackerAccessManager.canAccess( user, null, orgUnit ) );
+        assertFalse( trackerAccessManager.canAccess( user, null, orgUnit ),
+            "User should not have access to unspecified program" );
     }
 
     @Test
@@ -82,9 +113,39 @@ class DefaultTrackerAccessManagerTest
         Program program = new Program();
         program.setAccessLevel( CLOSED );
         OrganisationUnit orgUnit = new OrganisationUnit();
+
         when( organisationUnitService.isInUserHierarchy( user, orgUnit ) ).thenReturn( true );
 
-        Assertions.assertTrue( trackerAccessManager.canAccess( user, program, orgUnit ) );
+        assertTrue( trackerAccessManager.canAccess( user, program, orgUnit ),
+            "User should have access to closed program" );
+    }
+
+    @Test
+    void shouldNotHaveAccessWhenProgramClosedAndCaptureAccessNotAvailable()
+    {
+        User user = new User();
+        Program program = new Program();
+        program.setAccessLevel( CLOSED );
+        OrganisationUnit orgUnit = new OrganisationUnit();
+
+        when( organisationUnitService.isInUserHierarchy( user, orgUnit ) ).thenReturn( false );
+
+        assertFalse( trackerAccessManager.canAccess( user, program, orgUnit ),
+            "User should not have access to closed program" );
+    }
+
+    @Test
+    void shouldHaveAccessWhenProgramProtectedAndCaptureAccessAvailable()
+    {
+        User user = new User();
+        Program program = new Program();
+        program.setAccessLevel( PROTECTED );
+        OrganisationUnit orgUnit = new OrganisationUnit();
+
+        when( organisationUnitService.isInUserHierarchy( user, orgUnit ) ).thenReturn( true );
+
+        assertTrue( trackerAccessManager.canAccess( user, program, orgUnit ),
+            "User should have access to protected program" );
     }
 
     @Test
@@ -94,8 +155,10 @@ class DefaultTrackerAccessManagerTest
         Program program = new Program();
         program.setAccessLevel( PROTECTED );
         OrganisationUnit orgUnit = new OrganisationUnit();
+
         when( organisationUnitService.isInUserHierarchy( user, orgUnit ) ).thenReturn( false );
 
-        Assertions.assertFalse( trackerAccessManager.canAccess( user, program, orgUnit ) );
+        assertFalse( trackerAccessManager.canAccess( user, program, orgUnit ),
+            "User should not have access to protected program" );
     }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/deprecated/tracker/event/EventExportTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/deprecated/tracker/event/EventExportTests.java
@@ -142,8 +142,8 @@ public class EventExportTests
         return Stream.of(
             Arguments.of( "OU: root", "SELECTED", rootOu, false, null ),
             Arguments.of( "OU: capture", "SELECTED", captureOu, true, Arrays.asList( captureOu ) ),
-            Arguments.of( "OU: search", "SELECTED", searchOu, true, null ),
-            Arguments.of( "OU: data read", "SELECTED", dataReadOu, true, null ),
+            Arguments.of( "OU: search", "SELECTED", searchOu, true, Arrays.asList( searchOu ) ),
+            Arguments.of( "OU: data read", "SELECTED", dataReadOu, true, Arrays.asList( searchOu ) ),
             Arguments.of( "OU: data read ( DESCENDANTS ) ", "DESCENDANTS", captureOu, true,
                 Arrays.asList( captureOu ) ) );
     }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/deprecated/tracker/event/EventExportTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/deprecated/tracker/event/EventExportTests.java
@@ -142,8 +142,8 @@ public class EventExportTests
         return Stream.of(
             Arguments.of( "OU: root", "SELECTED", rootOu, false, null ),
             Arguments.of( "OU: capture", "SELECTED", captureOu, true, Arrays.asList( captureOu ) ),
-            Arguments.of( "OU: search", "SELECTED", searchOu, false, null ),
-            Arguments.of( "OU: data read", "SELECTED", dataReadOu, false, null ),
+            Arguments.of( "OU: search", "SELECTED", searchOu, true, null ),
+            Arguments.of( "OU: data read", "SELECTED", dataReadOu, true, null ),
             Arguments.of( "OU: data read ( DESCENDANTS ) ", "DESCENDANTS", captureOu, true,
                 Arrays.asList( captureOu ) ) );
     }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/deprecated/tracker/event/EventExportTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/deprecated/tracker/event/EventExportTests.java
@@ -143,7 +143,7 @@ public class EventExportTests
             Arguments.of( "OU: root", "SELECTED", rootOu, false, null ),
             Arguments.of( "OU: capture", "SELECTED", captureOu, true, Arrays.asList( captureOu ) ),
             Arguments.of( "OU: search", "SELECTED", searchOu, true, Arrays.asList( searchOu ) ),
-            Arguments.of( "OU: data read", "SELECTED", dataReadOu, true, Arrays.asList( searchOu ) ),
+            Arguments.of( "OU: data read", "SELECTED", dataReadOu, true, Arrays.asList( dataReadOu ) ),
             Arguments.of( "OU: data read ( DESCENDANTS ) ", "DESCENDANTS", captureOu, true,
                 Arrays.asList( captureOu ) ) );
     }

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -37,7 +37,6 @@
     <module>dhis-web-embedded-jetty</module>
     <module>dhis-test-coverage</module>
     <module>dhis-test-integration</module>
-    <module>dhis-test-e2e</module>
   </modules>
 
   <properties>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -37,6 +37,7 @@
     <module>dhis-web-embedded-jetty</module>
     <module>dhis-test-coverage</module>
     <module>dhis-test-integration</module>
+    <module>dhis-test-e2e</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
As stated by @Bekkalizer, when no program is specified in the request, we would want to give the user access to tracked entity type attributes and the tracked entity itself based on the search org unit. We would however not want to expose tracked entity attributes or enrollment data from protected or closed programs based on this same rule - these would have to be in capture scope. 

ticket: https://dhis2.atlassian.net/browse/DHIS2-15021