### PR TITLE
feat: rename job queues via name update [DHIS2-14929]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobQueueService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobQueueService.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.scheduling;
 
 import java.util.List;
 import java.util.Set;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.NotFoundException;
 
@@ -50,7 +52,7 @@ public interface JobQueueService {
    * @return all jobs that are part of the queue in execution order
    * @throws NotFoundException when no such queue exists
    */
-  List<JobConfiguration> getQueue(String name) throws NotFoundException;
+  List<JobConfiguration> getQueue(@Nonnull String name) throws NotFoundException;
 
   /**
    * Create a new queue sequence.
@@ -59,17 +61,23 @@ public interface JobQueueService {
    * @param cronExpression trigger CRON expression to start the queue sequence
    * @param sequence UIDs of the {@link JobConfiguration}s to run
    */
-  void createQueue(String name, String cronExpression, List<String> sequence)
+  void createQueue(
+      @Nonnull String name, @Nonnull String cronExpression, @Nonnull List<String> sequence)
       throws NotFoundException, ConflictException;
 
   /**
    * Update a queue sequence.
    *
    * @param name name of the queue
+   * @param newName potentially a new name for the queue, can be null or the same as name
    * @param newCronExpression trigger CRON expression to start the queue sequence
    * @param newSequence UIDs of the {@link JobConfiguration}s to run
    */
-  void updateQueue(String name, String newCronExpression, List<String> newSequence)
+  void updateQueue(
+      @Nonnull String name,
+      @CheckForNull String newName,
+      @Nonnull String newCronExpression,
+      @Nonnull List<String> newSequence)
       throws NotFoundException, ConflictException;
 
   /**
@@ -83,5 +91,5 @@ public interface JobQueueService {
    *
    * @param name name of the queue
    */
-  void deleteQueue(String name) throws NotFoundException;
+  void deleteQueue(@Nonnull String name) throws NotFoundException;
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobSchedulerControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobSchedulerControllerTest.java
@@ -240,6 +240,28 @@ class JobSchedulerControllerTest extends DhisControllerConvenienceTest {
   }
 
   @Test
+  void testUpdateQueue_WithRename() {
+    assertStatus(
+        HttpStatus.CREATED,
+        POST(
+            "/scheduler/queues/testQueue",
+            format("{'cronExpression':'0 0 1 ? * *','sequence':['%s','%s']}", jobIdA, jobIdC)));
+
+    assertStatus(
+        HttpStatus.NO_CONTENT,
+        PUT(
+            "/scheduler/queues/testQueue",
+            format(
+                "{'cronExpression':'0 0 2 ? * *','sequence':['%s','%s'],'name':'newName'}",
+                jobIdB, jobIdA)));
+
+    JsonObject queue = GET("/scheduler/queues/newName").content();
+    assertEquals("0 0 2 ? * *", queue.getString("cronExpression").string());
+    assertEquals(List.of(jobIdB, jobIdA), queue.getArray("sequence").stringValues());
+    assertStatus(HttpStatus.NOT_FOUND, GET("/scheduler/queues/testQueue"));
+  }
+
+  @Test
   void testUpdateQueue_NotExistingQueue() {
     JsonWebMessage message =
         assertWebMessage(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobSchedulerController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobSchedulerController.java
@@ -156,7 +156,8 @@ public class JobSchedulerController {
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public void updateQueue(@PathVariable String name, @RequestBody SchedulerQueue queue)
       throws NotFoundException, ConflictException {
-    jobQueueService.updateQueue(name, queue.getCronExpression(), queue.getSequence());
+    jobQueueService.updateQueue(
+        name, queue.getName(), queue.getCronExpression(), queue.getSequence());
   }
 
   @DeleteMapping("/queues/{name}")


### PR DESCRIPTION
### Summary
Small improvement that also closes a gap of undefined behaviour in the REST API of job queue update endpoint.

When the object send as new queue has a `name` property different than the name in the path used to existing queue with that name the different name is understood as the new name for that queue. Essentially a rename.

This is simply implemented by delete and create but now being run in a single transaction.

### Automatic Testing
Added a new test scenario to cover the rename via update.

### Manual Testing
* create a queue
* update the queue and give it a new name in the request body payload
* check the created queue now is available with the new name
* check the queue with the old name is not available any more