### PR TITLE
fix: always flush/close batch handlers in DVS import [DHIS2-15362]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
@@ -114,6 +114,7 @@ import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.util.ObjectUtils;
+import org.hisp.quick.BatchHandler;
 import org.hisp.quick.BatchHandlerFactory;
 import org.hisp.staxwax.factory.XMLFactory;
 import org.springframework.stereotype.Service;
@@ -626,14 +627,31 @@ public class DefaultDataValueSetService
     private ImportSummary importDataValueSet( ImportOptions options, JobConfiguration id,
         Callable<DataValueSetReader> createReader )
     {
+        BatchHandler<DataValue> dvBatch = batchHandlerFactory.createBatchHandler( DataValueBatchHandler.class );
+        BatchHandler<DataValueAudit> dvaBatch = batchHandlerFactory.createBatchHandler(
+            DataValueAuditBatchHandler.class );
+
+        notifier.clear( id );
+
         try ( DataValueSetReader reader = createReader.call() )
         {
-            return importDataValueSet( options, id, reader );
+            ImportSummary summary = importDataValueSet( options, id, reader, dvBatch, dvaBatch );
+
+            dvBatch.flush();
+            dvaBatch.flush();
+
+            NotificationLevel notificationLevel = options.getNotificationLevel( INFO );
+            notifier.notify( id, notificationLevel, "Import done", true )
+                .addJobSummary( id, notificationLevel, summary, ImportSummary.class );
+
+            return summary;
         }
         catch ( Exception ex )
         {
+            dvBatch.flush();
+            dvaBatch.flush();
             log.error( DebugUtils.getStackTrace( ex ) );
-            notifier.clear( id ).notify( id, ERROR, "Process failed: " + ex.getMessage(), true );
+            notifier.notify( id, ERROR, "Process failed: " + ex.getMessage(), true );
             return new ImportSummary( ImportStatus.ERROR, "The import process failed: " + ex.getMessage() );
         }
     }
@@ -655,16 +673,18 @@ public class DefaultDataValueSetService
      * If id scheme is specific in the data value set, any id schemes in the
      * import options will be ignored.
      */
-    private ImportSummary importDataValueSet( ImportOptions options, JobConfiguration id, DataValueSetReader reader )
+    private ImportSummary importDataValueSet( ImportOptions options, JobConfiguration id, DataValueSetReader reader,
+        BatchHandler<DataValue> dataValueBatchHandler, BatchHandler<DataValueAudit> auditBatchHandler )
     {
         DataValueSet dataValueSet = reader.readHeader();
-        final ImportContext context = createDataValueSetImportContext( options, dataValueSet );
+        final ImportContext context = createDataValueSetImportContext( options, dataValueSet,
+            dataValueBatchHandler, auditBatchHandler );
         logDataValueSetImportContextInfo( context );
 
         Clock clock = new Clock( log ).startClock()
             .logTime( "Starting data value import, options: " + context.getImportOptions() );
-        NotificationLevel notificationLevel = context.getImportOptions().getNotificationLevel( INFO );
-        notifier.clear( id ).notify( id, notificationLevel, "Process started" );
+        NotificationLevel notificationLevel = options.getNotificationLevel( INFO );
+        notifier.notify( id, notificationLevel, "Process started" );
 
         // ---------------------------------------------------------------------
         // Heat caches
@@ -729,13 +749,6 @@ public class DefaultDataValueSetService
             dataValue = reader.readNext();
         }
 
-        context.getDataValueBatchHandler().flush();
-
-        if ( !context.isSkipAudit() )
-        {
-            context.getAuditBatchHandler().flush();
-        }
-
         context.getSummary()
             .setImportCount( importCount )
             .setStatus( !context.getSummary().hasConflicts() ? ImportStatus.SUCCESS : ImportStatus.WARNING )
@@ -745,8 +758,6 @@ public class DefaultDataValueSetService
             "Data value import done, total: " + importCount.getTotalCount() + ", import: " + importCount.getImported()
                 + ", update: "
                 + importCount.getUpdated() + ", delete: " + importCount.getDeleted() );
-        notifier.notify( id, notificationLevel, "Import done", true )
-            .addJobSummary( id, notificationLevel, context.getSummary(), ImportSummary.class );
 
         return context.getSummary();
     }
@@ -1029,7 +1040,8 @@ public class DefaultDataValueSetService
             o -> o.getPropertyValue( context.getDataElementIdScheme() ) );
     }
 
-    private ImportContext createDataValueSetImportContext( ImportOptions options, DataValueSet data )
+    private ImportContext createDataValueSetImportContext( ImportOptions options, DataValueSet data,
+        BatchHandler<DataValue> dataValueBatchHandler, BatchHandler<DataValueAudit> auditBatchHandler )
     {
         options = ObjectUtils.firstNonNull( options, ImportOptions.getDefaultImportOptions() );
 
@@ -1106,10 +1118,8 @@ public class DefaultDataValueSetService
                 trimToNull( data.getPeriod() ) ) )
 
             // data processing
-            .dataValueBatchHandler( batchHandlerFactory
-                .createBatchHandler( DataValueBatchHandler.class ).init() )
-            .auditBatchHandler( skipAudit ? null
-                : batchHandlerFactory.createBatchHandler( DataValueAuditBatchHandler.class ).init() )
+            .dataValueBatchHandler( dataValueBatchHandler.init() )
+            .auditBatchHandler( skipAudit ? null : auditBatchHandler.init() )
             .singularNameForType( klass -> schemaService.getDynamicSchema( klass ).getSingular() )
             .build();
     }


### PR DESCRIPTION
To ensure the batch handlers for data values and data value audits are always flushed they are created outside the main try-catch construct and flushed both in the success path and the exception path. This can theoretically cause `flush()` being called twice in case the exception is thrown after the flush in the success path but before the return. This has no further consequence as calling flush multiple times will be considered as a NOOP. 

To allow following the code better the main notifier start/finish calls where also pulled to the main try-catch. 

In contrast to before the the batch handler for data value audit is always created but `init()` is only called when audit is enabled (init here means establishing the connection/start the TX). Calling `flush()` on an not yet open connection again is a NOOP.  