### PR TITLE
feat: multiple aocs for approvals/coc DHIS2-14371

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataapproval/DataApprovalService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataapproval/DataApprovalService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.dataapproval;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOptionCombo;
@@ -176,20 +177,21 @@ public interface DataApprovalService
         OrganisationUnit organisationUnit, CategoryOptionCombo attributeOptionCombo );
 
     /**
-     * Returns a list of approval status and permissions for all of the category
-     * option combos that the user is allowed to see.
+     * Returns a list of approval status and permissions for all the attribute
+     * option combos that the user is allowed to see or for specified attribute
+     * option combos.
      *
      * @param workflow workflow to check for approval.
      * @param period Period we are getting the status for
      * @param orgUnit Organisation unit we are getting the status for
      * @param orgUnitFilter Organisation unit filter for attribute option combos
      * @param attributeCombo attribute category combo to search within
-     * @param attributeOptionCombo Single attribute option combo to get for
+     * @param attributeOptionCombos attribute option combos to get
      * @return list of statuses and permissions
      */
     List<DataApprovalStatus> getUserDataApprovalsAndPermissions( DataApprovalWorkflow workflow,
         Period period, OrganisationUnit orgUnit, OrganisationUnit orgUnitFilter, CategoryCombo attributeCombo,
-        CategoryOptionCombo attributeOptionCombo );
+        Set<CategoryOptionCombo> attributeOptionCombos );
 
     /**
      * Deletes DataApprovals for the given organisation unit.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DefaultDataApprovalService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DefaultDataApprovalService.java
@@ -543,12 +543,11 @@ public class DefaultDataApprovalService
     @Transactional( readOnly = true )
     public List<DataApprovalStatus> getUserDataApprovalsAndPermissions( DataApprovalWorkflow workflow,
         Period period, OrganisationUnit orgUnit, OrganisationUnit orgUnitFilter, CategoryCombo attributeCombo,
-        CategoryOptionCombo attributeOptionCombo )
+        Set<CategoryOptionCombo> attributeOptionCombos )
     {
         List<DataApprovalStatus> statusList = dataApprovalStore.getDataApprovalStatuses(
             workflow, period, orgUnit == null ? null : Lists.newArrayList( orgUnit ),
-            orgUnit == null ? 0 : orgUnit.getHierarchyLevel(), orgUnitFilter, attributeCombo,
-            attributeOptionCombo == null ? null : Set.of( attributeOptionCombo ),
+            orgUnit == null ? 0 : orgUnit.getHierarchyLevel(), orgUnitFilter, attributeCombo, attributeOptionCombos,
             dataApprovalLevelService.getUserDataApprovalLevelsOrLowestLevel( currentUserService.getCurrentUser(),
                 workflow ),
             dataApprovalLevelService.getDataApprovalLevelMap() );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalServiceCategoryOptionGroupTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalServiceCategoryOptionGroupTest.java
@@ -605,7 +605,7 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
     {
         setUser( mockUserService );
         List<DataApprovalStatus> approvals = dataApprovalService.getUserDataApprovalsAndPermissions( workflow, period,
-            orgUnit, ouFilter, mechanismCategoryCombo, aoc );
+            orgUnit, ouFilter, mechanismCategoryCombo, Set.of( aoc ) );
         return approvals.stream()
             .map( status -> getStatusString( status ) )
             .sorted()

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalServiceCategoryOptionGroupTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalServiceCategoryOptionGroupTest.java
@@ -605,7 +605,7 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
     {
         setUser( mockUserService );
         List<DataApprovalStatus> approvals = dataApprovalService.getUserDataApprovalsAndPermissions( workflow, period,
-            orgUnit, ouFilter, mechanismCategoryCombo, Set.of( aoc ) );
+            orgUnit, ouFilter, mechanismCategoryCombo, aoc == null ? null : Set.of( aoc ) );
         return approvals.stream()
             .map( status -> getStatusString( status ) )
             .sorted()

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataApprovalController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataApprovalController.java
@@ -798,7 +798,7 @@ public class DataApprovalController
 
         if ( aoc == null )
         {
-            optionCombos.add( getAndValidateAttributeOptionCombo( null ) );
+            optionCombos.add( categoryService.getDefaultCategoryOptionCombo() );
         }
         else
         {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataApprovalController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataApprovalController.java
@@ -226,19 +226,7 @@ public class DataApprovalController
             orgUnits.add( getAndValidateOrgUnit( orgUnit ) );
         }
 
-        List<CategoryOptionCombo> optionCombos = new ArrayList<>();
-
-        if ( aoc == null )
-        {
-            optionCombos.add( getAndValidateAttributeOptionCombo( null ) );
-        }
-        else
-        {
-            for ( String optionCombo : aoc )
-            {
-                optionCombos.add( getAndValidateAttributeOptionCombo( optionCombo ) );
-            }
-        }
+        Set<CategoryOptionCombo> attributeOptionCombos = getAndValidateAttributeOptionCombos( aoc );
 
         List<DataApproval> dataApprovals = new ArrayList<>();
 
@@ -253,7 +241,7 @@ public class DataApprovalController
                 {
                     for ( OrganisationUnit orgUnit : orgUnits )
                     {
-                        for ( CategoryOptionCombo optionCombo : optionCombos )
+                        for ( CategoryOptionCombo optionCombo : attributeOptionCombos )
                         {
                             dataApprovals.add( new DataApproval( null, workflow, period, orgUnit, optionCombo ) );
                         }
@@ -379,14 +367,14 @@ public class DataApprovalController
         @OpenApi.Param( Period.class ) @RequestParam String pe,
         @OpenApi.Param( { UID.class, OrganisationUnit.class } ) @RequestParam( required = false ) String ou,
         @OpenApi.Param( { UID.class, OrganisationUnit.class } ) @RequestParam( required = false ) String ouFilter,
-        @OpenApi.Param( { UID.class, CategoryOptionCombo.class } ) @RequestParam( required = false ) String aoc )
+        @OpenApi.Param( { UID.class, CategoryOptionCombo.class } ) @RequestParam( required = false ) Set<String> aoc )
         throws WebMessageException
     {
         Set<DataApprovalWorkflow> workflows = getAndValidateWorkflows( ds, wf );
         Period period = getAndValidatePeriod( pe );
         OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ou );
         OrganisationUnit orgUnitFilter = organisationUnitService.getOrganisationUnit( ouFilter );
-        CategoryOptionCombo attributeOptionCombo = categoryService.getCategoryOptionCombo( aoc );
+        Set<CategoryOptionCombo> attributeOptionCombos = getAndValidateAttributeOptionCombos( aoc );
 
         if ( orgUnit != null && orgUnit.isRoot() )
         {
@@ -407,7 +395,7 @@ public class DataApprovalController
             for ( CategoryCombo attributeCombo : attributeCombos )
             {
                 statusList.addAll( dataApprovalService.getUserDataApprovalsAndPermissions( workflow, period, orgUnit,
-                    orgUnitFilter, attributeCombo, attributeOptionCombo ) );
+                    orgUnitFilter, attributeCombo, attributeOptionCombos ) );
             }
         }
 
@@ -801,6 +789,26 @@ public class DataApprovalController
         }
 
         return dataApprovalLevel;
+    }
+
+    private Set<CategoryOptionCombo> getAndValidateAttributeOptionCombos( Set<String> aoc )
+        throws WebMessageException
+    {
+        Set<CategoryOptionCombo> optionCombos = new HashSet<>();
+
+        if ( aoc == null )
+        {
+            optionCombos.add( getAndValidateAttributeOptionCombo( null ) );
+        }
+        else
+        {
+            for ( String optionCombo : aoc )
+            {
+                optionCombos.add( getAndValidateAttributeOptionCombo( optionCombo ) );
+            }
+        }
+
+        return optionCombos;
     }
 
     private CategoryOptionCombo getAndValidateAttributeOptionCombo( String aoc )


### PR DESCRIPTION
See the end of the description of [DHIS2-14371](https://dhis2.atlassian.net/browse/DHIS2-14371). PEPFAR needed multiple attributeOptionCombos on the `dataApprovals/categoryOptionCombos` endpoint. This PR allows a set of attributeOptionCombos to be specified rather than just a single attributeOptionCombo.

[DHIS2-14371]: https://dhis2.atlassian.net/browse/DHIS2-14371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ