### PR TITLE
feat: use hibernate bag tag to map java List [DHIS2-15509]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/SortableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/SortableObject.java
@@ -1,0 +1,7 @@
+package org.hisp.dhis.common;
+
+public interface SortableObject
+{
+    Integer getSortOrder();
+    void setSortOrder( Integer sortOrder );
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/SortableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/SortableObject.java
@@ -1,7 +1,34 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.common;
 
-public interface SortableObject
-{
-    Integer getSortOrder();
-    void setSortOrder( Integer sortOrder );
+public interface SortableObject {
+  Integer getSortOrder();
+
+  void setSortOrder(Integer sortOrder);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/SortableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/SortableObject.java
@@ -28,7 +28,9 @@
 package org.hisp.dhis.common;
 
 /**
- * Interface for objects that can be sorted when a List of that object is mapped in Hibernate using {@code <bag name="..." order-by="sort_order">}
+ * Interface for objects that can be sorted when a List of that object is mapped in Hibernate using
+ * {@code <bag name="..." order-by="sort_order">}
+ *
  * <p>The sort order is an integer value that is used to sort the objects in a list.
  */
 public interface SortableObject {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/SortableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/SortableObject.java
@@ -27,6 +27,10 @@
  */
 package org.hisp.dhis.common;
 
+/**
+ * Interface for objects that can be sorted when a List of that object is mapped in Hibernate using {@code <bag name="..." order-by="sort_order">}
+ * <p>The sort order is an integer value that is used to sort the objects in a list.
+ */
 public interface SortableObject {
   Integer getSortOrder();
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/Option.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/Option.java
@@ -37,15 +37,19 @@ import org.hisp.dhis.common.BaseNameableObject;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.common.ObjectStyle;
+import org.hisp.dhis.common.SortableObject;
 import org.hisp.dhis.schema.PropertyType;
 import org.hisp.dhis.schema.annotation.Property;
 
 /**
  * @author Chau Thu Tran
  */
-@JacksonXmlRootElement(localName = "option", namespace = DxfNamespaces.DXF_2_0)
-public class Option extends BaseNameableObject implements MetadataObject {
-  private OptionSet optionSet;
+@JacksonXmlRootElement( localName = "option", namespace = DxfNamespaces.DXF_2_0 )
+public class Option
+    extends BaseNameableObject
+    implements MetadataObject, SortableObject
+{
+    private OptionSet optionSet;
 
   private Integer sortOrder;
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/Option.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/Option.java
@@ -44,12 +44,9 @@ import org.hisp.dhis.schema.annotation.Property;
 /**
  * @author Chau Thu Tran
  */
-@JacksonXmlRootElement( localName = "option", namespace = DxfNamespaces.DXF_2_0 )
-public class Option
-    extends BaseNameableObject
-    implements MetadataObject, SortableObject
-{
-    private OptionSet optionSet;
+@JacksonXmlRootElement(localName = "option", namespace = DxfNamespaces.DXF_2_0)
+public class Option extends BaseNameableObject implements MetadataObject, SortableObject {
+  private OptionSet optionSet;
 
   private Integer sortOrder;
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/hibernate/HibernateOptionStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/hibernate/HibernateOptionStore.java
@@ -75,7 +75,7 @@ public class HibernateOptionStore extends HibernateIdentifiableObjectStore<Optio
       hql += "and lower(option.name) like lower('%" + key + "%') ";
     }
 
-    hql += "order by index(option)";
+    hql += "order by option.sortOrder";
 
     Query<Option> query = getQuery(hql);
     query.setParameter("optionSetId", optionSetId);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/OptionSet.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/option/hibernate/OptionSet.hbm.xml
@@ -31,12 +31,11 @@
 
     <property name="version" />
 
-    <list name="options" cascade="all">
+    <bag name="options" cascade="all" order-by="sort_order">
       <cache usage="read-write" />
       <key column="optionsetid" foreign-key="fk_optionsetmembers_optionsetid" />
-      <list-index column="sort_order" base="1" />
       <one-to-many class="org.hisp.dhis.option.Option" />
-    </list>
+    </bag>
 
     <!-- Dynamic attribute values -->
     <property name="attributeValues" type="jsbAttributeValues"/>

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/IdentifiableObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/IdentifiableObjectBundleHook.java
@@ -27,15 +27,12 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
 
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
-
 import lombok.AllArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.analytics.SortOrder;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeValue;
 import org.hisp.dhis.common.BaseIdentifiableObject;
@@ -76,41 +73,48 @@ public class IdentifiableObjectBundleHook extends AbstractObjectBundleHook<Ident
       baseIdentifiableObject.getSharing().setOwner(baseIdentifiableObject.getCreatedBy());
     }
 
-        Schema schema = schemaService.getDynamicSchema( HibernateProxyUtils.getRealClass( identifiableObject ) );
-        handleAttributeValues( identifiableObject, bundle, schema );
-        handleSkipSharing( identifiableObject, bundle );
-        handleSkipTranslation( identifiableObject, bundle );
-        handleSortOrder( identifiableObject, bundle, schema );
-    }
+    Schema schema =
+        schemaService.getDynamicSchema(HibernateProxyUtils.getRealClass(identifiableObject));
+    handleAttributeValues(identifiableObject, bundle, schema);
+    handleSkipSharing(identifiableObject, bundle);
+    handleSkipTranslation(identifiableObject, bundle);
+    handleSortOrder(identifiableObject, bundle, schema);
+  }
 
-    private void handleSortOrder( IdentifiableObject identifiableObject, ObjectBundle bundle, Schema schema )
-    {
-        findSortableProperty( schema )
-            .forEach( property -> {
-                List<IdentifiableObject> collection = ListUtils.emptyIfNull(
-                    ReflectionUtils.invokeGetterMethod( property.getFieldName(), identifiableObject ) );
-                for ( int i=0; i < collection.size(); i++ )
-                {
-                    IdentifiableObject item = collection.get( i );
-                    IdentifiableObject preheatedItem = bundle.getPreheat().get( bundle.getPreheatIdentifier(), item );
-                    SortableObject sortableItem = (SortableObject) preheatedItem;
-                    if ( sortableItem.getSortOrder() == null )
-                    {
-                        sortableItem.setSortOrder( i );
-                    }
-
-                    bundle.getPreheat().put( bundle.getPreheatIdentifier(), item );
+  private void handleSortOrder(
+      IdentifiableObject identifiableObject, ObjectBundle bundle, Schema schema) {
+    findSortableProperty(schema)
+        .forEach(
+            property -> {
+              List<IdentifiableObject> collection =
+                  ListUtils.emptyIfNull(
+                      ReflectionUtils.invokeGetterMethod(
+                          property.getFieldName(), identifiableObject));
+              for (int i = 0; i < collection.size(); i++) {
+                IdentifiableObject item = collection.get(i);
+                IdentifiableObject preheatedItem =
+                    bundle.getPreheat().get(bundle.getPreheatIdentifier(), item);
+                SortableObject sortableItem = (SortableObject) preheatedItem;
+                if (sortableItem.getSortOrder() == null) {
+                  sortableItem.setSortOrder(i);
                 }
-            } );
-    }
 
-    private List<Property> findSortableProperty( Schema schema )
-    {
-        return schema.getPersistedProperties().values().stream().filter( p -> p.isCollection()
-            && SortableObject.class.isAssignableFrom( p.getItemKlass() )
-            && schemaService.getDynamicSchema( p.getItemKlass() ).hasPersistedProperty( "sortOrder" ) )
-            .toList();
-    }
+                bundle.getPreheat().put(bundle.getPreheatIdentifier(), item);
+              }
+            });
+  }
+
+  private List<Property> findSortableProperty(Schema schema) {
+    return schema.getPersistedProperties().values().stream()
+        .filter(
+            p ->
+                p.isCollection()
+                    && SortableObject.class.isAssignableFrom(p.getItemKlass())
+                    && schemaService
+                        .getDynamicSchema(p.getItemKlass())
+                        .hasPersistedProperty("sortOrder"))
+        .toList();
+  }
 
   @Override
   public void preUpdate(

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/IdentifiableObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/IdentifiableObjectBundleHook.java
@@ -27,20 +27,28 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
 
+import java.util.Comparator;
 import java.util.Iterator;
+import java.util.List;
+
 import lombok.AllArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.analytics.SortOrder;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeValue;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectUtils;
+import org.hisp.dhis.common.SortableObject;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.hibernate.HibernateProxyUtils;
 import org.hisp.dhis.preheat.PreheatIdentifier;
+import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.system.util.ReflectionUtils;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -68,12 +76,41 @@ public class IdentifiableObjectBundleHook extends AbstractObjectBundleHook<Ident
       baseIdentifiableObject.getSharing().setOwner(baseIdentifiableObject.getCreatedBy());
     }
 
-    Schema schema =
-        schemaService.getDynamicSchema(HibernateProxyUtils.getRealClass(identifiableObject));
-    handleAttributeValues(identifiableObject, bundle, schema);
-    handleSkipSharing(identifiableObject, bundle);
-    handleSkipTranslation(identifiableObject, bundle);
-  }
+        Schema schema = schemaService.getDynamicSchema( HibernateProxyUtils.getRealClass( identifiableObject ) );
+        handleAttributeValues( identifiableObject, bundle, schema );
+        handleSkipSharing( identifiableObject, bundle );
+        handleSkipTranslation( identifiableObject, bundle );
+        handleSortOrder( identifiableObject, bundle, schema );
+    }
+
+    private void handleSortOrder( IdentifiableObject identifiableObject, ObjectBundle bundle, Schema schema )
+    {
+        findSortableProperty( schema )
+            .forEach( property -> {
+                List<IdentifiableObject> collection = ListUtils.emptyIfNull(
+                    ReflectionUtils.invokeGetterMethod( property.getFieldName(), identifiableObject ) );
+                for ( int i=0; i < collection.size(); i++ )
+                {
+                    IdentifiableObject item = collection.get( i );
+                    IdentifiableObject preheatedItem = bundle.getPreheat().get( bundle.getPreheatIdentifier(), item );
+                    SortableObject sortableItem = (SortableObject) preheatedItem;
+                    if ( sortableItem.getSortOrder() == null )
+                    {
+                        sortableItem.setSortOrder( i );
+                    }
+
+                    bundle.getPreheat().put( bundle.getPreheatIdentifier(), item );
+                }
+            } );
+    }
+
+    private List<Property> findSortableProperty( Schema schema )
+    {
+        return schema.getPersistedProperties().values().stream().filter( p -> p.isCollection()
+            && SortableObject.class.isAssignableFrom( p.getItemKlass() )
+            && schemaService.getDynamicSchema( p.getItemKlass() ).hasPersistedProperty( "sortOrder" ) )
+            .toList();
+    }
 
   @Override
   public void preUpdate(

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/IdentifiableObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/IdentifiableObjectBundleHook.java
@@ -109,6 +109,7 @@ public class IdentifiableObjectBundleHook extends AbstractObjectBundleHook<Ident
         .filter(
             p ->
                 p.getKlass().isAssignableFrom(List.class)
+                    && p.getItemKlass() != null
                     && SortableObject.class.isAssignableFrom(p.getItemKlass())
                     && schemaService
                         .getDynamicSchema(p.getItemKlass())

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/IdentifiableObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/IdentifiableObjectBundleHook.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -108,7 +109,7 @@ public class IdentifiableObjectBundleHook extends AbstractObjectBundleHook<Ident
     return schema.getPersistedProperties().values().stream()
         .filter(
             p ->
-                p.isCollection()
+                p.getKlass().isAssignableFrom(List.class)
                     && SortableObject.class.isAssignableFrom(p.getItemKlass())
                     && schemaService
                         .getDynamicSchema(p.getItemKlass())

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/IdentifiableObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/IdentifiableObjectBundleHook.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
 
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import lombok.AllArgsConstructor;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/IdentifiableObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/IdentifiableObjectBundleHook.java
@@ -116,7 +116,7 @@ public class IdentifiableObjectBundleHook extends AbstractObjectBundleHook<Ident
   }
 
   /**
-   * Fina all properties of given Schema class that are of type List which contains SortableObjects
+   * Find all properties of given Schema class that are of type List which contains SortableObjects
    * interface. The property must also have a property called sortOrder.
    *
    * @param schema Schema class to search for sortable properties

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/IdentifiableObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/IdentifiableObjectBundleHook.java
@@ -82,7 +82,9 @@ public class IdentifiableObjectBundleHook extends AbstractObjectBundleHook<Ident
   }
 
   /**
-   * This method loops through all sortable List of given object and sets the sortOrder value for each item in the List if it is not already set.
+   * This method loops through all sortable List of given object and sets the sortOrder value for
+   * each item in the List if it is not already set.
+   *
    * @param identifiableObject Object to set sortOrder on
    * @param bundle {@link ObjectBundle}
    * @param schema Schema of given object
@@ -114,7 +116,9 @@ public class IdentifiableObjectBundleHook extends AbstractObjectBundleHook<Ident
   }
 
   /**
-   * Fina all properties of given Schema class that are of type List which contains SortableObjects interface. The property must also have a property called sortOrder.
+   * Fina all properties of given Schema class that are of type List which contains SortableObjects
+   * interface. The property must also have a property called sortOrder.
+   *
    * @param schema Schema class to search for sortable properties
    * @return List of properties that are sortable
    */

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionObjectBundleHook.java
@@ -82,43 +82,6 @@ public class OptionObjectBundleHook extends AbstractObjectBundleHook<Option> {
     }
   }
 
-  @Override
-  public void preUpdate(Option option, Option persistedObject, ObjectBundle bundle) {
-    if (option.getOptionSet() == null) {
-      return;
-    }
-
-    OptionSet optionSet =
-        bundle
-            .getPreheat()
-            .get(bundle.getPreheatIdentifier(), OptionSet.class, option.getOptionSet().getUid());
-
-    if (optionSet != null) {
-      // Remove the existed option from OptionSet, will add the updating
-      // one
-      // in postUpdate()
-      optionSet.removeOption(persistedObject);
-    }
-  }
-
-  @Override
-  public void postUpdate(Option option, ObjectBundle bundle) {
-    if (option.getOptionSet() == null) {
-      return;
-    }
-
-    OptionSet optionSet =
-        bundle
-            .getPreheat()
-            .get(bundle.getPreheatIdentifier(), OptionSet.class, option.getOptionSet().getUid());
-
-    if (optionSet != null) {
-      // Add the updated Option to OptionSet, this will allow Hibernate to
-      // re-organize sortOrder gaps if any.
-      optionSet.addOption(option);
-    }
-  }
-
   /** Check for duplication of Option's name OR code within given OptionSet */
   private void checkDuplicateOption(
       OptionSet optionSet, Option checkOption, Consumer<ErrorReport> addReports) {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/SortableObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/SortableObjectBundleHook.java
@@ -1,3 +1,30 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
 
 import org.hisp.dhis.common.SortableObject;
@@ -5,20 +32,20 @@ import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.springframework.stereotype.Component;
 
 @Component
-public class SortableObjectBundleHook extends AbstractObjectBundleHook<SortableObject>{
+public class SortableObjectBundleHook extends AbstractObjectBundleHook<SortableObject> {
 
   @Override
   public void preCreate(SortableObject sortableObject, ObjectBundle bundle) {
-      if (sortableObject.getSortOrder() == null) {
-        sortableObject.setSortOrder(0);
-      }
+    if (sortableObject.getSortOrder() == null) {
+      sortableObject.setSortOrder(0);
+    }
   }
 
   @Override
   public void preUpdate(
       SortableObject sortableObject, SortableObject persistedObject, ObjectBundle bundle) {
-      if (sortableObject.getSortOrder() == null) {
-        sortableObject.setSortOrder(0);
-      }
+    if (sortableObject.getSortOrder() == null) {
+      sortableObject.setSortOrder(0);
+    }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/SortableObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/SortableObjectBundleHook.java
@@ -1,0 +1,24 @@
+package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
+
+import org.hisp.dhis.common.SortableObject;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SortableObjectBundleHook extends AbstractObjectBundleHook<SortableObject>{
+
+  @Override
+  public void preCreate(SortableObject sortableObject, ObjectBundle bundle) {
+      if (sortableObject.getSortOrder() == null) {
+        sortableObject.setSortOrder(0);
+      }
+  }
+
+  @Override
+  public void preUpdate(
+      SortableObject sortableObject, SortableObject persistedObject, ObjectBundle bundle) {
+      if (sortableObject.getSortOrder() == null) {
+        sortableObject.setSortOrder(0);
+      }
+  }
+}

--- a/dhis-2/dhis-test-e2e/.gitignore
+++ b/dhis-2/dhis-test-e2e/.gitignore
@@ -1,1 +1,2 @@
 coverage.csv
+allure-results

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/metadata/OptionActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/metadata/OptionActions.java
@@ -67,7 +67,8 @@ public class OptionActions {
     return optionActions.create(option);
   }
 
-  public String createOption(String optionName, String optionCode, String optionSetId, int sortOrder) {
+  public String createOption(
+      String optionName, String optionCode, String optionSetId, int sortOrder) {
     JsonObject option = new JsonObject();
 
     option.addProperty("name", optionName);

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/metadata/OptionActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/metadata/OptionActions.java
@@ -67,6 +67,23 @@ public class OptionActions {
     return optionActions.create(option);
   }
 
+  public String createOption(String optionName, String optionCode, String optionSetId, int sortOrder) {
+    JsonObject option = new JsonObject();
+
+    option.addProperty("name", optionName);
+    option.addProperty("code", optionCode);
+    option.addProperty("sortOrder", sortOrder);
+
+    if (optionSetId != null) {
+      JsonObject optionSet = new JsonObject();
+      optionSet.addProperty("id", optionSetId);
+
+      option.add("optionSet", optionSet);
+    }
+
+    return optionActions.create(option);
+  }
+
   /**
    * Creates an option set. If optionIds are provided, links options with option set.
    *

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/OptionSetTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/OptionSetTests.java
@@ -183,6 +183,7 @@ public class OptionSetTests extends ApiTest {
     return optionActions.createOption(
         "Option name auto" + DataGenerator.randomString(),
         "Option code auto" + DataGenerator.randomString(),
-        optionSetId, sortOrder);
+        optionSetId,
+        sortOrder);
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/OptionSetTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/OptionSetTests.java
@@ -97,11 +97,12 @@ public class OptionSetTests extends ApiTest {
 
   @Test
   public void shouldAddOptions() {
+
+    String createdOptionSet = createOptionSet();
     String option1 = createOption(createdOptionSet);
     String option2 = createOption(createdOptionSet);
 
     ApiResponse response = optionActions.optionSetActions.get(createdOptionSet);
-
     response
         .validate()
         .statusCode(200)

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/OptionSetTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/OptionSetTests.java
@@ -99,8 +99,8 @@ public class OptionSetTests extends ApiTest {
   public void shouldAddOptions() {
 
     String createdOptionSet = createOptionSet();
-    String option1 = createOption(createdOptionSet);
-    String option2 = createOption(createdOptionSet);
+    String option1 = createOption(createdOptionSet, 0);
+    String option2 = createOption(createdOptionSet, 1);
 
     ApiResponse response = optionActions.optionSetActions.get(createdOptionSet);
     response
@@ -177,5 +177,12 @@ public class OptionSetTests extends ApiTest {
         "Option name auto" + DataGenerator.randomString(),
         "Option code auto" + DataGenerator.randomString(),
         optionSetId);
+  }
+
+  private String createOption(String optionSetId, int sortOrder) {
+    return optionActions.createOption(
+        "Option name auto" + DataGenerator.randomString(),
+        "Option code auto" + DataGenerator.randomString(),
+        optionSetId, sortOrder);
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
@@ -243,30 +243,27 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest {
         message.find(JsonErrorReport.class, report -> report.getErrorCode() == ErrorCode.E6004));
   }
 
-    /**
-     * Import OptionSet with two Options, sort orders are 2 and 3.
-     */
-    @Test
-    void testImportOptionSetWithOptions()
-    {
-        POST( "/metadata", "{\"optionSets\":\n" +
-            "    [{\"name\": \"Device category\",\"id\": \"RHqFlB1Wm4d\",\"version\": 2,\"valueType\": \"TEXT\",\"options\":[{\"id\": \"Uh4HvjK6zg3\"},{\"id\": \"BQMei56UBl6\"}]}],\n"
-            +
-            "\"options\":\n" +
-            "    [{\"code\": \"Vaccine freezer\",\"name\": \"Vaccine freezer\",\"id\": \"BQMei56UBl6\",\"sortOrder\": 5,\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}},\n"
-            +
-            "    {\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"id\": \"Uh4HvjK6zg3\",\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}" )
-            .content( HttpStatus.OK );
+  /** Import OptionSet with two Options, sort orders are 2 and 3. */
+  @Test
+  void testImportOptionSetWithOptions() {
+    POST(
+            "/metadata",
+            "{\"optionSets\":\n"
+                + "    [{\"name\": \"Device category\",\"id\": \"RHqFlB1Wm4d\",\"version\": 2,\"valueType\": \"TEXT\",\"options\":[{\"id\": \"Uh4HvjK6zg3\"},{\"id\": \"BQMei56UBl6\"}]}],\n"
+                + "\"options\":\n"
+                + "    [{\"code\": \"Vaccine freezer\",\"name\": \"Vaccine freezer\",\"id\": \"BQMei56UBl6\",\"sortOrder\": 5,\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}},\n"
+                + "    {\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"id\": \"Uh4HvjK6zg3\",\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}")
+        .content(HttpStatus.OK);
 
     JsonObject response =
         GET("/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d").content();
 
-        assertEquals( 2, response.getObject( "options" ).size() );
-        assertEquals( 0, response.getNumber( "options[0].sortOrder" ).intValue() );
-        assertEquals( 5, response.getNumber( "options[1].sortOrder" ).intValue() );
-        assertEquals( "Uh4HvjK6zg3",  response.getString( "options[0].id" ).string() );
-        assertEquals( "BQMei56UBl6",  response.getString( "options[1].id" ).string() );
-    }
+    assertEquals(2, response.getObject("options").size());
+    assertEquals(0, response.getNumber("options[0].sortOrder").intValue());
+    assertEquals(5, response.getNumber("options[1].sortOrder").intValue());
+    assertEquals("Uh4HvjK6zg3", response.getString("options[0].id").string());
+    assertEquals("BQMei56UBl6", response.getString("options[1].id").string());
+  }
 
   /** Import OptionSet with two Options, one has sortOrder and the other doesn't */
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
@@ -243,25 +243,30 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest {
         message.find(JsonErrorReport.class, report -> report.getErrorCode() == ErrorCode.E6004));
   }
 
-  /** Import OptionSet with two Options, sort orders are 2 and 3. */
-  @Test
-  void testImportOptionSetWithOptions() {
-    POST(
-            "/metadata",
-            "{\"optionSets\":\n"
-                + "    [{\"name\": \"Device category\",\"id\": \"RHqFlB1Wm4d\",\"version\": 2,\"valueType\": \"TEXT\",\"options\":[{\"id\": \"Uh4HvjK6zg3\"},{\"id\": \"BQMei56UBl6\"}]}],\n"
-                + "\"options\":\n"
-                + "    [{\"code\": \"Vaccine freezer\",\"name\": \"Vaccine freezer\",\"id\": \"BQMei56UBl6\",\"sortOrder\": 2,\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}},\n"
-                + "    {\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"id\": \"Uh4HvjK6zg3\",\"sortOrder\": 3,\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}")
-        .content(HttpStatus.OK);
+    /**
+     * Import OptionSet with two Options, sort orders are 2 and 3.
+     */
+    @Test
+    void testImportOptionSetWithOptions()
+    {
+        POST( "/metadata", "{\"optionSets\":\n" +
+            "    [{\"name\": \"Device category\",\"id\": \"RHqFlB1Wm4d\",\"version\": 2,\"valueType\": \"TEXT\",\"options\":[{\"id\": \"Uh4HvjK6zg3\"},{\"id\": \"BQMei56UBl6\"}]}],\n"
+            +
+            "\"options\":\n" +
+            "    [{\"code\": \"Vaccine freezer\",\"name\": \"Vaccine freezer\",\"id\": \"BQMei56UBl6\",\"sortOrder\": 5,\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}},\n"
+            +
+            "    {\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"id\": \"Uh4HvjK6zg3\",\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}" )
+            .content( HttpStatus.OK );
 
     JsonObject response =
         GET("/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d").content();
 
-    assertEquals(2, response.getObject("options").size());
-    assertNotNull(response.get("options[0].sortOrder"));
-    assertNotNull(response.get("options[1].sortOrder"));
-  }
+        assertEquals( 2, response.getObject( "options" ).size() );
+        assertEquals( 0, response.getNumber( "options[0].sortOrder" ).intValue() );
+        assertEquals( 5, response.getNumber( "options[1].sortOrder" ).intValue() );
+        assertEquals( "Uh4HvjK6zg3",  response.getString( "options[0].id" ).string() );
+        assertEquals( "BQMei56UBl6",  response.getString( "options[1].id" ).string() );
+    }
 
   /** Import OptionSet with two Options, one has sortOrder and the other doesn't */
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OptionControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OptionControllerTest.java
@@ -69,7 +69,6 @@ class OptionControllerTest extends DhisControllerConvenienceTest {
     response = GET("/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d").content();
     assertEquals(2, response.getObject("options").size());
     assertEquals(1, response.getNumber("options[0].sortOrder").intValue());
-    // sortOrder 20 should be saved as 2.
     assertEquals("Uh4HvjK6zg3", response.getString("options[1].id").string());
     assertEquals(20, response.getNumber("options[1].sortOrder").intValue());
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OptionControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OptionControllerTest.java
@@ -71,7 +71,7 @@ class OptionControllerTest extends DhisControllerConvenienceTest {
     assertEquals(1, response.getNumber("options[0].sortOrder").intValue());
     // sortOrder 20 should be saved as 2.
     assertEquals("Uh4HvjK6zg3", response.getString("options[1].id").string());
-    assertEquals(2, response.getNumber("options[1].sortOrder").intValue());
+    assertEquals(20, response.getNumber("options[1].sortOrder").intValue());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OptionControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OptionControllerTest.java
@@ -75,6 +75,37 @@ class OptionControllerTest extends DhisControllerConvenienceTest {
   }
 
   @Test
+  void testImportOptionWithoutSortOrder()
+  {
+    String id =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/optionSets/",
+                "{'name': 'test', 'version': 2, 'valueType': 'TEXT', 'description':'desc' }"));
+    assertStatus(
+        HttpStatus.CREATED,
+        POST(
+            "/options/",
+            "{'optionSet': { 'id':'"
+                + id
+                + "'}, 'id':'Uh4HvjK6zg3', 'code': 'A', 'name': 'Anna', 'description': 'this-is-a'}"));
+    assertStatus(
+        HttpStatus.CREATED,
+        POST(
+            "/options/",
+            "{'optionSet': { 'id':'"
+                + id
+                + "'},'id':'BQMei56UBl6','code': 'B', 'name': 'Betta', 'description': 'this-is-b'}"));
+    JsonOptionSet set =
+        GET("/optionSets/{id}", id)
+            .content()
+            .as(JsonOptionSet.class);
+    assertEquals( "Uh4HvjK6zg3", set.getOptions().get(0).getId());
+    assertEquals( "BQMei56UBl6", set.getOptions().get(1).getId());
+  }
+
+  @Test
   void testOptionSetsWithDescription() {
     String id =
         assertStatus(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OptionControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OptionControllerTest.java
@@ -96,9 +96,11 @@ class OptionControllerTest extends DhisControllerConvenienceTest {
             "{'optionSet': { 'id':'"
                 + id
                 + "'},'id':'BQMei56UBl6','code': 'B', 'name': 'Betta', 'description': 'this-is-b'}"));
-    JsonOptionSet set = GET("/optionSets/{id}", id).content().as(JsonOptionSet.class);
+    JsonOptionSet set = GET("/optionSets/{id}?fields=options[id,sortOrder]", id).content().as(JsonOptionSet.class);
     assertEquals("Uh4HvjK6zg3", set.getOptions().get(0).getId());
+    assertEquals(0, set.getOptions().get(0).getSortOrder());
     assertEquals("BQMei56UBl6", set.getOptions().get(1).getId());
+    assertEquals(0, set.getOptions().get(1).getSortOrder());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OptionControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OptionControllerTest.java
@@ -96,7 +96,8 @@ class OptionControllerTest extends DhisControllerConvenienceTest {
             "{'optionSet': { 'id':'"
                 + id
                 + "'},'id':'BQMei56UBl6','code': 'B', 'name': 'Betta', 'description': 'this-is-b'}"));
-    JsonOptionSet set = GET("/optionSets/{id}?fields=options[id,sortOrder]", id).content().as(JsonOptionSet.class);
+    JsonOptionSet set =
+        GET("/optionSets/{id}?fields=options[id,sortOrder]", id).content().as(JsonOptionSet.class);
     assertEquals("Uh4HvjK6zg3", set.getOptions().get(0).getId());
     assertEquals(0, set.getOptions().get(0).getSortOrder());
     assertEquals("BQMei56UBl6", set.getOptions().get(1).getId());

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OptionControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OptionControllerTest.java
@@ -75,8 +75,7 @@ class OptionControllerTest extends DhisControllerConvenienceTest {
   }
 
   @Test
-  void testImportOptionWithoutSortOrder()
-  {
+  void testImportOptionWithoutSortOrder() {
     String id =
         assertStatus(
             HttpStatus.CREATED,
@@ -97,12 +96,9 @@ class OptionControllerTest extends DhisControllerConvenienceTest {
             "{'optionSet': { 'id':'"
                 + id
                 + "'},'id':'BQMei56UBl6','code': 'B', 'name': 'Betta', 'description': 'this-is-b'}"));
-    JsonOptionSet set =
-        GET("/optionSets/{id}", id)
-            .content()
-            .as(JsonOptionSet.class);
-    assertEquals( "Uh4HvjK6zg3", set.getOptions().get(0).getId());
-    assertEquals( "BQMei56UBl6", set.getOptions().get(1).getId());
+    JsonOptionSet set = GET("/optionSets/{id}", id).content().as(JsonOptionSet.class);
+    assertEquals("Uh4HvjK6zg3", set.getOptions().get(0).getId());
+    assertEquals("BQMei56UBl6", set.getOptions().get(1).getId());
   }
 
   @Test


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-15509

### Summary
- This PR adds a new mechanism for supporting map `java.util.List` to `<bag>` in `hbm.xml` file with or without `sortOrder` property. More details in jira [DHIS2-15509](https://dhis2.atlassian.net/browse/DHIS2-15509).
- A new interface `SortableObject` is added which should be implemented by Object mapped to a List that need to be sorted.
- Update `Option` to implement `SortableObject` interface as a POC. `OptionSet.hbm.xml` uses `<bag>` with `sortOrder` for  mapping `List<Option>`.
- Update `Category.hbm.xml` for mapping `categoryCombos` without `sortOrder` using `<bag>`.

### Test
- Several tests added to `OptionControllerTest` and `MetadataImportExportControllerTest` for testing import `OptionSet.options` with and without `sortOrder`.

[DHIS2-15509]: https://dhis2.atlassian.net/browse/DHIS2-15509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ