### PR TITLE
fix: include the root/parent for OU includeChildren [DHIS2-15517]

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OrganisationUnitControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OrganisationUnitControllerTest.java
@@ -70,19 +70,21 @@ class OrganisationUnitControllerTest extends DhisControllerConvenienceTest
     @Test
     void testGetChildren()
     {
-        assertListOfOrganisationUnits( GET( "/organisationUnits/{id}/children", ou0 ).content(), "L1", "L1x" );
-        assertListOfOrganisationUnits( GET( "/organisationUnits/{id}/children", ou1 ).content(), "L21", "L22" );
-        assertListOfOrganisationUnits( GET( "/organisationUnits/{id}/children", ou21 ).content(), "L31" );
+        assertListOfOrganisationUnits( GET( "/organisationUnits/{id}/children", ou0 ).content(), "L0", "L1", "L1x" );
+        assertListOfOrganisationUnits( GET( "/organisationUnits/{id}/children", ou1 ).content(), "L1", "L21", "L22" );
+        assertListOfOrganisationUnits( GET( "/organisationUnits/{id}/children", ou21 ).content(), "L21", "L31" );
     }
 
     @Test
     void testGetIncludeChildren()
     {
-        assertListOfOrganisationUnits( GET( "/organisationUnits/{id}?includeChildren=true", ou0 ).content(), "L1",
+        assertListOfOrganisationUnits( GET( "/organisationUnits/{id}?includeChildren=true", ou0 ).content(), "L0", "L1",
             "L1x" );
-        assertListOfOrganisationUnits( GET( "/organisationUnits/{id}?includeChildren=true", ou1 ).content(), "L21",
+        assertListOfOrganisationUnits( GET( "/organisationUnits/{id}?includeChildren=true", ou1 ).content(), "L1",
+            "L21",
             "L22" );
-        assertListOfOrganisationUnits( GET( "/organisationUnits/{id}?includeChildren=true", ou21 ).content(), "L31" );
+        assertListOfOrganisationUnits( GET( "/organisationUnits/{id}?includeChildren=true", ou21 ).content(), "L21",
+            "L31" );
     }
 
     @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -156,7 +157,7 @@ public class OrganisationUnitController
     {
         OrganisationUnit parent = getEntity( uid );
         return getObjectList( rpParameters, orderParams, response, currentUser, false,
-            params -> List.copyOf( parent.getChildren() ) );
+            params -> Stream.concat( Stream.of( parent ), parent.getChildren().stream() ).toList() );
     }
 
     @OpenApi.Param( name = "fields", value = String[].class )


### PR DESCRIPTION
When working on #13605 I accidentally did not include the parent of the children for `?includeChildren=true` and `/children` path. This fixes it. This only affects current dev version. 

It now is a bit odd that `organisationUnits/{uid}/children` would include the unit with the `uid` itself but since the idea is for the path version to replace the parameter version `?includeChildren=true` at some point in the future they better have the same behaviour. This oddity of including the unit itself is the same for `/descendants` and `/ancestors`. When using `level` however the list does not include the unit itself. This has always been like that so we keep it that way even if that feels a bit inconsistent. 