### PR TITLE
fix: Options (of option set) in events/aggregate API [DHIS2-15364]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
@@ -50,6 +50,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.EventOutputType;
 import org.hisp.dhis.analytics.SortOrder;
+import org.hisp.dhis.common.RequestTypeAware.EndpointAction;
+import org.hisp.dhis.common.RequestTypeAware.EndpointItem;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.program.ProgramStatus;
 
@@ -142,7 +144,9 @@ public class EventDataQueryRequest
 
     private boolean totalPages;
 
-    private RequestTypeAware.EndpointItem endpointItem;
+    private EndpointItem endpointItem;
+
+    private EndpointAction endpointAction;
 
     private boolean enhancedConditions;
 
@@ -194,6 +198,7 @@ public class EventDataQueryRequest
         queryRequest.paging = this.paging;
         queryRequest.totalPages = this.totalPages;
         queryRequest.endpointItem = this.endpointItem;
+        queryRequest.endpointAction = this.endpointAction;
         queryRequest.enhancedConditions = this.enhancedConditions;
         queryRequest.outputIdScheme = outputIdScheme;
         return request;
@@ -255,6 +260,7 @@ public class EventDataQueryRequest
                 .coordinateOuFallback( criteria.isCoordinateOuFallback() )
                 .totalPages( criteria.isTotalPages() )
                 .endpointItem( criteria.getEndpointItem() )
+                .endpointAction( criteria.getEndpointAction() )
                 .coordinateOuFallback( criteria.isCoordinateOuFallback() )
                 .enhancedConditions( criteria.isEnhancedConditions() );
 
@@ -359,6 +365,7 @@ public class EventDataQueryRequest
                 .sortOrder( criteria.getSortOrder() )
                 .totalPages( criteria.isTotalPages() )
                 .endpointItem( criteria.getEndpointItem() )
+                .endpointAction( criteria.getEndpointAction() )
                 .enhancedConditions( criteria.isEnhancedConditions() );
 
             if ( criteria.getDimension() == null )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/RequestTypeAware.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/RequestTypeAware.java
@@ -27,20 +27,27 @@
  */
 package org.hisp.dhis.common;
 
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.AGGREGATE;
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.OTHER;
 import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.QUERY;
 
 import lombok.Getter;
 
+/**
+ * Encapsulates some information about the current request and endpoint invoked.
+ * They are needed because of some internal rules.
+ */
 public class RequestTypeAware
 {
-    private EndpointAction endpointAction = EndpointAction.OTHER;
+    @Getter
+    private EndpointAction endpointAction = OTHER;
 
     @Getter
     private EndpointItem endpointItem;
 
-    public RequestTypeAware withQueryEndpointAction()
+    public RequestTypeAware withEndpointAction( EndpointAction endpointAction )
     {
-        endpointAction = QUERY;
+        this.endpointAction = endpointAction;
         return this;
     }
 
@@ -55,8 +62,14 @@ public class RequestTypeAware
         return QUERY == endpointAction;
     }
 
-    enum EndpointAction
+    public boolean isAggregateEndpoint()
     {
+        return AGGREGATE == endpointAction;
+    }
+
+    public enum EndpointAction
+    {
+        AGGREGATE,
         QUERY,
         OTHER
     }
@@ -67,5 +80,4 @@ public class RequestTypeAware
         ENROLLMENT,
         TRACKED_ENTITY_INSTANCE
     }
-
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EventDataQueryRequestTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EventDataQueryRequestTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.common;
 
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.QUERY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
@@ -59,7 +60,7 @@ public class EventDataQueryRequestTest
         assertEquals( eventDataQueryRequest.getDimension(), Set.of( Set.of( "pe:TODAY" ) ) );
 
         eventDataQueryRequest = EventDataQueryRequest.builder()
-            .fromCriteria( (EventsAnalyticsQueryCriteria) criteria.withQueryEndpointAction() )
+            .fromCriteria( (EventsAnalyticsQueryCriteria) criteria.withEndpointAction( QUERY ) )
             .build();
 
         assertEquals( eventDataQueryRequest.getDimension(), Set.of( Set.of( "pe:TODAY;YESTERDAY:INCIDENT_DATE" ) ) );
@@ -72,10 +73,10 @@ public class EventDataQueryRequestTest
             .fromCriteria( criteria )
             .build();
 
-        assertEquals( eventDataQueryRequest.getDimension(), Collections.emptySet() );
+        assertEquals( Collections.emptySet(), eventDataQueryRequest.getDimension() );
 
         eventDataQueryRequest = EventDataQueryRequest.builder()
-            .fromCriteria( (EventsAnalyticsQueryCriteria) criteria.withQueryEndpointAction() )
+            .fromCriteria( (EventsAnalyticsQueryCriteria) criteria.withEndpointAction( QUERY ) )
             .build();
 
         assertEquals( eventDataQueryRequest.getDimension(), Set.of( Set.of( "pe:TODAY:INCIDENT_DATE" ) ) );
@@ -91,7 +92,7 @@ public class EventDataQueryRequestTest
         criteria.setDimension( new HashSet<>( Set.of( "pe:LAST_MONTH" ) ) );
 
         EventDataQueryRequest eventDataQueryRequest = EventDataQueryRequest.builder()
-            .fromCriteria( (EventsAnalyticsQueryCriteria) criteria.withQueryEndpointAction() )
+            .fromCriteria( (EventsAnalyticsQueryCriteria) criteria.withEndpointAction( QUERY ) )
             .build();
 
         assertEquals( eventDataQueryRequest.getDimension(),
@@ -110,7 +111,7 @@ public class EventDataQueryRequestTest
         criteria.setDimension( new HashSet<>( Set.of( "pe:LAST_MONTH" ) ) );
 
         EventDataQueryRequest eventDataQueryRequest = EventDataQueryRequest.builder()
-            .fromCriteria( (EnrollmentAnalyticsQueryCriteria) criteria.withQueryEndpointAction() )
+            .fromCriteria( (EnrollmentAnalyticsQueryCriteria) criteria.withEndpointAction( QUERY ) )
             .build();
 
         assertEquals( eventDataQueryRequest.getDimension(),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -41,6 +41,7 @@ import static org.hisp.dhis.common.FallbackCoordinateFieldType.OU_GEOMETRY;
 import static org.hisp.dhis.common.FallbackCoordinateFieldType.PI_GEOMETRY;
 import static org.hisp.dhis.common.FallbackCoordinateFieldType.PSI_GEOMETRY;
 import static org.hisp.dhis.common.FallbackCoordinateFieldType.TEI_GEOMETRY;
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.QUERY;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -81,7 +82,8 @@ import org.hisp.dhis.common.FallbackCoordinateFieldType;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryItem;
-import org.hisp.dhis.common.RequestTypeAware;
+import org.hisp.dhis.common.RequestTypeAware.EndpointAction;
+import org.hisp.dhis.common.RequestTypeAware.EndpointItem;
 import org.hisp.dhis.common.ValueTypedDimensionalItemObject;
 import org.hisp.dhis.commons.collection.ListUtils;
 import org.hisp.dhis.dataelement.DataElement;
@@ -298,7 +300,10 @@ public class EventQueryParams
     protected boolean enhancedCondition = false;
 
     @Getter
-    protected RequestTypeAware.EndpointItem endpointItem;
+    protected EndpointItem endpointItem;
+
+    @Getter
+    protected EndpointAction endpointAction;
 
     // -------------------------------------------------------------------------
     // Constructors
@@ -370,6 +375,7 @@ public class EventQueryParams
         params.skipPartitioning = this.skipPartitioning;
         params.enhancedCondition = this.enhancedCondition;
         params.endpointItem = this.endpointItem;
+        params.endpointAction = this.endpointAction;
         return params;
     }
 
@@ -1142,6 +1148,11 @@ public class EventQueryParams
         return aggregateData;
     }
 
+    public boolean isComingFromQuery()
+    {
+        return endpointAction == QUERY;
+    }
+
     public Long getClusterSize()
     {
         return clusterSize;
@@ -1596,9 +1607,15 @@ public class EventQueryParams
             return params;
         }
 
-        public Builder withEndpointItem( RequestTypeAware.EndpointItem endpointItem )
+        public Builder withEndpointItem( EndpointItem endpointItem )
         {
             this.params.endpointItem = endpointItem;
+            return this;
+        }
+
+        public Builder withEndpointAction( EndpointAction endpointAction )
+        {
+            this.params.endpointAction = endpointAction;
             return this;
         }
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -225,7 +225,8 @@ public class DefaultEventDataQueryService
             .withApiVersion( request.getApiVersion() )
             .withLocale( locale )
             .withEnhancedConditions( request.isEnhancedConditions() )
-            .withEndpointItem( request.getEndpointItem() );
+            .withEndpointItem( request.getEndpointItem() )
+            .withEndpointAction( request.getEndpointAction() );
 
         if ( analyzeOnly )
         {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceMetadataTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceMetadataTest.java
@@ -31,7 +31,6 @@ import static org.hisp.dhis.common.QueryFilter.OPTION_SEP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -237,9 +236,8 @@ class EventAnalyticsServiceMetadataTest extends SingleSetupIntegrationTestBase
         }
         for ( Option option : deE.getOptionSet().getOptions() )
         {
-            // Because skipData is set to "true" and no option code is specified
-            // as filter.
-            assertNull( itemMap.get( option.getUid() ) );
+            // Because "aggregate" always returns options and its option set.
+            assertNotNull( itemMap.get( option.getUid() ) );
         }
         assertNotNull( itemMap.get( deA.getUid() ) );
         assertNotNull( itemMap.get( deE.getUid() ) );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EnrollmentAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EnrollmentAnalyticsController.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.QUERY;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.List;
@@ -48,6 +49,7 @@ import org.hisp.dhis.common.EnrollmentAnalyticsQueryCriteria;
 import org.hisp.dhis.common.EventDataQueryRequest;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.RequestTypeAware;
+import org.hisp.dhis.common.RequestTypeAware.EndpointAction;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.period.RelativePeriodEnum;
 import org.hisp.dhis.setting.SettingKey;
@@ -109,7 +111,7 @@ public class EnrollmentAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, true );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, true, QUERY );
 
         Grid grid = analyticsService.getEnrollments( params );
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_JSON,
@@ -131,7 +133,7 @@ public class EnrollmentAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_JSON,
             CacheStrategy.RESPECT_SYSTEM_SETTING );
@@ -147,7 +149,7 @@ public class EnrollmentAnalyticsController
         HttpServletResponse response )
         throws Exception
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_XML, CacheStrategy.RESPECT_SYSTEM_SETTING,
             "enrollments.xml", false );
@@ -163,7 +165,7 @@ public class EnrollmentAnalyticsController
         HttpServletResponse response )
         throws Exception
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_EXCEL, CacheStrategy.RESPECT_SYSTEM_SETTING,
             "enrollments.xls", true );
@@ -179,7 +181,7 @@ public class EnrollmentAnalyticsController
         HttpServletResponse response )
         throws Exception
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_CSV, CacheStrategy.RESPECT_SYSTEM_SETTING,
             "enrollments.csv", true );
@@ -195,7 +197,7 @@ public class EnrollmentAnalyticsController
         HttpServletResponse response )
         throws Exception
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_HTML, CacheStrategy.RESPECT_SYSTEM_SETTING,
             "enrollments.html", false );
@@ -211,7 +213,7 @@ public class EnrollmentAnalyticsController
         HttpServletResponse response )
         throws Exception
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_HTML, CacheStrategy.RESPECT_SYSTEM_SETTING,
             "enrollments.html", false );
@@ -256,7 +258,8 @@ public class EnrollmentAnalyticsController
     }
 
     private EventQueryParams getEventQueryParams( @PathVariable String program,
-        EnrollmentAnalyticsQueryCriteria criteria, DhisApiVersion apiVersion, boolean analyzeOnly )
+        EnrollmentAnalyticsQueryCriteria criteria, DhisApiVersion apiVersion, boolean analyzeOnly,
+        EndpointAction endpointAction )
     {
         criteria
             .definePageSize( systemSettingManager.getIntSetting( SettingKey.ANALYTICS_MAX_LIMIT ) );
@@ -265,7 +268,7 @@ public class EnrollmentAnalyticsController
             systemSettingManager.getSystemSetting( SettingKey.ANALYSIS_RELATIVE_PERIOD, RelativePeriodEnum.class ) );
 
         EventDataQueryRequest request = EventDataQueryRequest.builder()
-            .fromCriteria( (EnrollmentAnalyticsQueryCriteria) criteria.withQueryEndpointAction()
+            .fromCriteria( (EnrollmentAnalyticsQueryCriteria) criteria.withEndpointAction( endpointAction )
                 .withEndpointItem( RequestTypeAware.EndpointItem.ENROLLMENT ) )
             .program( program )
             .apiVersion( apiVersion )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EventAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EventAnalyticsController.java
@@ -28,6 +28,9 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.common.DimensionalObjectUtils.getItemsFromParam;
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.AGGREGATE;
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.OTHER;
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.QUERY;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.List;
@@ -51,6 +54,7 @@ import org.hisp.dhis.common.EventDataQueryRequest;
 import org.hisp.dhis.common.EventsAnalyticsQueryCriteria;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.RequestTypeAware;
+import org.hisp.dhis.common.RequestTypeAware.EndpointAction;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.period.RelativePeriodEnum;
 import org.hisp.dhis.setting.SettingKey;
@@ -121,7 +125,7 @@ public class EventAnalyticsController
         throws Exception
     {
 
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, true );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, true, AGGREGATE );
 
         configResponseForJson( response );
 
@@ -145,7 +149,7 @@ public class EventAnalyticsController
         HttpServletResponse response )
         throws Exception
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, AGGREGATE );
 
         configResponseForJson( response );
 
@@ -244,7 +248,7 @@ public class EventAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, OTHER );
 
         configResponseForJson( response );
 
@@ -266,7 +270,7 @@ public class EventAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, OTHER );
 
         params = new EventQueryParams.Builder( params )
             .withClusterSize( clusterSize )
@@ -292,7 +296,7 @@ public class EventAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, true );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, true, QUERY );
 
         configResponseForJson( response );
 
@@ -314,7 +318,7 @@ public class EventAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         configResponseForJson( response );
 
@@ -406,7 +410,7 @@ public class EventAnalyticsController
         HttpServletResponse response )
         throws Exception
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, AGGREGATE );
 
         contextUtils.configureResponse( response, contentType, CacheStrategy.RESPECT_SYSTEM_SETTING,
             file, false );
@@ -419,14 +423,14 @@ public class EventAnalyticsController
         String contentType, String file, boolean attachment,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         contextUtils.configureResponse( response, contentType, CacheStrategy.RESPECT_SYSTEM_SETTING, file, attachment );
         return analyticsService.getEvents( params );
     }
 
     private EventQueryParams getEventQueryParams( String program, EventsAnalyticsQueryCriteria criteria,
-        DhisApiVersion apiVersion, boolean analyzeOnly )
+        DhisApiVersion apiVersion, boolean analyzeOnly, EndpointAction endpointAction )
     {
         criteria
             .definePageSize( systemSettingManager.getIntSetting( SettingKey.ANALYTICS_MAX_LIMIT ) );
@@ -435,7 +439,7 @@ public class EventAnalyticsController
             systemSettingManager.getSystemSetting( SettingKey.ANALYSIS_RELATIVE_PERIOD, RelativePeriodEnum.class ) );
 
         EventDataQueryRequest request = EventDataQueryRequest.builder()
-            .fromCriteria( (EventsAnalyticsQueryCriteria) criteria.withQueryEndpointAction()
+            .fromCriteria( (EventsAnalyticsQueryCriteria) criteria.withEndpointAction( endpointAction )
                 .withEndpointItem( RequestTypeAware.EndpointItem.EVENT ) )
             .program( program )
             .apiVersion( apiVersion ).build();


### PR DESCRIPTION
**_[Backport from master/2.41]_**

The analytics endpoint `/events/aggregate` should return all options for the requested option sets. Even in cases where there are no grid results for the requested option set.

The behaviour for `/events/query` and `/events/enrollments` should remain the same (returns only options present in the response).

For testing scenarios and steps to reproduce this issue on Play, please see https://dhis2.atlassian.net/browse/DHIS2-15364.