### PR TITLE
fix: Make error message more clear [DHIS2-13611]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -318,6 +318,7 @@ public enum ErrorCode {
   E7133("Query cannot be executed, possibly because of invalid types or invalid operation"),
   E7134("Cannot retrieve total value for data elements with skip total category combination"),
   E7135("Date time is not parsable: `{0}`"),
+  E7143("Organisation unit or organisation unit level is not valid"),
 
   /* Event analytics */
   E7200("At least one organisation unit must be specified"),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
@@ -634,7 +634,7 @@ public class DefaultDataQueryService implements DataQueryService {
       }
 
       if (orgUnits.isEmpty()) {
-        throwIllegalQueryEx(ErrorCode.E7124, DimensionalObject.ORGUNIT_DIM_ID);
+        throwIllegalQueryEx(ErrorCode.E7143, DimensionalObject.ORGUNIT_DIM_ID);
       }
 
       // Remove duplicates


### PR DESCRIPTION
**_[Backport from master/2.41]_**

Small change to improve the error message for invalid org. units.
More details about the reasoning can be found at `DHIS2-13611`.
