### PR TITLE
fix: Move fields out of RequestParams and remove default values [TECH-1571]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/common/UID.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/common/UID.java
@@ -53,11 +53,6 @@ public final class UID {
     this.value = value;
   }
 
-  @Override
-  public String toString() {
-    return value;
-  }
-
   public static UID of(String value) {
     return new UID(value);
   }
@@ -66,11 +61,20 @@ public final class UID {
     return new UID(object.getUid());
   }
 
+  public static String toValue(UID uid) {
+    return uid == null ? null : uid.getValue();
+  }
+
   public static Set<String> toValueSet(Collection<UID> uids) {
     return uids.stream().map(UID::getValue).collect(toUnmodifiableSet());
   }
 
   public static List<String> toValueList(Collection<UID> uids) {
     return uids.stream().map(UID::getValue).toList();
+  }
+
+  @Override
+  public String toString() {
+    return value;
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller.tracker.export;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.commons.collections4.SetUtils;
 import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.feedback.BadRequestException;
@@ -62,7 +63,7 @@ public class RequestParamUtils {
       Set<UID> newParamUids)
       throws BadRequestException {
     Set<String> deprecatedParamParsedUids = parseUids(deprecatedParamUids);
-    if (!deprecatedParamParsedUids.isEmpty() && !newParamUids.isEmpty()) {
+    if (!deprecatedParamParsedUids.isEmpty() && !CollectionUtils.isEmpty(newParamUids)) {
       throw new BadRequestException(
           String.format(
               "Only one parameter of '%s' (deprecated; semicolon separated UIDs) and '%s' (comma separated UIDs) must be specified. Prefer '%s' as '%s' will be removed.",
@@ -71,7 +72,7 @@ public class RequestParamUtils {
 
     return !deprecatedParamParsedUids.isEmpty()
         ? deprecatedParamParsedUids.stream().map(UID::of).collect(Collectors.toSet())
-        : newParamUids;
+        : SetUtils.emptyIfNull(newParamUids);
   }
 
   /**

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParams.java
@@ -28,8 +28,6 @@
 package org.hisp.dhis.webapi.controller.tracker.export.trackedentity;
 
 import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -37,8 +35,6 @@ import org.hisp.dhis.common.AssignedUserSelectionMode;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.event.EventStatus;
-import org.hisp.dhis.fieldfiltering.FieldFilterParser;
-import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
@@ -60,7 +56,6 @@ import org.hisp.dhis.webapi.controller.tracker.view.User;
 @Data
 @NoArgsConstructor
 class RequestParams extends PagingAndSortingCriteriaAdapter {
-  static final String DEFAULT_FIELDS_PARAM = "*,!relationships,!enrollments,!events,!programOwners";
 
   /** Query filter for attributes */
   private String query;
@@ -82,10 +77,10 @@ class RequestParams extends PagingAndSortingCriteriaAdapter {
   private String orgUnit;
 
   @OpenApi.Property({UID[].class, OrganisationUnit.class})
-  private Set<UID> orgUnits = new HashSet<>();
+  private Set<UID> orgUnits;
 
   /** Selection mode for the specified organisation units, default is ACCESSIBLE. */
-  private OrganisationUnitSelectionMode ouMode = OrganisationUnitSelectionMode.DESCENDANTS;
+  private OrganisationUnitSelectionMode ouMode;
 
   /** a Program UID for which instances in the response must be enrolled in. */
   @OpenApi.Property({UID.class, Program.class})
@@ -135,7 +130,7 @@ class RequestParams extends PagingAndSortingCriteriaAdapter {
   private String trackedEntity;
 
   @OpenApi.Property({UID[].class, TrackedEntity.class})
-  private Set<UID> trackedEntities = new HashSet<>();
+  private Set<UID> trackedEntities;
 
   /** Selection mode for user assignment of events. */
   private AssignedUserSelectionMode assignedUserMode;
@@ -150,7 +145,7 @@ class RequestParams extends PagingAndSortingCriteriaAdapter {
   private String assignedUser;
 
   @OpenApi.Property({UID[].class, User.class})
-  private Set<UID> assignedUsers = new HashSet<>();
+  private Set<UID> assignedUsers;
 
   /** Program Stage UID, used for filtering TEIs based on the selected Program Stage */
   @OpenApi.Property({UID.class, ProgramStage.class})
@@ -179,7 +174,4 @@ class RequestParams extends PagingAndSortingCriteriaAdapter {
    * potentialDuplicate or not
    */
   private Boolean potentialDuplicate;
-
-  @OpenApi.Property(value = String[].class)
-  private List<FieldPath> fields = FieldFilterParser.parse(DEFAULT_FIELDS_PARAM);
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityFieldsParamMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityFieldsParamMapper.java
@@ -48,11 +48,23 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 class TrackedEntityFieldsParamMapper {
-  private final FieldFilterService fieldFilterService;
 
   private static final String FIELD_PROGRAM_OWNERS = "programOwners";
-
   private static final String FIELD_ENROLLMENTS = "enrollments";
+
+  private final FieldFilterService fieldFilterService;
+
+  private static TrackedEntityParams initUsingAllOrNoFields(Map<String, FieldPath> roots) {
+    TrackedEntityParams params = TrackedEntityParams.FALSE;
+
+    if (roots.containsKey(FieldPreset.ALL)) {
+      FieldPath p = roots.get(FieldPreset.ALL);
+      if (p.isRoot() && !p.isExclude()) {
+        params = TrackedEntityParams.TRUE;
+      }
+    }
+    return params;
+  }
 
   public TrackedEntityParams map(List<FieldPath> fields) {
     return map(fields, false);
@@ -93,18 +105,6 @@ class TrackedEntityFieldsParamMapper {
             fieldFilterService.filterIncludes(TrackedEntity.class, fields, FIELD_ENROLLMENTS),
             enrollmentParams);
     params = params.withTeiEnrollmentParams(teiEnrollmentParams);
-    return params;
-  }
-
-  private static TrackedEntityParams initUsingAllOrNoFields(Map<String, FieldPath> roots) {
-    TrackedEntityParams params = TrackedEntityParams.FALSE;
-
-    if (roots.containsKey(FieldPreset.ALL)) {
-      FieldPath p = roots.get(FieldPreset.ALL);
-      if (p.isRoot() && !p.isExclude()) {
-        params = TrackedEntityParams.TRUE;
-      }
-    }
     return params;
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.AssignedUserQueryParam;
+import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.fieldfiltering.FieldPath;
@@ -50,12 +51,8 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 class TrackedEntityRequestParamsMapper {
-  private final TrackedEntityFieldsParamMapper fieldsParamMapper;
 
-  public TrackedEntityOperationParams map(RequestParams requestParams, User user)
-      throws BadRequestException {
-    return map(requestParams, user, requestParams.getFields());
-  }
+  private final TrackedEntityFieldsParamMapper fieldsParamMapper;
 
   public TrackedEntityOperationParams map(
       RequestParams requestParams, User user, List<FieldPath> fields) throws BadRequestException {
@@ -81,12 +78,8 @@ class TrackedEntityRequestParamsMapper {
 
     return TrackedEntityOperationParams.builder()
         .query(queryFilter)
-        .programUid(
-            requestParams.getProgram() == null ? null : requestParams.getProgram().getValue())
-        .programStageUid(
-            requestParams.getProgramStage() == null
-                ? null
-                : requestParams.getProgramStage().getValue())
+        .programUid(UID.toValue(requestParams.getProgram()))
+        .programStageUid(UID.toValue(requestParams.getProgramStage()))
         .programStatus(requestParams.getProgramStatus())
         .followUp(requestParams.getFollowUp())
         .lastUpdatedStartDate(requestParams.getUpdatedAfter())
@@ -96,12 +89,12 @@ class TrackedEntityRequestParamsMapper {
         .programEnrollmentEndDate(requestParams.getEnrollmentEnrolledBefore())
         .programIncidentStartDate(requestParams.getEnrollmentOccurredAfter())
         .programIncidentEndDate(requestParams.getEnrollmentOccurredBefore())
-        .trackedEntityTypeUid(
-            requestParams.getTrackedEntityType() == null
-                ? null
-                : requestParams.getTrackedEntityType().getValue())
+        .trackedEntityTypeUid(UID.toValue(requestParams.getTrackedEntityType()))
         .organisationUnits(UID.toValueSet(orgUnitUids))
-        .organisationUnitMode(requestParams.getOuMode())
+        .organisationUnitMode(
+            requestParams.getOuMode() == null
+                ? OrganisationUnitSelectionMode.DESCENDANTS
+                : requestParams.getOuMode())
         .eventStatus(requestParams.getEventStatus())
         .eventStartDate(requestParams.getEventOccurredAfter())
         .eventEndDate(requestParams.getEventOccurredBefore())


### PR DESCRIPTION
This PR set default values in mapper and not in RequestParams as Spring binding doesn't work that way.
In order to make it work properly in all the endpoints, `List<PathField> fields` was moved out of `RequestParams` and passed as a `@RequestParam` in the controller.

PS. Sonar issues are just deprecated params