### PR TITLE
fix: /tracker/trackedEntities?order=createdAt DHIS2-15325 DHIS2-15325

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityQueryParams.java
@@ -973,14 +973,15 @@ public class TrackedEntityQueryParams {
         "trackedEntity",
         "uid",
         MAIN_QUERY_ALIAS), // Ordering by id is the same as ordering by created date
-    CREATED(CREATED_ID, "trackedentityinstanceid", MAIN_QUERY_ALIAS),
-    CREATED_AT("createdAt", "trackedentityinstanceid", MAIN_QUERY_ALIAS),
-    CREATED_AT_CLIENT("createdAtClient", "createdAtClient", MAIN_QUERY_ALIAS),
-    UPDATED_AT("updatedAt", "lastUpdated", MAIN_QUERY_ALIAS),
-    UPDATED_AT_CLIENT("updatedAtClient", "lastUpdatedAtClient", MAIN_QUERY_ALIAS),
+    // TODO(tracker): remove with old tracker
+    CREATED("created", CREATED_ID, MAIN_QUERY_ALIAS),
+    CREATED_AT("createdAt", CREATED_ID, MAIN_QUERY_ALIAS),
+    CREATED_AT_CLIENT("createdAtClient", "createdatclient", MAIN_QUERY_ALIAS),
+    UPDATED_AT("updatedAt", "lastupdated", MAIN_QUERY_ALIAS),
+    UPDATED_AT_CLIENT("updatedAtClient", "lastupdatedatclient", MAIN_QUERY_ALIAS),
     ENROLLED_AT(
         "enrolledAt",
-        "enrollmentDate",
+        "enrollmentdate",
         PROGRAM_INSTANCE_ALIAS), // this works only for the new endpoint
     // ORGUNIT_NAME( "orgUnitName", MAIN_QUERY_ALIAS+".organisationUnit.name" ),
     INACTIVE(INACTIVE_ID, "inactive", MAIN_QUERY_ALIAS);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
@@ -452,7 +452,7 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
             List.of(
                 "SELECT TEI.uid AS " + TRACKED_ENTITY_INSTANCE_ID,
                 "TEI.created AS " + CREATED_ID,
-                "TEI.lastUpdated AS " + LAST_UPDATED_ID,
+                "TEI.lastupdated AS " + LAST_UPDATED_ID,
                 "TEI.ou AS " + ORG_UNIT_ID,
                 "TEI.ouname AS " + ORG_UNIT_NAME,
                 "TET.uid AS " + TRACKED_ENTITY_ID,
@@ -527,8 +527,8 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
   }
 
   /**
-   * The subquery projection. If we are sorting by attribute, we need to include the value in the
-   * subquery projection.
+   * The sub-query projection. If we are sorting by attribute, we need to include the value in the
+   * sub-query projection.
    *
    * @param params
    * @return a SQL projection
@@ -540,7 +540,7 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
                 "TEI.trackedentityinstanceid",
                 "TEI.uid",
                 "TEI.created",
-                "TEI.lastUpdated",
+                "TEI.lastupdated",
                 "TEI.inactive",
                 "TEI.trackedentitytypeid",
                 "TEI.potentialduplicate",

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityServiceTest.java
@@ -323,7 +323,115 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
   }
 
   @Test
-  void shouldOrderEntitiesByIdWhenParamCreatedAtSupplied() {
+  void shouldOrderEntitiesByCreatedInAscOrder() {
+    injectSecurityContext(superUser);
+
+    entityInstanceA1.setCreated(DateTime.now().plusDays(1).toDate());
+    entityInstanceB1.setCreated(DateTime.now().toDate());
+    entityInstanceC1.setCreated(DateTime.now().minusDays(1).toDate());
+    entityInstanceD1.setCreated(DateTime.now().plusDays(2).toDate());
+    addEntityInstances();
+
+    TrackedEntityQueryParams params = new TrackedEntityQueryParams();
+
+    params.setOrgUnits(Set.of(organisationUnit));
+    params.setOrders(List.of(new OrderParam("created", SortDirection.ASC)));
+
+    List<Long> teiIdList = entityInstanceService.getTrackedEntityIds(params, true, true);
+
+    assertEquals(
+        List.of(
+            entityInstanceC1.getId(),
+            entityInstanceB1.getId(),
+            entityInstanceA1.getId(),
+            entityInstanceD1.getId()),
+        teiIdList);
+  }
+
+  @Test
+  void shouldOrderEntitiesByCreatedInDescOrder() {
+    injectSecurityContext(superUser);
+
+    entityInstanceA1.setCreated(DateTime.now().plusDays(1).toDate());
+    entityInstanceB1.setCreated(DateTime.now().toDate());
+    entityInstanceC1.setCreated(DateTime.now().minusDays(1).toDate());
+    entityInstanceD1.setCreated(DateTime.now().plusDays(2).toDate());
+    addEntityInstances();
+
+    TrackedEntityQueryParams params = new TrackedEntityQueryParams();
+
+    params.setOrgUnits(Set.of(organisationUnit));
+    params.setOrders(List.of(new OrderParam("created", SortDirection.DESC)));
+
+    List<Long> teiIdList = entityInstanceService.getTrackedEntityIds(params, true, true);
+
+    assertEquals(
+        List.of(
+            entityInstanceD1.getId(),
+            entityInstanceA1.getId(),
+            entityInstanceB1.getId(),
+            entityInstanceC1.getId()),
+        teiIdList);
+  }
+
+  @Test
+  void shouldOrderGridEntitiesByCreatedInAscOrder() {
+    injectSecurityContext(superUser);
+    trackedEntityAttribute.setDisplayInListNoProgram(true);
+    attributeService.addTrackedEntityAttribute(trackedEntityAttribute);
+
+    User user =
+        createAndAddUser(
+            false, "attributeFilterUser", Set.of(organisationUnit), Set.of(organisationUnit));
+    injectSecurityContext(user);
+
+    entityInstanceA1.setCreated(DateTime.now().plusDays(1).toDate());
+    entityInstanceB1.setCreated(DateTime.now().toDate());
+    initializeEntityInstance(entityInstanceA1);
+    initializeEntityInstance(entityInstanceB1);
+
+    TrackedEntityQueryParams params = new TrackedEntityQueryParams();
+    params.setOrgUnits(Set.of(organisationUnit));
+    params.setTrackedEntityType(trackedEntityType);
+    params.setOrders(List.of(new OrderParam("created", SortDirection.ASC)));
+    params.setQuery(new QueryFilter(QueryOperator.LIKE, ATTRIBUTE_VALUE));
+
+    Grid grid = entityInstanceService.getTrackedEntitiesGrid(params);
+    List<Object> uids = grid.getRows().stream().map(l -> l.get(0)).toList();
+
+    assertEquals(List.of("UID-B1", "UID-A1"), uids);
+  }
+
+  @Test
+  void shouldOrderGridEntitiesByCreatedInDescOrder() {
+    injectSecurityContext(superUser);
+    trackedEntityAttribute.setDisplayInListNoProgram(true);
+    attributeService.addTrackedEntityAttribute(trackedEntityAttribute);
+
+    User user =
+        createAndAddUser(
+            false, "attributeFilterUser", Set.of(organisationUnit), Set.of(organisationUnit));
+    injectSecurityContext(user);
+
+    entityInstanceA1.setCreated(DateTime.now().plusDays(1).toDate());
+    entityInstanceB1.setCreated(DateTime.now().toDate());
+    initializeEntityInstance(entityInstanceA1);
+    initializeEntityInstance(entityInstanceB1);
+
+    TrackedEntityQueryParams params = new TrackedEntityQueryParams();
+    params.setOrgUnits(Set.of(organisationUnit));
+    params.setTrackedEntityType(trackedEntityType);
+    params.setOrders(List.of(new OrderParam("created", SortDirection.DESC)));
+    params.setQuery(new QueryFilter(QueryOperator.LIKE, ATTRIBUTE_VALUE));
+
+    Grid grid = entityInstanceService.getTrackedEntitiesGrid(params);
+    List<Object> uids = grid.getRows().stream().map(l -> l.get(0)).toList();
+
+    assertEquals(List.of("UID-A1", "UID-B1"), uids);
+  }
+
+  @Test
+  void shouldOrderEntitiesByCreatedAtInAscOrder() {
     injectSecurityContext(superUser);
 
     entityInstanceA1.setCreated(DateTime.now().plusDays(1).toDate());
@@ -341,23 +449,50 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
 
     assertEquals(
         List.of(
-            entityInstanceA1.getId(),
-            entityInstanceB1.getId(),
             entityInstanceC1.getId(),
+            entityInstanceB1.getId(),
+            entityInstanceA1.getId(),
             entityInstanceD1.getId()),
         teiIdList);
   }
 
   @Test
-  void shouldOrderEntitiesByIdWhenParamUpdatedAtSupplied() {
+  void shouldOrderEntitiesByCreatedAtInDescOrder() {
     injectSecurityContext(superUser);
 
-    entityInstanceA1.setLastUpdated(DateTime.now().plusDays(1).toDate());
-    entityInstanceB1.setLastUpdated(DateTime.now().toDate());
-    entityInstanceC1.setLastUpdated(DateTime.now().minusDays(1).toDate());
-    entityInstanceD1.setLastUpdated(DateTime.now().plusDays(2).toDate());
+    entityInstanceA1.setCreated(DateTime.now().plusDays(1).toDate());
+    entityInstanceB1.setCreated(DateTime.now().toDate());
+    entityInstanceC1.setCreated(DateTime.now().minusDays(1).toDate());
+    entityInstanceD1.setCreated(DateTime.now().plusDays(2).toDate());
+    addEntityInstances();
+
+    TrackedEntityQueryParams params = new TrackedEntityQueryParams();
+
+    params.setOrgUnits(Set.of(organisationUnit));
+    params.setOrders(List.of(new OrderParam("createdAt", SortDirection.DESC)));
+
+    List<Long> teiIdList = entityInstanceService.getTrackedEntityIds(params, true, true);
+
+    assertEquals(
+        List.of(
+            entityInstanceD1.getId(),
+            entityInstanceA1.getId(),
+            entityInstanceB1.getId(),
+            entityInstanceC1.getId()),
+        teiIdList);
+  }
+
+  @Test
+  void shouldOrderEntitiesByUpdatedAtInAscOrder() {
+    injectSecurityContext(superUser);
 
     addEntityInstances();
+    // lastupdated is automatically set by the store; update entities in a certain order and expect
+    // that to be returned
+    entityInstanceService.updateTrackedEntity(entityInstanceD1);
+    entityInstanceService.updateTrackedEntity(entityInstanceB1);
+    entityInstanceService.updateTrackedEntity(entityInstanceC1);
+    entityInstanceService.updateTrackedEntity(entityInstanceA1);
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
 
@@ -368,15 +503,43 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
 
     assertEquals(
         List.of(
-            entityInstanceA1.getId(),
+            entityInstanceD1.getId(),
             entityInstanceB1.getId(),
             entityInstanceC1.getId(),
+            entityInstanceA1.getId()),
+        teiIdList);
+  }
+
+  @Test
+  void shouldOrderEntitiesByUpdatedAtInDescOrder() {
+    injectSecurityContext(superUser);
+
+    addEntityInstances();
+    // lastupdated is automatically set by the store; update entities in a certain order and expect
+    // that to be returned
+    entityInstanceService.updateTrackedEntity(entityInstanceD1);
+    entityInstanceService.updateTrackedEntity(entityInstanceB1);
+    entityInstanceService.updateTrackedEntity(entityInstanceC1);
+    entityInstanceService.updateTrackedEntity(entityInstanceA1);
+
+    TrackedEntityQueryParams params = new TrackedEntityQueryParams();
+
+    params.setOrgUnits(Set.of(organisationUnit));
+    params.setOrders(List.of(new OrderParam("updatedAt", SortDirection.DESC)));
+
+    List<Long> teiIdList = entityInstanceService.getTrackedEntityIds(params, true, true);
+
+    assertEquals(
+        List.of(
+            entityInstanceA1.getId(),
+            entityInstanceC1.getId(),
+            entityInstanceB1.getId(),
             entityInstanceD1.getId()),
         teiIdList);
   }
 
   @Test
-  void shouldOrderEntitiesByIdWhenParamTrackedEntitySupplied() {
+  void shouldOrderEntitiesByTrackedEntityUidInDescOrder() {
     injectSecurityContext(superUser);
 
     addEntityInstances();
@@ -398,7 +561,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
   }
 
   @Test
-  void shouldOrderEntitiesByLastUpdatedAtClientWhenParamUpdatedAtClientSupplied() {
+  void shouldOrderEntitiesByUpdatedAtClientInDescOrder() {
     injectSecurityContext(superUser);
 
     entityInstanceA1.setLastUpdatedAtClient(DateTime.now().plusDays(1).toDate());
@@ -424,7 +587,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
   }
 
   @Test
-  void shouldOrderEntitiesByEnrollmentDateWhenParamEnrolledAtSupplied() {
+  void shouldOrderEntitiesByEnrolledAtDateInDescOrder() {
     injectSecurityContext(superUser);
 
     addEntityInstances();
@@ -483,7 +646,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
   }
 
   @Test
-  void shouldSortEntitiesByIdWhenNoOrderParamProvided() {
+  void shouldOrderEntitiesByDefaultUsingTrackedEntityIdInAscOrderWhenNoOrderParamProvided() {
     injectSecurityContext(superUser);
     addEntityInstances();
 
@@ -639,66 +802,6 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
         entityInstanceService.getTrackedEntityCount(new TrackedEntityQueryParams(), true, true);
 
     assertEquals(0, trackedEntitiesCounter);
-  }
-
-  @Test
-  void shouldSortGridByTrackedEntityIdAscendingWhenParamCreatedAscendingProvided() {
-    injectSecurityContext(superUser);
-    trackedEntityAttribute.setDisplayInListNoProgram(true);
-    attributeService.addTrackedEntityAttribute(trackedEntityAttribute);
-
-    User user =
-        createAndAddUser(
-            false, "attributeFilterUser", Set.of(organisationUnit), Set.of(organisationUnit));
-    injectSecurityContext(user);
-
-    initializeEntityInstance(entityInstanceA1);
-    initializeEntityInstance(entityInstanceB1);
-
-    TrackedEntityQueryParams params = new TrackedEntityQueryParams();
-    params.setOrgUnits(Set.of(organisationUnit));
-    params.setTrackedEntityType(trackedEntityType);
-    params.setOrders(List.of(new OrderParam("created", SortDirection.ASC)));
-    params.setQuery(new QueryFilter(QueryOperator.LIKE, ATTRIBUTE_VALUE));
-
-    Grid grid = entityInstanceService.getTrackedEntitiesGrid(params);
-
-    assertEquals(
-        2,
-        grid.getRows().size(),
-        "Expected to find 2 rows in the grid, but found " + grid.getRows().size() + " instead");
-    assertEquals("UID-A1", grid.getRows().get(0).get(0));
-    assertEquals("UID-B1", grid.getRows().get(1).get(0));
-  }
-
-  @Test
-  void shouldSortGridByTrackedEntityIdDescendingWhenParamCreatedDescendingProvided() {
-    injectSecurityContext(superUser);
-    trackedEntityAttribute.setDisplayInListNoProgram(true);
-    attributeService.addTrackedEntityAttribute(trackedEntityAttribute);
-
-    User user =
-        createAndAddUser(
-            false, "attributeFilterUser", Set.of(organisationUnit), Set.of(organisationUnit));
-    injectSecurityContext(user);
-
-    initializeEntityInstance(entityInstanceA1);
-    initializeEntityInstance(entityInstanceB1);
-
-    TrackedEntityQueryParams params = new TrackedEntityQueryParams();
-    params.setOrgUnits(Set.of(organisationUnit));
-    params.setTrackedEntityType(trackedEntityType);
-    params.setOrders(List.of(new OrderParam("created", SortDirection.DESC)));
-    params.setQuery(new QueryFilter(QueryOperator.LIKE, ATTRIBUTE_VALUE));
-
-    Grid grid = entityInstanceService.getTrackedEntitiesGrid(params);
-
-    assertEquals(
-        2,
-        grid.getRows().size(),
-        "Expected to find 2 rows in the grid, but found " + grid.getRows().size() + " instead");
-    assertEquals("UID-B1", grid.getRows().get(0).get(0));
-    assertEquals("UID-A1", grid.getRows().get(1).get(0));
   }
 
   private void initializeEntityInstance(TrackedEntity entityInstance) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityStoreTest.java
@@ -36,8 +36,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.time.LocalDate;
-import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -55,8 +53,6 @@ import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
-import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
-import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -424,26 +420,6 @@ class TrackedEntityStoreTest extends TransactionalIntegrationTest {
                     atA, QueryOperator.EW, "em", ValueType.TEXT, AggregationType.NONE, null));
     teis = teiStore.getTrackedEntities(params);
     assertEquals(0, teis.size());
-  }
-
-  @Test
-  void testQueryOrderByIdInsteadOfCreatedDate() {
-    LocalDate now = LocalDate.now();
-    Date today = Date.from(now.atStartOfDay().toInstant(ZoneOffset.UTC));
-    Date tomorrow = Date.from(now.plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC));
-    teiA.setCreated(tomorrow);
-    teiB.setCreated(today);
-    teiStore.save(teiA);
-    teiStore.save(teiB);
-    enrollmentService.enrollTrackedEntity(teiB, prA, new Date(), new Date(), ouB);
-    // Get all
-    TrackedEntityQueryParams params = new TrackedEntityQueryParams();
-    params.setOrders(
-        List.of(new OrderParam(TrackedEntityQueryParams.CREATED_ID, SortDirection.ASC)));
-    List<TrackedEntity> teis = teiStore.getTrackedEntities(params);
-    assertEquals(2, teis.size());
-    assertEquals(teiA.getUid(), teis.get(0).getUid());
-    assertEquals(teiB.getUid(), teis.get(1).getUid());
   }
 
   @Test


### PR DESCRIPTION
which was ordering by tracked entity id instead of created column.

- Lowercase column names in OrderColumn mapper as we use lowercase for our SQL.
- Fix tests which asserted using the wrong order or assumed we can set the lastupdated date. lastupdated is automatically set by HibernateGenericStore. So to assert we can order by that column we can only update the entity in some order and expect that to be returned

https://dhis2.atlassian.net/browse/DHIS2-15325
(replaces https://github.com/dhis2/dhis2-core/pull/14035)

More bugs of that sort might exist. We are looking through some issues in https://docs.google.com/document/d/1Y5GNNoRKaNv3ObiDJ2rUKyTSJ0IFNYWZFzYWJofJeWo/edit