### PR TITLE
fix: Make error message more clear [DHIS2-13611]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -409,6 +409,7 @@ public enum ErrorCode {
   E7134("Cannot retrieve total value for data elements with skip total category combination"),
   E7135("Date time is not parsable: `{0}`"),
   E7136("Program is not specified"),
+  E7143("Organisation unit or organisation unit level is not valid"),
 
   /* Event analytics */
   E7200(Constants.AT_LEAST_ONE_ORGANISATION_UNIT_MUST_BE_SPECIFIED),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProducer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProducer.java
@@ -57,6 +57,7 @@ import static org.hisp.dhis.common.IdentifiableObjectUtils.getLocalPeriodIdentif
 import static org.hisp.dhis.common.IdentifiableProperty.UID;
 import static org.hisp.dhis.commons.collection.ListUtils.sort;
 import static org.hisp.dhis.feedback.ErrorCode.E7124;
+import static org.hisp.dhis.feedback.ErrorCode.E7143;
 import static org.hisp.dhis.hibernate.HibernateProxyUtils.getRealClass;
 import static org.hisp.dhis.organisationunit.OrganisationUnit.KEY_LEVEL;
 import static org.hisp.dhis.organisationunit.OrganisationUnit.KEY_ORGUNIT_GROUP;
@@ -412,7 +413,7 @@ public class DimensionalObjectProducer {
     }
 
     if (orgUnitAtLevels.isEmpty()) {
-      throwIllegalQueryEx(E7124, ORGUNIT_DIM_ID);
+      throwIllegalQueryEx(E7143, ORGUNIT_DIM_ID);
     }
 
     // Remove duplicates

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceTest.java
@@ -867,7 +867,7 @@ class DataQueryServiceTest extends SingleSetupIntegrationTestBase {
         DataQueryRequest.newBuilder().dimension(dimensionParams).build();
     assertThrowsErrorCode(
         IllegalQueryException.class,
-        ErrorCode.E7143,
+        ErrorCode.E7124,
         () -> dataQueryService.getFromRequest(dataQueryRequest));
   }
 
@@ -895,7 +895,7 @@ class DataQueryServiceTest extends SingleSetupIntegrationTestBase {
         DataQueryRequest.newBuilder().dimension(dimensionParams).build();
     assertThrowsErrorCode(
         IllegalQueryException.class,
-        ErrorCode.E7124,
+        ErrorCode.E7143,
         () -> dataQueryService.getFromRequest(dataQueryRequest));
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceTest.java
@@ -867,7 +867,7 @@ class DataQueryServiceTest extends SingleSetupIntegrationTestBase {
         DataQueryRequest.newBuilder().dimension(dimensionParams).build();
     assertThrowsErrorCode(
         IllegalQueryException.class,
-        ErrorCode.E7124,
+        ErrorCode.E7143,
         () -> dataQueryService.getFromRequest(dataQueryRequest));
   }
 


### PR DESCRIPTION
**_[Backport from master/2.41]_**

Small change to improve the error message for invalid org. units.
More details about the reasoning can be found at `DHIS2-13611`.
