### PR TITLE
fix: Append prog. stage name for items with same name [DHIS2-15501]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/GridHeader.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/GridHeader.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.common;
 
+import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSet;
@@ -66,6 +68,8 @@ public class GridHeader implements Serializable {
 
   private String programStage;
 
+  private String displayColumn;
+
   private transient RepeatableStageParams repeatableStageParams;
 
   // -------------------------------------------------------------------------
@@ -98,7 +102,7 @@ public class GridHeader implements Serializable {
    *
    * @param name formal header name.
    * @param hidden indicates whether header is hidden.
-   * @param meta indicates whether header is meta data.
+   * @param meta indicates whether header is metadata.
    */
   public GridHeader(String name, boolean hidden, boolean meta) {
     this(name);
@@ -170,6 +174,59 @@ public class GridHeader implements Serializable {
     this.repeatableStageParams = repeatableStageParams;
   }
 
+  /**
+   * @param name formal header name.
+   * @param column readable header title. displayColumn the custom display column.
+   * @param displayColumn the custom display column.
+   * @param valueType header value type.
+   * @param hidden indicates whether header is hidden.
+   * @param meta indicates whether header is metadata.
+   * @param optionSet option set.
+   * @param legendSet legend set.
+   */
+  public GridHeader(
+      String name,
+      String column,
+      String displayColumn,
+      ValueType valueType,
+      boolean hidden,
+      boolean meta,
+      OptionSet optionSet,
+      LegendSet legendSet) {
+    this(name, column, valueType, hidden, meta);
+    this.optionSet = optionSet;
+    this.legendSet = legendSet;
+    this.displayColumn = displayColumn;
+  }
+
+  /**
+   * @param name formal header name.
+   * @param column readable header title.
+   * @param displayColumn the custom display column.
+   * @param valueType header value type.
+   * @param hidden indicates whether header is hidden.
+   * @param meta indicates whether header is metadata.
+   * @param optionSet option set.
+   * @param legendSet legend set.
+   * @param programStage program stage.
+   * @param repeatableStageParams params for repeatable program stage.
+   */
+  public GridHeader(
+      String name,
+      String column,
+      String displayColumn,
+      ValueType valueType,
+      boolean hidden,
+      boolean meta,
+      OptionSet optionSet,
+      LegendSet legendSet,
+      String programStage,
+      RepeatableStageParams repeatableStageParams) {
+    this(name, column, displayColumn, valueType, hidden, meta, optionSet, legendSet);
+    this.programStage = programStage;
+    this.repeatableStageParams = repeatableStageParams;
+  }
+
   // -------------------------------------------------------------------------
   // Logic
   // -------------------------------------------------------------------------
@@ -202,6 +259,10 @@ public class GridHeader implements Serializable {
   @JsonProperty
   public String getColumn() {
     return column;
+  }
+
+  public String getDisplayColumn() {
+    return defaultIfEmpty(displayColumn, column);
   }
 
   @JsonProperty

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryItem.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.common;
 
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -322,6 +324,27 @@ public class QueryItem {
   // -------------------------------------------------------------------------
   // Static utilities
   // -------------------------------------------------------------------------
+
+  /**
+   * Returns the name that represents this object as a column in the analytics response grid.
+   *
+   * @param displayProperty the {@link DisplayProperty}.
+   * @param appendProgramStage if true, the program stage display name is appended.
+   * @return the column name for this object.
+   */
+  public String getColumnName(DisplayProperty displayProperty, boolean appendProgramStage) {
+    if (getItem() != null) {
+      String column = getItem().getDisplayProperty(displayProperty);
+
+      if (appendProgramStage && hasProgramStage()) {
+        column = column + " - " + getProgramStage().getDisplayProperty(displayProperty);
+      }
+
+      return column;
+    }
+
+    return EMPTY;
+  }
 
   public static List<QueryItem> getQueryItems(Collection<TrackedEntityAttribute> attributes) {
     List<QueryItem> queryItems = new ArrayList<>();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.analytics.event.data;
 
 import static java.util.Collections.emptyList;
 import static java.util.Optional.empty;
+import static java.util.stream.Collectors.counting;
+import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.joinWith;
@@ -135,6 +137,11 @@ public abstract class AbstractAnalyticsService {
               true));
     }
 
+    final DisplayProperty displayProperty = params.getDisplayProperty();
+    Map<String, Long> repeatedNames =
+        params.getItems().stream()
+            .collect(groupingBy(s -> s.getItem().getDisplayProperty(displayProperty), counting()));
+
     for (QueryItem item : params.getItems()) {
       /**
        * If the request contains an item of value type ORGANISATION_UNIT and the item UID is linked
@@ -146,14 +153,15 @@ public abstract class AbstractAnalyticsService {
         grid.addHeader(
             new GridHeader(
                 item.getItem().getUid(),
-                item.getItem().getDisplayProperty(params.getDisplayProperty()),
+                item.getItem().getDisplayProperty(displayProperty),
                 COORDINATE,
                 false,
                 true,
                 item.getOptionSet(),
                 item.getLegendSet()));
       } else if (hasNonDefaultRepeatableProgramStageOffset(item)) {
-        String column = item.getItem().getDisplayProperty(params.getDisplayProperty());
+        String column = item.getItem().getDisplayProperty(displayProperty);
+        String displayColumn = item.getColumnName(displayProperty, repeatedNames.get(column) > 1);
 
         RepeatableStageParams repeatableStageParams = item.getRepeatableStageParams();
 
@@ -163,6 +171,7 @@ public abstract class AbstractAnalyticsService {
             new GridHeader(
                 name,
                 column,
+                displayColumn,
                 repeatableStageParams.simpleStageValueExpected()
                     ? item.getValueType()
                     : ValueType.REFERENCE,
@@ -175,12 +184,14 @@ public abstract class AbstractAnalyticsService {
       } else {
         String uid = getItemUid(item);
 
-        String column = item.getItem().getDisplayProperty(params.getDisplayProperty());
+        String column = item.getItem().getDisplayProperty(displayProperty);
+        String displayColumn = item.getColumnName(displayProperty, repeatedNames.get(column) > 1);
 
         grid.addHeader(
             new GridHeader(
                 uid,
                 column,
+                displayColumn,
                 item.getValueType(),
                 false,
                 true,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsServiceTest.java
@@ -55,6 +55,8 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.MonthlyPeriodType;
 import org.hisp.dhis.period.Period;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.system.grid.ListGrid;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -140,23 +142,111 @@ class AbstractAnalyticsServiceTest {
     Grid grid = dummyAnalyticsService.getGrid(params);
 
     // Then
-    final List<GridHeader> headers = grid.getHeaders();
+    List<GridHeader> headers = grid.getHeaders();
     assertThat(headers, is(notNullValue()));
     assertThat(headers, hasSize(4));
 
-    assertHeader(headers.get(0), "ou", "ouA", ValueType.TEXT, String.class.getName());
-    assertHeader(
+    assertHeaderWithColumn(headers.get(0), "ou", "ouA", ValueType.TEXT, String.class.getName());
+    assertHeaderWithColumn(
         headers.get(1), deA.getUid(), deA.getName(), ValueType.TEXT, String.class.getName());
-    assertHeader(
+    assertHeaderWithColumn(
         headers.get(2), deB.getUid(), deB.getName(), ValueType.COORDINATE, Point.class.getName());
-    assertHeader(
+    assertHeaderWithColumn(
         headers.get(3), deC.getUid(), deC.getName(), ValueType.NUMBER, Double.class.getName());
   }
 
-  private void assertHeader(
+  @Test
+  void verifyHeaderCreationBasedOnQueryItemsAndDimensionsWithSameNamesMultiStage() {
+    ProgramStage psA = new ProgramStage("ps", new Program());
+    psA.setUid("psA12345678");
+
+    ProgramStage psB = new ProgramStage("ps", new Program());
+    psB.setUid("psB12345678");
+
+    DataElement deD = createDataElement('D', ValueType.NUMBER, AggregationType.COUNT);
+    deD.setName("same");
+
+    DataElement deE = createDataElement('E', ValueType.NUMBER, AggregationType.COUNT);
+    deE.setName("same");
+
+    DataElement deF = createDataElement('F', ValueType.NUMBER, AggregationType.COUNT);
+    deF.setName("unique");
+
+    DimensionalObject periods =
+        new BaseDimensionalObject(
+            DimensionalObject.PERIOD_DIM_ID, DimensionType.PERIOD, List.of(peA));
+
+    DimensionalObject orgUnits =
+        new BaseDimensionalObject(
+            DimensionalObject.ORGUNIT_DIM_ID, DimensionType.ORGANISATION_UNIT, "ouA", List.of(ouA));
+
+    QueryItem qiD = new QueryItem(deD, null, deD.getValueType(), deD.getAggregationType(), null);
+    qiD.setProgramStage(psA);
+
+    QueryItem qiE = new QueryItem(deE, null, deE.getValueType(), deE.getAggregationType(), null);
+    qiE.setProgramStage(psB);
+
+    QueryItem qiF = new QueryItem(deF, null, deF.getValueType(), deF.getAggregationType(), null);
+    qiF.setProgramStage(psA);
+
+    EventQueryParams params =
+        new EventQueryParams.Builder()
+            .addDimension(periods)
+            .addDimension(orgUnits)
+            .addItem(qiD)
+            .addItem(qiE)
+            .addItem(qiF)
+            .withSkipData(true)
+            .withSkipMeta(false)
+            .withApiVersion(DhisApiVersion.V33)
+            .build();
+
+    when(securityManager.withUserConstraints(any(EventQueryParams.class))).thenReturn(params);
+
+    Grid grid = dummyAnalyticsService.getGrid(params);
+
+    List<GridHeader> headers = grid.getHeaders();
+    assertThat(headers, is(notNullValue()));
+    assertThat(headers, hasSize(4));
+
+    assertHeaderWithColumn(headers.get(0), "ou", "ouA", ValueType.TEXT, String.class.getName());
+
+    // Same item names with different program stages.
+    assertHeaderWithDisplayColumn(
+        headers.get(1),
+        psA.getUid() + "." + deD.getUid(),
+        deD.getName(),
+        deD.getName() + " - " + psA.getName(),
+        ValueType.NUMBER,
+        Double.class.getName());
+    assertHeaderWithDisplayColumn(
+        headers.get(2),
+        psB.getUid() + "." + deE.getUid(),
+        deE.getName(),
+        deE.getName() + " - " + psB.getName(),
+        ValueType.NUMBER,
+        Double.class.getName());
+  }
+
+  private void assertHeaderWithColumn(
       GridHeader expected, String name, String column, ValueType valueType, String type) {
     assertThat("Header name does not match", expected.getName(), is(name));
     assertThat("Header column name does not match", expected.getColumn(), is(column));
+    assertThat("Header value type does not match", expected.getValueType(), is(valueType));
+    assertThat("Header type does not match", expected.getType(), is(type));
+  }
+
+  private void assertHeaderWithDisplayColumn(
+      GridHeader expected,
+      String name,
+      String column,
+      String displayColumn,
+      ValueType valueType,
+      String type) {
+    assertThat("Header name does not match", expected.getName(), is(name));
+    assertThat("Header column name does not match", expected.getColumn(), is(column));
+    assertThat(
+        "Header displayColumn name does not match", expected.getDisplayColumn(), is(displayColumn));
     assertThat("Header value type does not match", expected.getValueType(), is(valueType));
     assertThat("Header type does not match", expected.getType(), is(type));
   }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/GridUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/GridUtils.java
@@ -219,7 +219,7 @@ public class GridUtils {
     }
 
     for (GridHeader header : grid.getVisibleHeaders()) {
-      table.addCell(getItalicCell(header.getColumn()));
+      table.addCell(getItalicCell(header.getDisplayColumn()));
     }
 
     table.addCell(getEmptyCell(grid.getVisibleWidth(), 10));
@@ -322,7 +322,7 @@ public class GridUtils {
     for (GridHeader header : headers) {
       Cell cell = headerRow.createCell(columnIndex++, CellType.STRING);
       cell.setCellStyle(headerCellStyle);
-      cell.setCellValue(header.getColumn());
+      cell.setCellValue(header.getDisplayColumn());
     }
 
     rowNumber++;
@@ -380,7 +380,7 @@ public class GridUtils {
 
     if (!grid.getHeaders().isEmpty()) {
       while (headers.hasNext()) {
-        csvWriter.write(headers.next().getColumn());
+        csvWriter.write(headers.next().getDisplayColumn());
       }
 
       csvWriter.endRecord();

--- a/dhis-2/dhis-support/dhis-support-system/src/main/resources/grid-html.vm
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/resources/grid-html.vm
@@ -5,7 +5,7 @@
 <thead>
 <tr>
 #foreach( $header in $grid.getVisibleHeaders() )
-<th#if( $header.meta ) style="text-align:left"#end>$!encoder.htmlEncode( $header.column )</th>
+<th#if( $header.meta ) style="text-align:left"#end>$!encoder.htmlEncode( $header.displayColumn )</th>
 #end
 </tr>
 </thead>


### PR DESCRIPTION
**_[Backport from master/2.41]_**

These changes are related to the download/export of a Line Listing report.
Currently, we don't export the name of the program stage when we have two elements with the same name and different program stages. This leads to confusion, as the user doesn't know which element belongs to which program stage.

This fix will append also the program stage name, to the exported column, when there are elements with the same name and different program stages.
