### PR TITLE
fix: Gist API parse filter value correctly and allow single groups [DHIS2-15565] (2.40)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.gist;
 
+import static java.lang.Integer.parseInt;
 import static java.lang.Math.abs;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -38,6 +39,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.BiFunction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -165,11 +168,7 @@ public final class GistQuery {
   }
 
   public boolean hasFilterGroups() {
-    if (filters.size() <= 1) {
-      return false;
-    }
-    int group0 = filters.get(0).group;
-    return filters.stream().anyMatch(f -> f.group != group0);
+    return filters.size() > 1 && filters.stream().anyMatch(f -> f.getGroup() >= 0);
   }
 
   public GistQuery with(GistParams params) {
@@ -489,33 +488,31 @@ public final class GistQuery {
           : new Filter(group, propertyPath, operator, value, attribute);
     }
 
+    /**
+     * Expression syntax is (with : being any of the allowed delimiters)
+     *
+     * <pre>
+     *   [group : ] name : op [ : value ]
+     * </pre>
+     */
+    private static final Pattern FILTER_SPLIT =
+        Pattern.compile("(?:(\\d+)[:~@]{1,2})?([^:~@]+)[:~@]{1,2}([^:~@]+)(?:[:~@]{1,2}(.*))?");
+
     public static Filter parse(String filter) {
-      String[] parts = filter.split("(?:::|:|~|@)");
-      int group = 0;
-      int nameIndex = 0;
-      int opIndex = 1;
-      int valueIndex = 2;
-      if (parts[0].matches("[0-9]")) {
-        nameIndex++;
-        opIndex++;
-        valueIndex++;
-        group = Integer.parseInt(parts[0]);
-      }
-      if (parts.length == valueIndex) {
-        return new Filter(parts[nameIndex], Comparison.parse(parts[opIndex])).inGroup(group);
-      }
-      if (parts.length == valueIndex + 1) {
-        String value = parts[valueIndex];
-        if (value.startsWith("[") && value.endsWith("]")) {
-          return new Filter(
-                  parts[nameIndex],
-                  Comparison.parse(parts[opIndex]),
-                  value.substring(1, value.length() - 1).split(","))
-              .inGroup(group);
-        }
-        return new Filter(parts[nameIndex], Comparison.parse(parts[opIndex]), value).inGroup(group);
-      }
-      throw new IllegalArgumentException("Not a valid filter expression: " + filter);
+      Matcher m = FILTER_SPLIT.matcher(filter);
+      if (!m.matches())
+        throw new IllegalArgumentException("Not a valid filter expression: " + filter);
+      String group = m.group(1);
+      if (group == null || group.isEmpty()) group = "-1";
+      String name = m.group(2);
+      String op = m.group(3);
+      String value = m.group(4);
+      if (value == null || value.isEmpty())
+        return new Filter(name, Comparison.parse(op)).inGroup(parseInt(group));
+      if (!value.startsWith("[") || !value.endsWith("]"))
+        return new Filter(name, Comparison.parse(op), value).inGroup(parseInt(group));
+      String[] values = value.substring(1, value.length() - 1).split(",");
+      return new Filter(name, Comparison.parse(op), values).inGroup(parseInt(group));
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/gist/GistQueryTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/gist/GistQueryTest.java
@@ -42,9 +42,53 @@ import org.junit.jupiter.api.Test;
 class GistQueryTest {
 
   @Test
-  void testFilterParse() {
-    assertFilterEquals(Filter.parse("name:eq:2"), 0, "name", Comparison.EQ, "2");
-    assertFilterEquals(Filter.parse("1:name:eq:2"), 1, "name", Comparison.EQ, "2");
+  void testFilterParse_SimpleValue() {
+    assertFilterEquals("name:eq:2", -1, "name", Comparison.EQ, "2");
+    assertFilterEquals("name::eq::2", -1, "name", Comparison.EQ, "2");
+    assertFilterEquals("name~eq~2", -1, "name", Comparison.EQ, "2");
+    assertFilterEquals("name@eq@2", -1, "name", Comparison.EQ, "2");
+  }
+
+  @Test
+  void testFilterParse_SimpleValueWithDelimiter() {
+    assertFilterEquals("name:eq:2:3", -1, "name", Comparison.EQ, "2:3");
+  }
+
+  @Test
+  void testFilterParse_GroupSimpleValue() {
+    assertFilterEquals("1:name:eq:2", 1, "name", Comparison.EQ, "2");
+    assertFilterEquals("1~name~eq~2", 1, "name", Comparison.EQ, "2");
+    assertFilterEquals("1@name@eq@2", 1, "name", Comparison.EQ, "2");
+  }
+
+  @Test
+  void testFilterParse_GroupValueWithDelimiter() {
+    assertFilterEquals("1:name:eq:2:3", 1, "name", Comparison.EQ, "2:3");
+  }
+
+  @Test
+  void testFilterParse_ArrayValue() {
+    assertFilterEquals("name:eq:[1,2]", -1, "name", Comparison.EQ, "1", "2");
+  }
+
+  @Test
+  void testFilterParse_ArrayValueWithDelimiters() {
+    assertFilterEquals("name:eq:[1:1,2:2]", -1, "name", Comparison.EQ, "1:1", "2:2");
+  }
+
+  @Test
+  void testFilterParse_GroupArray() {
+    assertFilterEquals("1:name:eq:[1,2]", 1, "name", Comparison.EQ, "1", "2");
+  }
+
+  @Test
+  void testFilterParse_GroupArrayValueWithDelimiters() {
+    assertFilterEquals("2:name:eq:[1:1,2:2]", 2, "name", Comparison.EQ, "1:1", "2:2");
+  }
+
+  private void assertFilterEquals(
+      String filter, int group, String name, Comparison op, String... value) {
+    assertFilterEquals(Filter.parse(filter), group, name, op, value);
   }
 
   private void assertFilterEquals(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFilterControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFilterControllerTest.java
@@ -326,6 +326,26 @@ class GistFilterControllerTest extends AbstractGistControllerTest {
   }
 
   @Test
+  void testFilter_GroupsOR_SingleGroup() {
+    createDataSetsForOrganisationUnit(5, orgUnitId, "alpha");
+    createDataSetsForOrganisationUnit(5, orgUnitId, "beta");
+    createDataSetsForOrganisationUnit(5, orgUnitId, "gamma");
+    // both filters in group 2 are combined OR because root junction is
+    // implicitly AND
+    String url =
+        "/dataSets/gist?filter=2:name:like:alpha&filter=2:name:like:beta&headless=true&order=name";
+    JsonArray matches = GET(url).content();
+    assertEquals(10, matches.size());
+    assertTrue(
+        matches.asList(JsonObject.class).stream()
+            .allMatch(
+                obj -> {
+                  String name = obj.getString("name").string();
+                  return name.startsWith("alpha") || name.startsWith("beta");
+                }));
+  }
+
+  @Test
   void testFilter_GroupAND() {
     createDataSetsForOrganisationUnit(5, orgUnitId, "alpha");
     createDataSetsForOrganisationUnit(5, orgUnitId, "beta");


### PR DESCRIPTION
backport by cherry-pick from #14501