### PR TITLE
chore: Harmonize Relationship Controller [TECH-1572]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
@@ -79,7 +79,8 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
     TrackedEntityType trackedEntityType = trackedEntity.getTrackedEntityType();
 
     if (!aclService.canDataRead(user, trackedEntityType)) {
-      errors.add("User has no data read access to tracked entity: " + trackedEntityType.getUid());
+      errors.add(
+          "User has no data read access to tracked entity type: " + trackedEntityType.getUid());
     }
 
     return errors;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -102,6 +102,7 @@ public class DefaultEnrollmentService
     }
 
     Enrollment result = new Enrollment();
+    result.setId(enrollment.getId());
     result.setUid(enrollment.getUid());
 
     if (enrollment.getTrackedEntity() != null) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -98,6 +98,7 @@ public class DefaultEventService implements EventService {
     }
 
     Event result = new Event();
+    result.setId(event.getId());
     result.setUid(event.getUid());
 
     result.setStatus(event.getStatus());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -81,15 +81,15 @@ public class DefaultRelationshipService implements RelationshipService {
     }
 
     if (queryParams.getEntity() instanceof TrackedEntity te) {
-      return getRelationshipsByTrackedEntity(te, params.getPagingAndSortingCriteriaAdapter());
+      return getRelationshipsByTrackedEntity(te, queryParams);
     }
 
     if (queryParams.getEntity() instanceof Enrollment en) {
-      return getRelationshipsByEnrollment(en, params.getPagingAndSortingCriteriaAdapter());
+      return getRelationshipsByEnrollment(en, queryParams);
     }
 
     if (queryParams.getEntity() instanceof Event ev) {
-      return getRelationshipsByEvent(ev, params.getPagingAndSortingCriteriaAdapter());
+      return getRelationshipsByEvent(ev, queryParams);
     }
 
     throw new IllegalArgumentException("Unkown type");

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParams.java
@@ -32,6 +32,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.hisp.dhis.tracker.TrackerType;
+import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
 
 @Getter
 @Builder(toBuilder = true)
@@ -42,33 +43,9 @@ public class RelationshipOperationParams {
 
   public static final int DEFAULT_PAGE_SIZE = 50;
 
-  private Integer page;
-
-  private Integer pageSize;
-
-  private boolean totalPages;
-
-  private boolean skipPaging;
-
   private TrackerType type;
 
   private String identifier;
 
-  public boolean isPaging() {
-    return page != null || pageSize != null;
-  }
-
-  public int getPageWithDefault() {
-    return page != null && page > 0 ? page : DEFAULT_PAGE;
-  }
-
-  public int getPageSizeWithDefault() {
-    return pageSize != null && pageSize >= 0 ? pageSize : DEFAULT_PAGE_SIZE;
-  }
-
-  public void setDefaultPaging() {
-    this.page = DEFAULT_PAGE;
-    this.pageSize = DEFAULT_PAGE_SIZE;
-    this.skipPaging = false;
-  }
+  private PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParams.java
@@ -32,7 +32,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.hisp.dhis.tracker.TrackerType;
-import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
 
 @Getter
 @Builder(toBuilder = true)
@@ -47,5 +46,11 @@ public class RelationshipOperationParams {
 
   private String identifier;
 
-  private PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter;
+  private Integer page;
+
+  private Integer pageSize;
+
+  private boolean totalPages;
+
+  private boolean skipPaging;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapper.java
@@ -76,7 +76,7 @@ class RelationshipOperationParamsMapper {
   private TrackedEntity validateTrackedEntity(String uid) throws NotFoundException {
     TrackedEntity trackedEntity = trackedEntityService.getTrackedEntity(uid);
     if (trackedEntity == null) {
-      throw new NotFoundException("Tracked entity is specified but does not exist: " + uid);
+      throw new NotFoundException(TrackedEntity.class, uid);
     }
 
     return trackedEntity;
@@ -85,7 +85,7 @@ class RelationshipOperationParamsMapper {
   private Enrollment validateEnrollment(String uid) throws NotFoundException {
     Enrollment enrollment = enrollmentService.getEnrollment(uid);
     if (enrollment == null) {
-      throw new NotFoundException("Enrollment is specified but does not exist: " + uid);
+      throw new NotFoundException(Enrollment.class, uid);
     }
 
     return enrollment;
@@ -94,7 +94,7 @@ class RelationshipOperationParamsMapper {
   private Event validateEvent(String uid) throws NotFoundException {
     Event event = eventService.getEvent(uid);
     if (event == null) {
-      throw new NotFoundException("Event is specified but does not exist: " + uid);
+      throw new NotFoundException(Event.class, uid);
     }
 
     return event;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapper.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.relationship;
+
+import static org.hisp.dhis.tracker.export.relationship.RelationshipQueryParams.EMPTY;
+
+import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.feedback.NotFoundException;
+import org.hisp.dhis.tracker.export.enrollment.EnrollmentParams;
+import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
+import org.hisp.dhis.tracker.export.event.EventParams;
+import org.hisp.dhis.tracker.export.event.EventService;
+import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityParams;
+import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityService;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Maps {@link RelationshipOperationParams} to {@link RelationshipQueryParams} which is used to
+ * fetch enrollments from the DB.
+ */
+@Component
+@RequiredArgsConstructor
+class RelationshipOperationParamsMapper {
+
+  private final TrackedEntityService trackedEntityService;
+
+  private final EnrollmentService enrollmentService;
+
+  private final EventService eventService;
+
+  @Transactional(readOnly = true)
+  public RelationshipQueryParams map(RelationshipOperationParams params) throws NotFoundException {
+    try {
+      return new RelationshipQueryParams(
+          switch (params.getType()) {
+            case TRACKED_ENTITY -> trackedEntityService.getTrackedEntity(
+                params.getIdentifier(), TrackedEntityParams.TRUE, true);
+            case ENROLLMENT -> enrollmentService.getEnrollment(
+                params.getIdentifier(), EnrollmentParams.TRUE, true);
+            case EVENT -> eventService.getEvent(params.getIdentifier(), EventParams.TRUE);
+            case RELATIONSHIP -> null;
+          });
+    } catch (ForbiddenException ex) {
+      return EMPTY;
+    }
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipQueryParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2023, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,33 +25,17 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker.export.trackedentity;
+package org.hisp.dhis.tracker.export.relationship;
 
-import org.hisp.dhis.feedback.BadRequestException;
-import org.hisp.dhis.feedback.ForbiddenException;
-import org.hisp.dhis.feedback.NotFoundException;
-import org.hisp.dhis.trackedentity.TrackedEntity;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.common.IdentifiableObject;
 
-public interface TrackedEntityService {
+@RequiredArgsConstructor
+@Getter
+public class RelationshipQueryParams {
 
-  TrackedEntity getTrackedEntity(String uid, TrackedEntityParams params, boolean includeDeleted)
-      throws NotFoundException, ForbiddenException;
+  public static final RelationshipQueryParams EMPTY = new RelationshipQueryParams(null);
 
-  TrackedEntity getTrackedEntity(
-      TrackedEntity trackedEntity, TrackedEntityParams params, boolean includeDeleted)
-      throws ForbiddenException;
-
-  TrackedEntity getTrackedEntity(
-      String uid, String programIdentifier, TrackedEntityParams params, boolean includeDeleted)
-      throws NotFoundException, ForbiddenException;
-
-  /**
-   * Fetches {@see TrackedEntity}s based on the specified parameters.
-   *
-   * @param operationParams a {@see TrackedEntityOperationParams} instance with the operation
-   *     parameters
-   * @return {@see TrackedEntity}s
-   */
-  TrackedEntities getTrackedEntities(TrackedEntityOperationParams operationParams)
-      throws ForbiddenException, NotFoundException, BadRequestException;
+  private final IdentifiableObject entity;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipQueryParams.java
@@ -27,15 +27,23 @@
  */
 package org.hisp.dhis.tracker.export.relationship;
 
+import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
 
-@RequiredArgsConstructor
-@Getter
-public class RelationshipQueryParams {
+@Builder
+public class RelationshipQueryParams extends PagingAndSortingCriteriaAdapter {
 
-  public static final RelationshipQueryParams EMPTY = new RelationshipQueryParams(null);
+  public static final RelationshipQueryParams EMPTY = RelationshipQueryParams.builder().build();
 
-  private final IdentifiableObject entity;
+  @Getter private final IdentifiableObject entity;
+
+  private Integer page;
+
+  private Integer pageSize;
+
+  private boolean totalPages;
+
+  private boolean skipPaging;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
@@ -38,6 +38,13 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
 
 public interface RelationshipService {
+
+  List<Relationship> getRelationships(RelationshipOperationParams params)
+      throws ForbiddenException, NotFoundException;
+
+  int countRelationships(RelationshipOperationParams params)
+      throws ForbiddenException, NotFoundException;
+
   Relationship getRelationship(String id) throws ForbiddenException, NotFoundException;
 
   Optional<Relationship> findRelationshipByUid(String id)

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -185,6 +185,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
     }
 
     TrackedEntity result = new TrackedEntity();
+    result.setId(trackedEntity.getId());
     result.setUid(trackedEntity.getUid());
     result.setOrganisationUnit(trackedEntity.getOrganisationUnit());
     result.setTrackedEntityType(trackedEntity.getTrackedEntityType());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapperTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.relationship;
+
+import static org.hisp.dhis.tracker.TrackerType.ENROLLMENT;
+import static org.hisp.dhis.tracker.TrackerType.EVENT;
+import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import org.hisp.dhis.DhisConvenienceTest;
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.feedback.NotFoundException;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.tracker.export.enrollment.EnrollmentParams;
+import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
+import org.hisp.dhis.tracker.export.event.EventParams;
+import org.hisp.dhis.tracker.export.event.EventService;
+import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityParams;
+import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+// @MockitoSettings(strictness = Strictness.LENIENT) // common setup
+@ExtendWith(MockitoExtension.class)
+class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
+
+  private static final String TE_UID = "OBzmpRP6YUh";
+
+  private static final String EN_UID = "KSd4PejqBf9";
+
+  private static final String EV_UID = "TvjwTPToKHO";
+
+  @Mock private TrackedEntityService trackedEntityService;
+
+  @Mock private EnrollmentService enrollmentService;
+
+  @Mock private EventService eventService;
+
+  @InjectMocks private RelationshipOperationParamsMapper mapper;
+
+  private TrackedEntity trackedEntity;
+
+  private Enrollment enrollment;
+
+  private Event event;
+
+  @BeforeEach
+  public void setUp() {
+    OrganisationUnit organisationUnit = createOrganisationUnit('A');
+    Program program = createProgram('A');
+    ProgramStage programStage = createProgramStage('A', program);
+
+    trackedEntity = createTrackedEntity(organisationUnit);
+    trackedEntity.setUid(TE_UID);
+    enrollment = createEnrollment(program, trackedEntity, organisationUnit);
+    enrollment.setUid(EN_UID);
+    event = createEvent(programStage, enrollment, organisationUnit);
+    event.setUid(EV_UID);
+  }
+
+  @Test
+  void shouldMapTrackedEntityWhenATrackedEntityIsPassed()
+      throws NotFoundException, ForbiddenException {
+    when(trackedEntityService.getTrackedEntity(TE_UID, TrackedEntityParams.TRUE, true))
+        .thenReturn(trackedEntity);
+    RelationshipOperationParams params =
+        RelationshipOperationParams.builder().type(TRACKED_ENTITY).identifier(TE_UID).build();
+
+    RelationshipQueryParams queryParams = mapper.map(params);
+
+    assertInstanceOf(TrackedEntity.class, queryParams.getEntity());
+    assertEquals(TE_UID, queryParams.getEntity().getUid());
+  }
+
+  @Test
+  void shouldThrowNotFoundExceptionWhenTrackedEntityIsNotFound()
+      throws NotFoundException, ForbiddenException {
+    when(trackedEntityService.getTrackedEntity(TE_UID, TrackedEntityParams.TRUE, true))
+        .thenThrow(new NotFoundException(TrackedEntity.class, TE_UID));
+    RelationshipOperationParams params =
+        RelationshipOperationParams.builder().type(TRACKED_ENTITY).identifier(TE_UID).build();
+
+    assertThrows(NotFoundException.class, () -> mapper.map(params));
+  }
+
+  @Test
+  void shouldMapToNullWhenUserHasNoAccessToTrackedEntity()
+      throws NotFoundException, ForbiddenException {
+    when(trackedEntityService.getTrackedEntity(TE_UID, TrackedEntityParams.TRUE, true))
+        .thenThrow(new ForbiddenException("User has no access"));
+    RelationshipOperationParams params =
+        RelationshipOperationParams.builder().type(TRACKED_ENTITY).identifier(TE_UID).build();
+
+    RelationshipQueryParams queryParams = mapper.map(params);
+
+    assertNull(queryParams.getEntity());
+  }
+
+  @Test
+  void shouldMapEnrollmentWhenAEnrollmentIsPassed() throws NotFoundException, ForbiddenException {
+    when(enrollmentService.getEnrollment(EN_UID, EnrollmentParams.TRUE, true))
+        .thenReturn(enrollment);
+    RelationshipOperationParams params =
+        RelationshipOperationParams.builder().type(ENROLLMENT).identifier(EN_UID).build();
+
+    RelationshipQueryParams queryParams = mapper.map(params);
+
+    assertInstanceOf(Enrollment.class, queryParams.getEntity());
+    assertEquals(EN_UID, queryParams.getEntity().getUid());
+  }
+
+  @Test
+  void shouldThrowNotFoundExceptionWhenEnrollmentIsNotFound()
+      throws NotFoundException, ForbiddenException {
+    when(enrollmentService.getEnrollment(EN_UID, EnrollmentParams.TRUE, true))
+        .thenThrow(new NotFoundException(Enrollment.class, EN_UID));
+    RelationshipOperationParams params =
+        RelationshipOperationParams.builder().type(ENROLLMENT).identifier(EN_UID).build();
+
+    assertThrows(NotFoundException.class, () -> mapper.map(params));
+  }
+
+  @Test
+  void shouldMapToNullWhenUserHasNoAccessToEnrollment()
+      throws NotFoundException, ForbiddenException {
+    when(enrollmentService.getEnrollment(EN_UID, EnrollmentParams.TRUE, true))
+        .thenThrow(new ForbiddenException("User has no access"));
+    RelationshipOperationParams params =
+        RelationshipOperationParams.builder().type(ENROLLMENT).identifier(EN_UID).build();
+
+    RelationshipQueryParams queryParams = mapper.map(params);
+
+    assertNull(queryParams.getEntity());
+  }
+
+  @Test
+  void shouldMapEventWhenAEventIsPassed() throws NotFoundException, ForbiddenException {
+    when(eventService.getEvent(EV_UID, EventParams.TRUE)).thenReturn(event);
+    RelationshipOperationParams params =
+        RelationshipOperationParams.builder().type(EVENT).identifier(EV_UID).build();
+
+    RelationshipQueryParams queryParams = mapper.map(params);
+
+    assertInstanceOf(Event.class, queryParams.getEntity());
+    assertEquals(EV_UID, queryParams.getEntity().getUid());
+  }
+
+  @Test
+  void shouldThrowNotFoundExceptionWhenEventIsNotFound()
+      throws NotFoundException, ForbiddenException {
+    when(eventService.getEvent(EV_UID, EventParams.TRUE))
+        .thenThrow(new NotFoundException(Event.class, EV_UID));
+    RelationshipOperationParams params =
+        RelationshipOperationParams.builder().type(EVENT).identifier(EV_UID).build();
+
+    assertThrows(NotFoundException.class, () -> mapper.map(params));
+  }
+
+  @Test
+  void shouldMapToNullWhenUserHasNoAccessToEvent() throws NotFoundException, ForbiddenException {
+    when(eventService.getEvent(EV_UID, EventParams.TRUE))
+        .thenThrow(new ForbiddenException("User has no access"));
+    RelationshipOperationParams params =
+        RelationshipOperationParams.builder().type(EVENT).identifier(EV_UID).build();
+
+    RelationshipQueryParams queryParams = mapper.map(params);
+
+    assertNull(queryParams.getEntity());
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapperTest.java
@@ -32,25 +32,20 @@ import static org.hisp.dhis.tracker.TrackerType.EVENT;
 import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import org.hisp.dhis.DhisConvenienceTest;
-import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.trackedentity.TrackedEntity;
-import org.hisp.dhis.tracker.export.enrollment.EnrollmentParams;
-import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
-import org.hisp.dhis.tracker.export.event.EventParams;
-import org.hisp.dhis.tracker.export.event.EventService;
-import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityParams;
-import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityService;
+import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -58,7 +53,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-// @MockitoSettings(strictness = Strictness.LENIENT) // common setup
 @ExtendWith(MockitoExtension.class)
 class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
 
@@ -97,10 +91,8 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldMapTrackedEntityWhenATrackedEntityIsPassed()
-      throws NotFoundException, ForbiddenException {
-    when(trackedEntityService.getTrackedEntity(TE_UID, TrackedEntityParams.TRUE, true))
-        .thenReturn(trackedEntity);
+  void shouldMapTrackedEntityWhenATrackedEntityIsPassed() throws NotFoundException {
+    when(trackedEntityService.getTrackedEntity(TE_UID)).thenReturn(trackedEntity);
     RelationshipOperationParams params =
         RelationshipOperationParams.builder().type(TRACKED_ENTITY).identifier(TE_UID).build();
 
@@ -111,10 +103,8 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldThrowNotFoundExceptionWhenTrackedEntityIsNotFound()
-      throws NotFoundException, ForbiddenException {
-    when(trackedEntityService.getTrackedEntity(TE_UID, TrackedEntityParams.TRUE, true))
-        .thenThrow(new NotFoundException(TrackedEntity.class, TE_UID));
+  void shouldThrowNotFoundExceptionWhenTrackedEntityIsNotFound() {
+    when(trackedEntityService.getTrackedEntity(TE_UID)).thenReturn(null);
     RelationshipOperationParams params =
         RelationshipOperationParams.builder().type(TRACKED_ENTITY).identifier(TE_UID).build();
 
@@ -122,22 +112,8 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldMapToNullWhenUserHasNoAccessToTrackedEntity()
-      throws NotFoundException, ForbiddenException {
-    when(trackedEntityService.getTrackedEntity(TE_UID, TrackedEntityParams.TRUE, true))
-        .thenThrow(new ForbiddenException("User has no access"));
-    RelationshipOperationParams params =
-        RelationshipOperationParams.builder().type(TRACKED_ENTITY).identifier(TE_UID).build();
-
-    RelationshipQueryParams queryParams = mapper.map(params);
-
-    assertNull(queryParams.getEntity());
-  }
-
-  @Test
-  void shouldMapEnrollmentWhenAEnrollmentIsPassed() throws NotFoundException, ForbiddenException {
-    when(enrollmentService.getEnrollment(EN_UID, EnrollmentParams.TRUE, true))
-        .thenReturn(enrollment);
+  void shouldMapEnrollmentWhenAEnrollmentIsPassed() throws NotFoundException {
+    when(enrollmentService.getEnrollment(EN_UID)).thenReturn(enrollment);
     RelationshipOperationParams params =
         RelationshipOperationParams.builder().type(ENROLLMENT).identifier(EN_UID).build();
 
@@ -148,10 +124,8 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldThrowNotFoundExceptionWhenEnrollmentIsNotFound()
-      throws NotFoundException, ForbiddenException {
-    when(enrollmentService.getEnrollment(EN_UID, EnrollmentParams.TRUE, true))
-        .thenThrow(new NotFoundException(Enrollment.class, EN_UID));
+  void shouldThrowNotFoundExceptionWhenEnrollmentIsNotFound() {
+    when(enrollmentService.getEnrollment(EN_UID)).thenReturn(null);
     RelationshipOperationParams params =
         RelationshipOperationParams.builder().type(ENROLLMENT).identifier(EN_UID).build();
 
@@ -159,21 +133,8 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldMapToNullWhenUserHasNoAccessToEnrollment()
-      throws NotFoundException, ForbiddenException {
-    when(enrollmentService.getEnrollment(EN_UID, EnrollmentParams.TRUE, true))
-        .thenThrow(new ForbiddenException("User has no access"));
-    RelationshipOperationParams params =
-        RelationshipOperationParams.builder().type(ENROLLMENT).identifier(EN_UID).build();
-
-    RelationshipQueryParams queryParams = mapper.map(params);
-
-    assertNull(queryParams.getEntity());
-  }
-
-  @Test
-  void shouldMapEventWhenAEventIsPassed() throws NotFoundException, ForbiddenException {
-    when(eventService.getEvent(EV_UID, EventParams.TRUE)).thenReturn(event);
+  void shouldMapEventWhenAEventIsPassed() throws NotFoundException {
+    when(eventService.getEvent(EV_UID)).thenReturn(event);
     RelationshipOperationParams params =
         RelationshipOperationParams.builder().type(EVENT).identifier(EV_UID).build();
 
@@ -184,25 +145,11 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldThrowNotFoundExceptionWhenEventIsNotFound()
-      throws NotFoundException, ForbiddenException {
-    when(eventService.getEvent(EV_UID, EventParams.TRUE))
-        .thenThrow(new NotFoundException(Event.class, EV_UID));
+  void shouldThrowNotFoundExceptionWhenEventIsNotFound() {
+    when(eventService.getEvent(EV_UID)).thenReturn(null);
     RelationshipOperationParams params =
         RelationshipOperationParams.builder().type(EVENT).identifier(EV_UID).build();
 
     assertThrows(NotFoundException.class, () -> mapper.map(params));
-  }
-
-  @Test
-  void shouldMapToNullWhenUserHasNoAccessToEvent() throws NotFoundException, ForbiddenException {
-    when(eventService.getEvent(EV_UID, EventParams.TRUE))
-        .thenThrow(new ForbiddenException("User has no access"));
-    RelationshipOperationParams params =
-        RelationshipOperationParams.builder().type(EVENT).identifier(EV_UID).build();
-
-    RelationshipQueryParams queryParams = mapper.map(params);
-
-    assertNull(queryParams.getEntity());
   }
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -1618,12 +1618,12 @@ public abstract class DhisConvenienceTest {
   }
 
   public static Enrollment createEnrollment(
-      Program program, TrackedEntity tei, OrganisationUnit organisationUnit) {
-    Enrollment enrollment = new Enrollment(program, tei, organisationUnit);
+      Program program, TrackedEntity te, OrganisationUnit organisationUnit) {
+    Enrollment enrollment = new Enrollment(program, te, organisationUnit);
     enrollment.setAutoFields();
 
     enrollment.setProgram(program);
-    enrollment.setTrackedEntity(tei);
+    enrollment.setTrackedEntity(te);
     enrollment.setOrganisationUnit(organisationUnit);
     enrollment.setEnrollmentDate(new Date());
     enrollment.setIncidentDate(new Date());

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -154,7 +154,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
     manager.save(trackedEntityTypeAttribute);
 
     trackedEntityType.setTrackedEntityTypeAttributes(List.of(trackedEntityTypeAttribute));
-    manager.save(trackedEntityType);
+    manager.save(trackedEntityType, false);
 
     dataElement = createDataElement('A');
     manager.save(dataElement, false);
@@ -326,7 +326,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
   @Test
   void getRelationshipsByEventNotFound() {
     assertStartsWith(
-        "event with id Hq3Kc6HK4OZ",
+        "Event with id Hq3Kc6HK4OZ",
         GET("/tracker/relationships?event=Hq3Kc6HK4OZ").error(HttpStatus.NOT_FOUND).getMessage());
   }
 
@@ -424,7 +424,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
   @Test
   void getRelationshipsByEnrollmentNotFound() {
     assertStartsWith(
-        "enrollment with id Hq3Kc6HK4OZ",
+        "Enrollment with id Hq3Kc6HK4OZ",
         GET("/tracker/relationships?enrollment=Hq3Kc6HK4OZ")
             .error(HttpStatus.NOT_FOUND)
             .getMessage());
@@ -549,6 +549,23 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
   }
 
   @Test
+  void shouldRetrieveRelationshipWhenUserHasAccessToRelationship() {
+    TrackedEntity from = trackedEntity();
+    TrackedEntity to = trackedEntity();
+    Relationship r = relationship(from, to);
+
+    JsonList<JsonRelationship> relationships =
+        GET("/tracker/relationships?trackedEntity={tei}", from.getUid())
+            .content(HttpStatus.OK)
+            .getList("instances", JsonRelationship.class);
+
+    JsonObject relationship = assertFirstRelationship(r, relationships);
+    assertHasOnlyMembers(relationship, "relationship", "relationshipType", "from", "to");
+    assertHasOnlyUid(from.getUid(), "trackedEntity", relationship.getObject("from"));
+    assertHasOnlyUid(to.getUid(), "trackedEntity", relationship.getObject("to"));
+  }
+
+  @Test
   void getRelationshipsByTrackedEntityRelationshipsNoAccessToRelationshipType() {
     TrackedEntity from = trackedEntity();
     TrackedEntity to = trackedEntity();
@@ -607,7 +624,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
   @Test
   void getRelationshipsByTrackedEntityNotFound() {
     assertStartsWith(
-        "trackedEntity with id Hq3Kc6HK4OZ",
+        "TrackedEntity with id Hq3Kc6HK4OZ",
         GET("/tracker/relationships?trackedEntity=Hq3Kc6HK4OZ")
             .error(HttpStatus.NOT_FOUND)
             .getMessage());

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipRequestParamsMapper.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.relationship;
 
+import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
 import static org.hisp.dhis.tracker.TrackerType.ENROLLMENT;
 import static org.hisp.dhis.tracker.TrackerType.EVENT;
 import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
@@ -75,7 +76,10 @@ class RelationshipRequestParamsMapper {
             ObjectUtils.firstNonNull(
                     trackedEntity, requestParams.getEnrollment(), requestParams.getEvent())
                 .getValue())
-        .pagingAndSortingCriteriaAdapter(requestParams)
+        .page(requestParams.getPage())
+        .pageSize(requestParams.getPageSize())
+        .totalPages(requestParams.isTotalPages())
+        .skipPaging(toBooleanDefaultIfNull(requestParams.isSkipPaging(), false))
         .build();
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipRequestParamsMapper.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.relationship;
 
-import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
 import static org.hisp.dhis.tracker.TrackerType.ENROLLMENT;
 import static org.hisp.dhis.tracker.TrackerType.EVENT;
 import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
@@ -76,10 +75,7 @@ class RelationshipRequestParamsMapper {
             ObjectUtils.firstNonNull(
                     trackedEntity, requestParams.getEnrollment(), requestParams.getEvent())
                 .getValue())
-        .page(requestParams.getPage())
-        .pageSize(requestParams.getPageSize())
-        .totalPages(requestParams.isTotalPages())
-        .skipPaging(toBooleanDefaultIfNull(requestParams.isSkipPaging(), false))
+        .pagingAndSortingCriteriaAdapter(requestParams)
         .build();
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
@@ -28,20 +28,12 @@
 package org.hisp.dhis.webapi.controller.tracker.export.relationship;
 
 import static org.hisp.dhis.common.OpenApi.Response.Status;
-import static org.hisp.dhis.tracker.TrackerType.ENROLLMENT;
-import static org.hisp.dhis.tracker.TrackerType.EVENT;
-import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
 import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.RESOURCE_PATH;
 import static org.hisp.dhis.webapi.controller.tracker.export.relationship.RequestParams.DEFAULT_FIELDS_PARAM;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.ImmutableMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Function;
-import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
@@ -51,17 +43,12 @@ import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
-import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentService;
-import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.export.relationship.RelationshipOperationParams;
 import org.hisp.dhis.tracker.export.relationship.RelationshipService;
 import org.hisp.dhis.webapi.common.UID;
-import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
 import org.hisp.dhis.webapi.controller.tracker.export.OpenApiExport;
 import org.hisp.dhis.webapi.controller.tracker.view.Relationship;
@@ -101,79 +88,21 @@ class RelationshipsExportController {
 
   private final FieldFilterService fieldFilterService;
 
-  private Map<TrackerType, Function<String, ?>> objectRetrievers;
-
-  private Map<
-          TrackerType,
-          CheckedBiFunction<
-              Object,
-              PagingAndSortingCriteriaAdapter,
-              List<org.hisp.dhis.relationship.Relationship>>>
-      relationshipRetrievers;
-
-  @PostConstruct
-  void setupMaps() {
-    objectRetrievers =
-        ImmutableMap.<TrackerType, Function<String, ?>>builder()
-            .put(TRACKED_ENTITY, trackedEntityService::getTrackedEntity)
-            .put(ENROLLMENT, enrollmentService::getEnrollment)
-            .put(EVENT, eventService::getEvent)
-            .build();
-
-    relationshipRetrievers =
-        ImmutableMap
-            .<TrackerType,
-                CheckedBiFunction<
-                    Object,
-                    PagingAndSortingCriteriaAdapter,
-                    List<org.hisp.dhis.relationship.Relationship>>>
-                builder()
-            .put(TRACKED_ENTITY, getRelationshipsByTrackedEntity())
-            .put(ENROLLMENT, getRelationshipsByEnrollment())
-            .put(EVENT, getRelationshipsByEvent())
-            .build();
-  }
-
-  private CheckedBiFunction<
-          Object, PagingAndSortingCriteriaAdapter, List<org.hisp.dhis.relationship.Relationship>>
-      getRelationshipsByTrackedEntity() {
-    return (o, criteria) ->
-        relationshipService.getRelationshipsByTrackedEntity((TrackedEntity) o, criteria);
-  }
-
-  private CheckedBiFunction<
-          Object, PagingAndSortingCriteriaAdapter, List<org.hisp.dhis.relationship.Relationship>>
-      getRelationshipsByEnrollment() {
-    return (o, criteria) ->
-        relationshipService.getRelationshipsByEnrollment((Enrollment) o, criteria);
-  }
-
-  private CheckedBiFunction<
-          Object, PagingAndSortingCriteriaAdapter, List<org.hisp.dhis.relationship.Relationship>>
-      getRelationshipsByEvent() {
-    return (o, criteria) -> relationshipService.getRelationshipsByEvent((Event) o, criteria);
-  }
-
   @OpenApi.Response(status = Status.OK, value = OpenApiExport.ListResponse.class)
   @GetMapping
   PagingWrapper<ObjectNode> getRelationships(RequestParams requestParams)
       throws NotFoundException, BadRequestException, ForbiddenException {
 
     RelationshipOperationParams operationParams = mapper.map(requestParams);
-
-    List<org.hisp.dhis.webapi.controller.tracker.view.Relationship> relationships =
-        tryGetRelationshipFrom(
-            operationParams.getType(), operationParams.getIdentifier(), requestParams);
+    List<org.hisp.dhis.relationship.Relationship> relationships =
+        relationshipService.getRelationships(operationParams);
 
     PagingWrapper<ObjectNode> pagingWrapper = new PagingWrapper<>();
     if (requestParams.isPagingRequest()) {
       long count = 0L;
 
       if (requestParams.isTotalPages()) {
-        count =
-            tryGetRelationshipFrom(
-                    operationParams.getType(), operationParams.getIdentifier(), requestParams)
-                .size();
+        count = relationshipService.countRelationships(operationParams);
       }
 
       Pager pager =
@@ -184,7 +113,8 @@ class RelationshipsExportController {
     }
 
     List<ObjectNode> objectNodes =
-        fieldFilterService.toObjectNodes(relationships, requestParams.getFields());
+        fieldFilterService.toObjectNodes(
+            RELATIONSHIP_MAPPER.fromCollection(relationships), requestParams.getFields());
     return pagingWrapper.withInstances(objectNodes);
   }
 
@@ -198,41 +128,5 @@ class RelationshipsExportController {
         RELATIONSHIP_MAPPER.from(relationshipService.getRelationship(uid.getValue()));
 
     return ResponseEntity.ok(fieldFilterService.toObjectNode(relationship, fields));
-  }
-
-  private List<Relationship> tryGetRelationshipFrom(
-      TrackerType type, String identifier, PagingAndSortingCriteriaAdapter pagingAndSortingCriteria)
-      throws NotFoundException, ForbiddenException {
-    Object object = getObjectRetriever(type).apply(identifier);
-    if (object == null) {
-      throw new NotFoundException(
-          type.getName() + " with id " + identifier + " could not be found.");
-    }
-
-    return RELATIONSHIP_MAPPER.fromCollection(
-        getRelationshipRetriever(type).apply(object, pagingAndSortingCriteria));
-  }
-
-  private Function<String, ?> getObjectRetriever(TrackerType type) {
-    return Optional.ofNullable(type)
-        .map(objectRetrievers::get)
-        .orElseThrow(
-            () -> new IllegalArgumentException("Unable to detect object retriever from " + type));
-  }
-
-  private CheckedBiFunction<
-          Object, PagingAndSortingCriteriaAdapter, List<org.hisp.dhis.relationship.Relationship>>
-      getRelationshipRetriever(TrackerType type) {
-    return Optional.ofNullable(type)
-        .map(relationshipRetrievers::get)
-        .orElseThrow(
-            () ->
-                new IllegalArgumentException(
-                    "Unable to detect relationship retriever from " + type));
-  }
-
-  interface CheckedBiFunction<T, U, R> {
-
-    R apply(T t, U u) throws ForbiddenException, NotFoundException;
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RequestParams.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.webapi.controller.tracker.export.relationship;
 import java.util.List;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.fieldfiltering.FieldFilterParser;
 import org.hisp.dhis.fieldfiltering.FieldPath;
@@ -54,19 +53,15 @@ class RequestParams extends PagingAndSortingCriteriaAdapter {
    */
   @Deprecated(since = "2.41")
   @OpenApi.Property({UID.class, TrackedEntity.class})
-  @Setter
   private UID tei;
 
   @OpenApi.Property({UID.class, TrackedEntity.class})
-  @Setter
   private UID trackedEntity;
 
   @OpenApi.Property({UID.class, Enrollment.class})
-  @Setter
   private UID enrollment;
 
   @OpenApi.Property({UID.class, Event.class})
-  @Setter
   private UID event;
 
   @OpenApi.Property(value = String[].class)


### PR DESCRIPTION
Continuing from https://github.com/dhis2/dhis2-core/pull/14629

In this PR we moved all the service logic that was present in the Controller into the service. In the process we removed the direct dependency on `dhis-service-core` services and we are instead using `dhis-service-tracker` services.
This added ACL capabilities and it lead to set the `id` for entities in order to continue to use correctly `RelationshipStore` methods.

**What it is in this PR**
- Implement `getRelationships` method in `RelationshipService`
- Map `RelationshipOperationParams` to `RelationshipQueryParams` and validate input

**What it is NOT in this PR**
- Any kind of ACL fixes. The code was moved in order to maintain the logic of permissions as it was before.
- Any change to the repository layer.

**What is next**
- Harmonize nested relationships and nested entities between exporters