### PR TITLE
fix: Gist API - array fields as array of objects [DHIS2-15168]

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonString;
 import org.hisp.dhis.web.HttpStatus;
+import org.hisp.dhis.webapi.json.domain.JsonUserGroup;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -198,5 +199,20 @@ class GistFieldsControllerTest extends AbstractGistControllerTest {
   void testField_UserNameAutomaticFromTransformation() {
     JsonArray users = GET("/users/gist?fields=id,name&headless=true").content();
     assertEquals("FirstNameadmin Surnameadmin", users.getObject(0).getString("name").string());
+  }
+
+  @Test
+  void testNestedFieldsOfListProperty() {
+    JsonArray groups =
+        GET("/userGroups/gist?fields=id,name,users[id,username]&headless=true").content();
+    assertEquals(1, groups.size());
+    JsonUserGroup group = groups.get(0, JsonUserGroup.class);
+    JsonArray members = group.getArray("users");
+    assertTrue(members.isArray());
+    assertEquals(1, members.size());
+    JsonObject member = members.getObject(0);
+    assertTrue(member.has("id", "username"));
+    assertEquals(getSuperuserUid(), member.getString("id").string());
+    assertEquals("admin", member.getString("username").string());
   }
 }


### PR DESCRIPTION
### Summary
Nested properties of a collection property are shown as array of objects as opposed to object of array, for example:
https://play.dhis2.org/dev/api/userGroups/gist?fields=id,name,users[id,username]&headless=true shows currently
```json
[
  {
    "id": "L4XTzgbdza3",
    "name": "Wakiki",
    "users": {
      "id": [
        "UdIUgDExdIp",
        "qObaDc0JE3y",
        ...
      ],
      "username": [
        "philS",
        "geethaS",
        ...
      ]
  }
]
``` 
This is now instead shown as:
```json
[
  {
    "id": "L4XTzgbdza3",
    "name": "Wakiki",
    "users": [
      {
        "id": "UdIUgDExdIp",
        "username": "philS"
      },
      {
        "id": "qObaDc0JE3y",
        "username": "geethaS"
      },
     ...
     ]
  }
]
```
Further improvments:
* fixes a NPE when using multi pluck and the plucked value being `null` in the DB
* fixes so when using grouping filters the non group filters use the `rootJunction` combinator

### Automatic Testing
Added a new test scenario for nested properties that confirms it renders as array of objects.