### PR TITLE
feat: adds unique to dashboard code column [DHIS2-14847]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v41/V2_41_18__Unique_dashboard_code_column.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v41/V2_41_18__Unique_dashboard_code_column.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.db.migration.v41;
+
+import static org.hisp.dhis.db.migration.helper.UniqueValueUtils.updateUniqueValue;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.hisp.dhis.db.migration.helper.UniqueValueUtils.UniqueValueParams;
+
+/**
+ * Makes the {@code code} column of dashboards unique.
+ *
+ * @author Jan Bernitt
+ */
+@SuppressWarnings( "java:S101" )
+public class V2_41_18__Unique_dashboard_code_column extends BaseJavaMigration
+{
+    @Override
+    public void migrate( Context context )
+        throws Exception
+    {
+        updateUniqueValue( context, new UniqueValueParams( "dashboard", "dashboardid", "code", 50, true ) );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_19__Unique_dashboard_code_column.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_19__Unique_dashboard_code_column.sql
@@ -1,0 +1,2 @@
+alter table dashboard drop constraint if exists dashboard_unique_code;
+alter table dashboard add constraint dashboard_unique_code unique (code);


### PR DESCRIPTION
### Summary
Makes the `code` column unique for `dashboard` table. 

* `null` values are kept as is. 
* Non unique codes are updated, one row keeping the duplicate code, the other getting codes based on the duplicate code with a number attached so the code is unique again.

### Manual Testing
**OBS!** Before running the updated code:
* edit the existing dashboards in the database so two or more have the same code (best to create multiple cases, one with short code, one where multiple dashboards have same code of maximum length of 50 characters)

Use the updated code and start the server
* check no errors occur during startup
* confirm that the existing dashboards with the same code now got different codes
* confirm that trying to edit a dashboard and giving it an already used code results in an error
* confirm update procedure can handle duplicate codes that are already maximum length of 50 characters