### PR TITLE
feat: add query parameter orgUnitMode to /tracker in favor of ouMode

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityQueryParams.java
@@ -108,7 +108,7 @@ public class TrackedEntityQueryParams {
    * Organisation units for which instances in the response were registered at. Is related to the
    * specified OrganisationUnitMode.
    */
-  private Set<OrganisationUnit> organisationUnits = new HashSet<>();
+  private Set<OrganisationUnit> orgUnits = new HashSet<>();
 
   /** Program for which instances in the response must be enrolled in. */
   private Program program;
@@ -149,8 +149,7 @@ public class TrackedEntityQueryParams {
   private List<TrackedEntityType> trackedEntityTypes = Lists.newArrayList();
 
   /** Selection mode for the specified organisation units, default is DESCENDANTS. */
-  private OrganisationUnitSelectionMode organisationUnitMode =
-      OrganisationUnitSelectionMode.DESCENDANTS;
+  private OrganisationUnitSelectionMode orgUnitMode = OrganisationUnitSelectionMode.DESCENDANTS;
 
   private AssignedUserQueryParam assignedUserQueryParam = AssignedUserQueryParam.ALL;
 
@@ -245,7 +244,7 @@ public class TrackedEntityQueryParams {
 
   /** Adds an organisation unit to the parameters. */
   public TrackedEntityQueryParams addOrganisationUnit(OrganisationUnit unit) {
-    this.organisationUnits.add(unit);
+    this.orgUnits.add(unit);
     return this;
   }
 
@@ -288,20 +287,20 @@ public class TrackedEntityQueryParams {
    */
   public void handleOrganisationUnits() {
     if (user != null && isOrganisationUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE)) {
-      setOrganisationUnits(user.getTeiSearchOrganisationUnitsWithFallback());
-      setOrganisationUnitMode(OrganisationUnitSelectionMode.DESCENDANTS);
+      setOrgUnits(user.getTeiSearchOrganisationUnitsWithFallback());
+      setOrgUnitMode(OrganisationUnitSelectionMode.DESCENDANTS);
     } else if (user != null && isOrganisationUnitMode(OrganisationUnitSelectionMode.CAPTURE)) {
-      setOrganisationUnits(user.getOrganisationUnits());
-      setOrganisationUnitMode(OrganisationUnitSelectionMode.DESCENDANTS);
+      setOrgUnits(user.getOrganisationUnits());
+      setOrgUnitMode(OrganisationUnitSelectionMode.DESCENDANTS);
     } else if (isOrganisationUnitMode(CHILDREN)) {
-      Set<OrganisationUnit> orgUnits = new HashSet<>(getOrganisationUnits());
+      Set<OrganisationUnit> orgUnits = new HashSet<>(getOrgUnits());
 
-      for (OrganisationUnit organisationUnit : getOrganisationUnits()) {
+      for (OrganisationUnit organisationUnit : getOrgUnits()) {
         orgUnits.addAll(organisationUnit.getChildren());
       }
 
-      setOrganisationUnits(orgUnits);
-      setOrganisationUnitMode(OrganisationUnitSelectionMode.SELECTED);
+      setOrgUnits(orgUnits);
+      setOrgUnitMode(OrganisationUnitSelectionMode.SELECTED);
     }
   }
 
@@ -414,7 +413,7 @@ public class TrackedEntityQueryParams {
 
   /** Indicates whether this parameters specifies any organisation units. */
   public boolean hasOrganisationUnits() {
-    return organisationUnits != null && !organisationUnits.isEmpty();
+    return orgUnits != null && !orgUnits.isEmpty();
   }
 
   /** Indicates whether this parameters specifies a program. */
@@ -477,7 +476,7 @@ public class TrackedEntityQueryParams {
 
   /** Indicates whether this parameters is of the given organisation unit mode. */
   public boolean isOrganisationUnitMode(OrganisationUnitSelectionMode mode) {
-    return organisationUnitMode != null && organisationUnitMode.equals(mode);
+    return orgUnitMode != null && orgUnitMode.equals(mode);
   }
 
   /** Indicates whether this parameters specifies a programStage. */
@@ -573,7 +572,7 @@ public class TrackedEntityQueryParams {
         .add("query", query)
         .add("attributes", attributes)
         .add("filters", filters)
-        .add("organisationUnits", organisationUnits)
+        .add("orgUnits", orgUnits)
         .add("program", program)
         .add("programStatus", programStatus)
         .add("followUp", followUp)
@@ -585,7 +584,7 @@ public class TrackedEntityQueryParams {
         .add("programIncidentStartDate", programIncidentStartDate)
         .add("programIncidentEndDate", programIncidentEndDate)
         .add("trackedEntityType", trackedEntityType)
-        .add("organisationUnitMode", organisationUnitMode)
+        .add("orgUnitMode", orgUnitMode)
         .add("assignedUserQueryParam", assignedUserQueryParam)
         .add("eventStatus", eventStatus)
         .add("eventStartDate", eventStartDate)
@@ -637,17 +636,17 @@ public class TrackedEntityQueryParams {
     return this;
   }
 
-  public Set<OrganisationUnit> getOrganisationUnits() {
-    return organisationUnits;
+  public Set<OrganisationUnit> getOrgUnits() {
+    return orgUnits;
   }
 
-  public TrackedEntityQueryParams addOrganisationUnits(Set<OrganisationUnit> organisationUnits) {
-    this.organisationUnits.addAll(organisationUnits);
+  public TrackedEntityQueryParams addOrgUnits(Set<OrganisationUnit> orgUnits) {
+    this.orgUnits.addAll(orgUnits);
     return this;
   }
 
-  public TrackedEntityQueryParams setOrganisationUnits(Set<OrganisationUnit> organisationUnits) {
-    this.organisationUnits = organisationUnits;
+  public TrackedEntityQueryParams setOrgUnits(Set<OrganisationUnit> orgUnits) {
+    this.orgUnits = orgUnits;
     return this;
   }
 
@@ -772,13 +771,12 @@ public class TrackedEntityQueryParams {
     return this;
   }
 
-  public OrganisationUnitSelectionMode getOrganisationUnitMode() {
-    return organisationUnitMode;
+  public OrganisationUnitSelectionMode getOrgUnitMode() {
+    return orgUnitMode;
   }
 
-  public TrackedEntityQueryParams setOrganisationUnitMode(
-      OrganisationUnitSelectionMode organisationUnitMode) {
-    this.organisationUnitMode = organisationUnitMode;
+  public TrackedEntityQueryParams setOrgUnitMode(OrganisationUnitSelectionMode orgUnitMode) {
+    this.orgUnitMode = orgUnitMode;
     return this;
   }
 
@@ -971,15 +969,19 @@ public class TrackedEntityQueryParams {
   @Getter
   @AllArgsConstructor
   public enum OrderColumn {
-    TRACKEDENTITY("trackedEntity", "uid", MAIN_QUERY_ALIAS),
-    // Ordering by id is the same as ordering by created date
+    TRACKEDENTITY(
+        "trackedEntity",
+        "uid",
+        MAIN_QUERY_ALIAS), // Ordering by id is the same as ordering by created date
     CREATED(CREATED_ID, "trackedentityinstanceid", MAIN_QUERY_ALIAS),
     CREATED_AT("createdAt", "trackedentityinstanceid", MAIN_QUERY_ALIAS),
     CREATED_AT_CLIENT("createdAtClient", "createdAtClient", MAIN_QUERY_ALIAS),
     UPDATED_AT("updatedAt", "lastUpdated", MAIN_QUERY_ALIAS),
     UPDATED_AT_CLIENT("updatedAtClient", "lastUpdatedAtClient", MAIN_QUERY_ALIAS),
-    ENROLLED_AT("enrolledAt", "enrollmentDate", PROGRAM_INSTANCE_ALIAS),
-    // this works only for the new endpoint
+    ENROLLED_AT(
+        "enrolledAt",
+        "enrollmentDate",
+        PROGRAM_INSTANCE_ALIAS), // this works only for the new endpoint
     // ORGUNIT_NAME( "orgUnitName", MAIN_QUERY_ALIAS+".organisationUnit.name" ),
     INACTIVE(INACTIVE_ID, "inactive", MAIN_QUERY_ALIAS);
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/ProgramStageDataEntrySMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/ProgramStageDataEntrySMSListener.java
@@ -182,7 +182,7 @@ public class ProgramStageDataEntrySMSListener extends CommandSMSListener {
     item.setValueType(ValueType.PHONE_NUMBER);
 
     params.setProgram(program);
-    params.setOrganisationUnits(ous);
+    params.setOrgUnits(ous);
     params.getFilters().add(item);
 
     return params;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityService.java
@@ -838,10 +838,10 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
     Set<OrganisationUnit> searchOrgUnits = new HashSet<>();
 
     if (params.isOrganisationUnitMode(SELECTED)) {
-      searchOrgUnits = params.getOrganisationUnits();
+      searchOrgUnits = params.getOrgUnits();
     } else if (params.isOrganisationUnitMode(CHILDREN)
         || params.isOrganisationUnitMode(DESCENDANTS)) {
-      for (OrganisationUnit ou : params.getOrganisationUnits()) {
+      for (OrganisationUnit ou : params.getOrgUnits()) {
         searchOrgUnits.addAll(ou.getChildren());
       }
     } else if (params.isOrganisationUnitMode(ALL)) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityAttributeStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityAttributeStore.java
@@ -123,7 +123,7 @@ public class HibernateTrackedEntityAttributeStore
 
     if (params.hasOrganisationUnits()) {
       String orgUnitUids =
-          params.getOrganisationUnits().stream()
+          params.getOrgUnits().stream()
               .map(OrganisationUnit::getUid)
               .collect(Collectors.joining(", ", "'", "'"));
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
@@ -858,7 +858,7 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
 
       orgUnits.append("AND (");
 
-      for (OrganisationUnit organisationUnit : params.getOrganisationUnits()) {
+      for (OrganisationUnit organisationUnit : params.getOrgUnits()) {
 
         OrganisationUnit ou = organisationUnitStore.getByUid(organisationUnit.getUid());
         if (ou != null) {
@@ -870,7 +870,7 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
     } else if (!params.isOrganisationUnitMode(OrganisationUnitSelectionMode.ALL)) {
       orgUnits
           .append("AND OU.organisationunitid IN (")
-          .append(getCommaDelimitedString(getIdentifiers(params.getOrganisationUnits())))
+          .append(getCommaDelimitedString(getIdentifiers(params.getOrgUnits())))
           .append(") ");
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityServiceTest.java
@@ -97,7 +97,7 @@ class DefaultTrackedEntityServiceTest {
     when(currentUserService.getCurrentUser()).thenReturn(user);
 
     params = new TrackedEntityQueryParams();
-    params.setOrganisationUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE);
+    params.setOrgUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE);
     params.setProgram(new Program("Test program"));
     params.getProgram().setMaxTeiCountToReturn(10);
     params.setTrackedEntityUids(Set.of("1"));

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
@@ -67,7 +67,7 @@ public class EventOperationParams {
 
   private String orgUnitUid;
 
-  private OrganisationUnitSelectionMode orgUnitSelectionMode;
+  private OrganisationUnitSelectionMode orgUnitMode;
 
   private AssignedUserSelectionMode assignedUserMode;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
@@ -120,7 +120,7 @@ public class EventOperationParamsMapper {
     OrganisationUnit requestedOrgUnit = validateRequestedOrgUnit(operationParams.getOrgUnitUid());
 
     OrganisationUnitSelectionMode orgUnitMode =
-        getOrgUnitMode(requestedOrgUnit, operationParams.getOrgUnitSelectionMode());
+        getOrgUnitMode(requestedOrgUnit, operationParams.getOrgUnitMode());
     List<OrganisationUnit> accessibleOrgUnits =
         validateAccessibleOrgUnits(user, requestedOrgUnit, orgUnitMode, program);
     validateUser(user, program, programStage);
@@ -136,7 +136,7 @@ public class EventOperationParamsMapper {
 
     validateAttributeOptionCombo(attributeOptionCombo, user);
 
-    validateOrgUnitSelectionMode(operationParams, user, program);
+    validateOrgUnitMode(operationParams, user, program);
 
     Map<String, SortDirection> attributeOrders =
         getAttributesFromOrder(operationParams.getAttributeOrders());
@@ -168,7 +168,7 @@ public class EventOperationParamsMapper {
         .setTrackedEntity(trackedEntity)
         .setProgramStatus(operationParams.getProgramStatus())
         .setFollowUp(operationParams.getFollowUp())
-        .setOrgUnitSelectionMode(orgUnitMode)
+        .setOrgUnitMode(orgUnitMode)
         .setAssignedUserQueryParam(
             new AssignedUserQueryParam(
                 operationParams.getAssignedUserMode(), user, operationParams.getAssignedUsers()))
@@ -391,9 +391,9 @@ public class EventOperationParamsMapper {
     }
   }
 
-  private void validateOrgUnitSelectionMode(EventOperationParams params, User user, Program program)
+  private void validateOrgUnitMode(EventOperationParams params, User user, Program program)
       throws BadRequestException {
-    if (params.getOrgUnitSelectionMode() != null) {
+    if (params.getOrgUnitMode() != null) {
       String violation = getOrgUnitModeViolation(params, user, program);
       if (violation != null) {
         throw new BadRequestException(violation);
@@ -402,16 +402,16 @@ public class EventOperationParamsMapper {
   }
 
   private String getOrgUnitModeViolation(EventOperationParams params, User user, Program program) {
-    OrganisationUnitSelectionMode selectedOuMode = params.getOrgUnitSelectionMode();
+    OrganisationUnitSelectionMode orgUnitMode = params.getOrgUnitMode();
 
-    return switch (selectedOuMode) {
-      case ALL -> userCanSearchOuModeALL(user)
+    return switch (orgUnitMode) {
+      case ALL -> userCanSearchOrgUnitModeALL(user)
           ? null
           : "Current user is not authorized to query across all organisation units";
       case ACCESSIBLE -> getAccessibleScopeValidation(user, program);
       case CAPTURE -> getCaptureScopeValidation(user);
       case CHILDREN, SELECTED, DESCENDANTS -> params.getOrgUnitUid() == null
-          ? "Organisation unit is required for ouMode: " + params.getOrgUnitSelectionMode()
+          ? "Organisation unit is required for orgUnitMode: " + params.getOrgUnitMode()
           : null;
     };
   }
@@ -420,7 +420,7 @@ public class EventOperationParamsMapper {
     String violation = null;
 
     if (user == null) {
-      violation = "User is required for ouMode: " + OrganisationUnitSelectionMode.CAPTURE;
+      violation = "User is required for orgUnitMode: " + OrganisationUnitSelectionMode.CAPTURE;
     } else if (user.getOrganisationUnits().isEmpty()) {
       violation = "User needs to be assigned data capture orgunits";
     }
@@ -432,7 +432,7 @@ public class EventOperationParamsMapper {
     String violation;
 
     if (user == null) {
-      return "User is required for ouMode: " + OrganisationUnitSelectionMode.ACCESSIBLE;
+      return "User is required for orgUnitMode: " + OrganisationUnitSelectionMode.ACCESSIBLE;
     }
 
     if (program == null || program.isClosed() || program.isProtected()) {
@@ -450,7 +450,7 @@ public class EventOperationParamsMapper {
     return violation;
   }
 
-  private boolean userCanSearchOuModeALL(User user) {
+  private boolean userCanSearchOrgUnitModeALL(User user) {
     if (user == null) {
       return false;
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventSearchParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventSearchParams.java
@@ -112,7 +112,7 @@ public class EventSearchParams {
 
   private List<OrganisationUnit> accessibleOrgUnits = new ArrayList<>();
 
-  private OrganisationUnitSelectionMode orgUnitSelectionMode;
+  private OrganisationUnitSelectionMode orgUnitMode;
 
   private TrackedEntity trackedEntity;
 
@@ -330,13 +330,12 @@ public class EventSearchParams {
     return this;
   }
 
-  public OrganisationUnitSelectionMode getOrgUnitSelectionMode() {
-    return orgUnitSelectionMode;
+  public OrganisationUnitSelectionMode getOrgUnitMode() {
+    return orgUnitMode;
   }
 
-  public EventSearchParams setOrgUnitSelectionMode(
-      OrganisationUnitSelectionMode orgUnitSelectionMode) {
-    this.orgUnitSelectionMode = orgUnitSelectionMode;
+  public EventSearchParams setOrgUnitMode(OrganisationUnitSelectionMode orgUnitMode) {
+    this.orgUnitMode = orgUnitMode;
     return this;
   }
 
@@ -691,12 +690,12 @@ public class EventSearchParams {
   }
 
   public boolean isOrganisationUnitMode(OrganisationUnitSelectionMode mode) {
-    return orgUnitSelectionMode != null && orgUnitSelectionMode.equals(mode);
+    return orgUnitMode != null && orgUnitMode.equals(mode);
   }
 
   public boolean isPathOrganisationUnitMode() {
-    return orgUnitSelectionMode != null
-        && (orgUnitSelectionMode.equals(OrganisationUnitSelectionMode.DESCENDANTS)
-            || orgUnitSelectionMode.equals(OrganisationUnitSelectionMode.CHILDREN));
+    return orgUnitMode != null
+        && (orgUnitMode.equals(OrganisationUnitSelectionMode.DESCENDANTS)
+            || orgUnitMode.equals(OrganisationUnitSelectionMode.CHILDREN));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -28,8 +28,6 @@
 package org.hisp.dhis.tracker.export.event;
 
 import static java.util.Map.entry;
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ALL;
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CHILDREN;
 import static org.hisp.dhis.common.ValueType.NUMERIC_TYPES;
 import static org.hisp.dhis.system.util.SqlUtils.castToNumber;
 import static org.hisp.dhis.system.util.SqlUtils.lower;
@@ -1022,7 +1020,7 @@ public class JdbcEventStore implements EventStore {
   }
 
   private String getOrgUnitSql(EventSearchParams params, String ouTable) {
-    return switch (params.getOrgUnitSelectionMode()) {
+    return switch (params.getOrgUnitMode()) {
       case SELECTED -> getSelectedOrgUnitPath(params.getAccessibleOrgUnits(), ouTable);
       case CHILDREN -> getChildrenOrgUnitsPath(params.getAccessibleOrgUnits(), ouTable);
       case ALL -> null;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParams.java
@@ -104,10 +104,8 @@ public class TrackedEntityOperationParams {
   /** Tracked entity type to fetch. */
   private String trackedEntityTypeUid;
 
-  /** Selection mode for the specified organisation units, default is ACCESSIBLE. */
   @Builder.Default
-  private OrganisationUnitSelectionMode organisationUnitMode =
-      OrganisationUnitSelectionMode.DESCENDANTS;
+  private OrganisationUnitSelectionMode orgUnitMode = OrganisationUnitSelectionMode.DESCENDANTS;
 
   @Getter @Builder.Default
   private AssignedUserQueryParam assignedUserQueryParam = AssignedUserQueryParam.ALL;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapper.java
@@ -96,7 +96,7 @@ class TrackedEntityOperationParamsMapper {
             user,
             operationParams.getOrganisationUnits(),
             program,
-            operationParams.getOrganisationUnitMode());
+            operationParams.getOrgUnitMode());
 
     QueryFilter queryFilter = operationParams.getQuery();
 
@@ -129,8 +129,8 @@ class TrackedEntityOperationParamsMapper {
         .setProgramIncidentStartDate(operationParams.getProgramIncidentStartDate())
         .setProgramIncidentEndDate(operationParams.getProgramIncidentEndDate())
         .setTrackedEntityType(trackedEntityType)
-        .addOrganisationUnits(orgUnits)
-        .setOrganisationUnitMode(operationParams.getOrganisationUnitMode())
+        .addOrgUnits(orgUnits)
+        .setOrgUnitMode(operationParams.getOrgUnitMode())
         .setEventStatus(operationParams.getEventStatus())
         .setEventStartDate(operationParams.getEventStartDate())
         .setEventEndDate(operationParams.getEventEndDate())

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationMapperTest.java
@@ -322,8 +322,10 @@ class EventOperationMapperTest {
     // guaranteed
     Map<String, QueryFilter> expectedFilters =
         Map.of(
-            TEA_1_UID, new QueryFilter(QueryOperator.EQ, "2"),
-            TEA_2_UID, new QueryFilter(QueryOperator.LIKE, "foo"));
+            TEA_1_UID,
+            new QueryFilter(QueryOperator.EQ, "2"),
+            TEA_2_UID,
+            new QueryFilter(QueryOperator.LIKE, "foo"));
     assertAll(
         items.stream()
             .map(
@@ -474,8 +476,10 @@ class EventOperationMapperTest {
     // guaranteed
     Map<String, QueryFilter> expectedFilters =
         Map.of(
-            DE_1_UID, new QueryFilter(QueryOperator.EQ, "2"),
-            DE_2_UID, new QueryFilter(QueryOperator.LIKE, "foo"));
+            DE_1_UID,
+            new QueryFilter(QueryOperator.EQ, "2"),
+            DE_2_UID,
+            new QueryFilter(QueryOperator.LIKE, "foo"));
     assertAll(
         items.stream()
             .map(
@@ -552,7 +556,7 @@ class EventOperationMapperTest {
         EventOperationParams.builder()
             .programUid(program.getUid())
             .orgUnitUid(orgUnit.getUid())
-            .orgUnitSelectionMode(DESCENDANTS)
+            .orgUnitMode(DESCENDANTS)
             .build();
 
     EventSearchParams searchParams = mapper.map(requestParams);
@@ -578,7 +582,7 @@ class EventOperationMapperTest {
         EventOperationParams.builder()
             .programUid(program.getUid())
             .orgUnitUid(orgUnit.getUid())
-            .orgUnitSelectionMode(DESCENDANTS)
+            .orgUnitMode(DESCENDANTS)
             .build();
 
     EventSearchParams searchParams = mapper.map(requestParams);
@@ -605,7 +609,7 @@ class EventOperationMapperTest {
         EventOperationParams.builder()
             .programUid(program.getUid())
             .orgUnitUid(orgUnit.getUid())
-            .orgUnitSelectionMode(DESCENDANTS)
+            .orgUnitMode(DESCENDANTS)
             .build();
 
     ForbiddenException exception =
@@ -626,7 +630,7 @@ class EventOperationMapperTest {
         EventOperationParams.builder()
             .programUid(program.getUid())
             .orgUnitUid(orgUnit.getUid())
-            .orgUnitSelectionMode(DESCENDANTS)
+            .orgUnitMode(DESCENDANTS)
             .build();
 
     when(currentUserService.getCurrentUser()).thenReturn(user);
@@ -655,7 +659,7 @@ class EventOperationMapperTest {
         EventOperationParams.builder()
             .programUid(program.getUid())
             .orgUnitUid(orgUnit.getUid())
-            .orgUnitSelectionMode(CHILDREN)
+            .orgUnitMode(CHILDREN)
             .build();
 
     when(aclService.canDataRead(user, program)).thenReturn(true);
@@ -681,7 +685,7 @@ class EventOperationMapperTest {
         EventOperationParams.builder()
             .programUid(program.getUid())
             .orgUnitUid(orgUnit.getUid())
-            .orgUnitSelectionMode(CHILDREN)
+            .orgUnitMode(CHILDREN)
             .build();
 
     when(currentUserService.getCurrentUser()).thenReturn(user);
@@ -709,7 +713,7 @@ class EventOperationMapperTest {
         EventOperationParams.builder()
             .programUid(program.getUid())
             .orgUnitUid(orgUnit.getUid())
-            .orgUnitSelectionMode(CHILDREN)
+            .orgUnitMode(CHILDREN)
             .build();
 
     ForbiddenException exception =
@@ -733,7 +737,7 @@ class EventOperationMapperTest {
         EventOperationParams.builder()
             .programUid(program.getUid())
             .orgUnitUid(orgUnit.getUid())
-            .orgUnitSelectionMode(CHILDREN)
+            .orgUnitMode(CHILDREN)
             .build();
 
     ForbiddenException exception =
@@ -758,7 +762,7 @@ class EventOperationMapperTest {
         EventOperationParams.builder()
             .programUid(program.getUid())
             .orgUnitUid(orgUnit.getUid())
-            .orgUnitSelectionMode(CAPTURE)
+            .orgUnitMode(CAPTURE)
             .build();
 
     EventSearchParams searchParams = mapper.map(requestParams);
@@ -782,7 +786,7 @@ class EventOperationMapperTest {
         EventOperationParams.builder()
             .programUid(program.getUid())
             .orgUnitUid(orgUnit.getUid())
-            .orgUnitSelectionMode(ACCESSIBLE)
+            .orgUnitMode(ACCESSIBLE)
             .build();
 
     EventSearchParams searchParams = mapper.map(requestParams);
@@ -809,7 +813,7 @@ class EventOperationMapperTest {
         EventOperationParams.builder()
             .programUid(program.getUid())
             .orgUnitUid(orgUnit.getUid())
-            .orgUnitSelectionMode(SELECTED)
+            .orgUnitMode(SELECTED)
             .build();
 
     EventSearchParams searchParams = mapper.map(requestParams);
@@ -840,7 +844,7 @@ class EventOperationMapperTest {
 
     EventSearchParams searchParams = mapper.map(requestParams);
 
-    assertEquals(SELECTED, searchParams.getOrgUnitSelectionMode());
+    assertEquals(SELECTED, searchParams.getOrgUnitMode());
     assertContainsOnly(List.of(orgUnit), searchParams.getAccessibleOrgUnits());
   }
 
@@ -860,7 +864,7 @@ class EventOperationMapperTest {
 
     EventSearchParams searchParams = mapper.map(requestParams);
 
-    assertEquals(ACCESSIBLE, searchParams.getOrgUnitSelectionMode());
+    assertEquals(ACCESSIBLE, searchParams.getOrgUnitMode());
     assertContainsOnly(List.of(searchScopeOrgUnit), searchParams.getAccessibleOrgUnits());
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/OperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/OperationParamsMapperTest.java
@@ -185,7 +185,7 @@ class OperationParamsMapperTest {
             .assignedUserQueryParam(
                 new AssignedUserQueryParam(AssignedUserSelectionMode.CURRENT, user, null))
             .query(new QueryFilter(QueryOperator.EQ, "query-test"))
-            .organisationUnitMode(OrganisationUnitSelectionMode.DESCENDANTS)
+            .orgUnitMode(OrganisationUnitSelectionMode.DESCENDANTS)
             .programStatus(ProgramStatus.ACTIVE)
             .followUp(true)
             .lastUpdatedStartDate(getDate(2019, 1, 1))
@@ -296,8 +296,10 @@ class OperationParamsMapperTest {
     // guaranteed
     Map<String, QueryFilter> expectedFilters =
         Map.of(
-            TEA_1_UID, new QueryFilter(QueryOperator.EQ, "2"),
-            TEA_2_UID, new QueryFilter(QueryOperator.LIKE, "foo"));
+            TEA_1_UID,
+            new QueryFilter(QueryOperator.EQ, "2"),
+            TEA_2_UID,
+            new QueryFilter(QueryOperator.LIKE, "foo"));
     assertAll(
         items.stream()
             .map(
@@ -511,7 +513,7 @@ class OperationParamsMapperTest {
 
     TrackedEntityQueryParams params = mapper.map(operationParams);
 
-    assertContainsOnly(Set.of(orgUnit1, orgUnit2), params.getOrganisationUnits());
+    assertContainsOnly(Set.of(orgUnit1, orgUnit2), params.getOrgUnits());
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/aggregates/TrackedEntityAggregateTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/aggregates/TrackedEntityAggregateTest.java
@@ -121,7 +121,7 @@ class TrackedEntityAggregateTest extends TrackerTest {
           this.persistTrackedEntity();
         });
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityTypeA);
     queryParams.setIncludeAllAttributes(true);
     TrackedEntityInstanceParams params = TrackedEntityInstanceParams.FALSE;
@@ -182,7 +182,7 @@ class TrackedEntityAggregateTest extends TrackerTest {
           this.persistTrackedEntity();
         });
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityTypeA);
     queryParams.addFilter(
         new QueryItem(
@@ -208,7 +208,7 @@ class TrackedEntityAggregateTest extends TrackerTest {
           this.persistTrackedEntity();
         });
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityTypeA);
     queryParams.setLastUpdatedStartDate(Date.from(Instant.now().minus(1, ChronoUnit.DAYS)));
     queryParams.setLastUpdatedEndDate(new Date());
@@ -239,7 +239,7 @@ class TrackedEntityAggregateTest extends TrackerTest {
         });
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
     queryParams.setUserWithAssignedUsers(null, superUser, null);
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setProgram(programA);
     queryParams.setEventStatus(EventStatus.COMPLETED);
     queryParams.setEventStartDate(Date.from(Instant.now().minus(10, ChronoUnit.DAYS)));
@@ -278,7 +278,7 @@ class TrackedEntityAggregateTest extends TrackerTest {
   @Test
   void testIncludeDeletedIsPropagetedFromTeiToEnrollmentsAndEvents() {
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityTypeA);
     queryParams.setIncludeDeleted(true);
 
@@ -337,7 +337,7 @@ class TrackedEntityAggregateTest extends TrackerTest {
           this.persistTrackedEntityInstanceWithEnrollment();
         });
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityTypeA);
     queryParams.setIncludeAllAttributes(true);
     TrackedEntityInstanceParams params =
@@ -362,7 +362,7 @@ class TrackedEntityAggregateTest extends TrackerTest {
           this.persistTrackedEntityInstanceWithEnrollment();
         });
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityTypeA);
     queryParams.setIncludeAllAttributes(true);
     TrackedEntityInstanceParams params = TrackedEntityInstanceParams.FALSE;
@@ -385,7 +385,7 @@ class TrackedEntityAggregateTest extends TrackerTest {
           this.persistTrackedEntityInstanceWithEnrollmentAndEvents();
         });
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityTypeA);
     queryParams.setIncludeAllAttributes(true);
     TrackedEntityInstanceParams params =
@@ -408,7 +408,7 @@ class TrackedEntityAggregateTest extends TrackerTest {
   void testFetchTrackedEntityInstancesWithEventNotes() {
     doInTransaction(this::persistTrackedEntityInstanceWithEnrollmentAndEvents);
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityTypeA);
     queryParams.setIncludeAllAttributes(true);
     TrackedEntityInstanceParams params =
@@ -441,7 +441,7 @@ class TrackedEntityAggregateTest extends TrackerTest {
           this.persistTrackedEntityInstanceWithEnrollmentAndEvents();
         });
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityTypeA);
     queryParams.setIncludeAllAttributes(true);
     TrackedEntityInstanceParams params =
@@ -470,7 +470,7 @@ class TrackedEntityAggregateTest extends TrackerTest {
     final Date currentTime = new Date();
     doInTransaction(this::persistTrackedEntityInstanceWithEnrollmentAndEvents);
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityTypeA);
     queryParams.setIncludeAllAttributes(true);
     TrackedEntityInstanceParams params = TrackedEntityInstanceParams.FALSE;
@@ -497,7 +497,7 @@ class TrackedEntityAggregateTest extends TrackerTest {
     final Date currentTime = new Date();
     doInTransaction(this::persistTrackedEntityInstanceWithEnrollmentAndEvents);
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityTypeA);
     queryParams.setIncludeAllAttributes(true);
     TrackedEntityInstanceParams params =
@@ -553,7 +553,7 @@ class TrackedEntityAggregateTest extends TrackerTest {
     final Date currentTime = new Date();
     doInTransaction(this::persistTrackedEntityInstanceWithEnrollmentAndEvents);
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityTypeA);
     queryParams.setIncludeAllAttributes(true);
     TrackedEntityInstanceParams params =
@@ -603,7 +603,7 @@ class TrackedEntityAggregateTest extends TrackerTest {
     doInTransaction(
         () -> this.persistTrackedEntityInstanceWithEnrollmentAndEvents(enrollmentValues));
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityTypeA);
     queryParams.setIncludeAllAttributes(true);
     TrackedEntityInstanceParams params =
@@ -632,7 +632,7 @@ class TrackedEntityAggregateTest extends TrackerTest {
           teiUid[1] = t2.getUid();
         });
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityTypeA);
     queryParams.setIncludeAllAttributes(true);
     TrackedEntityInstanceParams params =
@@ -662,7 +662,7 @@ class TrackedEntityAggregateTest extends TrackerTest {
           relationshipItemsUid[1] = pi.getUid();
         });
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityTypeA);
     queryParams.setIncludeAllAttributes(true);
     TrackedEntityInstanceParams params =
@@ -705,7 +705,7 @@ class TrackedEntityAggregateTest extends TrackerTest {
           relationshipItemsUid[1] = psi.getUid();
         });
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityTypeA);
     queryParams.setIncludeAllAttributes(true);
     TrackedEntityInstanceParams params =
@@ -740,7 +740,7 @@ class TrackedEntityAggregateTest extends TrackerTest {
               trackedEntity, programA, organisationUnitA);
         });
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityTypeA);
     queryParams.setIncludeAllAttributes(true);
     TrackedEntityInstanceParams params =

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/aggregates/TrackedEntityAggregateUserTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/aggregates/TrackedEntityAggregateUserTest.java
@@ -77,7 +77,7 @@ class TrackedEntityAggregateUserTest extends TrackerTest {
           this.persistTrackedEntity();
         });
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityTypeA);
     queryParams.setIncludeAllAttributes(true);
     TrackedEntityInstanceParams params = TrackedEntityInstanceParams.FALSE;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/aggregates/TrackedEntityAttributesAggregateAclTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/aggregates/TrackedEntityAttributesAggregateAclTest.java
@@ -63,7 +63,7 @@ class TrackedEntityAttributesAggregateAclTest extends TrackerTest {
           this.persistTrackedEntity();
         });
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityTypeA);
     queryParams.setIncludeAllAttributes(true);
     TrackedEntityInstanceParams params = TrackedEntityInstanceParams.FALSE;
@@ -97,7 +97,7 @@ class TrackedEntityAttributesAggregateAclTest extends TrackerTest {
     final TrackedEntityType trackedEntityType =
         trackedEntityTypeService.getTrackedEntityType(tetUid);
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityType);
     queryParams.setIncludeAllAttributes(true);
     TrackedEntityInstanceParams params = TrackedEntityInstanceParams.FALSE;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/aggregates/TrackedEntityAttributesAggregateTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/aggregates/TrackedEntityAttributesAggregateTest.java
@@ -121,7 +121,7 @@ class TrackedEntityAttributesAggregateTest extends TrackerTest {
   void testTrackedEntityInstanceIncludeAllAttributes() {
     populatePrerequisites(false);
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityTypeA);
     queryParams.setIncludeAllAttributes(true);
     TrackedEntityInstanceParams params = TrackedEntityInstanceParams.FALSE;
@@ -135,7 +135,7 @@ class TrackedEntityAttributesAggregateTest extends TrackerTest {
     populatePrerequisites(true);
     injectSecurityContext(nonSuperUser);
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityTypeA);
     queryParams.setIncludeAllAttributes(true);
     final List<TrackedEntityInstance> trackedEntityInstances =
@@ -150,7 +150,7 @@ class TrackedEntityAttributesAggregateTest extends TrackerTest {
     populatePrerequisites(true);
     injectSecurityContext(nonSuperUser);
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setTrackedEntityType(trackedEntityTypeA);
     queryParams.setIncludeAllAttributes(true);
     TrackedEntityInstanceParams params = TrackedEntityInstanceParams.FALSE;
@@ -164,7 +164,7 @@ class TrackedEntityAttributesAggregateTest extends TrackerTest {
     populatePrerequisites(false);
     injectSecurityContext(nonSuperUser);
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setProgram(programB);
     TrackedEntityInstanceParams params = TrackedEntityInstanceParams.FALSE;
     final List<TrackedEntityInstance> trackedEntityInstances =
@@ -178,7 +178,7 @@ class TrackedEntityAttributesAggregateTest extends TrackerTest {
     populatePrerequisites(false);
     injectSecurityContext(nonSuperUser);
     TrackedEntityQueryParams queryParams = new TrackedEntityQueryParams();
-    queryParams.setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+    queryParams.setOrgUnits(Sets.newHashSet(organisationUnitA));
     queryParams.setProgram(programA);
     TrackedEntityInstanceParams params = TrackedEntityInstanceParams.FALSE;
     final List<TrackedEntityInstance> trackedEntityInstances =

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityQueryLimitTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityQueryLimitTest.java
@@ -145,8 +145,8 @@ class TrackedEntityQueryLimitTest extends SingleSetupIntegrationTestBase {
     systemSettingManager.saveSystemSetting(SettingKey.TRACKED_ENTITY_MAX_LIMIT, 3);
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
     params.setProgram(program);
-    params.setOrganisationUnits(Set.of(orgUnitA));
-    params.setOrganisationUnitMode(OrganisationUnitSelectionMode.ALL);
+    params.setOrgUnits(Set.of(orgUnitA));
+    params.setOrgUnitMode(OrganisationUnitSelectionMode.ALL);
     params.setUserWithAssignedUsers(null, user, null);
     params.setSkipPaging(true);
 
@@ -162,8 +162,8 @@ class TrackedEntityQueryLimitTest extends SingleSetupIntegrationTestBase {
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
     params.setProgram(program);
-    params.setOrganisationUnits(Set.of(orgUnitA));
-    params.setOrganisationUnitMode(OrganisationUnitSelectionMode.ALL);
+    params.setOrgUnits(Set.of(orgUnitA));
+    params.setOrgUnitMode(OrganisationUnitSelectionMode.ALL);
     params.setUserWithAssignedUsers(null, user, null);
     params.setSkipPaging(true);
 
@@ -176,8 +176,8 @@ class TrackedEntityQueryLimitTest extends SingleSetupIntegrationTestBase {
   void testDefaultMaxTeiLimit() {
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
     params.setProgram(program);
-    params.setOrganisationUnits(Set.of(orgUnitA));
-    params.setOrganisationUnitMode(OrganisationUnitSelectionMode.ALL);
+    params.setOrgUnits(Set.of(orgUnitA));
+    params.setOrgUnitMode(OrganisationUnitSelectionMode.ALL);
     params.setUserWithAssignedUsers(null, user, null);
     params.setSkipPaging(true);
 
@@ -192,8 +192,8 @@ class TrackedEntityQueryLimitTest extends SingleSetupIntegrationTestBase {
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
     params.setProgram(program);
-    params.setOrganisationUnits(Set.of(orgUnitA));
-    params.setOrganisationUnitMode(OrganisationUnitSelectionMode.ALL);
+    params.setOrgUnits(Set.of(orgUnitA));
+    params.setOrgUnitMode(OrganisationUnitSelectionMode.ALL);
     params.setUserWithAssignedUsers(null, user, null);
     params.setSkipPaging(true);
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityQueryTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityQueryTest.java
@@ -53,14 +53,14 @@ class TrackedEntityQueryTest extends SingleSetupIntegrationTestBase {
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
     TrackedEntityType trackedEntityTypeA = createTrackedEntityType('A');
     params.setTrackedEntityType(trackedEntityTypeA);
-    params.setOrganisationUnitMode(OrganisationUnitSelectionMode.ALL);
+    params.setOrgUnitMode(OrganisationUnitSelectionMode.ALL);
     instanceService.validate(params);
   }
 
   @Test
   void testTeiQueryParamsWithoutEitherProgramOrTrackedEntityType() {
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
-    params.setOrganisationUnitMode(OrganisationUnitSelectionMode.ALL);
+    params.setOrgUnitMode(OrganisationUnitSelectionMode.ALL);
     IllegalQueryException exception =
         assertThrows(IllegalQueryException.class, () -> instanceService.validate(params));
     assertEquals(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityServiceTest.java
@@ -282,7 +282,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     attributeValueService.addTrackedEntityAttributeValue(trackedEntityAttributeValue);
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
-    params.setOrganisationUnits(Set.of(organisationUnit));
+    params.setOrgUnits(Set.of(organisationUnit));
     params.setTrackedEntityType(trackedEntityType);
 
     params.setQuery(new QueryFilter(QueryOperator.LIKE, ATTRIBUTE_VALUE));
@@ -297,7 +297,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     injectSecurityContext(superUser);
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
-    params.setOrganisationUnits(Set.of(organisationUnit));
+    params.setOrgUnits(Set.of(organisationUnit));
     params.setTrackedEntityType(trackedEntityType);
 
     params.setQuery(new QueryFilter(QueryOperator.LIKE, ATTRIBUTE_VALUE));
@@ -313,7 +313,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     attributeService.addTrackedEntityAttribute(trackedEntityAttribute);
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
-    params.setOrganisationUnits(Set.of(organisationUnit));
+    params.setOrgUnits(Set.of(organisationUnit));
     params.setTrackedEntityType(trackedEntityType);
 
     params.setQuery(new QueryFilter(QueryOperator.LIKE, ATTRIBUTE_VALUE));
@@ -334,7 +334,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
 
-    params.setOrganisationUnits(Set.of(organisationUnit));
+    params.setOrgUnits(Set.of(organisationUnit));
     params.setOrders(List.of(new OrderParam("createdAt", SortDirection.ASC)));
 
     List<Long> teiIdList = entityInstanceService.getTrackedEntityIds(params, true, true);
@@ -361,7 +361,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
 
-    params.setOrganisationUnits(Set.of(organisationUnit));
+    params.setOrgUnits(Set.of(organisationUnit));
     params.setOrders(List.of(new OrderParam("updatedAt", SortDirection.ASC)));
 
     List<Long> teiIdList = entityInstanceService.getTrackedEntityIds(params, true, true);
@@ -383,7 +383,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
 
-    params.setOrganisationUnits(Set.of(organisationUnit));
+    params.setOrgUnits(Set.of(organisationUnit));
     params.setOrders(List.of(new OrderParam("trackedEntity", SortDirection.DESC)));
 
     List<Long> teiIdList = entityInstanceService.getTrackedEntityIds(params, true, true);
@@ -409,7 +409,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
 
-    params.setOrganisationUnits(Set.of(organisationUnit));
+    params.setOrgUnits(Set.of(organisationUnit));
     params.setOrders(List.of(new OrderParam("updatedAtClient", SortDirection.DESC)));
 
     List<Long> teiIdList = entityInstanceService.getTrackedEntityIds(params, true, true);
@@ -435,7 +435,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
 
-    params.setOrganisationUnits(Set.of(organisationUnit));
+    params.setOrgUnits(Set.of(organisationUnit));
     params.setOrders(List.of(new OrderParam("enrolledAt", SortDirection.DESC)));
 
     List<Long> teiIdList = entityInstanceService.getTrackedEntityIds(params, true, true);
@@ -465,7 +465,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
 
-    params.setOrganisationUnits(Set.of(organisationUnit));
+    params.setOrgUnits(Set.of(organisationUnit));
     params.setOrders(
         List.of(
             new OrderParam("inactive", SortDirection.DESC),
@@ -488,7 +488,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     addEntityInstances();
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
-    params.setOrganisationUnits(Set.of(organisationUnit));
+    params.setOrgUnits(Set.of(organisationUnit));
 
     List<Long> teiIdList = entityInstanceService.getTrackedEntityIds(params, true, true);
 
@@ -513,7 +513,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     setUpEntityAndAttributeValue(entityInstanceD1, "2-Attribute Value D1");
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
-    params.setOrganisationUnits(Set.of(organisationUnit));
+    params.setOrgUnits(Set.of(organisationUnit));
     params.setOrders(List.of(new OrderParam(trackedEntityAttribute.getUid(), SortDirection.ASC)));
     params.setAttributes(List.of(new QueryItem(trackedEntityAttribute)));
 
@@ -546,7 +546,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
 
-    params.setOrganisationUnits(Set.of(organisationUnit));
+    params.setOrgUnits(Set.of(organisationUnit));
     params.setOrders(
         List.of(
             new OrderParam(trackedEntityAttribute.getUid(), SortDirection.DESC),
@@ -579,7 +579,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
 
-    params.setOrganisationUnits(Set.of(organisationUnit));
+    params.setOrgUnits(Set.of(organisationUnit));
     params.setOrders(List.of(new OrderParam(tea.getUid(), SortDirection.DESC)));
 
     List<Long> teiIdList = entityInstanceService.getTrackedEntityIds(params, true, true);
@@ -608,7 +608,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
 
-    params.setOrganisationUnits(Set.of(organisationUnit));
+    params.setOrgUnits(Set.of(organisationUnit));
     params.setOrders(List.of(new OrderParam(tea.getUid(), SortDirection.ASC)));
 
     List<Long> teiIdList = entityInstanceService.getTrackedEntityIds(params, true, true);
@@ -656,7 +656,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     initializeEntityInstance(entityInstanceB1);
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
-    params.setOrganisationUnits(Set.of(organisationUnit));
+    params.setOrgUnits(Set.of(organisationUnit));
     params.setTrackedEntityType(trackedEntityType);
     params.setOrders(List.of(new OrderParam("created", SortDirection.ASC)));
     params.setQuery(new QueryFilter(QueryOperator.LIKE, ATTRIBUTE_VALUE));
@@ -686,7 +686,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     initializeEntityInstance(entityInstanceB1);
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
-    params.setOrganisationUnits(Set.of(organisationUnit));
+    params.setOrgUnits(Set.of(organisationUnit));
     params.setTrackedEntityType(trackedEntityType);
     params.setOrders(List.of(new OrderParam("created", SortDirection.DESC)));
     params.setQuery(new QueryFilter(QueryOperator.LIKE, ATTRIBUTE_VALUE));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityStoreTest.java
@@ -295,7 +295,7 @@ class TrackedEntityStoreTest extends TransactionalIntegrationTest {
     params =
         new TrackedEntityQueryParams()
             .addOrganisationUnit(ouB)
-            .setOrganisationUnitMode(OrganisationUnitSelectionMode.SELECTED);
+            .setOrgUnitMode(OrganisationUnitSelectionMode.SELECTED);
     teis = teiStore.getTrackedEntities(params);
     assertEquals(2, teis.size());
     assertTrue(teis.contains(teiB));
@@ -304,7 +304,7 @@ class TrackedEntityStoreTest extends TransactionalIntegrationTest {
     params =
         new TrackedEntityQueryParams()
             .addOrganisationUnit(ouB)
-            .setOrganisationUnitMode(OrganisationUnitSelectionMode.DESCENDANTS);
+            .setOrgUnitMode(OrganisationUnitSelectionMode.DESCENDANTS);
     teis = teiStore.getTrackedEntities(params);
     assertEquals(5, teis.size());
     assertTrue(teis.contains(teiB));
@@ -492,7 +492,7 @@ class TrackedEntityStoreTest extends TransactionalIntegrationTest {
     enrollmentService.enrollTrackedEntity(teiA, prA, new Date(), new Date(), ouA);
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
     params.setTrackedEntityType(trackedEntityTypeA);
-    params.setOrganisationUnitMode(OrganisationUnitSelectionMode.ALL);
+    params.setOrgUnitMode(OrganisationUnitSelectionMode.ALL);
     QueryItem queryItem = new QueryItem(atC);
     queryItem.setValueType(atC.getValueType());
     params.setAttributes(Collections.singletonList(queryItem));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/AclEventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/AclEventExporterTest.java
@@ -109,7 +109,7 @@ class AclEventExporterTest extends TrackerTest {
         EventOperationParams.builder()
             .programUid("pcxIanBWlSY")
             .orgUnitUid(orgUnit.getUid())
-            .orgUnitSelectionMode(DESCENDANTS)
+            .orgUnitMode(DESCENDANTS)
             .build();
 
     List<Event> events = eventService.getEvents(params).getEvents();
@@ -134,7 +134,7 @@ class AclEventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .orgUnitSelectionMode(DESCENDANTS)
+            .orgUnitMode(DESCENDANTS)
             .build();
 
     List<Event> events = eventService.getEvents(params).getEvents();
@@ -155,7 +155,7 @@ class AclEventExporterTest extends TrackerTest {
         EventOperationParams.builder()
             .programUid("pcxIanBWlSY")
             .orgUnitUid(orgUnit.getUid())
-            .orgUnitSelectionMode(CHILDREN)
+            .orgUnitMode(CHILDREN)
             .build();
 
     List<Event> events = eventService.getEvents(params).getEvents();
@@ -178,10 +178,7 @@ class AclEventExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
     EventOperationParams params =
-        EventOperationParams.builder()
-            .orgUnitUid(orgUnit.getUid())
-            .orgUnitSelectionMode(CHILDREN)
-            .build();
+        EventOperationParams.builder().orgUnitUid(orgUnit.getUid()).orgUnitMode(CHILDREN).build();
 
     List<Event> events = eventService.getEvents(params).getEvents();
 
@@ -200,7 +197,7 @@ class AclEventExporterTest extends TrackerTest {
         EventOperationParams.builder()
             .programUid(program.getUid())
             .orgUnitUid("DiszpKrYNg8")
-            .orgUnitSelectionMode(DESCENDANTS)
+            .orgUnitMode(DESCENDANTS)
             .build();
 
     ForbiddenException exception =
@@ -215,7 +212,7 @@ class AclEventExporterTest extends TrackerTest {
         EventOperationParams.builder()
             .programUid("pcxIanBWlSY")
             .orgUnitUid("DiszpKrYNg8")
-            .orgUnitSelectionMode(DESCENDANTS)
+            .orgUnitMode(DESCENDANTS)
             .build();
 
     ForbiddenException exception =
@@ -231,7 +228,7 @@ class AclEventExporterTest extends TrackerTest {
         EventOperationParams.builder()
             .programUid("pcxIanBWlSY")
             .orgUnitUid("uoNW0E3xXUy")
-            .orgUnitSelectionMode(SELECTED)
+            .orgUnitMode(SELECTED)
             .build();
 
     List<Event> events = eventService.getEvents(params).getEvents();
@@ -254,10 +251,7 @@ class AclEventExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
     EventOperationParams params =
-        EventOperationParams.builder()
-            .orgUnitUid(orgUnit.getUid())
-            .orgUnitSelectionMode(SELECTED)
-            .build();
+        EventOperationParams.builder().orgUnitUid(orgUnit.getUid()).orgUnitMode(SELECTED).build();
 
     List<Event> events = eventService.getEvents(params).getEvents();
 
@@ -283,7 +277,7 @@ class AclEventExporterTest extends TrackerTest {
         EventOperationParams.builder()
             .programUid("shPjYNifvMK")
             .orgUnitUid(orgUnit.getUid())
-            .orgUnitSelectionMode(SELECTED)
+            .orgUnitMode(SELECTED)
             .build();
 
     List<Event> events = eventService.getEvents(params).getEvents();
@@ -299,7 +293,7 @@ class AclEventExporterTest extends TrackerTest {
         EventOperationParams.builder()
             .programUid("pcxIanBWlSY")
             .orgUnitUid("uoNW0E3xXUy")
-            .orgUnitSelectionMode(ACCESSIBLE)
+            .orgUnitMode(ACCESSIBLE)
             .build();
 
     List<Event> events = eventService.getEvents(params).getEvents();
@@ -321,10 +315,7 @@ class AclEventExporterTest extends TrackerTest {
       throws ForbiddenException, BadRequestException {
     injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
     EventOperationParams params =
-        EventOperationParams.builder()
-            .programUid(program.getUid())
-            .orgUnitSelectionMode(ACCESSIBLE)
-            .build();
+        EventOperationParams.builder().programUid(program.getUid()).orgUnitMode(ACCESSIBLE).build();
 
     List<Event> events = eventService.getEvents(params).getEvents();
 
@@ -348,7 +339,7 @@ class AclEventExporterTest extends TrackerTest {
         EventOperationParams.builder()
             .programUid("pcxIanBWlSY")
             .orgUnitUid("uoNW0E3xXUy")
-            .orgUnitSelectionMode(CAPTURE)
+            .orgUnitMode(CAPTURE)
             .build();
 
     List<Event> events = eventService.getEvents(params).getEvents();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/deprecated/tracker/TrackedEntityCriteriaMapperTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/deprecated/tracker/TrackedEntityCriteriaMapperTest.java
@@ -171,8 +171,8 @@ class TrackedEntityCriteriaMapperTest extends DhisWebSpringTest {
     assertThat(queryParams.getQuery().getOperator(), is(QueryOperator.EQ));
     assertThat(queryParams.getProgram(), is(programA));
     assertThat(queryParams.getTrackedEntityType(), is(trackedEntityTypeA));
-    assertThat(queryParams.getOrganisationUnits(), hasSize(1));
-    assertThat(queryParams.getOrganisationUnits().iterator().next(), is(organisationUnit));
+    assertThat(queryParams.getOrgUnits(), hasSize(1));
+    assertThat(queryParams.getOrgUnits().iterator().next(), is(organisationUnit));
     assertThat(queryParams.getAttributes(), hasSize(2));
     assertTrue(
         queryParams.getAttributes().stream()

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/TrackedEntityInstanceCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/TrackedEntityInstanceCriteriaMapper.java
@@ -148,11 +148,11 @@ public class TrackedEntityInstanceCriteriaMapper {
             "User does not have access to organisation unit: " + orgUnit);
       }
 
-      params.getOrganisationUnits().add(organisationUnit);
+      params.getOrgUnits().add(organisationUnit);
     }
 
     if (criteria.getOuMode() == OrganisationUnitSelectionMode.CAPTURE && user != null) {
-      params.getOrganisationUnits().addAll(user.getOrganisationUnits());
+      params.getOrgUnits().addAll(user.getOrganisationUnits());
     }
 
     List<OrderParam> orderParams = toOrderParams(criteria.getOrder());
@@ -173,7 +173,7 @@ public class TrackedEntityInstanceCriteriaMapper {
         .setProgramIncidentStartDate(criteria.getProgramIncidentStartDate())
         .setProgramIncidentEndDate(criteria.getProgramIncidentEndDate())
         .setTrackedEntityType(validateTrackedEntityType(criteria))
-        .setOrganisationUnitMode(criteria.getOuMode())
+        .setOrgUnitMode(criteria.getOuMode())
         .setEventStatus(criteria.getEventStatus())
         .setEventStartDate(criteria.getEventStartDate())
         .setEventEndDate(criteria.getEventEndDate())

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramMessageController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramMessageController.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.event;
 
-import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedUidParameter;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedParameter;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.io.IOException;
@@ -100,11 +100,9 @@ public class ProgramMessageController extends AbstractCrudController<ProgramMess
       @RequestParam(required = false) Integer pageSize)
       throws BadRequestException, ConflictException {
     UID enrollmentUid =
-        validateDeprecatedUidParameter(
-            "programInstance", programInstance, "enrollment", enrollment);
+        validateDeprecatedParameter("programInstance", programInstance, "enrollment", enrollment);
     UID eventUid =
-        validateDeprecatedUidParameter(
-            "programStageInstance", programStageInstance, "event", event);
+        validateDeprecatedParameter("programStageInstance", programStageInstance, "event", event);
 
     if (enrollmentUid == null && eventUid == null) {
       throw new ConflictException("Enrollment or Event must be specified.");
@@ -137,11 +135,9 @@ public class ProgramMessageController extends AbstractCrudController<ProgramMess
       @RequestParam(required = false) Integer pageSize)
       throws BadRequestException {
     UID enrollmentUid =
-        validateDeprecatedUidParameter(
-            "programInstance", programInstance, "enrollment", enrollment);
+        validateDeprecatedParameter("programInstance", programInstance, "enrollment", enrollment);
     UID eventUid =
-        validateDeprecatedUidParameter(
-            "programStageInstance", programStageInstance, "event", event);
+        validateDeprecatedParameter("programStageInstance", programStageInstance, "event", event);
 
     ProgramMessageQueryParams params =
         programMessageService.getFromUrl(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceController.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.event;
 
-import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedUidParameter;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedParameter;
 
 import java.util.Date;
 import java.util.List;
@@ -86,11 +86,9 @@ public class ProgramNotificationInstanceController {
       @RequestParam(required = false, defaultValue = "50") int pageSize)
       throws BadRequestException {
     UID enrollmentUid =
-        validateDeprecatedUidParameter(
-            "programInstance", programInstance, "enrollment", enrollment);
+        validateDeprecatedParameter("programInstance", programInstance, "enrollment", enrollment);
     UID eventUid =
-        validateDeprecatedUidParameter(
-            "programStageInstance", programStageInstance, "event", event);
+        validateDeprecatedParameter("programStageInstance", programStageInstance, "event", event);
 
     ProgramNotificationInstanceParam params =
         ProgramNotificationInstanceParam.builder()

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
@@ -81,11 +81,11 @@ public class RequestParamUtils {
    * @param deprecatedParam value of deprecated request parameter
    * @param newParamName new request parameter replacing deprecated request parameter
    * @param newParam value of the request parameter
-   * @return value of the one request parameter that is non-empty
-   * @throws BadRequestException when both deprecated and new request parameter are non-empty
+   * @return value of the one request parameter that is non-null
+   * @throws BadRequestException when both deprecated and new request parameter are non-null
    */
-  public static UID validateDeprecatedUidParameter(
-      String deprecatedParamName, UID deprecatedParam, String newParamName, UID newParam)
+  public static <T> T validateDeprecatedParameter(
+      String deprecatedParamName, T deprecatedParam, String newParamName, T newParam)
       throws BadRequestException {
     if (newParam != null && deprecatedParam != null) {
       throw new BadRequestException(
@@ -106,15 +106,14 @@ public class RequestParamUtils {
    * @param newParamName new request parameter replacing deprecated request parameter
    * @param newParam value of the request parameter
    * @return value of the one request parameter that is non-empty
-   * @throws BadRequestException when both deprecated and new request parameter are non-empty
-   * @throws BadRequestException when both deprecated and new request parameter are empty
+   * @throws BadRequestException when both deprecated and new request parameter are non-null
+   * @throws BadRequestException when both deprecated and new request parameter are null
    */
   public static UID validateMandatoryDeprecatedUidParameter(
       String deprecatedParamName, UID deprecatedParam, String newParamName, UID newParam)
       throws BadRequestException {
     UID uid =
-        validateDeprecatedUidParameter(
-            deprecatedParamName, deprecatedParam, newParamName, newParam);
+        validateDeprecatedParameter(deprecatedParamName, deprecatedParam, newParamName, newParam);
 
     if (uid == null) {
       throw new BadRequestException(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
@@ -29,10 +29,12 @@ package org.hisp.dhis.webapi.controller.tracker.export.enrollment;
 
 import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
 import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedUidsParameter;
 
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
 import org.hisp.dhis.webapi.common.UID;
@@ -53,6 +55,10 @@ class EnrollmentRequestParamsMapper {
         validateDeprecatedUidsParameter(
             "orgUnit", requestParams.getOrgUnit(), "orgUnits", requestParams.getOrgUnits());
 
+    OrganisationUnitSelectionMode orgUnitMode =
+        validateDeprecatedParameter(
+            "ouMode", requestParams.getOuMode(), "orgUnitMode", requestParams.getOrgUnitMode());
+
     return EnrollmentOperationParams.builder()
         .programUid(
             requestParams.getProgram() != null ? requestParams.getProgram().getValue() : null)
@@ -71,7 +77,7 @@ class EnrollmentRequestParamsMapper {
                 ? requestParams.getTrackedEntity().getValue()
                 : null)
         .orgUnitUids(UID.toValueSet(orgUnits))
-        .orgUnitMode(requestParams.getOuMode())
+        .orgUnitMode(orgUnitMode)
         .page(requestParams.getPage())
         .pageSize(requestParams.getPageSize())
         .totalPages(requestParams.isTotalPages())

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/RequestParams.java
@@ -66,7 +66,13 @@ class RequestParams extends PagingAndSortingCriteriaAdapter {
   @OpenApi.Property({UID[].class, OrganisationUnit.class})
   private Set<UID> orgUnits = new HashSet<>();
 
+  /**
+   * @deprecated use {@link #orgUnitMode} instead.
+   */
+  @Deprecated(since = "2.41")
   private OrganisationUnitSelectionMode ouMode;
+
+  private OrganisationUnitSelectionMode orgUnitMode;
 
   @OpenApi.Property({UID.class, Program.class})
   private UID program;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.webapi.controller.tracker.export.event;
 
 import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
-import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedUidParameter;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedUidsParameter;
 
 import java.util.Collections;
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.tracker.export.event.EventOperationParams;
@@ -60,8 +61,12 @@ class EventRequestParamsMapper {
       JdbcEventStore.QUERY_PARAM_COL_MAP.keySet();
 
   public EventOperationParams map(RequestParams requestParams) throws BadRequestException {
+    OrganisationUnitSelectionMode orgUnitMode =
+        validateDeprecatedParameter(
+            "ouMode", requestParams.getOuMode(), "orgUnitMode", requestParams.getOrgUnitMode());
+
     UID attributeCategoryCombo =
-        validateDeprecatedUidParameter(
+        validateDeprecatedParameter(
             "attributeCc",
             requestParams.getAttributeCc(),
             "attributeCategoryCombo",
@@ -104,7 +109,7 @@ class EventRequestParamsMapper {
                 : null)
         .programStatus(requestParams.getProgramStatus())
         .followUp(requestParams.getFollowUp())
-        .orgUnitSelectionMode(requestParams.getOuMode())
+        .orgUnitMode(orgUnitMode)
         .assignedUserMode(requestParams.getAssignedUserMode())
         .assignedUsers(UID.toValueSet(assignedUsers))
         .startDate(requestParams.getOccurredAfter())

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/RequestParams.java
@@ -81,7 +81,13 @@ class RequestParams extends PagingAndSortingCriteriaAdapter {
   @OpenApi.Property({UID.class, OrganisationUnit.class})
   private UID orgUnit;
 
+  /**
+   * @deprecated use {@link #orgUnitMode} instead.
+   */
+  @Deprecated(since = "2.41")
   private OrganisationUnitSelectionMode ouMode;
+
+  private OrganisationUnitSelectionMode orgUnitMode;
 
   private AssignedUserSelectionMode assignedUserMode;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParams.java
@@ -84,8 +84,13 @@ class RequestParams extends PagingAndSortingCriteriaAdapter {
   @OpenApi.Property({UID[].class, OrganisationUnit.class})
   private Set<UID> orgUnits = new HashSet<>();
 
-  /** Selection mode for the specified organisation units, default is ACCESSIBLE. */
-  private OrganisationUnitSelectionMode ouMode = OrganisationUnitSelectionMode.DESCENDANTS;
+  /**
+   * @deprecated use {@link #orgUnitMode} instead.
+   */
+  @Deprecated(since = "2.41")
+  private OrganisationUnitSelectionMode ouMode;
+
+  private OrganisationUnitSelectionMode orgUnitMode;
 
   /** a Program UID for which instances in the response must be enrolled in. */
   @OpenApi.Property({UID.class, Program.class})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
@@ -29,12 +29,14 @@ package org.hisp.dhis.webapi.controller.tracker.export.trackedentity;
 
 import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
 import static org.hisp.dhis.tracker.export.OperationParamUtils.parseQueryFilter;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedUidsParameter;
 
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.AssignedUserQueryParam;
+import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.fieldfiltering.FieldPath;
@@ -70,6 +72,13 @@ class TrackedEntityRequestParamsMapper {
         validateDeprecatedUidsParameter(
             "orgUnit", requestParams.getOrgUnit(), "orgUnits", requestParams.getOrgUnits());
 
+    OrganisationUnitSelectionMode orgUnitMode =
+        validateDeprecatedParameter(
+            "ouMode", requestParams.getOuMode(), "orgUnitMode", requestParams.getOrgUnitMode());
+    if (orgUnitMode == null) {
+      orgUnitMode = OrganisationUnitSelectionMode.DESCENDANTS;
+    }
+
     QueryFilter queryFilter = parseQueryFilter(requestParams.getQuery());
 
     Set<UID> trackedEntities =
@@ -101,7 +110,7 @@ class TrackedEntityRequestParamsMapper {
                 ? null
                 : requestParams.getTrackedEntityType().getValue())
         .organisationUnits(UID.toValueSet(orgUnitUids))
-        .organisationUnitMode(requestParams.getOuMode())
+        .orgUnitMode(orgUnitMode)
         .eventStatus(requestParams.getEventStatus())
         .eventStartDate(requestParams.getEventOccurredAfter())
         .eventEndDate(requestParams.getEventOccurredBefore())

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/EnrollmentsExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/EnrollmentsExportController.md
@@ -16,7 +16,8 @@ Get an enrollment with given UID.
 
 ### `getEnrollmentByUid.parameter.fields`
 
-Get only the specified fields in the JSON response. This query parameter allows you to remove unnecessary fields from
+Get only the specified fields in the JSON response. This query parameter allows you to remove
+unnecessary fields from
 the response and in some cases decrease the response time. Refer to
 https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_metadata_field_filter
 for how to use it.
@@ -39,7 +40,8 @@ Get enrollments with given UID(s).
 
 ### `*.parameter.EnrollmentRequestParams.enrollment`
 
-**DEPRECATED as of 2.41:** Use parameter `enrollments` instead where UIDs have to be separated by comma!
+**DEPRECATED as of 2.41:** Use parameter `enrollments` instead where UIDs have to be separated by
+comma!
 
 `<enrollment1-uid>[;<enrollment2-uid>...]`
 
@@ -51,7 +53,8 @@ Get enrollments with given follow-up status of the instance for the given progra
 
 ### `*.parameter.EnrollmentRequestParams.includeDeleted`
 
-Get soft-deleted enrollments by specifying `includeDeleted=true`. Soft-deleted enrollments are excluded by default.
+Get soft-deleted enrollments by specifying `includeDeleted=true`. Soft-deleted enrollments are
+excluded by default.
 
 ### `*.parameter.EnrollmentRequestParams.orgUnits`
 
@@ -61,15 +64,22 @@ Get enrollments owned by given `orgUnit`.
 
 ### `*.parameter.EnrollmentRequestParams.orgUnit`
 
-**DEPRECATED as of 2.41:** Use parameter `orgUnits` instead where UIDs have to be separated by comma!
+**DEPRECATED as of 2.41:** Use parameter `orgUnits` instead where UIDs have to be separated by
+comma!
 
 `<orgUnit1-uid>[;<orgUnit2-uid>...]`
 
 Get enrollments owned by given `orgUnit`.
 
+### `*.parameter.EnrollmentRequestParams.orgUnitMode`
+
+Get enrollments using given organisation unit mode.
+
 ### `*.parameter.EnrollmentRequestParams.ouMode`
 
-Get enrollments using given organisation unit selection mode.
+**DEPRECATED as of 2.41:** Use parameter `orgUnitMode` instead.
+
+Get enrollments using given organisation unit mode.
 
 ### `*.parameter.EnrollmentRequestParams.program`
 
@@ -97,7 +107,8 @@ Get enrollments updated since given ISO-8601 duration.
 
 ### `*.parameter.EnrollmentRequestParams.fields`
 
-Get only the specified fields in the JSON response. This query parameter allows you to remove unnecessary fields from
+Get only the specified fields in the JSON response. This query parameter allows you to remove
+unnecessary fields from
 the JSON response and in some cases decrease the response time. Refer to
 https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_metadata_field_filter
 for how to use it.

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/EventsExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/EventsExportController.md
@@ -16,7 +16,8 @@ Get an event with given UID.
 
 ### `getEventByUid.parameter.fields`
 
-Get only the specified fields in the JSON response. This query parameter allows you to remove unnecessary fields from
+Get only the specified fields in the JSON response. This query parameter allows you to remove
+unnecessary fields from
 the response and in some cases decrease the response time. Refer to
 https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_metadata_field_filter
 for how to use it.
@@ -43,9 +44,15 @@ Get events of tracked entity with given UID.
 
 Get events owned by given `orgUnit`.
 
+### `*.parameter.EventRequestParams.orgUnitMode`
+
+Get events using given organisation unit mode.
+
 ### `*.parameter.EventRequestParams.ouMode`
 
-Get events using given organisation unit selection mode.
+**DEPRECATED as of 2.41:** Use parameter `orgUnitMode` instead.
+
+Get events using given organisation unit mode.
 
 ### `*.parameter.EventRequestParams.assignedUserMode`
 
@@ -53,16 +60,19 @@ Get events using given organisation unit selection mode.
 
 `<user1-uid>[,<user2-uid>...]`
 
-Get events that are assigned to the given user(s). Specifying `assignedUsers` is only valid if `assignedUserMode` is
+Get events that are assigned to the given user(s). Specifying `assignedUsers` is only valid
+if `assignedUserMode` is
 either `PROVIDED` or not specified.
 
 ### `*.parameter.EventRequestParams.assignedUser`
 
-**DEPRECATED as of 2.41:** Use parameter `assignedUsers` instead where UIDs have to be separated by comma!
+**DEPRECATED as of 2.41:** Use parameter `assignedUsers` instead where UIDs have to be separated by
+comma!
 
 `<user1-uid>[;<user2-uid>...]`
 
-Get events that are assigned to the given user(s). Specifying `assignedUser` is only valid if `assignedUserMode` is
+Get events that are assigned to the given user(s). Specifying `assignedUser` is only valid
+if `assignedUserMode` is
 either `PROVIDED` or not specified.
 
 ### `*.parameter.EventRequestParams.occurredAfter`
@@ -113,11 +123,13 @@ Get events with enrollments that were enrolled before given date.
 
 `<attributeCategoryOption1-uid>[;<attributeCategoryOption2-uid>...]`
 
-**DEPRECATED as of 2.41:** Use parameter `attributeCategoryOptions` instead where UIDs have to be separated by comma!
+**DEPRECATED as of 2.41:** Use parameter `attributeCategoryOptions` instead where UIDs have to be
+separated by comma!
 
 ### `*.parameter.EventRequestParams.includeDeleted`
 
-Get soft-deleted events by specifying `includeDeleted=true`. Soft-deleted events are excluded by default.
+Get soft-deleted events by specifying `includeDeleted=true`. Soft-deleted events are excluded by
+default.
 
 ### `*.parameter.EventRequestParams.events`
 
@@ -139,17 +151,20 @@ Get events with given UID(s).
 
 `<propertyName1:sortDirection>[,<propertyName2:sortDirection>...]`
 
-Get events in given order. Valid `sortDirection`s are `asc` and `desc`. `propName` is case-sensitive, `sortDirection`
+Get events in given order. Valid `sortDirection`s are `asc` and `desc`. `propName` is
+case-sensitive, `sortDirection`
 is case-insensitive.
 
-Supported properties are `assignedUser`, `assignedUserDisplayName`, `attributeOptionCombo`, `completedAt`,
+Supported properties
+are `assignedUser`, `assignedUserDisplayName`, `attributeOptionCombo`, `completedAt`,
 `completedBy`, `createdAt`, `createdBy`, `deleted`, `enrolledAt`, `enrollment`, `enrollmentStatus`, `event`, `followup`,
 `occurredAt`, `orgUnit`, `orgUnitName`, `program`, `programStage`, `scheduleAt`, `status`, `storedBy`, `trackedEntity`,
 `updatedAt`, `updatedBy`.
 
 ### `*.parameter.EventRequestParams.fields`
 
-Get only the specified fields in the JSON response. This query parameter allows you to remove unnecessary fields from
+Get only the specified fields in the JSON response. This query parameter allows you to remove
+unnecessary fields from
 the JSON response and in some cases decrease the response time. Refer to
 https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_metadata_field_filter
 for how to use it.
@@ -160,12 +175,18 @@ NOTE: this query parameter has no effect on a CSV response!
 
 `<filter1>[,<filter2>...]`
 
-Get events matching given filters on data values. A filter is a colon separated data element UID with operator and value
-pairs. Example: `filter=H9IlTX2X6SL:sw:A` with operator starts with `sw` followed by a value. Special characters
-like `+` need to be percent-encoded so `%2B` instead of `+`. Multiple operator/value pairs for the same data element
-like `filter=AuPLng5hLbE:gt:438901703:lt:448901704` are allowed. Repeating the same data element UID is not allowed.
-Operator and values are case-insensitive. A user needs metadata read access to the data element and data read access to
-the program (if the program is without registration) or the program stage (if the program is with registration).
+Get events matching given filters on data values. A filter is a colon separated data element UID
+with operator and value
+pairs. Example: `filter=H9IlTX2X6SL:sw:A` with operator starts with `sw` followed by a value.
+Special characters
+like `+` need to be percent-encoded so `%2B` instead of `+`. Multiple operator/value pairs for the
+same data element
+like `filter=AuPLng5hLbE:gt:438901703:lt:448901704` are allowed. Repeating the same data element UID
+is not allowed.
+Operator and values are case-insensitive. A user needs metadata read access to the data element and
+data read access to
+the program (if the program is without registration) or the program stage (if the program is with
+registration).
 
 Valid operators are:
 
@@ -190,12 +211,18 @@ Valid operators are:
 
 `<filter1>[,<filter2>...]`
 
-Get events matching given filters on tracked entity attributes. A filter is a colon separated attribute UID with
-optional operator and value pairs. Example: `filter=H9IlTX2X6SL:sw:A` with operator starts with `sw` followed by a
-value. Special characters like `+` need to be percent-encoded so `%2B` instead of `+`. Multiple operator/value pairs for
-the same attribute like `filter=AuPLng5hLbE:gt:438901703:lt:448901704` are allowed. Repeating the same attribute UID is
-not allowed. Operator and values are case-insensitive. A user needs metadata read access to the attribute and data
-read access to the program (if the program is without registration) or to the program stage (if the program is with
+Get events matching given filters on tracked entity attributes. A filter is a colon separated
+attribute UID with
+optional operator and value pairs. Example: `filter=H9IlTX2X6SL:sw:A` with operator starts with `sw`
+followed by a
+value. Special characters like `+` need to be percent-encoded so `%2B` instead of `+`. Multiple
+operator/value pairs for
+the same attribute like `filter=AuPLng5hLbE:gt:438901703:lt:448901704` are allowed. Repeating the
+same attribute UID is
+not allowed. Operator and values are case-insensitive. A user needs metadata read access to the
+attribute and data
+read access to the program (if the program is without registration) or to the program stage (if the
+program is with
 registration).
 
 Valid operators are:

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
@@ -18,7 +18,8 @@ Get a tracked entity with given UID.
 
 ### `getTrackedEntityByUid.parameter.fields`
 
-Get only the specified fields in the JSON response. This query parameter allows you to remove unnecessary fields from
+Get only the specified fields in the JSON response. This query parameter allows you to remove
+unnecessary fields from
 the response and in some cases decrease the response time. Refer to
 https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_metadata_field_filter
 for how to use it.
@@ -39,15 +40,22 @@ Get tracked entities owned by given `orgUnit`.
 
 ### `*.parameter.TrackedEntityRequestParams.orgUnit`
 
-**DEPRECATED as of 2.41:** Use parameter `orgUnits` instead where UIDs have to be separated by comma!
+**DEPRECATED as of 2.41:** Use parameter `orgUnits` instead where UIDs have to be separated by
+comma!
 
 `<orgUnit1-uid>[;<orgUnit2-uid>...]`
 
 Get tracked entities owned by given `orgUnit`.
 
+### `*.parameter.TrackedEntityRequestParams.orgUnitMode`
+
+Get tracked entities using given organisation unit mode.
+
 ### `*.parameter.TrackedEntityRequestParams.ouMode`
 
-Get events using given organisation unit selection mode.
+**DEPRECATED as of 2.41:** Use parameter `orgUnitMode` instead.
+
+Get tracked entities using given organisation unit mode.
 
 ### `*.parameter.TrackedEntityRequestParams.program`
 
@@ -79,7 +87,8 @@ Get tracked entities with given UID(s).
 
 ### `*.parameter.TrackedEntityRequestParams.trackedEntity`
 
-**DEPRECATED as of 2.41:** Use parameter `trackedEntities` instead where UIDs have to be separated by comma!
+**DEPRECATED as of 2.41:** Use parameter `trackedEntities` instead where UIDs have to be separated
+by comma!
 
 `<trackedEntity1-uid>[;<trackedEntity2-uid>...]`
 
@@ -91,16 +100,19 @@ Get tracked entities with given UID(s).
 
 `<user1-uid>[,<user2-uid>...]`
 
-Get tracked entities with an event assigned to given user(s). Specifying `assignedUsers` is only valid
+Get tracked entities with an event assigned to given user(s). Specifying `assignedUsers` is only
+valid
 if `assignedUserMode` is either `PROVIDED` or not specified.
 
 ### `*.parameter.TrackedEntityRequestParams.assignedUser`
 
-**DEPRECATED as of 2.41:** Use parameter `assignedUsers` instead where UIDs have to be separated by comma!
+**DEPRECATED as of 2.41:** Use parameter `assignedUsers` instead where UIDs have to be separated by
+comma!
 
 `<user1-uid>[;<user2-uid>...]`
 
-Get tracked entities with an event assigned to given user(s). Specifying `assignedUsers` is only valid
+Get tracked entities with an event assigned to given user(s). Specifying `assignedUsers` is only
+valid
 if `assignedUserMode` is either `PROVIDED` or not specified.
 
 ### `*.parameter.TrackedEntityRequestParams.programStage`
@@ -121,7 +133,8 @@ if `assignedUserMode` is either `PROVIDED` or not specified.
 
 ### `*.parameter.TrackedEntityRequestParams.fields`
 
-Get only the specified fields in the JSON response. This query parameter allows you to remove unnecessary fields from
+Get only the specified fields in the JSON response. This query parameter allows you to remove
+unnecessary fields from
 the JSON response and in some cases decrease the response time. Refer to
 https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_metadata_field_filter
 for how to use it.
@@ -132,11 +145,16 @@ NOTE: this query parameter has no effect on a CSV response!
 
 `<filter1>[,<filter2>...]`
 
-Get tracked entities matching given filters on attributes. A filter is a colon separated attribute UID with operator and
-value pairs. Example: `filter=H9IlTX2X6SL:sw:A` with operator starts with `sw` followed by a value. Special characters
-like `+` need to be percent-encoded so `%2B` instead of `+`. Multiple operator/value pairs for the same attribute
-like `filter=AuPLng5hLbE:gt:438901703:lt:448901704` are allowed. Repeating the same attribute UID is not allowed. A user
-needs metadata read access to the attribute and data read access to the program (if the program is without registration)
+Get tracked entities matching given filters on attributes. A filter is a colon separated attribute
+UID with operator and
+value pairs. Example: `filter=H9IlTX2X6SL:sw:A` with operator starts with `sw` followed by a value.
+Special characters
+like `+` need to be percent-encoded so `%2B` instead of `+`. Multiple operator/value pairs for the
+same attribute
+like `filter=AuPLng5hLbE:gt:438901703:lt:448901704` are allowed. Repeating the same attribute UID is
+not allowed. A user
+needs metadata read access to the attribute and data read access to the program (if the program is
+without registration)
 or the program stage (if the program is with registration).
 
 Valid operators are:

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapperTest.java
@@ -29,8 +29,10 @@ package org.hisp.dhis.webapi.controller.tracker.export.enrollment;
 
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
+import static org.hisp.dhis.utils.Assertions.assertStartsWith;
 import static org.hisp.dhis.webapi.controller.tracker.export.enrollment.RequestParams.DEFAULT_FIELDS_PARAM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -38,6 +40,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Set;
+import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.fieldfiltering.FieldFilterParser;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
@@ -107,6 +110,38 @@ class EnrollmentRequestParamsMapperTest {
     EnrollmentOperationParams params = mapper.map(requestParams);
 
     assertContainsOnly(Set.of(ORG_UNIT_1_UID, ORG_UNIT_2_UID), params.getOrgUnitUids());
+  }
+
+  @Test
+  void shouldMapOrgUnitModeGivenOrgUnitModeParam() throws BadRequestException {
+    RequestParams requestParams = new RequestParams();
+    requestParams.setOrgUnitMode(OrganisationUnitSelectionMode.SELECTED);
+
+    EnrollmentOperationParams params = mapper.map(requestParams);
+
+    assertEquals(OrganisationUnitSelectionMode.SELECTED, params.getOrgUnitMode());
+  }
+
+  @Test
+  void shouldMapOrgUnitModeGivenOuModeParam() throws BadRequestException {
+    RequestParams requestParams = new RequestParams();
+    requestParams.setOuMode(OrganisationUnitSelectionMode.SELECTED);
+
+    EnrollmentOperationParams params = mapper.map(requestParams);
+
+    assertEquals(OrganisationUnitSelectionMode.SELECTED, params.getOrgUnitMode());
+  }
+
+  @Test
+  void shouldThrowIfDeprecatedAndNewOrgUnitModeParameterIsSet() {
+    RequestParams requestParams = new RequestParams();
+    requestParams.setOuMode(OrganisationUnitSelectionMode.SELECTED);
+    requestParams.setOrgUnitMode(OrganisationUnitSelectionMode.SELECTED);
+
+    BadRequestException exception =
+        assertThrows(BadRequestException.class, () -> mapper.map(requestParams));
+
+    assertStartsWith("Only one parameter of 'ouMode' and 'orgUnitMode'", exception.getMessage());
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapperTest.java
@@ -33,6 +33,7 @@ import static org.hisp.dhis.DhisConvenienceTest.getDate;
 import static org.hisp.dhis.util.DateUtils.parseDate;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
+import static org.hisp.dhis.utils.Assertions.assertStartsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -60,7 +61,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class RequestParamsMapperTest {
+class TrackedEntityRequestParamsMapperTest {
   private static final String PROGRAM_UID = "XhBYIraw7sv";
 
   private static final String PROGRAM_STAGE_UID = "RpCr2u2pFqw";
@@ -137,6 +138,47 @@ class RequestParamsMapperTest {
         params.getOrders().stream()
             .anyMatch(
                 orderParam -> orderParam.equals(OrderCriteria.of("created", SortDirection.ASC))));
+  }
+
+  @Test
+  void shouldMapOrgUnitModeGivenOrgUnitModeParam() throws BadRequestException {
+    RequestParams requestParams = new RequestParams();
+    requestParams.setOrgUnitMode(OrganisationUnitSelectionMode.SELECTED);
+
+    TrackedEntityOperationParams params = mapper.map(requestParams, null);
+
+    assertEquals(OrganisationUnitSelectionMode.SELECTED, params.getOrgUnitMode());
+  }
+
+  @Test
+  void shouldMapOrgUnitModeGivenOuModeParam() throws BadRequestException {
+    RequestParams requestParams = new RequestParams();
+    requestParams.setOuMode(OrganisationUnitSelectionMode.SELECTED);
+
+    TrackedEntityOperationParams params = mapper.map(requestParams, null);
+
+    assertEquals(OrganisationUnitSelectionMode.SELECTED, params.getOrgUnitMode());
+  }
+
+  @Test
+  void shouldMapOrgUnitModeToDefaultGivenNoOrgUnitModeParamIsSet() throws BadRequestException {
+    RequestParams requestParams = new RequestParams();
+
+    TrackedEntityOperationParams params = mapper.map(requestParams, null);
+
+    assertEquals(OrganisationUnitSelectionMode.DESCENDANTS, params.getOrgUnitMode());
+  }
+
+  @Test
+  void shouldThrowIfDeprecatedAndNewOrgUnitModeParameterIsSet() {
+    RequestParams requestParams = new RequestParams();
+    requestParams.setOuMode(OrganisationUnitSelectionMode.SELECTED);
+    requestParams.setOrgUnitMode(OrganisationUnitSelectionMode.SELECTED);
+
+    BadRequestException exception =
+        assertThrows(BadRequestException.class, () -> mapper.map(requestParams, null));
+
+    assertStartsWith("Only one parameter of 'ouMode' and 'orgUnitMode'", exception.getMessage());
   }
 
   @Test


### PR DESCRIPTION
* add new query parameter `orgUnitMode` deprecating `ouMode` in /tracker/trackedEntities, /tracker/enrollments, /tracker/events
* consistently name fields `orgUnitMode`
* consistently use `orgUnitMode` in methods, variables, error messages
* /tracker/trackedEntities `RequestParams.ouMode` has a default of `DESCENDANTS` (other endpoints don't). Due to issue https://github.com/dhis2/dhis2-core/pull/14580 I set the default in the mapper. As this makes it easier to know whether the user passed both `ouMode` and `orgUnitMode` params.