### PR TITLE
chore: remove unimplemented query parameter attachment in new tracker exporter DHIS2-15390

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/RequestParams.java
@@ -151,8 +151,6 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
 
     private boolean skipMeta;
 
-    private String attachment;
-
     private boolean includeDeleted;
 
     /**

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParams.java
@@ -218,11 +218,6 @@ class RequestParams extends PagingAndSortingCriteriaAdapter
     private boolean includeAllAttributes;
 
     /**
-     * The file name in case of exporting as file
-     */
-    private String attachment;
-
-    /**
      * Potential Duplicate value for TEI. If null, we don't check whether a TEI
      * is a potentialDuplicate or not
      */


### PR DESCRIPTION
it seems it was added by accident

https://github.com/dhis2/dhis2-core/commit/622a9d2fea0bc9fdd47969a6941855cf6f51cb60#diff-fab20bc26fe8a2aea59d0ac43ed6ffc45eefec9e5087e58b8d7f7e67b92673a6  is the commit that added the attachment query parameter with no implementation.