### PR TITLE
fix: missing foreign key drop in flyway migration

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_16__Fix_hibernate_validate_ddl.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_16__Fix_hibernate_validate_ddl.sql
@@ -1,4 +1,5 @@
 ALTER TABLE programstageworkinglist alter column description type text;
 ALTER TABLE userrolerestrictions alter column userroleid type int8;
+ALTER TABLE userrolerestrictions DROP CONSTRAINT IF EXISTS fk_userrolerestrictions_userroleid;
 ALTER TABLE userrolerestrictions
     ADD CONSTRAINT fk_userrolerestrictions_userroleid FOREIGN KEY (userroleid) REFERENCES userrole (userroleid);


### PR DESCRIPTION
missing foreign key drop for fk_userrolerestrictions_userroleid