### PR TITLE
chore: Deprecate trackedEntityInstance param in ownership controller [TECH-1562]

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/TrackerOwnershipControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/TrackerOwnershipControllerTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
@@ -63,7 +64,7 @@ class TrackerOwnershipControllerTest extends DhisControllerConvenienceTest
     }
 
     @Test
-    void testUpdateTrackerProgramOwner()
+    void shouldUpdateTrackerProgramOwnerWhenUsingDeprecateTrackedEntityInstanceParam()
     {
         assertWebMessage( "OK", 200, "OK", "Ownership transferred",
             PUT( "/tracker/ownership/transfer?trackedEntityInstance={tei}&program={prog}&ou={ou}", teiId, pId, ouId )
@@ -71,10 +72,66 @@ class TrackerOwnershipControllerTest extends DhisControllerConvenienceTest
     }
 
     @Test
-    void testOverrideOwnershipAccess()
+    void shouldUpdateTrackerProgramOwner()
+    {
+        assertWebMessage( "OK", 200, "OK", "Ownership transferred",
+            PUT( "/tracker/ownership/transfer?trackedEntity={tei}&program={prog}&ou={ou}", teiId, pId, ouId )
+                .content( HttpStatus.OK ) );
+    }
+
+    @Test
+    void shouldFailToUpdateWhenGivenTrackedEntityAndTrackedEntityInstanceParameters()
+    {
+        assertEquals( "Only one parameter of 'trackedEntityInstance' and 'trackedEntity' must be specified. " +
+            "Prefer 'trackedEntity' as 'trackedEntityInstance' will be removed.",
+            PUT( "/tracker/ownership/transfer?trackedEntity={tei}&" +
+                "trackedEntityInstance={tei}&program={prog}&ou={ou}", teiId, teiId, pId, ouId )
+                .error( HttpStatus.BAD_REQUEST )
+                .getMessage() );
+    }
+
+    @Test
+    void shouldFailToUpdateWhenNoTrackedEntityOrTrackedEntityInstanceParametersArePresent()
+    {
+        assertEquals( "Required request parameter 'trackedEntity' is not present",
+            PUT( "/tracker/ownership/transfer?program={prog}&ou={ou}", pId, ouId )
+                .error( HttpStatus.BAD_REQUEST )
+                .getMessage() );
+    }
+
+    @Test
+    void shouldOverrideOwnershipAccessWhenUsingDeprecateTrackedEntityInstanceParam()
     {
         assertWebMessage( "OK", 200, "OK", "Temporary Ownership granted",
             POST( "/tracker/ownership/override?trackedEntityInstance={tei}&program={prog}&reason=42", teiId, pId )
                 .content( HttpStatus.OK ) );
+    }
+
+    @Test
+    void shouldOverrideOwnershipAccess()
+    {
+        assertWebMessage( "OK", 200, "OK", "Temporary Ownership granted",
+            POST( "/tracker/ownership/override?trackedEntity={tei}&program={prog}&reason=42", teiId, pId )
+                .content( HttpStatus.OK ) );
+    }
+
+    @Test
+    void shouldFailToOverrideWhenGivenTrackedEntityAndTrackedEntityInstanceParameters()
+    {
+        assertEquals( "Only one parameter of 'trackedEntityInstance' and 'trackedEntity' must be specified. " +
+            "Prefer 'trackedEntity' as 'trackedEntityInstance' will be removed.",
+            POST( "/tracker/ownership/override?trackedEntity={tei}&" +
+                "trackedEntityInstance={tei}&program={prog}&&reason=42", teiId, teiId, pId )
+                .error( HttpStatus.BAD_REQUEST )
+                .getMessage() );
+    }
+
+    @Test
+    void shouldFailToOverrideWhenNoTrackedEntityOrTrackedEntityInstanceParametersArePresent()
+    {
+        assertEquals( "Required request parameter 'trackedEntity' is not present",
+            POST( "/tracker/ownership/override?program=" + pId + "&reason=42" )
+                .error( HttpStatus.BAD_REQUEST )
+                .getMessage() );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackerOwnershipController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackerOwnershipController.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller.event;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateMandatoryDeprecatedUidParameter;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import org.hisp.dhis.common.DhisApiVersion;
@@ -39,6 +40,7 @@ import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.trackedentity.TrackerOwnershipManager;
 import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.webapi.common.UID;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -88,23 +90,34 @@ public class TrackerOwnershipController
 
     @PutMapping( value = "/transfer", produces = APPLICATION_JSON_VALUE )
     @ResponseBody
-    public WebMessage updateTrackerProgramOwner( @RequestParam String trackedEntityInstance,
+    public WebMessage updateTrackerProgramOwner(
+        @Deprecated( since = "2.41" ) @RequestParam( required = false ) UID trackedEntityInstance,
+        @RequestParam( required = false ) UID trackedEntity,
         @RequestParam String program,
         @RequestParam String ou )
     {
+        UID trackedEntityUid = validateMandatoryDeprecatedUidParameter( "trackedEntityInstance", trackedEntityInstance,
+            "trackedEntity", trackedEntity );
+
         trackerOwnershipAccessManager.transferOwnership(
-            trackedEntityService.getTrackedEntity( trackedEntityInstance ),
+            trackedEntityService.getTrackedEntity( trackedEntityUid.getValue() ),
             programService.getProgram( program ), organisationUnitService.getOrganisationUnit( ou ), false, false );
         return ok( "Ownership transferred" );
     }
 
     @PostMapping( value = "/override", produces = APPLICATION_JSON_VALUE )
     @ResponseBody
-    public WebMessage overrideOwnershipAccess( @RequestParam String trackedEntityInstance, @RequestParam String reason,
+    public WebMessage overrideOwnershipAccess(
+        @Deprecated( since = "2.41" ) @RequestParam( required = false ) UID trackedEntityInstance,
+        @RequestParam( required = false ) UID trackedEntity,
+        @RequestParam String reason,
         @RequestParam String program )
     {
+        UID trackedEntityUid = validateMandatoryDeprecatedUidParameter( "trackedEntityInstance", trackedEntityInstance,
+            "trackedEntity", trackedEntity );
+
         trackerOwnershipAccessManager.grantTemporaryOwnership(
-            trackedEntityService.getTrackedEntity( trackedEntityInstance ),
+            trackedEntityService.getTrackedEntity( trackedEntityUid.getValue() ),
             programService.getProgram( program ), currentUserService.getCurrentUser(), reason );
 
         return ok( "Temporary Ownership granted" );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackerOwnershipController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackerOwnershipController.java
@@ -34,6 +34,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
+import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.ProgramService;
@@ -95,6 +96,7 @@ public class TrackerOwnershipController
         @RequestParam( required = false ) UID trackedEntity,
         @RequestParam String program,
         @RequestParam String ou )
+        throws BadRequestException
     {
         UID trackedEntityUid = validateMandatoryDeprecatedUidParameter( "trackedEntityInstance", trackedEntityInstance,
             "trackedEntity", trackedEntity );
@@ -112,6 +114,7 @@ public class TrackerOwnershipController
         @RequestParam( required = false ) UID trackedEntity,
         @RequestParam String reason,
         @RequestParam String program )
+        throws BadRequestException
     {
         UID trackedEntityUid = validateMandatoryDeprecatedUidParameter( "trackedEntityInstance", trackedEntityInstance,
             "trackedEntity", trackedEntity );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
@@ -179,6 +179,36 @@ public class RequestParamUtils
     }
 
     /**
+     * Helps us transition mandatory request parameters from a deprecated to a
+     * new one. At least one parameter must be non-empty as the deprecated one
+     * was mandatory.
+     *
+     * @param deprecatedParamName request parameter name of deprecated parameter
+     * @param deprecatedParam value of deprecated request parameter
+     * @param newParamName new request parameter replacing deprecated request
+     *        parameter
+     * @param newParam value of the request parameter
+     * @return value of the one request parameter that is non-empty
+     * @throws IllegalArgumentException when both deprecated and new request
+     *         parameter are non-empty
+     * @throws IllegalArgumentException when both deprecated and new request
+     *         parameter are empty
+     */
+    public static UID validateMandatoryDeprecatedUidParameter( String deprecatedParamName, UID deprecatedParam,
+        String newParamName, UID newParam )
+    {
+        UID uid = validateDeprecatedUidParameter( deprecatedParamName, deprecatedParam, newParamName, newParam );
+
+        if ( uid == null )
+        {
+            throw new IllegalArgumentException(
+                String.format( "Required request parameter '%s' is not present", newParamName ) );
+        }
+
+        return uid;
+    }
+
+    /**
      * Parse semicolon separated string of UIDs.
      *
      * @param input string to parse

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
@@ -132,16 +132,17 @@ public class RequestParamUtils
      *        parameter
      * @param newParamUids new request parameter uids
      * @return uids from the request parameter containing uids
-     * @throws IllegalArgumentException when both deprecated and new request
+     * @throws BadRequestException when both deprecated and new request
      *         parameter contain uids
      */
     public static Set<UID> validateDeprecatedUidsParameter( String deprecatedParamName, String deprecatedParamUids,
         String newParamName, Set<UID> newParamUids )
+        throws BadRequestException
     {
         Set<String> deprecatedParamParsedUids = parseUids( deprecatedParamUids );
         if ( !deprecatedParamParsedUids.isEmpty() && !newParamUids.isEmpty() )
         {
-            throw new IllegalArgumentException(
+            throw new BadRequestException(
                 String.format(
                     "Only one parameter of '%s' (deprecated; semicolon separated UIDs) and '%s' (comma separated UIDs) must be specified. Prefer '%s' as '%s' will be removed.",
                     deprecatedParamName, newParamName, newParamName, deprecatedParamName ) );
@@ -161,15 +162,16 @@ public class RequestParamUtils
      *        parameter
      * @param newParam value of the request parameter
      * @return value of the one request parameter that is non-empty
-     * @throws IllegalArgumentException when both deprecated and new request
+     * @throws BadRequestException when both deprecated and new request
      *         parameter are non-empty
      */
     public static UID validateDeprecatedUidParameter( String deprecatedParamName, UID deprecatedParam,
         String newParamName, UID newParam )
+        throws BadRequestException
     {
         if ( newParam != null && deprecatedParam != null )
         {
-            throw new IllegalArgumentException(
+            throw new BadRequestException(
                 String.format(
                     "Only one parameter of '%s' and '%s' must be specified. Prefer '%s' as '%s' will be removed.",
                     deprecatedParamName, newParamName, newParamName, deprecatedParamName ) );
@@ -189,19 +191,20 @@ public class RequestParamUtils
      *        parameter
      * @param newParam value of the request parameter
      * @return value of the one request parameter that is non-empty
-     * @throws IllegalArgumentException when both deprecated and new request
+     * @throws BadRequestException when both deprecated and new request
      *         parameter are non-empty
-     * @throws IllegalArgumentException when both deprecated and new request
+     * @throws BadRequestException when both deprecated and new request
      *         parameter are empty
      */
     public static UID validateMandatoryDeprecatedUidParameter( String deprecatedParamName, UID deprecatedParam,
         String newParamName, UID newParam )
+        throws BadRequestException
     {
         UID uid = validateDeprecatedUidParameter( deprecatedParamName, deprecatedParam, newParamName, newParam );
 
         if ( uid == null )
         {
-            throw new IllegalArgumentException(
+            throw new BadRequestException(
                 String.format( "Required request parameter '%s' is not present", newParamName ) );
         }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
@@ -35,6 +35,7 @@ import java.util.Set;
 
 import lombok.RequiredArgsConstructor;
 
+import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
 import org.hisp.dhis.webapi.common.UID;
 import org.springframework.stereotype.Component;
@@ -51,6 +52,7 @@ class EnrollmentRequestParamsMapper
     private final EnrollmentFieldsParamMapper fieldsParamMapper;
 
     public EnrollmentOperationParams map( RequestParams requestParams )
+        throws BadRequestException
     {
         Set<UID> orgUnits = validateDeprecatedUidsParameter( "orgUnit", requestParams.getOrgUnit(), "orgUnits",
             requestParams.getOrgUnits() );

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapperTest.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Set;
 
+import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.fieldfiltering.FieldFilterParser;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentParams;
@@ -84,6 +85,7 @@ class EnrollmentRequestParamsMapperTest
 
     @Test
     void testMappingDoesNotFetchOptionalEmptyQueryParametersFromDB()
+        throws BadRequestException
     {
         RequestParams requestParams = new RequestParams();
 
@@ -94,6 +96,7 @@ class EnrollmentRequestParamsMapperTest
 
     @Test
     void testMappingOrgUnit()
+        throws BadRequestException
     {
         RequestParams requestParams = new RequestParams();
         requestParams.setOrgUnit( ORG_UNIT_1_UID + ";" + ORG_UNIT_2_UID );
@@ -106,6 +109,7 @@ class EnrollmentRequestParamsMapperTest
 
     @Test
     void testMappingOrgUnits()
+        throws BadRequestException
     {
         RequestParams requestParams = new RequestParams();
         requestParams.setOrgUnits( Set.of( UID.of( ORG_UNIT_1_UID ), UID.of( ORG_UNIT_2_UID ) ) );
@@ -118,6 +122,7 @@ class EnrollmentRequestParamsMapperTest
 
     @Test
     void testMappingProgram()
+        throws BadRequestException
     {
         RequestParams requestParams = new RequestParams();
         requestParams.setProgram( UID.of( PROGRAM_UID ) );
@@ -129,6 +134,7 @@ class EnrollmentRequestParamsMapperTest
 
     @Test
     void testMappingTrackedEntityType()
+        throws BadRequestException
     {
         RequestParams requestParams = new RequestParams();
         requestParams.setTrackedEntityType( UID.of( TRACKED_ENTITY_TYPE_UID ) );
@@ -140,6 +146,7 @@ class EnrollmentRequestParamsMapperTest
 
     @Test
     void testMappingTrackedEntity()
+        throws BadRequestException
     {
         RequestParams requestParams = new RequestParams();
         requestParams.setTrackedEntity( UID.of( TRACKED_ENTITY_UID ) );
@@ -151,6 +158,7 @@ class EnrollmentRequestParamsMapperTest
 
     @Test
     void testMappingOrderParams()
+        throws BadRequestException
     {
         RequestParams requestParams = new RequestParams();
         OrderCriteria order1 = OrderCriteria.of( "field1", SortDirection.ASC );
@@ -166,6 +174,7 @@ class EnrollmentRequestParamsMapperTest
 
     @Test
     void testMappingOrderParamsNoOrder()
+        throws BadRequestException
     {
         RequestParams requestParams = new RequestParams();
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParamsMapperTest.java
@@ -736,7 +736,7 @@ class RequestParamsMapperTest
         requestParams.setOrgUnit( "IsdLBTOBzMi" );
         requestParams.setOrgUnits( Set.of( UID.of( "IsdLBTOBzMi" ) ) );
 
-        assertThrows( IllegalArgumentException.class, () -> mapper.map( requestParams ) );
+        assertThrows( BadRequestException.class, () -> mapper.map( requestParams ) );
     }
 
     @Test
@@ -745,6 +745,6 @@ class RequestParamsMapperTest
         requestParams.setTrackedEntity( "IsdLBTOBzMi" );
         requestParams.setTrackedEntities( Set.of( UID.of( "IsdLBTOBzMi" ) ) );
 
-        assertThrows( IllegalArgumentException.class, () -> mapper.map( requestParams ) );
+        assertThrows( BadRequestException.class, () -> mapper.map( requestParams ) );
     }
 }


### PR DESCRIPTION
Deprecate legacy `trackedEntityIstance` param in favor of `trackedEntity` in ownership Controller.