### PR TITLE
fix: Duplicated ids for multi-staged dimensions [DHIS2-14493]

### DIFF
--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/BaseAnalyticalObjectTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/BaseAnalyticalObjectTest.java
@@ -27,18 +27,32 @@
  */
 package org.hisp.dhis.common;
 
+import static org.hisp.dhis.common.AnalyticsType.EVENT;
+import static org.hisp.dhis.common.DimensionType.PROGRAM_ATTRIBUTE;
+import static org.hisp.dhis.common.DimensionType.PROGRAM_DATA_ELEMENT;
+import static org.hisp.dhis.common.ValueType.BOOLEAN;
+import static org.hisp.dhis.common.ValueType.INTEGER;
+import static org.hisp.dhis.common.ValueType.TEXT;
+import static org.hisp.dhis.mapping.MapView.LAYER_THEMATIC1;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.eventchart.EventChart;
+import org.hisp.dhis.eventvisualization.EventVisualization;
 import org.hisp.dhis.mapping.MapView;
 import org.hisp.dhis.option.OptionSet;
+import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeDimension;
+import org.hisp.dhis.trackedentity.TrackedEntityDataElementDimension;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -52,8 +66,8 @@ class BaseAnalyticalObjectTest
     {
         TrackedEntityAttribute tea = new TrackedEntityAttribute();
         tea.setAutoFields();
-        tea.setValueType( ValueType.TEXT );
-        tea.setOptionSet( new OptionSet( "name", ValueType.BOOLEAN ) );
+        tea.setValueType( TEXT );
+        tea.setOptionSet( new OptionSet( "name", BOOLEAN ) );
 
         TrackedEntityAttributeDimension tead = new TrackedEntityAttributeDimension( tea, null, "EQ:10" );
 
@@ -68,8 +82,8 @@ class BaseAnalyticalObjectTest
         DimensionalObject dim = eventChart.getColumns().get( 0 );
 
         assertNotNull( dim );
-        assertEquals( DimensionType.PROGRAM_ATTRIBUTE, dim.getDimensionType() );
-        assertEquals( AnalyticsType.EVENT, dim.getAnalyticsType() );
+        assertEquals( PROGRAM_ATTRIBUTE, dim.getDimensionType() );
+        assertEquals( EVENT, dim.getAnalyticsType() );
         assertEquals( tead.getFilter(), dim.getFilter() );
         assertEquals( tead.getAttribute().getValueType(), dim.getValueType() );
         assertEquals( tead.getAttribute().getOptionSet(), dim.getOptionSet() );
@@ -103,9 +117,9 @@ class BaseAnalyticalObjectTest
         dsD.setCode( "D" );
         dsD.setName( "D" );
 
-        assertTrue( deA.equals( deC ) );
-        assertFalse( deA.equals( deB ) );
-        assertFalse( dsA.equals( dsD ) );
+        assertEquals( deA, deC );
+        assertNotEquals( deA, deB );
+        assertNotEquals( dsA, dsD );
     }
 
     @Test
@@ -114,7 +128,7 @@ class BaseAnalyticalObjectTest
         DataElement deA = new DataElement();
         deA.setAutoFields();
 
-        MapView mv = new MapView( MapView.LAYER_THEMATIC1 );
+        MapView mv = new MapView( LAYER_THEMATIC1 );
         mv.addDataDimensionItem( deA );
 
         assertEquals( 1, mv.getDataDimensionItems().size() );
@@ -128,7 +142,7 @@ class BaseAnalyticalObjectTest
         deA.setAutoFields();
         deB.setAutoFields();
 
-        MapView mv = new MapView( MapView.LAYER_THEMATIC1 );
+        MapView mv = new MapView( LAYER_THEMATIC1 );
         mv.addDataDimensionItem( deA );
         mv.addDataDimensionItem( deB );
 
@@ -138,5 +152,95 @@ class BaseAnalyticalObjectTest
 
         assertEquals( 1, mv.getDataDimensionItems().size() );
         assertEquals( deB, mv.getDataDimensionItems().get( 0 ).getDataElement() );
+    }
+
+    @Test
+    void testGetDimensionalObjectForDimensionUid()
+    {
+        String dimensionUid = "abc123abc11";
+        String dimensionName = "anyName";
+        String dimensionFilter = "gt:71";
+        ProgramStage programStage = new ProgramStage( "anyName", null );
+
+        TrackedEntityDataElementDimension dataElementDimension = stubTrackedEntityDataElementDimension( dimensionName,
+            dimensionUid, dimensionFilter );
+        dataElementDimension.setProgramStage( programStage );
+
+        List<TrackedEntityDataElementDimension> trackedEntityDataElementDimensions = List.of( dataElementDimension );
+
+        EventVisualization ev = new EventVisualization( "anyName" );
+        ev.setDataElementDimensions( trackedEntityDataElementDimensions );
+
+        Optional<DimensionalObject> result = ev.getDimensionalObject( dimensionUid );
+
+        assertNotNull( result.get(), "Must have a result." );
+
+        BaseDimensionalObject baseDimensionalObject = (BaseDimensionalObject) result.get();
+
+        assertEquals( PROGRAM_DATA_ELEMENT, baseDimensionalObject.getDimensionType() );
+        assertEquals( dimensionUid, baseDimensionalObject.getDimension() );
+        assertEquals( dimensionFilter, baseDimensionalObject.getFilter() );
+        assertNull( baseDimensionalObject.getDisplayName() );
+        assertNotNull( baseDimensionalObject.getProgramStage() );
+        assertEquals( dataElementDimension.getDataElement().getValueType(), baseDimensionalObject.getValueType() );
+    }
+
+    @Test
+    void testPopulateDimensionsForSameDimensionDifferentStages()
+    {
+        String sameDimensionUid = "abc123abc11";
+        String dimensionName = "anyName";
+        String dimensionFilter = "gt:71";
+        ProgramStage programStage1 = new ProgramStage( "anyStage1", null );
+        programStage1.setUid( "ps1234abc11" );
+
+        ProgramStage programStage2 = new ProgramStage( "anyStage2", null );
+        programStage1.setUid( "ps1234abc22" );
+
+        TrackedEntityDataElementDimension dataElementDimension1 = stubTrackedEntityDataElementDimension( dimensionName,
+            sameDimensionUid, dimensionFilter );
+        dataElementDimension1.setProgramStage( programStage1 );
+
+        TrackedEntityDataElementDimension dataElementDimension2 = stubTrackedEntityDataElementDimension( dimensionName,
+            sameDimensionUid, dimensionFilter );
+        dataElementDimension2.setProgramStage( programStage2 );
+
+        List<TrackedEntityDataElementDimension> trackedEntityDataElementDimensions = List.of( dataElementDimension1,
+            dataElementDimension2 );
+
+        List<String> sameDimensions = List.of( sameDimensionUid, sameDimensionUid );
+        List<DimensionalObject> dimensionalObjects = new ArrayList<>();
+
+        EventVisualization ev = new EventVisualization( "anyName" );
+        ev.setDataElementDimensions( trackedEntityDataElementDimensions );
+
+        ev.populateDimensions( sameDimensions, dimensionalObjects );
+
+        BaseDimensionalObject baseDimensionalObject1 = (BaseDimensionalObject) dimensionalObjects.get( 0 );
+        BaseDimensionalObject baseDimensionalObject2 = (BaseDimensionalObject) dimensionalObjects.get( 1 );
+
+        assertEquals( 2, dimensionalObjects.size() );
+        assertEquals( PROGRAM_DATA_ELEMENT, baseDimensionalObject1.getDimensionType() );
+        assertEquals( sameDimensionUid, baseDimensionalObject1.getDimension() );
+        assertEquals( dimensionFilter, baseDimensionalObject1.getFilter() );
+        assertNull( baseDimensionalObject1.getDisplayName() );
+        assertNotNull( baseDimensionalObject1.getProgramStage() );
+        assertEquals( programStage1, baseDimensionalObject1.getProgramStage() );
+        assertEquals( dataElementDimension1.getDataElement().getValueType(), baseDimensionalObject1.getValueType() );
+
+        assertEquals( PROGRAM_DATA_ELEMENT, baseDimensionalObject2.getDimensionType() );
+        assertEquals( sameDimensionUid, baseDimensionalObject2.getDimension() );
+        assertNotNull( baseDimensionalObject2.getProgramStage() );
+        assertEquals( programStage2, baseDimensionalObject2.getProgramStage() );
+    }
+
+    private TrackedEntityDataElementDimension stubTrackedEntityDataElementDimension( String deName, String deUid,
+        String deFilter )
+    {
+        DataElement dataElement = new DataElement( deName );
+        dataElement.setUid( deUid );
+        dataElement.setValueType( INTEGER );
+
+        return new TrackedEntityDataElementDimension( dataElement, null, null, deFilter );
     }
 }


### PR DESCRIPTION
**_[Backport from 2.40]_**

Some elements are associated with different program stages.
In event visualization, currently, the code does not handle such cases correctly. It does not allow repeated elements, even if they are associated with different program stages, to be saved/loaded.

This fix will allow elements associated with different program stages to be saved and loaded normally in event visualizations.
