### PR TITLE
ci: use qa group for finding a SL database instead of whoami [skip ci]

### DIFF
--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -213,7 +213,7 @@ pipeline {
                                 dir('scripts/databases') {
                                     env.DATABASE_ID = sh(
                                             returnStdout: true,
-                                            script: "./list.sh | jq -r '.[] | select(.name == \"whoami\") | .databases[] | select(.name == \"Sierra Leone - dev.sql.gz\") | .id'"
+                                            script: "./list.sh | jq -r '.[] | select(.name == \"sl\") | .databases[] | select(.name == \"Sierra Leone - dev.sql.gz\") | .id'"
                                     ).trim()
 
                                     sh '[ -n "$DATABASE_ID" ]'


### PR DESCRIPTION
The `whoami` group is meant to be used while developing the Instance Manager. We're now seeding the SL databases into the ["non-deployable"](https://github.com/dhis2-sre/im-manager/pull/311) `sl` group instead.