### PR TITLE
fix: Remove profile check in controller [TECH-671]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/PeriodTypeSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/PeriodTypeSupplierTest.java
@@ -33,7 +33,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodStore;
 import org.hisp.dhis.random.BeanRandomizer;
@@ -48,7 +47,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-import org.springframework.core.env.Environment;
 
 /**
  * @author Luciano Fiandesio
@@ -57,21 +55,14 @@ import org.springframework.core.env.Environment;
 @ExtendWith(MockitoExtension.class)
 class PeriodTypeSupplierTest {
 
-  private PeriodTypeSupplier supplier;
-
-  @Mock private PeriodStore periodStore;
-
-  @Mock private DhisConfigurationProvider conf;
-
-  @Mock private Environment env;
-
   private final BeanRandomizer rnd = BeanRandomizer.create();
+  private PeriodTypeSupplier supplier;
+  @Mock private PeriodStore periodStore;
 
   @BeforeEach
   public void setUp() {
     final PreheatCacheService cache = new DefaultPreheatCacheService();
     supplier = new PeriodTypeSupplier(periodStore, cache);
-    when(env.getActiveProfiles()).thenReturn(new String[] {});
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SchemaBasedControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SchemaBasedControllerTest.java
@@ -42,7 +42,7 @@ import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.web.HttpStatus;
-import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.webapi.DhisControllerIntegrationTest;
 import org.hisp.dhis.webapi.json.domain.JsonGenerator;
 import org.hisp.dhis.webapi.json.domain.JsonIdentifiableObject;
 import org.hisp.dhis.webapi.json.domain.JsonSchema;
@@ -57,7 +57,8 @@ import org.springframework.http.MediaType;
  *
  * @author Jan Bernitt
  */
-class SchemaBasedControllerTest extends DhisControllerConvenienceTest {
+class SchemaBasedControllerTest extends DhisControllerIntegrationTest {
+
   private static final Set<String> IGNORED_SCHEMAS =
       Set.of(
           "externalFileResource", // can't POST files

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserGroupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserGroupController.java
@@ -28,12 +28,9 @@
 package org.hisp.dhis.webapi.controller.user;
 
 import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.commons.util.SystemUtils;
 import org.hisp.dhis.schema.descriptors.UserGroupSchemaDescriptor;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -44,7 +41,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Controller
 @RequestMapping(value = UserGroupSchemaDescriptor.API_ENDPOINT)
 public class UserGroupController extends AbstractCrudController<UserGroup> {
-  @Autowired private Environment env;
 
   @Override
   protected void postUpdateEntity(UserGroup entity) {
@@ -53,16 +49,6 @@ public class UserGroupController extends AbstractCrudController<UserGroup> {
 
   @Override
   protected void postDeleteEntity(String entityUid) {
-    /*
-     * This function will caused error in
-     * SchemaBasedControllerTest.testCreateAndDeleteSchemaObjects because of
-     * H2 database being used. The test is instead covered in
-     * IdentifiableObjectManagerTest.testRemoveUserGroupFromSharing()
-     */
-    if (SystemUtils.isTestRun(env.getActiveProfiles())) {
-      return;
-    }
-
     manager.removeUserGroupFromSharing(entityUid);
   }
 }


### PR DESCRIPTION
Removing `env.getActiveProfiles()` call in controller to check if the profile is test and changing the test to use postgres instead of H2 as it is dealing with sharing (jsonb) that is not supported in H2