### PR TITLE
fix: Support dim. repetition and staged dim. [DHIS2-14956]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualization.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualization.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.eventvisualization;
 
 import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.ArrayUtils.contains;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.join;
 import static org.hisp.dhis.common.AnalyticsType.EVENT;
@@ -639,14 +640,15 @@ public class EventVisualization extends BaseAnalyticalObject
 
   /** Validates the state of the current list of {@link Sorting} objects (if one is defined). */
   public void validateSortingState() {
+    getColumns();
     List<String> columns = getColumnDimensions();
-    List<Sorting> sortings = getSorting().stream().toList();
+    List<Sorting> sortingList = getSorting().stream().toList();
 
-    sortings.forEach(
+    sortingList.forEach(
         s -> {
           if (isBlank(s.getDimension()) || s.getDirection() == null) {
             throw new IllegalArgumentException("Sorting is not valid");
-          } else if (!columns.contains(s.getDimension())) {
+          } else if (columns.stream().noneMatch(c -> contains(s.getDimension().split("\\."), c))) {
             throw new IllegalStateException(s.getDimension());
           }
         });

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/Sorting.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/Sorting.java
@@ -42,6 +42,7 @@ import org.hisp.dhis.analytics.SortOrder;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @NoArgsConstructor
 public class Sorting implements Serializable {
+  /** A dimension can have the format "uid", "uid.uid1", "uid.uid1.uid2" or "uid[-2].uid1". */
   @EqualsAndHashCode.Include
   @JsonProperty(required = true)
   @JacksonXmlProperty(namespace = DXF_2_0)

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -463,7 +463,7 @@ public enum ErrorCode {
   E7234("Query filter: `{0}` not valid for query item value type: `{1}`"),
   E7235("Either programId or programStageId must be specified"),
   E7236("Program stage '{0}' is not associated to program '{0}'"),
-  E7237("Sorting must have a dimension and a direction"),
+  E7237("Sorting must have a valid dimension and a direction"),
   E7238("Sorting dimension ‘{0}’ is not a column"),
 
   /* TEI analytics */


### PR DESCRIPTION
As part of this ticket, we should also support sorting for staged dimensions, including the ones with repetition as well. ie:

```
A03MvHHogjR.a3kGcGDCuk6
A03MvHHogjR[-2].a3kGcGDCuk6
```

This fix enables support for both cases.