### PR TITLE
fix: map lock exception cleanup parameters [DHIS2-15333]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.scheduling.parameters.DataIntegrityJobParameters;
 import org.hisp.dhis.scheduling.parameters.DataSynchronizationJobParameters;
 import org.hisp.dhis.scheduling.parameters.DisableInactiveUsersJobParameters;
 import org.hisp.dhis.scheduling.parameters.EventProgramsDataSynchronizationJobParameters;
+import org.hisp.dhis.scheduling.parameters.LockExceptionCleanupJobParameters;
 import org.hisp.dhis.scheduling.parameters.MetadataSyncJobParameters;
 import org.hisp.dhis.scheduling.parameters.MonitoringJobParameters;
 import org.hisp.dhis.scheduling.parameters.PredictorJobParameters;
@@ -342,6 +343,7 @@ public class JobConfiguration extends BaseIdentifiableObject implements Secondar
         @JsonSubTypes.Type( value = DataIntegrityJobParameters.class, name = "DATA_INTEGRITY" ),
         @JsonSubTypes.Type( value = AggregateDataExchangeJobParameters.class, name = "AGGREGATE_DATA_EXCHANGE" ),
         @JsonSubTypes.Type( value = SqlViewUpdateParameters.class, name = "SQL_VIEW_UPDATE" ),
+        @JsonSubTypes.Type( value = LockExceptionCleanupJobParameters.class, name = "LOCK_EXCEPTION_CLEANUP" ),
         @JsonSubTypes.Type( value = TestJobParameters.class, name = "TEST" )
     } )
     public JobParameters getJobParameters()

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationControllerTest.java
@@ -138,6 +138,17 @@ class JobConfigurationControllerTest extends DhisControllerConvenienceTest
     }
 
     @Test
+    void testLOCK_EXCEPTION_CLEANUP()
+    {
+        String jobId = assertStatus( HttpStatus.CREATED,
+            POST( "/jobConfigurations",
+                "{'name':'test','jobType':'LOCK_EXCEPTION_CLEANUP','cronExpression':'0 0 12 ? * MON-FRI',"
+                    + "'jobParameters':{'expiresAfterMonths':'3'}}" ) );
+        JsonObject parameters = assertJobConfigurationExists( jobId, "LOCK_EXCEPTION_CLEANUP" );
+        assertEquals( 3, parameters.getNumber( "expiresAfterMonths" ).intValue() );
+    }
+
+    @Test
     void testGetJobTypeInfo()
     {
         for ( JsonObject e : GET( "/jobConfigurations/jobTypes" ).content()


### PR DESCRIPTION
Due to a missing mapping via `JsonSubTypes.Type` the lock exception cleanup job parameters would get lost during mapping when stored.
