### PR TITLE
fix: flaky test in PatchServiceTest

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/patch/PatchServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/patch/PatchServiceTest.java
@@ -266,7 +266,9 @@ class PatchServiceTest extends SingleSetupIntegrationTestBase
         deB.getSharing().addUserGroupAccess( new UserGroupAccess( userGroup, "rw------" ) );
         deB.getSharing().addUserAccess( new UserAccess( adminUser, "rw------" ) );
         Patch diff = patchService.diff( new PatchParams( deA, deB ) );
-        assertEquals( 12, diff.getMutations().size() );
+        assertTrue( diff.getMutations().stream().map( Mutation::getPath ).toList().containsAll(
+            List.of( "displayDescription", "code", "dimensionItem", "displayName", "name", "description", "id",
+                "shortName", "displayFormName", "displayShortName" ) ) );
     }
 
     @Test


### PR DESCRIPTION
The 12 modifications included 2 timestamp properties, `created` and `lastUpdated`. I imagine in a fast execution these are the same and thus not different so they are not included in a diff making it 10 sometimes. 

To avoid this issue the assert was relaxed to only check for the 10 path we at least expect a diff for. 