### PR TITLE
fix: use utf-8 encoding for email sender service

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/message/EmailMessageSender.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/message/EmailMessageSender.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.message;
 
 import static java.util.Collections.singleton;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -291,6 +292,7 @@ public class EmailMessageSender
         throws EmailException
     {
         HtmlEmail email = new HtmlEmail();
+        email.setCharset( StandardCharsets.UTF_8.toString() );
         email.setHostName( hostName );
         email.setFrom( sender, getEmailName() );
         email.setSmtpPort( port );
@@ -306,12 +308,17 @@ public class EmailMessageSender
 
     private String renderPlainContent( String text, User sender )
     {
-        return sender == null ? text
+        String content = sender == null ? text
             : (text + LB + LB + sender.getName() + LB
-                + (sender.getOrganisationUnitsName() != null ? (sender.getOrganisationUnitsName() + LB)
-                    : StringUtils.EMPTY)
-                + (sender.getEmail() != null ? (sender.getEmail() + LB) : StringUtils.EMPTY)
-                + (sender.getPhoneNumber() != null ? (sender.getPhoneNumber() + LB) : StringUtils.EMPTY));
+                + getNullSafe( sender.getOrganisationUnitsName() )
+                + getNullSafe( sender.getEmail() )
+                + getNullSafe( sender.getPhoneNumber() ));
+        return new String( content.getBytes( StandardCharsets.UTF_8 ), StandardCharsets.UTF_8 );
+    }
+
+    private String getNullSafe( String value )
+    {
+        return value == null ? StringUtils.EMPTY : value + LB;
     }
 
     private String renderHtmlContent( String text, String footer, String serverBaseUrl, User sender )


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-14901

- The `EmailMessageSender` use `org.apache.commons.mail.HtmlEmail` which takes in a plain text message and a html message. This PR encode both messages with `StandardCharsets.UTF_8`.

### Test
- Use endpoint `api/email/notification?recipients=test@test.com&message={message}subject={subject}` for manually testing. Also need a SMTP server,  I use [this free tool](https://www.wpoven.com/tools/free-smtp-server-for-testing).
- Test steps as below:

1. Set up email server configurations in System Settings > Email.
2. Send a POST request to endpoint `api/email/notification?recipients=test@test.com&message={message}subject={subject}`. The message value must contain Arabic characters, or any other language.
3. Server return 200 with message "Email sent".
4. Check the email sent by DHIS2 in the test SMTP server inbox and verify if the email content has "???" characters. 