### PR TITLE
fix: sortOrder gaps in Category.categorycombos [DHIS2-15351]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/Category.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/category/hibernate/Category.hbm.xml
@@ -39,13 +39,12 @@
                     foreign-key="fk_category_categoryoptionid"/>
     </list>
 
-    <list name="categoryCombos" table="categorycombos_categories" inverse="true">
+    <bag name="categoryCombos" table="categorycombos_categories" inverse="true">
       <cache usage="read-write" />
       <key column="categoryid" foreign-key="fk_categorycombo_categoryid" />
-      <list-index column="sort_order" base="1" />
       <many-to-many class="org.hisp.dhis.category.CategoryCombo" column="categorycomboid"
         foreign-key="fk_categorycombos_categories_categorycomboid" />
-    </list>
+    </bag>
 
     <property name="dataDimension" column="datadimension" not-null="true" />
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller;
 import static org.hisp.dhis.web.WebClient.Body;
 import static org.hisp.dhis.web.WebClient.ContentType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -38,7 +39,10 @@ import java.io.IOException;
 import org.geojson.GeoJsonObject;
 import org.geojson.Polygon;
 import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.jsontree.JsonValue;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.webapi.json.domain.JsonAttributeValue;
@@ -46,6 +50,7 @@ import org.hisp.dhis.webapi.json.domain.JsonErrorReport;
 import org.hisp.dhis.webapi.json.domain.JsonIdentifiableObject;
 import org.hisp.dhis.webapi.json.domain.JsonImportSummary;
 import org.hisp.dhis.webapi.json.domain.JsonWebMessage;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -306,5 +311,24 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest
         assertEquals( 2, response.getObject( "options" ).size() );
         assertNotNull( response.get( "options[0].sortOrder" ) );
         assertNotNull( response.get( "options[1].sortOrder" ) );
+    }
+
+    @Test
+    @DisplayName( "Should not include null objects in collection Category.categorycombos or CategoryCombo.categories after importing" )
+    void testImportCategoryComboAndCategory()
+    {
+        POST( "/metadata",
+            Body( "metadata/category_and_categorycombo.json" ) ).content( HttpStatus.OK );
+        JsonMixed response = GET( "/categories/{uid}?fields=id,categoryCombos",
+            "IjOK1aXkjVO" ).content();
+        JsonList<JsonObject> catCombos = response.getList( "categoryCombos", JsonObject.class );
+        assertNotNull( catCombos );
+        assertFalse( catCombos.stream().anyMatch( JsonValue::isNull ) );
+
+        response = GET( "/categoryCombos/{uid}?fields=id,categoryCombos",
+            "TIAbMD7ETV6" ).content();
+        JsonList<JsonObject> categories = response.getList( "categories", JsonObject.class );
+        assertNotNull( categories );
+        assertFalse( categories.stream().anyMatch( JsonValue::isNull ) );
     }
 }

--- a/dhis-2/dhis-test-web-api/src/test/resources/metadata/category_and_categorycombo.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/metadata/category_and_categorycombo.json
@@ -1,0 +1,538 @@
+{
+  "categories": [
+    {
+      "name": "ageGroup",
+      "id": "IjOK1aXkjVO",
+      "code": "ageGroup",
+      "shortName": "ageGroup",
+      "dataDimensionType": "DISAGGREGATION",
+      "categoryOptions": [
+        {
+          "id": "BT49qinT8J7"
+        },
+        {
+          "id": "ihP2RNzP0fm"
+        },
+        {
+          "id": "N3B2jlgiRHX"
+        },
+        {
+          "id": "GKQoNeejjdU"
+        },
+        {
+          "id": "bByb9n23vPv"
+        },
+        {
+          "id": "CMBqeoNZCY8"
+        },
+        {
+          "id": "yWAJBUx0X7L"
+        },
+        {
+          "id": "Wb44TJgaIr7"
+        }
+      ]
+    },
+    {
+      "name": "sex",
+      "id": "Tv9b9dYOHMG",
+      "code": "sex",
+      "shortName": "sex",
+      "dataDimensionType": "DISAGGREGATION",
+      "categoryOptions": [
+        {
+          "id": "j8ft17oIEID"
+        },
+        {
+          "id": "paLPcwxxBRs"
+        }
+      ]
+    },
+    {
+      "name": "payment_status",
+      "id": "D6kthOINtaj",
+      "code": "payment_status",
+      "shortName": "payment_status",
+      "dataDimensionType": "DISAGGREGATION",
+      "categoryOptions": [
+        {
+          "id": "rX1JDBLwBiA"
+        },
+        {
+          "id": "C8KH26bjs7Q"
+        },
+        {
+          "id": "XmyWM5dAZox"
+        }
+      ]
+    },
+    {
+      "name": "payment_state",
+      "id": "YNcYTPXdB6r",
+      "code": "payment_state",
+      "shortName": "payment_state",
+      "dataDimensionType": "DISAGGREGATION",
+      "categoryOptions": [
+        {
+          "id": "xgxX1kA2tBt"
+        },
+        {
+          "id": "rQTOPbaZ6uJ"
+        }
+      ]
+    },
+    {
+      "name": "product",
+      "id": "VowiWrbnWr3",
+      "code": "product",
+      "shortName": "product",
+      "dataDimensionType": "DISAGGREGATION",
+      "categoryOptions": [
+        {
+          "id": "n6G8e1Bou9l"
+        }
+      ]
+    },
+    {
+      "name": "item_status",
+      "id": "CmKkpIAtKiZ",
+      "code": "item_status",
+      "shortName": "item_status",
+      "dataDimensionType": "DISAGGREGATION",
+      "categoryOptions": [
+        {
+          "id": "pm3cAUuPSoI"
+        },
+        {
+          "id": "RhMtzZxNr6r"
+        }
+      ]
+    },
+    {
+      "name": "item_type",
+      "id": "QY8oxETWP5x",
+      "code": "item_type",
+      "shortName": "item_type",
+      "dataDimensionType": "DISAGGREGATION",
+      "categoryOptions": [
+        {
+          "id": "u5ttdA70HEl"
+        },
+        {
+          "id": "rogTXSuXf1m"
+        },
+        {
+          "id": "k5hHXh6KrOo"
+        }
+      ]
+    }
+  ],
+  "categoryOptions": [
+    {
+      "name": "0-5",
+      "id": "BT49qinT8J7",
+      "code": "0-5",
+      "shortName": "0-5"
+    },
+    {
+      "name": "6-12",
+      "id": "ihP2RNzP0fm",
+      "code": "6-12",
+      "shortName": "6-12"
+    },
+    {
+      "name": "13-18",
+      "id": "N3B2jlgiRHX",
+      "code": "13-18",
+      "shortName": "13-18"
+    },
+    {
+      "name": "19-25",
+      "id": "GKQoNeejjdU",
+      "code": "19-25",
+      "shortName": "19-25"
+    },
+    {
+      "name": "26-35",
+      "id": "bByb9n23vPv",
+      "code": "26-35",
+      "shortName": "26-35"
+    },
+    {
+      "name": "36-55",
+      "id": "CMBqeoNZCY8",
+      "code": "36-55",
+      "shortName": "36-55"
+    },
+    {
+      "name": "56-75",
+      "id": "yWAJBUx0X7L",
+      "code": "56-75",
+      "shortName": "56-75"
+    },
+    {
+      "name": "76p",
+      "id": "Wb44TJgaIr7",
+      "code": "76p",
+      "shortName": "76p"
+    },
+    {
+      "name": "Male3",
+      "id": "j8ft17oIEID",
+      "code": "M",
+      "shortName": "M"
+    },
+    {
+      "name": "Female3",
+      "id": "paLPcwxxBRs",
+      "code": "F",
+      "shortName": "F"
+    },
+    {
+      "name": "Paid",
+      "id": "rX1JDBLwBiA",
+      "code": "paid",
+      "shortName": "paid"
+    },
+    {
+      "name": "Partialy paid",
+      "id": "C8KH26bjs7Q",
+      "code": "partialy-paid",
+      "shortName": "partialy-paid"
+    },
+    {
+      "name": "Not paid",
+      "id": "XmyWM5dAZox",
+      "code": "not-paid",
+      "shortName": "not-paid"
+    },
+    {
+      "name": "New",
+      "id": "xgxX1kA2tBt",
+      "code": "new",
+      "shortName": "new"
+    },
+    {
+      "name": "Renew",
+      "id": "rQTOPbaZ6uJ",
+      "code": "renew",
+      "shortName": "renew"
+    },
+    {
+      "name": "Sarh",
+      "id": "n6G8e1Bou9l",
+      "code": "TEST",
+      "shortName": "TEST"
+    },
+    {
+      "name": "Approved",
+      "id": "pm3cAUuPSoI",
+      "code": "approved",
+      "shortName": "approved"
+    },
+    {
+      "name": "Rejected",
+      "id": "RhMtzZxNr6r",
+      "code": "rejected",
+      "shortName": "rejected"
+    },
+    {
+      "name": "Emergency",
+      "id": "u5ttdA70HEl",
+      "code": "Emergency",
+      "shortName": "Emergency"
+    },
+    {
+      "name": "Referrals",
+      "id": "rogTXSuXf1m",
+      "code": "Referrals",
+      "shortName": "Referrals"
+    },
+    {
+      "name": "Other",
+      "id": "k5hHXh6KrOo",
+      "code": "Other",
+      "shortName": "Other"
+    }
+  ],
+  "categoryCombos": [
+    {
+      "name": "ageGroup_sex",
+      "id": "UBCZTtKoxWg",
+      "code": "age_sex",
+      "shortName": "age_sex",
+      "categories": [
+        {
+          "id": "IjOK1aXkjVO"
+        },
+        {
+          "id": "Tv9b9dYOHMG"
+        }
+      ],
+      "dataDimensionType": "DISAGGREGATION"
+    },
+    {
+      "name": "ageGroup_payment_state_payment_status_sex",
+      "id": "TIAbMD7ETV6",
+      "code": "age_pay_pay_sex",
+      "shortName": "age_pay_pay_sex",
+      "categories": [
+        {
+          "id": "IjOK1aXkjVO"
+        },
+        {
+          "id": "Tv9b9dYOHMG"
+        },
+        {
+          "id": "D6kthOINtaj"
+        },
+        {
+          "id": "YNcYTPXdB6r"
+        }
+      ],
+      "dataDimensionType": "DISAGGREGATION"
+    },
+    {
+      "name": "product",
+      "id": "BqWRQtkDcxa",
+      "code": "pro",
+      "shortName": "pro",
+      "categories": [
+        {
+          "id": "VowiWrbnWr3"
+        }
+      ],
+      "dataDimensionType": "DISAGGREGATION"
+    },
+    {
+      "name": "ageGroup_item_status_item_type_product_sex",
+      "id": "QVfLQguTOO1",
+      "code": "age_ite_ite_pro_sex",
+      "shortName": "age_ite_ite_pro_sex",
+      "categories": [
+        {
+          "id": "VowiWrbnWr3"
+        },
+        {
+          "id": "CmKkpIAtKiZ"
+        },
+        {
+          "id": "QY8oxETWP5x"
+        },
+        {
+          "id": "Tv9b9dYOHMG"
+        },
+        {
+          "id": "IjOK1aXkjVO"
+        }
+      ],
+      "dataDimensionType": "DISAGGREGATION"
+    },
+    {
+      "name": "ageGroup_claim_status_item_type_product_sex",
+      "id": "FEs7WKVk9B1",
+      "code": "age_cla_ite_pro_sex",
+      "shortName": "age_cla_ite_pro_sex",
+      "categories": [
+        {
+          "id": "VowiWrbnWr3"
+        },
+        {
+          "id": "CmKkpIAtKiZ"
+        },
+        {
+          "id": "QY8oxETWP5x"
+        },
+        {
+          "id": "Tv9b9dYOHMG"
+        },
+        {
+          "id": "IjOK1aXkjVO"
+        }
+      ],
+      "dataDimensionType": "DISAGGREGATION"
+    }
+  ],
+  "dataElements": [
+    {
+      "name": "NB_INSUREES",
+      "id": "IjXDFHSWw8n",
+      "code": "NB_INSUREES",
+      "shortName": "NB_INSUREES",
+      "aggregationType": "SUM",
+      "domainType": "AGGREGATE",
+      "valueType": "NUMBER",
+      "categoryCombo": {
+        "id": "UBCZTtKoxWg"
+      }
+    },
+    {
+      "name": "NB_FAMILY",
+      "id": "bPjbBbjECI1",
+      "code": "NB_FAMILY",
+      "shortName": "NB_FAMILY",
+      "aggregationType": "SUM",
+      "domainType": "AGGREGATE",
+      "valueType": "NUMBER",
+      "categoryCombo": {
+        "id": "TIAbMD7ETV6"
+      }
+    },
+    {
+      "name": "SUM_CONTRIBUTIONS",
+      "id": "eUHBJXdKBr8",
+      "code": "SUM_CONTRIBUTIONS",
+      "shortName": "SUM_CONTRIBUTIONS",
+      "aggregationType": "SUM",
+      "domainType": "AGGREGATE",
+      "valueType": "NUMBER",
+      "categoryCombo": {
+        "id": "BqWRQtkDcxa"
+      }
+    },
+    {
+      "name": "NB_CLAIM",
+      "id": "AYFt457XLmN",
+      "code": "NB_CLAIM",
+      "shortName": "NB_CLAIM",
+      "aggregationType": "SUM",
+      "domainType": "AGGREGATE",
+      "valueType": "NUMBER",
+      "categoryCombo": {
+        "id": "QVfLQguTOO1"
+      }
+    },
+    {
+      "name": "NB_CLAIM_ITEM",
+      "id": "cYBrQuKsAUS",
+      "code": "NB_CLAIM_ITEM",
+      "shortName": "NB_CLAIM_ITEM",
+      "aggregationType": "SUM",
+      "domainType": "AGGREGATE",
+      "valueType": "NUMBER",
+      "categoryCombo": {
+        "id": "FEs7WKVk9B1"
+      }
+    },
+    {
+      "name": "NB_CLAIM_SERVICE",
+      "id": "gdwnsTlNDVr",
+      "code": "NB_CLAIM_SERVICE",
+      "shortName": "NB_CLAIM_SERVICE",
+      "aggregationType": "SUM",
+      "domainType": "AGGREGATE",
+      "valueType": "NUMBER",
+      "categoryCombo": {
+        "id": "FEs7WKVk9B1"
+      }
+    },
+    {
+      "name": "NB_BENEFIT",
+      "id": "U3z5QNFJEkC",
+      "code": "NB_BENEFIT",
+      "shortName": "NB_BENEFIT",
+      "aggregationType": "SUM",
+      "domainType": "AGGREGATE",
+      "valueType": "NUMBER",
+      "categoryCombo": {
+        "id": "FEs7WKVk9B1"
+      }
+    },
+    {
+      "name": "SUM_ASKED_BENEFIT",
+      "id": "Gz0LtxKeRfQ",
+      "code": "SUM_ASKED_BENEFIT",
+      "shortName": "SUM_ASKED_BENEFIT",
+      "aggregationType": "SUM",
+      "domainType": "AGGREGATE",
+      "valueType": "NUMBER",
+      "categoryCombo": {
+        "id": "FEs7WKVk9B1"
+      }
+    }
+  ],
+  "dataSets": [
+    {
+      "name": "Enrolment",
+      "id": "tS4D4c2HiTk",
+      "code": "Enrolment",
+      "shortName": "Enrolment",
+      "dataSetElements": [
+        {
+          "dataElement": {
+            "id": "IjXDFHSWw8n"
+          },
+          "dataSet": {
+            "id": "tS4D4c2HiTk"
+          }
+        },
+        {
+          "dataElement": {
+            "id": "bPjbBbjECI1"
+          },
+          "dataSet": {
+            "id": "tS4D4c2HiTk"
+          }
+        },
+        {
+          "dataElement": {
+            "id": "eUHBJXdKBr8"
+          },
+          "dataSet": {
+            "id": "tS4D4c2HiTk"
+          }
+        }
+      ],
+      "periodType": "Monthly"
+    },
+    {
+      "name": "PROCESSED_CLAIM",
+      "id": "xPaW8A6hAAE",
+      "code": "PROCESSED_CLAIM",
+      "shortName": "PROCESSED_CLAIM",
+      "dataSetElements": [
+        {
+          "dataElement": {
+            "id": "AYFt457XLmN"
+          },
+          "dataSet": {
+            "id": "xPaW8A6hAAE"
+          }
+        },
+        {
+          "dataElement": {
+            "id": "cYBrQuKsAUS"
+          },
+          "dataSet": {
+            "id": "xPaW8A6hAAE"
+          }
+        },
+        {
+          "dataElement": {
+            "id": "gdwnsTlNDVr"
+          },
+          "dataSet": {
+            "id": "xPaW8A6hAAE"
+          }
+        },
+        {
+          "dataElement": {
+            "id": "U3z5QNFJEkC"
+          },
+          "dataSet": {
+            "id": "xPaW8A6hAAE"
+          }
+        },
+        {
+          "dataElement": {
+            "id": "Gz0LtxKeRfQ"
+          },
+          "dataSet": {
+            "id": "xPaW8A6hAAE"
+          }
+        }
+      ],
+      "periodType": "Monthly"
+    }
+  ]
+}


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-15351
### Summary
- After importing the payload attached in jira, User get `null` values in `categoryCombos` array from `api/categories/{id}` as below.
```json
"categoryCombos": [
    null,
    {
      "id": "TIAbMD7ETV6"
    },
    null,
    {
      "id": "FEs7WKVk9B1"
    }
  ],

```

### Issue
- The issue caused by `sort_order` gaps in table `categorycombos_categories`. Hibernate will inject `null` item to a List if there are gaps in `list-index` or `sort_order` column.
- Another issue is that the table `categorycombos_categories`  has only one `sort_order` column but both `CategoryCombo.categories` and `Category.categoryCombos` collections are mapped with this index column. This causes the list-index to be updated incorrectly. 
- In Maintenance app > Category page, we don't show `CategoryCombo` list,  so I think we can **remove** the `list-index` from `categoryCombos` property in `Category.hbm.xml` file. This will **solve** the reported issue.
- In hibernate xml mapping, a `<list>` tag  can be replaced by`<bag>` which is basically a list without `list-index`. It also has `order-by` attribute which we can use later if needed.

### Test
- Added unit test
- Manual test can be done using `categories.json` file attached in jira. Just import the file then send GET request to any `Category` in the payload, verify if there is `null` in `categoryCombos` array.