### PR TITLE
chore: allow turning off formatter for java via spotless DHIS2-15518

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventRepetition.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventRepetition.java
@@ -56,7 +56,7 @@ public class EventRepetition implements Serializable, EmbeddedObject {
   @Nonnull
   private Attribute parent;
 
-  /** The dimension associated with the event repedition. */
+  /** The dimension associated with the event repetition. */
   @JsonProperty
   @JacksonXmlProperty(namespace = DXF_2_0)
   @Nonnull
@@ -66,12 +66,15 @@ public class EventRepetition implements Serializable, EmbeddedObject {
    * Represents the list of event indexes to be queried. It holds a list of integers that are
    * interpreted as follows:
    *
-   * <p>// @formatter:off
-   *
-   * <p>1 = First event 2 = Second event 3 = Third event ... -2 = Third latest event -1 = Second
-   * latest event 0 = Latest event (default)
-   *
-   * <p>// @formatter:on
+   * <ul>
+   *   <li>1 = First event
+   *   <li>2 = Second event
+   *   <li>3 = Third event
+   *   <li>...
+   *   <li>-2 = Third latest event
+   *   <li>-1 = Second latest event
+   *   <li>0 = Latest event (default)
+   * </ul>
    */
   @JsonProperty
   @JacksonXmlProperty(namespace = DXF_2_0)

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/orgunit/handler/DataOrgUnitMergeHandler.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/orgunit/handler/DataOrgUnitMergeHandler.java
@@ -96,32 +96,28 @@ public class DataOrgUnitMergeHandler {
     // @formatter:off
     return String.format(
         // Delete existing target data values
-        "delete from datavalue where sourceid = :target_id; "
-            +
-            // Insert target data values for last modified source data values
-            "with dv_rank as ( "
-            +
+        "delete from datavalue where sourceid = :target_id; " +
+        // Insert target data values for last modified source data values
+        "with dv_rank as ( " +
             // Window over data value sources ranked by last modification
-            "select dv.*, row_number() over ("
-            + "partition by dv.dataelementid, dv.periodid, dv.categoryoptioncomboid, dv.attributeoptioncomboid "
-            + "order by dv.lastupdated desc, dv.created desc) as lastupdated_rank "
-            + "from datavalue dv "
-            + "where dv.sourceid in (:source_ids) "
-            + "and dv.deleted is false"
-            + ") "
-            +
-            // Insert target data values
-            "insert into datavalue ("
-            + "dataelementid, periodid, sourceid, categoryoptioncomboid, attributeoptioncomboid, "
-            + "value, storedby, created, lastupdated, comment, followup, deleted) "
-            + "select dataelementid, periodid, %s, categoryoptioncomboid, attributeoptioncomboid, "
-            + "value, storedby, created, lastupdated, comment, followup, false "
-            + "from dv_rank "
-            + "where dv_rank.lastupdated_rank = 1; "
-            +
-            // Delete source data values
-            "delete from datavalue where sourceid in (:source_ids);",
-        request.getTarget().getId());
+            "select dv.*, row_number() over (" +
+                "partition by dv.dataelementid, dv.periodid, dv.categoryoptioncomboid, dv.attributeoptioncomboid " +
+                "order by dv.lastupdated desc, dv.created desc) as lastupdated_rank " +
+            "from datavalue dv " +
+            "where dv.sourceid in (:source_ids) " +
+            "and dv.deleted is false" +
+        ") " +
+        // Insert target data values
+        "insert into datavalue (" +
+            "dataelementid, periodid, sourceid, categoryoptioncomboid, attributeoptioncomboid, " +
+            "value, storedby, created, lastupdated, comment, followup, deleted) " +
+        "select dataelementid, periodid, %s, categoryoptioncomboid, attributeoptioncomboid, " +
+            "value, storedby, created, lastupdated, comment, followup, false " +
+        "from dv_rank " +
+        "where dv_rank.lastupdated_rank = 1; " +
+        // Delete source data values
+        "delete from datavalue where sourceid in (:source_ids);",
+        request.getTarget().getId() );
     // @formatter:on
   }
 
@@ -149,7 +145,7 @@ public class DataOrgUnitMergeHandler {
   }
 
   private String getMergeDataApprovalsLastUpdatedSql(OrgUnitMergeRequest request) {
-    // @formatter:offT
+    // @formatter:off
     return String.format(
         // Delete existing target data approvals
         "delete from dataapproval where organisationunitid = :target_id; "

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/JdbcEventStore.java
@@ -1937,7 +1937,6 @@ public class JdbcEventStore implements EventStore {
 
   private void bindEventParamsForInsert(PreparedStatement ps, Event event)
       throws SQLException, JsonProcessingException {
-    // @formatter:off
     ps.setLong(1, event.getEnrollment().getId());
     ps.setLong(2, event.getProgramStage().getId());
     ps.setTimestamp(3, JdbcEventSupport.toTimestamp(event.getDueDate()));
@@ -1964,7 +1963,6 @@ public class JdbcEventStore implements EventStore {
       ps.setObject(21, null);
     }
     ps.setObject(22, eventDataValuesToJson(event.getEventDataValues(), this.jsonMapper));
-    // @formatter:on
   }
 
   private MapSqlParameterSource getSqlParametersForUpdate(org.hisp.dhis.program.Event event)

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/context/AssignedUserSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/context/AssignedUserSupplier.java
@@ -54,7 +54,6 @@ public class AssignedUserSupplier extends AbstractSupplier<Map<String, User>> {
 
   @Override
   public Map<String, User> get(ImportOptions importOptions, List<Event> events) {
-    // @formatter:off
     // Collect all the "assigned user" uids to pass as SQL query argument
     Set<String> userUids =
         events.stream()
@@ -67,7 +66,6 @@ public class AssignedUserSupplier extends AbstractSupplier<Map<String, User>> {
     for (Event event : events) {
       userToEvent.put(event.getAssignedUser(), event.getUid());
     }
-    // @formatter:on
 
     if (!userUids.isEmpty()) {
       final String sql = "select userinfoid, uid, code from userinfo " + "where uid in (:ids)";

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/context/NoteSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/context/NoteSupplier.java
@@ -61,7 +61,6 @@ public class NoteSupplier extends AbstractSupplier<Map<String, Note>> {
     //
     // Collects all the notes' UID
     //
-    // @formatter:off
     Set<String> notesUid =
         events.stream()
             .map(Event::getNotes)
@@ -69,7 +68,6 @@ public class NoteSupplier extends AbstractSupplier<Map<String, Note>> {
             .map(Note::getNote)
             .filter(Objects::nonNull)
             .collect(Collectors.toSet());
-    // @formatter:on
 
     if (isNotEmpty(notesUid)) {
       final String sql = "select uid from trackedentitycomment where uid in  (:ids)";
@@ -92,12 +90,10 @@ public class NoteSupplier extends AbstractSupplier<Map<String, Note>> {
           });
 
       for (Event event : events) {
-        // @formatter:off
         List<Note> eventNotes =
             event.getNotes().stream()
                 .filter(u -> !foundNotes.contains(u.getNote()))
                 .collect(Collectors.toList());
-        // @formatter:on
         if (isNotEmpty(eventNotes)) {
           persistableNotes.putAll(
               eventNotes.stream().collect(Collectors.toMap(Note::getNote, Function.identity())));

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/context/OrganisationUnitSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/context/OrganisationUnitSupplier.java
@@ -77,13 +77,11 @@ public class OrganisationUnitSupplier extends AbstractSupplier<Map<String, Organ
     // query
     // argument
     //
-    // @formatter:off
     final Set<String> orgUnitUids =
         events.stream()
             .filter(e -> e.getOrgUnit() != null)
             .map(Event::getOrgUnit)
             .collect(Collectors.toSet());
-    // @formatter:on
 
     if (isEmpty(orgUnitUids)) {
       return new HashMap<>();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/context/ProgramSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/context/ProgramSupplier.java
@@ -66,12 +66,35 @@ import org.springframework.stereotype.Component;
  * This supplier builds and caches a Map of all the Programs in the system. For each Program, the
  * following additional data is retrieved:
  *
- * @formatter:off
- *     <p>Program + | +---+ Program Stage (List) | | | +---+ User Access (ACL) | | | +---+ User
- *     Group Access (ACL) | | +---+ Category Combo | | +---+ Tracked Entity Instance | | | +---+
- *     User Access (ACL) | | | +---+ User Group Access (ACL) | | | +---+ Organizational Unit (List)
- *     | +---+ User Access (ACL) | +---+ User Group Access (ACL)
- * @formatter:on
+ * <pre>
+ * Program
+ * +
+ * |
+ * +---+ Program Stage (List)
+ * |           |
+ * |           +---+ User Access (ACL)
+ * |           |
+ * |           +---+ User Group Access (ACL)
+ * |
+ * |
+ * +---+ Category Combo
+ * |
+ * |
+ * +---+ Tracked Entity Instance
+ * |           |
+ * |           +---+ User Access (ACL)
+ * |           |
+ * |           +---+ User Group Access (ACL)
+ * |
+ * |
+ * |
+ * +---+ Organizational Unit (List)
+ * |
+ * +---+ User Access (ACL)
+ * |
+ * +---+ User Group Access (ACL)
+ * </pre>
+ *
  * @author Luciano Fiandesio
  */
 @Component("workContextProgramsSupplier")

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/context/TrackedEntityInstanceSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/context/TrackedEntityInstanceSupplier.java
@@ -67,14 +67,12 @@ public class TrackedEntityInstanceSupplier
     if (events == null) {
       return new HashMap<>();
     }
-    // @formatter:off
     // Collect all the org unit uids to pass as SQL query argument
     Set<String> teiUids =
         events.stream()
             .filter(e -> e.getTrackedEntityInstance() != null)
             .map(Event::getTrackedEntityInstance)
             .collect(Collectors.toSet());
-    // @formatter:on
 
     if (isEmpty(teiUids)) {
       return new HashMap<>();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/context/WorkContextLoader.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/context/WorkContextLoader.java
@@ -74,7 +74,6 @@ public class WorkContextLoader {
   private final SessionFactory sessionFactory;
 
   public WorkContextLoader(
-      // @formatter:off
       ProgramSupplier programSupplier,
       OrganisationUnitSupplier organisationUnitSupplier,
       TrackedEntityInstanceSupplier trackedEntityInstanceSupplier,
@@ -86,9 +85,7 @@ public class WorkContextLoader {
       AssignedUserSupplier assignedUserSupplier,
       ServiceDelegatorSupplier serviceDelegatorSupplier,
       ProgramOrgUnitSupplier programOrgUnitSupplier,
-      SessionFactory sessionFactory
-      // @formatter:on
-      ) {
+      SessionFactory sessionFactory) {
     this.programSupplier = programSupplier;
     this.organisationUnitSupplier = organisationUnitSupplier;
     this.trackedEntityInstanceSupplier = trackedEntityInstanceSupplier;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/insert/validation/EnrollmentRepeatableStageCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/insert/validation/EnrollmentRepeatableStageCheck.java
@@ -63,7 +63,6 @@ public class EnrollmentRepeatableStageCheck implements Checker {
      * Enrollment should never be null. If it's null, the EnrollmentCheck
      * should report this anomaly.
      */
-    // @formatter:off
     if (enrollment != null
         && tei != null
         && program.isRegistration()
@@ -78,7 +77,6 @@ public class EnrollmentRepeatableStageCheck implements Checker {
           .setReference(event.getEvent())
           .incrementIgnored();
     }
-    // @formatter:on
 
     return success();
   }
@@ -88,7 +86,6 @@ public class EnrollmentRepeatableStageCheck implements Checker {
       long programInstanceId,
       long programStageId,
       long trackedEntityInstanceId) {
-    // @formatter:off
     final String sql =
         "select exists( "
             + "select * "
@@ -100,7 +97,6 @@ public class EnrollmentRepeatableStageCheck implements Checker {
             + "  and pi.trackedentityinstanceid = ? "
             + "  and psi.status != 'SKIPPED'"
             + ")";
-    // @formatter:on
 
     return jdbcTemplate.queryForObject(
         sql, Boolean.class, programInstanceId, programStageId, trackedEntityInstanceId);

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathConverter.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathConverter.java
@@ -51,16 +51,14 @@ public class FieldPathConverter implements ConditionalGenericConverter {
   public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
     if (sourceType.isArray()) {
       /*
-       * @formatter:off
-       *
        * Undo Spring's splitting of
-       * `fields=attributes[attribute,value],deleted` into
-       * 0 = "attributes[attribute"
-       * 1 = "value]"
-       * 2 = "deleted"
+       * {@code fields=attributes[attribute,value],deleted} into
+       * <ul>
+       * <li>0 = "attributes[attribute"</li>
+       * <li>1 = "value]"</li>
+       * <li>2 = "deleted"</li>
+       * </ul>
        * separating nested fields attribute and value.
-       *
-       * @formatter:on
        */
       return FieldFilterParser.parse(String.join(",", (String[]) source));
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/DefaultValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/DefaultValidator.java
@@ -54,7 +54,6 @@ public class DefaultValidator implements Validator<TrackerBundle> {
   private final RelationshipValidator relationshipValidator;
 
   private Validator<TrackerBundle> bundleValidator() {
-    // @formatter:off
     return all(trackedEntityValidator, enrollmentValidator, eventValidator, relationshipValidator);
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/RuleEngineValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/RuleEngineValidator.java
@@ -51,9 +51,7 @@ public class RuleEngineValidator implements Validator<TrackerBundle> {
   private final EventRuleEngineValidator eventValidator;
 
   private Validator<TrackerBundle> bundleValidator() {
-    // @formatter:off
     return all(trackedEntityValidator, enrollmentValidator, eventValidator);
-    // @formatter:on
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/EnrollmentRuleEngineValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/EnrollmentRuleEngineValidator.java
@@ -45,9 +45,7 @@ public class EnrollmentRuleEngineValidator implements Validator<TrackerBundle> {
 
   public EnrollmentRuleEngineValidator(
       RuleEngineValidator ruleValidator, AttributeValidator attributeValidator) {
-    // @formatter:off
     validator = each(TrackerBundle::getEnrollments, all(ruleValidator, attributeValidator));
-    // @formatter:on
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/EnrollmentValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/EnrollmentValidator.java
@@ -46,7 +46,6 @@ public class EnrollmentValidator implements Validator<TrackerBundle> {
   public EnrollmentValidator(
       SecurityOwnershipValidator securityOwnershipValidator,
       AttributeValidator attributeValidator) {
-    // @formatter:off
     validator =
         each(
             TrackerBundle::getEnrollments,
@@ -64,7 +63,6 @@ public class EnrollmentValidator implements Validator<TrackerBundle> {
                     new GeoValidator(),
                     new DateValidator(),
                     attributeValidator)));
-    // @formatter:on
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/EventRuleEngineValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/EventRuleEngineValidator.java
@@ -43,9 +43,7 @@ public class EventRuleEngineValidator implements Validator<TrackerBundle> {
   private final Validator<TrackerBundle> validator;
 
   public EventRuleEngineValidator(RuleEngineValidator ruleEngineValidator) {
-    // @formatter:off
     validator = each(TrackerBundle::getEvents, all(ruleEngineValidator, new DataValuesValidator()));
-    // @formatter:on
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/EventValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/EventValidator.java
@@ -47,7 +47,6 @@ public class EventValidator implements Validator<TrackerBundle> {
   public EventValidator(
       SecurityOwnershipValidator securityOwnershipValidator,
       CategoryOptValidator categoryOptValidator) {
-    // @formatter:off
     validator =
         all(
             each(
@@ -68,7 +67,6 @@ public class EventValidator implements Validator<TrackerBundle> {
                         new DataValuesValidator(),
                         new AssignedUserValidator()))),
             field(TrackerBundle::getEvents, new RepeatedEventsValidator()));
-    // @formatter:on
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/relationship/RelationshipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/relationship/RelationshipValidator.java
@@ -43,7 +43,6 @@ public class RelationshipValidator implements Validator<TrackerBundle> {
   private final Validator<TrackerBundle> validator;
 
   public RelationshipValidator() {
-    // @formatter:off
     validator =
         each(
             TrackerBundle::getRelationships,
@@ -55,7 +54,6 @@ public class RelationshipValidator implements Validator<TrackerBundle> {
                 new LinkValidator(),
                 new ConstraintValidator(),
                 new DuplicationValidator()));
-    // @formatter:on
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/TrackedEntityValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/TrackedEntityValidator.java
@@ -47,7 +47,6 @@ public class TrackedEntityValidator implements Validator<TrackerBundle> {
   public TrackedEntityValidator(
       SecurityOwnershipValidator securityOwnershipValidator,
       AttributeValidator attributeValidator) {
-    // @formatter:off
     validator =
         each(
             TrackerBundle::getTrackedEntities,
@@ -59,7 +58,6 @@ public class TrackedEntityValidator implements Validator<TrackerBundle> {
                 new UpdatableFieldsValidator(),
                 securityOwnershipValidator,
                 all(attributeValidator)));
-    // @formatter:on
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/PersistablesFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/PersistablesFilterTest.java
@@ -66,17 +66,18 @@ class PersistablesFilterTest {
   @Test
   void testCreateAndUpdateValidEntitiesCanBePersisted() {
     // @formatter:off
-    Setup setup =
-        new Setup.Builder()
-            .trackedEntity("xK7H53f4Hc2")
-            .enrollment("t1zaUjKgT3p")
-            .event("Qck4PQ7TMun")
-            .trackedEntity("QxGbKYwChDM")
-            .enrollment("Ok4Fe5moc3N")
-            .event("Ox1qBWsnVwE")
-            .event("jNyGqnwryNi")
-            .relationship("Te3IC6TpnBB", trackedEntity("xK7H53f4Hc2"), trackedEntity("QxGbKYwChDM"))
-            .build();
+    Setup setup = new Setup.Builder()
+        .trackedEntity( "xK7H53f4Hc2" )
+            .enrollment( "t1zaUjKgT3p" )
+                .event( "Qck4PQ7TMun" )
+        .trackedEntity( "QxGbKYwChDM" )
+            .enrollment( "Ok4Fe5moc3N" )
+                .event( "Ox1qBWsnVwE" )
+                .event( "jNyGqnwryNi" )
+        .relationship("Te3IC6TpnBB",
+            trackedEntity("xK7H53f4Hc2"),
+            trackedEntity("QxGbKYwChDM") )
+        .build();
     // @formatter:on
 
     PersistablesFilter.Result persistable =
@@ -95,17 +96,14 @@ class PersistablesFilterTest {
   @Test
   void testCreateAndUpdateValidEntitiesReferencingParentsNotInPayload() {
     // @formatter:off
-    Setup setup =
-        new Setup.Builder()
-            .trackedEntity("xK7H53f4Hc2")
-            .isInDB()
-            .isNotInPayload()
-            .enrollment("t1zaUjKgT3p")
-            .enrollment("Ok4Fe5moc3N")
-            .isInDB()
-            .isNotInPayload()
-            .event("Ox1qBWsnVwE")
-            .relationship("Te3IC6TpnBB", trackedEntity("xK7H53f4Hc2"), enrollment("Ok4Fe5moc3N"))
+    Setup setup = new Setup.Builder()
+            .trackedEntity( "xK7H53f4Hc2" ).isInDB().isNotInPayload()
+                .enrollment( "t1zaUjKgT3p")
+            .enrollment( "Ok4Fe5moc3N").isInDB().isNotInPayload()
+                .event( "Ox1qBWsnVwE" )
+            .relationship("Te3IC6TpnBB",
+                    trackedEntity("xK7H53f4Hc2"),
+                    enrollment("Ok4Fe5moc3N") )
             .build();
     // @formatter:on
 
@@ -123,15 +121,11 @@ class PersistablesFilterTest {
   @Test
   void testCreateAndUpdateValidEntitiesCanBePersistedIfTheyExist() {
     // @formatter:off
-    Setup setup =
-        new Setup.Builder()
-            .trackedEntity("xK7H53f4Hc2")
-            .isInDB()
-            .enrollment("t1zaUjKgT3p")
-            .isInDB()
-            .event("Qck4PQ7TMun")
-            .isInDB()
-            .build();
+    Setup setup = new Setup.Builder()
+        .trackedEntity( "xK7H53f4Hc2" ).isInDB()
+        .enrollment( "t1zaUjKgT3p" ).isInDB()
+        .event( "Qck4PQ7TMun" ).isInDB()
+        .build();
     // @formatter:on
 
     PersistablesFilter.Result persistable =
@@ -147,13 +141,10 @@ class PersistablesFilterTest {
   @Test
   void testCreateAndUpdateValidEnrollmentOfInvalidTeiCanBeUpdatedIfTeiExists() {
     // @formatter:off
-    Setup setup =
-        new Setup.Builder()
-            .trackedEntity("xK7H53f4Hc2")
-            .isNotValid()
-            .isInDB()
-            .enrollment("t1zaUjKgT3p")
-            .build();
+    Setup setup = new Setup.Builder()
+        .trackedEntity( "xK7H53f4Hc2" ).isNotValid().isInDB()
+            .enrollment( "t1zaUjKgT3p" )
+        .build();
     // @formatter:on
 
     PersistablesFilter.Result persistable =
@@ -168,12 +159,10 @@ class PersistablesFilterTest {
   @Test
   void testCreateAndUpdateValidEnrollmentOfInvalidTeiCannotBeUpdatedIfTeiDoesNotExist() {
     // @formatter:off
-    Setup setup =
-        new Setup.Builder()
-            .trackedEntity("xK7H53f4Hc2")
-            .isNotValid()
-            .enrollment("t1zaUjKgT3p")
-            .build();
+    Setup setup = new Setup.Builder()
+        .trackedEntity( "xK7H53f4Hc2" ).isNotValid()
+            .enrollment( "t1zaUjKgT3p" )
+        .build();
     // @formatter:on
 
     PersistablesFilter.Result persistable =
@@ -194,14 +183,11 @@ class PersistablesFilterTest {
   @Test
   void testCreateAndUpdateValidEventOfInvalidEnrollmentCanBeUpdatedIfEnrollmentExists() {
     // @formatter:off
-    Setup setup =
-        new Setup.Builder()
-            .trackedEntity("xK7H53f4Hc2")
-            .enrollment("t1zaUjKgT3p")
-            .isNotValid()
-            .isInDB()
-            .event("Qck4PQ7TMun")
-            .build();
+    Setup setup = new Setup.Builder()
+        .trackedEntity( "xK7H53f4Hc2" )
+            .enrollment( "t1zaUjKgT3p" ).isNotValid().isInDB()
+                .event( "Qck4PQ7TMun" )
+        .build();
     // @formatter:on
 
     PersistablesFilter.Result persistable =
@@ -217,13 +203,11 @@ class PersistablesFilterTest {
   @Test
   void testCreateAndUpdateValidEventOfInvalidEnrollmentCannotBeCreatedIfEnrollmentDoesNotExist() {
     // @formatter:off
-    Setup setup =
-        new Setup.Builder()
-            .trackedEntity("xK7H53f4Hc2")
-            .enrollment("t1zaUjKgT3p")
-            .isNotValid()
-            .event("Qck4PQ7TMun")
-            .build();
+    Setup setup = new Setup.Builder()
+        .trackedEntity( "xK7H53f4Hc2" )
+            .enrollment( "t1zaUjKgT3p" ).isNotValid()
+                .event( "Qck4PQ7TMun" )
+        .build();
     // @formatter:on
 
     PersistablesFilter.Result persistable =
@@ -241,13 +225,11 @@ class PersistablesFilterTest {
   @Test
   void testCreateAndUpdateInvalidEventOfValidEnrollmentCannotBePersisted() {
     // @formatter:off
-    Setup setup =
-        new Setup.Builder()
-            .trackedEntity("xK7H53f4Hc2")
-            .enrollment("t1zaUjKgT3p")
-            .event("Qck4PQ7TMun")
-            .isNotValid()
-            .build();
+    Setup setup = new Setup.Builder()
+        .trackedEntity( "xK7H53f4Hc2" )
+            .enrollment( "t1zaUjKgT3p" )
+                .event( "Qck4PQ7TMun" ).isNotValid()
+        .build();
     // @formatter:on
 
     PersistablesFilter.Result persistable =
@@ -263,12 +245,13 @@ class PersistablesFilterTest {
   @Test
   void testCreateAndUpdateInvalidRelationshipCannotBePersisted() {
     // @formatter:off
-    Setup setup =
-        new Setup.Builder()
-            .trackedEntity("xK7H53f4Hc2")
-            .trackedEntity("QxGbKYwChDM")
-            .relationship("Te3IC6TpnBB", trackedEntity("xK7H53f4Hc2"), trackedEntity("QxGbKYwChDM"))
-            .isNotValid()
+    Setup setup = new Setup.Builder()
+            .trackedEntity( "xK7H53f4Hc2" )
+            .trackedEntity( "QxGbKYwChDM" )
+            .relationship("Te3IC6TpnBB",
+                    trackedEntity("xK7H53f4Hc2"),
+                    trackedEntity("QxGbKYwChDM")
+                ).isNotValid()
             .build();
     // @formatter:on
 
@@ -284,14 +267,13 @@ class PersistablesFilterTest {
   @Test
   void testCreateAndUpdateValidRelationshipWithInvalidButExistingFrom() {
     // @formatter:off
-    Setup setup =
-        new Setup.Builder()
-            .trackedEntity("xK7H53f4Hc2")
-            .isNotValid()
-            .isInDB()
-            .trackedEntity("QxGbKYwChDM")
-            .relationship("Te3IC6TpnBB", trackedEntity("xK7H53f4Hc2"), trackedEntity("QxGbKYwChDM"))
-            .build();
+    Setup setup = new Setup.Builder()
+        .trackedEntity( "xK7H53f4Hc2" ).isNotValid().isInDB()
+        .trackedEntity( "QxGbKYwChDM" )
+        .relationship("Te3IC6TpnBB",
+            trackedEntity("xK7H53f4Hc2"),
+            trackedEntity("QxGbKYwChDM") )
+        .build();
     // @formatter:on
 
     PersistablesFilter.Result persistable =
@@ -306,12 +288,12 @@ class PersistablesFilterTest {
   @Test
   void testCreateAndUpdateValidRelationshipWithInvalidFromCannotBeCreated() {
     // @formatter:off
-    Setup setup =
-        new Setup.Builder()
-            .trackedEntity("xK7H53f4Hc2")
-            .enrollment("QxGbKYwChDM")
-            .isNotValid()
-            .relationship("Te3IC6TpnBB", enrollment("QxGbKYwChDM"), trackedEntity("xK7H53f4Hc2"))
+    Setup setup = new Setup.Builder()
+            .trackedEntity( "xK7H53f4Hc2" )
+                .enrollment( "QxGbKYwChDM" ).isNotValid()
+            .relationship("Te3IC6TpnBB",
+                enrollment("QxGbKYwChDM"),
+                trackedEntity("xK7H53f4Hc2") )
             .build();
     // @formatter:on
 
@@ -333,13 +315,13 @@ class PersistablesFilterTest {
   @Test
   void testCreateAndUpdateValidRelationshipWithInvalidToCannotBeCreated() {
     // @formatter:off
-    Setup setup =
-        new Setup.Builder()
-            .trackedEntity("xK7H53f4Hc2")
-            .enrollment("QxGbKYwChDM")
-            .event("QxGbKYwChDM")
-            .isNotValid()
-            .relationship("Te3IC6TpnBB", trackedEntity("xK7H53f4Hc2"), event("QxGbKYwChDM"))
+    Setup setup = new Setup.Builder()
+            .trackedEntity( "xK7H53f4Hc2" )
+                .enrollment( "QxGbKYwChDM" )
+                    .event( "QxGbKYwChDM" ).isNotValid()
+            .relationship("Te3IC6TpnBB",
+                trackedEntity("xK7H53f4Hc2"),
+                event("QxGbKYwChDM") )
             .build();
     // @formatter:on
 
@@ -367,15 +349,14 @@ class PersistablesFilterTest {
     // persisted.
 
     // @formatter:off
-    Setup setup =
-        new Setup.Builder()
-            .trackedEntity("xK7H53f4Hc2")
-            .isNotValid()
-            .enrollment("t1zaUjKgT3p")
-            .isNotValid()
-            .relationship("Te3IC6TpnBB", trackedEntity("xK7H53f4Hc2"), enrollment("t1zaUjKgT3p"))
-            .isNotValid()
-            .build();
+    Setup setup = new Setup.Builder()
+        .trackedEntity( "xK7H53f4Hc2" ).isNotValid()
+        .enrollment( "t1zaUjKgT3p" ).isNotValid()
+        .relationship("Te3IC6TpnBB",
+            trackedEntity("xK7H53f4Hc2"),
+            enrollment("t1zaUjKgT3p")
+        ).isNotValid()
+        .build();
     // @formatter:on
 
     PersistablesFilter.Result persistable =
@@ -391,16 +372,17 @@ class PersistablesFilterTest {
   @Test
   void testDeleteValidEntitiesCanBeDeleted() {
     // @formatter:off
-    Setup setup =
-        new Setup.Builder()
-            .trackedEntity("xK7H53f4Hc2")
-            .enrollment("t1zaUjKgT3p")
-            .event("Qck4PQ7TMun")
-            .trackedEntity("QxGbKYwChDM")
-            .enrollment("Ok4Fe5moc3N")
-            .event("Ox1qBWsnVwE")
-            .event("jNyGqnwryNi")
-            .relationship("Te3IC6TpnBB", trackedEntity("xK7H53f4Hc2"), trackedEntity("QxGbKYwChDM"))
+    Setup setup = new Setup.Builder()
+            .trackedEntity( "xK7H53f4Hc2" )
+                .enrollment( "t1zaUjKgT3p" )
+                    .event( "Qck4PQ7TMun" )
+            .trackedEntity( "QxGbKYwChDM" )
+                .enrollment( "Ok4Fe5moc3N" )
+                    .event( "Ox1qBWsnVwE" )
+                    .event( "jNyGqnwryNi" )
+            .relationship("Te3IC6TpnBB",
+                trackedEntity("xK7H53f4Hc2"),
+                trackedEntity("QxGbKYwChDM") )
             .build();
     // @formatter:on
 
@@ -420,13 +402,11 @@ class PersistablesFilterTest {
   @Test
   void testDeleteInvalidTrackedEntityCannotBeDeletedButItsChildrenCan() {
     // @formatter:off
-    Setup setup =
-        new Setup.Builder()
-            .trackedEntity("xK7H53f4Hc2")
-            .isNotValid()
-            .enrollment("t1zaUjKgT3p")
-            .event("Qck4PQ7TMun")
-            .event("Ox1qBWsnVwE")
+    Setup setup = new Setup.Builder()
+            .trackedEntity( "xK7H53f4Hc2" ).isNotValid()
+                .enrollment( "t1zaUjKgT3p" )
+                    .event( "Qck4PQ7TMun" )
+                    .event( "Ox1qBWsnVwE" )
             .build();
     // @formatter:on
 
@@ -448,14 +428,13 @@ class PersistablesFilterTest {
     // persisted.
 
     // @formatter:off
-    Setup setup =
-        new Setup.Builder()
-            .trackedEntity("xK7H53f4Hc2")
-            .isNotValid()
-            .enrollment("t1zaUjKgT3p")
-            .isNotValid()
-            .relationship("Te3IC6TpnBB", trackedEntity("xK7H53f4Hc2"), enrollment("t1zaUjKgT3p"))
-            .isNotValid()
+    Setup setup = new Setup.Builder()
+            .trackedEntity( "xK7H53f4Hc2" ).isNotValid()
+                .enrollment( "t1zaUjKgT3p" ).isNotValid()
+            .relationship("Te3IC6TpnBB",
+                    trackedEntity("xK7H53f4Hc2"),
+                    enrollment("t1zaUjKgT3p")
+                ).isNotValid()
             .build();
     // @formatter:on
 
@@ -472,15 +451,16 @@ class PersistablesFilterTest {
   @Test
   void testDeleteInvalidRelationshipPreventsDeletionOfTrackedEntityAndEvent() {
     // @formatter:off
-    Setup setup =
-        new Setup.Builder()
-            .trackedEntity("xK7H53f4Hc2")
-            .enrollment("t1zaUjKgT3p")
-            .event("Qck4PQ7TMun")
-            .trackedEntity("QxGbKYwChDM")
-            .enrollment("Ok4Fe5moc3N")
-            .relationship("Te3IC6TpnBB", trackedEntity("xK7H53f4Hc2"), event("Qck4PQ7TMun"))
-            .isNotValid()
+    Setup setup = new Setup.Builder()
+            .trackedEntity( "xK7H53f4Hc2" )
+                .enrollment( "t1zaUjKgT3p" )
+                    .event( "Qck4PQ7TMun" )
+            .trackedEntity( "QxGbKYwChDM" )
+                .enrollment( "Ok4Fe5moc3N" )
+            .relationship("Te3IC6TpnBB",
+                    trackedEntity("xK7H53f4Hc2"),
+                    event("Qck4PQ7TMun")
+                ).isNotValid()
             .build();
     // @formatter:on
 
@@ -514,15 +494,16 @@ class PersistablesFilterTest {
   @Test
   void testDeleteInvalidRelationshipPreventsDeletionOfEnrollmentAndEvent() {
     // @formatter:off
-    Setup setup =
-        new Setup.Builder()
-            .trackedEntity("xK7H53f4Hc2")
-            .enrollment("t1zaUjKgT3p")
-            .event("QxGbKYwChDM")
-            .event("Ox1qBWsnVwE")
-            .enrollment("Ok4Fe5moc3N")
-            .relationship("Te3IC6TpnBB", event("QxGbKYwChDM"), enrollment("t1zaUjKgT3p"))
-            .isNotValid()
+    Setup setup = new Setup.Builder()
+            .trackedEntity( "xK7H53f4Hc2" )
+                .enrollment( "t1zaUjKgT3p" )
+                    .event( "QxGbKYwChDM" )
+                    .event( "Ox1qBWsnVwE" )
+                .enrollment( "Ok4Fe5moc3N" )
+            .relationship("Te3IC6TpnBB",
+                    event("QxGbKYwChDM"),
+                    enrollment("t1zaUjKgT3p")
+                ).isNotValid()
             .build();
     // @formatter:on
 
@@ -553,13 +534,13 @@ class PersistablesFilterTest {
   @Test
   void testDeleteValidRelationshipWithInvalidFrom() {
     // @formatter:off
-    Setup setup =
-        new Setup.Builder()
-            .trackedEntity("QxGbKYwChDM")
-            .trackedEntity("xK7H53f4Hc2")
-            .enrollment("t1zaUjKgT3p")
-            .isNotValid()
-            .relationship("Te3IC6TpnBB", enrollment("t1zaUjKgT3p"), trackedEntity("QxGbKYwChDM"))
+    Setup setup = new Setup.Builder()
+            .trackedEntity( "QxGbKYwChDM" )
+            .trackedEntity( "xK7H53f4Hc2" )
+                .enrollment( "t1zaUjKgT3p" ).isNotValid()
+            .relationship("Te3IC6TpnBB",
+                    enrollment("t1zaUjKgT3p"),
+                    trackedEntity("QxGbKYwChDM") )
             .build();
     // @formatter:on
 
@@ -575,17 +556,14 @@ class PersistablesFilterTest {
   @Test
   void testDeleteValidEntitiesReferencingParentsNotInPayload() {
     // @formatter:off
-    Setup setup =
-        new Setup.Builder()
-            .trackedEntity("xK7H53f4Hc2")
-            .isInDB()
-            .isNotInPayload()
-            .enrollment("t1zaUjKgT3p")
-            .enrollment("Ok4Fe5moc3N")
-            .isInDB()
-            .isNotInPayload()
-            .event("Ox1qBWsnVwE")
-            .relationship("Te3IC6TpnBB", trackedEntity("xK7H53f4Hc2"), enrollment("Ok4Fe5moc3N"))
+    Setup setup = new Setup.Builder()
+            .trackedEntity( "xK7H53f4Hc2").isInDB().isNotInPayload()
+            .enrollment( "t1zaUjKgT3p")
+            .enrollment( "Ok4Fe5moc3N").isInDB().isNotInPayload()
+            .event( "Ox1qBWsnVwE" )
+            .relationship("Te3IC6TpnBB",
+                    trackedEntity("xK7H53f4Hc2"),
+                    enrollment("Ok4Fe5moc3N") )
             .build();
     // @formatter:on
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/AllTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/AllTest.java
@@ -66,7 +66,6 @@ class AllTest {
 
   @Test
   void testAllAreCalled() {
-    // @formatter:off
     Validator<String> validator =
         all(
             (r, b, s) -> addError(r, "V1"),
@@ -85,7 +84,6 @@ class AllTest {
   void testAllDoesNotCallValidatorIfItShouldNotRunOnGivenStrategy() {
     bundle = TrackerBundle.builder().importStrategy(UPDATE).build();
 
-    // @formatter:off
     Validator<String> validator =
         all(
             (r, b, s) -> addError(r, "V1"),
@@ -114,7 +112,6 @@ class AllTest {
             .resolvedStrategyMap(new EnumMap<>(Map.of(TrackerType.EVENT, Map.of("event1", UPDATE))))
             .build();
 
-    // @formatter:off
     Validator<Event> validator =
         all(
             new Validator<>() {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/EachTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/EachTest.java
@@ -70,7 +70,6 @@ class EachTest {
 
   @Test
   void testCallsValidatorForEachItemInCollection() {
-    // @formatter:off
     Validator<Enrollment> validator =
         each(Enrollment::getNotes, (r, b, n) -> addError(r, n.getNote()));
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/SeqTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/SeqTest.java
@@ -69,7 +69,6 @@ class SeqTest {
 
   @Test
   void testSeqCallsUntilFirstError() {
-    // @formatter:off
     Validator<String> validator =
         seq(
             new MatchingValidator("V1", "one"), // no error so moving on to the next validator
@@ -85,7 +84,6 @@ class SeqTest {
 
   @Test
   void testWrappedAddErrorIfNullStopsExecutionIfGivenObjectIsNull() {
-    // @formatter:off
     Validator<String> validator =
         seq((r, b, s) -> r.addErrorIfNull(s, dummyDto(), E1011), (r, b, s) -> addError(r, "V2"));
 
@@ -97,7 +95,6 @@ class SeqTest {
   @Test
   void
       testWrappedAddErrorIfNullStopsExecutionIfGivenObjectIsNullAndNextCallInSameValidatorDoesNotAddError() {
-    // @formatter:off
     Validator<String> validator =
         seq(
             (r, b, s) -> {
@@ -113,7 +110,6 @@ class SeqTest {
 
   @Test
   void testWrappedAddErrorIfNullDoesNotStopExecutionIfGivenObjectIsNotNull() {
-    // @formatter:off
     Validator<String> validator =
         seq((r, b, s) -> r.addErrorIfNull(s, dummyDto(), E1011), (r, b, s) -> addError(r, "V2"));
 
@@ -124,7 +120,6 @@ class SeqTest {
 
   @Test
   void testWrappedAddErrorIfStopsExecutionIfGivenPredicateSucceeds() {
-    // @formatter:off
     Validator<String> validator =
         seq(
             (r, b, s) -> r.addErrorIf(() -> true, dummyDto(), E1011),
@@ -138,7 +133,6 @@ class SeqTest {
   @Test
   void
       testWrappedAddErrorIfStopsExecutionIfGivenPredicateSucceedsAndNextCallInSameValidatorDoesNotAddError() {
-    // @formatter:off
     Validator<String> validator =
         seq(
             (r, b, s) -> {
@@ -154,7 +148,6 @@ class SeqTest {
 
   @Test
   void testWrappedAddErrorIfDoesNotStopExecutionIfGivenPredicateFails() {
-    // @formatter:off
     Validator<String> validator =
         seq(
             (r, b, s) -> r.addErrorIf(() -> false, dummyDto(), E1011),
@@ -196,7 +189,6 @@ class SeqTest {
             .resolvedStrategyMap(new EnumMap<>(Map.of(TrackerType.EVENT, Map.of("event1", UPDATE))))
             .build();
 
-    // @formatter:off
     Validator<Event> validator =
         seq(
             new Validator<>() {

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/dataanalysis/jdbc/JdbcDataAnalysisStore.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/dataanalysis/jdbc/JdbcDataAnalysisStore.java
@@ -150,36 +150,26 @@ public class JdbcDataAnalysisStore implements DataAnalysisStore {
 
     // @formatter:off
     String sql =
-        "select dv.dataelementid, dv.periodid, dv.sourceid, dv.categoryoptioncomboid, dv.attributeoptioncomboid, "
-            + "dv.value, dv.storedby, dv.lastupdated, "
-            + "dv.created, dv.comment, dv.followup, ou.name as sourcename, de.name as dataelementname, "
-            + "pt.name as periodtypename, pe.startdate, pe.enddate, coc.name as categoryoptioncomboname, "
-            + "mm.minimumvalue, mm.maximumvalue "
-            + "from datavalue dv "
-            + "left join minmaxdataelement mm on dv.dataelementid = mm.dataelementid "
-            + "and dv.categoryoptioncomboid = mm.categoryoptioncomboid and dv.sourceid = mm.sourceid "
-            + "inner join dataelement de on dv.dataelementid = de.dataelementid "
-            + "inner join period pe on dv.periodid = pe.periodid "
-            + "inner join periodtype pt on pe.periodtypeid = pt.periodtypeid "
-            + "inner join organisationunit ou on dv.sourceid = ou.organisationunitid "
-            + "inner join categoryoptioncombo coc on dv.categoryoptioncomboid = coc.categoryoptioncomboid "
-            + "where dv.dataelementid in ("
-            + dataElementIds
-            + ") "
-            + "and dv.categoryoptioncomboid in ("
-            + categoryOptionComboIds
-            + ") "
-            + "and dv.periodid in ("
-            + periodIds
-            + ") "
-            + "and ("
-            + "cast(dv.value as "
-            + statementBuilder.getDoubleColumnType()
-            + ") < mm.minimumvalue "
-            + "or cast(dv.value as "
-            + statementBuilder.getDoubleColumnType()
-            + ") > mm.maximumvalue) "
-            + "and (";
+        "select dv.dataelementid, dv.periodid, dv.sourceid, dv.categoryoptioncomboid, dv.attributeoptioncomboid, " +
+            "dv.value, dv.storedby, dv.lastupdated, " +
+            "dv.created, dv.comment, dv.followup, ou.name as sourcename, de.name as dataelementname, " +
+            "pt.name as periodtypename, pe.startdate, pe.enddate, coc.name as categoryoptioncomboname, " +
+            "mm.minimumvalue, mm.maximumvalue " +
+        "from datavalue dv " +
+        "left join minmaxdataelement mm on dv.dataelementid = mm.dataelementid " +
+            "and dv.categoryoptioncomboid = mm.categoryoptioncomboid and dv.sourceid = mm.sourceid " +
+        "inner join dataelement de on dv.dataelementid = de.dataelementid " +
+        "inner join period pe on dv.periodid = pe.periodid " +
+        "inner join periodtype pt on pe.periodtypeid = pt.periodtypeid " +
+        "inner join organisationunit ou on dv.sourceid = ou.organisationunitid " +
+        "inner join categoryoptioncombo coc on dv.categoryoptioncomboid = coc.categoryoptioncomboid " +
+        "where dv.dataelementid in (" + dataElementIds + ") " +
+        "and dv.categoryoptioncomboid in (" + categoryOptionComboIds + ") " +
+        "and dv.periodid in (" + periodIds + ") " +
+        "and (" +
+            "cast(dv.value as " + statementBuilder.getDoubleColumnType() + ") < mm.minimumvalue " +
+            "or cast(dv.value as " + statementBuilder.getDoubleColumnType() + ") > mm.maximumvalue) " +
+        "and (";
     // @formatter:on
 
     for (OrganisationUnit parent : parents) {
@@ -231,25 +221,18 @@ public class JdbcDataAnalysisStore implements DataAnalysisStore {
     String periodIds = TextUtils.getCommaDelimitedString(getIdentifiers(periods));
 
     // @formatter:off
-    String sql =
-        "select dv.dataelementid, dv.periodid, dv.sourceid, "
-            + "dv.categoryoptioncomboid, dv.attributeoptioncomboid, dv.value, dv.storedby, dv.lastupdated, "
-            + "dv.created, dv.comment, dv.followup, ou.name as sourcename, "
-            + "? as dataelementname, pt.name as periodtypename, pe.startdate, pe.enddate, "
-            + "? as categoryoptioncomboname "
-            + "from datavalue dv "
-            + "inner join period pe on dv.periodid = pe.periodid "
-            + "inner join periodtype pt on pe.periodtypeid = pt.periodtypeid "
-            + "inner join organisationunit ou on dv.sourceid = ou.organisationunitid "
-            + "where dv.dataelementid = "
-            + dataElement.getId()
-            + " "
-            + "and dv.categoryoptioncomboid = "
-            + categoryOptionCombo.getId()
-            + " "
-            + "and dv.periodid in ("
-            + periodIds
-            + ") and (";
+    String sql = "select dv.dataelementid, dv.periodid, dv.sourceid, " +
+        "dv.categoryoptioncomboid, dv.attributeoptioncomboid, dv.value, dv.storedby, dv.lastupdated, " +
+        "dv.created, dv.comment, dv.followup, ou.name as sourcename, " +
+        "? as dataelementname, pt.name as periodtypename, pe.startdate, pe.enddate, " +
+        "? as categoryoptioncomboname " +
+        "from datavalue dv " +
+        "inner join period pe on dv.periodid = pe.periodid " +
+        "inner join periodtype pt on pe.periodtypeid = pt.periodtypeid " +
+        "inner join organisationunit ou on dv.sourceid = ou.organisationunitid " +
+        "where dv.dataelementid = " + dataElement.getId() + " " +
+        "and dv.categoryoptioncomboid = " + categoryOptionCombo.getId() + " " +
+        "and dv.periodid in (" + periodIds + ") and (";
     // @formatter:on
 
     for (Long orgUnitUid : organisationUnits) {
@@ -302,29 +285,22 @@ public class JdbcDataAnalysisStore implements DataAnalysisStore {
 
     // @formatter:off
     String sql =
-        "select dv.dataelementid, dv.periodid, dv.sourceid, "
-            + "dv.categoryoptioncomboid, dv.attributeoptioncomboid, dv.value, dv.storedby, dv.lastupdated, "
-            + "dv.created, dv.comment, dv.followup, ou.name as sourcename, de.name as dataelementname, "
-            + "pt.name as periodtypename, pe.startdate, pe.enddate, coc.name as categoryoptioncomboname, "
-            + "mm.minimumvalue, mm.maximumvalue "
-            + "from datavalue dv "
-            + "left join minmaxdataelement mm on dv.dataelementid = mm.dataelementid "
-            + "and dv.categoryoptioncomboid = mm.categoryoptioncomboid and dv.sourceid = mm.sourceid "
-            + "inner join dataelement de on dv.dataelementid = de.dataelementid "
-            + "inner join period pe on dv.periodid = pe.periodid "
-            + "inner join periodtype pt on pe.periodtypeid = pt.periodtypeid "
-            + "inner join organisationunit ou on dv.sourceid = ou.organisationunitid "
-            + "inner join categoryoptioncombo coc on dv.categoryoptioncomboid = coc.categoryoptioncomboid "
-            + "where dv.dataelementid in ("
-            + dataElementIds
-            + ") "
-            + "and dv.categoryoptioncomboid in ("
-            + categoryOptionComboIds
-            + ") "
-            + "and dv.periodid in ("
-            + periodIds
-            + ") "
-            + "and (";
+        "select dv.dataelementid, dv.periodid, dv.sourceid, " +
+            "dv.categoryoptioncomboid, dv.attributeoptioncomboid, dv.value, dv.storedby, dv.lastupdated, " +
+            "dv.created, dv.comment, dv.followup, ou.name as sourcename, de.name as dataelementname, " +
+        "pt.name as periodtypename, pe.startdate, pe.enddate, coc.name as categoryoptioncomboname, " +
+        "mm.minimumvalue, mm.maximumvalue " +
+        "from datavalue dv " +
+        "left join minmaxdataelement mm on dv.dataelementid = mm.dataelementid " +
+        "and dv.categoryoptioncomboid = mm.categoryoptioncomboid and dv.sourceid = mm.sourceid " +
+        "inner join dataelement de on dv.dataelementid = de.dataelementid " +
+        "inner join period pe on dv.periodid = pe.periodid " +
+        "inner join periodtype pt on pe.periodtypeid = pt.periodtypeid " +
+        "inner join organisationunit ou on dv.sourceid = ou.organisationunitid " +
+        "inner join categoryoptioncombo coc on dv.categoryoptioncomboid = coc.categoryoptioncomboid " +
+        "where dv.dataelementid in (" + dataElementIds + ") " +
+        "and dv.categoryoptioncomboid in (" + categoryOptionComboIds + ") " +
+        "and dv.periodid in (" + periodIds + ") " + "and (";
     // @formatter:on
 
     for (OrganisationUnit parent : parents) {

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/outlierdetection/service/MinMaxOutlierDetectionManager.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/outlierdetection/service/MinMaxOutlierDetectionManager.java
@@ -68,39 +68,34 @@ public class MinMaxOutlierDetectionManager {
 
     // @formatter:off
     final String sql =
-        "select de.uid as de_uid, ou.uid as ou_uid, coc.uid as coc_uid, aoc.uid as aoc_uid, "
-            + "de.name as de_name, ou.name as ou_name, coc.name as coc_name, aoc.name as aoc_name, "
-            + "pe.startdate as pe_start_date, pt.name as pt_name, "
-            + "dv.value::double precision as value, dv.followup as follow_up, "
-            + "least(abs(dv.value::double precision - mm.minimumvalue), "
-            + "abs(dv.value::double precision - mm.maximumvalue)) as bound_abs_dev, "
-            + "mm.minimumvalue as lower_bound, "
-            + "mm.maximumvalue as upper_bound "
-            + "from datavalue dv "
-            + "inner join dataelement de on dv.dataelementid = de.dataelementid "
-            + "inner join categoryoptioncombo coc on dv.categoryoptioncomboid = coc.categoryoptioncomboid "
-            + "inner join categoryoptioncombo aoc on dv.attributeoptioncomboid = aoc.categoryoptioncomboid "
-            + "inner join period pe on dv.periodid = pe.periodid "
-            + "inner join periodtype pt on pe.periodtypeid = pt.periodtypeid "
-            + "inner join organisationunit ou on dv.sourceid = ou.organisationunitid "
-            +
-            // Min-max value join
-            "inner join minmaxdataelement mm on (dv.dataelementid = mm.dataelementid "
-            + "and dv.sourceid = mm.sourceid and dv.categoryoptioncomboid = mm.categoryoptioncomboid) "
-            + "where dv.dataelementid in (:data_element_ids) "
-            + "and pe.startdate >= :start_date "
-            + "and pe.enddate <= :end_date "
-            + "and "
-            + ouPathClause
-            + " "
-            + "and dv.deleted is false "
-            +
-            // Filter for values outside the min-max range
-            "and (dv.value::double precision < mm.minimumvalue or dv.value::double precision > mm.maximumvalue) "
-            +
-            // Order and limit
-            "order by bound_abs_dev desc "
-            + "limit :max_results;";
+        "select de.uid as de_uid, ou.uid as ou_uid, coc.uid as coc_uid, aoc.uid as aoc_uid, " +
+            "de.name as de_name, ou.name as ou_name, coc.name as coc_name, aoc.name as aoc_name, " +
+            "pe.startdate as pe_start_date, pt.name as pt_name, " +
+            "dv.value::double precision as value, dv.followup as follow_up, " +
+            "least(abs(dv.value::double precision - mm.minimumvalue), " +
+            "abs(dv.value::double precision - mm.maximumvalue)) as bound_abs_dev, " +
+            "mm.minimumvalue as lower_bound, " +
+            "mm.maximumvalue as upper_bound " +
+        "from datavalue dv " +
+        "inner join dataelement de on dv.dataelementid = de.dataelementid " +
+        "inner join categoryoptioncombo coc on dv.categoryoptioncomboid = coc.categoryoptioncomboid " +
+        "inner join categoryoptioncombo aoc on dv.attributeoptioncomboid = aoc.categoryoptioncomboid " +
+        "inner join period pe on dv.periodid = pe.periodid " +
+        "inner join periodtype pt on pe.periodtypeid = pt.periodtypeid " +
+        "inner join organisationunit ou on dv.sourceid = ou.organisationunitid " +
+        // Min-max value join
+        "inner join minmaxdataelement mm on (dv.dataelementid = mm.dataelementid " +
+        "and dv.sourceid = mm.sourceid and dv.categoryoptioncomboid = mm.categoryoptioncomboid) " +
+        "where dv.dataelementid in (:data_element_ids) " +
+        "and pe.startdate >= :start_date " +
+        "and pe.enddate <= :end_date " +
+        "and " + ouPathClause + " " +
+        "and dv.deleted is false " +
+        // Filter for values outside the min-max range
+        "and (dv.value::double precision < mm.minimumvalue or dv.value::double precision > mm.maximumvalue) " +
+        // Order and limit
+        "order by bound_abs_dev desc " +
+        "limit :max_results;";
     // @formatter:on
 
     final SqlParameterSource params =

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/outlierdetection/service/ZScoreOutlierDetectionManager.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/outlierdetection/service/ZScoreOutlierDetectionManager.java
@@ -90,76 +90,64 @@ public class ZScoreOutlierDetectionManager {
 
     // @formatter:off
     final String sql =
-        "select dvs.de_uid, dvs.ou_uid, dvs.coc_uid, dvs.aoc_uid, "
-            + "dvs.de_name, dvs.ou_name, dvs.coc_name, dvs.aoc_name, dvs.value, dvs.follow_up, "
-            + "dvs.pe_start_date, dvs.pt_name, "
-            + "stats.middle_value as middle_value, "
-            + "stats.std_dev as std_dev, "
-            + "abs(dvs.value::double precision - stats.middle_value) as middle_value_abs_dev, "
-            + "abs(dvs.value::double precision - stats.middle_value) / stats.std_dev as z_score, "
-            + "stats.middle_value - (stats.std_dev * :threshold) as lower_bound, "
-            + "stats.middle_value + (stats.std_dev * :threshold) as upper_bound "
-            +
-            // Data value query
-            "from ("
-            + "select dv.dataelementid, dv.sourceid, dv.periodid, "
-            + "dv.categoryoptioncomboid, dv.attributeoptioncomboid, "
-            + "de.uid as de_uid, ou.uid as ou_uid, coc.uid as coc_uid, aoc.uid as aoc_uid, "
-            + "de.name as de_name, ou.name as ou_name, coc.name as coc_name, aoc.name as aoc_name, "
-            + "pe.startdate as pe_start_date, pt.name as pt_name, "
-            + "dv.value as value, dv.followup as follow_up "
-            + "from datavalue dv "
-            + "inner join dataelement de on dv.dataelementid = de.dataelementid "
-            + "inner join categoryoptioncombo coc on dv.categoryoptioncomboid = coc.categoryoptioncomboid "
-            + "inner join categoryoptioncombo aoc on dv.attributeoptioncomboid = aoc.categoryoptioncomboid "
-            + "inner join period pe on dv.periodid = pe.periodid "
-            + "inner join periodtype pt on pe.periodtypeid = pt.periodtypeid "
-            + "inner join organisationunit ou on dv.sourceid = ou.organisationunitid "
-            + "where dv.dataelementid in (:data_element_ids) "
-            + "and pe.startdate >= :start_date "
-            + "and pe.enddate <= :end_date "
-            + "and "
-            + ouPathClause
-            + " "
-            + "and dv.deleted is false"
-            + ") as dvs "
-            +
-            // Mean or Median and std dev mapping query
-            "inner join ("
-            + "select dv.dataelementid as dataelementid, dv.sourceid as sourceid, "
-            + "dv.categoryoptioncomboid as categoryoptioncomboid, "
-            + "dv.attributeoptioncomboid as attributeoptioncomboid, "
-            + middle_stats_calc
-            + " as middle_value, "
-            + "stddev_pop(dv.value::double precision) as std_dev "
-            + "from datavalue dv "
-            + "inner join period pe on dv.periodid = pe.periodid "
-            + "inner join organisationunit ou on dv.sourceid = ou.organisationunitid "
-            + "where dv.dataelementid in (:data_element_ids) "
-            + dataStartDateClause
-            + dataEndDateClause
-            + "and "
-            + ouPathClause
-            + " "
-            + "and dv.deleted is false "
-            + "group by dv.dataelementid, dv.sourceid, dv.categoryoptioncomboid, dv.attributeoptioncomboid"
-            + ") as stats "
-            +
-            // Query join
-            "on dvs.dataelementid = stats.dataelementid "
-            + "and dvs.sourceid = stats.sourceid "
-            + "and dvs.categoryoptioncomboid = stats.categoryoptioncomboid "
-            + "and dvs.attributeoptioncomboid = stats.attributeoptioncomboid "
-            + "where stats.std_dev != 0.0 "
-            +
-            // Filter on z-score threshold
-            "and (abs(dvs.value::double precision - stats.middle_value) / stats.std_dev) >= :threshold "
-            +
-            // Order and limit
-            "order by "
-            + order
-            + " desc "
-            + "limit :max_results;";
+        "select dvs.de_uid, dvs.ou_uid, dvs.coc_uid, dvs.aoc_uid, " +
+            "dvs.de_name, dvs.ou_name, dvs.coc_name, dvs.aoc_name, dvs.value, dvs.follow_up, " +
+            "dvs.pe_start_date, dvs.pt_name, " +
+            "stats.middle_value as middle_value, " +
+            "stats.std_dev as std_dev, " +
+            "abs(dvs.value::double precision - stats.middle_value) as middle_value_abs_dev, " +
+            "abs(dvs.value::double precision - stats.middle_value) / stats.std_dev as z_score, " +
+            "stats.middle_value - (stats.std_dev * :threshold) as lower_bound, " +
+            "stats.middle_value + (stats.std_dev * :threshold) as upper_bound " +
+        // Data value query
+        "from (" +
+            "select dv.dataelementid, dv.sourceid, dv.periodid, " +
+            "dv.categoryoptioncomboid, dv.attributeoptioncomboid, " +
+            "de.uid as de_uid, ou.uid as ou_uid, coc.uid as coc_uid, aoc.uid as aoc_uid, " +
+            "de.name as de_name, ou.name as ou_name, coc.name as coc_name, aoc.name as aoc_name, " +
+            "pe.startdate as pe_start_date, pt.name as pt_name, " +
+            "dv.value as value, dv.followup as follow_up " +
+            "from datavalue dv " +
+            "inner join dataelement de on dv.dataelementid = de.dataelementid " +
+            "inner join categoryoptioncombo coc on dv.categoryoptioncomboid = coc.categoryoptioncomboid " +
+            "inner join categoryoptioncombo aoc on dv.attributeoptioncomboid = aoc.categoryoptioncomboid " +
+            "inner join period pe on dv.periodid = pe.periodid " +
+            "inner join periodtype pt on pe.periodtypeid = pt.periodtypeid " +
+            "inner join organisationunit ou on dv.sourceid = ou.organisationunitid " +
+            "where dv.dataelementid in (:data_element_ids) " +
+            "and pe.startdate >= :start_date " +
+            "and pe.enddate <= :end_date " +
+            "and " + ouPathClause + " " +
+            "and dv.deleted is false" +
+        ") as dvs " +
+        // Mean or Median and std dev mapping query
+        "inner join (" +
+            "select dv.dataelementid as dataelementid, dv.sourceid as sourceid, " +
+            "dv.categoryoptioncomboid as categoryoptioncomboid, " +
+            "dv.attributeoptioncomboid as attributeoptioncomboid, " +
+            middle_stats_calc +" as middle_value, "+
+            "stddev_pop(dv.value::double precision) as std_dev " +
+            "from datavalue dv " +
+            "inner join period pe on dv.periodid = pe.periodid " +
+            "inner join organisationunit ou on dv.sourceid = ou.organisationunitid " +
+            "where dv.dataelementid in (:data_element_ids) " +
+            dataStartDateClause +
+            dataEndDateClause +
+            "and " + ouPathClause + " " +
+            "and dv.deleted is false " +
+            "group by dv.dataelementid, dv.sourceid, dv.categoryoptioncomboid, dv.attributeoptioncomboid" +
+        ") as stats " +
+        // Query join
+        "on dvs.dataelementid = stats.dataelementid " +
+        "and dvs.sourceid = stats.sourceid " +
+        "and dvs.categoryoptioncomboid = stats.categoryoptioncomboid " +
+        "and dvs.attributeoptioncomboid = stats.attributeoptioncomboid " +
+        "where stats.std_dev != 0.0 " +
+        // Filter on z-score threshold
+        "and (abs(dvs.value::double precision - stats.middle_value) / stats.std_dev) >= :threshold " +
+        // Order and limit
+        "order by " + order + " desc " +
+        "limit :max_results;";
     // @formatter:on
 
     final SqlParameterSource params =

--- a/dhis-2/dhis-test-e2e/pom.xml
+++ b/dhis-2/dhis-test-e2e/pom.xml
@@ -192,6 +192,10 @@
               <enabled>true</enabled>
             </upToDateChecking>
             <java>
+              <toggleOffOn>
+                <off>@formatter:off</off>
+                <on>@formatter:on</on>
+              </toggleOffOn>
               <googleJavaFormat/>
               <trimTrailingWhitespace/>
               <licenseHeader>
@@ -200,7 +204,8 @@
             </java>
             <pom>
               <toggleOffOn>
-                <off>formatter:off</off><on>formatter:on</on>
+                <off>@formatter:off</off>
+                <on>@formatter:on</on>
               </toggleOffOn>
               <includes>
                 <include>pom.xml</include>

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/security/JwtBearerTokenTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/security/JwtBearerTokenTest.java
@@ -68,7 +68,6 @@ import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 class JwtBearerTokenTest extends DhisControllerWithJwtTokenAuthTest {
-  // @formatter:off
   public static final String EXPIRED_GOOGLE_JWT_TOKEN =
       "eyJhbGciOiJSUzI1NiIsImtpZCI6ImU4NzMyZGIwNjI4NzUxNTU1NjIx"
           + "M2I4MGFjYmNmZDA4Y2ZiMzAyYTkiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhenAiO"
@@ -83,7 +82,6 @@ class JwtBearerTokenTest extends DhisControllerWithJwtTokenAuthTest {
           + "8VTjFFEijgfW1IIy_BWI8gDY6iCK7qgOATdYnCyJteWBMKRPr5wVSN05TT3xxLzsE7C5ViOzHAm2v6XrrsEhfcjNmwKmlljjpImTwtUS"
           + "TBS3DWoWsHaNqXfE3rO0M7231FWl2X0vk5oO-KycNoS1vDZLAvdf6QRJVnPMkQ6Cx5XSMSYEmUmFqM3Sj2ip0Q48hAe4ydzIgRWdGbzG"
           + "nMH3euqGWr4_G_EBvVqfVPnBF0YA";
-  // @formatter:on
 
   public static final String GOOGLE_CLIENT_ID =
       "1019417002544-mqa7flk4mjohrgsbg9bta9bvluoj85o0.apps.googleusercontent.com";

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/security/utils/Jwks.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/security/utils/Jwks.java
@@ -49,12 +49,10 @@ public final class Jwks {
     KeyPair keyPair = KeyGeneratorUtils.generateRsaKey();
     RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
     RSAPrivateKey privateKey = (RSAPrivateKey) keyPair.getPrivate();
-    // @formatter:off
     return new RSAKey.Builder(publicKey)
         .privateKey(privateKey)
         .keyID(UUID.randomUUID().toString())
         .build();
-    // @formatter:on
   }
 
   public static ECKey generateEc() {
@@ -62,18 +60,14 @@ public final class Jwks {
     ECPublicKey publicKey = (ECPublicKey) keyPair.getPublic();
     ECPrivateKey privateKey = (ECPrivateKey) keyPair.getPrivate();
     Curve curve = Curve.forECParameterSpec(publicKey.getParams());
-    // @formatter:off
     return new ECKey.Builder(curve, publicKey)
         .privateKey(privateKey)
         .keyID(UUID.randomUUID().toString())
         .build();
-    // @formatter:on
   }
 
   public static OctetSequenceKey generateSecret() {
     SecretKey secretKey = KeyGeneratorUtils.generateSecretKey();
-    // @formatter:off
     return new OctetSequenceKey.Builder(secretKey).keyID(UUID.randomUUID().toString()).build();
-    // @formatter:on
   }
 }

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1926,13 +1926,13 @@
                     <arg value="--short=7"/>
                     <arg value="HEAD"/>
                   </exec>
-                  <!-- formatter:off -->
+                  <!-- @formatter:off -->
                   <echo file="${project.build.outputDirectory}/build.properties">
 build.version=${project.version}
 build.time=${now}
 build.revision=${revision}
 jasperreports.version=${jasperreports.version}
-                  <!-- formatter:on -->
+                  <!-- @formatter:on -->
                   </echo>
                 </target>
               </configuration>
@@ -1965,6 +1965,10 @@ jasperreports.version=${jasperreports.version}
               <enabled>true</enabled>
             </upToDateChecking>
             <java>
+              <toggleOffOn>
+                <off>@formatter:off</off>
+                <on>@formatter:on</on>
+              </toggleOffOn>
               <googleJavaFormat/>
               <trimTrailingWhitespace/>
               <licenseHeader>
@@ -1973,7 +1977,8 @@ jasperreports.version=${jasperreports.version}
             </java>
             <pom>
               <toggleOffOn>
-                <off>formatter:off</off><on>formatter:on</on>
+                <off>@formatter:off</off>
+                <on>@formatter:on</on>
               </toggleOffOn>
               <includes>
                 <include>pom.xml</include>


### PR DESCRIPTION
google java formatter cannot be disabled. spotless allows us to disable any formatter https://github.com/diffplug/spotless/tree/main/plugin-maven\#spotlessoff-and-spotlesson Use the same pattern we used before (the one recognized by the Eclipse formatter) also for disabling the pom.xml formatter

We should only turn off the formatter when absolutely necessary. Like when creating a DSL that represents a tree that would otherwise get flattened or complex SQL statements. Javadocs should use the appropriate html tags to avoid unwanted formatting.