### PR TITLE
fix: leader only job as job type property [DHIS2-15288] (2.38)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
@@ -424,13 +424,9 @@ public class JobConfiguration extends BaseIdentifiableObject implements Secondar
   }
 
   @JacksonXmlProperty
-  @JsonProperty
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   public boolean isLeaderOnlyJob() {
-    return leaderOnlyJob;
-  }
-
-  public void setLeaderOnlyJob(boolean leaderOnlyJob) {
-    this.leaderOnlyJob = leaderOnlyJob;
+    return !jobType.isRunOnAllNodes();
   }
 
   public boolean isInMemoryJob() {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
@@ -168,6 +168,14 @@ public enum JobType {
     this.relativeApiElements = relativeApiElements;
   }
 
+  /**
+   * @return when true, this job type should run on all nodes, if false it should only run on the
+   *     current leader node.
+   */
+  public boolean isRunOnAllNodes() {
+    return this == LEADER_ELECTION;
+  }
+
   public boolean isUsingNotifications() {
     return this == RESOURCE_TABLE || this == ANALYTICS_TABLE || this == CONTINUOUS_ANALYTICS_TABLE;
   }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobConfigurationTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobConfigurationTest.java
@@ -53,7 +53,6 @@ class JobConfigurationTest {
     jobConfiguration.setJobStatus(JobStatus.COMPLETED);
     jobConfiguration.setJobParameters(jobParameters);
     jobConfiguration.setEnabled(true);
-    jobConfiguration.setLeaderOnlyJob(true);
     jobConfiguration.setCronExpression("0 0 6 * * ?");
   }
 
@@ -64,7 +63,6 @@ class JobConfigurationTest {
     jc.setJobStatus(JobStatus.COMPLETED);
     jc.setJobParameters(jobParameters);
     jc.setEnabled(true);
-    jc.setLeaderOnlyJob(false);
     assertFalse(jobConfiguration.hasNonConfigurableJobChanges(jc));
   }
 
@@ -75,7 +73,6 @@ class JobConfigurationTest {
     jc.setJobStatus(JobStatus.COMPLETED);
     jc.setJobParameters(jobParameters);
     jc.setEnabled(true);
-    jc.setLeaderOnlyJob(true);
     jc.setCronExpression("0 0 12 * * ?");
     assertFalse(jobConfiguration.hasNonConfigurableJobChanges(jc));
   }
@@ -87,7 +84,6 @@ class JobConfigurationTest {
     jc.setJobStatus(JobStatus.COMPLETED);
     jc.setJobParameters(jobParameters);
     jc.setEnabled(false);
-    jc.setLeaderOnlyJob(true);
     assertTrue(jobConfiguration.hasNonConfigurableJobChanges(jc));
   }
 
@@ -98,7 +94,6 @@ class JobConfigurationTest {
     jc.setJobStatus(JobStatus.COMPLETED);
     jc.setJobParameters(jobParameters);
     jc.setEnabled(true);
-    jc.setLeaderOnlyJob(true);
     assertTrue(jobConfiguration.hasNonConfigurableJobChanges(jc));
   }
 
@@ -109,7 +104,6 @@ class JobConfigurationTest {
     jc.setJobStatus(JobStatus.STOPPED);
     jc.setJobParameters(jobParameters);
     jc.setEnabled(true);
-    jc.setLeaderOnlyJob(true);
     assertTrue(jobConfiguration.hasNonConfigurableJobChanges(jc));
   }
 
@@ -120,7 +114,6 @@ class JobConfigurationTest {
     jc.setJobStatus(JobStatus.COMPLETED);
     jc.setJobParameters(new MockJobParameters());
     jc.setEnabled(true);
-    jc.setLeaderOnlyJob(true);
     assertTrue(jobConfiguration.hasNonConfigurableJobChanges(jc));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/SchedulerStart.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/SchedulerStart.java
@@ -223,7 +223,6 @@ public class SchedulerStart extends AbstractStartupRoutine {
               SystemJob.LEADER_ELECTION.type,
               format(SystemJob.LEADER_ELECTION.cron, leaderElectionTime),
               null);
-      leaderElectionJobConfiguration.setLeaderOnlyJob(false);
       leaderElectionJobConfiguration.setUid(SystemJob.LEADER_ELECTION.uid);
       addAndScheduleJob(leaderElectionJobConfiguration);
     } else {
@@ -241,7 +240,6 @@ public class SchedulerStart extends AbstractStartupRoutine {
       JobConfiguration configuration = new JobConfiguration(job.name, job.type, job.cron, null);
       if (init != null) init.accept(configuration);
       configuration.setUid(job.uid);
-      configuration.setLeaderOnlyJob(true);
       addAndScheduleJob(configuration);
     }
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/scheduling/hibernate/JobConfiguration.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/scheduling/hibernate/JobConfiguration.hbm.xml
@@ -50,10 +50,6 @@
 
         <property name="enabled" not-null="true" type="boolean" />
 
-        <property name="leaderOnlyJob" not-null="true" type="boolean">
-            <column name="leaderonlyjob" default="false" />
-        </property>
-
         <property name="jobParameters" column="jsonbjobparameters" type="jbJobParameters" />
     </class>
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/SchedulingManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/SchedulingManagerTest.java
@@ -105,13 +105,16 @@ class SchedulingManagerTest {
     when(cacheProvider.createRunningJobsInfoCache()).thenReturn(new TestCache<>());
     when(cacheProvider.createCompletedJobsInfoCache()).thenReturn(new TestCache<>());
 
+    LeaderManager leaderManager = mock(LeaderManager.class);
+    when(leaderManager.isLeader()).thenReturn(true);
+
     schedulingManager =
         new DefaultSchedulingManager(
             new DefaultJobService(applicationContext),
             jobConfigurationService,
             mock(MessageService.class),
             mock(Notifier.class),
-            mock(LeaderManager.class),
+            leaderManager,
             taskScheduler,
             mock(AsyncTaskExecutor.class),
             cacheProvider);

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/leader/election/RedisLeaderManager.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/leader/election/RedisLeaderManager.java
@@ -100,7 +100,6 @@ public class RedisLeaderManager implements LeaderManager {
           this.nodeUuid, calendar.getTime().toString());
       JobConfiguration leaderRenewalJobConfiguration =
           new JobConfiguration(CLUSTER_LEADER_RENEWAL, JobType.LEADER_RENEWAL, null, true);
-      leaderRenewalJobConfiguration.setLeaderOnlyJob(true);
       schedulingManager.scheduleWithStartTime(leaderRenewalJobConfiguration, calendar.getTime());
     }
   }


### PR DESCRIPTION
cherry-pick backport from #14570

manual merge required in two files to get less lines around the change.
Also dropped the DB migration script. The DB column will just exist unused.