### PR TITLE
fix: Boolean type aggregation [DHIS2-15440]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -881,6 +881,19 @@ public class EventQueryParams
     }
 
     /**
+     * Checks if a value dimension with a boolean value type exists.
+     *
+     * @return true if a value dimension with a boolean value type exists, false
+     *         if not.
+     */
+    public boolean hasBooleanValueDimension()
+    {
+        return hasValueDimension() &&
+            value instanceof ValueTypedDimensionalItemObject &&
+            ((ValueTypedDimensionalItemObject) value).getValueType().isBoolean();
+    }
+
+    /**
      * Checks if a value dimension with a text value type exists.
      *
      * @return true if a value dimension with a text value type exists, false if

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -691,7 +691,7 @@ public abstract class AbstractJdbcEventAnalyticsManager
         {
             return quoteAlias( params.getValue().getUid() );
         }
-        else if ( params.hasNumericValueDimension() )
+        else if ( params.hasNumericValueDimension() || params.hasBooleanValueDimension() )
         {
             String function = params.getAggregationTypeFallback().getAggregationType().getValue();
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/EventQueryParamsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/EventQueryParamsTest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.analytics.event;
 
 import static org.hisp.dhis.analytics.TimeField.SCHEDULED_DATE;
 import static org.hisp.dhis.common.DimensionType.PERIOD;
+import static org.hisp.dhis.common.ValueType.BOOLEAN;
 import static org.hisp.dhis.period.PeriodTypeEnum.MONTHLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -187,6 +188,28 @@ class EventQueryParamsTest extends DhisConvenienceTest
 
         assertTrue( paramsA.hasNumericValueDimension() );
         assertFalse( paramsB.hasNumericValueDimension() );
+    }
+
+    @Test
+    void testHasBooleanDimensionValue()
+    {
+        DataElement boolElement = createDataElement( 'A' );
+        boolElement.setValueType( BOOLEAN );
+
+        DataElement notBoolElement = createDataElement( 'B' );
+
+        EventQueryParams paramsA = new EventQueryParams.Builder()
+            .withOrganisationUnits( List.of( ouA, ouB ) )
+            .withValue( boolElement )
+            .build();
+
+        EventQueryParams paramsB = new EventQueryParams.Builder()
+            .withOrganisationUnits( List.of( ouA, ouB ) )
+            .withValue( notBoolElement )
+            .build();
+
+        assertTrue( paramsA.hasBooleanValueDimension() );
+        assertFalse( paramsB.hasBooleanValueDimension() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -47,8 +47,7 @@ import static org.hisp.dhis.common.QueryOperator.NE;
 import static org.hisp.dhis.common.QueryOperator.NEQ;
 import static org.hisp.dhis.common.QueryOperator.NIEQ;
 import static org.hisp.dhis.common.QueryOperator.NILIKE;
-import static org.hisp.dhis.common.ValueType.NUMBER;
-import static org.hisp.dhis.common.ValueType.TEXT;
+import static org.hisp.dhis.common.ValueType.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -233,6 +232,21 @@ class AbstractJdbcEventAnalyticsManagerTest extends EventAnalyticsTest
     String getTableName()
     {
         return "";
+    }
+
+    @Test
+    void verifyGetAggregateClauseWithBooleanValue()
+    {
+        DataElement booleanElement = createDataElement( 'A' );
+        booleanElement.setValueType( BOOLEAN );
+
+        EventQueryParams params = new EventQueryParams.Builder( createRequestParams() )
+            .withValue( booleanElement )
+            .build();
+
+        String clause = eventSubject.getAggregateClause( params );
+
+        assertThat( clause, is( "sum(ax.\"" + booleanElement.getUid() + "\")" ) );
     }
 
     @Test


### PR DESCRIPTION
**_[Backport from maste/2.41]_**

Fixes the analytics aggregation for boolean types. Currently, the API is counting data elements of boolean types, instead of aggregating them.
This is related to the endpoint `/analytics`.
A new check is being added to also ensure that boolean types are aggregated, restoring the original behaviour (from older versions 2.36 and previous).