### PR TITLE
fix: Gist API - array fields as array of objects [DHIS2-15168] (2.38)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -87,6 +87,10 @@
       <artifactId>cron-utils</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.hisp.dhis</groupId>
+      <artifactId>json-tree</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-email</artifactId>
     </dependency>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
@@ -50,11 +50,14 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
@@ -66,6 +69,7 @@ import org.hisp.dhis.gist.GistQuery.Comparison;
 import org.hisp.dhis.gist.GistQuery.Field;
 import org.hisp.dhis.gist.GistQuery.Filter;
 import org.hisp.dhis.gist.GistQuery.Owner;
+import org.hisp.dhis.jsontree.JsonNode;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.query.JpaQueryUtils;
@@ -568,18 +572,63 @@ final class GistBuilder {
   }
 
   private String createPluckTransformerHQL(int index, Field field, Property property) {
-    String tableName = "t_" + index;
+    String plucked = field.getTransformationArgument();
     RelativePropertyContext itemContext = context.switchedTo(property.getItemKlass());
+    List<Property> pluckedProperties =
+        plucked == null || plucked.isEmpty()
+            ? List.of()
+            : Stream.of(field.getTransformationArgument().split(","))
+                .map(itemContext::resolveMandatory)
+                .collect(toList());
+    if (pluckedProperties.size() > 1
+        || pluckedProperties.stream().anyMatch(p -> p.getKlass() != String.class)) {
+      return createMultiPluckTransformerHQL(index, field, property);
+    }
     String propertyName = determineReferenceProperty(field, itemContext, true);
     if (propertyName == null || property.getItemKlass() == Period.class) {
       // give up
       return createSizeTransformerHQL(index, field, property, "");
     }
+    String tableName = "t_" + index;
     String accessFilter = createAccessFilterHQL(itemContext, tableName);
     return String.format(
         "(select array_agg(%1$s.%2$s) from %3$s %1$s where %1$s in elements(e.%4$s) and %5$s)",
         tableName,
         propertyName,
+        property.getItemKlass().getSimpleName(),
+        getMemberPath(field.getPropertyPath()),
+        accessFilter);
+  }
+
+  private String createMultiPluckTransformerHQL(int index, Field field, Property property) {
+    RelativePropertyContext itemContext = context.switchedTo(property.getItemKlass());
+    List<Property> plucked =
+        Stream.of(field.getTransformationArgument().split(","))
+            .map(itemContext::resolveMandatory)
+            .collect(toList());
+
+    Function<Property, String> path =
+        p ->
+            p.getFieldName()
+                + (IdentifiableObject.class.isAssignableFrom(p.getKlass()) ? ".uid" : "");
+    String tableName = "t_" + index;
+    String pluckedObj =
+        plucked.stream()
+            .map(p -> String.format("'%3$s', %1$s.%2$s", tableName, path.apply(p), p.getName()))
+            .collect(joining(","));
+    String accessFilter = createAccessFilterHQL(itemContext, tableName);
+
+    addTransformer(
+        row ->
+            row[index] =
+                row[index] == null
+                    ? null
+                    : Stream.of((String[]) row[index]).map(JsonNode::of).toArray(JsonNode[]::new));
+
+    return String.format(
+        "(select array_agg(json_build_object(%2$s)) from %3$s %1$s where %1$s in elements(e.%4$s) and %5$s)",
+        tableName,
+        pluckedObj,
         property.getItemKlass().getSimpleName(),
         getMemberPath(field.getPropertyPath()),
         accessFilter);
@@ -613,7 +662,11 @@ final class GistBuilder {
   }
 
   private String getPluckPropertyName(Field field, Class<?> ownerType, boolean forceTextual) {
-    String propertyName = field.getTransformationArgument();
+    return getPluckPropertyName(field.getTransformationArgument(), ownerType, forceTextual);
+  }
+
+  private String getPluckPropertyName(
+      String propertyName, Class<?> ownerType, boolean forceTextual) {
     Property property = context.switchedTo(ownerType).resolveMandatory(propertyName);
     if (forceTextual && property.getKlass() != String.class) {
       throw new UnsupportedOperationException(
@@ -704,13 +757,13 @@ final class GistBuilder {
     Map<Integer, List<Filter>> grouped =
         filters.stream().collect(groupingBy(Filter::getGroup, toList()));
     StringBuilder hql = new StringBuilder();
-    for (List<Filter> group : grouped.values()) {
-      if (!group.isEmpty()) {
+    for (Entry<Integer, List<Filter>> group : grouped.entrySet()) {
+      if (!group.getValue().isEmpty()) {
         hql.append('(');
-        for (Filter f : group) {
+        for (Filter f : group.getValue()) {
           int index = filters.indexOf(f);
           hql.append(createFilterHQL(index, f));
-          hql.append(groupJunction);
+          hql.append(group.getKey() >= 0 ? groupJunction : rootJunction);
         }
         hql.append("1=1");
         hql.append(')');

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistParams.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistParams.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.gist;
 
 import lombok.Data;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.query.Junction;
 
 /**
@@ -37,7 +36,6 @@ import org.hisp.dhis.query.Junction;
  * @author Jan Bernitt
  */
 @Data
-@OpenApi.Shared
 public final class GistParams {
   String locale = "";
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistParams.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistParams.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.gist;
+
+import lombok.Data;
+import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.query.Junction;
+
+/**
+ * Web API input params for {@link GistQuery}.
+ *
+ * @author Jan Bernitt
+ */
+@Data
+@OpenApi.Shared
+public final class GistParams {
+  String locale = "";
+
+  GistAutoType auto;
+
+  int page = 1;
+
+  int pageSize = 50;
+
+  /**
+   * The name of the property in the response object that holds the list of response objects when a
+   * paged response is used.
+   */
+  String pageListName;
+
+  boolean translate = true;
+
+  boolean inverse = false;
+
+  boolean total = false;
+
+  boolean absoluteUrls = false;
+
+  boolean headless = false;
+
+  boolean describe = false;
+
+  boolean references = true;
+
+  Junction.Type rootJunction = Junction.Type.AND;
+
+  String fields;
+
+  String filter;
+
+  String order;
+
+  public GistAutoType getAuto(GistAutoType defaultValue) {
+    return auto == null ? defaultValue : auto;
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistPlanner.java
@@ -297,7 +297,7 @@ class GistPlanner {
       if (path.indexOf('[') >= 0) {
         String outerPath = path.substring(0, path.indexOf('['));
         String innerList = path.substring(path.indexOf('[') + 1, path.lastIndexOf(']'));
-        for (String innerFieldName : innerList.split(",")) {
+        for (String innerFieldName : innerList.split(GistQuery.FIELD_SPLIT)) {
           Field child = Field.parse(innerFieldName);
           expanded.add(
               child

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
@@ -46,8 +46,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.hisp.dhis.common.NamedParams;
 import org.hisp.dhis.common.PrimaryKeyObject;
+import org.hisp.dhis.query.Junction;
 import org.hisp.dhis.schema.annotation.Gist.Transform;
 
 /**
@@ -171,26 +171,37 @@ public final class GistQuery {
     return filters.size() > 1 && filters.stream().anyMatch(f -> f.getGroup() >= 0);
   }
 
-  public GistQuery with(NamedParams params) {
-    int page = abs(params.getInt("page", 1));
-    int size = Math.min(1000, abs(params.getInt("pageSize", 50)));
+  public GistQuery with(GistParams params) {
+    int page = abs(params.getPage());
+    int size = Math.min(1000, abs(params.getPageSize()));
     return toBuilder()
         .pageSize(size)
         .pageOffset(Math.max(0, page - 1) * size)
-        .translate(params.getBoolean("translate", true))
-        .inverse(params.getBoolean("inverse", false))
-        .total(params.getBoolean("total", false))
-        .absoluteUrls(params.getBoolean("absoluteUrls", false))
-        .headless(params.getBoolean("headless", false))
-        .describe(params.getBoolean("describe", false))
-        .references(params.getBoolean("references", true))
-        .anyFilter(params.getString("rootJunction", "AND").equalsIgnoreCase("OR"))
+        .translate(params.isTranslate())
+        .inverse(params.isInverse())
+        .total(params.isTotal())
+        .absoluteUrls(params.isAbsoluteUrls())
+        .headless(params.isHeadless())
+        .describe(params.isDescribe())
+        .references(params.isReferences())
+        .anyFilter(params.getRootJunction() == Junction.Type.OR)
         .fields(
-            params.getStrings("fields", FIELD_SPLIT).stream().map(Field::parse).collect(toList()))
+            getStrings(params.getFields(), FIELD_SPLIT).stream()
+                .map(Field::parse)
+                .collect(toList()))
         .filters(
-            params.getStrings("filter", FIELD_SPLIT).stream().map(Filter::parse).collect(toList()))
-        .orders(params.getStrings("order").stream().map(Order::parse).collect(toList()))
+            getStrings(params.getFilter(), FIELD_SPLIT).stream()
+                .map(Filter::parse)
+                .collect(toList()))
+        .orders(getStrings(params.getOrder(), ",").stream().map(Order::parse).collect(toList()))
         .build();
+  }
+
+  private static List<String> getStrings(String value, String splitRegex) {
+    if (value == null || value.isEmpty()) {
+      return emptyList();
+    }
+    return asList(value.split(splitRegex));
   }
 
   public GistQuery withOwner(Owner owner) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
@@ -70,7 +70,7 @@ public final class GistQuery {
    * Fields allow {@code property[sub,sub]} syntax where a comma occurs as part of the property
    * name. These commas need to be ignored when splitting a {@code fields} parameter list.
    */
-  private static final String FIELD_SPLIT = ",(?![^\\[\\]]*\\]|[^\\(\\)]*\\))";
+  static final String FIELD_SPLIT = ",(?![^\\[\\]]*\\]|[^\\(\\)]*\\)|([a-zA-Z0-9]+,?)+\\))";
 
   /** Query properties about the owner of the collection property. */
   @Getter

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistValidator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistValidator.java
@@ -111,10 +111,12 @@ final class GistValidator {
     Transform transformation = f.getTransformation();
     String transArgs = f.getTransformationArgument();
     if (transformation == Transform.PLUCK && transArgs != null) {
-      Property plucked = context.switchedTo(getBaseType(field)).resolveMandatory(transArgs);
-      if (!plucked.isPersisted()) {
-        throw createIllegalProperty(
-            plucked, "Property `%s` cannot be plucked as it is not a persistent field.");
+      for (String arg : transArgs.split(",")) {
+        Property plucked = context.switchedTo(getBaseType(field)).resolveMandatory(arg);
+        if (!plucked.isPersisted()) {
+          throw createIllegalProperty(
+              plucked, "Property `%s` cannot be plucked as it is not a persistent field.");
+        }
       }
     }
     if (transformation == Transform.FROM) {

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/h2/H2SqlFunction.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/h2/H2SqlFunction.java
@@ -39,6 +39,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.jsontree.JsonDocument.JsonNodeType;
 import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.jsontree.JsonString;
+import org.hisp.dhis.jsontree.JsonTypedAccess;
 import org.hisp.dhis.jsontree.JsonValue;
 import org.postgresql.util.PGobject;
 
@@ -79,7 +80,12 @@ public class H2SqlFunction {
     if (content == null) {
       return "null";
     }
-    return new JsonResponse(content).get("$").node().getType().name().toLowerCase();
+    return new JsonResponse(content, JsonTypedAccess.GLOBAL)
+        .get("$")
+        .node()
+        .getType()
+        .name()
+        .toLowerCase();
   }
 
   // Postgres inbuilt function
@@ -89,7 +95,7 @@ public class H2SqlFunction {
       if (content == null) {
         return null;
       }
-      JsonValue value = new JsonResponse(content).get(toJsonPath(paths));
+      JsonValue value = new JsonResponse(content, JsonTypedAccess.GLOBAL).get(toJsonPath(paths));
       if (!value.exists()) {
         return null;
       }
@@ -110,7 +116,7 @@ public class H2SqlFunction {
       if (content == null) {
         return null;
       }
-      JsonValue value = new JsonResponse(content).get(toJsonPath(paths));
+      JsonValue value = new JsonResponse(content, JsonTypedAccess.GLOBAL).get(toJsonPath(paths));
       if (!value.exists()) {
         return null;
       }

--- a/dhis-2/dhis-support/dhis-support-test/src/test/java/org/hisp/dhis/webapi/json/domain/DomainJsonResponseTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/test/java/org/hisp/dhis/webapi/json/domain/DomainJsonResponseTest.java
@@ -35,6 +35,7 @@ import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonMap;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonResponse;
+import org.hisp.dhis.jsontree.JsonTypedAccess;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -116,6 +117,6 @@ class DomainJsonResponseTest {
   }
 
   private JsonResponse createJSON(String content) {
-    return new JsonResponse(content.replace('\'', '"'));
+    return new JsonResponse(content.replace('\'', '"'), JsonTypedAccess.GLOBAL);
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/WebClient.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/WebClient.java
@@ -49,6 +49,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.apache.commons.lang3.ArrayUtils;
 import org.hisp.dhis.jsontree.JsonResponse;
+import org.hisp.dhis.jsontree.JsonTypedAccess;
 import org.hisp.dhis.webapi.json.domain.JsonError;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.hisp.dhis.webapi.utils.WebClientUtils;
@@ -327,7 +328,7 @@ public interface WebClient {
             String.format(
                 "{\"status\": \"error\",\"httpStatus\":\"%s\",\"httpStatusCode\":%d, \"message\":%s}",
                 status().name(), response.getStatus(), errorMessage);
-        return new JsonResponse(error).as(JsonError.class);
+        return new JsonResponse(error, JsonTypedAccess.GLOBAL).as(JsonError.class);
       }
       return contentUnchecked().as(JsonError.class);
     }
@@ -337,7 +338,7 @@ public interface WebClient {
     }
 
     public JsonResponse contentUnchecked() {
-      return failOnException(() -> new JsonResponse(response.getContent()));
+      return failOnException(() -> new JsonResponse(response.getContent(), JsonTypedAccess.GLOBAL));
     }
 
     public String location() {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
@@ -39,9 +39,8 @@ import org.hisp.dhis.attribute.Attribute.ObjectType;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonString;
-import org.junit.jupiter.api.Disabled;
-import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.json.domain.JsonUserGroup;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
@@ -40,6 +40,8 @@ import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonString;
 import org.junit.jupiter.api.Disabled;
+import org.hisp.dhis.web.HttpStatus;
+import org.hisp.dhis.webapi.json.domain.JsonUserGroup;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
@@ -105,7 +107,7 @@ class GistFieldsControllerTest extends AbstractGistControllerTest {
     switchToSuperuser();
     users = GET("/users/gist?headless=true").content();
     user0 = users.getObject(0);
-    assertTrue(user0.node().members().keySet().size() > 4);
+    assertTrue(user0.size() > 4);
   }
 
   /*
@@ -253,5 +255,20 @@ class GistFieldsControllerTest extends AbstractGistControllerTest {
   void testField_UserNameAutomaticFromTransformation() {
     JsonArray users = GET("/users/gist?fields=id,name&headless=true").content();
     assertEquals("admin admin", users.getObject(0).getString("name").string());
+  }
+
+  @Test
+  void testNestedFieldsOfListProperty() {
+    JsonArray groups =
+        GET("/userGroups/gist?fields=id,name,users[id,username]&headless=true").content();
+    assertEquals(1, groups.size());
+    JsonUserGroup group = groups.get(0, JsonUserGroup.class);
+    JsonArray members = group.getArray("users");
+    assertTrue(members.isArray());
+    assertEquals(1, members.size());
+    JsonObject member = members.getObject(0);
+    assertTrue(member.has("id", "username"));
+    assertEquals(getSuperuserUid(), member.getString("id").string());
+    assertEquals("admin", member.getString("username").string());
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistPagerControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistPagerControllerTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonObject;
@@ -39,13 +40,24 @@ import org.junit.jupiter.api.Test;
  * @author Jan Bernitt
  */
 class GistPagerControllerTest extends AbstractGistControllerTest {
-
   @Test
   void testPager_Total_ResultBased() {
     JsonObject gist =
         GET("/users/{uid}/userGroups/gist?fields=name,users&total=true", getSuperuserUid())
             .content();
     assertHasPager(gist, 1, 50, 1);
+  }
+
+  @Test
+  void testPager_CustomPageListName() {
+    JsonObject gist =
+        GET(
+                "/users/{uid}/userGroups/gist?fields=name,users&total=true&pageListName=matches",
+                getSuperuserUid())
+            .content();
+    JsonArray matches = gist.getArray("matches");
+    assertTrue(matches.exists());
+    assertTrue(matches.isArray());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistValidationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistValidationControllerTest.java
@@ -127,8 +127,8 @@ class GistValidationControllerTest extends AbstractGistControllerTest {
   @Test
   void testValidation_Field_MultiPluck() {
     assertEquals(
-        "Property `name, displayName` does not exist in userGroup",
-        GET("/users/gist?fields=id,userGroups~pluck(name, displayName)")
+        "Property `foo` does not exist in userGroup",
+        GET("/users/gist?fields=id,userGroups~pluck(name,foo)")
             .error(HttpStatus.BAD_REQUEST)
             .getMessage());
   }
@@ -182,8 +182,7 @@ class GistValidationControllerTest extends AbstractGistControllerTest {
             .getObject("sharing")
             .node()
             .extract()
-            .members()
-            .get("public")
+            .member("public")
             .replaceWith("\"--------\"")
             .toString();
     assertStatus(HttpStatus.NO_CONTENT, PUT("/userGroups/" + userGroupId + "/sharing", sharing));

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramStageControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramStageControllerTest.java
@@ -68,6 +68,6 @@ class ProgramStageControllerTest extends DhisControllerConvenienceTest {
     JsonResponse programStage = GET("/programStages/{id}", programStageId).content();
     assertEquals("VoZMWi7rBgj", programStage.getString("program.id").string());
     JsonResponse program = GET("/programs/{id}", "VoZMWi7rBgj").content();
-    assertEquals(programStageId, program.getString("$.programStages[0].id").string());
+    assertEquals(programStageId, program.getString("programStages[0].id").string());
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramStageControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramStageControllerTest.java
@@ -68,6 +68,6 @@ class ProgramStageControllerTest extends DhisControllerConvenienceTest {
     JsonResponse programStage = GET("/programStages/{id}", programStageId).content();
     assertEquals("VoZMWi7rBgj", programStage.getString("program.id").string());
     JsonResponse program = GET("/programs/{id}", "VoZMWi7rBgj").content();
-    assertEquals(programStageId, program.getJsonDocument().get("$.programStages[0].id").value());
+    assertEquals(programStageId, program.getString("$.programStages[0].id").string());
   }
 }

--- a/dhis-2/dhis-web-api/pom.xml
+++ b/dhis-2/dhis-web-api/pom.xml
@@ -66,6 +66,10 @@
       <artifactId>dhis-service-field-filtering</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.hisp.dhis</groupId>
+      <artifactId>json-tree</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
@@ -82,6 +82,7 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
   @Autowired private GistService gistService;
 
   @Autowired private UserSettingService userSettingService;
+
   // --------------------------------------------------------------------------
   // GET Gist
   // --------------------------------------------------------------------------

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
@@ -88,8 +88,7 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
 
   @GetMapping(value = "/{uid}/gist", produces = APPLICATION_JSON_VALUE)
   public @ResponseBody ResponseEntity<JsonNode> getObjectGist(
-      @PathVariable("uid") String uid, GistParams params)
-      throws NotFoundException {
+      @PathVariable("uid") String uid, GistParams params) throws NotFoundException {
     return gistToJsonObjectResponse(
         uid,
         createGistQuery(params, getEntityClass(), GistAutoType.L)
@@ -100,9 +99,7 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
       value = {"/{uid}/gist", "/{uid}/gist.csv"},
       produces = "text/csv")
   public void getObjectGistAsCsv(
-      @PathVariable("uid") String uid,
-      GistParams params,
-      HttpServletResponse response)
+      @PathVariable("uid") String uid, GistParams params, HttpServletResponse response)
       throws IOException {
     gistToCsvResponse(
         response,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
@@ -42,10 +42,9 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.common.NamedParams;
 import org.hisp.dhis.common.PrimaryKeyObject;
-import org.hisp.dhis.common.UserContext;
 import org.hisp.dhis.gist.GistAutoType;
+import org.hisp.dhis.gist.GistParams;
 import org.hisp.dhis.gist.GistQuery;
 import org.hisp.dhis.gist.GistQuery.Comparison;
 import org.hisp.dhis.gist.GistQuery.Filter;
@@ -55,6 +54,7 @@ import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.user.UserSettingKey;
+import org.hisp.dhis.user.UserSettingService;
 import org.hisp.dhis.webapi.CsvBuilder;
 import org.hisp.dhis.webapi.JsonBuilder;
 import org.hisp.dhis.webapi.controller.exception.BadRequestException;
@@ -75,34 +75,38 @@ import org.springframework.web.bind.annotation.ResponseBody;
  */
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
 public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject> {
-
   @Autowired protected ObjectMapper jsonMapper;
 
   @Autowired protected SchemaService schemaService;
 
   @Autowired private GistService gistService;
 
+  @Autowired private UserSettingService userSettingService;
   // --------------------------------------------------------------------------
   // GET Gist
   // --------------------------------------------------------------------------
 
   @GetMapping(value = "/{uid}/gist", produces = APPLICATION_JSON_VALUE)
   public @ResponseBody ResponseEntity<JsonNode> getObjectGist(
-      @PathVariable("uid") String uid, HttpServletRequest request, HttpServletResponse response)
+      @PathVariable("uid") String uid, GistParams params)
       throws NotFoundException {
     return gistToJsonObjectResponse(
         uid,
-        createGistQuery(request, getEntityClass(), GistAutoType.L)
+        createGistQuery(params, getEntityClass(), GistAutoType.L)
             .withFilter(new Filter("id", Comparison.EQ, uid)));
   }
 
-  @GetMapping(value = "/{uid}/gist", produces = "text/csv")
+  @GetMapping(
+      value = {"/{uid}/gist", "/{uid}/gist.csv"},
+      produces = "text/csv")
   public void getObjectGistAsCsv(
-      @PathVariable("uid") String uid, HttpServletRequest request, HttpServletResponse response)
+      @PathVariable("uid") String uid,
+      GistParams params,
+      HttpServletResponse response)
       throws IOException {
     gistToCsvResponse(
         response,
-        createGistQuery(request, getEntityClass(), GistAutoType.L)
+        createGistQuery(params, getEntityClass(), GistAutoType.L)
             .withFilter(new Filter("id", Comparison.EQ, uid))
             .toBuilder()
             .typedAttributeValues(false)
@@ -111,17 +115,19 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
 
   @GetMapping(value = "/gist", produces = APPLICATION_JSON_VALUE)
   public @ResponseBody ResponseEntity<JsonNode> getObjectListGist(
-      HttpServletRequest request, HttpServletResponse response) {
+      GistParams params, HttpServletRequest request) {
     return gistToJsonArrayResponse(
-        request, createGistQuery(request, getEntityClass(), GistAutoType.S), getSchema());
+        request, params, createGistQuery(params, getEntityClass(), GistAutoType.S), getSchema());
   }
 
-  @GetMapping(value = "/gist", produces = "text/csv")
-  public void getObjectListGistAsCsv(HttpServletRequest request, HttpServletResponse response)
+  @GetMapping(
+      value = {"/gist", "/gist.csv"},
+      produces = "text/csv")
+  public void getObjectListGistAsCsv(GistParams params, HttpServletResponse response)
       throws IOException {
     gistToCsvResponse(
         response,
-        createGistQuery(request, getEntityClass(), GistAutoType.S).toBuilder()
+        createGistQuery(params, getEntityClass(), GistAutoType.S).toBuilder()
             .typedAttributeValues(false)
             .build());
   }
@@ -130,42 +136,46 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
   public @ResponseBody ResponseEntity<JsonNode> getObjectPropertyGist(
       @PathVariable("uid") String uid,
       @PathVariable("property") String property,
-      HttpServletRequest request,
-      HttpServletResponse response)
-      throws Exception {
+      GistParams params,
+      HttpServletRequest request)
+      throws BadRequestException, NotFoundException {
     Property objProperty = getSchema().getProperty(property);
     if (objProperty == null) {
       throw new BadRequestException("No such property: " + property);
     }
 
-    if (!objProperty.isCollection()) {
+    if (!objProperty.isCollection()
+        || !PrimaryKeyObject.class.isAssignableFrom(objProperty.getItemKlass())) {
       return gistToJsonObjectResponse(
           uid,
-          createGistQuery(request, getEntityClass(), GistAutoType.L)
+          createGistQuery(params, getEntityClass(), GistAutoType.L)
               .withFilter(new Filter("id", Comparison.EQ, uid))
               .withField(property));
     }
 
     return gistToJsonArrayResponse(
         request,
-        createPropertyQuery(uid, property, request, objProperty),
+        params,
+        createPropertyQuery(uid, property, params, objProperty),
         schemaService.getDynamicSchema(objProperty.getItemKlass()));
   }
 
-  @GetMapping(value = "/{uid}/{property}/gist", produces = "text/csv")
+  @GetMapping(
+      value = {"/{uid}/{property}/gist", "/{uid}/{property}/gist.csv"},
+      produces = "text/csv")
   public void getObjectPropertyGistAsCsv(
       @PathVariable("uid") String uid,
       @PathVariable("property") String property,
-      HttpServletRequest request,
+      GistParams params,
       HttpServletResponse response)
-      throws Exception {
+      throws BadRequestException, IOException {
     Property objProperty = getSchema().getProperty(property);
     if (objProperty == null) {
       throw new BadRequestException("No such property: " + property);
     }
     gistToCsvResponse(
         response,
-        createPropertyQuery(uid, property, request, objProperty).toBuilder()
+        createPropertyQuery(uid, property, params, objProperty).toBuilder()
             .typedAttributeValues(false)
             .build());
   }
@@ -174,27 +184,24 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
   private GistQuery createPropertyQuery(
       @PathVariable("uid") String uid,
       @PathVariable("property") String property,
-      HttpServletRequest request,
+      GistParams params,
       Property objProperty) {
     return createGistQuery(
-            request, (Class<IdentifiableObject>) objProperty.getItemKlass(), GistAutoType.M)
+            params, (Class<IdentifiableObject>) objProperty.getItemKlass(), GistAutoType.M)
         .withOwner(
             Owner.builder().id(uid).type(getEntityClass()).collectionProperty(property).build());
   }
 
-  private static GistQuery createGistQuery(
-      HttpServletRequest request,
-      Class<? extends PrimaryKeyObject> elementType,
-      GistAutoType autoDefault) {
-    NamedParams params = new NamedParams(request::getParameter, request::getParameterValues);
+  private GistQuery createGistQuery(
+      GistParams params, Class<? extends PrimaryKeyObject> elementType, GistAutoType autoDefault) {
     Locale translationLocale =
-        !params.getString("locale", "").isEmpty()
-            ? Locale.forLanguageTag(params.getString("locale"))
-            : UserContext.getUserSetting(UserSettingKey.DB_LOCALE);
+        !params.getLocale().isEmpty()
+            ? Locale.forLanguageTag(params.getLocale())
+            : (Locale) userSettingService.getUserSetting(UserSettingKey.DB_LOCALE);
     return GistQuery.builder()
         .elementType(elementType)
-        .autoType(params.getEnum("auto", autoDefault))
-        .contextRoot(ContextUtils.getRootPath(request))
+        .autoType(params.getAuto(autoDefault))
+        .contextRoot(ContextUtils.getRootPath(ContextUtils.getRequest()))
         .translationLocale(translationLocale)
         .typedAttributeValues(true)
         .build()
@@ -211,13 +218,13 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
     JsonNode body =
         new JsonBuilder(jsonMapper).skipNullOrEmpty().toArray(query.getFieldNames(), elements);
     if (body.isEmpty()) {
-      throw NotFoundException.notFoundUid(uid);
+      throw new NotFoundException(getEntityClass().getSimpleName(), uid);
     }
     return ResponseEntity.ok().cacheControl(noCache().cachePrivate()).body(body.get(0));
   }
 
   private ResponseEntity<JsonNode> gistToJsonArrayResponse(
-      HttpServletRequest request, GistQuery query, Schema schema) {
+      HttpServletRequest request, GistParams params, GistQuery query, Schema schema) {
     if (query.isDescribe()) {
       return gistDescribeToJsonObjectResponse(query);
     }
@@ -226,9 +233,11 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
     JsonBuilder responseBuilder = new JsonBuilder(jsonMapper);
     JsonNode body = responseBuilder.skipNullOrEmpty().toArray(query.getFieldNames(), elements);
     if (!query.isHeadless()) {
+      String property =
+          params.getPageListName() == null ? schema.getPlural() : params.getPageListName();
       body =
           responseBuilder.toObject(
-              asList("pager", schema.getPlural()),
+              asList("pager", property),
               gistService.pager(query, elements, request.getParameterMap()),
               body);
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataWorkflowController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataWorkflowController.java
@@ -36,13 +36,13 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.metadata.MetadataValidationException;
 import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.feedback.Status;
+import org.hisp.dhis.gist.GistParams;
 import org.hisp.dhis.metadata.MetadataAdjustParams;
 import org.hisp.dhis.metadata.MetadataProposal;
 import org.hisp.dhis.metadata.MetadataProposalSchemaDescriptor;
@@ -82,16 +82,14 @@ public class MetadataWorkflowController extends AbstractGistReadOnlyController<M
   private final MetadataWorkflowService service;
 
   @GetMapping(value = "/{uid}", produces = APPLICATION_JSON_VALUE)
-  public ResponseEntity<JsonNode> getProposal(
-      @PathVariable("uid") String uid, HttpServletRequest request, HttpServletResponse response)
+  public ResponseEntity<JsonNode> getProposal(@PathVariable("uid") String uid, GistParams params)
       throws NotFoundException {
-    return getObjectGist(uid, request, response);
+    return getObjectGist(uid, params);
   }
 
   @GetMapping(value = "", produces = APPLICATION_JSON_VALUE)
-  public ResponseEntity<JsonNode> getProposals(
-      HttpServletRequest request, HttpServletResponse response) {
-    return getObjectListGist(request, response);
+  public ResponseEntity<JsonNode> getProposals(GistParams params, HttpServletRequest request) {
+    return getObjectListGist(params, request);
   }
 
   @PostMapping(value = "", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -88,7 +88,7 @@
     <!-- HISP Quick and Staxwax -->
     <dhis-hisp-quick.version>1.4.0</dhis-hisp-quick.version>
     <dhis-hisp-staxwax.version>2.0.0</dhis-hisp-staxwax.version>
-    <dhis-json-tree.version>0.2.0</dhis-json-tree.version>
+    <dhis-json-tree.version>0.5.0</dhis-json-tree.version>
 
     <!-- Security-->
     <spring-security.version>5.8.3</spring-security.version>


### PR DESCRIPTION
backport based on #14554
After that I needed to revert any addition of OpenAPI annotations and use the old exceptions (not from the feedback package) as well as some small updates due to small API changes in the newer version of json-tree when constructing the `JsonResponse`.