### PR TITLE
fix: Analytics /events takes default relative period for analytics [DHIS2-15468] 

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/PeriodCriteriaUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/PeriodCriteriaUtils.java
@@ -87,6 +87,8 @@ public class PeriodCriteriaUtils
     private static boolean hasPeriod( EventsAnalyticsQueryCriteria criteria )
     {
         return criteria.getDimension().stream().anyMatch( d -> d.startsWith( PERIOD_DIM_ID ) )
+            || (criteria.getFilter() != null
+                && criteria.getFilter().stream().anyMatch( d -> d.startsWith( PERIOD_DIM_ID ) ))
             || !isBlank( criteria.getEventDate() )
             || !isBlank( criteria.getEnrollmentDate() )
             || (criteria.getStartDate() != null && criteria.getEndDate() != null)

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/PeriodCriteriaUtilsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/PeriodCriteriaUtilsTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.util;
 
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
+import static org.hisp.dhis.period.RelativePeriodEnum.LAST_3_DAYS;
 import static org.hisp.dhis.period.RelativePeriodEnum.LAST_5_YEARS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -79,6 +80,36 @@ class PeriodCriteriaUtilsTest
         assertNull( eventsAnalyticsQueryCriteria.getDesc() );
         assertEquals( eventsAnalyticsQueryCriteria.getDimension().stream().findFirst().get(),
             PERIOD_DIM_ID + ":" + LAST_5_YEARS );
+    }
+
+    @Test
+    void testDefineDefaultPeriodDimensionCriteriaWithOrderBy_Event_forNoRelativePeriod_andFilter()
+    {
+        // given
+        EventsAnalyticsQueryCriteria eventsAnalyticsQueryCriteria = configureEventsAnalyticsQueryCriteriaWithFilter(
+            PERIOD_DIM_ID + ":" + LAST_3_DAYS.name() );
+
+        // when
+        // then
+        assertFalse( eventsAnalyticsQueryCriteria.getDimension().stream().findFirst().isPresent() );
+        assertTrue( eventsAnalyticsQueryCriteria.getFilter().stream().findFirst().isPresent() );
+        assertEquals( eventsAnalyticsQueryCriteria.getFilter().stream().findFirst().get(),
+            PERIOD_DIM_ID + ":" + LAST_3_DAYS );
+    }
+
+    @Test
+    void testDefineDefaultPeriodDimensionCriteriaWithOrderBy_Enrollment_forNoRelativePeriod_andFilter()
+    {
+        // given
+        EnrollmentAnalyticsQueryCriteria enrollmentAnalyticsQueryCriteria = configureEnrollmentsAnalyticsQueryCriteriaWithFilter(
+            PERIOD_DIM_ID + ":" + LAST_3_DAYS.name() );
+
+        // when
+        // then
+        assertFalse( enrollmentAnalyticsQueryCriteria.getDimension().stream().findFirst().isPresent() );
+        assertTrue( enrollmentAnalyticsQueryCriteria.getFilter().stream().findFirst().isPresent() );
+        assertEquals( enrollmentAnalyticsQueryCriteria.getFilter().stream().findFirst().get(),
+            PERIOD_DIM_ID + ":" + LAST_3_DAYS );
     }
 
     @Test
@@ -184,6 +215,36 @@ class PeriodCriteriaUtilsTest
         }
 
         return eventsAnalyticsQueryCriteria;
+    }
+
+    private EventsAnalyticsQueryCriteria configureEventsAnalyticsQueryCriteriaWithFilter( String period )
+    {
+        EventsAnalyticsQueryCriteria eventsAnalyticsQueryCriteria = getDefaultEventsAnalyticsQueryCriteria();
+
+        if ( period != null )
+        {
+            Set<String> filters = new HashSet<>();
+            filters.add( period );
+            eventsAnalyticsQueryCriteria.setFilter( filters );
+            eventsAnalyticsQueryCriteria.getFilter().add( period );
+        }
+
+        return eventsAnalyticsQueryCriteria;
+    }
+
+    private EnrollmentAnalyticsQueryCriteria configureEnrollmentsAnalyticsQueryCriteriaWithFilter( String period )
+    {
+        EnrollmentAnalyticsQueryCriteria enrollmentAnalyticsQueryCriteria = getDefaultEnrollmentsAnalyticsQueryCriteria();
+
+        if ( period != null )
+        {
+            Set<String> filters = new HashSet<>();
+            filters.add( period );
+            enrollmentAnalyticsQueryCriteria.setFilter( filters );
+            enrollmentAnalyticsQueryCriteria.getFilter().add( period );
+        }
+
+        return enrollmentAnalyticsQueryCriteria;
     }
 
     private EventsAnalyticsQueryCriteria configureEventsAnalyticsQueryCriteriaWithEventDate()


### PR DESCRIPTION
_**[Backport from master/2.41]**_
This fix addresses the issue related to `pe` and `filter` in analytics.
Currently, the `pe` in the `filter` is being ignored, and the default `pe` defined in system settings is being used in every request.
