### PR TITLE
fix: test that OpenAPI JSON document is semantically valid [DHIS2-15432]

### DIFF
--- a/dhis-2/dhis-test-web-api/pom.xml
+++ b/dhis-2/dhis-test-web-api/pom.xml
@@ -455,6 +455,12 @@
       <artifactId>log4j-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.swagger.parser.v3</groupId>
+      <artifactId>swagger-parser</artifactId>
+      <version>2.1.15</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/dhis-2/dhis-test-web-api/pom.xml
+++ b/dhis-2/dhis-test-web-api/pom.xml
@@ -458,7 +458,13 @@
     <dependency>
       <groupId>io.swagger.parser.v3</groupId>
       <artifactId>swagger-parser</artifactId>
-      <version>2.1.15</version>
+      <version>${swagger.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger.parser.v3</groupId>
+      <artifactId>swagger-parser-core</artifactId>
+      <version>${swagger.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
@@ -29,11 +29,17 @@ package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.utils.Assertions.assertGreaterOrEqual;
 import static org.hisp.dhis.utils.Assertions.assertLessOrEqual;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
 
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.junit.jupiter.api.Test;
+
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
 
 /**
  * Tests the {@link org.hisp.dhis.webapi.openapi.OpenApiController} with Mock
@@ -47,7 +53,7 @@ import org.junit.jupiter.api.Test;
 class OpenApiControllerTest extends DhisControllerConvenienceTest
 {
     @Test
-    void testGetOpenApiDocument()
+    void testGetOpenApiDocumentJson()
     {
         JsonObject doc = GET( "/openapi/openapi.json?failOnNameClash=true" ).content();
         assertTrue( doc.isObject() );
@@ -56,6 +62,10 @@ class OpenApiControllerTest extends DhisControllerConvenienceTest
         assertGreaterOrEqual( 1, doc.getObject( "components.securitySchemes" ).size() );
         assertGreaterOrEqual( 200, doc.getObject( "components.schemas" ).size() );
         assertGreaterOrEqual( 200, doc.getObject( "components.schemas" ).size() );
+
+        SwaggerParseResult result = new OpenAPIParser().readContents( doc.node().getDeclaration(), null,
+            null );
+        assertEquals( List.of(), result.getMessages(), "There should not be any errors" );
     }
 
     @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeAllController.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeAllController.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletResponse;
 
 import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,6 +41,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@OpenApi.Ignore
 @Controller
 @RequestMapping( "/type/testAll" )
 @ApiVersion( DhisApiVersion.ALL )

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeAllExcludeV32Controller.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeAllExcludeV32Controller.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletResponse;
 
 import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,6 +41,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@OpenApi.Ignore
 @Controller
 @RequestMapping( "/type/testAllExcludeV32" )
 @ApiVersion( value = DhisApiVersion.ALL, exclude = DhisApiVersion.V32 )

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeDefaultAllController.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeDefaultAllController.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletResponse;
 
 import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,6 +41,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@OpenApi.Ignore
 @Controller
 @RequestMapping( "/type/testDefaultAll" )
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeDefaultController.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeDefaultController.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletResponse;
 
 import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,6 +41,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@OpenApi.Ignore
 @Controller
 @RequestMapping( "/type/testDefault" )
 @ApiVersion( DhisApiVersion.DEFAULT )

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeDefaultV31Controller.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeDefaultV31Controller.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletResponse;
 
 import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,6 +41,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@OpenApi.Ignore
 @Controller
 @RequestMapping( "/type/testDefaultV31" )
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.V31 } )

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeV31V32Controller.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/type/ApiTypeV31V32Controller.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletResponse;
 
 import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,6 +41,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@OpenApi.Ignore
 @Controller
 @RequestMapping( "/type/testV31V32" )
 @ApiVersion( { DhisApiVersion.V31, DhisApiVersion.V32 } )

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/type/BaseWithVersionController.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/type/BaseWithVersionController.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletResponse;
 
 import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -39,6 +40,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@OpenApi.Ignore
 @ApiVersion( DhisApiVersion.V31 )
 public abstract class BaseWithVersionController
 {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tei/TeiAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tei/TeiAnalyticsController.java
@@ -74,11 +74,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 @OpenApi.Tags( "analytics" )
 @RestController
 @RequiredArgsConstructor
-@RequestMapping( TeiAnalyticsController.TRACKED_ENTITIES )
+@RequestMapping( "/analytics/trackedEntities" )
 class TeiAnalyticsController
 {
-    static final String TRACKED_ENTITIES = "analytics/trackedEntities";
-
     @Nonnull
     private final TeiAnalyticsQueryService teiAnalyticsQueryService;
 
@@ -103,7 +101,7 @@ class TeiAnalyticsController
     @Nonnull
     private final ContextUtils contextUtils;
 
-    @GetMapping( value = "query/{trackedEntityType}", produces = { APPLICATION_JSON_VALUE, "application/javascript" } )
+    @GetMapping( value = "/query/{trackedEntityType}", produces = { APPLICATION_JSON_VALUE, "application/javascript" } )
     Grid getGrid(
         @PathVariable String trackedEntityType,
         TeiQueryRequest teiQueryRequest,
@@ -113,7 +111,7 @@ class TeiAnalyticsController
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_ANALYTICS_EXPLAIN')" )
-    @GetMapping( value = "query/{trackedEntityType}/explain", produces = { APPLICATION_JSON_VALUE,
+    @GetMapping( value = "/query/{trackedEntityType}/explain", produces = { APPLICATION_JSON_VALUE,
         "application/javascript" } )
     Grid getGridExplain(
         @PathVariable String trackedEntityType,

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -197,6 +197,7 @@
     <testcontainers.version>1.18.3</testcontainers.version>
     <jsonassert.version>1.5.1</jsonassert.version>
     <awaitility.version>4.2.0</awaitility.version>
+    <swagger.version>2.1.15</swagger.version>
     <easy-random.version>5.0.0</easy-random.version>
     <tree.version>0.2.5</tree.version>
     <h2.version>2.1.214</h2.version>


### PR DESCRIPTION
The generated OpenAPI document could become semantically invalid. This means it is valid JSON but values in the tree are not valid with regards to the OpenAPI spec. Mostly this happens with paths that do not conform to the expectations.

To prevent this from happening silently the validity is checked using swagger validation. 

The fixes needed were:
* ignore any controller defined in test sources using `@OpenApi.Ignore`
* make sure paths start with a `/` ( `TeiAnalyticsController`)