### PR TITLE
fix: only read patch body once from HTTP input stream [DHIS2-15516] (2.37)

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -251,7 +251,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
                 throw new BadRequestException( "Payload can not contain objects or arrays." );
             }
         }
-        return patchService.diff( new PatchParams( mapper.readTree( request.getInputStream() ) ) );
+        return patchService.diff( new PatchParams( jsonNode ) );
     }
 
     @RequestMapping( value = "/{uid}/{property}", method = { RequestMethod.PUT, RequestMethod.PATCH } )


### PR DESCRIPTION
The `mapper.readTree( request.getInputStream() )` was already performed earlier so apparently some containers then throw an exception. This second check was introduced in #13578.

Locally I could not reproduce it but the effect was that re-reading the input the input was empty. Correct is to reuse the deserialised object from the first `mapper.readTree( request.getInputStream() )` call.