### PR TITLE
fix: PI count() for text values DHIS2-14769

### DIFF
--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/VectorCount.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/VectorCount.java
@@ -29,17 +29,25 @@ package org.hisp.dhis.parser.expression.function;
 
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 
+import java.util.List;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 
 /**
  * Vector function: count
  *
+ * <p>Note: This class extends {@link VectorFunction<String>} because count should apply to data
+ * elements of any data type, and any data type cna be cast to {@link String} for syntax checking.
+ *
  * @author Jim Grace
  */
-public class VectorCount extends VectorFunctionDoubleArray {
+public class VectorCount extends VectorFunction<String> {
+  public VectorCount() {
+    super(String.class);
+  }
+
   @Override
-  public Object aggregate(double[] values) {
-    return Double.valueOf(values.length);
+  public final Object aggregate(List<String> values, List<String> args) {
+    return Double.valueOf(values.size());
   }
 
   @Override

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/VectorFunctionDoubleArray.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/VectorFunctionDoubleArray.java
@@ -35,7 +35,11 @@ import org.apache.commons.lang3.ArrayUtils;
  *
  * @author Jim Grace
  */
-public abstract class VectorFunctionDoubleArray extends VectorFunction {
+public abstract class VectorFunctionDoubleArray extends VectorFunction<Double> {
+  public VectorFunctionDoubleArray() {
+    super(Double.class);
+  }
+
   @Override
   public final Object aggregate(List<Double> values, List<Double> args) {
     return aggregate(ArrayUtils.toPrimitive(values.toArray(new Double[0])));

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/VectorMedian.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/VectorMedian.java
@@ -35,7 +35,11 @@ import java.util.List;
  *
  * @author Jim Grace
  */
-public class VectorMedian extends VectorFunction {
+public class VectorMedian extends VectorFunction<Double> {
+  public VectorMedian() {
+    super(Double.class);
+  }
+
   private static VectorPercentileCont percentileContinuous = new VectorPercentileCont();
 
   @Override

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/VectorPercentileBase.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/VectorPercentileBase.java
@@ -44,7 +44,11 @@ import org.apache.commons.math3.stat.descriptive.rank.Percentile.EstimationType;
  *
  * @author Jim Grace
  */
-public abstract class VectorPercentileBase extends VectorFunction {
+public abstract class VectorPercentileBase extends VectorFunction<Double> {
+  public VectorPercentileBase() {
+    super(Double.class);
+  }
+
   private final Percentile percentile = new Percentile().withEstimationType(getEstimationType());
 
   @Override

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
@@ -37,6 +37,7 @@ import static java.util.stream.IntStream.range;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hisp.dhis.analytics.AggregationType.AVERAGE;
+import static org.hisp.dhis.analytics.AggregationType.CUSTOM;
 import static org.hisp.dhis.analytics.AggregationType.FIRST;
 import static org.hisp.dhis.analytics.AggregationType.FIRST_AVERAGE_ORG_UNIT;
 import static org.hisp.dhis.analytics.AggregationType.LAST;
@@ -48,6 +49,7 @@ import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getList;
 import static org.hisp.dhis.common.ValueType.INTEGER;
 import static org.hisp.dhis.common.ValueType.ORGANISATION_UNIT;
+import static org.hisp.dhis.common.ValueType.TEXT;
 import static org.hisp.dhis.period.PeriodType.getPeriodTypeByName;
 import static org.hisp.dhis.program.AnalyticsType.ENROLLMENT;
 import static org.hisp.dhis.program.AnalyticsType.EVENT;
@@ -211,6 +213,8 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
 
   private DataElement deA;
 
+  private DataElement deB;
+
   private DataElement deU;
 
   private TrackedEntityAttribute atU;
@@ -328,8 +332,12 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
     deA.setUid("deInteger0A");
     dataElementService.addDataElement(deA);
 
+    deB = createDataElement('B', TEXT, NONE);
+    deB.setUid("deText0000B");
+    dataElementService.addDataElement(deB);
+
     deU = createDataElement('U', ORGANISATION_UNIT, NONE);
-    deU.setUid("deOrgUnitU");
+    deU.setUid("deOrgUnit0U");
     dataElementService.addDataElement(deU);
 
     // Program Stages
@@ -342,6 +350,7 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
     ProgramStage psB = createProgramStage('B', 0);
     psB.setUid("progrStageB");
     psB.addDataElement(deA, 1);
+    psB.addDataElement(deB, 2);
     idObjectManager.save(psB);
 
     // Programs
@@ -437,56 +446,64 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
     eventB1.setDueDate(jan15);
     eventB1.setExecutionDate(jan15);
     eventB1.setUid("event0000B1");
-    eventB1.setEventDataValues(Set.of(new EventDataValue(deA.getUid(), "10")));
+    eventB1.setEventDataValues(
+        Set.of(new EventDataValue(deA.getUid(), "10"), new EventDataValue(deB.getUid(), "A")));
     eventB1.setAttributeOptionCombo(cocDefault);
 
     Event eventB2 = createEvent(psB, piB, ouI);
     eventB2.setDueDate(jan20);
     eventB2.setExecutionDate(jan20);
     eventB2.setUid("event0000B2");
-    eventB2.setEventDataValues(Set.of(new EventDataValue(deA.getUid(), "20")));
+    eventB2.setEventDataValues(
+        Set.of(new EventDataValue(deA.getUid(), "20"), new EventDataValue(deB.getUid(), "B")));
     eventB2.setAttributeOptionCombo(cocDefault);
 
     Event eventB3 = createEvent(psB, piB, ouJ);
     eventB3.setDueDate(jan15);
     eventB3.setExecutionDate(jan15);
     eventB3.setUid("event0000B3");
-    eventB3.setEventDataValues(Set.of(new EventDataValue(deA.getUid(), "30")));
+    eventB3.setEventDataValues(
+        Set.of(new EventDataValue(deA.getUid(), "30"), new EventDataValue(deB.getUid(), "C")));
     eventB3.setAttributeOptionCombo(cocDefault);
 
     Event eventB4 = createEvent(psB, piB, ouJ);
     eventB4.setDueDate(jan20);
     eventB4.setExecutionDate(jan20);
     eventB4.setUid("event0000B4");
-    eventB4.setEventDataValues(Set.of(new EventDataValue(deA.getUid(), "40")));
+    eventB4.setEventDataValues(
+        Set.of(new EventDataValue(deA.getUid(), "40"), new EventDataValue(deB.getUid(), "D")));
     eventB4.setAttributeOptionCombo(cocDefault);
 
     Event eventB5 = createEvent(psB, piB, ouI);
     eventB5.setDueDate(feb15);
     eventB5.setExecutionDate(feb15);
     eventB5.setUid("event0000B5");
-    eventB5.setEventDataValues(Set.of(new EventDataValue(deA.getUid(), "50")));
+    eventB5.setEventDataValues(
+        Set.of(new EventDataValue(deA.getUid(), "50"), new EventDataValue(deB.getUid(), "E")));
     eventB5.setAttributeOptionCombo(cocDefault);
 
     Event eventB6 = createEvent(psB, piB, ouI);
     eventB6.setDueDate(feb15Noon);
     eventB6.setExecutionDate(feb15Noon);
     eventB6.setUid("event0000B6");
-    eventB6.setEventDataValues(Set.of(new EventDataValue(deA.getUid(), "60")));
+    eventB6.setEventDataValues(
+        Set.of(new EventDataValue(deA.getUid(), "60"), new EventDataValue(deB.getUid(), "F")));
     eventB6.setAttributeOptionCombo(cocDefault);
 
     Event eventB7 = createEvent(psB, piB, ouJ);
     eventB7.setDueDate(feb15);
     eventB7.setExecutionDate(feb15);
     eventB7.setUid("event0000B7");
-    eventB7.setEventDataValues(Set.of(new EventDataValue(deA.getUid(), "70")));
+    eventB7.setEventDataValues(
+        Set.of(new EventDataValue(deA.getUid(), "70"), new EventDataValue(deB.getUid(), "G")));
     eventB7.setAttributeOptionCombo(cocDefault);
 
     Event eventB8 = createEvent(psB, piB, ouJ);
     eventB8.setDueDate(feb15Noon);
     eventB8.setExecutionDate(feb15Noon);
     eventB8.setUid("event0000B8");
-    eventB8.setEventDataValues(Set.of(new EventDataValue(deA.getUid(), "80")));
+    eventB8.setEventDataValues(
+        Set.of(new EventDataValue(deA.getUid(), "80"), new EventDataValue(deB.getUid(), "H")));
     eventB8.setAttributeOptionCombo(cocDefault);
 
     saveEvents(
@@ -751,7 +768,7 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
 
     assertGridContains(
         // Headers
-        List.of("eventdate", "ou", "deOrgUnitU"),
+        List.of("eventdate", "ou", "deOrgUnit0U"),
         // Grid
         List.of(
             List.of("2017-01-15 00:00:00.0", "ouabcdefghD", "OrganisationUnitL"),
@@ -769,7 +786,7 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
 
     assertGridContains(
         // Headers
-        List.of("eventdate", "ou", "deOrgUnitU"),
+        List.of("eventdate", "ou", "deOrgUnit0U"),
         // Grid
         List.of(
             List.of("2017-01-15 00:00:00.0", "ouabcdefghE", "OrganisationUnitL"),
@@ -789,7 +806,7 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
     // there is no monthly aggregation.
     assertGridContains(
         // Headers
-        List.of("eventdate", "ou", "deOrgUnitU"),
+        List.of("eventdate", "ou", "deOrgUnit0U"),
         // Grid
         List.of(
             List.of("2017-01-15 00:00:00.0", "ouabcdefghE", "OrganisationUnitL"),
@@ -809,7 +826,7 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
     // there is no monthly aggregation.
     assertGridContains(
         // Headers
-        List.of("eventdate", "ou", "deOrgUnitU"),
+        List.of("eventdate", "ou", "deOrgUnit0U"),
         // Grid
         List.of(
             List.of("2017-01-15 00:00:00.0", "ouabcdefghH", "OrganisationUnitL"),
@@ -826,7 +843,7 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
 
     assertGridContains(
         // Headers
-        List.of("eventdate", "ou", "deOrgUnitU"),
+        List.of("eventdate", "ou", "deOrgUnit0U"),
         // Grid
         List.of(
             List.of("2017-01-15 00:00:00.0", "ouabcdefghI", "OrganisationUnitL"),
@@ -844,7 +861,7 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
 
     assertGridContains(
         // Headers
-        List.of("eventdate", "ou", "deOrgUnitU"),
+        List.of("eventdate", "ou", "deOrgUnit0U"),
         // Grid
         List.of(
             List.of("2017-01-15 00:00:00.0", "ouabcdefghL", "OrganisationUnitL"),
@@ -1194,6 +1211,40 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
         getTestAggregatedGrid(AVERAGE));
   }
 
+  @Test
+  void testEventProgramIndicatorCustomCountIntegers() {
+    assertGridContains(
+        // Headers
+        List.of("pe", "ou", "value"),
+        // Grid
+        List.of(
+            List.of("201701", "ouabcdefghI", "2.0"), // count(10,20)
+            List.of("201701", "ouabcdefghJ", "2.0"), // count(30,40)
+            List.of("201701", "ouabcdefghA", "4.0"), // count(10,20,30,40)
+            List.of("201702", "ouabcdefghI", "2.0"), // count(50,60)
+            List.of("201702", "ouabcdefghJ", "2.0"), // count(70,80)
+            List.of("201702", "ouabcdefghA", "4.0") // count(50,60,70,80)
+            ),
+        getTestAggregatedGrid("count(#{progrStageB.deInteger0A})", CUSTOM));
+  }
+
+  @Test
+  void testEventProgramIndicatorCustomCountOrgUnits() {
+    assertGridContains(
+        // Headers
+        List.of("pe", "ou", "value"),
+        // Grid
+        List.of(
+            List.of("201701", "ouabcdefghI", "2.0"), // count("A","B")
+            List.of("201701", "ouabcdefghJ", "2.0"), // count("C","D")
+            List.of("201701", "ouabcdefghA", "4.0"), // count("A","B","C","D")
+            List.of("201702", "ouabcdefghI", "2.0"), // count("E","F")
+            List.of("201702", "ouabcdefghJ", "2.0"), // count("G","H")
+            List.of("201702", "ouabcdefghA", "4.0") // count("E","F","G","H")
+            ),
+        getTestAggregatedGrid("count(#{progrStageB.deText0000B})", CUSTOM));
+  }
+
   // -------------------------------------------------------------------------
   // Supportive test methods
   // -------------------------------------------------------------------------
@@ -1240,8 +1291,12 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
 
   /** Gets a grid to test aggregation types */
   private Grid getTestAggregatedGrid(AggregationType aggregationType) {
-    ProgramIndicator pi =
-        createProgramIndicatorB(EVENT, "#{progrStageB.deInteger0A}", null, aggregationType);
+    return getTestAggregatedGrid("#{progrStageB.deInteger0A}", aggregationType);
+  }
+
+  /** Gets a grid to test aggregation types with a custom expression */
+  private Grid getTestAggregatedGrid(String expression, AggregationType aggregationType) {
+    ProgramIndicator pi = createProgramIndicatorB(EVENT, expression, null, aggregationType);
 
     EventQueryParams params =
         getBaseEventQueryParamsBuilder()
@@ -1296,8 +1351,8 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
    *   <li>has rows with expected values in those columns
    * </ol>
    *
-   * Note that the headers and the expected values do not have to include every column in the grid.
-   * They need only include those columns needed for the test.
+   * <p>Note that the headers and the expected values do not have to include every column in the
+   * grid. They need only include those columns needed for the test.
    *
    * <p>The grid rows may be found in any order. The expected and actual rows are converted to text
    * strings and sorted.


### PR DESCRIPTION
See [DHIS2-14769](https://dhis2.atlassian.net/browse/DHIS2-14769).

The problem is that the count() expression function, implemented by `VectorCount`, relied on `VectorFunction` (by way of `VectorFunctionDoubleArray`), and `VectorFunction` only assembled a vector of past period `Double` values. So the count() function worked only on numeric data elements, not on text or any other type. It should be able to work on data elements of any value type.

The solution is to make `VectorFunction` a Generic class with a type parameter that could be either `String` (as used by the count() function) or `Double` (as used by all other vector functions.) VectorCount then extends `VectorFunction<String>`. (It doesn't actually need the services provided by `VectorFunctionDoubleArray` because it can count the items in a list and doesn't need them to be in an array.)

`VectorCount` requires the values to be of type `String` because internally any type of value can be cast to `String`.