### PR TITLE
chore: deprecate /tracker/events?attributeCc in favor of attributeCategoryCombo TECH-1536

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
@@ -338,6 +338,15 @@ class EventsExportControllerTest extends DhisControllerConvenienceTest
                 .getMessage() );
     }
 
+    @Test
+    void getEventsFailsIfGivenAttributeCcAndAttributeCategoryCombo()
+    {
+        assertStartsWith( "Only one parameter of 'attributeCc' and 'attributeCategoryCombo'",
+            GET( "/tracker/events?attributeCc=FQnYqKlIHxd&attributeCategoryCombo=YApXsOpwiXk" )
+                .error( HttpStatus.BAD_REQUEST )
+                .getMessage() );
+    }
+
     private TrackedEntityType trackedEntityTypeAccessible()
     {
         TrackedEntityType type = trackedEntityType( 'A' );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
@@ -172,6 +172,32 @@ public class RequestParamUtils
     }
 
     /**
+     * Helps us transition request parameters from a deprecated to a new one.
+     *
+     * @param deprecatedParamName request parameter name of deprecated parameter
+     * @param deprecatedParam value of deprecated request parameter
+     * @param newParamName new request parameter replacing deprecated request
+     *        parameter
+     * @param newParam value of the request parameter
+     * @return value of the one request parameter that is non-empty
+     * @throws IllegalArgumentException when both deprecated and new request
+     *         parameter are non-empty
+     */
+    public static UID validateDeprecatedUidParameter( String deprecatedParamName, UID deprecatedParam,
+        String newParamName, UID newParam )
+    {
+        if ( newParam != null && deprecatedParam != null )
+        {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Only one parameter of '%s' and '%s' must be specified. Prefer '%s' as '%s' will be removed.",
+                    deprecatedParamName, newParamName, newParamName, deprecatedParamName ) );
+        }
+
+        return newParam != null ? newParam : deprecatedParam;
+    }
+
+    /**
      * Parse semicolon separated string of UIDs.
      *
      * @param input string to parse

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller.tracker.export.event;
 import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseAttributeQueryItems;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseQueryItem;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedUidParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedUidsParameter;
 
 import java.util.ArrayList;
@@ -119,12 +120,14 @@ class EventRequestParamsMapper
 
         TrackedEntity trackedEntity = validateTrackedEntity( requestParams.getTrackedEntity() );
 
+        UID attributeCategoryCombo = validateDeprecatedUidParameter( "attributeCc", requestParams.getAttributeCc(),
+            "attributeCategoryCombo", requestParams.getAttributeCategoryCombo() );
         Set<UID> attributeCategoryOptions = validateDeprecatedUidsParameter( "attributeCos",
             requestParams.getAttributeCos(),
             "attributeCategoryOptions",
             requestParams.getAttributeCategoryOptions() );
         CategoryOptionCombo attributeOptionCombo = categoryOptionComboService.getAttributeOptionCombo(
-            requestParams.getAttributeCc() != null ? requestParams.getAttributeCc().getValue() : null,
+            attributeCategoryCombo != null ? attributeCategoryCombo.getValue() : null,
             UID.toValueSet( attributeCategoryOptions ),
             true );
         validateAttributeOptionCombo( attributeOptionCombo, user );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/RequestParams.java
@@ -126,8 +126,15 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
 
     private EventStatus status;
 
+    /**
+     * @deprecated use {@link #attributeCategoryCombo}
+     */
+    @Deprecated( since = "2.41" )
     @OpenApi.Property( { UID.class, CategoryCombo.class } )
     private UID attributeCc;
+
+    @OpenApi.Property( { UID.class, CategoryCombo.class } )
+    private UID attributeCategoryCombo;
 
     /**
      * Semicolon-delimited list of category option UIDs.

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/EventsExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/EventsExportController.md
@@ -84,7 +84,11 @@ Get events with enrollments that were enrolled before given date.
 
 ### `*.parameter.EventRequestParams.status`
 
+### `*.parameter.EventRequestParams.attributeCategoryCombo`
+
 ### `*.parameter.EventRequestParams.attributeCc`
+
+**DEPRECATED as of 2.41:** Use parameter `attributeCategoryCombo` instead.
 
 ### `*.parameter.EventRequestParams.attributeCategoryOptions`
 


### PR DESCRIPTION
The majority of our API does not use acronyms. We should be consistent. The Event import/export payload for example uses fields attributeOptionCombo, attributeCategoryOptions. Its just natural to thus to use the same names or way of writing them as query parameters.