### PR TITLE
chore: Hide pagination in service [TECH-1591]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-tracker/pom.xml
@@ -7,10 +7,10 @@
     <artifactId>dhis-services</artifactId>
     <version>2.41-SNAPSHOT</version>
   </parent>
-
   <artifactId>dhis-service-tracker</artifactId>
   <packaging>jar</packaging>
   <name>DHIS Tracker services</name>
+
   <properties>
     <rootDir>../../</rootDir>
   </properties>
@@ -140,10 +140,6 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-xml</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.locationtech.jts</groupId>
       <artifactId>jts-core</artifactId>
     </dependency>
@@ -243,7 +239,8 @@
                 <bannedDependencies>
                   <excludes>
                     <exclude>org.hisp.dhis:dhis-service-dxf2</exclude>
-                    <message>New tracker should not depend on old tracker code which will be removed. Parts of old tracker are located in dhis-service-dxf2.</message>
+                    <message>New tracker should not depend on old tracker code which will be
+                      removed. Parts of old tracker are located in dhis-service-dxf2.</message>
                   </excludes>
                 </bannedDependencies>
               </rules>

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -66,6 +66,7 @@ import org.springframework.stereotype.Service;
 @Service("org.hisp.dhis.tracker.export.enrollment.EnrollmentService")
 public class DefaultEnrollmentService
     implements org.hisp.dhis.tracker.export.enrollment.EnrollmentService {
+
   private final EnrollmentService enrollmentService;
 
   private final TrackerOwnershipManager trackerOwnershipAccessManager;
@@ -188,29 +189,28 @@ public class DefaultEnrollmentService
   @Override
   public Enrollments getEnrollments(EnrollmentOperationParams params)
       throws ForbiddenException, BadRequestException {
-    Enrollments enrollments = new Enrollments();
-
     EnrollmentQueryParams queryParams = paramsMapper.map(params);
 
     List<Enrollment> enrollmentList =
-        new ArrayList<>(enrollmentService.getEnrollments(queryParams));
-    if (!params.isSkipPaging()) {
-      Pager pager;
+        getEnrollments(
+            new ArrayList<>(enrollmentService.getEnrollments(queryParams)),
+            params.getEnrollmentParams(),
+            params.isIncludeDeleted());
 
-      if (params.isTotalPages()) {
-        int count = enrollmentService.countEnrollments(queryParams);
-        pager = new Pager(params.getPageWithDefault(), count, params.getPageSizeWithDefault());
-      } else {
-        pager = handleLastPageFlag(queryParams, enrollmentList);
-      }
-
-      enrollments.setPager(pager);
+    if (params.isSkipPaging()) {
+      return Enrollments.withoutPagination(enrollmentList);
     }
 
-    enrollments.setEnrollments(
-        getEnrollments(enrollmentList, params.getEnrollmentParams(), params.isIncludeDeleted()));
+    Pager pager;
 
-    return enrollments;
+    if (params.isTotalPages()) {
+      int count = enrollmentService.countEnrollments(queryParams);
+      pager = new Pager(params.getPageWithDefault(), count, params.getPageSizeWithDefault());
+    } else {
+      pager = handleLastPageFlag(queryParams, enrollmentList);
+    }
+
+    return Enrollments.of(enrollmentList, pager);
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/Enrollments.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/Enrollments.java
@@ -27,71 +27,22 @@
  */
 package org.hisp.dhis.tracker.export.enrollment;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import org.hisp.dhis.common.DxfNamespaces;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.program.Enrollment;
 
-@JacksonXmlRootElement(localName = "enrollments", namespace = DxfNamespaces.DXF_2_0)
+@RequiredArgsConstructor(staticName = "of")
+@Getter
+@EqualsAndHashCode
 public class Enrollments {
-  private List<Enrollment> enrollments = new ArrayList<>();
 
-  private Pager pager;
+  private final List<Enrollment> enrollments;
+  private final Pager pager;
 
-  public Enrollments() {}
-
-  @JsonProperty("enrollments")
-  @JacksonXmlElementWrapper(
-      localName = "enrollments",
-      useWrapping = false,
-      namespace = DxfNamespaces.DXF_2_0)
-  @JacksonXmlProperty(localName = "enrollment", namespace = DxfNamespaces.DXF_2_0)
-  public List<Enrollment> getEnrollments() {
-    return enrollments;
-  }
-
-  public void setEnrollments(List<Enrollment> enrollments) {
-    this.enrollments = enrollments;
-  }
-
-  public Pager getPager() {
-    return this.pager;
-  }
-
-  public void setPager(Pager pager) {
-    this.pager = pager;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    Enrollments that = (Enrollments) o;
-
-    return Objects.equals(enrollments, that.enrollments);
-  }
-
-  @Override
-  public int hashCode() {
-    int result = 0;
-    result = 31 * result + (enrollments != null ? enrollments.hashCode() : 0);
-    return result;
-  }
-
-  @Override
-  public String toString() {
-    return "Enrollments{" + "enrollments=" + enrollments + '}';
+  public static Enrollments withoutPagination(List<Enrollment> enrollments) {
+    return new Enrollments(enrollments, null);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -65,6 +65,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class DefaultEventService implements EventService {
+
   private final CurrentUserService currentUserService;
 
   private final EventStore eventStore;
@@ -175,11 +176,8 @@ public class DefaultEventService implements EventService {
       operationParams.setDefaultPaging();
     }
 
-    Events events = new Events();
-
     if (operationParams.isSkipPaging()) {
-      events.setEvents(eventStore.getEvents(searchParams, emptyMap()));
-      return events;
+      return Events.withoutPagination(eventStore.getEvents(searchParams, emptyMap()));
     }
 
     Pager pager;
@@ -196,16 +194,13 @@ public class DefaultEventService implements EventService {
       pager = handleLastPageFlag(operationParams, eventList);
     }
 
-    events.setPager(pager);
-    events.setEvents(eventList);
-
-    return events;
+    return Events.of(eventList, pager);
   }
 
   /**
    * This method will apply the logic related to the parameter 'totalPages=false'. This works in
-   * conjunction with the method: {@link
-   * EventStore#getEvents(EventSearchParams,Map<String,Set<String>>)}
+   * conjunction with the method: {@link EventStore#getEvents(EventSearchParams,
+   * Map<String,Set<String>>)}
    *
    * <p>This is needed because we need to query (pageSize + 1) at DB level. The resulting query will
    * allow us to evaluate if we are in the last page or not. And this is what his method does,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/Events.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/Events.java
@@ -27,102 +27,22 @@
  */
 package org.hisp.dhis.tracker.export.event;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import org.hisp.dhis.common.DxfNamespaces;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.program.Event;
 
-/**
- * @author Morten Olav Hansen <mortenoh@gmail.com>
- */
-@JacksonXmlRootElement(localName = "events", namespace = DxfNamespaces.DXF_2_0)
+@RequiredArgsConstructor(staticName = "of")
+@Getter
+@EqualsAndHashCode
 public class Events {
-  private String program;
 
-  private String enrollment;
+  private final List<Event> events;
+  private final Pager pager;
 
-  private List<Event> events = new ArrayList<>();
-
-  private Map<Object, Object> metaData;
-
-  private Pager pager;
-
-  public Events() {}
-
-  @JsonProperty
-  @JacksonXmlProperty(isAttribute = true)
-  public String getProgram() {
-    return program;
-  }
-
-  public void setProgram(String program) {
-    this.program = program;
-  }
-
-  @JsonProperty
-  @JacksonXmlProperty(isAttribute = true)
-  public String getEnrollment() {
-    return enrollment;
-  }
-
-  public void setEnrollment(String enrollment) {
-    this.enrollment = enrollment;
-  }
-
-  @JsonProperty
-  @JacksonXmlElementWrapper(
-      localName = "events",
-      useWrapping = false,
-      namespace = DxfNamespaces.DXF_2_0)
-  @JacksonXmlProperty(localName = "event", namespace = DxfNamespaces.DXF_2_0)
-  public List<Event> getEvents() {
-    return events;
-  }
-
-  public void setEvents(List<Event> events) {
-    this.events = events;
-  }
-
-  @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
-  public Map<Object, Object> getMetaData() {
-    return metaData;
-  }
-
-  @JsonIgnore
-  public void setMetaData(Map<Object, Object> metaData) {
-    this.metaData = metaData;
-  }
-
-  @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
-  public Pager getPager() {
-    return pager;
-  }
-
-  @JsonIgnore
-  public void setPager(Pager pager) {
-    this.pager = pager;
-  }
-
-  @Override
-  public String toString() {
-    return "Events{"
-        + "program='"
-        + program
-        + '\''
-        + ", enrollment='"
-        + enrollment
-        + '\''
-        + ", events="
-        + events
-        + '}';
+  public static Events withoutPagination(List<Event> events) {
+    return new Events(events, null);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntities.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntities.java
@@ -27,31 +27,23 @@
  */
 package org.hisp.dhis.tracker.export.trackedentity;
 
-import org.hisp.dhis.feedback.BadRequestException;
-import org.hisp.dhis.feedback.ForbiddenException;
-import org.hisp.dhis.feedback.NotFoundException;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 
-public interface TrackedEntityService {
+@RequiredArgsConstructor(staticName = "of")
+@Getter
+@EqualsAndHashCode
+public class TrackedEntities {
 
-  TrackedEntity getTrackedEntity(String uid, TrackedEntityParams params, boolean includeDeleted)
-      throws NotFoundException, ForbiddenException;
+  public static final TrackedEntities EMPTY = new TrackedEntities(List.of(), null);
+  private final List<TrackedEntity> trackedEntityList;
+  private final Pager pager;
 
-  TrackedEntity getTrackedEntity(
-      TrackedEntity trackedEntity, TrackedEntityParams params, boolean includeDeleted)
-      throws NotFoundException, ForbiddenException;
-
-  TrackedEntity getTrackedEntity(
-      String uid, String programIdentifier, TrackedEntityParams params, boolean includeDeleted)
-      throws NotFoundException, ForbiddenException;
-
-  /**
-   * Fetches {@see TrackedEntity}s based on the specified parameters.
-   *
-   * @param operationParams a {@see TrackedEntityOperationParams} instance with the operation
-   *     parameters
-   * @return {@see TrackedEntity}s
-   */
-  TrackedEntities getTrackedEntities(TrackedEntityOperationParams operationParams)
-      throws ForbiddenException, NotFoundException, BadRequestException;
+  public static TrackedEntities withoutPagination(List<TrackedEntity> trackedEntityList) {
+    return new TrackedEntities(trackedEntityList, null);
+  }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntities.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntities.java
@@ -40,10 +40,10 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
 public class TrackedEntities {
 
   public static final TrackedEntities EMPTY = new TrackedEntities(List.of(), null);
-  private final List<TrackedEntity> trackedEntityList;
+  private final List<TrackedEntity> trackedEntities;
   private final Pager pager;
 
-  public static TrackedEntities withoutPagination(List<TrackedEntity> trackedEntityList) {
-    return new TrackedEntities(trackedEntityList, null);
+  public static TrackedEntities withoutPagination(List<TrackedEntity> trackedEntities) {
+    return new TrackedEntities(trackedEntities, null);
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -426,7 +426,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     final List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams);
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
 
     assertContainsOnly(List.of(trackedEntityA, trackedEntityB), trackedEntities);
   }
@@ -442,7 +442,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     final List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams);
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     assertContainsOnly(
@@ -465,7 +465,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     final List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams);
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
 
     assertContainsOnly(List.of(trackedEntityA.getUid()), uids(trackedEntities));
     assertContainsOnly(Set.of(enrollmentA.getUid()), uids(trackedEntities.get(0).getEnrollments()));
@@ -506,7 +506,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     final List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams);
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     assertContainsOnly(
@@ -524,7 +524,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     final List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams);
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     assertContainsOnly(
@@ -541,7 +541,8 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .programUid(programA.getUid())
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     assertContainsOnly(
@@ -559,7 +560,8 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .filters(teaA.getUid() + ":eq:M'M")
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
 
     assertIsEmpty(trackedEntities);
   }
@@ -575,7 +577,8 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .lastUpdatedEndDate(new Date())
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
 
@@ -588,7 +591,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .lastUpdatedEndDate(new Date())
             .build();
 
-    assertIsEmpty(trackedEntityService.getTrackedEntities(operationParams));
+    assertIsEmpty(trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList());
   }
 
   @Test
@@ -605,27 +608,39 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .eventEndDate(Date.from(Instant.now().plus(10, ChronoUnit.DAYS)));
 
     final List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(builder.eventStatus(EventStatus.COMPLETED).build());
+        trackedEntityService
+            .getTrackedEntities(builder.eventStatus(EventStatus.COMPLETED).build())
+            .getTrackedEntityList();
     assertEquals(4, trackedEntities.size());
     // Update status to active
     final List<TrackedEntity> limitedTrackedEntities =
-        trackedEntityService.getTrackedEntities(builder.eventStatus(EventStatus.ACTIVE).build());
+        trackedEntityService
+            .getTrackedEntities(builder.eventStatus(EventStatus.ACTIVE).build())
+            .getTrackedEntityList();
     assertIsEmpty(limitedTrackedEntities);
     // Update status to overdue
     final List<TrackedEntity> limitedTrackedEntities2 =
-        trackedEntityService.getTrackedEntities(builder.eventStatus(EventStatus.OVERDUE).build());
+        trackedEntityService
+            .getTrackedEntities(builder.eventStatus(EventStatus.OVERDUE).build())
+            .getTrackedEntityList();
     assertIsEmpty(limitedTrackedEntities2);
     // Update status to schedule
     final List<TrackedEntity> limitedTrackedEntities3 =
-        trackedEntityService.getTrackedEntities(builder.eventStatus(EventStatus.OVERDUE).build());
+        trackedEntityService
+            .getTrackedEntities(builder.eventStatus(EventStatus.OVERDUE).build())
+            .getTrackedEntityList();
     assertIsEmpty(limitedTrackedEntities3);
     // Update status to schedule
     final List<TrackedEntity> limitedTrackedEntities4 =
-        trackedEntityService.getTrackedEntities(builder.eventStatus(EventStatus.SCHEDULE).build());
+        trackedEntityService
+            .getTrackedEntities(builder.eventStatus(EventStatus.SCHEDULE).build())
+            .getTrackedEntityList();
     assertIsEmpty(limitedTrackedEntities4);
     // Update status to visited
     final List<TrackedEntity> limitedTrackedEntities5 =
-        trackedEntityService.getTrackedEntities(builder.eventStatus(EventStatus.VISITED).build());
+        trackedEntityService
+            .getTrackedEntities(builder.eventStatus(EventStatus.VISITED).build())
+            .getTrackedEntityList();
     assertIsEmpty(limitedTrackedEntities5);
   }
 
@@ -641,7 +656,8 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .trackedEntityParams(TrackedEntityParams.TRUE)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     TrackedEntity trackedEntity = trackedEntities.get(0);
@@ -662,7 +678,8 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     enrollmentService.deleteEnrollment(enrollmentA);
     eventService.deleteEvent(eventA);
 
-    trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    trackedEntities =
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     trackedEntity = trackedEntities.get(0);
@@ -695,7 +712,8 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .includeDeleted(false)
             .trackedEntityParams(TrackedEntityParams.TRUE)
             .build();
-    trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    trackedEntities =
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     trackedEntity = trackedEntities.get(0);
@@ -721,7 +739,8 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .trackedEntityParams(params)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
 
     assertContainsOnly(List.of(trackedEntityA.getUid()), uids(trackedEntities));
     assertContainsOnly(
@@ -750,7 +769,8 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .includeAllAttributes(true)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     assertIsEmpty(trackedEntities.get(0).getEnrollments());
@@ -770,7 +790,8 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .trackedEntityParams(params)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     assertContainsOnly(
@@ -801,7 +822,8 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .trackedEntityParams(params)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
 
     assertContainsOnly(List.of(trackedEntityA.getUid()), uids(trackedEntities));
     assertContainsOnly(
@@ -826,7 +848,8 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .includeAllAttributes(true)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
 
     TrackedEntity trackedEntity = trackedEntities.get(0);
     assertAll(
@@ -859,7 +882,8 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .trackedEntityParams(params)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
 
     List<Enrollment> enrollments = new ArrayList<>(trackedEntities.get(0).getEnrollments());
     Optional<Enrollment> enrollmentOpt =
@@ -904,7 +928,8 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .trackedEntityParams(params)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
 
     List<Enrollment> enrollments = new ArrayList<>(trackedEntities.get(0).getEnrollments());
     Optional<Enrollment> enrollmentOpt =
@@ -956,7 +981,8 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .trackedEntityParams(params)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
 
     TrackedEntity trackedEntity = trackedEntities.get(0);
     Optional<RelationshipItem> relOpt =
@@ -982,7 +1008,8 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .trackedEntityParams(params)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
 
     TrackedEntity trackedEntity = trackedEntities.get(0);
     Optional<RelationshipItem> relOpt =
@@ -1008,7 +1035,8 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .trackedEntityParams(params)
             .build();
 
-    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
 
     TrackedEntity trackedEntity = trackedEntities.get(0);
     Optional<RelationshipItem> relOpt =

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -426,7 +426,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     final List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
 
     assertContainsOnly(List.of(trackedEntityA, trackedEntityB), trackedEntities);
   }
@@ -442,7 +442,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     final List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     assertContainsOnly(
@@ -465,7 +465,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     final List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
 
     assertContainsOnly(List.of(trackedEntityA.getUid()), uids(trackedEntities));
     assertContainsOnly(Set.of(enrollmentA.getUid()), uids(trackedEntities.get(0).getEnrollments()));
@@ -506,7 +506,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     final List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     assertContainsOnly(
@@ -524,7 +524,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     final List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     assertContainsOnly(
@@ -542,7 +542,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     assertContainsOnly(
@@ -561,7 +561,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
 
     assertIsEmpty(trackedEntities);
   }
@@ -578,7 +578,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
 
@@ -591,7 +591,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .lastUpdatedEndDate(new Date())
             .build();
 
-    assertIsEmpty(trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList());
+    assertIsEmpty(trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities());
   }
 
   @Test
@@ -610,37 +610,37 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     final List<TrackedEntity> trackedEntities =
         trackedEntityService
             .getTrackedEntities(builder.eventStatus(EventStatus.COMPLETED).build())
-            .getTrackedEntityList();
+            .getTrackedEntities();
     assertEquals(4, trackedEntities.size());
     // Update status to active
     final List<TrackedEntity> limitedTrackedEntities =
         trackedEntityService
             .getTrackedEntities(builder.eventStatus(EventStatus.ACTIVE).build())
-            .getTrackedEntityList();
+            .getTrackedEntities();
     assertIsEmpty(limitedTrackedEntities);
     // Update status to overdue
     final List<TrackedEntity> limitedTrackedEntities2 =
         trackedEntityService
             .getTrackedEntities(builder.eventStatus(EventStatus.OVERDUE).build())
-            .getTrackedEntityList();
+            .getTrackedEntities();
     assertIsEmpty(limitedTrackedEntities2);
     // Update status to schedule
     final List<TrackedEntity> limitedTrackedEntities3 =
         trackedEntityService
             .getTrackedEntities(builder.eventStatus(EventStatus.OVERDUE).build())
-            .getTrackedEntityList();
+            .getTrackedEntities();
     assertIsEmpty(limitedTrackedEntities3);
     // Update status to schedule
     final List<TrackedEntity> limitedTrackedEntities4 =
         trackedEntityService
             .getTrackedEntities(builder.eventStatus(EventStatus.SCHEDULE).build())
-            .getTrackedEntityList();
+            .getTrackedEntities();
     assertIsEmpty(limitedTrackedEntities4);
     // Update status to visited
     final List<TrackedEntity> limitedTrackedEntities5 =
         trackedEntityService
             .getTrackedEntities(builder.eventStatus(EventStatus.VISITED).build())
-            .getTrackedEntityList();
+            .getTrackedEntities();
     assertIsEmpty(limitedTrackedEntities5);
   }
 
@@ -657,7 +657,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     TrackedEntity trackedEntity = trackedEntities.get(0);
@@ -678,8 +678,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     enrollmentService.deleteEnrollment(enrollmentA);
     eventService.deleteEvent(eventA);
 
-    trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
+    trackedEntities = trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     trackedEntity = trackedEntities.get(0);
@@ -712,8 +711,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .includeDeleted(false)
             .trackedEntityParams(TrackedEntityParams.TRUE)
             .build();
-    trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
+    trackedEntities = trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     trackedEntity = trackedEntities.get(0);
@@ -740,7 +738,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
 
     assertContainsOnly(List.of(trackedEntityA.getUid()), uids(trackedEntities));
     assertContainsOnly(
@@ -770,7 +768,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     assertIsEmpty(trackedEntities.get(0).getEnrollments());
@@ -791,7 +789,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
 
     assertContainsOnly(List.of(trackedEntityA), trackedEntities);
     assertContainsOnly(
@@ -823,7 +821,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
 
     assertContainsOnly(List.of(trackedEntityA.getUid()), uids(trackedEntities));
     assertContainsOnly(
@@ -849,7 +847,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
 
     TrackedEntity trackedEntity = trackedEntities.get(0);
     assertAll(
@@ -883,7 +881,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
 
     List<Enrollment> enrollments = new ArrayList<>(trackedEntities.get(0).getEnrollments());
     Optional<Enrollment> enrollmentOpt =
@@ -929,7 +927,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
 
     List<Enrollment> enrollments = new ArrayList<>(trackedEntities.get(0).getEnrollments());
     Optional<Enrollment> enrollmentOpt =
@@ -982,7 +980,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
 
     TrackedEntity trackedEntity = trackedEntities.get(0);
     Optional<RelationshipItem> relOpt =
@@ -1009,7 +1007,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
 
     TrackedEntity trackedEntity = trackedEntities.get(0);
     Optional<RelationshipItem> relOpt =
@@ -1036,7 +1034,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .build();
 
     List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList();
+        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
 
     TrackedEntity trackedEntity = trackedEntities.get(0);
     Optional<RelationshipItem> relOpt =

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -49,7 +49,6 @@ import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
@@ -57,6 +56,7 @@ import org.hisp.dhis.fieldfiltering.FieldFilterParser;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.tracker.export.trackedentity.TrackedEntities;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityOperationParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityService;
@@ -85,6 +85,7 @@ import org.springframework.web.bind.annotation.RestController;
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
 @RequiredArgsConstructor
 class TrackedEntitiesExportController {
+
   protected static final String TRACKED_ENTITIES = "trackedEntities";
 
   /**
@@ -117,28 +118,20 @@ class TrackedEntitiesExportController {
       throws BadRequestException, ForbiddenException, NotFoundException {
     TrackedEntityOperationParams operationParams = paramsMapper.map(requestParams, currentUser);
 
-    List<TrackedEntity> trackedEntities =
-        TRACKED_ENTITY_MAPPER.fromCollection(
-            trackedEntityService.getTrackedEntities(operationParams));
+    TrackedEntities trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
 
     PagingWrapper<ObjectNode> pagingWrapper = new PagingWrapper<>();
 
     if (requestParams.isPagingRequest()) {
-      long count = 0L;
-
-      if (requestParams.isTotalPages()) {
-        count = trackedEntityService.getTrackedEntityCount(operationParams, true, true);
-      }
-
-      Pager pager =
-          new Pager(
-              requestParams.getPageWithDefault(), count, requestParams.getPageSizeWithDefault());
-
-      pagingWrapper = pagingWrapper.withPager(PagingWrapper.Pager.fromLegacy(requestParams, pager));
+      pagingWrapper =
+          pagingWrapper.withPager(
+              PagingWrapper.Pager.fromLegacy(requestParams, trackedEntities.getPager()));
     }
 
     List<ObjectNode> objectNodes =
-        fieldFilterService.toObjectNodes(trackedEntities, requestParams.getFields());
+        fieldFilterService.toObjectNodes(
+            TRACKED_ENTITY_MAPPER.fromCollection(trackedEntities.getTrackedEntityList()),
+            requestParams.getFields());
     return pagingWrapper.withInstances(objectNodes);
   }
 
@@ -161,7 +154,7 @@ class TrackedEntitiesExportController {
 
     List<TrackedEntity> trackedEntities =
         TRACKED_ENTITY_MAPPER.fromCollection(
-            trackedEntityService.getTrackedEntities(operationParams));
+            trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList());
 
     OutputStream outputStream = response.getOutputStream();
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -130,7 +130,7 @@ class TrackedEntitiesExportController {
 
     List<ObjectNode> objectNodes =
         fieldFilterService.toObjectNodes(
-            TRACKED_ENTITY_MAPPER.fromCollection(trackedEntities.getTrackedEntityList()),
+            TRACKED_ENTITY_MAPPER.fromCollection(trackedEntities.getTrackedEntities()),
             requestParams.getFields());
     return pagingWrapper.withInstances(objectNodes);
   }
@@ -154,7 +154,7 @@ class TrackedEntitiesExportController {
 
     List<TrackedEntity> trackedEntities =
         TRACKED_ENTITY_MAPPER.fromCollection(
-            trackedEntityService.getTrackedEntities(operationParams).getTrackedEntityList());
+            trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities());
 
     OutputStream outputStream = response.getOutputStream();
 


### PR DESCRIPTION
The goal of this PR is to harmonize `TrackedEntityController` with the controllers of other entities, it is not to be intended as a solution for pagination as it will be tackled in some other epic.

The idea is to make the service return a wrapping object that holds the info about the list of tracked entities and the pagination information.