### PR TITLE
feat: add keys for trackedEntity, enrollment, event object counts TECH-1551

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Objects.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Objects.java
@@ -87,9 +87,24 @@ public enum Objects
     MAP( "map", Map.class ),
     DASHBOARD( "dashboard", Dashboard.class ),
     PROGRAM( "program", Program.class ),
-    PROGRAMSTAGEINSTANCE( "programStageInstance", Event.class ),
-    PROGRAMINSTANCE( "programInstance", Enrollment.class ),
-    TRACKEDENTITYINSTANCE( "trackedEntityInstance", TrackedEntity.class ),
+    /**
+     * @deprecated use {@link #TRACKEDENTITY} instead
+     */
+    @Deprecated( since = "2.41" )
+    TRACKEDENTITYINSTANCE("trackedEntityInstance", TrackedEntity.class ),
+    /**
+     * @deprecated use {@link #ENROLLMENT} instead
+     */
+    @Deprecated( since = "2.41" )
+    PROGRAMINSTANCE("programInstance", Enrollment.class ),
+    /**
+     * @deprecated use {@link #EVENT} instead
+     */
+    @Deprecated( since = "2.41" )
+    PROGRAMSTAGEINSTANCE("programStageInstance", Event.class ),
+    TRACKEDENTITY( "trackedEntity", TrackedEntity.class ),
+    ENROLLMENT( "enrollment", Enrollment.class ),
+    EVENT( "event", Event.class ),
     TRACKEDENTITYATTRIBUTE( "trackedEntityAttribute", TrackedEntityAttribute.class ),
     EXPRESSIONDIMENSIONITEM( "expressionDimensionItem", ExpressionDimensionItem.class );
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/statistics/jdbc/JdbcStatisticsProvider.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/statistics/jdbc/JdbcStatisticsProvider.java
@@ -79,9 +79,16 @@ public class JdbcStatisticsProvider
         // Data, use approximate counts
 
         map.put( Objects.DATAVALUE, approximateCount( "datavalue" ) );
-        map.put( Objects.TRACKEDENTITYINSTANCE, approximateCount( "trackedentityinstance" ) );
-        map.put( Objects.PROGRAMINSTANCE, approximateCount( "programinstance" ) );
-        map.put( Objects.PROGRAMSTAGEINSTANCE, approximateCount( "programstageinstance" ) );
+
+        Long trackedEntities = approximateCount( "trackedentityinstance" );
+        map.put( Objects.TRACKEDENTITY, trackedEntities );
+        map.put( Objects.TRACKEDENTITYINSTANCE, trackedEntities );
+        Long enrollments = approximateCount( "programinstance" );
+        map.put( Objects.ENROLLMENT, enrollments );
+        map.put( Objects.PROGRAMINSTANCE, enrollments );
+        Long events = approximateCount( "programstageinstance" );
+        map.put( Objects.EVENT, events );
+        map.put( Objects.PROGRAMSTAGEINSTANCE, events );
 
         return map;
     }


### PR DESCRIPTION
Add keys for `trackedEntity`, `enrollment`, `event` object counts next to the ones with the old keys `trackedEntityInstance`, `programInstance`, `programStageInstance`. Deprecate the old enums to give the frontend time to migrate.

```sh
curl --no-progress-meter -u admin:district 'http://localhost:8080/api/dataSummary' | jq
{
  "objectCounts": {
    "indicator": 77,
    "trackedEntity": 73124,
    "visualization": 292,
    "period": 384,
    "programStageInstance": 423395,
    "organisationUnit": 1332,
    "validationRule": 37,
    "dataValue": 4933875,
    "dataElement": 1036,
    "program": 14,
    "organisationUnitGroup": 18,
    "trackedEntityInstance": 73124,
    "enrollment": 73152,
    "programInstance": 73152,
    "indicatorType": 5,
    "eventVisualization": 50,
    "event": 423395,
    "userGroup": 34,
    "dataSet": 26,
    "map": 93,
    "indicatorGroup": 17,
    "dataElementGroup": 84,
    "user": 130,
    "dashboard": 27
  },
  "activeUsers": {
    "0": 1,
    "1": 1,
    "2": 1,
    "7": 1,
    "30": 1
  },
  "userInvitations": {
    "all": 0,
    "expired": 0
  },
  "dataValueCount": {
    "0": 0,
    "1": 0,
    "7": 0,
    "30": 0
  },
  "eventCount": {
    "0": 0,
    "1": 0,
    "7": 0,
    "30": 0
  },
  "system": {
    "version": "2.41-SNAPSHOT",
    "revision": "bfb63fe",
    "buildTime": "2023-06-06T05:23:09.000",
    "systemId": "eed3d451-4ff5-4193-b951-ffcc68954299",
    "serverDate": "2023-06-06T03:32:18.571"
  }
}

curl --no-progress-meter -u admin:district 'http://localhost:8080/api/system/objectCounts' | jq
{
  "indicator": 77,
  "trackedEntity": 73124,
  "visualization": 292,
  "period": 384,
  "programStageInstance": 423395,
  "organisationUnit": 1332,
  "validationRule": 37,
  "dataValue": 4933875,
  "dataElement": 1036,
  "program": 14,
  "organisationUnitGroup": 18,
  "trackedEntityInstance": 73124,
  "enrollment": 73152,
  "programInstance": 73152,
  "indicatorType": 5,
  "eventVisualization": 50,
  "event": 423395,
  "userGroup": 34,
  "dataSet": 26,
  "map": 93,
  "indicatorGroup": 17,
  "dataElementGroup": 84,
  "user": 130,
  "dashboard": 27
}
```