### PR TITLE
fix: Gist API parse filter value correctly and allow single groups [DHIS2-15565] (2.39)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/gist/GistQueryTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/gist/GistQueryTest.java
@@ -42,9 +42,53 @@ import org.junit.jupiter.api.Test;
 class GistQueryTest {
 
   @Test
-  void testFilterParse() {
-    assertFilterEquals(Filter.parse("name:eq:2"), 0, "name", Comparison.EQ, "2");
-    assertFilterEquals(Filter.parse("1:name:eq:2"), 1, "name", Comparison.EQ, "2");
+  void testFilterParse_SimpleValue() {
+    assertFilterEquals("name:eq:2", -1, "name", Comparison.EQ, "2");
+    assertFilterEquals("name::eq::2", -1, "name", Comparison.EQ, "2");
+    assertFilterEquals("name~eq~2", -1, "name", Comparison.EQ, "2");
+    assertFilterEquals("name@eq@2", -1, "name", Comparison.EQ, "2");
+  }
+
+  @Test
+  void testFilterParse_SimpleValueWithDelimiter() {
+    assertFilterEquals("name:eq:2:3", -1, "name", Comparison.EQ, "2:3");
+  }
+
+  @Test
+  void testFilterParse_GroupSimpleValue() {
+    assertFilterEquals("1:name:eq:2", 1, "name", Comparison.EQ, "2");
+    assertFilterEquals("1~name~eq~2", 1, "name", Comparison.EQ, "2");
+    assertFilterEquals("1@name@eq@2", 1, "name", Comparison.EQ, "2");
+  }
+
+  @Test
+  void testFilterParse_GroupValueWithDelimiter() {
+    assertFilterEquals("1:name:eq:2:3", 1, "name", Comparison.EQ, "2:3");
+  }
+
+  @Test
+  void testFilterParse_ArrayValue() {
+    assertFilterEquals("name:eq:[1,2]", -1, "name", Comparison.EQ, "1", "2");
+  }
+
+  @Test
+  void testFilterParse_ArrayValueWithDelimiters() {
+    assertFilterEquals("name:eq:[1:1,2:2]", -1, "name", Comparison.EQ, "1:1", "2:2");
+  }
+
+  @Test
+  void testFilterParse_GroupArray() {
+    assertFilterEquals("1:name:eq:[1,2]", 1, "name", Comparison.EQ, "1", "2");
+  }
+
+  @Test
+  void testFilterParse_GroupArrayValueWithDelimiters() {
+    assertFilterEquals("2:name:eq:[1:1,2:2]", 2, "name", Comparison.EQ, "1:1", "2:2");
+  }
+
+  private void assertFilterEquals(
+      String filter, int group, String name, Comparison op, String... value) {
+    assertFilterEquals(Filter.parse(filter), group, name, op, value);
   }
 
   private void assertFilterEquals(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFilterControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFilterControllerTest.java
@@ -329,6 +329,26 @@ class GistFilterControllerTest extends AbstractGistControllerTest {
   }
 
   @Test
+  void testFilter_GroupsOR_SingleGroup() {
+    createDataSetsForOrganisationUnit(5, orgUnitId, "alpha");
+    createDataSetsForOrganisationUnit(5, orgUnitId, "beta");
+    createDataSetsForOrganisationUnit(5, orgUnitId, "gamma");
+    // both filters in group 2 are combined OR because root junction is
+    // implicitly AND
+    String url =
+        "/dataSets/gist?filter=2:name:like:alpha&filter=2:name:like:beta&headless=true&order=name";
+    JsonArray matches = GET(url).content();
+    assertEquals(10, matches.size());
+    assertTrue(
+        matches.asList(JsonObject.class).stream()
+            .allMatch(
+                obj -> {
+                  String name = obj.getString("name").string();
+                  return name.startsWith("alpha") || name.startsWith("beta");
+                }));
+  }
+
+  @Test
   void testFilter_GroupAND() {
     createDataSetsForOrganisationUnit(5, orgUnitId, "alpha");
     createDataSetsForOrganisationUnit(5, orgUnitId, "beta");


### PR DESCRIPTION
backport by cherry-pick from #14501