### PR TITLE
fix: Options (of option set) in events/aggregate API [DHIS2-15364]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
@@ -46,6 +46,8 @@ import lombok.Getter;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.EventOutputType;
 import org.hisp.dhis.analytics.SortOrder;
+import org.hisp.dhis.common.RequestTypeAware.EndpointAction;
+import org.hisp.dhis.common.RequestTypeAware.EndpointItem;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.program.ProgramStatus;
 
@@ -138,7 +140,9 @@ public class EventDataQueryRequest
 
     private boolean totalPages;
 
-    private RequestTypeAware.EndpointItem endpointItem;
+    private EndpointItem endpointItem;
+
+    private EndpointAction endpointAction;
 
     private boolean enhancedConditions;
 
@@ -190,6 +194,7 @@ public class EventDataQueryRequest
         queryRequest.paging = this.paging;
         queryRequest.totalPages = this.totalPages;
         queryRequest.endpointItem = this.endpointItem;
+        queryRequest.endpointAction = this.endpointAction;
         queryRequest.enhancedConditions = this.enhancedConditions;
         queryRequest.outputIdScheme = outputIdScheme;
         return request;
@@ -252,6 +257,7 @@ public class EventDataQueryRequest
                 .defaultCoordinateFallback( criteria.isDefaultCoordinateFallback() )
                 .totalPages( criteria.isTotalPages() )
                 .endpointItem( criteria.getEndpointItem() )
+                .endpointAction( criteria.getEndpointAction() )
                 .enhancedConditions( criteria.isEnhancedConditions() );
 
             if ( criteria.getDimension() == null )
@@ -328,6 +334,7 @@ public class EventDataQueryRequest
                 .sortOrder( criteria.getSortOrder() )
                 .totalPages( criteria.isTotalPages() )
                 .endpointItem( criteria.getEndpointItem() )
+                .endpointAction( criteria.getEndpointAction() )
                 .enhancedConditions( criteria.isEnhancedConditions() );
 
             if ( criteria.getDimension() == null )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/RequestTypeAware.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/RequestTypeAware.java
@@ -27,20 +27,28 @@
  */
 package org.hisp.dhis.common;
 
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.AGGREGATE;
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.OTHER;
 import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.QUERY;
 
 import lombok.Getter;
 
+/**
+ * Encapsulates some information about the current request and endpoint invoked.
+ * They are needed because of some internal rules.
+ */
 public class RequestTypeAware
 {
-    private EndpointAction endpointAction = EndpointAction.OTHER;
+
+    @Getter
+    private EndpointAction endpointAction = OTHER;
 
     @Getter
     private EndpointItem endpointItem;
 
-    public RequestTypeAware withQueryEndpointAction()
+    public RequestTypeAware withEndpointAction( EndpointAction endpointAction )
     {
-        endpointAction = QUERY;
+        this.endpointAction = endpointAction;
         return this;
     }
 
@@ -55,8 +63,14 @@ public class RequestTypeAware
         return QUERY == endpointAction;
     }
 
-    enum EndpointAction
+    public boolean isAggregateEndpoint()
     {
+        return AGGREGATE == endpointAction;
+    }
+
+    public enum EndpointAction
+    {
+        AGGREGATE,
         QUERY,
         OTHER
     }
@@ -67,5 +81,4 @@ public class RequestTypeAware
         ENROLLMENT,
         TRACKED_ENTITY_INSTANCE
     }
-
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EventDataQueryRequestTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EventDataQueryRequestTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.common;
 
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.QUERY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
@@ -59,7 +60,7 @@ public class EventDataQueryRequestTest
         assertEquals( eventDataQueryRequest.getDimension(), Set.of( Set.of( "pe:TODAY" ) ) );
 
         eventDataQueryRequest = EventDataQueryRequest.builder()
-            .fromCriteria( (EventsAnalyticsQueryCriteria) criteria.withQueryEndpointAction() )
+            .fromCriteria( (EventsAnalyticsQueryCriteria) criteria.withEndpointAction( QUERY ) )
             .build();
 
         assertEquals( eventDataQueryRequest.getDimension(), Set.of( Set.of( "pe:TODAY;YESTERDAY:INCIDENT_DATE" ) ) );
@@ -72,10 +73,10 @@ public class EventDataQueryRequestTest
             .fromCriteria( criteria )
             .build();
 
-        assertEquals( eventDataQueryRequest.getDimension(), Collections.emptySet() );
+        assertEquals( Collections.emptySet(), eventDataQueryRequest.getDimension() );
 
         eventDataQueryRequest = EventDataQueryRequest.builder()
-            .fromCriteria( (EventsAnalyticsQueryCriteria) criteria.withQueryEndpointAction() )
+            .fromCriteria( (EventsAnalyticsQueryCriteria) criteria.withEndpointAction( QUERY ) )
             .build();
 
         assertEquals( eventDataQueryRequest.getDimension(), Set.of( Set.of( "pe:TODAY:INCIDENT_DATE" ) ) );
@@ -91,7 +92,7 @@ public class EventDataQueryRequestTest
         criteria.setDimension( new HashSet<>( Set.of( "pe:LAST_MONTH" ) ) );
 
         EventDataQueryRequest eventDataQueryRequest = EventDataQueryRequest.builder()
-            .fromCriteria( (EventsAnalyticsQueryCriteria) criteria.withQueryEndpointAction() )
+            .fromCriteria( (EventsAnalyticsQueryCriteria) criteria.withEndpointAction( QUERY ) )
             .build();
 
         assertEquals( eventDataQueryRequest.getDimension(),
@@ -110,7 +111,7 @@ public class EventDataQueryRequestTest
         criteria.setDimension( new HashSet<>( Set.of( "pe:LAST_MONTH" ) ) );
 
         EventDataQueryRequest eventDataQueryRequest = EventDataQueryRequest.builder()
-            .fromCriteria( (EnrollmentAnalyticsQueryCriteria) criteria.withQueryEndpointAction() )
+            .fromCriteria( (EnrollmentAnalyticsQueryCriteria) criteria.withEndpointAction( QUERY ) )
             .build();
 
         assertEquals( eventDataQueryRequest.getDimension(),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -37,6 +37,7 @@ import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObjectUtils.asList;
 import static org.hisp.dhis.common.DimensionalObjectUtils.asTypedList;
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.QUERY;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -76,7 +77,8 @@ import org.hisp.dhis.common.DisplayProperty;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryItem;
-import org.hisp.dhis.common.RequestTypeAware;
+import org.hisp.dhis.common.RequestTypeAware.EndpointAction;
+import org.hisp.dhis.common.RequestTypeAware.EndpointItem;
 import org.hisp.dhis.common.ValueTypedDimensionalItemObject;
 import org.hisp.dhis.commons.collection.ListUtils;
 import org.hisp.dhis.dataelement.DataElement;
@@ -284,7 +286,10 @@ public class EventQueryParams
     protected boolean enhancedCondition = false;
 
     @Getter
-    protected RequestTypeAware.EndpointItem endpointItem;
+    protected EndpointItem endpointItem;
+
+    @Getter
+    protected EndpointAction endpointAction;
 
     // -------------------------------------------------------------------------
     // Constructors
@@ -355,6 +360,7 @@ public class EventQueryParams
         params.skipPartitioning = this.skipPartitioning;
         params.enhancedCondition = this.enhancedCondition;
         params.endpointItem = this.endpointItem;
+        params.endpointAction = this.endpointAction;
         return params;
     }
 
@@ -1108,6 +1114,11 @@ public class EventQueryParams
         return aggregateData;
     }
 
+    public boolean isComingFromQuery()
+    {
+        return endpointAction == QUERY;
+    }
+
     public Long getClusterSize()
     {
         return clusterSize;
@@ -1545,9 +1556,15 @@ public class EventQueryParams
             return params;
         }
 
-        public Builder withEndpointItem( RequestTypeAware.EndpointItem endpointItem )
+        public Builder withEndpointItem( EndpointItem endpointItem )
         {
             this.params.endpointItem = endpointItem;
+            return this;
+        }
+
+        public Builder withEndpointAction( EndpointAction endpointAction )
+        {
+            this.params.endpointAction = endpointAction;
             return this;
         }
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -226,7 +226,8 @@ public class DefaultEventDataQueryService
             .withApiVersion( request.getApiVersion() )
             .withLocale( locale )
             .withEnhancedConditions( request.isEnhancedConditions() )
-            .withEndpointItem( request.getEndpointItem() );
+            .withEndpointItem( request.getEndpointItem() )
+            .withEndpointAction( request.getEndpointAction() );
 
         if ( analyzeOnly )
         {

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/AnalyticsQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/AnalyticsQueryTest.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.analytics;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hisp.dhis.analytics.ValidationHelper.containsRow;
 import static org.hisp.dhis.analytics.ValidationHelper.validateRow;
 
 import java.util.List;
@@ -75,8 +74,8 @@ public class AnalyticsQueryTest extends AnalyticsApiTest
             .statusCode( 200 )
             .body( "rows", hasSize( equalTo( 2 ) ) );
 
-        containsRow( response, List.of( "M3xtLkYBlKI.fyjPqlHE7Dn", "202107", "" ) );
-        containsRow( response, List.of( "M3xtLkYBlKI.fyjPqlHE7Dn", "202107", "Some insecticide resistance" ) );
+        validateRow( response, List.of( "M3xtLkYBlKI.fyjPqlHE7Dn", "202107", "" ) );
+        validateRow( response, List.of( "M3xtLkYBlKI.fyjPqlHE7Dn", "202107", "Some insecticide resistance" ) );
     }
 
     @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/ValidationHelper.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/ValidationHelper.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.analytics;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 
 import java.util.List;
@@ -74,20 +74,106 @@ public class ValidationHelper
     }
 
     /**
+     * Validate/assert all attributes of the given header (represented by the
+     * index), matching each argument with its respective header attribute
+     * value.
+     *
+     * @param response
+     * @param headerIndex of the header
+     * @param name
+     * @param column
+     * @param valueType
+     * @param type
+     * @param hidden
+     * @param meta
+     * @param optionSet
+     */
+    public static void validateHeader( ApiResponse response, int headerIndex, String name,
+        String column, String valueType, String type, boolean hidden, boolean meta, String optionSet )
+    {
+        response.validate()
+            .body( "headers[" + headerIndex + "].name", equalTo( name ) )
+            .body( "headers[" + headerIndex + "].column", equalTo( column ) )
+            .body( "headers[" + headerIndex + "].valueType", equalTo( valueType ) )
+            .body( "headers[" + headerIndex + "].type", equalTo( type ) )
+            .body( "headers[" + headerIndex + "].hidden", is( hidden ) )
+            .body( "headers[" + headerIndex + "].meta", is( meta ) )
+            .body( "headers[" + headerIndex + "].optionSet", is( optionSet ) );
+    }
+
+    /**
+     * Validate/assert all attributes of the given header (represented by the
+     * index), matching each argument with its respective header attribute
+     * value.
+     *
+     * @param response
+     * @param headerIndex
+     * @param name
+     * @param column
+     * @param valueType
+     * @param type
+     * @param hidden
+     * @param meta
+     * @param programStage
+     * @param repeatableStageParams
+     * @param stageOffset
+     */
+
+    public static void validateHeader( ApiResponse response, int headerIndex, String name,
+        String column, String valueType, String type, boolean hidden, boolean meta, String programStage,
+        String repeatableStageParams, int stageOffset )
+    {
+        response.validate()
+            .body( "headers[" + headerIndex + "].name", equalTo( name ) )
+            .body( "headers[" + headerIndex + "].column", equalTo( column ) )
+            .body( "headers[" + headerIndex + "].valueType", equalTo( valueType ) )
+            .body( "headers[" + headerIndex + "].type", equalTo( type ) )
+            .body( "headers[" + headerIndex + "].hidden", is( hidden ) )
+            .body( "headers[" + headerIndex + "].programStage", equalTo( programStage ) )
+            .body( "headers[" + headerIndex + "].repeatableStageParams", equalTo( repeatableStageParams ) )
+            .body( "headers[" + headerIndex + "].stageOffset", equalTo( stageOffset ) );
+    }
+
+    /**
+     * Validate/assert all attributes of the given rowContext (represented by
+     * the row and column index), matching each argument with its respective
+     * repeatableStageValueStatus value.
+     *
+     * @param response
+     * @param rowIndex
+     * @param colIndex
+     * @param repeatableStageValueStatus
+     */
+    public static void validateRowContext( ApiResponse response, int rowIndex, int colIndex,
+        String repeatableStageValueStatus )
+    {
+        response.validate()
+            .body( "rowContext." + rowIndex + "." + colIndex + ".valueStatus",
+                equalTo( repeatableStageValueStatus ) );
+    }
+
+    /**
+     * Validate/assert that all values of the given row are present in the given
+     * response.
+     *
+     * @param response
+     * @param rowIndex
+     * @param expectedValues
+     */
+    public static void validateRow( ApiResponse response, int rowIndex, List<String> expectedValues )
+    {
+        response.validate().body( "rows[" + rowIndex + "]", equalTo( expectedValues ) );
+    }
+
+    /**
      * Validate/assert that all values of the given row are present in the given
      * response.
      *
      * @param response
      * @param expectedValues
      */
-    public static void validateRow( ApiResponse response, int rowIndex, List<String> expectedValues )
+    public static void validateRow( ApiResponse response, List<String> expectedValues )
     {
-        response.validate()
-            .body( "rows[" + rowIndex + "]", equalTo( expectedValues ) );
-    }
-
-    public static void containsRow( ApiResponse response, List<String> expectedValues )
-    {
-        response.validate().body( "rows", hasItem( expectedValues ) );
+        response.validate().body( "rows", hasItems( expectedValues ) );
     }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/EventAggregateTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/EventAggregateTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.event;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hisp.dhis.analytics.ValidationHelper.validateHeader;
+
+import org.hisp.dhis.AnalyticsApiTest;
+import org.hisp.dhis.actions.analytics.AnalyticsEventActions;
+import org.hisp.dhis.dto.ApiResponse;
+import org.hisp.dhis.helpers.QueryParamsBuilder;
+import org.junit.jupiter.api.Test;
+
+public class EventAggregateTest extends AnalyticsApiTest
+{
+    private final AnalyticsEventActions analyticsEventActions = new AnalyticsEventActions();
+
+    @Test
+    void testMetadataInfoForOptionSetForAggregate()
+    {
+        // Given
+        QueryParamsBuilder params = new QueryParamsBuilder()
+            .add(
+                "dimension=ou:ImspTQPwCqd,pe:LAST_12_MONTHS,C0aLZo75dgJ.B6TnnFMgmCk,C0aLZo75dgJ.Z1rLc1rVHK8,C0aLZo75dgJ.CklPZdOd6H1" )
+            .add( "filter=C0aLZo75dgJ.vTKipVM0GsX,C0aLZo75dgJ.h5FuguPFF2j,C0aLZo75dgJ.aW66s2QSosT" )
+            .add( "stage=C0aLZo75dgJ" )
+            .add( "displayProperty=NAME" )
+            .add( "outputType=ENROLLMENT" )
+            .add( "totalPages=false" );
+
+        // When
+        ApiResponse response = analyticsEventActions.aggregate().get( "qDkgAbB5Jlk", JSON, JSON, params );
+        response.validate()
+            .statusCode( 200 )
+            .body( "headers", hasSize( equalTo( 6 ) ) )
+            .body( "height", equalTo( 0 ) )
+            .body( "width", equalTo( 0 ) )
+            .body( "rows", hasSize( equalTo( 0 ) ) )
+
+            .body( "metaData.items", hasKey( "CklPZdOd6H1" ) )
+            .body( "metaData.items", hasKey( "AZK4rjJCss5" ) )
+            .body( "metaData.items", hasKey( "UrUdMteQzlT" ) );
+
+        validateHeader( response, 0, "Z1rLc1rVHK8", "Date of birth (mal) is estimated", "TRUE_ONLY",
+            "java.lang.Boolean", false, true );
+        validateHeader( response, 1, "CklPZdOd6H1", "Sex", "TEXT", "java.lang.String",
+            false, true, "hiQ3QFheQ3O" );
+        validateHeader( response, 2, "B6TnnFMgmCk", "Age (years)", "INTEGER_ZERO_OR_POSITIVE",
+            "java.lang.Integer", false, true );
+        validateHeader( response, 3, "ou", "Organisation unit", "TEXT", "java.lang.String", false, true );
+        validateHeader( response, 4, "pe", "Period", "TEXT", "java.lang.String", false, true );
+        validateHeader( response, 5, "value", "Value", "NUMBER", "java.lang.Double", false, false );
+    }
+}

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/EventQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/EventQueryTest.java
@@ -289,4 +289,34 @@ public class EventQueryTest extends AnalyticsApiTest
                 "ACTIVE",
                 "DiszpKrYNg8" ) );
     }
+
+    @Test
+    void testMetadataInfoForOptionSetForQuery()
+    {
+        // Given
+        QueryParamsBuilder params = new QueryParamsBuilder()
+                .add(
+                        "dimension=ou:ImspTQPwCqd,pe:LAST_12_MONTHS,C0aLZo75dgJ.B6TnnFMgmCk,C0aLZo75dgJ.Z1rLc1rVHK8,C0aLZo75dgJ.CklPZdOd6H1" )
+                .add( "filter=C0aLZo75dgJ.vTKipVM0GsX,C0aLZo75dgJ.h5FuguPFF2j,C0aLZo75dgJ.aW66s2QSosT" )
+                .add( "stage=C0aLZo75dgJ" )
+                .add( "displayProperty=NAME" )
+                .add( "outputType=ENROLLMENT" )
+                .add( "totalPages=false" );
+
+        // When
+        ApiResponse response = analyticsEventActions.query().get( "qDkgAbB5Jlk", JSON, JSON, params );
+        response.validate()
+                .statusCode( 200 )
+                .body( "headers", hasSize( equalTo( 24 ) ) )
+                .body( "height", equalTo( 0 ) )
+                .body( "width", equalTo( 0 ) )
+                .body( "rows", hasSize( equalTo( 0 ) ) )
+
+                .body( "metaData.items", hasKey( "CklPZdOd6H1" ) )
+                .body( "metaData.items", not( hasKey( "AZK4rjJCss5" ) ) )
+                .body( "metaData.items", not( hasKey( "UrUdMteQzlT" ) ) );
+
+        validateHeader( response, 22, "C0aLZo75dgJ.CklPZdOd6H1", "Sex", "TEXT", "java.lang.String",
+                false, true, "hiQ3QFheQ3O" );
+    }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/EventQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/EventQueryTest.java
@@ -295,28 +295,28 @@ public class EventQueryTest extends AnalyticsApiTest
     {
         // Given
         QueryParamsBuilder params = new QueryParamsBuilder()
-                .add(
-                        "dimension=ou:ImspTQPwCqd,pe:LAST_12_MONTHS,C0aLZo75dgJ.B6TnnFMgmCk,C0aLZo75dgJ.Z1rLc1rVHK8,C0aLZo75dgJ.CklPZdOd6H1" )
-                .add( "filter=C0aLZo75dgJ.vTKipVM0GsX,C0aLZo75dgJ.h5FuguPFF2j,C0aLZo75dgJ.aW66s2QSosT" )
-                .add( "stage=C0aLZo75dgJ" )
-                .add( "displayProperty=NAME" )
-                .add( "outputType=ENROLLMENT" )
-                .add( "totalPages=false" );
+            .add(
+                "dimension=ou:ImspTQPwCqd,pe:LAST_12_MONTHS,C0aLZo75dgJ.B6TnnFMgmCk,C0aLZo75dgJ.Z1rLc1rVHK8,C0aLZo75dgJ.CklPZdOd6H1" )
+            .add( "filter=C0aLZo75dgJ.vTKipVM0GsX,C0aLZo75dgJ.h5FuguPFF2j,C0aLZo75dgJ.aW66s2QSosT" )
+            .add( "stage=C0aLZo75dgJ" )
+            .add( "displayProperty=NAME" )
+            .add( "outputType=ENROLLMENT" )
+            .add( "totalPages=false" );
 
         // When
         ApiResponse response = analyticsEventActions.query().get( "qDkgAbB5Jlk", JSON, JSON, params );
         response.validate()
-                .statusCode( 200 )
-                .body( "headers", hasSize( equalTo( 24 ) ) )
-                .body( "height", equalTo( 0 ) )
-                .body( "width", equalTo( 0 ) )
-                .body( "rows", hasSize( equalTo( 0 ) ) )
+            .statusCode( 200 )
+            .body( "headers", hasSize( equalTo( 24 ) ) )
+            .body( "height", equalTo( 0 ) )
+            .body( "width", equalTo( 0 ) )
+            .body( "rows", hasSize( equalTo( 0 ) ) )
 
-                .body( "metaData.items", hasKey( "CklPZdOd6H1" ) )
-                .body( "metaData.items", not( hasKey( "AZK4rjJCss5" ) ) )
-                .body( "metaData.items", not( hasKey( "UrUdMteQzlT" ) ) );
+            .body( "metaData.items", hasKey( "CklPZdOd6H1" ) )
+            .body( "metaData.items", not( hasKey( "AZK4rjJCss5" ) ) )
+            .body( "metaData.items", not( hasKey( "UrUdMteQzlT" ) ) );
 
         validateHeader( response, 22, "C0aLZo75dgJ.CklPZdOd6H1", "Sex", "TEXT", "java.lang.String",
-                false, true, "hiQ3QFheQ3O" );
+            false, true, "hiQ3QFheQ3O" );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceMetadataTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceMetadataTest.java
@@ -31,7 +31,6 @@ import static org.hisp.dhis.common.QueryFilter.OPTION_SEP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -251,9 +250,8 @@ class EventAnalyticsServiceMetadataTest extends SingleSetupIntegrationTestBase
         }
         for ( Option option : deE.getOptionSet().getOptions() )
         {
-            // Because skipData is set to "true" and no option code is specified
-            // as filter.
-            assertNull( itemMap.get( option.getUid() ) );
+            // Because "aggregate" always returns options and its option set.
+            assertNotNull( itemMap.get( option.getUid() ) );
         }
         assertNotNull( itemMap.get( deA.getUid() ) );
         assertNotNull( itemMap.get( deE.getUid() ) );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EnrollmentAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EnrollmentAnalyticsController.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.QUERY;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.List;
@@ -50,6 +51,7 @@ import org.hisp.dhis.common.EventDataQueryRequest;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.RequestTypeAware;
+import org.hisp.dhis.common.RequestTypeAware.EndpointAction;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.period.RelativePeriodEnum;
 import org.hisp.dhis.setting.SettingKey;
@@ -113,7 +115,7 @@ public class EnrollmentAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, true );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, true, QUERY );
 
         Grid grid = analyticsService.getEnrollments( params );
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_JSON,
@@ -135,7 +137,7 @@ public class EnrollmentAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_JSON,
             CacheStrategy.RESPECT_SYSTEM_SETTING );
@@ -151,7 +153,7 @@ public class EnrollmentAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_XML, CacheStrategy.RESPECT_SYSTEM_SETTING,
             "enrollments.xml", false );
@@ -167,7 +169,7 @@ public class EnrollmentAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_EXCEL, CacheStrategy.RESPECT_SYSTEM_SETTING,
             "enrollments.xls", true );
@@ -183,7 +185,7 @@ public class EnrollmentAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_CSV, CacheStrategy.RESPECT_SYSTEM_SETTING,
             "enrollments.csv", true );
@@ -199,7 +201,7 @@ public class EnrollmentAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_HTML, CacheStrategy.RESPECT_SYSTEM_SETTING,
             "enrollments.html", false );
@@ -215,7 +217,7 @@ public class EnrollmentAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_HTML, CacheStrategy.RESPECT_SYSTEM_SETTING,
             "enrollments.html", false );
@@ -262,7 +264,8 @@ public class EnrollmentAnalyticsController
     }
 
     private EventQueryParams getEventQueryParams( @PathVariable String program,
-        EnrollmentAnalyticsQueryCriteria criteria, DhisApiVersion apiVersion, boolean analyzeOnly )
+        EnrollmentAnalyticsQueryCriteria criteria, DhisApiVersion apiVersion, boolean analyzeOnly,
+        EndpointAction endpointAction )
     {
         criteria
             .definePageSize( systemSettingManager.getIntSetting( SettingKey.ANALYTICS_MAX_LIMIT ) );
@@ -271,8 +274,9 @@ public class EnrollmentAnalyticsController
             systemSettingManager.getSystemSetting( SettingKey.ANALYSIS_RELATIVE_PERIOD, RelativePeriodEnum.class ) );
 
         EventDataQueryRequest request = EventDataQueryRequest.builder()
-            .fromCriteria( (EnrollmentAnalyticsQueryCriteria) criteria.withQueryEndpointAction()
-                .withEndpointItem( RequestTypeAware.EndpointItem.ENROLLMENT ) )
+            .fromCriteria(
+                (EnrollmentAnalyticsQueryCriteria) criteria.withEndpointAction( endpointAction )
+                    .withEndpointItem( RequestTypeAware.EndpointItem.ENROLLMENT ) )
             .program( program )
             .apiVersion( apiVersion )
             .build();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EventAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EventAnalyticsController.java
@@ -28,6 +28,9 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.common.DimensionalObjectUtils.getItemsFromParam;
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.AGGREGATE;
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.OTHER;
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.QUERY;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.List;
@@ -52,6 +55,7 @@ import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.PrefixedDimension;
 import org.hisp.dhis.common.RequestTypeAware;
+import org.hisp.dhis.common.RequestTypeAware.EndpointAction;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.period.RelativePeriodEnum;
 import org.hisp.dhis.setting.SettingKey;
@@ -124,7 +128,7 @@ public class EventAnalyticsController
         HttpServletResponse response )
         throws Exception
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, true );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, true, AGGREGATE );
 
         configResponseForJson( response );
 
@@ -148,7 +152,7 @@ public class EventAnalyticsController
         HttpServletResponse response )
         throws Exception
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, AGGREGATE );
 
         configResponseForJson( response );
 
@@ -248,7 +252,7 @@ public class EventAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, OTHER );
 
         configResponseForJson( response );
 
@@ -270,7 +274,7 @@ public class EventAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, OTHER );
 
         params = new EventQueryParams.Builder( params )
             .withClusterSize( clusterSize )
@@ -296,7 +300,7 @@ public class EventAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, true );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, true, QUERY );
 
         configResponseForJson( response );
 
@@ -318,7 +322,7 @@ public class EventAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         configResponseForJson( response );
 
@@ -411,7 +415,7 @@ public class EventAnalyticsController
         HttpServletResponse response )
         throws Exception
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, AGGREGATE );
 
         contextUtils.configureResponse( response, contentType,
             CacheStrategy.RESPECT_SYSTEM_SETTING, file, false );
@@ -425,7 +429,7 @@ public class EventAnalyticsController
         String contentType, String file, boolean attachment,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         contextUtils.configureResponse( response, contentType, CacheStrategy.RESPECT_SYSTEM_SETTING, file, attachment );
 
@@ -433,7 +437,7 @@ public class EventAnalyticsController
     }
 
     private EventQueryParams getEventQueryParams( String program, EventsAnalyticsQueryCriteria criteria,
-        DhisApiVersion apiVersion, boolean analyzeOnly )
+        DhisApiVersion apiVersion, boolean analyzeOnly, EndpointAction endpointAction )
     {
         criteria.definePageSize( systemSettingManager.getIntSetting( SettingKey.ANALYTICS_MAX_LIMIT ) );
 
@@ -442,7 +446,7 @@ public class EventAnalyticsController
 
         EventDataQueryRequest request = EventDataQueryRequest.builder()
             .fromCriteria( (EventsAnalyticsQueryCriteria) criteria
-                .withQueryEndpointAction()
+                .withEndpointAction( endpointAction )
                 .withEndpointItem( RequestTypeAware.EndpointItem.EVENT ) )
             .program( program )
             .apiVersion( apiVersion ).build();


### PR DESCRIPTION
**_[Backport from master/2.41]_**

The analytics endpoint `/events/aggregate` should return all options for the requested option sets. Even in cases where there are no grid results for the requested option set.

The behaviour for `/events/query` and `/events/enrollments` should remain the same (returns only options present in the response).

For testing scenarios and steps to reproduce this issue on Play, please see https://dhis2.atlassian.net/browse/DHIS2-15364.