### PR TITLE
feat: change page list name property with request parameter [DHIS2-15411]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistParams.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistParams.java
@@ -49,6 +49,12 @@ public final class GistParams
 
     int pageSize = 50;
 
+    /**
+     * The name of the property in the response object that holds the list of
+     * response objects when a paged response is used.
+     */
+    String pageListName;
+
     boolean translate = true;
 
     boolean inverse = false;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistPagerControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistPagerControllerTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonObject;
@@ -41,13 +42,23 @@ import org.junit.jupiter.api.Test;
  */
 class GistPagerControllerTest extends AbstractGistControllerTest
 {
-
     @Test
     void testPager_Total_ResultBased()
     {
         JsonObject gist = GET( "/users/{uid}/userGroups/gist?fields=name,users&total=true", getSuperuserUid() )
             .content();
         assertHasPager( gist, 1, 50, 1 );
+    }
+
+    @Test
+    void testPager_CustomPageListName()
+    {
+        JsonObject gist = GET( "/users/{uid}/userGroups/gist?fields=name,users&total=true&pageListName=matches",
+            getSuperuserUid() )
+            .content();
+        JsonArray matches = gist.getArray( "matches" );
+        assertTrue( matches.exists() );
+        assertTrue( matches.isArray() );
     }
 
     @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
@@ -140,7 +140,7 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
     public @ResponseBody ResponseEntity<JsonNode> getObjectListGist(
         GistParams params, HttpServletRequest request )
     {
-        return gistToJsonArrayResponse( request, createGistQuery( params, getEntityClass(), GistAutoType.S ),
+        return gistToJsonArrayResponse( request, params, createGistQuery( params, getEntityClass(), GistAutoType.S ),
             getSchema() );
     }
 
@@ -175,7 +175,7 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
                 .withField( property ) );
         }
 
-        return gistToJsonArrayResponse( request, createPropertyQuery( uid, property, params, objProperty ),
+        return gistToJsonArrayResponse( request, params, createPropertyQuery( uid, property, params, objProperty ),
             schemaService.getDynamicSchema( objProperty.getItemKlass() ) );
     }
 
@@ -243,7 +243,7 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
     }
 
     private ResponseEntity<JsonNode> gistToJsonArrayResponse( HttpServletRequest request,
-        GistQuery query, Schema schema )
+        GistParams params, GistQuery query, Schema schema )
     {
         if ( query.isDescribe() )
         {
@@ -255,7 +255,8 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
         JsonNode body = responseBuilder.skipNullOrEmpty().toArray( query.getFieldNames(), elements );
         if ( !query.isHeadless() )
         {
-            body = responseBuilder.toObject( asList( "pager", schema.getPlural() ),
+            String property = params.getPageListName() == null ? schema.getPlural() : params.getPageListName();
+            body = responseBuilder.toObject( asList( "pager", property ),
                 gistService.pager( query, elements, request.getParameterMap() ), body );
         }
         return ResponseEntity.ok().cacheControl( noCache().cachePrivate() ).body( body );


### PR DESCRIPTION
### Summary
Small feature requested by @Birkbjo to allow providing a custom name for the array property of the response that holds the response objects in case a pager object is used. 

New parameter is called `pageListName` (as it only affects paged results).

### ManualTesting
Query for `/api/dataElements/gist?pageListName=xyz` produces a response shapre:
```json
{
  "pager": {}
  "xyz": []
}
```

### Automatic Testing
A new test scenario was added.