### PR TITLE
chore: Deprecate legacy params in audits controller [TECH-1549]

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AuditControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AuditControllerTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.web.WebClientUtils.assertStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.security.acl.AccessStringHelper;
+import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.sharing.UserAccess;
+import org.hisp.dhis.web.HttpStatus;
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class AuditControllerTest extends DhisControllerConvenienceTest
+{
+
+    private static final String DATA_ELEMENT_VALUE = "value";
+
+    @Autowired
+    private IdentifiableObjectManager manager;
+
+    private OrganisationUnit orgUnit;
+
+    private OrganisationUnit anotherOrgUnit;
+
+    private Program program;
+
+    private ProgramStage programStage;
+
+    private User owner;
+
+    private User user;
+
+    private TrackedEntityType trackedEntityType;
+
+    private TrackedEntity te1;
+
+    private TrackedEntity te2;
+
+    private Enrollment enrollment;
+
+    private Event event1;
+
+    private Event event2;
+
+    @BeforeEach
+    void setUp()
+    {
+        owner = makeUser( "owner" );
+
+        orgUnit = createOrganisationUnit( 'A' );
+        orgUnit.getSharing().setOwner( owner );
+        manager.save( orgUnit, false );
+
+        anotherOrgUnit = createOrganisationUnit( 'B' );
+        anotherOrgUnit.getSharing().setOwner( owner );
+        manager.save( anotherOrgUnit, false );
+
+        user = createUserWithId( "tester", CodeGenerator.generateUid() );
+        user.addOrganisationUnit( orgUnit );
+        user.setTeiSearchOrganisationUnits( Set.of( orgUnit ) );
+        this.userService.updateUser( user );
+
+        program = createProgram( 'A' );
+        program.addOrganisationUnit( orgUnit );
+        program.getSharing().setOwner( owner );
+        program.getSharing().addUserAccess( userAccess() );
+        manager.save( program, false );
+
+        programStage = createProgramStage( 'A', program );
+        programStage.getSharing().setOwner( owner );
+        programStage.getSharing().addUserAccess( userAccess() );
+        manager.save( programStage, false );
+
+        trackedEntityType = trackedEntityTypeAccessible();
+
+        te1 = createTrackedEntity( orgUnit );
+        te1.setTrackedEntityType( trackedEntityType );
+        te1.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
+        te1.getSharing().setOwner( owner );
+        manager.save( te1, false );
+
+        te2 = createTrackedEntity( orgUnit );
+        te2.setTrackedEntityType( trackedEntityType );
+        te2.getSharing().setPublicAccess( AccessStringHelper.DEFAULT );
+        te2.getSharing().setOwner( owner );
+        manager.save( te2, false );
+
+        enrollment = createEnrollment( program, te1, te1.getOrganisationUnit() );
+        manager.save( enrollment );
+
+        event1 = createEvent( programStage, enrollment, enrollment.getOrganisationUnit() );
+        manager.save( event1 );
+
+        event2 = createEvent( programStage, enrollment, enrollment.getOrganisationUnit() );
+        manager.save( event2 );
+    }
+
+    @Test
+    void shouldFailGetDataValueAuditsWhenGivenPsiAndEventsParameters()
+    {
+        assertEquals(
+            "Only one parameter of 'psi' (deprecated; semicolon separated UIDs) and 'events' (comma separated UIDs) must be specified. Prefer 'events' as 'psi' will be removed.",
+            GET( "/audits/trackedEntityDataValue?psi={deprecatedEvents}&events={events}",
+                event1.getUid() + ";" + event2.getUid(),
+                event1.getUid() + "," + event2.getUid() )
+                .error( HttpStatus.BAD_REQUEST )
+                .getMessage() );
+    }
+
+    @Test
+    void shouldSuccessToGetDataValueAuditsWhenPassingOnlyPsiParameter()
+    {
+        assertStatus( HttpStatus.OK,
+            GET( "/audits/trackedEntityDataValue?psi={events}", event1.getUid() + ";" + event2.getUid() ) );
+    }
+
+    @Test
+    void shouldSuccessToGetDataValueAuditsWhenPassingOnlyEventsParameter()
+    {
+        assertStatus( HttpStatus.OK,
+            GET( "/audits/trackedEntityDataValue?events={events}", event1.getUid() + "," + event2.getUid() ) );
+    }
+
+    @Test
+    void shouldFailGetAttributeValueAuditsWhenGivenTeiAndTrackedEntitiesParameters()
+    {
+        assertEquals(
+            "Only one parameter of 'tei' (deprecated; semicolon separated UIDs) and 'trackedEntities' (comma separated UIDs) must be specified. Prefer 'trackedEntities' as 'tei' will be removed.",
+            GET( "/audits/trackedEntityAttributeValue?tei={te}&trackedEntities={te}",
+                te1.getUid() + ";" + te2.getUid(),
+                te1.getUid() + "," + te2.getUid() )
+                .error( HttpStatus.BAD_REQUEST )
+                .getMessage() );
+    }
+
+    @Test
+    void shouldSuccessToGetAttributeValueAuditsWhenPassingOnlyTeiParameter()
+    {
+        assertStatus( HttpStatus.OK,
+            GET( "/audits/trackedEntityAttributeValue?tei={te}", te1.getUid() + ";" + te2.getUid() ) );
+    }
+
+    @Test
+    void shouldSuccessToGetAttributeValueAuditsWhenPassingOnlyTrackedEntitiesParameter()
+    {
+        assertStatus( HttpStatus.OK,
+            GET( "/audits/trackedEntityAttributeValue?trackedEntities={te}", te1.getUid() + "," + te2.getUid() ) );
+    }
+
+    private TrackedEntityType trackedEntityTypeAccessible()
+    {
+        TrackedEntityType type = createTrackedEntityType( 'A' );
+        type.getSharing().addUserAccess( userAccess() );
+        manager.save( type, false );
+        return type;
+    }
+
+    private UserAccess userAccess()
+    {
+        UserAccess a = new UserAccess();
+        a.setUser( user );
+        a.setAccess( AccessStringHelper.FULL );
+        return a;
+    }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AuditControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AuditControllerTest.java
@@ -187,6 +187,41 @@ class AuditControllerTest extends DhisControllerConvenienceTest
             GET( "/audits/trackedEntityAttributeValue?trackedEntities={te}", te1.getUid() + "," + te2.getUid() ) );
     }
 
+    @Test
+    void shouldFailGetTrackedEntityInstanceAuditsWhenGivenTeiAndTrackedEntitiesParameters()
+    {
+        assertEquals(
+            "Only one parameter of 'tei' (deprecated; semicolon separated UIDs) and 'trackedEntities' (comma separated UIDs) must be specified. Prefer 'trackedEntities' as 'tei' will be removed.",
+            GET( "/audits/trackedEntityInstance?tei={te}&trackedEntities={te}",
+                te1.getUid() + ";" + te2.getUid(),
+                te1.getUid() + "," + te2.getUid() )
+                .error( HttpStatus.BAD_REQUEST )
+                .getMessage() );
+    }
+
+    @Test
+    void shouldSuccessToGetTrackedEntityInstanceAuditsWhenPassingOnlyTeiParameter()
+    {
+        assertStatus( HttpStatus.OK,
+            GET( "/audits/trackedEntityInstance?tei={te}", te1.getUid() + ";" + te2.getUid() ) );
+    }
+
+    @Test
+    void shouldSuccessToGetTrackedEntityInstanceAuditsWhenPassingOnlyTrackedEntitiesParameter()
+    {
+        assertStatus( HttpStatus.OK,
+            GET( "/audits/trackedEntityInstance?trackedEntities={te}", te1.getUid() + "," + te2.getUid() ) );
+    }
+
+    @Test
+    void shouldSuccessToGetTrackedEntityAuditsGivenIgnoredLegacyTeiParamAndTrackedEntitiesParam()
+    {
+        assertStatus( HttpStatus.OK,
+            GET( "/audits/trackedEntity?tei={te}&trackedEntities={te}",
+                te1.getUid() + ";" + te2.getUid(),
+                te1.getUid() + "," + te2.getUid() ) );
+    }
+
     private TrackedEntityType trackedEntityTypeAccessible()
     {
         TrackedEntityType type = createTrackedEntityType( 'A' );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AuditController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AuditController.java
@@ -441,6 +441,9 @@ public class AuditController
         return rootNode;
     }
 
+    /**
+     * @deprecated use {@link #getTrackedEnityAudit} instead.
+     */
     @Deprecated( since = "2.41" )
     @GetMapping( "trackedEntityInstance" )
     public RootNode getTrackedEnityInstanceAudit(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AuditController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AuditController.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.commons.collection.CollectionUtils.emptyIfNull;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedUidsParameter;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -53,7 +54,6 @@ import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.PagerUtils;
-import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataapproval.DataApprovalAudit;
 import org.hisp.dhis.dataapproval.DataApprovalAuditQueryParams;
 import org.hisp.dhis.dataapproval.DataApprovalAuditService;
@@ -68,6 +68,7 @@ import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.dxf2.webmessage.responses.FileResourceWebMessageResponse;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.fileresource.FileResource;
@@ -94,6 +95,7 @@ import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueAudi
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueAudit;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueAuditService;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.webapi.common.UID;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.hisp.dhis.webapi.utils.HeaderUtils;
@@ -257,8 +259,10 @@ public class AuditController
     public RootNode getTrackedEntityDataValueAudit(
         @OpenApi.Param( { UID[].class, DataElement.class } ) @RequestParam( required = false ) List<String> de,
         @OpenApi.Param( { UID[].class, OrganisationUnit.class } ) @RequestParam( required = false ) List<String> ou,
+        @Deprecated( since = "2.41" ) @OpenApi.Param( { UID[].class,
+            Event.class } ) @RequestParam( required = false, defaultValue = "" ) List<String> psi,
         @OpenApi.Param( { UID[].class,
-            Event.class } ) @RequestParam( required = false ) List<String> psi,
+            Event.class } ) @RequestParam( required = false, defaultValue = "" ) Set<UID> events,
         @OpenApi.Param( { UID[].class, ProgramStage.class } ) @RequestParam( required = false ) List<String> ps,
         @RequestParam( required = false ) Date startDate,
         @RequestParam( required = false ) Date endDate,
@@ -268,6 +272,7 @@ public class AuditController
         @RequestParam( required = false ) Boolean paging,
         @RequestParam( required = false, defaultValue = "50" ) int pageSize,
         @RequestParam( required = false, defaultValue = "1" ) int page )
+        throws BadRequestException
     {
         List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
 
@@ -279,7 +284,7 @@ public class AuditController
         List<DataElement> dataElements = manager.loadByUid( DataElement.class, de );
         List<OrganisationUnit> orgUnits = manager.loadByUid( OrganisationUnit.class, ou );
         List<ProgramStage> programStages = manager.loadByUid( ProgramStage.class, ps );
-        List<Event> events = manager.loadByUid( Event.class, psi );
+        Set<UID> eventUids = validateDeprecatedUidsParameter( "psi", String.join( ";", psi ), "events", events );
         List<AuditType> auditTypes = emptyIfNull( auditType );
 
         List<TrackedEntityDataValueAudit> dataValueAudits;
@@ -288,7 +293,7 @@ public class AuditController
         TrackedEntityDataValueAuditQueryParams params = new TrackedEntityDataValueAuditQueryParams()
             .setDataElements( dataElements )
             .setOrgUnits( orgUnits )
-            .setEvents( events )
+            .setEvents( manager.loadByUid( Event.class, UID.toValueSet( eventUids ) ) )
             .setProgramStages( programStages )
             .setStartDate( startDate )
             .setEndDate( endDate )
@@ -306,16 +311,7 @@ public class AuditController
             pager = new Pager( page, total, pageSize );
 
             dataValueAudits = trackedEntityDataValueAuditService.getTrackedEntityDataValueAudits(
-                new TrackedEntityDataValueAuditQueryParams()
-                    .setDataElements( dataElements )
-                    .setOrgUnits( orgUnits )
-                    .setEvents( events )
-                    .setProgramStages( programStages )
-                    .setStartDate( startDate )
-                    .setEndDate( endDate )
-                    .setOuMode( ouMode )
-                    .setAuditTypes( auditTypes )
-                    .setPager( pager ) );
+                params.setPager( pager ) );
         }
 
         RootNode rootNode = NodeUtils.createMetadata();
@@ -338,19 +334,22 @@ public class AuditController
     public RootNode getTrackedEntityAttributeValueAudit(
         @OpenApi.Param( { UID[].class,
             TrackedEntityAttribute.class } ) @RequestParam( required = false ) List<String> tea,
+        @Deprecated( since = "2.41" ) @OpenApi.Param( { UID[].class,
+            TrackedEntity.class } ) @RequestParam( required = false, defaultValue = "" ) List<String> tei,
         @OpenApi.Param( { UID[].class,
-            TrackedEntity.class } ) @RequestParam( required = false ) List<String> tei,
+            TrackedEntity.class } ) @RequestParam( required = false, defaultValue = "" ) Set<UID> trackedEntities,
         @RequestParam( required = false ) List<AuditType> auditType,
         @RequestParam( required = false ) Boolean skipPaging,
         @RequestParam( required = false ) Boolean paging,
         @RequestParam( required = false, defaultValue = "50" ) int pageSize,
         @RequestParam( required = false, defaultValue = "1" ) int page )
-        throws WebMessageException
+        throws BadRequestException
     {
         List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
 
         List<TrackedEntityAttribute> trackedEntityAttributes = manager.loadByUid( TrackedEntityAttribute.class, tea );
-        List<TrackedEntity> trackedEntities = manager.loadByUid( TrackedEntity.class, tei );
+        Set<UID> teUids = validateDeprecatedUidsParameter( "tei", String.join( ";", tei ), "trackedEntities",
+            trackedEntities );
         List<AuditType> auditTypes = emptyIfNull( auditType );
 
         List<TrackedEntityAttributeValueAudit> attributeValueAudits;
@@ -358,7 +357,7 @@ public class AuditController
 
         TrackedEntityAttributeValueAuditQueryParams params = new TrackedEntityAttributeValueAuditQueryParams()
             .setTrackedEntityAttributes( trackedEntityAttributes )
-            .setTrackedEntities( trackedEntities )
+            .setTrackedEntities( manager.loadByUid( TrackedEntity.class, UID.toValueList( teUids ) ) )
             .setAuditTypes( auditTypes );
 
         if ( PagerUtils.isSkipPaging( skipPaging, paging ) )
@@ -373,11 +372,7 @@ public class AuditController
             pager = new Pager( page, total, pageSize );
 
             attributeValueAudits = trackedEntityAttributeValueAuditService.getTrackedEntityAttributeValueAudits(
-                new TrackedEntityAttributeValueAuditQueryParams()
-                    .setTrackedEntityAttributes( trackedEntityAttributes )
-                    .setTrackedEntities( trackedEntities )
-                    .setAuditTypes( auditTypes )
-                    .setPager( pager ) );
+                params.setPager( pager ) );
         }
 
         RootNode rootNode = NodeUtils.createMetadata();


### PR DESCRIPTION
Deprecate legacy `tei` and `psi` params in favor of `trackedEntities` and `events` in audit Controller.