### PR TITLE
feat: Program Copy - Program Indicator work [DHIS2-15279]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramIndicator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramIndicator.java
@@ -490,8 +490,4 @@ public class ProgramIndicator
         copy.setStyle( original.getStyle() );
         copy.setTranslations( original.getTranslations() );
     }
-
-    public record ProgramIndicatorTuple( ProgramIndicator original, ProgramIndicator copy )
-    {
-    }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramIndicator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramIndicator.java
@@ -481,6 +481,7 @@ public class ProgramIndicator
         copy.setExpression( original.getExpression() );
         copy.setFilter( original.getFilter() );
         copy.setFormName( original.getFormName() );
+        copy.setGroups( new HashSet<>() );
         copy.setName( prefix + original.getName() );
         copy.setOrgUnitField( original.getOrgUnitField() );
         copy.setPublicAccess( original.getPublicAccess() );
@@ -488,5 +489,9 @@ public class ProgramIndicator
         copy.setShortName( prefix + original.getShortName() );
         copy.setStyle( original.getStyle() );
         copy.setTranslations( original.getTranslations() );
+    }
+
+    public record ProgramIndicatorTuple( ProgramIndicator original, ProgramIndicator copy )
+    {
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStage.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStage.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.program;
 
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -596,26 +595,13 @@ public class ProgramStage
         return copy;
     }
 
-    public static ProgramStage deepCopy( ProgramStage original, ProgramStage copy,
-        Map<String, ProgramIndicator.ProgramIndicatorTuple> indicatorMappings, Map<String, String> copyOptions )
+    public static ProgramStage deepCopy( ProgramStage original, ProgramStage copy )
     {
         copy.setProgramStageDataElements(
             copySet( copy, original.getProgramStageDataElements(), ProgramStageDataElement.copyOf ) );
-        copyStageSections( copy, original.getProgramStageSections(), indicatorMappings, copyOptions );
+        copy.setProgramStageSections(
+            copySet( copy, original.getProgramStageSections(), ProgramStageSection.copyOf ) );
         return copy;
-    }
-
-    private static void copyStageSections( ProgramStage copy, Set<ProgramStageSection> originalStageSections,
-        Map<String, ProgramIndicator.ProgramIndicatorTuple> indicatorMappings, Map<String, String> copyOptions )
-    {
-
-        Set<ProgramStageSection> stageSections = new HashSet<>();
-        for ( ProgramStageSection pss : originalStageSections )
-        {
-            ProgramStageSection copySection = ProgramStageSection.copyOf( pss, copy, indicatorMappings, copyOptions );
-            stageSections.add( copySection );
-        }
-        copy.setProgramStageSections( stageSections );
     }
 
     private static void setShallowCopyValues( ProgramStage copy, ProgramStage original )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStage.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStage.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.program;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -595,13 +596,26 @@ public class ProgramStage
         return copy;
     }
 
-    public static ProgramStage deepCopy( ProgramStage original, ProgramStage copy )
+    public static ProgramStage deepCopy( ProgramStage original, ProgramStage copy,
+        Map<String, ProgramIndicator.ProgramIndicatorTuple> indicatorMappings, Map<String, String> copyOptions )
     {
         copy.setProgramStageDataElements(
             copySet( copy, original.getProgramStageDataElements(), ProgramStageDataElement.copyOf ) );
-        copy.setProgramStageSections(
-            copySet( copy, original.getProgramStageSections(), ProgramStageSection.copyOf ) );
+        copyStageSections( copy, original.getProgramStageSections(), indicatorMappings, copyOptions );
         return copy;
+    }
+
+    private static void copyStageSections( ProgramStage copy, Set<ProgramStageSection> originalStageSections,
+        Map<String, ProgramIndicator.ProgramIndicatorTuple> indicatorMappings, Map<String, String> copyOptions )
+    {
+
+        Set<ProgramStageSection> stageSections = new HashSet<>();
+        for ( ProgramStageSection pss : originalStageSections )
+        {
+            ProgramStageSection copySection = ProgramStageSection.copyOf( pss, copy, indicatorMappings, copyOptions );
+            stageSections.add( copySection );
+        }
+        copy.setProgramStageSections( stageSections );
     }
 
     private static void setShallowCopyValues( ProgramStage copy, ProgramStage original )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageSection.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageSection.java
@@ -29,8 +29,7 @@ package org.hisp.dhis.program;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.function.BiFunction;
 
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.BaseNameableObject;
@@ -216,68 +215,14 @@ public class ProgramStageSection
         this.renderType = renderType;
     }
 
-    public static ProgramStageSection copyOf( ProgramStageSection original, ProgramStage stage,
-        Map<String, ProgramIndicator.ProgramIndicatorTuple> indicatorMappings, Map<String, String> copyOptions )
-    {
+    public static final BiFunction<ProgramStageSection, ProgramStage, ProgramStageSection> copyOf = ( original,
+        stage ) -> {
         ProgramStageSection copy = new ProgramStageSection();
         copy.setProgramStage( stage );
         copy.setAutoFields();
         setShallowCopyValues( copy, original );
-        setDeepCopyValues( copy, original, indicatorMappings, copyOptions );
         return copy;
-    }
-
-    private static void setDeepCopyValues( ProgramStageSection copy, ProgramStageSection original,
-        Map<String, ProgramIndicator.ProgramIndicatorTuple> indicatorMappings, Map<String, String> copyOptions )
-    {
-        copyIndicators( copy, original, indicatorMappings, copyOptions );
-    }
-
-    /**
-     * This method copies the List of {@link ProgramIndicator} in the
-     * {@link ProgramStageSection}. It takes in a mapping of
-     * {@link ProgramIndicator} as a param, so it can use an existing mapping if
-     * found. If no mapping is found then a new {@link ProgramIndicator} is
-     * created.
-     *
-     * @param copy The {@link ProgramStageSection} copy which will have its List
-     *        of {@link ProgramIndicator} set.
-     * @param original {@link ProgramStageSection} to copy
-     * @param indicatorMappings Mapping of {@link ProgramIndicator} with the
-     *        original {@link ProgramIndicator} UID as key and the
-     *        {@link org.hisp.dhis.program.ProgramIndicator.ProgramIndicatorTuple}
-     *        as the value.
-     * @param copyOptions Map of copy options to apply to a
-     *        {@link ProgramIndicator}
-     */
-    private static void copyIndicators( ProgramStageSection copy, ProgramStageSection original,
-        Map<String, ProgramIndicator.ProgramIndicatorTuple> indicatorMappings, Map<String, String> copyOptions )
-    {
-        List<ProgramIndicator> copyIndicators = new ArrayList<>();
-        List<ProgramIndicator> originalIndicators = original.getProgramIndicators();
-        if ( Objects.nonNull( originalIndicators ) )
-        {
-            for ( ProgramIndicator pi : originalIndicators )
-            {
-                ProgramIndicator indicatorCopy;
-                if ( indicatorMappings.containsKey( pi.getUid() ) )
-                {
-                    indicatorCopy = indicatorMappings.get( pi.getUid() ).copy();
-                }
-                else
-                {
-                    indicatorCopy = ProgramIndicator.copyOf( pi, getParentProgram( copy ), copyOptions );
-                }
-                copyIndicators.add( indicatorCopy );
-            }
-        }
-        copy.setProgramIndicators( copyIndicators );
-    }
-
-    private static Program getParentProgram( ProgramStageSection copy )
-    {
-        return copy.getProgramStage().getProgram();
-    }
+    };
 
     private static void setShallowCopyValues( ProgramStageSection copy, ProgramStageSection original )
     {
@@ -286,7 +231,7 @@ public class ProgramStageSection
         copy.setFormName( original.getFormName() );
         copy.setLastUpdatedBy( original.getLastUpdatedBy() );
         copy.setName( original.getName() );
-
+        copy.setProgramIndicators( new ArrayList<>() );
         copy.setPublicAccess( original.getPublicAccess() );
         copy.setRenderType( original.getRenderType() );
         copy.setSharing( original.getSharing() );

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageSection.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageSection.java
@@ -29,7 +29,8 @@ package org.hisp.dhis.program;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.BiFunction;
+import java.util.Map;
+import java.util.Objects;
 
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.BaseNameableObject;
@@ -215,14 +216,68 @@ public class ProgramStageSection
         this.renderType = renderType;
     }
 
-    public static final BiFunction<ProgramStageSection, ProgramStage, ProgramStageSection> copyOf = ( original,
-        stage ) -> {
+    public static ProgramStageSection copyOf( ProgramStageSection original, ProgramStage stage,
+        Map<String, ProgramIndicator.ProgramIndicatorTuple> indicatorMappings, Map<String, String> copyOptions )
+    {
         ProgramStageSection copy = new ProgramStageSection();
         copy.setProgramStage( stage );
         copy.setAutoFields();
         setShallowCopyValues( copy, original );
+        setDeepCopyValues( copy, original, indicatorMappings, copyOptions );
         return copy;
-    };
+    }
+
+    private static void setDeepCopyValues( ProgramStageSection copy, ProgramStageSection original,
+        Map<String, ProgramIndicator.ProgramIndicatorTuple> indicatorMappings, Map<String, String> copyOptions )
+    {
+        copyIndicators( copy, original, indicatorMappings, copyOptions );
+    }
+
+    /**
+     * This method copies the List of {@link ProgramIndicator} in the
+     * {@link ProgramStageSection}. It takes in a mapping of
+     * {@link ProgramIndicator} as a param, so it can use an existing mapping if
+     * found. If no mapping is found then a new {@link ProgramIndicator} is
+     * created.
+     *
+     * @param copy The {@link ProgramStageSection} copy which will have its List
+     *        of {@link ProgramIndicator} set.
+     * @param original {@link ProgramStageSection} to copy
+     * @param indicatorMappings Mapping of {@link ProgramIndicator} with the
+     *        original {@link ProgramIndicator} UID as key and the
+     *        {@link org.hisp.dhis.program.ProgramIndicator.ProgramIndicatorTuple}
+     *        as the value.
+     * @param copyOptions Map of copy options to apply to a
+     *        {@link ProgramIndicator}
+     */
+    private static void copyIndicators( ProgramStageSection copy, ProgramStageSection original,
+        Map<String, ProgramIndicator.ProgramIndicatorTuple> indicatorMappings, Map<String, String> copyOptions )
+    {
+        List<ProgramIndicator> copyIndicators = new ArrayList<>();
+        List<ProgramIndicator> originalIndicators = original.getProgramIndicators();
+        if ( Objects.nonNull( originalIndicators ) )
+        {
+            for ( ProgramIndicator pi : originalIndicators )
+            {
+                ProgramIndicator indicatorCopy;
+                if ( indicatorMappings.containsKey( pi.getUid() ) )
+                {
+                    indicatorCopy = indicatorMappings.get( pi.getUid() ).copy();
+                }
+                else
+                {
+                    indicatorCopy = ProgramIndicator.copyOf( pi, getParentProgram( copy ), copyOptions );
+                }
+                copyIndicators.add( indicatorCopy );
+            }
+        }
+        copy.setProgramIndicators( copyIndicators );
+    }
+
+    private static Program getParentProgram( ProgramStageSection copy )
+    {
+        return copy.getProgramStage().getProgram();
+    }
 
     private static void setShallowCopyValues( ProgramStageSection copy, ProgramStageSection original )
     {
@@ -231,7 +286,7 @@ public class ProgramStageSection
         copy.setFormName( original.getFormName() );
         copy.setLastUpdatedBy( original.getLastUpdatedBy() );
         copy.setName( original.getName() );
-        copy.setProgramIndicators( ObjectUtils.copyOf( original.getProgramIndicators() ) );
+
         copy.setPublicAccess( original.getPublicAccess() );
         copy.setRenderType( original.getRenderType() );
         copy.setSharing( original.getSharing() );

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/program/ProgramIndicatorTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/program/ProgramIndicatorTest.java
@@ -96,7 +96,7 @@ class ProgramIndicatorTest
         assertEquals( customPrefix + original.getShortName(), copy.getShortName() );
     }
 
-    private ProgramIndicator getNewProgramIndicator( Program program )
+    static ProgramIndicator getNewProgramIndicator( Program program )
     {
         ProgramIndicator pi = new ProgramIndicator();
         pi.setAutoFields();

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/program/ProgramStageSectionTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/program/ProgramStageSectionTest.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.ObjectStyle;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.render.DeviceRenderTypeMap;
@@ -61,19 +62,19 @@ class ProgramStageSectionTest
         ProgramStage originalStage = new ProgramStage( "program stage 1", originalProgram );
         ProgramStage copyStage = ProgramStage.shallowCopy( originalStage, copyProgram );
         ProgramStageSection original = getNewProgramStageSection( originalStage, originalProgram );
-        ProgramStageSection copy = ProgramStageSection.copyOf( original, copyStage, Map.of(), Map.of() );
+        ProgramStageSection copy = ProgramStageSection.copyOf.apply( original, copyStage );
 
         assertNotSame( original, copy );
         assertNotEquals( original, copy );
         assertNotEquals( original.getProgramStage(), copy.getProgramStage() );
         assertNotSame( original.getProgramStage(), copy.getProgramStage() );
         assertNotEquals( original.getUid(), copy.getUid() );
-        Set<String> originalIndicators = original.getProgramIndicators().stream().map( pi -> pi.getProgram().getUid() )
+        Set<String> originalIndicators = original.getProgramIndicators().stream().map( BaseIdentifiableObject::getUid )
             .collect( Collectors.toSet() );
-        Set<String> copyIndicators = copy.getProgramIndicators().stream().map( pi -> pi.getProgram().getUid() )
+        Set<String> copyIndicators = copy.getProgramIndicators().stream().map( BaseIdentifiableObject::getUid )
             .collect( Collectors.toSet() );
-        originalIndicators.retainAll( copyIndicators );
-        assertTrue( originalIndicators.isEmpty() );
+        assertEquals( 1, originalIndicators.size() );
+        assertEquals( 0, copyIndicators.size() );
         assertNotEquals( original.getProgramIndicators(), copy.getProgramIndicators() );
 
         assertTrue( notEqualsOrBothNull( original.getCode(), copy.getCode() ) );
@@ -99,7 +100,7 @@ class ProgramStageSectionTest
         ProgramStage originalStage = new ProgramStage( "program stage 1", originalProgram );
         ProgramStage copyStage = ProgramStage.shallowCopy( originalStage, copyProgram );
         ProgramStageSection original = getNewProgramStageSectionWithNulls();
-        ProgramStageSection copy = ProgramStageSection.copyOf( original, copyStage, Map.of(), Map.of() );
+        ProgramStageSection copy = ProgramStageSection.copyOf.apply( original, copyStage );
 
         assertNotSame( original, copy );
         assertNotEquals( original, copy );
@@ -133,7 +134,7 @@ class ProgramStageSectionTest
     void testExpectedFieldCount()
     {
         Field[] allClassFieldsIncludingInherited = getAllFields( ProgramStageSection.class );
-        assertEquals( 27, allClassFieldsIncludingInherited.length );
+        assertEquals( 28, allClassFieldsIncludingInherited.length );
     }
 
     public static ProgramStageSection getNewProgramStageSection( ProgramStage original, Program program )

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/program/ProgramStageTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/program/ProgramStageTest.java
@@ -193,8 +193,8 @@ class ProgramStageTest
 
     private Set<ProgramStageSection> getProgramStageSections( ProgramStage programStage )
     {
-        ProgramStageSection pss1 = getNewProgramStageSection( programStage );
-        ProgramStageSection pss2 = getNewProgramStageSection( programStage );
+        ProgramStageSection pss1 = getNewProgramStageSection( programStage, programStage.getProgram() );
+        ProgramStageSection pss2 = getNewProgramStageSection( programStage, programStage.getProgram() );
         return Set.of( pss1, pss2 );
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/copy/CopyService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/copy/CopyService.java
@@ -39,6 +39,8 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
+import lombok.RequiredArgsConstructor;
+
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentService;
@@ -57,8 +59,6 @@ import org.hisp.dhis.programrule.ProgramRuleVariable;
 import org.hisp.dhis.programrule.ProgramRuleVariableService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import lombok.RequiredArgsConstructor;
 
 /**
  * Service that allows copying of a {@link Program} and other {@link Program}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/copy/CopyServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/copy/CopyServiceTest.java
@@ -140,7 +140,7 @@ class CopyServiceTest extends DhisConvenienceTest
             .addProgramStageDataElement( any( ProgramStageDataElement.class ) );
         verify( programStageSectionService, times( 2 ) )
             .saveProgramStageSection( any( ProgramStageSection.class ) );
-        verify( programIndicatorService, times( 3 ) ).addProgramIndicator( any( ProgramIndicator.class ) );
+        verify( programIndicatorService, times( 1 ) ).addProgramIndicator( any( ProgramIndicator.class ) );
         verify( programRuleVariableService, times( 1 ) ).addProgramRuleVariable( any( ProgramRuleVariable.class ) );
         verify( programSectionService, times( 1 ) ).addProgramSection( any( ProgramSection.class ) );
         verify( enrollmentService, times( 1 ) ).addEnrollment( any( Enrollment.class ) );
@@ -215,9 +215,7 @@ class CopyServiceTest extends DhisConvenienceTest
             .map( ProgramIndicator::getUid ).collect( Collectors.toSet() );
 
         assertEquals( 2, originalProgramStageSectionIndicators.size() );
-        assertEquals( 2, copyProgramStageSectionIndicators.size() );
-        originalProgramStageSectionIndicators.retainAll( copyProgramStageSectionIndicators );
-        assertTrue( originalProgramStageSectionIndicators.isEmpty() );
+        assertEquals( 0, copyProgramStageSectionIndicators.size() );
     }
 
     @Test

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonProgramStageSection.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonProgramStageSection.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.json.domain;
 
+import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
 
 /**
@@ -34,4 +35,8 @@ import org.hisp.dhis.jsontree.JsonObject;
  */
 public interface JsonProgramStageSection extends JsonObject, JsonNameableObject
 {
+    default JsonList<JsonProgramIndicator> getProgramStageSectionIndicators()
+    {
+        return getList( "programIndicators", JsonProgramIndicator.class );
+    }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerIntegrationTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.web.WebClientUtils.assertStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.hisp.dhis.association.jdbc.JdbcOrgUnitAssociationsStore;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.web.HttpStatus;
+import org.hisp.dhis.web.WebClient;
+import org.hisp.dhis.webapi.DhisControllerIntegrationTest;
+import org.hisp.dhis.webapi.controller.tracker.JsonEnrollment;
+import org.hisp.dhis.webapi.json.domain.JsonWebMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * This Integration test using Postgres is necessary as the H2 DB doesn't work
+ * with {@link JdbcOrgUnitAssociationsStore#checkOrganisationUnitsAssociations}.
+ * A ClassCastException is thrown. H2 uses a different object type for its
+ * result set which doesn't allow the cast to String[] when creating the orgUnit
+ * <-> program relationship map.
+ *
+ * @author David Mackessy
+ */
+
+class ProgramControllerIntegrationTest extends DhisControllerIntegrationTest
+{
+
+    @Autowired
+    private ObjectMapper jsonMapper;
+
+    public static final String PROGRAM_UID = "PrZMWi7rBga";
+
+    public static final String ORG_UNIT_UID = "Orgunit1000";
+
+    @BeforeEach
+    public void testSetup()
+        throws JsonProcessingException
+    {
+        DataElement dataElement1 = createDataElement( 'a' );
+        DataElement dataElement2 = createDataElement( 'b' );
+        dataElement1.setUid( "deabcdefgha" );
+        dataElement2.setUid( "deabcdefghb" );
+        TrackedEntityAttribute tea1 = createTrackedEntityAttribute( 'a' );
+        TrackedEntityAttribute tea2 = createTrackedEntityAttribute( 'b' );
+        tea1.setUid( "TEA1nnnnnaa" );
+        tea2.setUid( "TEA1nnnnnab" );
+        POST( "/dataElements", jsonMapper.writeValueAsString( dataElement1 ) )
+            .content( HttpStatus.CREATED );
+        POST( "/dataElements", jsonMapper.writeValueAsString( dataElement2 ) )
+            .content( HttpStatus.CREATED );
+        POST( "/trackedEntityAttributes", jsonMapper.writeValueAsString( tea1 ) )
+            .content( HttpStatus.CREATED );
+        POST( "/trackedEntityAttributes", jsonMapper.writeValueAsString( tea2 ) )
+            .content( HttpStatus.CREATED );
+
+        POST( "/metadata", WebClient.Body( "program/create_program.json" ) )
+            .content( HttpStatus.OK );
+    }
+
+    @Test
+    void testCopyProgramEnrollments()
+    {
+        assertStatus( HttpStatus.CREATED, POST( "/trackedEntityTypes",
+            "{'description': 'add TET for Enrollment test','id':'TEType10000','name':'Tracked Entity Type 1'}" ) );
+
+        assertStatus( HttpStatus.CREATED, POST( "/trackedEntityAttributes/",
+            "{'name':'attrA', 'id':'TEAttr10000','shortName':'attrA', 'valueType':'TEXT', 'aggregationType':'NONE'}" ) );
+
+        String teiId = assertStatus( HttpStatus.OK, POST( "/trackedEntityInstances", "{\n" +
+            "  'trackedEntityType': 'TEType10000',\n" +
+            "  'program': 'PrZMWi7rBga',\n" +
+            "  'status': 'ACTIVE',\n" +
+            "  'orgUnit': '" + ORG_UNIT_UID + "',\n" +
+            "  'enrollmentDate': '2023-06-16',\n" +
+            "  'incidentDate': '2023-06-16'\n" +
+            "}" ) );
+
+        JsonWebMessage msg = (POST( "/enrollments", "{\n" +
+            "  'trackedEntityInstance': '" + teiId + "',\n" +
+            "  'program': 'PrZMWi7rBga',\n" +
+            "  'status': 'ACTIVE',\n" +
+            "  'orgUnit': '" + ORG_UNIT_UID + "',\n" +
+            "  'enrollmentDate': '2023-06-16',\n" +
+            "  'incidentDate': '2023-06-16'\n" +
+            "}" )).content().as( JsonWebMessage.class );
+
+        POST(
+            "/programs/%s/copy".formatted( PROGRAM_UID ) )
+            .content( HttpStatus.CREATED )
+            .as( JsonWebMessage.class );
+
+        JsonWebMessage enrollmentsForOrgUnit = GET( "/tracker/enrollments?orgUnit=%s".formatted( ORG_UNIT_UID ) )
+            .content( HttpStatus.OK )
+            .as( JsonWebMessage.class );
+
+        JsonList<JsonEnrollment> enrollments = enrollmentsForOrgUnit.getList( "instances", JsonEnrollment.class );
+        Set<JsonEnrollment> originalProgramEnrollments = enrollments.stream()
+            .filter( enrollment -> enrollment.getProgram().equals( PROGRAM_UID ) )
+            .collect( Collectors.toSet() );
+
+        assertEquals( 2, enrollments.size() );
+        assertEquals( 1, originalProgramEnrollments.size() );
+    }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerIntegrationTest.java
@@ -112,14 +112,14 @@ class ProgramControllerIntegrationTest extends DhisControllerIntegrationTest
             "  'incidentDate': '2023-06-16'\n" +
             "}" ) );
 
-        JsonWebMessage msg = (POST( "/enrollments", "{\n" +
+        POST( "/enrollments", "{\n" +
             "  'trackedEntityInstance': '" + teiId + "',\n" +
             "  'program': 'PrZMWi7rBga',\n" +
             "  'status': 'ACTIVE',\n" +
             "  'orgUnit': '" + ORG_UNIT_UID + "',\n" +
             "  'enrollmentDate': '2023-06-16',\n" +
             "  'incidentDate': '2023-06-16'\n" +
-            "}" )).content().as( JsonWebMessage.class );
+            "}" ).content( HttpStatus.CREATED );
 
         POST(
             "/programs/%s/copy".formatted( PROGRAM_UID ) )

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerTest.java
@@ -180,9 +180,8 @@ class ProgramControllerTest extends DhisControllerConvenienceTest
     void testCopyProgramIndicatorDbConstraintsWithNoCopyOptions()
     {
         //1st copy with no copy option request param succeeds
-        JsonWebMessage response = POST( "/programs/%s/copy".formatted( PROGRAM_UID ) )
-            .content( HttpStatus.CREATED )
-            .as( JsonWebMessage.class );
+        POST( "/programs/%s/copy".formatted( PROGRAM_UID ) )
+            .content( HttpStatus.CREATED );
 
         //2nd copy with no copy option request param should fail
         JsonWebMessage response2 = POST( "/programs/%s/copy".formatted( PROGRAM_UID ) )

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerTest.java
@@ -37,7 +37,6 @@ import java.util.stream.Collectors;
 
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.jsontree.JsonList;
-import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.web.WebClient;
@@ -88,9 +87,8 @@ class ProgramControllerTest extends DhisControllerConvenienceTest
         POST( "/trackedEntityAttributes", jsonMapper.writeValueAsString( tea2 ) )
             .content( HttpStatus.CREATED );
 
-        JsonMixed content = POST( "/metadata", WebClient.Body( "program/create_program.json" ) )
-            .content( HttpStatus.OK );
-        System.out.println( content );
+        POST( "/metadata", WebClient.Body( "program/create_program.json" ) )
+            .content( HttpStatus.OK ).as( JsonWebMessage.class );
     }
 
     @Test
@@ -126,15 +124,13 @@ class ProgramControllerTest extends DhisControllerConvenienceTest
         JsonProgramStage jsonCopiedProgramStage = GET( "/programStages/" + copiedStage.getId() )
             .content( HttpStatus.OK )
             .as( JsonProgramStage.class );
-        System.out.println( copiedStage );
-        System.out.println( jsonCopiedProgramStage );
 
         assertEquals( 2, jsonCopiedProgramStage.getProgramStageSections().size() );
         assertEquals( 2, jsonCopiedProgramStage.getProgramStageDataElements().size() );
     }
 
     @Test
-    void testCopyProgramWith2ProgramSectionsVariablesIndicatorsAttributes()
+    void testCopyProgramWithProgramSectionsVariablesIndicatorsAttributes()
     {
         JsonWebMessage response = POST( "/programs/%s/copy".formatted( PROGRAM_UID ) )
             .content( HttpStatus.CREATED )
@@ -178,6 +174,51 @@ class ProgramControllerTest extends DhisControllerConvenienceTest
             .collect( Collectors.toSet() );
         copiedTrackedEntityAttributesUids.removeAll( Set.of( "PTEAmWi7rBa", "PTEAmWi7rBb" ) );
         assertEquals( 2, copiedTrackedEntityAttributesUids.size() );
+    }
+
+    @Test
+    void testCopyProgramIndicatorDbConstraintsWithNoCopyOptions()
+    {
+        //1st copy with no copy option request param succeeds
+        JsonWebMessage response = POST( "/programs/%s/copy".formatted( PROGRAM_UID ) )
+            .content( HttpStatus.CREATED )
+            .as( JsonWebMessage.class );
+
+        //2nd copy with no copy option request param should fail
+        JsonWebMessage response2 = POST( "/programs/%s/copy".formatted( PROGRAM_UID ) )
+            .content( HttpStatus.INTERNAL_SERVER_ERROR )
+            .as( JsonWebMessage.class );
+
+        assertTrue( response2.getMessage().contains( "Unique index or primary key violation" ) );
+        assertTrue( response2.getMessage()
+            .contains( "uk_7udjng39j4ddafjn57r58v7oq_INDEX_4 ON public.programindicator" ) );
+    }
+
+    @Test
+    void testCopyProgramIndicatorDbConstraintsWithCopyOptions()
+    {
+        //1st copy with no copy option request param succeeds
+        POST( "/programs/%s/copy".formatted( PROGRAM_UID ) )
+            .content( HttpStatus.CREATED )
+            .as( JsonWebMessage.class );
+
+        //2nd copy with copy option request param won't fail as the ProgramIndicator will have new unique name & shortName
+        String prefix = "zzz";
+        JsonWebMessage response2 = POST( "/programs/%s/copy?prefix=%s".formatted( PROGRAM_UID, prefix ) )
+            .content( HttpStatus.CREATED )
+            .as( JsonWebMessage.class );
+
+        String secondCopiedProgramUid = getMatchingGroupFromPattern( response2.getMessage(), "'(.*?)'", 1 );
+        JsonProgram copiedProgram = GET( "/programs/{id}", secondCopiedProgramUid ).content( HttpStatus.OK )
+            .as( JsonProgram.class );
+
+        String copiedIndicatorUid = copiedProgram.getProgramIndicators().get( 0 ).getId();
+        JsonProgramIndicator copiedIndicator = GET( "/programIndicators/{id}", copiedIndicatorUid )
+            .content( HttpStatus.OK )
+            .as( JsonProgramIndicator.class );
+
+        assertTrue( copiedIndicator.getName().startsWith( prefix ) );
+        assertTrue( copiedIndicator.getShortName().startsWith( prefix ) );
     }
 
     @Test

--- a/dhis-2/dhis-test-web-api/src/test/resources/program/create_program.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/program/create_program.json
@@ -6,6 +6,11 @@
       "shortName": "test program",
       "description": "program description",
       "programType": "WITH_REGISTRATION",
+      "organisationUnits": [
+        {
+          "id": "Orgunit1000"
+        }
+      ],
       "programStages": [
         {
           "id": "PSzMWi7rBga"
@@ -30,6 +35,9 @@
       "programIndicators": [
         {
           "id": "PInmWi7rBga"
+        },
+        {
+          "id": "PInmWi7rBgb"
         }
       ],
       "programTrackedEntityAttributes": [
@@ -152,6 +160,25 @@
       "program": {
         "id": "PrZMWi7rBga"
       }
+    }
+  ],
+  "organisationUnits": [
+    {
+      "featureType": "NONE",
+      "uuid": "eb380b08-6cc6-4aca-9b67-e1247e02db33",
+      "lastUpdated": "2016-03-17T01:51:39.609+0000",
+      "shortName": "Country",
+      "attributeValues": [],
+      "openingDate": "2016-03-17",
+      "id": "Orgunit1000",
+      "description": "org desc",
+      "programs": [
+        {
+          "id": "PrZMWi7rBga"
+        }
+      ],
+      "name": "Country",
+      "created": "2016-03-17T01:51:39.597+0000"
     }
   ]
 }


### PR DESCRIPTION
# Summary
Add & update code for `ProgramIndicator` copying.  
`ProgramStageSection` `indicators` will be set as empty as an initial approach to avoid over complicating things for now.

There are `ProgramIndicator`s at 2 different levels of a `Program`:
1. `Program` -> `programIndicators`  
2. `Program` -> `ProgramStage` - `ProgramStageSection` -> `programIndicators`  

`ProgramIndicator` property `groups` is set to an empty Set for now as this can be much more complex. If that is required later we can implement then.

# Testing
- Tests added for checking empty list for copied `ProgramIndicator`s in `ProgramStageSection`
- `Enrollment`s test added
  - An integration test was needed to test `Enrollment`s as H2 throws an error when the class `JdbcOrgUnitAssociationsStore` calls one of its methods (see the test for more info in the Javadoc)
- DB constraint tests added as `ProgramIndicator` has unique constraints on its `name` and `shortName` properties
- Some existing tests improved by checking for new UIDs in copied objects