### PR TITLE
fix: /tracker/trackedEntities?order=createdAt DHIS2-15325 [2.39]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
@@ -1002,16 +1002,16 @@ public class TrackedEntityInstanceQueryParams {
   @AllArgsConstructor
   public enum OrderColumn {
     TRACKEDENTITY("trackedEntityInstance", "uid", MAIN_QUERY_ALIAS),
-    // Ordering by id is the same as ordering by created date
-    CREATED(CREATED_ID, "trackedentityinstanceid", MAIN_QUERY_ALIAS),
-    CREATED_AT("createdAt", "trackedentityinstanceid", MAIN_QUERY_ALIAS),
-    CREATED_AT_CLIENT("createdAtClient", "createdAtClient", MAIN_QUERY_ALIAS),
-    UPDATED_AT("lastUpdated", "lastUpdated", MAIN_QUERY_ALIAS),
-    UPDATED_AT_CLIENT("updatedAtClient", "lastUpdatedAtClient", MAIN_QUERY_ALIAS),
-    ENROLLED_AT("enrolledAt", "enrollmentDate", PROGRAM_INSTANCE_ALIAS),
-    // this works only for the new endpoint
-    // ORGUNIT_NAME( "orgUnitName",
-    // MAIN_QUERY_ALIAS+".organisationUnit.name" ),
+    CREATED("created", CREATED_ID, MAIN_QUERY_ALIAS),
+    CREATED_AT("createdAt", CREATED_ID, MAIN_QUERY_ALIAS),
+    CREATED_AT_CLIENT("createdAtClient", "createdatclient", MAIN_QUERY_ALIAS),
+    UPDATED_AT("lastUpdated", "lastupdated", MAIN_QUERY_ALIAS),
+    UPDATED_AT_CLIENT("updatedAtClient", "lastupdatedatclient", MAIN_QUERY_ALIAS),
+    ENROLLED_AT(
+        "enrolledAt",
+        "enrollmentdate",
+        PROGRAM_INSTANCE_ALIAS), // this works only for the new endpoint
+    // ORGUNIT_NAME( "orgUnitName", MAIN_QUERY_ALIAS+".organisationUnit.name" ),
     INACTIVE(INACTIVE_ID, "inactive", MAIN_QUERY_ALIAS);
 
     private final String propName;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -431,7 +431,7 @@ public class HibernateTrackedEntityInstanceStore
             List.of(
                 "SELECT TEI.uid AS " + TRACKED_ENTITY_INSTANCE_ID,
                 "TEI.created AS " + CREATED_ID,
-                "TEI.lastUpdated AS " + LAST_UPDATED_ID,
+                "TEI.lastupdated AS " + LAST_UPDATED_ID,
                 "TEI.ou AS " + ORG_UNIT_ID,
                 "TEI.ouname AS " + ORG_UNIT_NAME,
                 "TET.uid AS " + TRACKED_ENTITY_ID,
@@ -508,8 +508,8 @@ public class HibernateTrackedEntityInstanceStore
   }
 
   /**
-   * The subquery projection. If we are sorting by attribute, we need to include the value in the
-   * subquery projection.
+   * The sub-query projection. If we are sorting by attribute, we need to include the value in the
+   * sub-query projection.
    *
    * @param params
    * @return a SQL projection
@@ -521,7 +521,7 @@ public class HibernateTrackedEntityInstanceStore
                 "TEI.trackedentityinstanceid",
                 "TEI.uid",
                 "TEI.created",
-                "TEI.lastUpdated",
+                "TEI.lastupdated",
                 "TEI.inactive",
                 "TEI.trackedentitytypeid",
                 "TEI.potentialduplicate",

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceStoreTest.java
@@ -36,8 +36,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.time.LocalDate;
-import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -55,7 +53,6 @@ import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
-import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -423,28 +420,6 @@ class TrackedEntityInstanceStoreTest extends TransactionalIntegrationTest {
                     atA, QueryOperator.EW, "em", ValueType.TEXT, AggregationType.NONE, null));
     teis = teiStore.getTrackedEntityInstances(params);
     assertEquals(0, teis.size());
-  }
-
-  @Test
-  void testQueryOrderByIdInsteadOfCreatedDate() {
-    LocalDate now = LocalDate.now();
-    Date today = Date.from(now.atStartOfDay().toInstant(ZoneOffset.UTC));
-    Date tomorrow = Date.from(now.plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC));
-    teiA.setCreated(tomorrow);
-    teiB.setCreated(today);
-    teiStore.save(teiA);
-    teiStore.save(teiB);
-    programInstanceService.enrollTrackedEntityInstance(teiB, prA, new Date(), new Date(), ouB);
-    // Get all
-    TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
-    params.setOrders(
-        List.of(
-            new OrderParam(
-                TrackedEntityInstanceQueryParams.CREATED_ID, OrderParam.SortDirection.ASC)));
-    List<TrackedEntityInstance> teis = teiStore.getTrackedEntityInstances(params);
-    assertEquals(2, teis.size());
-    assertEquals(teiA.getUid(), teis.get(0).getUid());
-    assertEquals(teiB.getUid(), teis.get(1).getUid());
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/webrequest/tracker/TrackerTrackedEntityCriteriaTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/webrequest/tracker/TrackerTrackedEntityCriteriaTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.event.webrequest.tracker;
+
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+
+import java.util.List;
+import org.hisp.dhis.webapi.controller.event.mapper.OrderParam.SortDirection;
+import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
+import org.junit.jupiter.api.Test;
+
+class TrackerTrackedEntityCriteriaTest {
+
+  @Test
+  void shouldTranslateNewTrackerFieldNameTrackedEntityToOldTrackerFieldName() {
+    TrackerTrackedEntityCriteria criteria = new TrackerTrackedEntityCriteria();
+    criteria.setOrder(List.of(OrderCriteria.of("trackedEntity", SortDirection.DESC)));
+
+    assertContainsOnly(
+        List.of(OrderCriteria.of("trackedEntityInstance", SortDirection.DESC)),
+        criteria.getOrder());
+  }
+
+  @Test
+  void shouldTranslateNewTrackerFieldNameCreatedAtToOldTrackerFieldName() {
+    TrackerTrackedEntityCriteria criteria = new TrackerTrackedEntityCriteria();
+    criteria.setOrder(List.of(OrderCriteria.of("createdAt", SortDirection.DESC)));
+
+    assertContainsOnly(
+        List.of(OrderCriteria.of("created", SortDirection.DESC)), criteria.getOrder());
+  }
+
+  @Test
+  void shouldTranslateNewTrackerFieldNameUpdatedAtToOldTrackerFieldName() {
+    TrackerTrackedEntityCriteria criteria = new TrackerTrackedEntityCriteria();
+    criteria.setOrder(List.of(OrderCriteria.of("updatedAt", SortDirection.DESC)));
+
+    assertContainsOnly(
+        List.of(OrderCriteria.of("lastUpdated", SortDirection.DESC)), criteria.getOrder());
+  }
+
+  @Test
+  void shouldKeepNewTrackerFieldNameThatDoesNotHaveARegisteredOldTrackerFieldName() {
+    TrackerTrackedEntityCriteria criteria = new TrackerTrackedEntityCriteria();
+    criteria.setOrder(List.of(OrderCriteria.of("enrolledAt", SortDirection.DESC)));
+
+    assertContainsOnly(
+        List.of(OrderCriteria.of("enrolledAt", SortDirection.DESC)), criteria.getOrder());
+  }
+}


### PR DESCRIPTION
backport of https://github.com/dhis2/dhis2-core/pull/14631

Note that < 2.40 we have some extra logic affecting the users `order` param field names. Due to that some field names in `TrackedEntityInstanceQueryParams.OrderColumn` refer to old tracker field names.

## Order field name translation logic

1. The `PagingAndSortingCriteria` translates from new tracker field names to old tracker ones. These field names are registered in the criteria classes (called `RequestParam` in master; this translation does not exist >= 2.40).

Here is where the new/old tracker names are registered
https://github.com/dhis2/dhis2-core/blob/d5afd349a184bb44323ab18ef6790045163d68e1/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/tracker/TrackerTrackedEntityCriteria.java#L147-L169

I added a test

`webapi/controller/event/webrequest/tracker/TrackerTrackedEntityCriteriaTest.java`

to show how the translation works.

`order=<fieldname>` in new tracker endpoints
* are translated to old tracker field names ONLY if there is a registered mapping
* if there is no mapping they are left as is

2. TrackedEntityInstanceQueryParams maps from field names to columns

For example

`TRACKEDENTITY("trackedEntityInstance", "uid", MAIN_QUERY_ALIAS),`

takes the old tracker field name and maps it to the `uid` column. This works for old and new tracker as the new tracker name `trackedEntity` has been translated to `trackedEntityInstance` in step 1. 😅 