### PR TITLE
fix: Update User API when updating UserGroups to update lastUpdatedBy [DHIS2-15357]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
@@ -208,6 +208,7 @@ public class DefaultUserGroupService
             if ( !updates.contains( userGroup ) && canAddOrRemoveMember( userGroup.getUid(), currentUser ) )
             {
                 userGroup.removeUser( user );
+                userGroupStore.update( userGroup, currentUser );
             }
         }
 
@@ -216,7 +217,7 @@ public class DefaultUserGroupService
             if ( canAddOrRemoveMember( userGroup.getUid(), currentUser ) )
             {
                 userGroup.addUser( user );
-                userGroupStore.updateNoAcl( userGroup );
+                userGroupStore.update( userGroup, currentUser );
             }
         }
     }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonUserGroup.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonUserGroup.java
@@ -50,4 +50,9 @@ public interface JsonUserGroup extends JsonIdentifiableObject
     {
         return getList( "managedByGroups", JsonUserGroup.class );
     }
+
+    default String getUsername()
+    {
+        return getString( "username" ).string();
+    }
 }


### PR DESCRIPTION

# Summary
The APP UI uses the following endpoint to add/remove a `User` to a `UserGroup`
- `PUT /api/users/{id}` - with `User` body 

## Existing behaviour
When adding/removing a `User` to/from a `UserGroup` using this API the `lastUpdatedBy` property is not being updated in the updated `UserGroup`

## New Behaviour
A change in the `DefaultUserGroupService` will now ensure that the `UserGroup` property `lastUpdatedBy` gets updated when called through this API.

## Note
Here are several other APIs (probably more) that can update a `UserGroup` - all of which already work as expected (`lastUpdatedBy` updating correctly). These have been manually tested during this bug analysis.
- `User` API
  - Add
    - `POST /api/users/{id}/userGroups/{id}`
  - Remove
    - `DELETE /api/users/{id}/userGroups/{id}`
- `UserGroup` API
  - Add
    - `POST /api/userGroups/{id}/users/{id}`
    - `PUT /api/userGroups/{id}` - with `UserGroup` body
  - Remove
    - `DELETE /api/userGroups/{id}/userGroups/{id}`
    - `PUT /api/userGroups/{id}` - with `UserGroup` body

# Testing
## Updated API
- Automated tests added testing adding/removing `User` to/from `UserGroup` and checking the `lastUpdatedBy` property
- Manually tested locally

## Existing APIs
- tested manually to confirm behaviour
