### PR TITLE
fix: Options (of option set) in events/aggregate API [DHIS2-15364]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
@@ -50,6 +50,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.EventOutputType;
 import org.hisp.dhis.analytics.SortOrder;
+import org.hisp.dhis.common.RequestTypeAware.EndpointAction;
+import org.hisp.dhis.common.RequestTypeAware.EndpointItem;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.program.ProgramStatus;
 
@@ -142,7 +144,9 @@ public class EventDataQueryRequest
 
     private boolean totalPages;
 
-    private RequestTypeAware.EndpointItem endpointItem;
+    private EndpointItem endpointItem;
+
+    private EndpointAction endpointAction;
 
     private boolean enhancedConditions;
 
@@ -194,6 +198,7 @@ public class EventDataQueryRequest
         queryRequest.paging = this.paging;
         queryRequest.totalPages = this.totalPages;
         queryRequest.endpointItem = this.endpointItem;
+        queryRequest.endpointAction = this.endpointAction;
         queryRequest.enhancedConditions = this.enhancedConditions;
         queryRequest.outputIdScheme = outputIdScheme;
         return request;
@@ -256,6 +261,7 @@ public class EventDataQueryRequest
                 .defaultCoordinateFallback( criteria.isDefaultCoordinateFallback() )
                 .totalPages( criteria.isTotalPages() )
                 .endpointItem( criteria.getEndpointItem() )
+                .endpointAction( criteria.getEndpointAction() )
                 .enhancedConditions( criteria.isEnhancedConditions() );
 
             if ( criteria.getDimension() == null )
@@ -360,6 +366,7 @@ public class EventDataQueryRequest
                 .sortOrder( criteria.getSortOrder() )
                 .totalPages( criteria.isTotalPages() )
                 .endpointItem( criteria.getEndpointItem() )
+                .endpointAction( criteria.getEndpointAction() )
                 .enhancedConditions( criteria.isEnhancedConditions() );
 
             if ( criteria.getDimension() == null )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/RequestTypeAware.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/RequestTypeAware.java
@@ -27,20 +27,28 @@
  */
 package org.hisp.dhis.common;
 
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.AGGREGATE;
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.OTHER;
 import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.QUERY;
 
 import lombok.Getter;
 
+/**
+ * Encapsulates some information about the current request and endpoint invoked.
+ * They are needed because of some internal rules.
+ */
 public class RequestTypeAware
 {
-    private EndpointAction endpointAction = EndpointAction.OTHER;
+
+    @Getter
+    private EndpointAction endpointAction = OTHER;
 
     @Getter
     private EndpointItem endpointItem;
 
-    public RequestTypeAware withQueryEndpointAction()
+    public RequestTypeAware withEndpointAction( EndpointAction endpointAction )
     {
-        endpointAction = QUERY;
+        this.endpointAction = endpointAction;
         return this;
     }
 
@@ -55,8 +63,14 @@ public class RequestTypeAware
         return QUERY == endpointAction;
     }
 
-    enum EndpointAction
+    public boolean isAggregateEndpoint()
     {
+        return AGGREGATE == endpointAction;
+    }
+
+    public enum EndpointAction
+    {
+        AGGREGATE,
         QUERY,
         OTHER
     }
@@ -67,5 +81,4 @@ public class RequestTypeAware
         ENROLLMENT,
         TRACKED_ENTITY_INSTANCE
     }
-
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EventDataQueryRequestTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EventDataQueryRequestTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.common;
 
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.QUERY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
@@ -59,7 +60,7 @@ public class EventDataQueryRequestTest
         assertEquals( eventDataQueryRequest.getDimension(), Set.of( Set.of( "pe:TODAY" ) ) );
 
         eventDataQueryRequest = EventDataQueryRequest.builder()
-            .fromCriteria( (EventsAnalyticsQueryCriteria) criteria.withQueryEndpointAction() )
+            .fromCriteria( (EventsAnalyticsQueryCriteria) criteria.withEndpointAction( QUERY ) )
             .build();
 
         assertEquals( eventDataQueryRequest.getDimension(), Set.of( Set.of( "pe:TODAY;YESTERDAY:INCIDENT_DATE" ) ) );
@@ -72,10 +73,10 @@ public class EventDataQueryRequestTest
             .fromCriteria( criteria )
             .build();
 
-        assertEquals( eventDataQueryRequest.getDimension(), Collections.emptySet() );
+        assertEquals( Collections.emptySet(), eventDataQueryRequest.getDimension() );
 
         eventDataQueryRequest = EventDataQueryRequest.builder()
-            .fromCriteria( (EventsAnalyticsQueryCriteria) criteria.withQueryEndpointAction() )
+            .fromCriteria( (EventsAnalyticsQueryCriteria) criteria.withEndpointAction( QUERY ) )
             .build();
 
         assertEquals( eventDataQueryRequest.getDimension(), Set.of( Set.of( "pe:TODAY:INCIDENT_DATE" ) ) );
@@ -91,7 +92,7 @@ public class EventDataQueryRequestTest
         criteria.setDimension( new HashSet<>( Set.of( "pe:LAST_MONTH" ) ) );
 
         EventDataQueryRequest eventDataQueryRequest = EventDataQueryRequest.builder()
-            .fromCriteria( (EventsAnalyticsQueryCriteria) criteria.withQueryEndpointAction() )
+            .fromCriteria( (EventsAnalyticsQueryCriteria) criteria.withEndpointAction( QUERY ) )
             .build();
 
         assertEquals( eventDataQueryRequest.getDimension(),
@@ -110,7 +111,7 @@ public class EventDataQueryRequestTest
         criteria.setDimension( new HashSet<>( Set.of( "pe:LAST_MONTH" ) ) );
 
         EventDataQueryRequest eventDataQueryRequest = EventDataQueryRequest.builder()
-            .fromCriteria( (EnrollmentAnalyticsQueryCriteria) criteria.withQueryEndpointAction() )
+            .fromCriteria( (EnrollmentAnalyticsQueryCriteria) criteria.withEndpointAction( QUERY ) )
             .build();
 
         assertEquals( eventDataQueryRequest.getDimension(),

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/analytics/ValidationHelper.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/analytics/ValidationHelper.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.analytics;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 
 import java.util.List;
@@ -60,16 +61,108 @@ public class ValidationHelper
      * @param hidden
      * @param meta
      */
-    public static void validateHeader( final ApiResponse response, final int headerIndex, final String name,
-        final String column, final String valueType, final String type, final boolean hidden, final boolean meta )
+    public static void validateHeader( ApiResponse response, int headerIndex, String name,
+                                       String column, String valueType, String type, boolean hidden, boolean meta )
     {
         response.validate()
-            .body( "headers[" + headerIndex + "].name", equalTo( name ) )
-            .body( "headers[" + headerIndex + "].column", equalTo( column ) )
-            .body( "headers[" + headerIndex + "].valueType", equalTo( valueType ) )
-            .body( "headers[" + headerIndex + "].type", equalTo( type ) )
-            .body( "headers[" + headerIndex + "].hidden", is( hidden ) )
-            .body( "headers[" + headerIndex + "].meta", is( meta ) );
+                .body( "headers[" + headerIndex + "].name", equalTo( name ) )
+                .body( "headers[" + headerIndex + "].column", equalTo( column ) )
+                .body( "headers[" + headerIndex + "].valueType", equalTo( valueType ) )
+                .body( "headers[" + headerIndex + "].type", equalTo( type ) )
+                .body( "headers[" + headerIndex + "].hidden", is( hidden ) )
+                .body( "headers[" + headerIndex + "].meta", is( meta ) );
+    }
+
+    /**
+     * Validate/assert all attributes of the given header (represented by the
+     * index), matching each argument with its respective header attribute
+     * value.
+     *
+     * @param response
+     * @param headerIndex of the header
+     * @param name
+     * @param column
+     * @param valueType
+     * @param type
+     * @param hidden
+     * @param meta
+     * @param optionSet
+     */
+    public static void validateHeader( ApiResponse response, int headerIndex, String name,
+                                       String column, String valueType, String type, boolean hidden, boolean meta, String optionSet )
+    {
+        response.validate()
+                .body( "headers[" + headerIndex + "].name", equalTo( name ) )
+                .body( "headers[" + headerIndex + "].column", equalTo( column ) )
+                .body( "headers[" + headerIndex + "].valueType", equalTo( valueType ) )
+                .body( "headers[" + headerIndex + "].type", equalTo( type ) )
+                .body( "headers[" + headerIndex + "].hidden", is( hidden ) )
+                .body( "headers[" + headerIndex + "].meta", is( meta ) )
+                .body( "headers[" + headerIndex + "].optionSet", is( optionSet ) );
+    }
+
+    /**
+     * Validate/assert all attributes of the given header (represented by the
+     * index), matching each argument with its respective header attribute
+     * value.
+     *
+     * @param response
+     * @param headerIndex
+     * @param name
+     * @param column
+     * @param valueType
+     * @param type
+     * @param hidden
+     * @param meta
+     * @param programStage
+     * @param repeatableStageParams
+     * @param stageOffset
+     */
+
+    public static void validateHeader( ApiResponse response, int headerIndex, String name,
+                                       String column, String valueType, String type, boolean hidden, boolean meta, String programStage,
+                                       String repeatableStageParams, int stageOffset )
+    {
+        response.validate()
+                .body( "headers[" + headerIndex + "].name", equalTo( name ) )
+                .body( "headers[" + headerIndex + "].column", equalTo( column ) )
+                .body( "headers[" + headerIndex + "].valueType", equalTo( valueType ) )
+                .body( "headers[" + headerIndex + "].type", equalTo( type ) )
+                .body( "headers[" + headerIndex + "].hidden", is( hidden ) )
+                .body( "headers[" + headerIndex + "].programStage", equalTo( programStage ) )
+                .body( "headers[" + headerIndex + "].repeatableStageParams", equalTo( repeatableStageParams ) )
+                .body( "headers[" + headerIndex + "].stageOffset", equalTo( stageOffset ) );
+    }
+
+    /**
+     * Validate/assert all attributes of the given rowContext (represented by
+     * the row and column index), matching each argument with its respective
+     * repeatableStageValueStatus value.
+     *
+     * @param response
+     * @param rowIndex
+     * @param colIndex
+     * @param repeatableStageValueStatus
+     */
+    public static void validateRowContext( ApiResponse response, int rowIndex, int colIndex,
+                                           String repeatableStageValueStatus )
+    {
+        response.validate()
+                .body( "rowContext." + rowIndex + "." + colIndex + ".valueStatus",
+                        equalTo( repeatableStageValueStatus ) );
+    }
+
+    /**
+     * Validate/assert that all values of the given row are present in the given
+     * response.
+     *
+     * @param response
+     * @param rowIndex
+     * @param expectedValues
+     */
+    public static void validateRow( ApiResponse response, int rowIndex, List<String> expectedValues )
+    {
+        response.validate().body( "rows[" + rowIndex + "]", equalTo( expectedValues ) );
     }
 
     /**
@@ -79,9 +172,8 @@ public class ValidationHelper
      * @param response
      * @param expectedValues
      */
-    public static void validateRow( final ApiResponse response, final int rowIndex, final List<String> expectedValues )
+    public static void validateRow( ApiResponse response, List<String> expectedValues )
     {
-        response.validate()
-            .body( "rows[" + rowIndex + "]", equalTo( expectedValues ) );
+        response.validate().body( "rows", hasItems( expectedValues ) );
     }
 }

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/analytics/ValidationHelper.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/analytics/ValidationHelper.java
@@ -62,15 +62,15 @@ public class ValidationHelper
      * @param meta
      */
     public static void validateHeader( ApiResponse response, int headerIndex, String name,
-                                       String column, String valueType, String type, boolean hidden, boolean meta )
+        String column, String valueType, String type, boolean hidden, boolean meta )
     {
         response.validate()
-                .body( "headers[" + headerIndex + "].name", equalTo( name ) )
-                .body( "headers[" + headerIndex + "].column", equalTo( column ) )
-                .body( "headers[" + headerIndex + "].valueType", equalTo( valueType ) )
-                .body( "headers[" + headerIndex + "].type", equalTo( type ) )
-                .body( "headers[" + headerIndex + "].hidden", is( hidden ) )
-                .body( "headers[" + headerIndex + "].meta", is( meta ) );
+            .body( "headers[" + headerIndex + "].name", equalTo( name ) )
+            .body( "headers[" + headerIndex + "].column", equalTo( column ) )
+            .body( "headers[" + headerIndex + "].valueType", equalTo( valueType ) )
+            .body( "headers[" + headerIndex + "].type", equalTo( type ) )
+            .body( "headers[" + headerIndex + "].hidden", is( hidden ) )
+            .body( "headers[" + headerIndex + "].meta", is( meta ) );
     }
 
     /**
@@ -89,16 +89,16 @@ public class ValidationHelper
      * @param optionSet
      */
     public static void validateHeader( ApiResponse response, int headerIndex, String name,
-                                       String column, String valueType, String type, boolean hidden, boolean meta, String optionSet )
+        String column, String valueType, String type, boolean hidden, boolean meta, String optionSet )
     {
         response.validate()
-                .body( "headers[" + headerIndex + "].name", equalTo( name ) )
-                .body( "headers[" + headerIndex + "].column", equalTo( column ) )
-                .body( "headers[" + headerIndex + "].valueType", equalTo( valueType ) )
-                .body( "headers[" + headerIndex + "].type", equalTo( type ) )
-                .body( "headers[" + headerIndex + "].hidden", is( hidden ) )
-                .body( "headers[" + headerIndex + "].meta", is( meta ) )
-                .body( "headers[" + headerIndex + "].optionSet", is( optionSet ) );
+            .body( "headers[" + headerIndex + "].name", equalTo( name ) )
+            .body( "headers[" + headerIndex + "].column", equalTo( column ) )
+            .body( "headers[" + headerIndex + "].valueType", equalTo( valueType ) )
+            .body( "headers[" + headerIndex + "].type", equalTo( type ) )
+            .body( "headers[" + headerIndex + "].hidden", is( hidden ) )
+            .body( "headers[" + headerIndex + "].meta", is( meta ) )
+            .body( "headers[" + headerIndex + "].optionSet", is( optionSet ) );
     }
 
     /**
@@ -120,18 +120,18 @@ public class ValidationHelper
      */
 
     public static void validateHeader( ApiResponse response, int headerIndex, String name,
-                                       String column, String valueType, String type, boolean hidden, boolean meta, String programStage,
-                                       String repeatableStageParams, int stageOffset )
+        String column, String valueType, String type, boolean hidden, boolean meta, String programStage,
+        String repeatableStageParams, int stageOffset )
     {
         response.validate()
-                .body( "headers[" + headerIndex + "].name", equalTo( name ) )
-                .body( "headers[" + headerIndex + "].column", equalTo( column ) )
-                .body( "headers[" + headerIndex + "].valueType", equalTo( valueType ) )
-                .body( "headers[" + headerIndex + "].type", equalTo( type ) )
-                .body( "headers[" + headerIndex + "].hidden", is( hidden ) )
-                .body( "headers[" + headerIndex + "].programStage", equalTo( programStage ) )
-                .body( "headers[" + headerIndex + "].repeatableStageParams", equalTo( repeatableStageParams ) )
-                .body( "headers[" + headerIndex + "].stageOffset", equalTo( stageOffset ) );
+            .body( "headers[" + headerIndex + "].name", equalTo( name ) )
+            .body( "headers[" + headerIndex + "].column", equalTo( column ) )
+            .body( "headers[" + headerIndex + "].valueType", equalTo( valueType ) )
+            .body( "headers[" + headerIndex + "].type", equalTo( type ) )
+            .body( "headers[" + headerIndex + "].hidden", is( hidden ) )
+            .body( "headers[" + headerIndex + "].programStage", equalTo( programStage ) )
+            .body( "headers[" + headerIndex + "].repeatableStageParams", equalTo( repeatableStageParams ) )
+            .body( "headers[" + headerIndex + "].stageOffset", equalTo( stageOffset ) );
     }
 
     /**
@@ -145,11 +145,11 @@ public class ValidationHelper
      * @param repeatableStageValueStatus
      */
     public static void validateRowContext( ApiResponse response, int rowIndex, int colIndex,
-                                           String repeatableStageValueStatus )
+        String repeatableStageValueStatus )
     {
         response.validate()
-                .body( "rowContext." + rowIndex + "." + colIndex + ".valueStatus",
-                        equalTo( repeatableStageValueStatus ) );
+            .body( "rowContext." + rowIndex + "." + colIndex + ".valueStatus",
+                equalTo( repeatableStageValueStatus ) );
     }
 
     /**

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/analytics/event/EventQueryTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/analytics/event/EventQueryTest.java
@@ -289,4 +289,34 @@ public class EventQueryTest extends AnalyticsApiTest
                 "ACTIVE",
                 "DiszpKrYNg8" ) );
     }
+
+    @Test
+    void testMetadataInfoForOptionSetForQuery()
+    {
+        // Given
+        QueryParamsBuilder params = new QueryParamsBuilder()
+            .add(
+                "dimension=ou:ImspTQPwCqd,pe:LAST_12_MONTHS,C0aLZo75dgJ.B6TnnFMgmCk,C0aLZo75dgJ.Z1rLc1rVHK8,C0aLZo75dgJ.CklPZdOd6H1" )
+            .add( "filter=C0aLZo75dgJ.vTKipVM0GsX,C0aLZo75dgJ.h5FuguPFF2j,C0aLZo75dgJ.aW66s2QSosT" )
+            .add( "stage=C0aLZo75dgJ" )
+            .add( "displayProperty=NAME" )
+            .add( "outputType=ENROLLMENT" )
+            .add( "totalPages=false" );
+
+        // When
+        ApiResponse response = analyticsEventActions.query().get( "qDkgAbB5Jlk", JSON, JSON, params );
+        response.validate()
+            .statusCode( 200 )
+            .body( "headers", hasSize( equalTo( 24 ) ) )
+            .body( "height", equalTo( 0 ) )
+            .body( "width", equalTo( 0 ) )
+            .body( "rows", hasSize( equalTo( 0 ) ) )
+
+            .body( "metaData.items", hasKey( "CklPZdOd6H1" ) )
+            .body( "metaData.items", not( hasKey( "AZK4rjJCss5" ) ) )
+            .body( "metaData.items", not( hasKey( "UrUdMteQzlT" ) ) );
+
+        validateHeader( response, 22, "C0aLZo75dgJ.CklPZdOd6H1", "Sex", "TEXT", "java.lang.String",
+            false, true, "hiQ3QFheQ3O" );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -37,6 +37,7 @@ import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObjectUtils.asList;
 import static org.hisp.dhis.common.DimensionalObjectUtils.asTypedList;
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.QUERY;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -76,7 +77,8 @@ import org.hisp.dhis.common.DisplayProperty;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryItem;
-import org.hisp.dhis.common.RequestTypeAware;
+import org.hisp.dhis.common.RequestTypeAware.EndpointAction;
+import org.hisp.dhis.common.RequestTypeAware.EndpointItem;
 import org.hisp.dhis.common.ValueTypedDimensionalItemObject;
 import org.hisp.dhis.commons.collection.ListUtils;
 import org.hisp.dhis.dataelement.DataElement;
@@ -284,7 +286,10 @@ public class EventQueryParams
     protected boolean enhancedCondition = false;
 
     @Getter
-    protected RequestTypeAware.EndpointItem endpointItem;
+    protected EndpointItem endpointItem;
+
+    @Getter
+    protected EndpointAction endpointAction;
 
     // -------------------------------------------------------------------------
     // Constructors
@@ -355,6 +360,7 @@ public class EventQueryParams
         params.skipPartitioning = this.skipPartitioning;
         params.enhancedCondition = this.enhancedCondition;
         params.endpointItem = this.endpointItem;
+        params.endpointAction = this.endpointAction;
         return params;
     }
 
@@ -1108,6 +1114,11 @@ public class EventQueryParams
         return aggregateData;
     }
 
+    public boolean isComingFromQuery()
+    {
+        return endpointAction == QUERY;
+    }
+
     public Long getClusterSize()
     {
         return clusterSize;
@@ -1545,9 +1556,15 @@ public class EventQueryParams
             return params;
         }
 
-        public Builder withEndpointItem( RequestTypeAware.EndpointItem endpointItem )
+        public Builder withEndpointItem( EndpointItem endpointItem )
         {
             this.params.endpointItem = endpointItem;
+            return this;
+        }
+
+        public Builder withEndpointAction( EndpointAction endpointAction )
+        {
+            this.params.endpointAction = endpointAction;
             return this;
         }
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.analytics.event.data;
 
 import static java.util.Collections.emptyList;
+import static java.util.Optional.empty;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.joinWith;
@@ -54,6 +55,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import lombok.RequiredArgsConstructor;
@@ -331,8 +333,17 @@ public abstract class AbstractAnalyticsService
                 optionItems.addAll( getItemOptions( params.getItemOptions(), params.getItems() ) );
             }
 
-            metadata.put( ITEMS.getKey(), getMetadataItems( params, periodKeywords, optionItems, grid ) );
-            metadata.put( DIMENSIONS.getKey(), getDimensionItems( params, optionsPresentInGrid ) );
+            if ( params.isComingFromQuery() )
+            {
+                metadata.put( ITEMS.getKey(), getMetadataItems( params, periodKeywords, optionItems, grid ) );
+                metadata.put( DIMENSIONS.getKey(), getDimensionItems( params, Optional.of( optionsPresentInGrid ) ) );
+            }
+            else
+            {
+                metadata.put( ITEMS.getKey(), getMetadataItems( params ) );
+                metadata.put( DIMENSIONS.getKey(), getDimensionItems( params, empty() ) );
+            }
+
             maybeAddOrgUnitHierarchyInfo( params, metadata, grid );
 
             grid.setMetaData( metadata );
@@ -370,6 +381,48 @@ public abstract class AbstractAnalyticsService
                     getParentNameGraphMap( activeOrgUnits, roots, true ) );
             }
         }
+    }
+
+    /**
+     * Creates the map of {@link MetadataItem} based on the given params and
+     * internal rules.
+     *
+     * @param params the {@link EventQueryParams}.
+     * @return a {@link Map} of metadata item identifiers represented by
+     *         {@link MetadataItem}.
+     */
+    private Map<String, MetadataItem> getMetadataItems( EventQueryParams params )
+    {
+        Map<String, MetadataItem> metadataItemMap = AnalyticsUtils.getDimensionMetadataItemMap( params );
+
+        boolean includeDetails = params.isIncludeMetadataDetails();
+
+        if ( params.hasValueDimension() )
+        {
+            DimensionalItemObject value = params.getValue();
+            metadataItemMap.put( value.getUid(),
+                new MetadataItem( value.getDisplayProperty( params.getDisplayProperty() ),
+                    includeDetails ? value.getUid() : null, value.getCode() ) );
+        }
+
+        params.getItemLegends().stream()
+            .filter( Objects::nonNull )
+            .forEach( legend -> metadataItemMap.put( legend.getUid(),
+                new MetadataItem( legend.getDisplayName(), includeDetails ? legend.getUid() : null,
+                    legend.getCode() ) ) );
+
+        params.getItemOptions().stream()
+            .filter( Objects::nonNull )
+            .forEach( option -> metadataItemMap.put( option.getUid(),
+                new MetadataItem( option.getDisplayName(), includeDetails ? option.getUid() : null,
+                    option.getCode() ) ) );
+
+        params.getItemsAndItemFilters().stream()
+            .filter( Objects::nonNull )
+            .forEach( item -> metadataItemMap.put( item.getItemId(),
+                new MetadataItem( item.getItem().getDisplayName(), includeDetails ? item.getItem() : null ) ) );
+
+        return metadataItemMap;
     }
 
     /**
@@ -493,11 +546,11 @@ public abstract class AbstractAnalyticsService
      * identifiers.
      *
      * @param params the {@link EventQueryParams}.
-     * @param itemOptions the data query parameters.
-     * @return a map.
+     * @param itemOptions the item options to be added into dimension items.
+     * @return a {@link Map} of dimension items.
      */
     private Map<String, List<String>> getDimensionItems( EventQueryParams params,
-        Map<String, List<Option>> itemOptions )
+        Optional<Map<String, List<Option>>> itemOptions )
     {
         Calendar calendar = PeriodType.getCalendar();
 
@@ -519,10 +572,20 @@ public abstract class AbstractAnalyticsService
 
             if ( item.hasOptionSet() )
             {
-                // The call itemOptions.get( itemUid ) can return null.
-                // The query item can't have both legends and options.
-                dimensionItems.put( itemUid,
-                    getDimensionItemUidsFrom( itemOptions.get( itemUid ), item.getOptionSetFilterItemsOrAll() ) );
+                if ( itemOptions.isPresent() )
+                {
+                    Map<String, List<Option>> itemOptionsMap = itemOptions.get();
+
+                    // The call itemOptions.get( itemUid ) can return null.
+                    // The query item can't have both legends and options.
+                    dimensionItems.put( itemUid,
+                        getDimensionItemUidsFrom( itemOptionsMap.get( itemUid ),
+                            item.getOptionSetFilterItemsOrAll() ) );
+                }
+                else
+                {
+                    dimensionItems.put( item.getItemId(), item.getOptionSetFilterItemsOrAll() );
+                }
             }
             else if ( item.hasLegendSet() )
             {
@@ -534,7 +597,15 @@ public abstract class AbstractAnalyticsService
             }
         }
 
-        for ( QueryItem item : params.getItemFilters() )
+        addItemFiltersToDimensionItems( params.getItemFilters(), dimensionItems );
+
+        return dimensionItems;
+    }
+
+    private static void addItemFiltersToDimensionItems( List<QueryItem> itemsFilter,
+        Map<String, List<String>> dimensionItems )
+    {
+        for ( QueryItem item : itemsFilter )
         {
             if ( item.hasOptionSet() )
             {
@@ -552,8 +623,6 @@ public abstract class AbstractAnalyticsService
                         : emptyList() );
             }
         }
-
-        return dimensionItems;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -226,7 +226,8 @@ public class DefaultEventDataQueryService
             .withApiVersion( request.getApiVersion() )
             .withLocale( locale )
             .withEnhancedConditions( request.isEnhancedConditions() )
-            .withEndpointItem( request.getEndpointItem() );
+            .withEndpointItem( request.getEndpointItem() )
+            .withEndpointAction( request.getEndpointAction() );
 
         if ( analyzeOnly )
         {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceMetadataTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceMetadataTest.java
@@ -31,7 +31,6 @@ import static org.hisp.dhis.common.QueryFilter.OPTION_SEP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -251,9 +250,8 @@ class EventAnalyticsServiceMetadataTest extends SingleSetupIntegrationTestBase
         }
         for ( Option option : deE.getOptionSet().getOptions() )
         {
-            // Because skipData is set to "true" and no option code is specified
-            // as filter.
-            assertNull( itemMap.get( option.getUid() ) );
+            // Because "aggregate" always returns options and its option set.
+            assertNotNull( itemMap.get( option.getUid() ) );
         }
         assertNotNull( itemMap.get( deA.getUid() ) );
         assertNotNull( itemMap.get( deE.getUid() ) );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EnrollmentAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EnrollmentAnalyticsController.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.QUERY;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.List;
@@ -49,6 +50,7 @@ import org.hisp.dhis.common.EventDataQueryRequest;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.RequestTypeAware;
+import org.hisp.dhis.common.RequestTypeAware.EndpointAction;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.period.RelativePeriodEnum;
 import org.hisp.dhis.setting.SettingKey;
@@ -111,7 +113,7 @@ public class EnrollmentAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, true );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, true, QUERY );
 
         Grid grid = analyticsService.getEnrollments( params );
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_JSON,
@@ -133,7 +135,7 @@ public class EnrollmentAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_JSON,
             CacheStrategy.RESPECT_SYSTEM_SETTING );
@@ -149,7 +151,7 @@ public class EnrollmentAnalyticsController
         HttpServletResponse response )
         throws Exception
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_XML, CacheStrategy.RESPECT_SYSTEM_SETTING,
             "enrollments.xml", false );
@@ -165,7 +167,7 @@ public class EnrollmentAnalyticsController
         HttpServletResponse response )
         throws Exception
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_EXCEL, CacheStrategy.RESPECT_SYSTEM_SETTING,
             "enrollments.xls", true );
@@ -181,7 +183,7 @@ public class EnrollmentAnalyticsController
         HttpServletResponse response )
         throws Exception
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_CSV, CacheStrategy.RESPECT_SYSTEM_SETTING,
             "enrollments.csv", true );
@@ -197,7 +199,7 @@ public class EnrollmentAnalyticsController
         HttpServletResponse response )
         throws Exception
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_HTML, CacheStrategy.RESPECT_SYSTEM_SETTING,
             "enrollments.html", false );
@@ -213,7 +215,7 @@ public class EnrollmentAnalyticsController
         HttpServletResponse response )
         throws Exception
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_HTML, CacheStrategy.RESPECT_SYSTEM_SETTING,
             "enrollments.html", false );
@@ -258,7 +260,8 @@ public class EnrollmentAnalyticsController
     }
 
     private EventQueryParams getEventQueryParams( @PathVariable String program,
-        EnrollmentAnalyticsQueryCriteria criteria, DhisApiVersion apiVersion, boolean analyzeOnly )
+        EnrollmentAnalyticsQueryCriteria criteria, DhisApiVersion apiVersion, boolean analyzeOnly,
+        EndpointAction endpointAction )
     {
         criteria
             .definePageSize( systemSettingManager.getIntSetting( SettingKey.ANALYTICS_MAX_LIMIT ) );
@@ -267,8 +270,9 @@ public class EnrollmentAnalyticsController
             systemSettingManager.getSystemSetting( SettingKey.ANALYSIS_RELATIVE_PERIOD, RelativePeriodEnum.class ) );
 
         EventDataQueryRequest request = EventDataQueryRequest.builder()
-            .fromCriteria( (EnrollmentAnalyticsQueryCriteria) criteria.withQueryEndpointAction()
-                .withEndpointItem( RequestTypeAware.EndpointItem.ENROLLMENT ) )
+            .fromCriteria(
+                (EnrollmentAnalyticsQueryCriteria) criteria.withEndpointAction( endpointAction )
+                    .withEndpointItem( RequestTypeAware.EndpointItem.ENROLLMENT ) )
             .program( program )
             .apiVersion( apiVersion )
             .build();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EventAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EventAnalyticsController.java
@@ -28,6 +28,9 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.common.DimensionalObjectUtils.getItemsFromParam;
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.AGGREGATE;
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.OTHER;
+import static org.hisp.dhis.common.RequestTypeAware.EndpointAction.QUERY;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.List;
@@ -52,6 +55,7 @@ import org.hisp.dhis.common.EventsAnalyticsQueryCriteria;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.RequestTypeAware;
+import org.hisp.dhis.common.RequestTypeAware.EndpointAction;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.period.RelativePeriodEnum;
 import org.hisp.dhis.setting.SettingKey;
@@ -123,7 +127,7 @@ public class EventAnalyticsController
         HttpServletResponse response )
         throws Exception
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, true );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, true, AGGREGATE );
 
         configResponseForJson( response );
 
@@ -147,7 +151,7 @@ public class EventAnalyticsController
         HttpServletResponse response )
         throws Exception
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, AGGREGATE );
 
         configResponseForJson( response );
 
@@ -246,7 +250,7 @@ public class EventAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, OTHER );
 
         configResponseForJson( response );
 
@@ -268,7 +272,7 @@ public class EventAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, OTHER );
 
         params = new EventQueryParams.Builder( params )
             .withClusterSize( clusterSize )
@@ -294,7 +298,7 @@ public class EventAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, true );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, true, QUERY );
 
         configResponseForJson( response );
 
@@ -316,7 +320,7 @@ public class EventAnalyticsController
         DhisApiVersion apiVersion,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         configResponseForJson( response );
 
@@ -408,7 +412,7 @@ public class EventAnalyticsController
         HttpServletResponse response )
         throws Exception
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, AGGREGATE );
 
         contextUtils.configureResponse( response, contentType,
             CacheStrategy.RESPECT_SYSTEM_SETTING, file, false );
@@ -422,7 +426,7 @@ public class EventAnalyticsController
         String contentType, String file, boolean attachment,
         HttpServletResponse response )
     {
-        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
+        EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false, QUERY );
 
         contextUtils.configureResponse( response, contentType, CacheStrategy.RESPECT_SYSTEM_SETTING, file, attachment );
 
@@ -430,7 +434,7 @@ public class EventAnalyticsController
     }
 
     private EventQueryParams getEventQueryParams( String program, EventsAnalyticsQueryCriteria criteria,
-        DhisApiVersion apiVersion, boolean analyzeOnly )
+        DhisApiVersion apiVersion, boolean analyzeOnly, EndpointAction endpointAction )
     {
         criteria.definePageSize( systemSettingManager.getIntSetting( SettingKey.ANALYTICS_MAX_LIMIT ) );
 
@@ -439,7 +443,7 @@ public class EventAnalyticsController
 
         EventDataQueryRequest request = EventDataQueryRequest.builder()
             .fromCriteria( (EventsAnalyticsQueryCriteria) criteria
-                .withQueryEndpointAction()
+                .withEndpointAction( endpointAction )
                 .withEndpointItem( RequestTypeAware.EndpointItem.EVENT ) )
             .program( program )
             .apiVersion( apiVersion ).build();


### PR DESCRIPTION
**_[Backport from master/2.41]_**

The analytics endpoint `/events/aggregate` should return all options for the requested option sets. Even in cases where there are no grid results for the requested option set.

The behaviour for `/events/query` and `/events/enrollments` should remain the same (returns only options present in the response).

For testing scenarios and steps to reproduce this issue on Play, please see https://dhis2.atlassian.net/browse/DHIS2-15364.