### PR TITLE
fix: data value sets export CSV via file extionsion [DHIS2-15294]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
@@ -127,17 +127,10 @@ public class DataValueSetController
     {
         switch ( format )
         {
-        case "xml":
-            getDataValueSetXml( params, attachment, compression, response );
-            break;
-        case "adx+xml":
-            getDataValueSetXmlAdx( params, attachment, compression, response );
-            break;
-        case "csv":
-            getDataValueSetCsv( params, attachment, compression, response );
-            break;
-        default:
-            getDataValueSetJson( params, attachment, compression, response );
+        case "xml" -> getDataValueSetXml( params, attachment, compression, response );
+        case "adx+xml" -> getDataValueSetXmlAdx( params, attachment, compression, response );
+        case "csv" -> getDataValueSetCsv( params, attachment, compression, response );
+        default -> getDataValueSetJson( params, attachment, compression, response );
         }
     }
 
@@ -150,7 +143,7 @@ public class DataValueSetController
     {
         getDataValueSet( attachment, compression, "xml", response, CONTENT_TYPE_XML,
             () -> dataValueSetService.getFromUrl( params ),
-            ( exportParams, out ) -> dataValueSetService.exportDataValueSetXml( exportParams, out ) );
+            dataValueSetService::exportDataValueSetXml );
     }
 
     @OpenApi.Response( DataValueSet.class )
@@ -184,11 +177,11 @@ public class DataValueSetController
     {
         getDataValueSet( attachment, compression, "json", response, CONTENT_TYPE_JSON,
             () -> dataValueSetService.getFromUrl( params ),
-            ( exportParams, out ) -> dataValueSetService.exportDataValueSetJson( exportParams, out ) );
+            dataValueSetService::exportDataValueSetJson );
     }
 
     @OpenApi.Response( String.class )
-    @GetMapping( produces = CONTENT_TYPE_CSV )
+    @GetMapping( produces = { CONTENT_TYPE_CSV, "text/csv" } )
     public void getDataValueSetCsv( DataValueSetQueryParams params,
         @RequestParam( required = false ) String attachment,
         @RequestParam( required = false ) String compression,


### PR DESCRIPTION
### Summary
The reason the mapping did not work is that `.csv` is mapped to `text/csv` while the endpoint was mapped for `application/csv`. To fix that the `text/csv` was added as an alternative media type for the CSV endpoint method. 

### Manual Testing
* Login
* request `dataValueSets.csv?dataSet=pBOMPrpg1QX&period=202301&orgUnit=DiszpKrYNg8`
* check CSV file download start (no error page is shown)