### PR TITLE
chore: Harmonize Relationship Controller [TECH-1572]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ForbiddenException.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ForbiddenException.java
@@ -59,6 +59,10 @@ public final class ForbiddenException extends Exception implements Error {
     this.code = ErrorCode.E1006;
   }
 
+  public ForbiddenException(Class<?> type, String uid) {
+    this("User has no access to " + type.getSimpleName() + ":" + uid);
+  }
+
   public ForbiddenException(ErrorCode code, Object... args) {
     super(MessageFormat.format(code.getMessage(), args));
     this.code = code;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapper.java
@@ -94,7 +94,7 @@ class RelationshipOperationParamsMapper {
 
     List<String> errors = accessManager.canRead(user, trackedEntity);
     if (!errors.isEmpty()) {
-      throw new ForbiddenException("User has no access to TrackedEntity: " + uid);
+      throw new ForbiddenException(TrackedEntity.class, uid);
     }
 
     return trackedEntity;
@@ -109,7 +109,7 @@ class RelationshipOperationParamsMapper {
 
     List<String> errors = accessManager.canRead(user, enrollment, false);
     if (!errors.isEmpty()) {
-      throw new ForbiddenException("User has no access to Enrollment: " + uid);
+      throw new ForbiddenException(Enrollment.class, uid);
     }
 
     return enrollment;
@@ -123,7 +123,7 @@ class RelationshipOperationParamsMapper {
 
     List<String> errors = accessManager.canRead(user, event, false);
     if (!errors.isEmpty()) {
-      throw new ForbiddenException("User has no access to Event: " + uid);
+      throw new ForbiddenException(Event.class, uid);
     }
 
     return event;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapperTest.java
@@ -35,7 +35,9 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import org.hisp.dhis.DhisConvenienceTest;
+import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
@@ -46,6 +48,9 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
+import org.hisp.dhis.trackedentity.TrackerAccessManager;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -68,6 +73,10 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
 
   @Mock private EventService eventService;
 
+  @Mock private TrackerAccessManager accessManager;
+
+  @Mock private CurrentUserService currentUserService;
+
   @InjectMocks private RelationshipOperationParamsMapper mapper;
 
   private TrackedEntity trackedEntity;
@@ -75,6 +84,8 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
   private Enrollment enrollment;
 
   private Event event;
+
+  private User user;
 
   @BeforeEach
   public void setUp() {
@@ -88,11 +99,17 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
     enrollment.setUid(EN_UID);
     event = createEvent(programStage, enrollment, organisationUnit);
     event.setUid(EV_UID);
+
+    user = new User();
+
+    when(currentUserService.getCurrentUser()).thenReturn(user);
   }
 
   @Test
-  void shouldMapTrackedEntityWhenATrackedEntityIsPassed() throws NotFoundException {
+  void shouldMapTrackedEntityWhenATrackedEntityIsPassed()
+      throws NotFoundException, ForbiddenException {
     when(trackedEntityService.getTrackedEntity(TE_UID)).thenReturn(trackedEntity);
+    when(accessManager.canRead(user, trackedEntity)).thenReturn(List.of());
     RelationshipOperationParams params =
         RelationshipOperationParams.builder().type(TRACKED_ENTITY).identifier(TE_UID).build();
 
@@ -112,8 +129,19 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldMapEnrollmentWhenAEnrollmentIsPassed() throws NotFoundException {
+  void shouldThrowForbiddenExceptionWhenUserHasNoAccessToTrackedEntity() {
+    when(trackedEntityService.getTrackedEntity(TE_UID)).thenReturn(trackedEntity);
+    when(accessManager.canRead(user, trackedEntity)).thenReturn(List.of("error"));
+    RelationshipOperationParams params =
+        RelationshipOperationParams.builder().type(TRACKED_ENTITY).identifier(TE_UID).build();
+
+    assertThrows(ForbiddenException.class, () -> mapper.map(params));
+  }
+
+  @Test
+  void shouldMapEnrollmentWhenAEnrollmentIsPassed() throws NotFoundException, ForbiddenException {
     when(enrollmentService.getEnrollment(EN_UID)).thenReturn(enrollment);
+    when(accessManager.canRead(user, enrollment, false)).thenReturn(List.of());
     RelationshipOperationParams params =
         RelationshipOperationParams.builder().type(ENROLLMENT).identifier(EN_UID).build();
 
@@ -133,8 +161,19 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldMapEventWhenAEventIsPassed() throws NotFoundException {
+  void shouldThrowForbiddenExceptionWhenUserHasNoAccessToEnrollment() {
+    when(enrollmentService.getEnrollment(EN_UID)).thenReturn(enrollment);
+    when(accessManager.canRead(user, enrollment, false)).thenReturn(List.of("error"));
+    RelationshipOperationParams params =
+        RelationshipOperationParams.builder().type(ENROLLMENT).identifier(EN_UID).build();
+
+    assertThrows(ForbiddenException.class, () -> mapper.map(params));
+  }
+
+  @Test
+  void shouldMapEventWhenAEventIsPassed() throws NotFoundException, ForbiddenException {
     when(eventService.getEvent(EV_UID)).thenReturn(event);
+    when(accessManager.canRead(user, event, false)).thenReturn(List.of());
     RelationshipOperationParams params =
         RelationshipOperationParams.builder().type(EVENT).identifier(EV_UID).build();
 
@@ -151,5 +190,15 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
         RelationshipOperationParams.builder().type(EVENT).identifier(EV_UID).build();
 
     assertThrows(NotFoundException.class, () -> mapper.map(params));
+  }
+
+  @Test
+  void shouldThrowForbiddenExceptionWhenUserHasNoAccessToEvent() {
+    when(eventService.getEvent(EV_UID)).thenReturn(event);
+    when(accessManager.canRead(user, event, false)).thenReturn(List.of("error"));
+    RelationshipOperationParams params =
+        RelationshipOperationParams.builder().type(EVENT).identifier(EV_UID).build();
+
+    assertThrows(ForbiddenException.class, () -> mapper.map(params));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapperTest.java
@@ -120,7 +120,7 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldThrowNotFoundExceptionWhenTrackedEntityIsNotFound() {
+  void shouldThrowWhenTrackedEntityIsNotFound() {
     when(trackedEntityService.getTrackedEntity(TE_UID)).thenReturn(null);
     RelationshipOperationParams params =
         RelationshipOperationParams.builder().type(TRACKED_ENTITY).identifier(TE_UID).build();
@@ -129,7 +129,7 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldThrowForbiddenExceptionWhenUserHasNoAccessToTrackedEntity() {
+  void shouldThrowWhenUserHasNoAccessToTrackedEntity() {
     when(trackedEntityService.getTrackedEntity(TE_UID)).thenReturn(trackedEntity);
     when(accessManager.canRead(user, trackedEntity)).thenReturn(List.of("error"));
     RelationshipOperationParams params =
@@ -152,7 +152,7 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldThrowNotFoundExceptionWhenEnrollmentIsNotFound() {
+  void shouldThrowWhenEnrollmentIsNotFound() {
     when(enrollmentService.getEnrollment(EN_UID)).thenReturn(null);
     RelationshipOperationParams params =
         RelationshipOperationParams.builder().type(ENROLLMENT).identifier(EN_UID).build();
@@ -161,7 +161,7 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldThrowForbiddenExceptionWhenUserHasNoAccessToEnrollment() {
+  void shouldThrowWhenUserHasNoAccessToEnrollment() {
     when(enrollmentService.getEnrollment(EN_UID)).thenReturn(enrollment);
     when(accessManager.canRead(user, enrollment, false)).thenReturn(List.of("error"));
     RelationshipOperationParams params =
@@ -184,7 +184,7 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldThrowNotFoundExceptionWhenEventIsNotFound() {
+  void shouldThrowWhenEventIsNotFound() {
     when(eventService.getEvent(EV_UID)).thenReturn(null);
     RelationshipOperationParams params =
         RelationshipOperationParams.builder().type(EVENT).identifier(EV_UID).build();
@@ -193,7 +193,7 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldThrowForbiddenExceptionWhenUserHasNoAccessToEvent() {
+  void shouldThrowWhenUserHasNoAccessToEvent() {
     when(eventService.getEvent(EV_UID)).thenReturn(event);
     when(accessManager.canRead(user, event, false)).thenReturn(List.of("error"));
     RelationshipOperationParams params =

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -588,18 +588,6 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
   }
 
   @Test
-  void shouldReturnForbiddenWhenGetRelationshipsWithBothEndsNotAccessible() {
-    TrackedEntity from = trackedEntityNotInSearchScope();
-    TrackedEntity to = trackedEntityNotInSearchScope();
-    relationship(from, to);
-    this.switchContextToUser(user);
-
-    assertEquals(
-        HttpStatus.FORBIDDEN,
-        GET("/tracker/relationships?trackedEntity={tei}", from.getUid()).status());
-  }
-
-  @Test
   void shouldReturnForbiddenWhenGetRelationshipsByNotAccessibleTrackedEntity() {
     TrackedEntity from = trackedEntityNotInSearchScope();
     TrackedEntity to = trackedEntity();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -577,7 +577,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
   }
 
   @Test
-  void getRelationshipsByTrackedEntityRelationshipsNoAccessToRelationshipItemTo() {
+  void shouldRetrieveNoRelationshipsWhenUserHasNoAccessToRelationshipItemTo() {
     TrackedEntity from = trackedEntity();
     TrackedEntity to = trackedEntityNotInSearchScope();
     relationship(from, to);
@@ -588,7 +588,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
   }
 
   @Test
-  void shouldReturnForbiddenWhenGetRelationshipsByNotAccessibleTrackedEntity() {
+  void shouldReturnForbiddenWhenUserHasNoAccessToRelationshipItemFrom() {
     TrackedEntity from = trackedEntityNotInSearchScope();
     TrackedEntity to = trackedEntity();
     relationship(from, to);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -588,37 +588,41 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
   }
 
   @Test
-  void getRelationshipsByTrackedEntityRelationshipsNoAccessToBothRelationshipItems() {
+  void shouldReturnForbiddenWhenGetRelationshipsWithBothEndsNotAccessible() {
     TrackedEntity from = trackedEntityNotInSearchScope();
     TrackedEntity to = trackedEntityNotInSearchScope();
     relationship(from, to);
     this.switchContextToUser(user);
 
-    assertNoRelationships(
-        GET("/tracker/relationships?trackedEntity={tei}", from.getUid()).content(HttpStatus.OK));
+    assertEquals(
+        HttpStatus.FORBIDDEN,
+        GET("/tracker/relationships?trackedEntity={tei}", from.getUid()).status());
   }
 
   @Test
-  void getRelationshipsByTrackedEntityRelationshipsNoAccessToRelationshipItemFrom() {
+  void shouldReturnForbiddenWhenGetRelationshipsByNotAccessibleTrackedEntity() {
     TrackedEntity from = trackedEntityNotInSearchScope();
     TrackedEntity to = trackedEntity();
     relationship(from, to);
     this.switchContextToUser(user);
 
-    assertNoRelationships(
-        GET("/tracker/relationships?trackedEntity={tei}", from.getUid()).content(HttpStatus.OK));
+    assertEquals(
+        HttpStatus.FORBIDDEN,
+        GET("/tracker/relationships?trackedEntity={tei}", from.getUid()).status());
   }
 
   @Test
-  void getRelationshipsByTrackedEntityRelationshipsNoAccessToTrackedEntityType() {
+  void
+      shouldReturnForbiddenWhenGetRelationshipsByTrackedEntityWithNotAccessibleTrackedEntityType() {
     TrackedEntityType type = trackedEntityTypeNotAccessible();
     TrackedEntity from = trackedEntity(type);
     TrackedEntity to = trackedEntity(type);
     relationship(from, to);
     this.switchContextToUser(user);
 
-    assertNoRelationships(
-        GET("/tracker/relationships?trackedEntity={tei}", from.getUid()).content(HttpStatus.OK));
+    assertEquals(
+        HttpStatus.FORBIDDEN,
+        GET("/tracker/relationships?trackedEntity={tei}", from.getUid()).status());
   }
 
   @Test


### PR DESCRIPTION
Continuing from https://github.com/dhis2/dhis2-core/pull/14677

Client retrieves relationships specifying one end of the relationships, if the user has no access to such entity a `FORBIDDEN` error is returned.
Access control is done on both ends of the relationship. If the other end (the one not specified by the client) is not accessible, it is filtered out.
@Bekkalizer @JoakimSM do you agree with the behavior?

**What it is in this PR**
- Check access for entities used to filter the relationships.

**What is next**
- Harmonize nested relationships and nested entities between exporters