### PR TITLE
feat: Program Copy - Add permission check [DHIS2-15279]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramTrackedEntityAttribute.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramTrackedEntityAttribute.java
@@ -288,18 +288,18 @@ public class ProgramTrackedEntityAttribute
     private static void setShallowCopyValues( ProgramTrackedEntityAttribute copy,
         ProgramTrackedEntityAttribute original )
     {
-        copy.setAttribute( original.getAttribute() );
-        copy.setDisplayInList( original.isDisplayInList() );
-        copy.setSortOrder( original.getSortOrder() );
-        copy.setMandatory( original.isMandatory() );
+        copy.setAccess( original.getAccess() );
         copy.setAllowFutureDate( original.getAllowFutureDate() );
+        copy.setAttribute( original.getAttribute() );
+        copy.setAttributeValues( original.getAttributeValues() );
+        copy.setDisplayInList( original.isDisplayInList() );
+        copy.setMandatory( original.isMandatory() );
+        copy.setPublicAccess( original.getPublicAccess() );
         copy.setRenderOptionsAsRadio( original.getRenderOptionsAsRadio() );
         copy.setRenderType( original.getRenderType() );
         copy.setSearchable( original.isSearchable() );
-        copy.setAccess( original.getAccess() );
-        copy.setPublicAccess( original.getPublicAccess() );
-        copy.setAttributeValues( original.getAttributeValues() );
         copy.setSharing( original.getSharing() );
+        copy.setSortOrder( original.getSortOrder() );
         copy.setTranslations( original.getTranslations() );
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/ProgramRuleVariable.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/ProgramRuleVariable.java
@@ -254,14 +254,14 @@ public class ProgramRuleVariable
     private static void setShallowCopyValues( ProgramRuleVariable copy, ProgramRuleVariable original )
     {
         copy.setAccess( original.getAccess() );
+        copy.setAttribute( original.getAttribute() );
+        copy.setAttributeValues( original.getAttributeValues() );
+        copy.setDataElement( original.getDataElement() );
         copy.setName( original.getName() );
         copy.setPublicAccess( original.getPublicAccess() );
-        copy.setAttributeValues( original.getAttributeValues() );
         copy.setSharing( original.getSharing() );
-        copy.setTranslations( original.getTranslations() );
         copy.setSourceType( original.getSourceType() );
-        copy.setAttribute( original.getAttribute() );
-        copy.setDataElement( original.getDataElement() );
+        copy.setTranslations( original.getTranslations() );
         copy.setUseCodeForOptionSet( original.getUseCodeForOptionSet() );
         copy.setValueType( original.getValueType() );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/copy/CopyService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/copy/CopyService.java
@@ -39,6 +39,8 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
+import lombok.RequiredArgsConstructor;
+
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.Enrollment;
@@ -60,8 +62,6 @@ import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.user.CurrentUserService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import lombok.RequiredArgsConstructor;
 
 /**
  * Service that allows copying of a {@link Program} and other {@link Program}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/copy/CopyService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/copy/CopyService.java
@@ -109,6 +109,8 @@ public class CopyService
      *        {@link Program} name property.
      * @return {@link Program} copy
      * @throws NotFoundException if the {@link Program} is not found.
+     * @throws ForbiddenException if {@link org.hisp.dhis.user.User} has no
+     *         write access to {@link Program}
      */
     @Transactional
     public Program copyProgram( String uid, Map<String, String> copyOptions )

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerIntegrationTest.java
@@ -168,4 +168,62 @@ class ProgramControllerIntegrationTest extends DhisControllerIntegrationTest
 
         assertStatus( HttpStatus.CREATED, POST( "/programs/%s/copy".formatted( PROGRAM_UID ) ) );
     }
+
+    @Test
+    void testCopyProgramWithNoPublicSharingWithUserAddedWithWriteOnlyAccess()
+    {
+        User userWithPublicAuths = switchToNewUser( "test1", "F_PROGRAM_PUBLIC_ADD",
+            "F_PROGRAM_INDICATOR_PUBLIC_ADD" );
+
+        switchToSuperuser();
+        manager.save( userWithPublicAuths );
+        PUT( "/programs/" + PROGRAM_UID, "{\n" +
+            "    'id': '" + PROGRAM_UID + "',\n" +
+            "    'name': 'test program',\n" +
+            "    'shortName': 'test program',\n" +
+            "    'programType': 'WITH_REGISTRATION',\n" +
+            "    'sharing': {\n" +
+            "        'public': '--------',\n" +
+            "        'users': {\n" +
+            "           '" + userWithPublicAuths.getUid() + "': {\n" +
+            "              'id': '" + userWithPublicAuths.getUid() + "',\n" +
+            "              'access': '-w------'\n" +
+            "        }\n" +
+            "     }\n" +
+            "    }\n" +
+            "}" ).content( HttpStatus.OK );
+
+        switchContextToUser( userWithPublicAuths );
+
+        assertStatus( HttpStatus.NOT_FOUND, POST( "/programs/%s/copy".formatted( PROGRAM_UID ) ) );
+    }
+
+    @Test
+    void testCopyProgramWithNoPublicSharingWithUserAddedWithReadOnlyAccess()
+    {
+        User userWithPublicAuths = switchToNewUser( "test1", "F_PROGRAM_PUBLIC_ADD",
+            "F_PROGRAM_INDICATOR_PUBLIC_ADD" );
+
+        switchToSuperuser();
+        manager.save( userWithPublicAuths );
+        PUT( "/programs/" + PROGRAM_UID, "{\n" +
+            "    'id': '" + PROGRAM_UID + "',\n" +
+            "    'name': 'test program',\n" +
+            "    'shortName': 'test program',\n" +
+            "    'programType': 'WITH_REGISTRATION',\n" +
+            "    'sharing': {\n" +
+            "        'public': '--------',\n" +
+            "        'users': {\n" +
+            "           '" + userWithPublicAuths.getUid() + "': {\n" +
+            "              'id': '" + userWithPublicAuths.getUid() + "',\n" +
+            "              'access': 'r-------'\n" +
+            "        }\n" +
+            "     }\n" +
+            "    }\n" +
+            "}" ).content( HttpStatus.OK );
+
+        switchContextToUser( userWithPublicAuths );
+
+        assertStatus( HttpStatus.FORBIDDEN, POST( "/programs/%s/copy".formatted( PROGRAM_UID ) ) );
+    }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerIntegrationTest.java
@@ -37,6 +37,7 @@ import org.hisp.dhis.association.jdbc.JdbcOrgUnitAssociationsStore;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.user.User;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.web.WebClient;
 import org.hisp.dhis.webapi.DhisControllerIntegrationTest;
@@ -137,5 +138,34 @@ class ProgramControllerIntegrationTest extends DhisControllerIntegrationTest
 
         assertEquals( 2, enrollments.size() );
         assertEquals( 1, originalProgramEnrollments.size() );
+    }
+
+    @Test
+    void testCopyProgramWithNoPublicSharingWithUserAdded()
+    {
+        User userWithPublicAuths = switchToNewUser( "test1", "F_PROGRAM_PUBLIC_ADD",
+            "F_PROGRAM_INDICATOR_PUBLIC_ADD" );
+
+        switchToSuperuser();
+        manager.save( userWithPublicAuths );
+        PUT( "/programs/" + PROGRAM_UID, "{\n" +
+            "    'id': '" + PROGRAM_UID + "',\n" +
+            "    'name': 'test program',\n" +
+            "    'shortName': 'test program',\n" +
+            "    'programType': 'WITH_REGISTRATION',\n" +
+            "    'sharing': {\n" +
+            "        'public': '--------',\n" +
+            "        'users': {\n" +
+            "           '" + userWithPublicAuths.getUid() + "': {\n" +
+            "              'id': '" + userWithPublicAuths.getUid() + "',\n" +
+            "              'access': 'rw------'\n" +
+            "        }\n" +
+            "     }\n" +
+            "    }\n" +
+            "}" ).content( HttpStatus.OK );
+
+        switchContextToUser( userWithPublicAuths );
+
+        assertStatus( HttpStatus.CREATED, POST( "/programs/%s/copy".formatted( PROGRAM_UID ) ) );
     }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerTest.java
@@ -268,7 +268,6 @@ class ProgramControllerTest extends DhisControllerConvenienceTest
         JsonWebMessage response = POST( "/programs/%s/copy".formatted( PROGRAM_UID ) )
             .content( HttpStatus.FORBIDDEN )
             .as( JsonWebMessage.class );
-        System.out.println( response );
         assertEquals( "You don't have write permissions for Program PrZMWi7rBga", response.getMessage() );
     }
 
@@ -310,5 +309,24 @@ class ProgramControllerTest extends DhisControllerConvenienceTest
         assertEquals( 2, authorities.size() );
 
         assertStatus( HttpStatus.CREATED, POST( "/programs/%s/copy".formatted( PROGRAM_UID ) ) );
+    }
+
+    @Test
+    void testCopyProgramWithNoPublicSharing()
+    {
+        PUT( "/programs/" + PROGRAM_UID, "{\n" +
+            "    'id': '" + PROGRAM_UID + "',\n" +
+            "    'name': 'test program',\n" +
+            "    'shortName': 'test program',\n" +
+            "    'programType': 'WITH_REGISTRATION',\n" +
+            "    'sharing': {\n" +
+            "        'public': '--------'\n" +
+            "    }\n" +
+            "}" ).content( HttpStatus.OK );
+
+        switchToNewUser( "test1", "F_PROGRAM_PUBLIC_ADD",
+            "F_PROGRAM_INDICATOR_PUBLIC_ADD" );
+
+        assertStatus( HttpStatus.NOT_FOUND, POST( "/programs/%s/copy".formatted( PROGRAM_UID ) ) );
     }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerTest.java
@@ -260,9 +260,7 @@ class ProgramControllerTest extends DhisControllerConvenienceTest
     void testCopyProgramWithUserWithNoAuthorities()
     {
         User userWithNoAuthorities = switchToNewUser( "test1" );
-        Set<String> authorities = userWithNoAuthorities.getUserRoles().stream()
-            .flatMap( role -> role.getAuthorities().stream() )
-            .collect( Collectors.toSet() );
+        Set<String> authorities = userWithNoAuthorities.getAllAuthorities();
         assertEquals( 0, authorities.size() );
 
         JsonWebMessage response = POST( "/programs/%s/copy".formatted( PROGRAM_UID ) )
@@ -275,9 +273,7 @@ class ProgramControllerTest extends DhisControllerConvenienceTest
     void testCopyProgramWithUserWithProgramPrivateAddAuthority()
     {
         User userWithInsufficientAuthorities = switchToNewUser( "test1", "F_PROGRAM_PRIVATE_ADD" );
-        Set<String> authorities = userWithInsufficientAuthorities.getUserRoles().stream()
-            .flatMap( role -> role.getAuthorities().stream() )
-            .collect( Collectors.toSet() );
+        Set<String> authorities = userWithInsufficientAuthorities.getAllAuthorities();
         assertEquals( 1, authorities.size() );
 
         JsonWebMessage response = POST( "/programs/%s/copy".formatted( PROGRAM_UID ) )
@@ -290,9 +286,7 @@ class ProgramControllerTest extends DhisControllerConvenienceTest
     void testCopyProgramWithUserWithProgramAuthorityOnly()
     {
         User userWithInsufficientAuthorities = switchToNewUser( "test1", "F_PROGRAM_PUBLIC_ADD" );
-        Set<String> authorities = userWithInsufficientAuthorities.getUserRoles().stream()
-            .flatMap( role -> role.getAuthorities().stream() )
-            .collect( Collectors.toSet() );
+        Set<String> authorities = userWithInsufficientAuthorities.getAllAuthorities();
         assertEquals( 1, authorities.size() );
 
         assertStatus( HttpStatus.FORBIDDEN, POST( "/programs/%s/copy".formatted( PROGRAM_UID ) ) );
@@ -303,9 +297,7 @@ class ProgramControllerTest extends DhisControllerConvenienceTest
     {
         User userWithRequiredAuthorities = switchToNewUser( "test1", "F_PROGRAM_PUBLIC_ADD",
             "F_PROGRAM_INDICATOR_PUBLIC_ADD" );
-        Set<String> authorities = userWithRequiredAuthorities.getUserRoles().stream()
-            .flatMap( role -> role.getAuthorities().stream() )
-            .collect( Collectors.toSet() );
+        Set<String> authorities = userWithRequiredAuthorities.getAllAuthorities();
         assertEquals( 2, authorities.size() );
 
         assertStatus( HttpStatus.CREATED, POST( "/programs/%s/copy".formatted( PROGRAM_UID ) ) );

--- a/dhis-2/dhis-test-web-api/src/test/resources/program/create_program.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/program/create_program.json
@@ -6,6 +6,11 @@
       "shortName": "test program",
       "description": "program description",
       "programType": "WITH_REGISTRATION",
+      "sharing": {
+        "public": "rw------",
+        "external": false,
+        "owner": "M5zQapPyTZI"
+      },
       "organisationUnits": [
         {
           "id": "Orgunit1000"

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
@@ -36,8 +36,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import lombok.RequiredArgsConstructor;
-
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.SetValuedMap;
 import org.hisp.dhis.common.OpenApi;
@@ -46,6 +44,7 @@ import org.hisp.dhis.dxf2.metadata.MetadataExportParams;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.feedback.ConflictException;
+import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fieldfilter.Defaults;
 import org.hisp.dhis.program.Program;
@@ -70,6 +69,8 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 import com.google.common.collect.Lists;
+
+import lombok.RequiredArgsConstructor;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -138,12 +139,14 @@ public class ProgramController
     }
 
     @PostMapping( "/{uid}/copy" )
+    //    @PreAuthorize( "hasRole('ALL') or hasRole('F_PROGRAM_PRIVATE_ADD')" )
     @ResponseStatus( HttpStatus.CREATED )
     @ResponseBody
     public WebMessage copyProgram( @PathVariable( "uid" ) String uid,
         @RequestParam( required = false ) Map<String, String> copyOptions )
         throws NotFoundException,
-        ConflictException
+        ConflictException,
+        ForbiddenException
     {
         Program programCopy = null;
         try

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
@@ -139,7 +139,6 @@ public class ProgramController
     }
 
     @PostMapping( "/{uid}/copy" )
-    //    @PreAuthorize( "hasRole('ALL') or hasRole('F_PROGRAM_PRIVATE_ADD')" )
     @ResponseStatus( HttpStatus.CREATED )
     @ResponseBody
     public WebMessage copyProgram( @PathVariable( "uid" ) String uid,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
@@ -36,6 +36,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import lombok.RequiredArgsConstructor;
+
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.SetValuedMap;
 import org.hisp.dhis.common.OpenApi;
@@ -69,8 +71,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 import com.google.common.collect.Lists;
-
-import lombok.RequiredArgsConstructor;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>


### PR DESCRIPTION
# Summary
- Add permission check to the `Program` Copy endpoint
`AclService` check added to check if user has write access to the `Program` being copied.
- It seems that the required `AuthorityType`s to copy a `Program` are:
  - F_PROGRAM_PUBLIC_ADD
  - F_PROGRAM_INDICATOR_PUBLIC_ADD

Different responses can be returned depending on the access the User has:
- no read access -> NOT_FOUND response
- no write access -> FORBIDDEN response. 

This is because there is a get done first to get the Program by its UID (read access required)
- no exception is thrown in this operation. Only a null object is returned from the service. So it's hard to determine if the object is genuinely not found or if it's a permission issue.

Then when saving the write access is checked, which can throw a permission error.

# Test
- Add service test when `User` has no write access.
- Add web tests to test numerous scenarios with different auth scenarios.
- 3 Integration tests were required for testing when no public access on the `Program` but sharing has been updated to include a specific `User`. (jsonb function doesn't work with H2)
    - user with read only access
    - user with write only access
    - user with read & write access