### PR TITLE
fix: event with multiple notes returned multiple times by /tracker/events DHIS2-15603 [2.40]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -373,6 +373,7 @@ public class JdbcEventStore implements EventStore {
 
     setAccessiblePrograms(user, params);
 
+    Map<String, Event> eventsByUid = new HashMap<>(params.getPageSizeWithDefault());
     List<Event> events = new ArrayList<>();
     List<Long> relationshipIds = new ArrayList<>();
 
@@ -399,90 +400,106 @@ public class JdbcEventStore implements EventStore {
 
             validateIdentifiersPresence(resultSet, params.getIdSchemes(), true);
 
-            Event event = new Event();
+            Event event;
+            if (eventsByUid.containsKey(psiUid)) {
+              event = eventsByUid.get(psiUid);
+            } else {
+              event = new Event();
+              eventsByUid.put(psiUid, event);
 
-            if (!params.isSkipEventId()) {
-              event.setUid(psiUid);
-              event.setEvent(psiUid);
-            }
-
-            event.setTrackedEntityInstance(resultSet.getString("tei_uid"));
-            event.setStatus(EventStatus.valueOf(resultSet.getString(PSI_STATUS)));
-
-            ProgramType programType = ProgramType.fromValue(resultSet.getString("p_type"));
-
-            event.setProgram(resultSet.getString("p_identifier"));
-            event.setProgramType(programType);
-            event.setProgramStage(resultSet.getString("ps_identifier"));
-            event.setOrgUnit(resultSet.getString("ou_uid"));
-            event.setDeleted(resultSet.getBoolean("psi_deleted"));
-
-            if (programType != ProgramType.WITHOUT_REGISTRATION) {
-              event.setEnrollment(resultSet.getString("pi_uid"));
-              event.setEnrollmentStatus(
-                  EnrollmentStatus.fromProgramStatus(
-                      ProgramStatus.valueOf(resultSet.getString("pi_status"))));
-              event.setFollowup(resultSet.getBoolean("pi_followup"));
-            }
-
-            event.setAttributeOptionCombo(resultSet.getString("coc_identifier"));
-            event.setAttributeCategoryOptions(resultSet.getString("co_uids"));
-            event.setOptionSize(resultSet.getInt("option_size"));
-
-            event.setTrackedEntityInstance(resultSet.getString("tei_uid"));
-
-            event.setStoredBy(resultSet.getString("psi_storedby"));
-            event.setOrgUnitName(resultSet.getString("ou_name"));
-            event.setDueDate(DateUtils.getIso8601NoTz(resultSet.getDate("psi_duedate")));
-            event.setEventDate(DateUtils.getIso8601NoTz(resultSet.getDate("psi_executiondate")));
-            event.setCreated(DateUtils.getIso8601NoTz(resultSet.getDate("psi_created")));
-            event.setCreatedByUserInfo(
-                jsonToUserInfo(resultSet.getString("psi_createdbyuserinfo"), jsonMapper));
-            event.setLastUpdated(DateUtils.getIso8601NoTz(resultSet.getDate("psi_lastupdated")));
-            event.setLastUpdatedByUserInfo(
-                jsonToUserInfo(resultSet.getString("psi_lastupdatedbyuserinfo"), jsonMapper));
-
-            event.setCompletedBy(resultSet.getString("psi_completedby"));
-            event.setCompletedDate(
-                DateUtils.getIso8601NoTz(resultSet.getDate("psi_completeddate")));
-
-            if (resultSet.getObject("psi_geometry") != null) {
-              try {
-                Geometry geom = new WKTReader().read(resultSet.getString("psi_geometry"));
-
-                event.setGeometry(geom);
-              } catch (ParseException e) {
-                log.error("Unable to read geometry for event '" + event.getUid() + "': ", e);
+              if (!params.isSkipEventId()) {
+                event.setUid(psiUid);
+                event.setEvent(psiUid);
               }
-            }
 
-            if (resultSet.getObject("user_assigned") != null) {
-              event.setAssignedUser(resultSet.getString("user_assigned"));
-              event.setAssignedUserUsername(resultSet.getString("user_assigned_username"));
-              event.setAssignedUserDisplayName(resultSet.getString("user_assigned_name"));
-              event.setAssignedUserFirstName(resultSet.getString("user_assigned_first_name"));
-              event.setAssignedUserSurname(resultSet.getString("user_assigned_surname"));
-            }
+              event.setTrackedEntityInstance(resultSet.getString("tei_uid"));
+              event.setStatus(EventStatus.valueOf(resultSet.getString(PSI_STATUS)));
 
-            events.add(event);
+              ProgramType programType = ProgramType.fromValue(resultSet.getString("p_type"));
 
-            if (!StringUtils.isEmpty(resultSet.getString("psi_eventdatavalues"))) {
-              Set<EventDataValue> eventDataValues =
-                  convertEventDataValueJsonIntoSet(resultSet.getString("psi_eventdatavalues"));
+              event.setProgram(resultSet.getString("p_identifier"));
+              event.setProgramType(programType);
+              event.setProgramStage(resultSet.getString("ps_identifier"));
+              event.setOrgUnit(resultSet.getString("ou_uid"));
+              event.setDeleted(resultSet.getBoolean("psi_deleted"));
 
-              for (EventDataValue dv : eventDataValues) {
-                DataValue dataValue = convertEventDataValueIntoDtoDataValue(dv);
+              if (programType != ProgramType.WITHOUT_REGISTRATION) {
+                event.setEnrollment(resultSet.getString("pi_uid"));
+                event.setEnrollmentStatus(
+                    EnrollmentStatus.fromProgramStatus(
+                        ProgramStatus.valueOf(resultSet.getString("pi_status"))));
+                event.setFollowup(resultSet.getBoolean("pi_followup"));
+              }
 
-                if (params.isSynchronizationQuery()) {
-                  dataValue.setSkipSynchronization(
-                      psdesWithSkipSyncTrue.containsKey(resultSet.getString("ps_uid"))
-                          && psdesWithSkipSyncTrue
-                              .get(resultSet.getString("ps_uid"))
-                              .contains(dv.getDataElement()));
+              event.setAttributeOptionCombo(resultSet.getString("coc_identifier"));
+              event.setAttributeCategoryOptions(resultSet.getString("co_uids"));
+              event.setOptionSize(resultSet.getInt("option_size"));
+
+              event.setTrackedEntityInstance(resultSet.getString("tei_uid"));
+
+              event.setStoredBy(resultSet.getString("psi_storedby"));
+              event.setOrgUnitName(resultSet.getString("ou_name"));
+              event.setDueDate(DateUtils.getIso8601NoTz(resultSet.getDate("psi_duedate")));
+              event.setEventDate(DateUtils.getIso8601NoTz(resultSet.getDate("psi_executiondate")));
+              event.setCreated(DateUtils.getIso8601NoTz(resultSet.getDate("psi_created")));
+              event.setCreatedByUserInfo(
+                  jsonToUserInfo(resultSet.getString("psi_createdbyuserinfo"), jsonMapper));
+              event.setLastUpdated(DateUtils.getIso8601NoTz(resultSet.getDate("psi_lastupdated")));
+              event.setLastUpdatedByUserInfo(
+                  jsonToUserInfo(resultSet.getString("psi_lastupdatedbyuserinfo"), jsonMapper));
+
+              event.setCompletedBy(resultSet.getString("psi_completedby"));
+              event.setCompletedDate(
+                  DateUtils.getIso8601NoTz(resultSet.getDate("psi_completeddate")));
+
+              if (resultSet.getObject("psi_geometry") != null) {
+                try {
+                  Geometry geom = new WKTReader().read(resultSet.getString("psi_geometry"));
+
+                  event.setGeometry(geom);
+                } catch (ParseException e) {
+                  log.error("Unable to read geometry for event '" + event.getUid() + "': ", e);
                 }
-
-                event.getDataValues().add(dataValue);
               }
+
+              if (resultSet.getObject("user_assigned") != null) {
+                event.setAssignedUser(resultSet.getString("user_assigned"));
+                event.setAssignedUserUsername(resultSet.getString("user_assigned_username"));
+                event.setAssignedUserDisplayName(resultSet.getString("user_assigned_name"));
+                event.setAssignedUserFirstName(resultSet.getString("user_assigned_first_name"));
+                event.setAssignedUserSurname(resultSet.getString("user_assigned_surname"));
+              }
+
+              if (!StringUtils.isEmpty(resultSet.getString("psi_eventdatavalues"))) {
+                Set<EventDataValue> eventDataValues =
+                    convertEventDataValueJsonIntoSet(resultSet.getString("psi_eventdatavalues"));
+
+                for (EventDataValue dv : eventDataValues) {
+                  DataValue dataValue = convertEventDataValueIntoDtoDataValue(dv);
+
+                  if (params.isSynchronizationQuery()) {
+                    dataValue.setSkipSynchronization(
+                        psdesWithSkipSyncTrue.containsKey(resultSet.getString("ps_uid"))
+                            && psdesWithSkipSyncTrue
+                                .get(resultSet.getString("ps_uid"))
+                                .contains(dv.getDataElement()));
+                  }
+
+                  event.getDataValues().add(dataValue);
+                }
+              }
+
+              if (params.isIncludeRelationships() && resultSet.getObject("psi_rl") != null) {
+                PGobject pGobject = (PGobject) resultSet.getObject("psi_rl");
+
+                if (pGobject != null) {
+                  String value = pGobject.getValue();
+
+                  relationshipIds.addAll(Lists.newArrayList(gson.fromJson(value, Long[].class)));
+                }
+              }
+
+              events.add(event);
             }
 
             if (resultSet.getString("psinote_value") != null
@@ -509,16 +526,6 @@ public class JdbcEventStore implements EventStore {
 
               event.getNotes().add(note);
               notes.add(resultSet.getString("psinote_id"));
-            }
-
-            if (params.isIncludeRelationships() && resultSet.getObject("psi_rl") != null) {
-              PGobject pGobject = (PGobject) resultSet.getObject("psi_rl");
-
-              if (pGobject != null) {
-                String value = pGobject.getValue();
-
-                relationshipIds.addAll(Lists.newArrayList(gson.fromJson(value, Long[].class)));
-              }
             }
           }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -66,11 +66,14 @@ import org.hisp.dhis.dxf2.events.event.Event;
 import org.hisp.dhis.dxf2.events.event.EventSearchParams;
 import org.hisp.dhis.dxf2.events.event.EventService;
 import org.hisp.dhis.dxf2.events.event.Events;
+import org.hisp.dhis.dxf2.events.event.Note;
+import org.hisp.dhis.dxf2.events.trackedentity.Relationship;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.ProgramType;
+import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.user.User;
@@ -118,13 +121,15 @@ class EventExporterTest extends TrackerTest {
 
   private TrackedEntityInstance trackedEntityInstance;
 
+  private User importUser;
+
   @Override
   protected void initTest() throws IOException {
     setUpMetadata("tracker/simple_metadata.json");
-    User userA = userService.getUser("M5zQapPyTZI");
+    importUser = userService.getUser("M5zQapPyTZI");
     assertNoErrors(
         trackerImportService.importTracker(
-            fromJson("tracker/event_and_enrollment.json", userA.getUid())));
+            fromJson("tracker/event_and_enrollment.json", importUser.getUid())));
     orgUnit = get(OrganisationUnit.class, "h4w96yEMlzO");
     programStage = get(ProgramStage.class, "NpsdDv6kKSO");
     program = programStage.getProgram();
@@ -147,6 +152,74 @@ class EventExporterTest extends TrackerTest {
 
   private Stream<Arguments> getEventsFunctions() {
     return Stream.of(Arguments.of(eventsFunction), Arguments.of(eventsGridFunction));
+  }
+
+  @Test
+  void shouldReturnEventsWithRelationships() {
+    EventSearchParams params = new EventSearchParams();
+    params.setOrgUnit(orgUnit);
+    params.setEvents(Set.of("pTzf9KYMk72"));
+    params.setIncludeRelationships(true);
+
+    Events events = eventService.getEvents(params);
+
+    assertContainsOnly(List.of("pTzf9KYMk72"), eventUids(events));
+    List<String> relationships =
+        events.getEvents().get(0).getRelationships().stream()
+            .map(Relationship::getRelationship)
+            .collect(Collectors.toList());
+    assertContainsOnly(List.of("oLT07jKRu9e", "yZxjxJli9mO"), relationships);
+  }
+
+  @Test
+  void shouldReturnEventsWithNotes() {
+    EventSearchParams params = new EventSearchParams();
+    params.setOrgUnit(orgUnit);
+    params.setEvents(Set.of("pTzf9KYMk72"));
+    params.setIncludeRelationships(true);
+
+    Events events = eventService.getEvents(params);
+
+    assertContainsOnly(List.of("pTzf9KYMk72"), eventUids(events));
+    List<Note> notes = events.getEvents().get(0).getNotes();
+    assertContainsOnly(
+        List.of("SGuCABkhpgn", "DRKO4xUVrpr"),
+        notes.stream().map(Note::getNote).collect(Collectors.toList()));
+    assertAll(
+        () -> assertNote(importUser, "comment value", notes.get(0)),
+        () -> assertNote(importUser, "comment value", notes.get(1)));
+  }
+
+  @Test
+  void shouldReturnPaginatedEventsWithNotesGivenNonDefaultPageSize() {
+    EventSearchParams params = new EventSearchParams();
+    params.setOrgUnit(orgUnit);
+    params.setEvents(Set.of("pTzf9KYMk72", "D9PbzJY8bJM"));
+    params.addOrders(List.of(new OrderParam("occurredAt", SortDirection.DESC)));
+
+    params.setPage(1);
+    params.setPageSize(1);
+
+    Events firstPage = eventService.getEvents(params);
+
+    assertAll(
+        "first page",
+        () -> assertSlimPager(1, 1, false, firstPage),
+        () -> assertEquals(List.of("D9PbzJY8bJM"), eventUids(firstPage)));
+
+    params.setPage(2);
+
+    Events secondPage = eventService.getEvents(params);
+
+    assertAll(
+        "second (last) page",
+        () -> assertSlimPager(2, 1, true, secondPage),
+        () -> assertEquals(List.of("pTzf9KYMk72"), eventUids(secondPage)));
+
+    params.setPage(2);
+    params.setPageSize(3);
+
+    assertIsEmpty(getEvents(params));
   }
 
   @ParameterizedTest
@@ -434,7 +507,7 @@ class EventExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldReturnPublicEventsWithMultipleCategoryOptionsGivenNonDefaultPageSize() {
+  void shouldReturnPaginatedPublicEventsWithMultipleCategoryOptionsGivenNonDefaultPageSize() {
     OrganisationUnit orgUnit = get(OrganisationUnit.class, "DiszpKrYNg8");
     Program program = get(Program.class, "iS7eutanDry");
 
@@ -484,7 +557,8 @@ class EventExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldReturnEventsWithMultipleCategoryOptionsGivenNonDefaultPageSizeAndTotalPages() {
+  void
+      shouldReturnPaginatedEventsWithMultipleCategoryOptionsGivenNonDefaultPageSizeAndTotalPages() {
     OrganisationUnit orgUnit = get(OrganisationUnit.class, "DiszpKrYNg8");
     Program program = get(Program.class, "iS7eutanDry");
 
@@ -1053,12 +1127,52 @@ class EventExporterTest extends TrackerTest {
             new OrderParam("toUpdate000", SortDirection.ASC)));
     params.addOrders(params.getAttributeOrders());
 
+    Events events = eventService.getEvents(params);
+
+    assertEquals(List.of("D9PbzJY8bJM", "pTzf9KYMk72"), eventUids(events));
     List<String> trackedEntities =
-        eventService.getEvents(params).getEvents().stream()
+        events.getEvents().stream()
             .map(Event::getTrackedEntityInstance)
             .collect(Collectors.toList());
 
     assertEquals(List.of("dUE514NMOlo", "QS6w44flWAf"), trackedEntities);
+  }
+
+  @Test
+  void shouldOrderEventsByMultipleAttributesAndPaginateWhenGivenNonDefaultPageSize() {
+    EventSearchParams params = new EventSearchParams();
+    params.setOrgUnit(orgUnit);
+    params.addFilterAttributes(List.of(queryItem("toUpdate000"), queryItem("toDelete000")));
+    params.addAttributeOrders(
+        List.of(
+            new OrderParam("toDelete000", SortDirection.DESC),
+            new OrderParam("toUpdate000", SortDirection.ASC)));
+    params.addOrders(params.getAttributeOrders());
+
+    params.setPage(1);
+    params.setPageSize(1);
+
+    Events firstPage = eventService.getEvents(params);
+
+    assertAll(
+        "first page",
+        () -> assertSlimPager(1, 1, false, firstPage),
+        () -> assertEquals(List.of("D9PbzJY8bJM"), eventUids(firstPage)));
+
+    params.setPage(2);
+    params.setPageSize(1);
+
+    Events secondPage = eventService.getEvents(params);
+
+    assertAll(
+        "second (last) page",
+        () -> assertSlimPager(2, 1, true, secondPage),
+        () -> assertEquals(List.of("pTzf9KYMk72"), eventUids(secondPage)));
+
+    params.setPage(3);
+    params.setPageSize(3);
+
+    assertIsEmpty(getEvents(params));
   }
 
   @Test
@@ -1248,6 +1362,13 @@ class EventExporterTest extends TrackerTest {
     assertEquals(List.of("dUE514NMOlo", "QS6w44flWAf"), trackedEntities);
   }
 
+  private void assertNote(User expectedLastUpdatedBy, String expectedNote, Note actual) {
+    assertEquals(expectedNote, actual.getValue());
+    UserInfoSnapshot lastUpdatedBy = actual.getLastUpdatedBy();
+    assertEquals(expectedLastUpdatedBy.getUid(), lastUpdatedBy.getUid());
+    assertEquals(expectedLastUpdatedBy.getUsername(), lastUpdatedBy.getUsername());
+  }
+
   private DataElement dataElement(String uid) {
     return dataElementService.getDataElement(uid);
   }
@@ -1281,10 +1402,6 @@ class EventExporterTest extends TrackerTest {
     return t;
   }
 
-  private static List<String> eventUids(Events events) {
-    return events.getEvents().stream().map(Event::getEvent).collect(Collectors.toList());
-  }
-
   private static void assertSlimPager(int pageNumber, int pageSize, boolean isLast, Events events) {
     assertInstanceOf(
         SlimPager.class, events.getPager(), "SlimPager should be returned if totalPages=false");
@@ -1307,5 +1424,13 @@ class EventExporterTest extends TrackerTest {
         () -> assertEquals(pageNumber, pager.getPage(), "number of current page"),
         () -> assertEquals(pageSize, pager.getPageSize(), "page size"),
         () -> assertEquals(totalCount, pager.getTotal(), "total page count"));
+  }
+
+  private List<String> getEvents(EventSearchParams params) {
+    return eventUids(eventService.getEvents(params));
+  }
+
+  private static List<String> eventUids(Events events) {
+    return events.getEvents().stream().map(Event::getEvent).collect(Collectors.toList());
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
@@ -250,7 +250,20 @@
           "providedElsewhere": false
         }
       ],
-      "notes": []
+      "notes": [
+        {
+          "note": "SGuCABkhpgn",
+          "storedAt": "2019-01-28T12:10:38.108",
+          "value": "comment value",
+          "storedBy": "admin"
+        },
+        {
+          "note": "DRKO4xUVrpr",
+          "storedAt": "2019-01-28T12:10:38.108",
+          "value": "comment value",
+          "storedBy": "admin"
+        }
+      ]
     },
     {
       "event": "D9PbzJY8bJM",
@@ -271,12 +284,12 @@
       "relationships": [],
       "occurredAt": "2020-01-28T00:00:00.000",
       "executionDate": "2019-01-28T00:00:00.000",
-      "updatedAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
       "storedBy": "admin",
       "followup": false,
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
+      "updatedAt": "2019-01-28T00:00:00.000",
       "updatedAt": "2019-01-28T12:10:38.109",
       "attributeOptionCombo": {
         "idScheme": "UID",
@@ -695,6 +708,41 @@
       ]
     }
   ],
-  "relationships": [],
+  "relationships": [
+    {
+      "relationship": "oLT07jKRu9e",
+      "relationshipType": {
+        "idScheme": "UID",
+        "identifier": "TV9oB9LT3sh"
+      },
+      "createdAt": "2018-10-01T12:17:30.163",
+      "updatedAt": "2018-10-01T12:17:30.163",
+      "bidirectional": false,
+      "deleted": false,
+      "from": {
+        "trackedEntity": "QS6w44flWAf"
+      },
+      "to": {
+        "event": "pTzf9KYMk72"
+      }
+    },
+    {
+      "relationship": "yZxjxJli9mO",
+      "relationshipType": {
+        "idScheme": "UID",
+        "identifier": "TV9oB9LT3sh"
+      },
+      "createdAt": "2018-10-01T12:17:30.163",
+      "updatedAt": "2018-10-01T12:17:30.163",
+      "bidirectional": false,
+      "deleted": false,
+      "from": {
+        "trackedEntity": "dUE514NMOlo"
+      },
+      "to": {
+        "event": "pTzf9KYMk72"
+      }
+    }
+  ],
   "username": "system-process"
 }


### PR DESCRIPTION
backport portions of https://github.com/dhis2/dhis2-core/pull/14659
which fix https://dhis2.atlassian.net/browse/DHIS2-15603 in <= 2.40

* fix aggregation of events with multiple comments
* data values are already aggregated in JSONB string so we can set them once in the "new event" branch
* relationship ids are already aggregated in SQL so we can set them once in the "new event" branch

