### PR TITLE
feat: Add new 'ieq' operator for case insensitive exact text filter [DHIS2-12167]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultJpaQueryParser.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultJpaQueryParser.java
@@ -118,6 +118,10 @@ public class DefaultJpaQueryParser implements QueryParser {
         {
           return Restrictions.eq(path, parseValue(valueType, arg));
         }
+      case "ieq":
+        {
+          return Restrictions.ilike(path, parseValue(valueType, arg), MatchMode.EXACT);
+        }
       case "!eq":
       case "neq":
       case "ne":

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultJpaQueryParser.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultJpaQueryParser.java
@@ -65,7 +65,7 @@ public class DefaultJpaQueryParser implements QueryParser {
     for (String filter : filters) {
       String[] split = filter.split(":");
 
-      if (!(split.length >= 2)) {
+      if (split.length < 2) {
         throw new QueryParserException("Invalid filter => " + filter);
       }
 
@@ -113,146 +113,65 @@ public class DefaultJpaQueryParser implements QueryParser {
       Property property, Class<?> valueType, String path, String operator, Object arg)
       throws QueryParserException {
 
-    switch (operator) {
-      case "eq":
-        {
-          return Restrictions.eq(path, parseValue(valueType, arg));
-        }
-      case "ieq":
-        {
-          return Restrictions.ilike(path, parseValue(valueType, arg), MatchMode.EXACT);
-        }
-      case "!eq":
-      case "neq":
-      case "ne":
-        {
-          return Restrictions.ne(path, parseValue(valueType, arg));
-        }
-      case "gt":
-        {
-          return Restrictions.gt(path, parseValue(valueType, arg));
-        }
-      case "lt":
-        {
-          return Restrictions.lt(path, parseValue(valueType, arg));
-        }
-      case "gte":
-      case "ge":
-        {
-          return Restrictions.ge(path, parseValue(valueType, arg));
-        }
-      case "lte":
-      case "le":
-        {
-          return Restrictions.le(path, parseValue(valueType, arg));
-        }
-      case "like":
-        {
-          return Restrictions.like(path, parseValue(valueType, arg), MatchMode.ANYWHERE);
-        }
-      case "!like":
-        {
-          return Restrictions.notLike(path, parseValue(valueType, arg), MatchMode.ANYWHERE);
-        }
-      case "$like":
-        {
-          return Restrictions.like(path, parseValue(valueType, arg), MatchMode.START);
-        }
-      case "!$like":
-        {
-          return Restrictions.notLike(path, parseValue(valueType, arg), MatchMode.START);
-        }
-      case "like$":
-        {
-          return Restrictions.like(path, parseValue(valueType, arg), MatchMode.END);
-        }
-      case "!like$":
-        {
-          return Restrictions.notLike(path, parseValue(valueType, arg), MatchMode.END);
-        }
-      case "ilike":
-        {
-          return Restrictions.ilike(path, parseValue(valueType, arg), MatchMode.ANYWHERE);
-        }
-      case "!ilike":
-        {
-          return Restrictions.notIlike(path, parseValue(valueType, arg), MatchMode.ANYWHERE);
-        }
-      case "startsWith":
-      case "$ilike":
-        {
-          return Restrictions.ilike(path, parseValue(valueType, arg), MatchMode.START);
-        }
-      case "!$ilike":
-        {
-          return Restrictions.notIlike(path, parseValue(valueType, arg), MatchMode.START);
-        }
-      case "token":
-        {
-          return Restrictions.token(path, parseValue(valueType, arg), MatchMode.START);
-        }
-      case "!token":
-        {
-          return Restrictions.notToken(path, parseValue(valueType, arg), MatchMode.START);
-        }
-      case "endsWith":
-      case "ilike$":
-        {
-          return Restrictions.ilike(path, parseValue(valueType, arg), MatchMode.END);
-        }
-      case "!ilike$":
-        {
-          return Restrictions.notIlike(path, parseValue(valueType, arg), MatchMode.END);
-        }
-      case "in":
-        {
-          Collection values = null;
+    return switch (operator) {
+      case "eq" -> Restrictions.eq(path, parseValue(valueType, arg));
+      case "ieq" -> Restrictions.ilike(path, parseValue(valueType, arg), MatchMode.EXACT);
+      case "!eq", "neq", "ne" -> Restrictions.ne(path, parseValue(valueType, arg));
+      case "gt" -> Restrictions.gt(path, parseValue(valueType, arg));
+      case "lt" -> Restrictions.lt(path, parseValue(valueType, arg));
+      case "gte", "ge" -> Restrictions.ge(path, parseValue(valueType, arg));
+      case "lte", "le" -> Restrictions.le(path, parseValue(valueType, arg));
+      case "like" -> Restrictions.like(path, parseValue(valueType, arg), MatchMode.ANYWHERE);
+      case "!like" -> Restrictions.notLike(path, parseValue(valueType, arg), MatchMode.ANYWHERE);
+      case "$like" -> Restrictions.like(path, parseValue(valueType, arg), MatchMode.START);
+      case "!$like" -> Restrictions.notLike(path, parseValue(valueType, arg), MatchMode.START);
+      case "like$" -> Restrictions.like(path, parseValue(valueType, arg), MatchMode.END);
+      case "!like$" -> Restrictions.notLike(path, parseValue(valueType, arg), MatchMode.END);
+      case "ilike" -> Restrictions.ilike(path, parseValue(valueType, arg), MatchMode.ANYWHERE);
+      case "!ilike" -> Restrictions.notIlike(path, parseValue(valueType, arg), MatchMode.ANYWHERE);
+      case "startsWith", "$ilike" -> Restrictions.ilike(
+          path, parseValue(valueType, arg), MatchMode.START);
+      case "!$ilike" -> Restrictions.notIlike(path, parseValue(valueType, arg), MatchMode.START);
+      case "token" -> Restrictions.token(path, parseValue(valueType, arg), MatchMode.START);
+      case "!token" -> Restrictions.notToken(path, parseValue(valueType, arg), MatchMode.START);
+      case "endsWith", "ilike$" -> Restrictions.ilike(
+          path, parseValue(valueType, arg), MatchMode.END);
+      case "!ilike$" -> Restrictions.notIlike(path, parseValue(valueType, arg), MatchMode.END);
+      case "in" -> {
+        Collection values = null;
 
-          if (property.isCollection()) {
-            values = parseValue(Collection.class, property.getItemKlass(), arg);
-          } else {
-            values = parseValue(Collection.class, valueType, arg);
-          }
+        if (property.isCollection()) {
+          values = parseValue(Collection.class, property.getItemKlass(), arg);
+        } else {
+          values = parseValue(Collection.class, valueType, arg);
+        }
 
-          if (values == null || values.isEmpty()) {
-            throw new QueryParserException("Invalid argument `" + arg + "` for in operator.");
-          }
+        if (values == null || values.isEmpty()) {
+          throw new QueryParserException("Invalid argument `" + arg + "` for in operator.");
+        }
 
-          return Restrictions.in(path, values);
-        }
-      case "!in":
-        {
-          Collection values = null;
+        yield Restrictions.in(path, values);
+      }
+      case "!in" -> {
+        Collection values = null;
 
-          if (property.isCollection()) {
-            values = parseValue(Collection.class, property.getItemKlass(), arg);
-          } else {
-            values = parseValue(Collection.class, valueType, arg);
-          }
+        if (property.isCollection()) {
+          values = parseValue(Collection.class, property.getItemKlass(), arg);
+        } else {
+          values = parseValue(Collection.class, valueType, arg);
+        }
 
-          if (values == null || values.isEmpty()) {
-            throw new QueryParserException("Invalid argument `" + arg + "` for in operator.");
-          }
+        if (values == null || values.isEmpty()) {
+          throw new QueryParserException("Invalid argument `" + arg + "` for in operator.");
+        }
 
-          return Restrictions.notIn(path, values);
-        }
-      case "null":
-        {
-          return Restrictions.isNull(path);
-        }
-      case "!null":
-        {
-          return Restrictions.isNotNull(path);
-        }
-      case "empty":
-        {
-          return Restrictions.isEmpty(path);
-        }
-      default:
-        {
-          throw new QueryParserException("`" + operator + "` is not a valid operator.");
-        }
-    }
+        yield Restrictions.notIn(path, values);
+      }
+      case "null" -> Restrictions.isNull(path);
+      case "!null" -> Restrictions.isNotNull(path);
+      case "empty" -> Restrictions.isEmpty(path);
+      default -> throw new QueryParserException("`" + operator + "` is not a valid operator.");
+    };
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
@@ -55,6 +55,7 @@ import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 public final class QueryUtils {
 
   private static final String UNABLE_TO_PARSE = "Unable to parse `";
+
   private QueryUtils() {
     throw new UnsupportedOperationException("util");
   }
@@ -147,7 +148,7 @@ public final class QueryUtils {
     }
 
     throw new QueryParserException(
-            UNABLE_TO_PARSE + value + "` to `" + klass.getSimpleName() + "`.");
+        UNABLE_TO_PARSE + value + "` to `" + klass.getSimpleName() + "`.");
   }
 
   /**
@@ -159,14 +160,14 @@ public final class QueryUtils {
   @SuppressWarnings({"unchecked", "rawtypes"})
   public static <T> T getEnumValue(Class<?> klass, String value) {
     Optional<? extends Enum<?>> enumValue =
-            Enums.getIfPresent((Class<? extends Enum>) klass, value).toJavaUtil();
+        Enums.getIfPresent((Class<? extends Enum>) klass, value).toJavaUtil();
 
     if (enumValue.isPresent()) {
       return (T) enumValue.get();
     }
     Object[] possibleValues = klass.getEnumConstants();
     throw new QueryParserException(
-            UNABLE_TO_PARSE
+        UNABLE_TO_PARSE
             + value
             + "` as `"
             + klass

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
@@ -259,6 +259,10 @@ public final class QueryUtils {
         {
           return "= " + QueryUtils.parseValue(value);
         }
+      case "ieq":
+        {
+          return " ilike '" + value + "'";
+        }
       case "!eq":
       case "ne":
       case "neq":

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.query;
 
 import com.google.common.base.Enums;
-import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,7 +37,7 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.persistence.TypedQuery;
@@ -54,6 +53,8 @@ import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 public final class QueryUtils {
+
+  private static final String UNABLE_TO_PARSE = "Unable to parse `";
   private QueryUtils() {
     throw new UnsupportedOperationException("util");
   }
@@ -78,28 +79,28 @@ public final class QueryUtils {
       try {
         return (T) Integer.valueOf(value);
       } catch (Exception ex) {
-        throw new QueryParserException("Unable to parse `" + value + "` as `Integer`.");
+        throw new QueryParserException(UNABLE_TO_PARSE + value + "` as `Integer`.");
       }
     }
     if (Boolean.class.isAssignableFrom(klass)) {
       try {
         return (T) Boolean.valueOf(value);
       } catch (Exception ex) {
-        throw new QueryParserException("Unable to parse `" + value + "` as `Boolean`.");
+        throw new QueryParserException(UNABLE_TO_PARSE + value + "` as `Boolean`.");
       }
     }
     if (Float.class.isAssignableFrom(klass)) {
       try {
         return (T) Float.valueOf(value);
       } catch (Exception ex) {
-        throw new QueryParserException("Unable to parse `" + value + "` as `Float`.");
+        throw new QueryParserException(UNABLE_TO_PARSE + value + "` as `Float`.");
       }
     }
     if (Double.class.isAssignableFrom(klass)) {
       try {
         return (T) Double.valueOf(value);
       } catch (Exception ex) {
-        throw new QueryParserException("Unable to parse `" + value + "` as `Double`.");
+        throw new QueryParserException(UNABLE_TO_PARSE + value + "` as `Double`.");
       }
     }
     if (Date.class.isAssignableFrom(klass)) {
@@ -107,7 +108,7 @@ public final class QueryUtils {
         Date date = DateUtils.parseDate(value);
         return (T) date;
       } catch (Exception ex) {
-        throw new QueryParserException("Unable to parse `" + value + "` as `Date`.");
+        throw new QueryParserException(UNABLE_TO_PARSE + value + "` as `Date`.");
       }
     }
     if (Enum.class.isAssignableFrom(klass)) {
@@ -146,7 +147,7 @@ public final class QueryUtils {
     }
 
     throw new QueryParserException(
-        "Unable to parse `" + value + "` to `" + klass.getSimpleName() + "`.");
+            UNABLE_TO_PARSE + value + "` to `" + klass.getSimpleName() + "`.");
   }
 
   /**
@@ -158,14 +159,14 @@ public final class QueryUtils {
   @SuppressWarnings({"unchecked", "rawtypes"})
   public static <T> T getEnumValue(Class<?> klass, String value) {
     Optional<? extends Enum<?>> enumValue =
-        Enums.getIfPresent((Class<? extends Enum>) klass, value);
+            Enums.getIfPresent((Class<? extends Enum>) klass, value).toJavaUtil();
 
     if (enumValue.isPresent()) {
       return (T) enumValue.get();
     }
     Object[] possibleValues = klass.getEnumConstants();
     throw new QueryParserException(
-        "Unable to parse `"
+            UNABLE_TO_PARSE
             + value
             + "` as `"
             + klass
@@ -177,7 +178,7 @@ public final class QueryUtils {
     if (value == null || StringUtils.isEmpty(value)) {
       return null;
     }
-    if (NumberUtils.isNumber(value)) {
+    if (NumberUtils.isCreatable(value)) {
       return value;
     }
     return "'" + value + "'";
@@ -254,108 +255,32 @@ public final class QueryUtils {
       throw new QueryParserException("Filter Operator is null");
     }
 
-    switch (operator) {
-      case "eq":
-        {
-          return "= " + QueryUtils.parseValue(value);
-        }
-      case "ieq":
-        {
-          return " ilike '" + value + "'";
-        }
-      case "!eq":
-      case "ne":
-      case "neq":
-        {
-          return "!= " + QueryUtils.parseValue(value);
-        }
-      case "gt":
-        {
-          return "> " + QueryUtils.parseValue(value);
-        }
-      case "lt":
-        {
-          return "< " + QueryUtils.parseValue(value);
-        }
-      case "gte":
-      case "ge":
-        {
-          return ">= " + QueryUtils.parseValue(value);
-        }
-      case "lte":
-      case "le":
-        {
-          return "<= " + QueryUtils.parseValue(value);
-        }
-      case "like":
-        {
-          return "like '%" + value + "%'";
-        }
-      case "!like":
-        {
-          return "not like '%" + value + "%'";
-        }
-      case "^like":
-        {
-          return " like '" + value + "%'";
-        }
-      case "!^like":
-        {
-          return " not like '" + value + "%'";
-        }
-      case "$like":
-        {
-          return " like '%" + value + "'";
-        }
-      case "!$like":
-        {
-          return " not like '%" + value + "'";
-        }
-      case "ilike":
-        {
-          return " ilike '%" + value + "%'";
-        }
-      case "!ilike":
-        {
-          return " not ilike '%" + value + "%'";
-        }
-      case "^ilike":
-        {
-          return " ilike '" + value + "%'";
-        }
-      case "!^ilike":
-        {
-          return " not ilike '" + value + "%'";
-        }
-      case "$ilike":
-        {
-          return " ilike '%" + value + "'";
-        }
-      case "!$ilike":
-        {
-          return " not ilike '%" + value + "'";
-        }
-      case "in":
-        {
-          return "in " + QueryUtils.convertCollectionValue(value);
-        }
-      case "!in":
-        {
-          return " not in " + QueryUtils.convertCollectionValue(value);
-        }
-      case "null":
-        {
-          return "is null";
-        }
-      case "!null":
-        {
-          return "is not null";
-        }
-      default:
-        {
-          throw new QueryParserException("`" + operator + "` is not a valid operator.");
-        }
-    }
+    return switch (operator) {
+      case "eq" -> "= " + QueryUtils.parseValue(value);
+      case "ieq" -> " ilike '" + value + "'";
+      case "!eq", "ne", "neq" -> "!= " + QueryUtils.parseValue(value);
+      case "gt" -> "> " + QueryUtils.parseValue(value);
+      case "lt" -> "< " + QueryUtils.parseValue(value);
+      case "gte", "ge" -> ">= " + QueryUtils.parseValue(value);
+      case "lte", "le" -> "<= " + QueryUtils.parseValue(value);
+      case "like" -> "like '%" + value + "%'";
+      case "!like" -> "not like '%" + value + "%'";
+      case "^like" -> " like '" + value + "%'";
+      case "!^like" -> " not like '" + value + "%'";
+      case "$like" -> " like '%" + value + "'";
+      case "!$like" -> " not like '%" + value + "'";
+      case "ilike" -> " ilike '%" + value + "%'";
+      case "!ilike" -> " not ilike '%" + value + "%'";
+      case "^ilike" -> " ilike '" + value + "%'";
+      case "!^ilike" -> " not ilike '" + value + "%'";
+      case "$ilike" -> " ilike '%" + value + "'";
+      case "!$ilike" -> " not ilike '%" + value + "'";
+      case "in" -> "in " + QueryUtils.convertCollectionValue(value);
+      case "!in" -> " not in " + QueryUtils.convertCollectionValue(value);
+      case "null" -> "is null";
+      case "!null" -> "is not null";
+      default -> throw new QueryParserException("`" + operator + "` is not a valid operator.");
+    };
   }
 
   /**
@@ -376,7 +301,7 @@ public final class QueryUtils {
         .filter(orderCriteria -> isValid(orderCriteria, schema))
         .distinct()
         .map(OrderCriteria::toOrderParam)
-        .collect(Collectors.toList());
+        .toList();
   }
 
   private static boolean isValid(OrderCriteria orderCriteria, Schema schema) {

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/QueryUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/QueryUtilsTest.java
@@ -175,6 +175,7 @@ class QueryUtilsTest {
   void testParseFilterOperator() {
     assertEquals("= 5", QueryUtils.parseFilterOperator("eq", "5"));
     assertEquals("= 'ABC'", QueryUtils.parseFilterOperator("eq", "ABC"));
+    assertEquals(" ilike 'abc'", QueryUtils.parseFilterOperator("ieq", "abc"));
     assertEquals("like '%abc%'", QueryUtils.parseFilterOperator("like", "abc"));
     assertEquals(" like '%abc'", QueryUtils.parseFilterOperator("$like", "abc"));
     assertEquals("in ('a','b','c')", QueryUtils.parseFilterOperator("in", "[a,b,c]"));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/query/QueryParserTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/query/QueryParserTest.java
@@ -36,6 +36,7 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitStore;
 import org.hisp.dhis.query.operators.EqualOperator;
+import org.hisp.dhis.query.operators.LikeOperator;
 import org.hisp.dhis.query.operators.NullOperator;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.test.integration.IntegrationTestBase;
@@ -92,6 +93,21 @@ class QueryParserTest extends IntegrationTestBase {
     assertEquals("id", restriction.getPath());
     assertEquals("2", restriction.getOperator().getArgs().get(0));
     assertTrue(restriction.getOperator() instanceof EqualOperator);
+  }
+
+  @Test
+  void ieqOperator() throws QueryParserException {
+    Query query =
+        queryParser.parse(DataElement.class, Arrays.asList("name:ieq:Test1", "name:ieq:test2"));
+    assertEquals(2, query.getCriterions().size());
+    Restriction restriction = (Restriction) query.getCriterions().get(0);
+    assertEquals("name", restriction.getPath());
+    assertEquals("Test1", restriction.getOperator().getArgs().get(0));
+    assertTrue(restriction.getOperator() instanceof LikeOperator<?>);
+    restriction = (Restriction) query.getCriterions().get(1);
+    assertEquals("name", restriction.getPath());
+    assertEquals("test2", restriction.getOperator().getArgs().get(0));
+    assertTrue(restriction.getOperator() instanceof LikeOperator<?>);
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/query/QueryServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/query/QueryServiceTest.java
@@ -200,7 +200,7 @@ class QueryServiceTest extends SingleSetupIntegrationTestBase {
   }
 
   @Test
-  void getIlikeQueryMatchMIXcase() {
+  void getIlikeQueryMatchMixCase() {
     Query query = Query.from(schemaService.getDynamicSchema(DataElement.class));
     query.add(Restrictions.ilike("name", "DAtAEleMEntA", MatchMode.EXACT));
     List<? extends IdentifiableObject> objects = queryService.query(query);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/query/QueryServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/query/QueryServiceTest.java
@@ -182,6 +182,87 @@ class QueryServiceTest extends SingleSetupIntegrationTestBase {
   }
 
   @Test
+  void getIlikeQueryMatchAllLowercase() {
+    Query query = Query.from(schemaService.getDynamicSchema(DataElement.class));
+    query.add(Restrictions.ilike("name", "dataelementa", MatchMode.EXACT));
+    List<? extends IdentifiableObject> objects = queryService.query(query);
+    assertEquals(1, objects.size());
+    assertEquals("DataElementA", objects.get(0).getName());
+  }
+
+  @Test
+  void getIlikeQueryMatchAllUppercase() {
+    Query query = Query.from(schemaService.getDynamicSchema(DataElement.class));
+    query.add(Restrictions.ilike("name", "DATAELEMENTA", MatchMode.EXACT));
+    List<? extends IdentifiableObject> objects = queryService.query(query);
+    assertEquals(1, objects.size());
+    assertEquals("DataElementA", objects.get(0).getName());
+  }
+
+  @Test
+  void getIlikeQueryMatchMIXcase() {
+    Query query = Query.from(schemaService.getDynamicSchema(DataElement.class));
+    query.add(Restrictions.ilike("name", "DAtAEleMEntA", MatchMode.EXACT));
+    List<? extends IdentifiableObject> objects = queryService.query(query);
+    assertEquals(1, objects.size());
+    assertEquals("DataElementA", objects.get(0).getName());
+  }
+
+  @Test
+  void getIlikeQueryNoMatchExtraCharAtEnd() {
+    Query query = Query.from(schemaService.getDynamicSchema(DataElement.class));
+    query.add(Restrictions.ilike("name", "dataelementaa", MatchMode.EXACT));
+    List<? extends IdentifiableObject> objects = queryService.query(query);
+    assertEquals(0, objects.size());
+  }
+
+  @Test
+  void getIlikeQueryNoMatchExtraCharAtStart() {
+    Query query = Query.from(schemaService.getDynamicSchema(DataElement.class));
+    query.add(Restrictions.ilike("name", "ddataelementa", MatchMode.EXACT));
+    List<? extends IdentifiableObject> objects = queryService.query(query);
+    assertEquals(0, objects.size());
+  }
+
+  @Test
+  void getIeqQueryUrlMatch() throws QueryParserException {
+    Query query =
+        queryService.getQueryFromUrl(
+            DataElement.class,
+            Lists.newArrayList("name:ieq:dataelementa"),
+            Lists.newArrayList(),
+            new Pagination());
+    List<? extends IdentifiableObject> objects = queryService.query(query);
+    assertEquals(1, objects.size());
+    assertEquals("DataElementA", objects.get(0).getName());
+  }
+
+  @Test
+  void getIeqQueryUrlMatchMixedCase() throws QueryParserException {
+    Query query =
+        queryService.getQueryFromUrl(
+            DataElement.class,
+            Lists.newArrayList("name:ieq:dAtAeLeMeNta"),
+            Lists.newArrayList(),
+            new Pagination());
+    List<? extends IdentifiableObject> objects = queryService.query(query);
+    assertEquals(1, objects.size());
+    assertEquals("DataElementA", objects.get(0).getName());
+  }
+
+  @Test
+  void getIeqQueryUrlNoMatchExtraCharAtStart() throws QueryParserException {
+    Query query =
+        queryService.getQueryFromUrl(
+            DataElement.class,
+            Lists.newArrayList("name:ieq:ddataelementa"),
+            Lists.newArrayList(),
+            new Pagination());
+    List<? extends IdentifiableObject> objects = queryService.query(query);
+    assertEquals(0, objects.size());
+  }
+
+  @Test
   void getNeQuery() {
     Query query = Query.from(schemaService.getDynamicSchema(DataElement.class));
     query.add(Restrictions.ne("id", "deabcdefghA"));

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
@@ -49,6 +49,7 @@ import org.hisp.dhis.webapi.json.domain.JsonAttributeValue;
 import org.hisp.dhis.webapi.json.domain.JsonErrorReport;
 import org.hisp.dhis.webapi.json.domain.JsonIdentifiableObject;
 import org.hisp.dhis.webapi.json.domain.JsonImportSummary;
+import org.hisp.dhis.webapi.json.domain.JsonProgram;
 import org.hisp.dhis.webapi.json.domain.JsonWebMessage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -201,6 +202,40 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest {
     assertEquals(
         "VoZMWi7rBgf",
         GET("/programs/{id}", "VoZMWi7rBgj").content().getString("programStages[0].id").string());
+  }
+
+  @Test
+  void testGetWithIeqFilter() {
+    POST(
+            "/metadata/",
+            "{'programs':[{'name':'Test Program', 'id':'VoZMWi7rBgj', 'shortName':'test program','programType':'WITH_REGISTRATION', 'version':'5'}]}")
+        .content(HttpStatus.OK);
+
+    assertEquals(
+        "Test Program",
+        GET("/metadata?programs=true&filter=name:ieq:test program")
+            .content()
+            .getList("programs", JsonProgram.class)
+            .get(0)
+            .getName());
+  }
+
+  @Test
+  void testGetWithIeqFilterNonString() {
+    POST(
+            "/metadata/",
+            "{'programs':[{'name':'Test Program', 'id':'VoZMWi7rBgj', 'shortName':'test program','programType':'WITH_REGISTRATION', 'version':'5'}]}")
+        .content(HttpStatus.OK);
+
+    JsonWebMessage response =
+        GET("/metadata?programs=true&filter=version:ieq:5")
+            .content(HttpStatus.Series.CLIENT_ERROR)
+            .as(JsonWebMessage.class);
+
+    assertEquals(
+        "Value `5` of type `Integer` is not supported by this operator.", response.getMessage());
+    assertEquals(409, response.getHttpStatusCode());
+    assertEquals("Conflict", response.getHttpStatus());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OrganisationUnitControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OrganisationUnitControllerTest.java
@@ -31,12 +31,16 @@ import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
 import static org.hisp.dhis.web.WebClientUtils.objectReference;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.List;
+import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.webapi.json.domain.JsonIdentifiableObject;
+import org.hisp.dhis.webapi.json.domain.JsonOrganisationUnit;
+import org.hisp.dhis.webapi.json.domain.JsonWebMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -71,6 +75,16 @@ class OrganisationUnitControllerTest extends DhisControllerConvenienceTest {
         GET("/organisationUnits/{id}/children", ou1).content(), "L1", "L21", "L22");
     assertListOfOrganisationUnits(
         GET("/organisationUnits/{id}/children", ou21).content(), "L21", "L31");
+  }
+
+  @Test
+  void testGetOrgUnitWithIeqFilter() {
+    JsonWebMessage jsonWebMessage =
+        GET("/organisationUnits?filter=name:ieq:l0").content().as(JsonWebMessage.class);
+    JsonList<JsonOrganisationUnit> organisationUnits =
+        jsonWebMessage.getList("organisationUnits", JsonOrganisationUnit.class);
+    assertFalse(organisationUnits.isEmpty());
+    assertEquals("L0", organisationUnits.get(0).getDisplayName());
   }
 
   @Test


### PR DESCRIPTION
# Summary
New feature request to add new operator `ieq` which performs a case insensitive exact string match

## Change
New operator `ieq` added which allows filtering for case insensitive exact string match.
- Implemented using ilike exact match
- only works for string type

Some Sonar changes implemented also
- merge switch cases
- simplify operator used (use `<` instead of `!>=`)

Scenario
`Program` with name `My Program`
| Filter query | Match |
| ----------- | -------- |
| filter=name:ieq:my program | true |
| filter=name:ieq:MY ProGram | true |
| filter=name:ieq:MY PROGRAM | true |
| filter=name:ieq:mmy program | false |
| filter=name:ieq:my programm | false |
| filter=name:ieq:mmy programm | false |

# Testing
## Automated
Tests added to check
- filtering for exact match
  - all lowercase
  - all uppercase
  - mixed case
- extra char at start
- extra char at end
- calling base endpoints e.g. `/organisationUnits?filter=name:ieq:l0`
- calling metadata endpoint e.g. `/api/metadata?programs=true&filter=name:ieq:test program`
- query params parsed correctly
- error when performed on non string property

## Manual
- check existing `dataElement`s with `GET /api/dataElements`
- filter by using new operator on any existing dataElement `GET /api/dataElements?filter=name:ieq:{data element name}`
  - passing in the data element name with different cases should not affect the response
  - the use of upper or lowercase will not be taken into consideration

Testing on non string values should return an error
- `GET /api/metadata?programs=true&filter=version:ieq:5`
```json
{
    "httpStatus": "Conflict",
    "httpStatusCode": 409,
    "status": "ERROR",
    "message": "Value `5` of type `Integer` is not supported by this operator."
}
```