### PR TITLE
chore: Remove includeDeleted from field params [TECH-1571]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.tracker.export.relationship;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
@@ -57,6 +56,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class DefaultRelationshipService implements RelationshipService {
+
   private final CurrentUserService currentUserService;
 
   private final TrackerAccessManager trackerAccessManager;
@@ -116,7 +116,7 @@ public class DefaultRelationshipService implements RelationshipService {
             .stream()
             .filter(
                 r -> trackerAccessManager.canRead(currentUserService.getCurrentUser(), r).isEmpty())
-            .collect(Collectors.toList());
+            .toList();
     return map(relationships);
   }
 
@@ -129,7 +129,7 @@ public class DefaultRelationshipService implements RelationshipService {
         relationshipStore.getByEnrollment(enrollment, pagingAndSortingCriteriaAdapter).stream()
             .filter(
                 r -> trackerAccessManager.canRead(currentUserService.getCurrentUser(), r).isEmpty())
-            .collect(Collectors.toList());
+            .toList();
     return map(relationships);
   }
 
@@ -141,7 +141,7 @@ public class DefaultRelationshipService implements RelationshipService {
         relationshipStore.getByEvent(event, pagingAndSortingCriteriaAdapter).stream()
             .filter(
                 r -> trackerAccessManager.canRead(currentUserService.getCurrentUser(), r).isEmpty())
-            .collect(Collectors.toList());
+            .toList();
     return map(relationships);
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -185,7 +185,9 @@ public class DefaultRelationshipService implements RelationshipService {
     if (item.getTrackedEntity() != null) {
       result.setTrackedEntity(
           trackedEntityService.getTrackedEntity(
-              item.getTrackedEntity(), TrackedEntityParams.TRUE.withIncludeRelationships(false)));
+              item.getTrackedEntity(),
+              TrackedEntityParams.TRUE.withIncludeRelationships(false),
+              false));
     } else if (item.getEnrollment() != null) {
       result.setEnrollment(
           enrollmentService.getEnrollment(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -101,19 +101,20 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
   private final TrackedEntityOperationParamsMapper mapper;
 
   @Override
-  public TrackedEntity getTrackedEntity(String uid, TrackedEntityParams params)
+  public TrackedEntity getTrackedEntity(
+      String uid, TrackedEntityParams params, boolean includeDeleted)
       throws NotFoundException, ForbiddenException {
     TrackedEntity daoTrackedEntity = teiService.getTrackedEntity(uid);
     if (daoTrackedEntity == null) {
       throw new NotFoundException(TrackedEntity.class, uid);
     }
 
-    return getTrackedEntity(daoTrackedEntity, params);
+    return getTrackedEntity(daoTrackedEntity, params, includeDeleted);
   }
 
   @Override
   public TrackedEntity getTrackedEntity(
-      String uid, String programIdentifier, TrackedEntityParams params)
+      String uid, String programIdentifier, TrackedEntityParams params, boolean includeDeleted)
       throws NotFoundException, ForbiddenException {
     Program program = null;
 
@@ -125,7 +126,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
       }
     }
 
-    TrackedEntity trackedEntity = getTrackedEntity(uid, params);
+    TrackedEntity trackedEntity = getTrackedEntity(uid, params, includeDeleted);
 
     if (program != null) {
       if (!trackerAccessManager
@@ -165,7 +166,8 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
 
   @Override
   public TrackedEntity getTrackedEntity(
-      @Nonnull TrackedEntity trackedEntity, TrackedEntityParams params) throws ForbiddenException {
+      @Nonnull TrackedEntity trackedEntity, TrackedEntityParams params, boolean includeDeleted)
+      throws ForbiddenException {
     User user = currentUserService.getCurrentUser();
     List<String> errors = trackerAccessManager.canRead(user, trackedEntity);
 
@@ -190,10 +192,11 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
     result.setLastUpdatedByUserInfo(trackedEntity.getLastUpdatedByUserInfo());
     result.setGeometry(trackedEntity.getGeometry());
     if (params.isIncludeRelationships()) {
-      result.setRelationshipItems(getRelationshipItems(trackedEntity, params, user));
+      result.setRelationshipItems(
+          getRelationshipItems(trackedEntity, params, user, includeDeleted));
     }
     if (params.isIncludeEnrollments()) {
-      result.setEnrollments(getEnrollments(trackedEntity, params, user));
+      result.setEnrollments(getEnrollments(trackedEntity, params, user, includeDeleted));
     }
     if (params.isIncludeProgramOwners()) {
       result.setProgramOwners(trackedEntity.getProgramOwners());
@@ -204,14 +207,14 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
   }
 
   private Set<RelationshipItem> getRelationshipItems(
-      TrackedEntity trackedEntity, TrackedEntityParams params, User user) {
+      TrackedEntity trackedEntity, TrackedEntityParams params, User user, boolean includeDeleted) {
     Set<RelationshipItem> items = new HashSet<>();
 
     for (RelationshipItem relationshipItem : trackedEntity.getRelationshipItems()) {
       Relationship daoRelationship = relationshipItem.getRelationship();
 
       if (trackerAccessManager.canRead(user, daoRelationship).isEmpty()
-          && (params.isIncludeDeleted() || !daoRelationship.isDeleted())) {
+          && (includeDeleted || !daoRelationship.isDeleted())) {
         items.add(relationshipItem);
       }
     }
@@ -219,15 +222,15 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
   }
 
   private Set<Enrollment> getEnrollments(
-      TrackedEntity trackedEntity, TrackedEntityParams params, User user) {
+      TrackedEntity trackedEntity, TrackedEntityParams params, User user, boolean includeDeleted) {
     Set<Enrollment> enrollments = new HashSet<>();
 
     for (Enrollment enrollment : trackedEntity.getEnrollments()) {
       if (trackerAccessManager.canRead(user, enrollment, false).isEmpty()
-          && (params.isIncludeDeleted() || !enrollment.isDeleted())) {
+          && (includeDeleted || !enrollment.isDeleted())) {
         Set<Event> events = new HashSet<>();
         for (Event event : enrollment.getEvents()) {
-          if (params.isIncludeDeleted() || !event.isDeleted()) {
+          if (includeDeleted || !event.isDeleted()) {
             events.add(event);
           }
         }
@@ -247,7 +250,8 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
         .collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
-  private RelationshipItem withNestedEntity(TrackedEntity trackedEntity, RelationshipItem item)
+  private RelationshipItem withNestedEntity(
+      TrackedEntity trackedEntity, RelationshipItem item, boolean includeDeleted)
       throws ForbiddenException, NotFoundException {
     // relationships of relationship items are not mapped to JSON so there is no need to fetch them
     RelationshipItem result = new RelationshipItem();
@@ -261,7 +265,8 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
         result.setTrackedEntity(
             getTrackedEntity(
                 item.getTrackedEntity().getUid(),
-                TrackedEntityParams.TRUE.withIncludeRelationships(false)));
+                TrackedEntityParams.TRUE.withIncludeRelationships(false),
+                includeDeleted));
       }
     } else if (item.getEnrollment() != null) {
       result.setEnrollment(
@@ -292,7 +297,10 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
         this.trackedEntityAggregate.find(
             ids, operationParams.getTrackedEntityParams(), queryParams);
 
-    mapRelationshipItems(trackedEntities, operationParams.getTrackedEntityParams());
+    mapRelationshipItems(
+        trackedEntities,
+        operationParams.getTrackedEntityParams(),
+        operationParams.isIncludeDeleted());
 
     addSearchAudit(trackedEntities, queryParams.getUser());
 
@@ -304,17 +312,18 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
    * event) in our API. The aggregate stores currently do not support that, so we need to fetch the
    * entities individually.
    */
-  private void mapRelationshipItems(List<TrackedEntity> trackedEntities, TrackedEntityParams params)
+  private void mapRelationshipItems(
+      List<TrackedEntity> trackedEntities, TrackedEntityParams params, boolean includeDeleted)
       throws ForbiddenException, NotFoundException {
     if (params.isIncludeRelationships()) {
       for (TrackedEntity trackedEntity : trackedEntities) {
-        mapRelationshipItems(trackedEntity);
+        mapRelationshipItems(trackedEntity, includeDeleted);
       }
     }
     if (params.getEnrollmentParams().isIncludeRelationships()) {
       for (TrackedEntity trackedEntity : trackedEntities) {
         for (Enrollment enrollment : trackedEntity.getEnrollments()) {
-          mapRelationshipItems(enrollment, trackedEntity);
+          mapRelationshipItems(enrollment, trackedEntity, includeDeleted);
         }
       }
     }
@@ -322,54 +331,59 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
       for (TrackedEntity trackedEntity : trackedEntities) {
         for (Enrollment enrollment : trackedEntity.getEnrollments()) {
           for (Event event : enrollment.getEvents()) {
-            mapRelationshipItems(event, trackedEntity);
+            mapRelationshipItems(event, trackedEntity, includeDeleted);
           }
         }
       }
     }
   }
 
-  private void mapRelationshipItems(TrackedEntity trackedEntity)
+  private void mapRelationshipItems(TrackedEntity trackedEntity, boolean includeDeleted)
       throws ForbiddenException, NotFoundException {
     Set<RelationshipItem> result = new HashSet<>();
 
     for (RelationshipItem item : trackedEntity.getRelationshipItems()) {
-      result.add(mapRelationshipItem(item, trackedEntity, trackedEntity));
+      result.add(mapRelationshipItem(item, trackedEntity, trackedEntity, includeDeleted));
     }
 
     trackedEntity.setRelationshipItems(result);
   }
 
-  private void mapRelationshipItems(Enrollment enrollment, TrackedEntity trackedEntity)
+  private void mapRelationshipItems(
+      Enrollment enrollment, TrackedEntity trackedEntity, boolean includeDeleted)
       throws ForbiddenException, NotFoundException {
     Set<RelationshipItem> result = new HashSet<>();
 
     for (RelationshipItem item : enrollment.getRelationshipItems()) {
-      result.add(mapRelationshipItem(item, enrollment, trackedEntity));
+      result.add(mapRelationshipItem(item, enrollment, trackedEntity, includeDeleted));
     }
 
     enrollment.setRelationshipItems(result);
   }
 
-  private void mapRelationshipItems(Event event, TrackedEntity trackedEntity)
+  private void mapRelationshipItems(
+      Event event, TrackedEntity trackedEntity, boolean includeDeleted)
       throws ForbiddenException, NotFoundException {
     Set<RelationshipItem> result = new HashSet<>();
 
     for (RelationshipItem item : event.getRelationshipItems()) {
-      result.add(mapRelationshipItem(item, event, trackedEntity));
+      result.add(mapRelationshipItem(item, event, trackedEntity, includeDeleted));
     }
 
     event.setRelationshipItems(result);
   }
 
   private RelationshipItem mapRelationshipItem(
-      RelationshipItem item, BaseIdentifiableObject itemOwner, TrackedEntity trackedEntity)
+      RelationshipItem item,
+      BaseIdentifiableObject itemOwner,
+      TrackedEntity trackedEntity,
+      boolean includeDeleted)
       throws ForbiddenException, NotFoundException {
     Relationship rel = item.getRelationship();
-    RelationshipItem from = withNestedEntity(trackedEntity, rel.getFrom());
+    RelationshipItem from = withNestedEntity(trackedEntity, rel.getFrom(), includeDeleted);
     from.setRelationship(rel);
     rel.setFrom(from);
-    RelationshipItem to = withNestedEntity(trackedEntity, rel.getTo());
+    RelationshipItem to = withNestedEntity(trackedEntity, rel.getTo(), includeDeleted);
     to.setRelationship(rel);
     rel.setTo(to);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -192,11 +192,10 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
     result.setLastUpdatedByUserInfo(trackedEntity.getLastUpdatedByUserInfo());
     result.setGeometry(trackedEntity.getGeometry());
     if (params.isIncludeRelationships()) {
-      result.setRelationshipItems(
-          getRelationshipItems(trackedEntity, params, user, includeDeleted));
+      result.setRelationshipItems(getRelationshipItems(trackedEntity, user, includeDeleted));
     }
     if (params.isIncludeEnrollments()) {
-      result.setEnrollments(getEnrollments(trackedEntity, params, user, includeDeleted));
+      result.setEnrollments(getEnrollments(trackedEntity, user, includeDeleted));
     }
     if (params.isIncludeProgramOwners()) {
       result.setProgramOwners(trackedEntity.getProgramOwners());
@@ -207,7 +206,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
   }
 
   private Set<RelationshipItem> getRelationshipItems(
-      TrackedEntity trackedEntity, TrackedEntityParams params, User user, boolean includeDeleted) {
+      TrackedEntity trackedEntity, User user, boolean includeDeleted) {
     Set<RelationshipItem> items = new HashSet<>();
 
     for (RelationshipItem relationshipItem : trackedEntity.getRelationshipItems()) {
@@ -222,7 +221,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
   }
 
   private Set<Enrollment> getEnrollments(
-      TrackedEntity trackedEntity, TrackedEntityParams params, User user, boolean includeDeleted) {
+      TrackedEntity trackedEntity, User user, boolean includeDeleted) {
     Set<Enrollment> enrollments = new HashSet<>();
 
     for (Enrollment enrollment : trackedEntity.getEnrollments()) {
@@ -411,7 +410,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
             .filter(tei -> tei.getTrackedEntityType() != null)
             .filter(tei -> tetMap.get(tei.getTrackedEntityType().getUid()).isAllowAuditLog())
             .map(tei -> new TrackedEntityAudit(tei.getUid(), accessedBy, AuditType.SEARCH))
-            .collect(Collectors.toList());
+            .toList();
 
     if (!auditable.isEmpty()) {
       trackedEntityAuditService.addTrackedEntityAudit(auditable);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityParams.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.tracker.export.trackedentity;
 
 import lombok.Value;
 import lombok.With;
-import org.hisp.dhis.tracker.export.enrollment.EnrollmentEventsParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentParams;
 import org.hisp.dhis.tracker.export.event.EventParams;
 
@@ -40,10 +39,10 @@ import org.hisp.dhis.tracker.export.event.EventParams;
 @Value
 public class TrackedEntityParams {
   public static final TrackedEntityParams TRUE =
-      new TrackedEntityParams(true, TrackedEntityEnrollmentParams.TRUE, true, true, false);
+      new TrackedEntityParams(true, TrackedEntityEnrollmentParams.TRUE, true, true);
 
   public static final TrackedEntityParams FALSE =
-      new TrackedEntityParams(false, TrackedEntityEnrollmentParams.FALSE, false, false, false);
+      new TrackedEntityParams(false, TrackedEntityEnrollmentParams.FALSE, false, false);
 
   boolean includeRelationships;
 
@@ -53,8 +52,6 @@ public class TrackedEntityParams {
 
   boolean includeAttributes;
 
-  boolean includeDeleted;
-
   public boolean isIncludeEnrollments() {
     return teiEnrollmentParams.isIncludeEnrollments();
   }
@@ -63,23 +60,7 @@ public class TrackedEntityParams {
     return this.teiEnrollmentParams.getEnrollmentParams();
   }
 
-  public TrackedEntityParams withEnrollmentParams(EnrollmentParams enrollmentParams) {
-    return this.withTeiEnrollmentParams(
-        getTeiEnrollmentParams().withEnrollmentParams(enrollmentParams));
-  }
-
   public EventParams getEventParams() {
     return getEnrollmentParams().getEnrollmentEventsParams().getEventParams();
-  }
-
-  public TrackedEntityParams withEventParams(EventParams eventParams) {
-    EnrollmentParams enrollmentParams = this.teiEnrollmentParams.getEnrollmentParams();
-
-    EnrollmentEventsParams eventParamsToUpdate =
-        enrollmentParams.getEnrollmentEventsParams().withEventParams(eventParams);
-
-    return withTeiEnrollmentParams(
-        this.teiEnrollmentParams.withEnrollmentParams(
-            enrollmentParams.withEnrollmentEventsParams(eventParamsToUpdate)));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
@@ -34,13 +34,15 @@ import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 
 public interface TrackedEntityService {
-  TrackedEntity getTrackedEntity(String uid, TrackedEntityParams params)
+  TrackedEntity getTrackedEntity(String uid, TrackedEntityParams params, boolean includeDeleted)
       throws NotFoundException, ForbiddenException;
 
-  TrackedEntity getTrackedEntity(TrackedEntity trackedEntity, TrackedEntityParams params)
+  TrackedEntity getTrackedEntity(
+      TrackedEntity trackedEntity, TrackedEntityParams params, boolean includeDeleted)
       throws NotFoundException, ForbiddenException;
 
-  TrackedEntity getTrackedEntity(String uid, String programIdentifier, TrackedEntityParams params)
+  TrackedEntity getTrackedEntity(
+      String uid, String programIdentifier, TrackedEntityParams params, boolean includeDeleted)
       throws NotFoundException, ForbiddenException;
 
   /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/AbstractStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/AbstractStore.java
@@ -45,14 +45,10 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
  */
 abstract class AbstractStore {
   protected static final int PARITITION_SIZE = 20000;
-
-  protected final NamedParameterJdbcTemplate jdbcTemplate;
-
   private static final String GET_RELATIONSHIP_ID_BY_ENTITY_ID_SQL =
       "select ri.%s as id, r.relationshipid "
           + "FROM relationshipitem ri left join relationship r on ri.relationshipid = r.relationshipid "
           + "where ri.%s in (:ids)";
-
   private static final String GET_RELATIONSHIP_BY_RELATIONSHIP_ID =
       "select "
           + "r.uid as rel_uid, r.created, r.lastupdated, rst.name as reltype_name, rst.uid as reltype_uid, rst.bidirectional as reltype_bi, "
@@ -76,6 +72,7 @@ abstract class AbstractStore {
           + "where ri.relationshipitemid = r.from_relationshipitemid)) from_uid "
           + "from relationship r join relationshiptype rst on r.relationshiptypeid = rst.relationshiptypeid "
           + "where r.relationshipid in (:ids)";
+  protected final NamedParameterJdbcTemplate jdbcTemplate;
 
   protected AbstractStore(JdbcTemplate jdbcTemplate) {
     this.jdbcTemplate = new NamedParameterJdbcTemplate(jdbcTemplate);
@@ -107,7 +104,7 @@ abstract class AbstractStore {
                 getRelationshipEntityColumn(),
                 getRelationshipEntityColumn()));
 
-    if (!ctx.getParams().isIncludeDeleted()) {
+    if (!ctx.getQueryParams().isIncludeDeleted()) {
       getRelationshipsHavingIdSQL.append(" AND r.deleted is false");
     }
     // Get all the relationship ids that have at least one relationship item

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -99,6 +99,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @author Luciano Fiandesio
  */
 class TrackedEntityServiceTest extends IntegrationTestBase {
+
   @Autowired protected UserService _userService;
 
   @Autowired private TrackedEntityService trackedEntityService;
@@ -152,12 +153,6 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
   private Relationship relationshipB;
 
   private Relationship relationshipC;
-
-  private static List<String> uids(Collection<? extends BaseIdentifiableObject> trackedEntities) {
-    return trackedEntities.stream()
-        .map(BaseIdentifiableObject::getUid)
-        .collect(Collectors.toList());
-  }
 
   @Override
   protected void setUpTest() throws Exception {
@@ -628,6 +623,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
   }
 
   @Test
+  @Disabled("IncludeDeleted param is not working when TE has a deleted relationship")
   void shouldIncludeDeletedEnrollmentAndEvents()
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntityOperationParams operationParams =
@@ -1017,6 +1013,12 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     assertAll(
         () -> assertEquals(trackedEntityA.getUid(), actual.getFrom().getTrackedEntity().getUid()),
         () -> assertEquals(eventA.getUid(), actual.getTo().getEvent().getUid()));
+  }
+
+  private List<String> uids(Collection<? extends BaseIdentifiableObject> trackedEntities) {
+    return trackedEntities.stream()
+        .map(BaseIdentifiableObject::getUid)
+        .collect(Collectors.toList());
   }
 
   private Set<String> attributeNames(final Collection<TrackedEntityAttributeValue> attributes) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -154,6 +154,13 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
 
   private Relationship relationshipC;
 
+  private static List<String> uids(
+      Collection<? extends BaseIdentifiableObject> identifiableObjects) {
+    return identifiableObjects.stream()
+        .map(BaseIdentifiableObject::getUid)
+        .collect(Collectors.toList());
+  }
+
   @Override
   protected void setUpTest() throws Exception {
     userService = _userService;
@@ -1013,12 +1020,6 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     assertAll(
         () -> assertEquals(trackedEntityA.getUid(), actual.getFrom().getTrackedEntity().getUid()),
         () -> assertEquals(eventA.getUid(), actual.getTo().getEvent().getUid()));
-  }
-
-  private List<String> uids(Collection<? extends BaseIdentifiableObject> trackedEntities) {
-    return trackedEntities.stream()
-        .map(BaseIdentifiableObject::getUid)
-        .collect(Collectors.toList());
   }
 
   private Set<String> attributeNames(final Collection<TrackedEntityAttributeValue> attributes) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -99,9 +99,9 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @author Luciano Fiandesio
  */
 class TrackedEntityServiceTest extends IntegrationTestBase {
-  @Autowired private TrackedEntityService trackedEntityService;
-
   @Autowired protected UserService _userService;
+
+  @Autowired private TrackedEntityService trackedEntityService;
 
   @Autowired private EnrollmentService enrollmentService;
 
@@ -152,6 +152,12 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
   private Relationship relationshipB;
 
   private Relationship relationshipC;
+
+  private static List<String> uids(Collection<? extends BaseIdentifiableObject> trackedEntities) {
+    return trackedEntities.stream()
+        .map(BaseIdentifiableObject::getUid)
+        .collect(Collectors.toList());
+  }
 
   @Override
   protected void setUpTest() throws Exception {
@@ -702,7 +708,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
   void shouldReturnTrackedEntityAndEnrollmentsGivenTheyShouldBeIncluded()
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntityParams params =
-        new TrackedEntityParams(false, TrackedEntityEnrollmentParams.TRUE, false, false, false);
+        new TrackedEntityParams(false, TrackedEntityEnrollmentParams.TRUE, false, false);
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
             .organisationUnits(Set.of(orgUnitA.getUid()))
@@ -751,7 +757,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
   void shouldReturnTrackedEntityWithEventsAndNotesGivenTheyShouldBeIncluded()
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntityParams params =
-        new TrackedEntityParams(false, TrackedEntityEnrollmentParams.TRUE, true, false, false);
+        new TrackedEntityParams(false, TrackedEntityEnrollmentParams.TRUE, true, false);
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
             .organisationUnits(Set.of(orgUnitA.getUid()))
@@ -783,11 +789,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntityParams params =
         new TrackedEntityParams(
-            false,
-            TrackedEntityEnrollmentParams.TRUE.withIncludeEvents(false),
-            false,
-            false,
-            false);
+            false, TrackedEntityEnrollmentParams.TRUE.withIncludeEvents(false), false, false);
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
             .organisationUnits(Set.of(orgUnitA.getUid()))
@@ -845,7 +847,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
       throws ForbiddenException, NotFoundException, BadRequestException {
     final Date currentTime = new Date();
     TrackedEntityParams params =
-        new TrackedEntityParams(false, TrackedEntityEnrollmentParams.TRUE, false, false, false);
+        new TrackedEntityParams(false, TrackedEntityEnrollmentParams.TRUE, false, false);
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
             .organisationUnits(Set.of(orgUnitA.getUid()))
@@ -890,7 +892,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
       throws ForbiddenException, NotFoundException, BadRequestException {
     final Date currentTime = new Date();
     TrackedEntityParams params =
-        new TrackedEntityParams(false, TrackedEntityEnrollmentParams.TRUE, false, false, false);
+        new TrackedEntityParams(false, TrackedEntityEnrollmentParams.TRUE, false, false);
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
             .organisationUnits(Set.of(orgUnitA.getUid()))
@@ -943,7 +945,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
   void shouldReturnTrackedEntityWithRelationshipsTei2Tei()
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntityParams params =
-        new TrackedEntityParams(true, TrackedEntityEnrollmentParams.FALSE, false, false, false);
+        new TrackedEntityParams(true, TrackedEntityEnrollmentParams.FALSE, false, false);
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
             .organisationUnits(Set.of(orgUnitA.getUid()))
@@ -969,7 +971,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
   void returnTrackedEntityRelationshipsWithTei2Enrollment()
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntityParams params =
-        new TrackedEntityParams(true, TrackedEntityEnrollmentParams.FALSE, false, false, false);
+        new TrackedEntityParams(true, TrackedEntityEnrollmentParams.FALSE, false, false);
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
             .organisationUnits(Set.of(orgUnitA.getUid()))
@@ -995,7 +997,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
   void shouldReturnTrackedEntityRelationshipsWithTei2Event()
       throws ForbiddenException, NotFoundException, BadRequestException {
     TrackedEntityParams params =
-        new TrackedEntityParams(true, TrackedEntityEnrollmentParams.TRUE, false, false, false);
+        new TrackedEntityParams(true, TrackedEntityEnrollmentParams.TRUE, false, false);
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
             .organisationUnits(Set.of(orgUnitA.getUid()))
@@ -1015,12 +1017,6 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     assertAll(
         () -> assertEquals(trackedEntityA.getUid(), actual.getFrom().getTrackedEntity().getUid()),
         () -> assertEquals(eventA.getUid(), actual.getTo().getEvent().getUid()));
-  }
-
-  private static List<String> uids(Collection<? extends BaseIdentifiableObject> trackedEntities) {
-    return trackedEntities.stream()
-        .map(BaseIdentifiableObject::getUid)
-        .collect(Collectors.toList());
   }
 
   private Set<String> attributeNames(final Collection<TrackedEntityAttributeValue> attributes) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -83,6 +83,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest {
+
   private static final String TEA_UID = "TvjwTPToKHO";
 
   private static final String EVENT_OCCURRED_AT = "2023-03-23T12:23:00.000";
@@ -110,6 +111,8 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   private TrackedEntityAttribute tea;
 
   private TrackedEntityAttribute tea2;
+
+  private TrackedEntity softDeletedTrackedEntity;
 
   @BeforeEach
   void setUp() {
@@ -163,6 +166,10 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
 
     trackedEntityType.setTrackedEntityTypeAttributes(List.of(trackedEntityTypeAttribute));
     manager.save(trackedEntityType, false);
+
+    softDeletedTrackedEntity = createTrackedEntity(orgUnit);
+    softDeletedTrackedEntity.setDeleted(true);
+    manager.save(softDeletedTrackedEntity, false);
   }
 
   @Test
@@ -388,6 +395,14 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
     assertEquals(
         "TrackedEntity with id Hq3Kc6HK4OZ could not be found.",
         GET("/tracker/trackedEntities/Hq3Kc6HK4OZ").error(HttpStatus.NOT_FOUND).getMessage());
+  }
+
+  @Test
+  void shouldReturnNotFoundWhenGettingASoftDeletedTrackedEntityById() {
+    String uid = softDeletedTrackedEntity.getUid();
+    assertEquals(
+        "TrackedEntity with id " + uid + " could not be found.",
+        GET("/tracker/trackedEntities/" + uid).error(HttpStatus.NOT_FOUND).getMessage());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -399,10 +399,9 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
 
   @Test
   void shouldReturnNotFoundWhenGettingASoftDeletedTrackedEntityById() {
-    String uid = softDeletedTrackedEntity.getUid();
     assertEquals(
-        "TrackedEntity with id " + uid + " could not be found.",
-        GET("/tracker/trackedEntities/" + uid).error(HttpStatus.NOT_FOUND).getMessage());
+        HttpStatus.NOT_FOUND,
+        GET("/tracker/trackedEntities/" + softDeletedTrackedEntity.getUid()).status());
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -200,7 +200,10 @@ class TrackedEntitiesExportController {
     TrackedEntity trackedEntity =
         TRACKED_ENTITY_MAPPER.from(
             trackedEntityService.getTrackedEntity(
-                uid.getValue(), program == null ? null : program.getValue(), trackedEntityParams));
+                uid.getValue(),
+                program == null ? null : program.getValue(),
+                trackedEntityParams,
+                false));
 
     return ResponseEntity.ok(fieldFilterService.toObjectNode(trackedEntity, fields));
   }
@@ -218,7 +221,7 @@ class TrackedEntitiesExportController {
 
     TrackedEntity trackedEntity =
         TRACKED_ENTITY_MAPPER.from(
-            trackedEntityService.getTrackedEntity(uid, program, trackedEntityParams));
+            trackedEntityService.getTrackedEntity(uid, program, trackedEntityParams, false));
 
     OutputStream outputStream = response.getOutputStream();
     response.setContentType(CONTENT_TYPE_CSV);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityFieldsParamMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityFieldsParamMapper.java
@@ -48,17 +48,25 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 class TrackedEntityFieldsParamMapper {
-  private final FieldFilterService fieldFilterService;
-
   private static final String FIELD_PROGRAM_OWNERS = "programOwners";
 
   private static final String FIELD_ENROLLMENTS = "enrollments";
 
-  public TrackedEntityParams map(List<FieldPath> fields) {
-    return map(fields, false);
+  private final FieldFilterService fieldFilterService;
+
+  private static TrackedEntityParams initUsingAllOrNoFields(Map<String, FieldPath> roots) {
+    TrackedEntityParams params = TrackedEntityParams.FALSE;
+
+    if (roots.containsKey(FieldPreset.ALL)) {
+      FieldPath p = roots.get(FieldPreset.ALL);
+      if (p.isRoot() && !p.isExclude()) {
+        params = TrackedEntityParams.TRUE;
+      }
+    }
+    return params;
   }
 
-  public TrackedEntityParams map(List<FieldPath> fields, boolean includeDeleted) {
+  public TrackedEntityParams map(List<FieldPath> fields) {
     Map<String, FieldPath> roots = rootFields(fields);
 
     TrackedEntityParams params = initUsingAllOrNoFields(roots);
@@ -71,7 +79,6 @@ class TrackedEntityFieldsParamMapper {
     params =
         params.withIncludeAttributes(
             fieldFilterService.filterIncludes(TrackedEntity.class, fields, FIELD_ATTRIBUTES));
-    params = params.withIncludeDeleted(includeDeleted);
 
     EventParams eventParams =
         new EventParams(
@@ -93,18 +100,6 @@ class TrackedEntityFieldsParamMapper {
             fieldFilterService.filterIncludes(TrackedEntity.class, fields, FIELD_ENROLLMENTS),
             enrollmentParams);
     params = params.withTeiEnrollmentParams(teiEnrollmentParams);
-    return params;
-  }
-
-  private static TrackedEntityParams initUsingAllOrNoFields(Map<String, FieldPath> roots) {
-    TrackedEntityParams params = TrackedEntityParams.FALSE;
-
-    if (roots.containsKey(FieldPreset.ALL)) {
-      FieldPath p = roots.get(FieldPreset.ALL);
-      if (p.isRoot() && !p.isExclude()) {
-        params = TrackedEntityParams.TRUE;
-      }
-    }
     return params;
   }
 }


### PR DESCRIPTION
This PR removed redundant `includeDeleted` filed from `TrackedEntityParams`.
A failing test was disabled and it will be fixed when harmonizing the relationship controller.

**Next Steps**

- Use a `TrackedEntities` object to return result from the server to hide some of the pagination complexity? (It is done this way in other entities)
- Correclty set default values in mapper and not in `RequestParams` as Spring binding doesn't work that way