### PR TITLE
fix: Validate Hibernate schema using hibernate.hbm2ddl.auto = validate [ TECH-1576 ]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/expressiondimensionitem/hibernate/ExpressionDimensionItem.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/expressiondimensionitem/hibernate/ExpressionDimensionItem.hbm.xml
@@ -18,9 +18,9 @@
 
         <property name="name" column="name" not-null="true" length="230" />
 
-        <property name="shortName" not-null="true" type="text" length="50" />
+        <property name="shortName" not-null="true" length="50" />
 
-        <property name="formName" type="text" />
+        <property name="formName"  />
 
         <property name="description" type="text" />
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/scheduling/hibernate/JobConfiguration.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/scheduling/hibernate/JobConfiguration.hbm.xml
@@ -48,7 +48,7 @@
             </type>
         </property>
 
-        <property name="executedBy" type="text" column="executedby" length="11" />
+        <property name="executedBy" column="executedby" length="11" />
 
         <property name="lastExecuted" type="timestamp" />
 

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_16__Fix_hibernate_validate_ddl.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_16__Fix_hibernate_validate_ddl.sql
@@ -1,0 +1,4 @@
+ALTER TABLE programstageworkinglist alter column description type text;
+ALTER TABLE userrolerestrictions alter column userroleid type int8;
+ALTER TABLE userrolerestrictions
+    ADD CONSTRAINT fk_userrolerestrictions_userroleid FOREIGN KEY (userroleid) REFERENCES userrole (userroleid);

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -129,7 +129,10 @@ public enum ConfigurationKey
     USE_QUERY_CACHE( "hibernate.cache.use_query_cache", "true", false ),
 
     /**
-     * Sets 'hibernate.hbm2ddl.auto', used in tests only. (default: validate)
+     * Sets 'hibernate.hbm2ddl.auto' (default: validate). This can be overridden
+     * by the same property loaded by any class implementing
+     * {@link DhisConfigurationProvider} like
+     * {@link DefaultDhisConfigurationProvider} from dhis.conf at runtime
      */
     CONNECTION_SCHEMA( "connection.schema", "validate", false ),
 

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -129,9 +129,9 @@ public enum ConfigurationKey
     USE_QUERY_CACHE( "hibernate.cache.use_query_cache", "true", false ),
 
     /**
-     * Sets 'hibernate.hbm2ddl.auto', used in tests only. (default: none)
+     * Sets 'hibernate.hbm2ddl.auto', used in tests only. (default: validate)
      */
-    CONNECTION_SCHEMA( "connection.schema", "none", false ),
+    CONNECTION_SCHEMA( "connection.schema", "validate", false ),
 
     /**
      * Max size of connection pool (default: 80).

--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/postgresTestConfig.conf
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/postgresTestConfig.conf
@@ -1,6 +1,6 @@
 filestore.provider = transient
 filestore.container = files
-connection.schema=none
+connection.schema=validate
 encryption.password=54C73D06-1D34-477F-94B0-8F94E59BE41D
 
 hibernate.cache.use_query_cache=false


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/TECH-1576

add `validate` to hibernate.hbm2ddl.auto at startup and Postgres test setup

To align with DB:

- adds a foreign key from `userrolerestrictions` to `userrole`
- `description` filed is set to `text` in DB
- fields that are not as `description` are no longer `text` in the XML mapping files
