### PR TITLE
docs: Document program and includeAllAttributes params in TE Controller [TECH-1568]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
@@ -10,6 +10,9 @@ Get a tracked entity with given UID.
 
 ### `getTrackedEntityByUid.parameter.program`
 
+Get tracked entities enrolled in the specified `program`.
+When a `program` is specified, all the Tracked Entity attributes and the Program specific ones are included.
+
 ## Common for all endpoints
 
 ### `*.parameter.TrackedEntityRequestParams.query`
@@ -101,6 +104,11 @@ if `assignedUserMode` is either `PROVIDED` or not specified.
 ### `*.parameter.TrackedEntityRequestParams.includeDeleted`
 
 ### `*.parameter.TrackedEntityRequestParams.includeAllAttributes`
+
+Include in the response all the attributes linked to a Tracked Entity. By default, only the Tracked
+Entity attributes are returned, not the Program specific ones.
+If a `program` is specified, `includeAllAttributes` is ignored and all the Tracked Entity attributes 
+and the Program specific ones are included.
 
 ### `*.parameter.TrackedEntityRequestParams.potentialDuplicate`
 


### PR DESCRIPTION
In this PR we are just documenting how the API is working today. We may need to check again if this behavior makes sense.

Attributes are linked to a TE but they are divided between the ones that are linked directly to a TE and the ones that are specific to a `Program`.

`IncludeAllAttributes` param will show all the attributes TE and Program ones, but only if `program` is not specified.
If `program` is specified all the TE attributes and the Program ones linked to the specified Program are shown.
In the case that a `program` is specified then `includeAllAttributes` is just ignored.

**Open issues**
- `IncludeAllAttributes` seems to not work fine when attributes are specified in `fields`
- `program` is filtering the entity in the response and it is manipulating the fields in the response at the same time.
- Should we have a validation for `program` and `includeAllAttributes` used together or should we make them work independently?