### PR TITLE
fix: get all available org units depending on org unit mode [DHIS2-15394]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityQueryParams.java
@@ -148,7 +148,7 @@ public class TrackedEntityQueryParams {
   /** Tracked entity types to fetch. */
   private List<TrackedEntityType> trackedEntityTypes = Lists.newArrayList();
 
-  /** Selection mode for the specified organisation units, default is ACCESSIBLE. */
+  /** Selection mode for the specified organisation units, default is DESCENDANTS. */
   private OrganisationUnitSelectionMode organisationUnitMode =
       OrganisationUnitSelectionMode.DESCENDANTS;
 
@@ -280,9 +280,11 @@ public class TrackedEntityQueryParams {
 
   /**
    * Prepares the organisation units of the given parameters to simplify querying. Mode ACCESSIBLE
-   * is converted to DESCENDANTS for organisation units linked to the given user, and mode CHILDREN
-   * is converted to CHILDREN for organisation units including all their children. Mode can be
-   * DESCENDANTS, SELECTED, ALL only after invoking this method.
+   * is converted to DESCENDANTS for organisation units linked to the search scope of the given
+   * user. Mode CAPTURE is converted to DESCENDANTS too, but using organisation units linked to the
+   * user's capture scope, and mode CHILDREN is converted to SELECTED for organisation units
+   * including all their children. Mode can be DESCENDANTS, SELECTED, ALL only after invoking this
+   * method.
    */
   public void handleOrganisationUnits() {
     if (user != null && isOrganisationUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE)) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventSearchParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventSearchParams.java
@@ -112,6 +112,8 @@ public class EventSearchParams {
 
   private OrganisationUnit orgUnit;
 
+  private List<OrganisationUnit> accessibleOrgUnits = new ArrayList<>();
+
   private OrganisationUnitSelectionMode orgUnitSelectionMode;
 
   private TrackedEntity trackedEntity;
@@ -327,6 +329,15 @@ public class EventSearchParams {
 
   public EventSearchParams setOrgUnit(OrganisationUnit orgUnit) {
     this.orgUnit = orgUnit;
+    return this;
+  }
+
+  public List<OrganisationUnit> getAccessibleOrgUnits() {
+    return accessibleOrgUnits;
+  }
+
+  public EventSearchParams setAccessibleOrgUnits(List<OrganisationUnit> accessibleOrgUnits) {
+    this.accessibleOrgUnits = accessibleOrgUnits;
     return this;
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/AclEventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/AclEventExporterTest.java
@@ -1,0 +1,444 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.event;
+
+import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
+import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
+import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CHILDREN;
+import static org.hisp.dhis.common.OrganisationUnitSelectionMode.DESCENDANTS;
+import static org.hisp.dhis.common.OrganisationUnitSelectionMode.SELECTED;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.commons.collection.CollectionUtils;
+import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.tracker.TrackerTest;
+import org.hisp.dhis.tracker.imports.TrackerImportService;
+import org.hisp.dhis.user.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class AclEventExporterTest extends TrackerTest {
+
+  @Autowired private EventService eventService;
+
+  @Autowired private TrackerImportService trackerImportService;
+
+  @Autowired private IdentifiableObjectManager manager;
+
+  private OrganisationUnit orgUnit;
+
+  private Program program;
+
+  @Override
+  protected void initTest() throws IOException {
+    setUpMetadata("tracker/simple_metadata.json");
+    User userA = userService.getUser("M5zQapPyTZI");
+    assertNoErrors(
+        trackerImportService.importTracker(
+            fromJson("tracker/event_and_enrollment.json", userA.getUid())));
+    orgUnit = get(OrganisationUnit.class, "h4w96yEMlzO");
+    ProgramStage programStage = get(ProgramStage.class, "NpsdDv6kKSO");
+    program = programStage.getProgram();
+
+    // to test that events are only returned if the user has read access to ALL COs of an events COC
+    CategoryOption categoryOption = get(CategoryOption.class, "yMj2MnmNI8L");
+    categoryOption.getSharing().setOwner("o1HMTIzBGo7");
+    manager.update(categoryOption);
+
+    manager.flush();
+
+    injectSecurityContext(userService.getUser("M5zQapPyTZI"));
+  }
+
+  @BeforeEach
+  void setUp() {
+    // needed as some tests are run using another user (injectSecurityContext) while most tests
+    // expect to be run by admin
+    injectAdminUser();
+  }
+
+  @Test
+  void shouldReturnEventsWhenProgramClosedOuModeDescendantsAndOrgUnitInCaptureScope()
+      throws ForbiddenException, BadRequestException {
+    injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
+    EventOperationParams params =
+        EventOperationParams.builder()
+            .programUid("pcxIanBWlSY")
+            .orgUnitUid(orgUnit.getUid())
+            .orgUnitSelectionMode(DESCENDANTS)
+            .build();
+
+    List<Event> events = eventService.getEvents(params).getEvents();
+
+    assertFalse(
+        events.isEmpty(),
+        "Expected to find events when ou mode descendants and org units in capture scope");
+    events.forEach(
+        e ->
+            assertEquals(
+                "uoNW0E3xXUy",
+                e.getOrganisationUnit().getUid(),
+                "Expected to find descendant org unit uoNW0E3xXUy, but found "
+                    + e.getOrganisationUnit().getUid()
+                    + " instead"));
+  }
+
+  @Test
+  void shouldReturnEventsWhenNoProgramSpecifiedOuModeDescendantsAndOrgUnitInSearchScope()
+      throws ForbiddenException, BadRequestException {
+    injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
+    EventOperationParams params =
+        EventOperationParams.builder()
+            .orgUnitUid(orgUnit.getUid())
+            .orgUnitSelectionMode(DESCENDANTS)
+            .build();
+
+    List<Event> events = eventService.getEvents(params).getEvents();
+
+    assertFalse(
+        events.isEmpty(),
+        "Expected to find events when no program specified, ou mode descendants and org units in search scope");
+    assertContainsOnly(
+        events.stream().map(e -> e.getOrganisationUnit().getUid()).toList(),
+        List.of("uoNW0E3xXUy", "h4w96yEMlzO", "tSsGrtfRzjY"));
+  }
+
+  @Test
+  void shouldReturnEventsWhenProgramClosedOuModeChildrenAndOrgUnitInCaptureScope()
+      throws ForbiddenException, BadRequestException {
+    injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
+    EventOperationParams params =
+        EventOperationParams.builder()
+            .programUid("pcxIanBWlSY")
+            .orgUnitUid(orgUnit.getUid())
+            .orgUnitSelectionMode(CHILDREN)
+            .build();
+
+    List<Event> events = eventService.getEvents(params).getEvents();
+
+    assertFalse(
+        events.isEmpty(),
+        "Expected to find events when ou mode children and org units in capture scope");
+    events.forEach(
+        e ->
+            assertEquals(
+                "uoNW0E3xXUy",
+                e.getOrganisationUnit().getUid(),
+                "Expected to find children org unit uoNW0E3xXUy, but found "
+                    + e.getOrganisationUnit().getUid()
+                    + " instead"));
+  }
+
+  @Test
+  void shouldReturnEventsWhenNoProgramSpecifiedOuModeChildrenAndOrgUnitInSearchScope()
+      throws ForbiddenException, BadRequestException {
+    injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
+    EventOperationParams params =
+        EventOperationParams.builder()
+            .orgUnitUid(orgUnit.getUid())
+            .orgUnitSelectionMode(CHILDREN)
+            .build();
+
+    List<Event> events = eventService.getEvents(params).getEvents();
+
+    assertFalse(
+        events.isEmpty(),
+        "Expected to find events when no program specified, ou mode children and org units in search scope");
+    events.forEach(
+        e ->
+            assertEquals(
+                "uoNW0E3xXUy",
+                e.getOrganisationUnit().getUid(),
+                "Expected to find children org unit uoNW0E3xXUy, but found "
+                    + e.getOrganisationUnit().getUid()
+                    + " instead"));
+  }
+
+  @Test
+  void shouldFailWhenProgramIsOpenAndOrgUnitNotInSearchScope() {
+    injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
+    EventOperationParams params =
+        EventOperationParams.builder()
+            .programUid(program.getUid())
+            .orgUnitUid("DiszpKrYNg8")
+            .orgUnitSelectionMode(DESCENDANTS)
+            .build();
+
+    ForbiddenException exception =
+        assertThrows(ForbiddenException.class, () -> eventService.getEvents(params));
+    assertEquals("User does not have access to orgUnit: DiszpKrYNg8", exception.getMessage());
+  }
+
+  @Test
+  void shouldFailWhenProgramIsClosedAndOrgUnitNotInCaptureScope() {
+    injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
+    EventOperationParams params =
+        EventOperationParams.builder()
+            .programUid("pcxIanBWlSY")
+            .orgUnitUid("DiszpKrYNg8")
+            .orgUnitSelectionMode(DESCENDANTS)
+            .build();
+
+    ForbiddenException exception =
+        assertThrows(ForbiddenException.class, () -> eventService.getEvents(params));
+    assertEquals("User does not have access to orgUnit: DiszpKrYNg8", exception.getMessage());
+  }
+
+  @Test
+  void shouldReturnEventsWhenProgramClosedOuModeSelectedAndOrgUnitInCaptureScope()
+      throws ForbiddenException, BadRequestException {
+    injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
+    EventOperationParams params =
+        EventOperationParams.builder()
+            .programUid("pcxIanBWlSY")
+            .orgUnitUid("uoNW0E3xXUy")
+            .orgUnitSelectionMode(SELECTED)
+            .build();
+
+    List<Event> events = eventService.getEvents(params).getEvents();
+
+    assertFalse(
+        events.isEmpty(),
+        "Expected to find events when ou mode selected and org units in capture scope");
+    events.forEach(
+        e ->
+            assertEquals(
+                "uoNW0E3xXUy",
+                e.getOrganisationUnit().getUid(),
+                "Expected to find selected org unit uoNW0E3xXUy, but found "
+                    + e.getOrganisationUnit().getUid()
+                    + " instead"));
+  }
+
+  @Test
+  void shouldReturnEventsWhenNoProgramSpecifiedOuModeSelectedAndOrgUnitInSearchScope()
+      throws ForbiddenException, BadRequestException {
+    injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
+    EventOperationParams params =
+        EventOperationParams.builder()
+            .orgUnitUid(orgUnit.getUid())
+            .orgUnitSelectionMode(SELECTED)
+            .build();
+
+    List<Event> events = eventService.getEvents(params).getEvents();
+
+    assertFalse(
+        events.isEmpty(),
+        "Expected to find events when no program specified, ou mode descendants and org units in search scope");
+
+    events.forEach(
+        e ->
+            assertEquals(
+                "h4w96yEMlzO",
+                e.getOrganisationUnit().getUid(),
+                "Expected to find selected org unit h4w96yEMlzO, but found "
+                    + e.getOrganisationUnit().getUid()
+                    + " instead"));
+  }
+
+  @Test
+  void shouldReturnNoEventsWhenProgramOpenOuModeSelectedAndNoProgramEvents()
+      throws ForbiddenException, BadRequestException {
+    injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
+    EventOperationParams params =
+        EventOperationParams.builder()
+            .programUid("shPjYNifvMK")
+            .orgUnitUid(orgUnit.getUid())
+            .orgUnitSelectionMode(SELECTED)
+            .build();
+
+    List<Event> events = eventService.getEvents(params).getEvents();
+
+    assertTrue(events.isEmpty(), "Expected to find no events, but found: " + events.size());
+  }
+
+  @Test
+  void shouldReturnEventsWhenProgramClosedOuModeAccessible()
+      throws ForbiddenException, BadRequestException {
+    injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
+    EventOperationParams params =
+        EventOperationParams.builder()
+            .programUid("pcxIanBWlSY")
+            .orgUnitUid("uoNW0E3xXUy")
+            .orgUnitSelectionMode(ACCESSIBLE)
+            .build();
+
+    List<Event> events = eventService.getEvents(params).getEvents();
+
+    assertFalse(
+        events.isEmpty(), "Expected to find events when ou mode accessible and program closed");
+    events.forEach(
+        e ->
+            assertEquals(
+                "uoNW0E3xXUy",
+                e.getOrganisationUnit().getUid(),
+                "Expected to find accessible org unit uoNW0E3xXUy, but found "
+                    + e.getOrganisationUnit().getUid()
+                    + " instead"));
+  }
+
+  @Test
+  void shouldReturnEventsWhenProgramOpenOuModeAccessible()
+      throws ForbiddenException, BadRequestException {
+    injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
+    EventOperationParams params =
+        EventOperationParams.builder()
+            .programUid(program.getUid())
+            .orgUnitSelectionMode(ACCESSIBLE)
+            .build();
+
+    List<Event> events = eventService.getEvents(params).getEvents();
+
+    assertFalse(
+        events.isEmpty(), "Expected to find events when ou mode accessible and program open");
+    events.forEach(
+        e ->
+            assertEquals(
+                "h4w96yEMlzO",
+                e.getOrganisationUnit().getUid(),
+                "Expected to find accessible org unit h4w96yEMlzO, but found "
+                    + e.getOrganisationUnit().getUid()
+                    + " instead"));
+  }
+
+  @Test
+  void shouldReturnEventsWhenProgramOpenOuModeCapture()
+      throws ForbiddenException, BadRequestException {
+    injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
+    EventOperationParams params =
+        EventOperationParams.builder()
+            .programUid("pcxIanBWlSY")
+            .orgUnitUid("uoNW0E3xXUy")
+            .orgUnitSelectionMode(CAPTURE)
+            .build();
+
+    List<Event> events = eventService.getEvents(params).getEvents();
+
+    assertFalse(
+        events.isEmpty(), "Expected to find events when ou mode capture and program closed");
+    events.forEach(
+        e ->
+            assertEquals(
+                "uoNW0E3xXUy",
+                e.getOrganisationUnit().getUid(),
+                "Expected to find capture org unit uoNW0E3xXUy, but found "
+                    + e.getOrganisationUnit().getUid()
+                    + " instead"));
+  }
+
+  @Test
+  void shouldReturnSelectedOrgUnitEventsWhenNoOuModeSpecifiedAndUserHasAccessToOrgUnit()
+      throws ForbiddenException, BadRequestException {
+    injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
+    EventOperationParams params =
+        EventOperationParams.builder().programUid("pcxIanBWlSY").orgUnitUid("uoNW0E3xXUy").build();
+
+    List<Event> events = eventService.getEvents(params).getEvents();
+
+    assertFalse(
+        events.isEmpty(), "Expected to find selected org unit events when ou mode not specified");
+    events.forEach(
+        e ->
+            assertEquals(
+                "uoNW0E3xXUy",
+                e.getOrganisationUnit().getUid(),
+                "Expected to find accessible org unit uoNW0E3xXUy, but found "
+                    + e.getOrganisationUnit().getUid()
+                    + " instead"));
+  }
+
+  @Test
+  void shouldFailWhenNoOuModeSpecifiedAndUserHasNoAccessToOrgUnit() {
+    injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
+    EventOperationParams params =
+        EventOperationParams.builder().programUid("pcxIanBWlSY").orgUnitUid("DiszpKrYNg8").build();
+
+    ForbiddenException exception =
+        assertThrows(ForbiddenException.class, () -> eventService.getEvents(params));
+    assertEquals("User does not have access to orgUnit: DiszpKrYNg8", exception.getMessage());
+  }
+
+  @Test
+  void shouldReturnAccessibleOrgUnitEventsWhenNoOrgUnitSpecifiedNorOuModeSpecified()
+      throws ForbiddenException, BadRequestException {
+    injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
+    EventOperationParams params = EventOperationParams.builder().programUid("pcxIanBWlSY").build();
+
+    List<Event> events = eventService.getEvents(params).getEvents();
+
+    assertFalse(
+        events.isEmpty(), "Expected to find accessible org unit events when ou mode not specified");
+    events.forEach(
+        e ->
+            assertEquals(
+                "uoNW0E3xXUy",
+                e.getOrganisationUnit().getUid(),
+                "Expected to find accessible org unit uoNW0E3xXUy, but found "
+                    + e.getOrganisationUnit().getUid()
+                    + " instead"));
+  }
+
+  private void assertContainsOnly(List<String> actualOrgUnits, List<String> expectedOrgUnits) {
+    List<String> missing = CollectionUtils.difference(expectedOrgUnits, actualOrgUnits);
+    List<String> extra = CollectionUtils.difference(actualOrgUnits, expectedOrgUnits);
+
+    assertAll(
+        "assertContainsAllOrgUnits found mismatch",
+        () ->
+            assertTrue(
+                missing.isEmpty(),
+                () -> String.format("Expected %s to be in %s", missing, actualOrgUnits)),
+        () ->
+            assertTrue(
+                extra.isEmpty(),
+                () -> String.format("Expected %s NOT to be in %s", extra, actualOrgUnits)));
+  }
+
+  private <T extends IdentifiableObject> T get(Class<T> type, String uid) {
+    T t = manager.get(type, uid);
+    assertNotNull(t, () -> String.format("metadata with uid '%s' should have been created", uid));
+    return t;
+  }
+}

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -119,6 +119,8 @@ class EventExporterTest extends TrackerTest {
     manager.update(categoryOption);
 
     manager.flush();
+
+    injectSecurityContext(userService.getUser("M5zQapPyTZI"));
   }
 
   @BeforeEach

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
@@ -126,6 +126,138 @@
         }
       ],
       "enrollments": []
+    },
+    {
+      "trackedEntity": "mHWCacsGYYn",
+      "trackedEntityType": {
+        "idScheme": "UID",
+        "identifier": "ja8NY4PW7Xm"
+      },
+      "createdAt": "2020-02-20T12:09:21.844",
+      "updatedAt": "2020-02-20T12:09:21.844",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
+      "inactive": false,
+      "deleted": false,
+      "potentialDuplicate": false,
+      "relationships": [],
+      "attributes": [
+        {
+          "valueType": "TEXT",
+          "attribute": {
+            "idScheme": "UID",
+            "identifier": "toDelete000"
+          },
+          "value": "just day"
+        },
+        {
+          "valueType": "TEXT",
+          "attribute": {
+            "idScheme": "UID",
+            "identifier": "toUpdate000"
+          },
+          "value": "summer day"
+        },
+        {
+          "valueType": "INTEGER",
+          "attribute": {
+            "idScheme": "UID",
+            "identifier": "numericAttr"
+          },
+          "value": 88
+        }
+      ],
+      "enrollments": []
+    },
+    {
+      "trackedEntity": "QesgJkTyTCk",
+      "trackedEntityType": {
+        "idScheme": "UID",
+        "identifier": "ja8NY4PW7Xm"
+      },
+      "createdAt": "2020-02-20T12:09:21.844",
+      "updatedAt": "2020-02-20T12:09:21.844",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
+      "inactive": false,
+      "deleted": false,
+      "potentialDuplicate": false,
+      "relationships": [],
+      "attributes": [
+        {
+          "valueType": "TEXT",
+          "attribute": {
+            "idScheme": "UID",
+            "identifier": "toDelete000"
+          },
+          "value": "just day"
+        },
+        {
+          "valueType": "TEXT",
+          "attribute": {
+            "idScheme": "UID",
+            "identifier": "toUpdate000"
+          },
+          "value": "summer day"
+        },
+        {
+          "valueType": "INTEGER",
+          "attribute": {
+            "idScheme": "UID",
+            "identifier": "numericAttr"
+          },
+          "value": 88
+        }
+      ],
+      "enrollments": []
+    },
+    {
+      "trackedEntity": "guVNoAerxWo",
+      "trackedEntityType": {
+        "idScheme": "UID",
+        "identifier": "ja8NY4PW7Xm"
+      },
+      "createdAt": "2020-02-20T12:09:21.844",
+      "updatedAt": "2020-02-20T12:09:21.844",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "tSsGrtfRzjY"
+      },
+      "inactive": false,
+      "deleted": false,
+      "potentialDuplicate": false,
+      "relationships": [],
+      "attributes": [
+        {
+          "valueType": "TEXT",
+          "attribute": {
+            "idScheme": "UID",
+            "identifier": "toDelete000"
+          },
+          "value": "just day"
+        },
+        {
+          "valueType": "TEXT",
+          "attribute": {
+            "idScheme": "UID",
+            "identifier": "toUpdate000"
+          },
+          "value": "summer day"
+        },
+        {
+          "valueType": "INTEGER",
+          "attribute": {
+            "idScheme": "UID",
+            "identifier": "numericAttr"
+          },
+          "value": 88
+        }
+      ],
+      "enrollments": []
     }
   ],
   "enrollments": [
@@ -169,6 +301,78 @@
       "orgUnitName": "Mbokie CHP",
       "enrolledAt": "2021-03-28T12:05:00.000",
       "occurredAt": "2021-03-28T12:05:00.000",
+      "dueDate": "2021-02-28T12:05:00.000",
+      "followUp": false,
+      "deleted": false,
+      "events": [],
+      "relationships": [],
+      "attributes": [],
+      "notes": []
+    },
+    {
+      "enrollment": "JuioKiICQqI",
+      "createdAtClient": "2017-01-26T13:48:13.363",
+      "trackedEntity": "mHWCacsGYYn",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "shPjYNifvMK"
+      },
+      "status": "ACTIVE",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "uoNW0E3xXUy"
+      },
+      "orgUnitName": "test-orgunit-2",
+      "enrolledAt": "2021-02-28T12:05:00.000",
+      "occurredAt": "2021-02-28T12:05:00.000",
+      "dueDate": "2021-02-28T12:05:00.000",
+      "followUp": false,
+      "deleted": false,
+      "events": [],
+      "relationships": [],
+      "attributes": [],
+      "notes": []
+    },
+    {
+      "enrollment": "iHFHfPKTSYP",
+      "createdAtClient": "2017-01-26T13:48:13.363",
+      "trackedEntity": "QesgJkTyTCk",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "pcxIanBWlSY"
+      },
+      "status": "ACTIVE",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "uoNW0E3xXUy"
+      },
+      "orgUnitName": "test-orgunit-2",
+      "enrolledAt": "2021-02-28T12:05:00.000",
+      "occurredAt": "2021-02-28T12:05:00.000",
+      "dueDate": "2021-02-28T12:05:00.000",
+      "followUp": false,
+      "deleted": false,
+      "events": [],
+      "relationships": [],
+      "attributes": [],
+      "notes": []
+    },
+    {
+      "enrollment": "ipBifypAQTo",
+      "createdAtClient": "2017-01-26T13:48:13.363",
+      "trackedEntity": "guVNoAerxWo",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "UWRnoyBjvqi"
+      },
+      "status": "ACTIVE",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "tSsGrtfRzjY"
+      },
+      "orgUnitName": "test-orgunit-3",
+      "enrolledAt": "2021-02-28T12:05:00.000",
+      "occurredAt": "2021-02-28T12:05:00.000",
       "dueDate": "2021-02-28T12:05:00.000",
       "followUp": false,
       "deleted": false,
@@ -355,6 +559,82 @@
         "surname": "Traore",
         "username": "admin"
       }
+    },
+    {
+      "event": "jxgFyJEMUPf",
+      "status": "COMPLETED",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "shPjYNifvMK"
+      },
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "SKNvpoLioON"
+      },
+      "enrollment": "JuioKiICQqI",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "uoNW0E3xXUy"
+      },
+      "relationships": [],
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "storedBy": "admin",
+      "followup": false,
+      "deleted": false,
+      "createdAt": "2019-01-28T12:10:38.108",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
+      "completedBy": "admin",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "notes": []
+    },
+    {
+      "event": "JaRDIvcEcEx",
+      "status": "COMPLETED",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "pcxIanBWlSY"
+      },
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "ebGXHEqqEMF"
+      },
+      "enrollment": "iHFHfPKTSYP",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "uoNW0E3xXUy"
+      },
+      "relationships": [],
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "storedBy": "admin",
+      "followup": false,
+      "deleted": false,
+      "createdAt": "2019-01-28T12:10:38.108",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
+      "completedBy": "admin",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "notes": []
     },
     {
       "event": "QRYjLTiJTrA",
@@ -711,6 +991,38 @@
           "value": "12"
         }
       ]
+    },
+    {
+      "event": "gvULMgNiAfM",
+      "status": "COMPLETED",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "UWRnoyBjvqi"
+      },
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "ZfzckZBvDkA"
+      },
+      "enrollment": "ipBifypAQTo",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "tSsGrtfRzjY"
+      },
+      "relationships": [],
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "storedBy": "admin",
+      "followup": false,
+      "deleted": false,
+      "createdAt": "2019-01-28T12:10:38.108",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
+      "completedBy": "admin",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "notes": []
     }
   ],
   "relationships": [],

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/simple_metadata.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/simple_metadata.json
@@ -1117,6 +1117,132 @@
         }
       ],
       "programStageSections": []
+    },
+    {
+      "lastUpdated": "2020-05-31T11:41:22.426",
+      "id": "SKNvpoLioON",
+      "created": "2020-05-31T09:02:52.687",
+      "name": "test-program-stage2",
+      "allowGenerateNextVisit": false,
+      "preGenerateUID": false,
+      "publicAccess": "rwrw----",
+      "description": "test-program-stage2",
+      "openAfterEnrollment": false,
+      "repeatable": true,
+      "remindCompleted": false,
+      "displayGenerateEventBox": true,
+      "generatedByEnrollmentDate": false,
+      "validationStrategy": "ON_COMPLETE",
+      "autoGenerateEvent": true,
+      "sortOrder": 1,
+      "hideDueDate": false,
+      "blockEntryForm": false,
+      "enableUserAssignment": false,
+      "minDaysFromStart": 0,
+      "program": {
+        "id": "shPjYNifvMK"
+      },
+      "lastUpdatedBy": {
+        "id": "FIgVWzUCkpw"
+      },
+      "user": {
+        "id": "FIgVWzUCkpw"
+      },
+      "notificationTemplates": [
+        {
+          "id": "FdIeUL4gyoB"
+        }
+      ],
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": [],
+      "programStageSections": [],
+      "programStageDataElements": []
+    },
+    {
+      "lastUpdated": "2020-05-31T11:41:22.426",
+      "id": "ebGXHEqqEMF",
+      "created": "2020-05-31T09:02:52.687",
+      "name": "test-program-stage-closed",
+      "allowGenerateNextVisit": false,
+      "preGenerateUID": false,
+      "publicAccess": "rwrw----",
+      "description": "test-program-stage-closed",
+      "openAfterEnrollment": false,
+      "repeatable": true,
+      "remindCompleted": false,
+      "displayGenerateEventBox": true,
+      "generatedByEnrollmentDate": false,
+      "validationStrategy": "ON_COMPLETE",
+      "autoGenerateEvent": true,
+      "sortOrder": 1,
+      "hideDueDate": false,
+      "blockEntryForm": false,
+      "enableUserAssignment": false,
+      "minDaysFromStart": 0,
+      "program": {
+        "id": "shPjYNifvMK"
+      },
+      "lastUpdatedBy": {
+        "id": "FIgVWzUCkpw"
+      },
+      "user": {
+        "id": "FIgVWzUCkpw"
+      },
+      "notificationTemplates": [
+        {
+          "id": "FdIeUL4gyoB"
+        }
+      ],
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": [],
+      "programStageSections": [],
+      "programStageDataElements": []
+    },
+    {
+      "lastUpdated": "2020-05-31T11:41:22.426",
+      "id": "ZfzckZBvDkA",
+      "created": "2020-05-31T09:02:52.687",
+      "name": "test-program-stage-low-level-org-unit",
+      "allowGenerateNextVisit": false,
+      "preGenerateUID": false,
+      "publicAccess": "rwrw----",
+      "description": "test-program-stage-low-level-org-unit",
+      "openAfterEnrollment": false,
+      "repeatable": true,
+      "remindCompleted": false,
+      "displayGenerateEventBox": true,
+      "generatedByEnrollmentDate": false,
+      "validationStrategy": "ON_COMPLETE",
+      "autoGenerateEvent": true,
+      "sortOrder": 1,
+      "hideDueDate": false,
+      "blockEntryForm": false,
+      "enableUserAssignment": false,
+      "minDaysFromStart": 0,
+      "program": {
+        "id": "UWRnoyBjvqi"
+      },
+      "lastUpdatedBy": {
+        "id": "FIgVWzUCkpw"
+      },
+      "user": {
+        "id": "FIgVWzUCkpw"
+      },
+      "notificationTemplates": [
+        {
+          "id": "FdIeUL4gyoB"
+        }
+      ],
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": [],
+      "programStageSections": [],
+      "programStageDataElements": []
     }
   ],
   "users": [
@@ -1324,6 +1450,61 @@
           "id": "DiszpKrYNg8"
         }
       ]
+    },
+    {
+      "id": "FIgVWzUCkpw",
+      "created": "2020-05-31T08:57:59.048",
+      "surname": "child level 2",
+      "email": "aaaa@dhis2.org",
+      "firstName": "child level 2",
+      "password": "Test123###...",
+      "phoneNumber": "+4740332255",
+      "name": "child level 2",
+      "displayName": "child level 2",
+      "externalAuth": false,
+      "externalAccess": false,
+      "disabled": false,
+      "twoFA": false,
+      "passwordLastUpdated": "2020-05-31T08:57:59.060",
+      "invitation": false,
+      "selfRegistered": false,
+      "favorite": false,
+      "username": "childlevel2",
+      "access": {
+        "read": true,
+        "update": true,
+        "externalize": true,
+        "delete": true,
+        "write": true,
+        "manage": true
+      },
+      "favorites": [],
+      "cogsDimensionConstraints": [],
+      "catDimensionConstraints": [],
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userRoles": [
+        {
+          "id": "UbhT3bXWUyb"
+        }
+      ],
+      "userAccesses": [],
+      "teiSearchOrganisationUnits": [
+        {
+          "id": "h4w96yEMlzO"
+        }
+      ],
+      "organisationUnits": [
+        {
+          "id": "uoNW0E3xXUy"
+        }
+      ],
+      "dataViewOrganisationUnits": [
+        {
+          "id": "uoNW0E3xXUy"
+        }
+      ]
     }
   ],
   "organisationUnits": [
@@ -1359,6 +1540,28 @@
       "openingDate": "2020-05-31T00:00:00.000",
       "parent": {
         "id": "h4w96yEMlzO"
+      },
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "attributeValues": [],
+      "translations": []
+    },
+    {
+      "id": "tSsGrtfRzjY",
+      "name": "test-orgunit-3",
+      "level": 3,
+      "created": "2020-05-31T09:05:34.570",
+      "lastUpdated": "2020-05-31T11:41:22.385",
+      "shortName": "test-program-rule",
+      "path": "/h4w96yEMlzO/uoNW0E3xXUy/tSsGrtfRzjY",
+      "closedDate": "2020-12-27T00:00:00.000",
+      "openingDate": "2020-05-31T00:00:00.000",
+      "parent": {
+        "id": "uoNW0E3xXUy"
       },
       "lastUpdatedBy": {
         "id": "M5zQapPyTZI"
@@ -1550,6 +1753,162 @@
           "id": "qLZC0lvvxQH"
         }
       ]
+    },
+    {
+      "id": "shPjYNifvMK",
+      "name": "test-program",
+      "shortName": "test-program",
+      "lastUpdated": "2020-05-31T11:41:22.438",
+      "created": "2020-05-31T09:02:52.718",
+      "publicAccess": "rwrw----",
+      "completeEventsExpiryDays": 0,
+      "ignoreOverdueEvents": false,
+      "skipOffline": false,
+      "minAttributesRequiredToSearch": 1,
+      "displayFrontPageList": false,
+      "onlyEnrollOnce": false,
+      "programType": "WITH_REGISTRATION",
+      "accessLevel": "OPEN",
+      "version": 2,
+      "maxTeiCountToReturn": 0,
+      "selectIncidentDatesInFuture": false,
+      "displayIncidentDate": true,
+      "selectEnrollmentDatesInFuture": false,
+      "expiryDays": 0,
+      "useFirstStageDuringRegistration": false,
+      "categoryCombo": {
+        "id": "bjDvmb4bfuf"
+      },
+      "lastUpdatedBy": {
+        "id": "FIgVWzUCkpw"
+      },
+      "trackedEntityType": {
+        "id": "ja8NY4PW7Xm"
+      },
+      "user": {
+        "id": "FIgVWzUCkpw"
+      },
+      "programTrackedEntityAttributes": [],
+      "notificationTemplates": [],
+      "translations": [],
+      "organisationUnits": [
+        {
+          "id": "uoNW0E3xXUy"
+        }
+      ],
+      "userGroupAccesses": [],
+      "programSections": [],
+      "attributeValues": [],
+      "programStages": [
+        {
+          "id": "SKNvpoLioON"
+        }
+      ],
+      "userAccesses": []
+    },
+    {
+      "id": "pcxIanBWlSY",
+      "name": "test-program-closed",
+      "shortName": "test-program-closed",
+      "lastUpdated": "2020-05-31T11:41:22.438",
+      "created": "2020-05-31T09:02:52.718",
+      "publicAccess": "rwrw----",
+      "completeEventsExpiryDays": 0,
+      "ignoreOverdueEvents": false,
+      "skipOffline": false,
+      "minAttributesRequiredToSearch": 1,
+      "displayFrontPageList": false,
+      "onlyEnrollOnce": false,
+      "programType": "WITH_REGISTRATION",
+      "accessLevel": "CLOSED",
+      "version": 2,
+      "maxTeiCountToReturn": 0,
+      "selectIncidentDatesInFuture": false,
+      "displayIncidentDate": true,
+      "selectEnrollmentDatesInFuture": false,
+      "expiryDays": 0,
+      "useFirstStageDuringRegistration": false,
+      "categoryCombo": {
+        "id": "bjDvmb4bfuf"
+      },
+      "lastUpdatedBy": {
+        "id": "FIgVWzUCkpw"
+      },
+      "trackedEntityType": {
+        "id": "ja8NY4PW7Xm"
+      },
+      "user": {
+        "id": "FIgVWzUCkpw"
+      },
+      "programTrackedEntityAttributes": [],
+      "notificationTemplates": [],
+      "translations": [],
+      "organisationUnits": [
+        {
+          "id": "uoNW0E3xXUy"
+        }
+      ],
+      "userGroupAccesses": [],
+      "programSections": [],
+      "attributeValues": [],
+      "programStages": [
+        {
+          "id": "ebGXHEqqEMF"
+        }
+      ],
+      "userAccesses": []
+    },
+    {
+      "id": "UWRnoyBjvqi",
+      "name": "test-program-low-level-org-unit",
+      "shortName": "test-program-low-level-org-unit",
+      "lastUpdated": "2020-05-31T11:41:22.438",
+      "created": "2020-05-31T09:02:52.718",
+      "publicAccess": "rwrw----",
+      "completeEventsExpiryDays": 0,
+      "ignoreOverdueEvents": false,
+      "skipOffline": false,
+      "minAttributesRequiredToSearch": 1,
+      "displayFrontPageList": false,
+      "onlyEnrollOnce": false,
+      "programType": "WITH_REGISTRATION",
+      "accessLevel": "CLOSED",
+      "version": 2,
+      "maxTeiCountToReturn": 0,
+      "selectIncidentDatesInFuture": false,
+      "displayIncidentDate": true,
+      "selectEnrollmentDatesInFuture": false,
+      "expiryDays": 0,
+      "useFirstStageDuringRegistration": false,
+      "categoryCombo": {
+        "id": "bjDvmb4bfuf"
+      },
+      "lastUpdatedBy": {
+        "id": "FIgVWzUCkpw"
+      },
+      "trackedEntityType": {
+        "id": "ja8NY4PW7Xm"
+      },
+      "user": {
+        "id": "FIgVWzUCkpw"
+      },
+      "programTrackedEntityAttributes": [],
+      "notificationTemplates": [],
+      "translations": [],
+      "organisationUnits": [
+        {
+          "id": "tSsGrtfRzjY"
+        }
+      ],
+      "userGroupAccesses": [],
+      "programSections": [],
+      "attributeValues": [],
+      "programStages": [
+        {
+          "id": "ZfzckZBvDkA"
+        }
+      ],
+      "userAccesses": []
     }
   ],
   "userRoles": [


### PR DESCRIPTION
When a request uses the ouMode DESCENDANTS or CHILDREN, we don't check whether the user has access to any of the children org units related to the one in the request. More on this [here](https://docs.google.com/document/d/18C_NfbvoH0Dt4tySlsBMWsOJpTS0E_2TLtYCZVyIjNw/edit?pli=1).

To fix this, there are two steps:

    New validation in the service layer in case the mode is one of the two mentioned above. It gets all the lower level related org units and if any of them is the same as the capture scope/search scope org unit, the user is granted access.
    Added a clause in the sql query, where we filter by the particular org unit(s) the user has access to.

Ticket: https://dhis2.atlassian.net/browse/DHIS2-15394