### PR TITLE
fix: Long text does not display in pivot tables in data visualizer app [DHIS2-14188]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
@@ -50,8 +50,8 @@ public enum ValueType
     TEXT( String.class, true ),
     LONG_TEXT( String.class, true ),
     LETTER( String.class, true ),
-    PHONE_NUMBER( String.class, false ),
-    EMAIL( String.class, false ),
+    PHONE_NUMBER( String.class, true ),
+    EMAIL( String.class, true ),
     BOOLEAN( Boolean.class, true ),
     TRUE_ONLY( Boolean.class, true ),
     DATE( LocalDate.class, false ),
@@ -65,11 +65,11 @@ public enum ValueType
     INTEGER_NEGATIVE( Integer.class, true ),
     INTEGER_ZERO_OR_POSITIVE( Integer.class, true ),
     TRACKER_ASSOCIATE( TrackedEntityInstance.class, false ),
-    USERNAME( String.class, false ),
+    USERNAME( String.class, true ),
     COORDINATE( Point.class, true ),
     ORGANISATION_UNIT( OrganisationUnit.class, false ),
     AGE( Date.class, false ),
-    URL( String.class, false ),
+    URL( String.class, true ),
     FILE_RESOURCE( String.class, true, FileTypeValueOptions.class ),
     IMAGE( String.class, false, FileTypeValueOptions.class );
 
@@ -191,9 +191,9 @@ public enum ValueType
         {
             return false;
         }
-        if ( this == TEXT )
+        if ( TEXT_TYPES.contains( this ) )
         {
-            return aggregationType == AggregationType.NONE;
+            return true;
         }
         else
         {

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/ValueTypeTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/ValueTypeTest.java
@@ -50,19 +50,12 @@ public class ValueTypeTest
     public void aggregatableFlagOfTextValueTypeIsTrueWhenCalled()
     {
         // arrange act assert
-        assertTrue( ValueType.TEXT.isAggregatable( AggregationType.NONE ) );
-        assertTrue( ValueType.LONG_TEXT.isAggregatable( AggregationType.COUNT ) );
-        assertTrue( ValueType.LETTER.isAggregatable( AggregationType.SUM ) );
-
-    }
-
-    @Test
-    public void aggregatableFlagOfTextValueTypeIsFalseWhenCalled()
-    {
-        // arrange act assert
-        assertFalse( ValueType.TEXT.isAggregatable( AggregationType.COUNT ) );
-        assertFalse( ValueType.LONG_TEXT.isAggregatable( AggregationType.CUSTOM ) );
-        assertFalse( ValueType.LETTER.isAggregatable( AggregationType.DEFAULT ) );
+        assertTrue( ValueType.LONG_TEXT.isAggregatable( AggregationType.NONE ) );
+        assertTrue( ValueType.LETTER.isAggregatable( AggregationType.NONE ) );
+        assertTrue( ValueType.USERNAME.isAggregatable( AggregationType.NONE ) );
+        assertTrue( ValueType.EMAIL.isAggregatable( AggregationType.NONE ) );
+        assertTrue( ValueType.PHONE_NUMBER.isAggregatable( AggregationType.NONE ) );
+        assertTrue( ValueType.URL.isAggregatable( AggregationType.NONE ) );
     }
 
     @Test


### PR DESCRIPTION
**_[Backport from master/2.41]_**

This fixes the aggregation type for type text types.
 Pivot tables created in the Data Visualizer app fail to display fields of “Long Text” type.