### PR TITLE
fix: mapping of comments in get /tracker/events DHIS2-15600

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
@@ -201,7 +201,8 @@ public class EventOperationParamsMapper {
         .addAttributeOrders(attributeOrderParams)
         .setEvents(operationParams.getEvents())
         .setEnrollments(operationParams.getEnrollments())
-        .setIncludeDeleted(operationParams.isIncludeDeleted());
+        .setIncludeDeleted(operationParams.isIncludeDeleted())
+        .setIncludeRelationships(operationParams.isIncludeRelationships());
   }
 
   private Program validateProgram(String programUid) throws BadRequestException {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -67,6 +67,7 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -141,12 +142,12 @@ public class JdbcEventStore implements EventStore {
           + " psinote.creator                as psinote_storedby,"
           + " psinote.uid                    as psinote_uid,"
           + " psinote.lastupdated            as psinote_lastupdated,"
-          + " userinfo.userinfoid            as usernote_id,"
-          + " userinfo.code                  as usernote_code,"
-          + " userinfo.uid                   as usernote_uid,"
-          + " userinfo.username              as usernote_username,"
-          + " userinfo.firstname             as userinfo_firstname,"
-          + " userinfo.surname               as userinfo_surname"
+          + " userinfo.userinfoid            as psinote_user_id,"
+          + " userinfo.code                  as psinote_user_code,"
+          + " userinfo.uid                   as psinote_user_uid,"
+          + " userinfo.username              as psinote_user_username,"
+          + " userinfo.firstname             as psinote_user_firstname,"
+          + " userinfo.surname               as psinote_user_surname"
           + " from eventcomments psic"
           + " inner join trackedentitycomment psinote"
           + " on psic.trackedentitycommentid = psinote.trackedentitycommentid"
@@ -282,6 +283,7 @@ public class JdbcEventStore implements EventStore {
 
     setAccessiblePrograms(user, params);
 
+    Map<String, Event> eventsByUid = new HashMap<>(params.getPageSizeWithDefault());
     List<Event> events = new ArrayList<>();
     List<Long> relationshipIds = new ArrayList<>();
 
@@ -308,93 +310,108 @@ public class JdbcEventStore implements EventStore {
 
             validateIdentifiersPresence(resultSet, params.getIdSchemes());
 
-            Event event = new Event();
+            Event event;
+            if (eventsByUid.containsKey(eventUid)) {
+              event = eventsByUid.get(eventUid);
+            } else {
+              event = new Event();
+              eventsByUid.put(eventUid, event);
 
-            if (!params.isSkipEventId()) {
-              event.setUid(eventUid);
-            }
-
-            TrackedEntity tei = new TrackedEntity();
-            tei.setUid(resultSet.getString("tei_uid"));
-            event.setStatus(EventStatus.valueOf(resultSet.getString(EVENT_STATUS)));
-            ProgramType programType = ProgramType.fromValue(resultSet.getString("p_type"));
-            Program program = new Program();
-            program.setUid(resultSet.getString("p_identifier"));
-            program.setProgramType(programType);
-            Enrollment enrollment = new Enrollment();
-            enrollment.setUid(resultSet.getString("pi_uid"));
-            enrollment.setProgram(program);
-            enrollment.setTrackedEntity(tei);
-            OrganisationUnit ou = new OrganisationUnit();
-            ou.setUid(resultSet.getString("ou_uid"));
-            ou.setName(resultSet.getString("ou_name"));
-            ProgramStage ps = new ProgramStage();
-            ps.setUid(resultSet.getString("ps_identifier"));
-            event.setDeleted(resultSet.getBoolean("psi_deleted"));
-
-            enrollment.setStatus(ProgramStatus.valueOf(resultSet.getString("pi_status")));
-            enrollment.setFollowup(resultSet.getBoolean("pi_followup"));
-            event.setEnrollment(enrollment);
-            event.setProgramStage(ps);
-            event.setOrganisationUnit(ou);
-            CategoryOptionCombo coc = new CategoryOptionCombo();
-            coc.setUid(resultSet.getString("coc_identifier"));
-
-            Set<CategoryOption> options =
-                Arrays.stream(resultSet.getString("co_uids").split(";"))
-                    .map(
-                        optionUid -> {
-                          CategoryOption option = new CategoryOption();
-                          option.setUid(optionUid);
-                          return option;
-                        })
-                    .collect(Collectors.toSet());
-            coc.setCategoryOptions(options);
-
-            event.setAttributeOptionCombo(coc);
-
-            event.setStoredBy(resultSet.getString("psi_storedby"));
-            event.setDueDate(resultSet.getDate("psi_duedate"));
-            event.setExecutionDate(resultSet.getDate("psi_executiondate"));
-            event.setCreated(resultSet.getDate("psi_created"));
-            event.setCreatedByUserInfo(
-                EventUtils.jsonToUserInfo(
-                    resultSet.getString("psi_createdbyuserinfo"), jsonMapper));
-            event.setLastUpdated(resultSet.getDate("psi_lastupdated"));
-            event.setLastUpdatedByUserInfo(
-                EventUtils.jsonToUserInfo(
-                    resultSet.getString("psi_lastupdatedbyuserinfo"), jsonMapper));
-
-            event.setCompletedBy(resultSet.getString("psi_completedby"));
-            event.setCompletedDate(resultSet.getDate("psi_completeddate"));
-
-            if (resultSet.getObject("psi_geometry") != null) {
-              try {
-                Geometry geom = new WKTReader().read(resultSet.getString("psi_geometry"));
-
-                event.setGeometry(geom);
-              } catch (ParseException e) {
-                log.error("Unable to read geometry for event '" + event.getUid() + "': ", e);
+              if (!params.isSkipEventId()) {
+                event.setUid(eventUid);
               }
-            }
 
-            if (resultSet.getObject("user_assigned") != null) {
-              User eventUser = new User();
-              eventUser.setUid(resultSet.getString("user_assigned"));
-              eventUser.setUsername(resultSet.getString("user_assigned_username"));
-              eventUser.setName(resultSet.getString("user_assigned_name"));
-              eventUser.setFirstName(resultSet.getString("user_assigned_first_name"));
-              eventUser.setSurname(resultSet.getString("user_assigned_surname"));
-              event.setAssignedUser(eventUser);
-            }
+              TrackedEntity tei = new TrackedEntity();
+              tei.setUid(resultSet.getString("tei_uid"));
+              event.setStatus(EventStatus.valueOf(resultSet.getString(EVENT_STATUS)));
+              ProgramType programType = ProgramType.fromValue(resultSet.getString("p_type"));
+              Program program = new Program();
+              program.setUid(resultSet.getString("p_identifier"));
+              program.setProgramType(programType);
+              Enrollment enrollment = new Enrollment();
+              enrollment.setUid(resultSet.getString("pi_uid"));
+              enrollment.setProgram(program);
+              enrollment.setTrackedEntity(tei);
+              OrganisationUnit ou = new OrganisationUnit();
+              ou.setUid(resultSet.getString("ou_uid"));
+              ou.setName(resultSet.getString("ou_name"));
+              ProgramStage ps = new ProgramStage();
+              ps.setUid(resultSet.getString("ps_identifier"));
+              event.setDeleted(resultSet.getBoolean("psi_deleted"));
 
-            events.add(event);
+              enrollment.setStatus(ProgramStatus.valueOf(resultSet.getString("pi_status")));
+              enrollment.setFollowup(resultSet.getBoolean("pi_followup"));
+              event.setEnrollment(enrollment);
+              event.setProgramStage(ps);
+              event.setOrganisationUnit(ou);
 
-            if (!StringUtils.isEmpty(resultSet.getString("psi_eventdatavalues"))) {
-              Set<EventDataValue> eventDataValues =
-                  convertEventDataValueJsonIntoSet(resultSet.getString("psi_eventdatavalues"));
+              CategoryOptionCombo coc = new CategoryOptionCombo();
+              coc.setUid(resultSet.getString("coc_identifier"));
+              Set<CategoryOption> options =
+                  Arrays.stream(resultSet.getString("co_uids").split(";"))
+                      .map(
+                          optionUid -> {
+                            CategoryOption option = new CategoryOption();
+                            option.setUid(optionUid);
+                            return option;
+                          })
+                      .collect(Collectors.toSet());
+              coc.setCategoryOptions(options);
+              event.setAttributeOptionCombo(coc);
 
-              event.getEventDataValues().addAll(eventDataValues);
+              event.setStoredBy(resultSet.getString("psi_storedby"));
+              event.setDueDate(resultSet.getDate("psi_duedate"));
+              event.setExecutionDate(resultSet.getDate("psi_executiondate"));
+              event.setCreated(resultSet.getDate("psi_created"));
+              event.setCreatedByUserInfo(
+                  EventUtils.jsonToUserInfo(
+                      resultSet.getString("psi_createdbyuserinfo"), jsonMapper));
+              event.setLastUpdated(resultSet.getDate("psi_lastupdated"));
+              event.setLastUpdatedByUserInfo(
+                  EventUtils.jsonToUserInfo(
+                      resultSet.getString("psi_lastupdatedbyuserinfo"), jsonMapper));
+
+              event.setCompletedBy(resultSet.getString("psi_completedby"));
+              event.setCompletedDate(resultSet.getDate("psi_completeddate"));
+
+              if (resultSet.getObject("psi_geometry") != null) {
+                try {
+                  Geometry geom = new WKTReader().read(resultSet.getString("psi_geometry"));
+
+                  event.setGeometry(geom);
+                } catch (ParseException e) {
+                  log.error("Unable to read geometry for event '" + event.getUid() + "': ", e);
+                }
+              }
+
+              if (resultSet.getObject("user_assigned") != null) {
+                User eventUser = new User();
+                eventUser.setUid(resultSet.getString("user_assigned"));
+                eventUser.setUsername(resultSet.getString("user_assigned_username"));
+                eventUser.setName(resultSet.getString("user_assigned_name"));
+                eventUser.setFirstName(resultSet.getString("user_assigned_first_name"));
+                eventUser.setSurname(resultSet.getString("user_assigned_surname"));
+                event.setAssignedUser(eventUser);
+              }
+
+              if (!StringUtils.isEmpty(resultSet.getString("psi_eventdatavalues"))) {
+                Set<EventDataValue> eventDataValues =
+                    convertEventDataValueJsonIntoSet(resultSet.getString("psi_eventdatavalues"));
+
+                event.getEventDataValues().addAll(eventDataValues);
+              }
+
+              if (params.isIncludeRelationships() && resultSet.getObject("psi_rl") != null) {
+                PGobject pGobject = (PGobject) resultSet.getObject("psi_rl");
+
+                if (pGobject != null) {
+                  String value = pGobject.getValue();
+
+                  relationshipIds.addAll(Lists.newArrayList(gson.fromJson(value, Long[].class)));
+                }
+              }
+
+              events.add(event);
             }
 
             if (resultSet.getString("psinote_value") != null
@@ -405,31 +422,21 @@ public class JdbcEventStore implements EventStore {
               note.setCreated(resultSet.getDate("psinote_storeddate"));
               note.setCreator(resultSet.getString("psinote_storedby"));
 
-              if (resultSet.getObject("usernoteupdated_id") != null) {
-                User userNote = new User();
-                userNote.setId(resultSet.getLong("usernoteupdated_id"));
-                userNote.setCode(resultSet.getString("usernoteupdated_code"));
-                userNote.setUid(resultSet.getString("usernoteupdated_uid"));
-                userNote.setUsername(resultSet.getString("usernoteupdated_username"));
-                userNote.setFirstName(resultSet.getString("usernoteupdated_firstname"));
-                userNote.setSurname(resultSet.getString("usernoteupdated_surname"));
-                note.setLastUpdatedBy(userNote);
+              if (resultSet.getObject("psinote_user_id") != null) {
+                User noteLastUpdatedBy = new User();
+                noteLastUpdatedBy.setId(resultSet.getLong("psinote_user_id"));
+                noteLastUpdatedBy.setCode(resultSet.getString("psinote_user_code"));
+                noteLastUpdatedBy.setUid(resultSet.getString("psinote_user_uid"));
+                noteLastUpdatedBy.setUsername(resultSet.getString("psinote_user_username"));
+                noteLastUpdatedBy.setFirstName(resultSet.getString("psinote_user_firstname"));
+                noteLastUpdatedBy.setSurname(resultSet.getString("psinote_user_surname"));
+                note.setLastUpdatedBy(noteLastUpdatedBy);
               }
 
               note.setLastUpdated(resultSet.getDate("psinote_lastupdated"));
 
               event.getComments().add(note);
               notes.add(resultSet.getString("psinote_id"));
-            }
-
-            if (params.isIncludeRelationships() && resultSet.getObject("psi_rl") != null) {
-              PGobject pGobject = (PGobject) resultSet.getObject("psi_rl");
-
-              if (pGobject != null) {
-                String value = pGobject.getValue();
-
-                relationshipIds.addAll(Lists.newArrayList(gson.fromJson(value, Long[].class)));
-              }
             }
           }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -48,6 +48,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdSchemes;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -67,9 +68,12 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.ProgramType;
+import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 import org.hisp.dhis.tracker.TrackerTest;
+import org.hisp.dhis.tracker.export.event.EventOperationParams.EventOperationParamsBuilder;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
@@ -100,14 +104,15 @@ class EventExporterTest extends TrackerTest {
   private Program program;
 
   private TrackedEntity trackedEntity;
+  private User importUser;
 
   @Override
   protected void initTest() throws IOException {
     setUpMetadata("tracker/simple_metadata.json");
-    User userA = userService.getUser("M5zQapPyTZI");
+    importUser = userService.getUser("M5zQapPyTZI");
     assertNoErrors(
         trackerImportService.importTracker(
-            fromJson("tracker/event_and_enrollment.json", userA.getUid())));
+            fromJson("tracker/event_and_enrollment.json", importUser.getUid())));
     orgUnit = get(OrganisationUnit.class, "h4w96yEMlzO");
     programStage = get(ProgramStage.class, "NpsdDv6kKSO");
     program = programStage.getProgram();
@@ -142,6 +147,73 @@ class EventExporterTest extends TrackerTest {
 
     assertEquals(
         get(Event.class, "D9PbzJY8bJM").getAssignedUser(), events.get(0).getAssignedUser());
+  }
+
+  @Test
+  void shouldReturnEventsWithRelationships() throws ForbiddenException, BadRequestException {
+    EventOperationParams params =
+        EventOperationParams.builder()
+            .orgUnitUid(orgUnit.getUid())
+            .events(Set.of("pTzf9KYMk72"))
+            .includeRelationships(true)
+            .build();
+
+    List<Event> events = eventService.getEvents(params).getEvents();
+
+    assertContainsOnly(List.of("pTzf9KYMk72"), uids(events));
+    List<Relationship> relationships =
+        events.get(0).getRelationshipItems().stream().map(i -> i.getRelationship()).toList();
+    assertContainsOnly(List.of("oLT07jKRu9e", "yZxjxJli9mO"), uids(relationships));
+  }
+
+  @Test
+  void shouldReturnEventsWithNotes() throws ForbiddenException, BadRequestException {
+    EventOperationParams params =
+        EventOperationParams.builder()
+            .orgUnitUid(orgUnit.getUid())
+            .events(Set.of("pTzf9KYMk72"))
+            .build();
+
+    List<Event> events = eventService.getEvents(params).getEvents();
+
+    assertContainsOnly(List.of("pTzf9KYMk72"), uids(events));
+    List<TrackedEntityComment> notes = events.get(0).getComments();
+    assertContainsOnly(List.of("SGuCABkhpgn", "DRKO4xUVrpr"), uids(notes));
+    assertAll(
+        () -> assertNote(importUser, "comment value", notes.get(0)),
+        () -> assertNote(importUser, "comment value", notes.get(1)));
+  }
+
+  @Test
+  void shouldReturnPaginatedEventsWithNotesGivenNonDefaultPageSize()
+      throws ForbiddenException, BadRequestException {
+    EventOperationParamsBuilder paramsBuilder =
+        EventOperationParams.builder()
+            .orgUnitUid(orgUnit.getUid())
+            .events(Set.of("pTzf9KYMk72", "D9PbzJY8bJM"))
+            .orders(List.of(new OrderParam("occurredAt", SortDirection.DESC)));
+
+    EventOperationParams params = paramsBuilder.page(1).pageSize(1).build();
+
+    Events firstPage = eventService.getEvents(params);
+
+    assertAll(
+        "first page",
+        () -> assertSlimPager(1, 1, false, firstPage),
+        () -> assertEquals(List.of("D9PbzJY8bJM"), eventUids(firstPage)));
+
+    params = paramsBuilder.page(2).pageSize(1).build();
+
+    Events secondPage = eventService.getEvents(params);
+
+    assertAll(
+        "second (last) page",
+        () -> assertSlimPager(2, 1, true, secondPage),
+        () -> assertEquals(List.of("pTzf9KYMk72"), eventUids(secondPage)));
+
+    params = paramsBuilder.page(3).pageSize(3).build();
+
+    assertIsEmpty(getEvents(params));
   }
 
   @Test
@@ -360,19 +432,18 @@ class EventExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldReturnPublicEventsWithMultipleCategoryOptionsGivenNonDefaultPageSize()
+  void shouldReturnPaginatedPublicEventsWithMultipleCategoryOptionsGivenNonDefaultPageSize()
       throws ForbiddenException, BadRequestException {
     OrganisationUnit orgUnit = get(OrganisationUnit.class, "DiszpKrYNg8");
     Program program = get(Program.class, "iS7eutanDry");
 
-    EventOperationParams params =
+    EventOperationParamsBuilder paramsBuilder =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
             .programUid(program.getUid())
-            .orders(List.of(new OrderParam("occurredAt", SortDirection.DESC)))
-            .page(1)
-            .pageSize(3)
-            .build();
+            .orders(List.of(new OrderParam("occurredAt", SortDirection.DESC)));
+
+    EventOperationParams params = paramsBuilder.page(1).pageSize(3).build();
 
     Events firstPage = eventService.getEvents(params);
 
@@ -383,14 +454,7 @@ class EventExporterTest extends TrackerTest {
             assertEquals(
                 List.of("ck7DzdxqLqA", "OTmjvJDn0Fu", "kWjSezkXHVp"), eventUids(firstPage)));
 
-    params =
-        EventOperationParams.builder()
-            .orgUnitUid(orgUnit.getUid())
-            .programUid(program.getUid())
-            .orders(List.of(new OrderParam("occurredAt", SortDirection.DESC)))
-            .page(2)
-            .pageSize(3)
-            .build();
+    params = paramsBuilder.page(2).pageSize(3).build();
 
     Events secondPage = eventService.getEvents(params);
 
@@ -401,20 +465,13 @@ class EventExporterTest extends TrackerTest {
             assertEquals(
                 List.of("lumVtWwwy0O", "QRYjLTiJTrA", "cadc5eGj0j7"), eventUids(secondPage)));
 
-    params =
-        EventOperationParams.builder()
-            .orgUnitUid(orgUnit.getUid())
-            .programUid(program.getUid())
-            .orders(List.of(new OrderParam("occurredAt", SortDirection.DESC)))
-            .page(3)
-            .pageSize(3)
-            .build();
+    params = paramsBuilder.page(3).pageSize(3).build();
 
     assertIsEmpty(getEvents(params));
   }
 
   @Test
-  void shouldReturnEventsWithMultipleCategoryOptionsGivenNonDefaultPageSizeAndTotalPages()
+  void shouldReturnPaginatedEventsWithMultipleCategoryOptionsGivenNonDefaultPageSizeAndTotalPages()
       throws ForbiddenException, BadRequestException {
     OrganisationUnit orgUnit = get(OrganisationUnit.class, "DiszpKrYNg8");
     Program program = get(Program.class, "iS7eutanDry");
@@ -1021,12 +1078,53 @@ class EventExporterTest extends TrackerTest {
                     new OrderParam("toUpdate000", SortDirection.ASC)))
             .build();
 
+    List<Event> events = eventService.getEvents(params).getEvents();
+
+    assertEquals(List.of("D9PbzJY8bJM", "pTzf9KYMk72"), uids(events));
     List<String> trackedEntities =
-        eventService.getEvents(params).getEvents().stream()
+        events.stream()
             .map(event -> event.getEnrollment().getTrackedEntity().getUid())
             .collect(Collectors.toList());
-
     assertEquals(List.of("dUE514NMOlo", "QS6w44flWAf"), trackedEntities);
+  }
+
+  @Test
+  void shouldOrderEventsByMultipleAttributesAndPaginateWhenGivenNonDefaultPageSize()
+      throws ForbiddenException, BadRequestException {
+    EventOperationParamsBuilder paramsBuilder =
+        EventOperationParams.builder()
+            .orgUnitUid(orgUnit.getUid())
+            .filterAttributes("toUpdate000,toDelete000")
+            .attributeOrders(
+                List.of(
+                    OrderCriteria.of("toDelete000", SortDirection.DESC),
+                    OrderCriteria.of("toUpdate000", SortDirection.ASC)))
+            .orders(
+                List.of(
+                    new OrderParam("toDelete000", SortDirection.DESC),
+                    new OrderParam("toUpdate000", SortDirection.ASC)));
+
+    EventOperationParams params = paramsBuilder.page(1).pageSize(1).build();
+
+    Events firstPage = eventService.getEvents(params);
+
+    assertAll(
+        "first page",
+        () -> assertSlimPager(1, 1, false, firstPage),
+        () -> assertEquals(List.of("D9PbzJY8bJM"), eventUids(firstPage)));
+
+    params = paramsBuilder.page(2).pageSize(1).build();
+
+    Events secondPage = eventService.getEvents(params);
+
+    assertAll(
+        "second (last) page",
+        () -> assertSlimPager(2, 1, true, secondPage),
+        () -> assertEquals(List.of("pTzf9KYMk72"), eventUids(secondPage)));
+
+    params = paramsBuilder.page(3).pageSize(3).build();
+
+    assertIsEmpty(getEvents(params));
   }
 
   @Test
@@ -1245,6 +1343,12 @@ class EventExporterTest extends TrackerTest {
     assertEquals(List.of("dUE514NMOlo", "QS6w44flWAf"), trackedEntities);
   }
 
+  private void assertNote(
+      User expectedLastUpdatedBy, String expectedNote, TrackedEntityComment actual) {
+    assertEquals(expectedNote, actual.getCommentText());
+    assertEquals(expectedLastUpdatedBy, actual.getLastUpdatedBy());
+  }
+
   private DataElement dataElement(String uid) {
     return dataElementService.getDataElement(uid);
   }
@@ -1274,10 +1378,6 @@ class EventExporterTest extends TrackerTest {
     return t;
   }
 
-  private static List<String> eventUids(Events events) {
-    return events.getEvents().stream().map(Event::getUid).collect(Collectors.toList());
-  }
-
   private static void assertSlimPager(int pageNumber, int pageSize, boolean isLast, Events events) {
     assertInstanceOf(
         SlimPager.class, events.getPager(), "SlimPager should be returned if totalPages=false");
@@ -1304,8 +1404,14 @@ class EventExporterTest extends TrackerTest {
 
   private List<String> getEvents(EventOperationParams params)
       throws ForbiddenException, BadRequestException {
-    return eventService.getEvents(params).getEvents().stream()
-        .map(Event::getUid)
-        .collect(Collectors.toList());
+    return uids(eventService.getEvents(params).getEvents());
+  }
+
+  private static List<String> eventUids(Events events) {
+    return uids(events.getEvents());
+  }
+
+  private static List<String> uids(List<? extends BaseIdentifiableObject> identifiableObject) {
+    return identifiableObject.stream().map(BaseIdentifiableObject::getUid).toList();
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
@@ -454,7 +454,20 @@
           "providedElsewhere": false
         }
       ],
-      "notes": []
+      "notes": [
+        {
+          "note": "SGuCABkhpgn",
+          "storedAt": "2019-01-28T12:10:38.108",
+          "value": "comment value",
+          "storedBy": "admin"
+        },
+        {
+          "note": "DRKO4xUVrpr",
+          "storedAt": "2019-01-28T12:10:38.108",
+          "value": "comment value",
+          "storedBy": "admin"
+        }
+      ]
     },
     {
       "event": "D9PbzJY8bJM",
@@ -475,12 +488,12 @@
       "relationships": [],
       "occurredAt": "2020-01-28T00:00:00.000",
       "executionDate": "2019-01-28T00:00:00.000",
-      "updatedAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
       "storedBy": "admin",
       "followup": false,
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
+      "updatedAt": "2019-01-28T00:00:00.000",
       "updatedAt": "2019-01-28T12:10:38.109",
       "attributeOptionCombo": {
         "idScheme": "UID",
@@ -1025,6 +1038,41 @@
       "notes": []
     }
   ],
-  "relationships": [],
+  "relationships": [
+    {
+      "relationship": "oLT07jKRu9e",
+      "relationshipType": {
+        "idScheme": "UID",
+        "identifier": "TV9oB9LT3sh"
+      },
+      "createdAt": "2018-10-01T12:17:30.163",
+      "updatedAt": "2018-10-01T12:17:30.163",
+      "bidirectional": false,
+      "deleted": false,
+      "from": {
+        "trackedEntity": "QS6w44flWAf"
+      },
+      "to": {
+        "event": "pTzf9KYMk72"
+      }
+    },
+    {
+      "relationship": "yZxjxJli9mO",
+      "relationshipType": {
+        "idScheme": "UID",
+        "identifier": "TV9oB9LT3sh"
+      },
+      "createdAt": "2018-10-01T12:17:30.163",
+      "updatedAt": "2018-10-01T12:17:30.163",
+      "bidirectional": false,
+      "deleted": false,
+      "from": {
+        "trackedEntity": "dUE514NMOlo"
+      },
+      "to": {
+        "event": "pTzf9KYMk72"
+      }
+    }
+  ],
   "username": "system-process"
 }


### PR DESCRIPTION
* fixes a wrong SQL alias: `org.springframework.jdbc.BadSqlGrammarException: PreparedStatementCallback; bad SQL grammar [select ... ] nested exception is org.postgresql.util.PSQLException: The column name usernoteupdated_id was not found in this ResultSet`.
* As the alias `usernote` for the lastupdated user was too generic and confusing I prefixed it with `psinote_user_` so its clear that its the event notes user. Note the `psi` to `event` alias change will be tackled in another issue.
* fix DHIS2-15603 (see description below)
* fix setting `includeRelationships` when mapping from operation params to search params. This was introduced only in master in our refactorings.
* data values are already aggregated in JSONB string so we can set them
  once in the "new event" branch
* relationship ids are already aggregated in SQL so we can set them once in the "new event" branch
* add tests for multiple notes (also with pagination) and an event with relationships

## Additional bug (DHIS2-15603)

When adding a test for events with multiple notes I discovered 
https://dhis2.atlassian.net/browse/DHIS2-15603

Events with multiple comments and likely also and relationships will be returned multiple times.

We removed the aggregation logic [in Java](https://github.com/dhis2/dhis2-core/pull/13253). The collection fields notes leads to a DB result set that is notes * of rows per event that we then aggregate in Java into a single event. This logic was removed. The reason it was removed was that this aggregation was no longer needed for category options as we now aggregate them in SQL. However, its still needed for notes. Note that this does not affect event.dataValues as these are stored in JSONB. This does also not affect relationships as relationship ids are [also aggregated in SQL](https://github.com/dhis2/dhis2-core/blob/012479a59b57955ec39543a5913d9fb3fe2dee18/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java#L133). So we can think of event.dataValues as already aggregated in SQL. The reason this did not surface is probably that we did not have a test for these collections with more then one element.