### PR TITLE
chore: implement /tracker/event?order consistently with other endpoints TECH-1606

### DIFF
--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/webapi/controller/event/webrequest/OrderCriteriaTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/webapi/controller/event/webrequest/OrderCriteriaTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.event.webrequest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class OrderCriteriaTest {
+
+  @Test
+  void fromOrderString() {
+
+    List<OrderCriteria> orderCriteria =
+        OrderCriteria.fromOrderString("one:desc,, two:asc  ,three  ");
+
+    assertNotNull(orderCriteria);
+    assertEquals(
+        4, orderCriteria.size(), String.format("Expected 4 item, instead got %s", orderCriteria));
+    assertEquals(OrderCriteria.of("one", SortDirection.DESC), orderCriteria.get(0));
+    assertEquals(OrderCriteria.of("", SortDirection.ASC), orderCriteria.get(1));
+    assertEquals(OrderCriteria.of(" two", SortDirection.ASC), orderCriteria.get(2));
+    assertEquals(OrderCriteria.of("three", SortDirection.ASC), orderCriteria.get(3));
+  }
+
+  @ValueSource(strings = {"one:desc", "one:Desc", "one:DESC"})
+  @ParameterizedTest
+  void fromOrderStringSortDirectionParsingIsCaseInsensitive(String source) {
+
+    List<OrderCriteria> orderCriteria = OrderCriteria.fromOrderString(source);
+
+    assertNotNull(orderCriteria);
+    assertEquals(
+        1, orderCriteria.size(), String.format("Expected 1 item, instead got %s", orderCriteria));
+    assertEquals(OrderCriteria.of("one", SortDirection.DESC), orderCriteria.get(0));
+  }
+
+  @Test
+  void fromOrderStringDefaultsToAscGivenFieldAndColon() {
+
+    List<OrderCriteria> orderCriteria = OrderCriteria.fromOrderString("one:");
+
+    assertNotNull(orderCriteria);
+    assertEquals(
+        1, orderCriteria.size(), String.format("Expected 1 item, instead got %s", orderCriteria));
+    assertEquals(OrderCriteria.of("one", SortDirection.ASC), orderCriteria.get(0));
+  }
+
+  @Test
+  void fromOrderStringDefaultsSortDirectionToAscGivenAnUnknownSortDirection() {
+
+    List<OrderCriteria> orderCriteria = OrderCriteria.fromOrderString("one:wrong");
+
+    assertNotNull(orderCriteria);
+    assertEquals(
+        1, orderCriteria.size(), String.format("Expected 1 item, instead got %s", orderCriteria));
+    assertEquals(OrderCriteria.of("one", SortDirection.ASC), orderCriteria.get(0));
+  }
+
+  @Test
+  void fromOrderStringReturnsEmptyListGivenEmptyOrder() {
+
+    List<OrderCriteria> orderCriteria = OrderCriteria.fromOrderString(" ");
+
+    assertNotNull(orderCriteria);
+    assertEquals(
+        0, orderCriteria.size(), String.format("Expected 0 items, instead got %s", orderCriteria));
+  }
+
+  @Test
+  void fromOrderStringReturnsNullGivenOrderWithMoreThanTwoProperties() {
+
+    List<OrderCriteria> orderCriteria = OrderCriteria.fromOrderString("one:desc:wrong");
+
+    assertNotNull(orderCriteria);
+    assertEquals(
+        1, orderCriteria.size(), String.format("Expected 1 item, instead got %s", orderCriteria));
+    assertNull(orderCriteria.get(0));
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -198,6 +198,11 @@ public class DefaultEventService implements EventService {
     return Events.of(eventList, pager);
   }
 
+  @Override
+  public Set<String> getOrderableFields() {
+    return eventStore.getOrderableFields();
+  }
+
   /**
    * This method will apply the logic related to the parameter 'totalPages=false'. This works in
    * conjunction with the method: {@link EventStore#getEvents(EventSearchParams,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventSearchParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventSearchParams.java
@@ -52,49 +52,6 @@ import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
  * @author Lars Helge Overland
  */
 public class EventSearchParams {
-  public static final String EVENT_ID = "event";
-
-  public static final String EVENT_ENROLLMENT_ID = "enrollment";
-
-  public static final String EVENT_CREATED_AT_ID = "createdAt";
-
-  public static final String EVENT_CREATED_BY_ID = "createdBy";
-
-  public static final String EVENT_UPDATED_AT_ID = "updatedAt";
-
-  public static final String EVENT_UPDATED_BY = "updatedBy";
-
-  public static final String EVENT_STORED_BY_ID = "storedBy";
-
-  public static final String EVENT_COMPLETED_BY_ID = "completedBy";
-
-  public static final String EVENT_COMPLETED_AT_ID = "completedAt";
-
-  public static final String EVENT_SCHEDULE_AT_DATE_ID = "scheduleAt";
-
-  public static final String EVENT_OCCURRED_AT_DATE_ID = "occurredAt";
-
-  public static final String EVENT_ORG_UNIT_ID = "orgUnit";
-
-  public static final String EVENT_ORG_UNIT_NAME = "orgUnitName";
-
-  public static final String EVENT_STATUS_ID = "status";
-
-  public static final String EVENT_LONGITUDE_ID = "longitude";
-
-  public static final String EVENT_LATITUDE_ID = "latitude";
-
-  public static final String EVENT_PROGRAM_STAGE_ID = "programStage";
-
-  public static final String EVENT_PROGRAM_ID = "program";
-
-  public static final String EVENT_ATTRIBUTE_OPTION_COMBO_ID = "attributeOptionCombo";
-
-  public static final String EVENT_DELETED = "deleted";
-
-  public static final String EVENT_GEOMETRY = "geometry";
-
-  public static final String PAGER_META_KEY = "pager";
 
   public static final int DEFAULT_PAGE = 1;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.export.event;
 
+import java.util.Set;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
@@ -41,4 +42,6 @@ public interface EventService {
   Event getEvent(Event event, EventParams eventParams) throws ForbiddenException;
 
   Events getEvents(EventOperationParams params) throws BadRequestException, ForbiddenException;
+
+  Set<String> getOrderableFields();
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventStore.java
@@ -38,5 +38,7 @@ import org.hisp.dhis.program.Event;
 public interface EventStore {
   List<Event> getEvents(EventSearchParams params, Map<String, Set<String>> psdesWithSkipSyncTrue);
 
+  Set<String> getOrderableFields();
+
   int getEventCount(EventSearchParams params);
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -32,25 +32,6 @@ import static org.hisp.dhis.common.ValueType.NUMERIC_TYPES;
 import static org.hisp.dhis.system.util.SqlUtils.castToNumber;
 import static org.hisp.dhis.system.util.SqlUtils.lower;
 import static org.hisp.dhis.system.util.SqlUtils.quote;
-import static org.hisp.dhis.tracker.export.event.EventSearchParams.EVENT_ATTRIBUTE_OPTION_COMBO_ID;
-import static org.hisp.dhis.tracker.export.event.EventSearchParams.EVENT_COMPLETED_AT_ID;
-import static org.hisp.dhis.tracker.export.event.EventSearchParams.EVENT_COMPLETED_BY_ID;
-import static org.hisp.dhis.tracker.export.event.EventSearchParams.EVENT_CREATED_AT_ID;
-import static org.hisp.dhis.tracker.export.event.EventSearchParams.EVENT_CREATED_BY_ID;
-import static org.hisp.dhis.tracker.export.event.EventSearchParams.EVENT_DELETED;
-import static org.hisp.dhis.tracker.export.event.EventSearchParams.EVENT_ENROLLMENT_ID;
-import static org.hisp.dhis.tracker.export.event.EventSearchParams.EVENT_GEOMETRY;
-import static org.hisp.dhis.tracker.export.event.EventSearchParams.EVENT_ID;
-import static org.hisp.dhis.tracker.export.event.EventSearchParams.EVENT_OCCURRED_AT_DATE_ID;
-import static org.hisp.dhis.tracker.export.event.EventSearchParams.EVENT_ORG_UNIT_ID;
-import static org.hisp.dhis.tracker.export.event.EventSearchParams.EVENT_ORG_UNIT_NAME;
-import static org.hisp.dhis.tracker.export.event.EventSearchParams.EVENT_PROGRAM_ID;
-import static org.hisp.dhis.tracker.export.event.EventSearchParams.EVENT_PROGRAM_STAGE_ID;
-import static org.hisp.dhis.tracker.export.event.EventSearchParams.EVENT_SCHEDULE_AT_DATE_ID;
-import static org.hisp.dhis.tracker.export.event.EventSearchParams.EVENT_STATUS_ID;
-import static org.hisp.dhis.tracker.export.event.EventSearchParams.EVENT_STORED_BY_ID;
-import static org.hisp.dhis.tracker.export.event.EventSearchParams.EVENT_UPDATED_AT_ID;
-import static org.hisp.dhis.tracker.export.event.EventSearchParams.EVENT_UPDATED_BY;
 import static org.hisp.dhis.util.DateUtils.addDays;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -153,6 +134,25 @@ public class JdbcEventStore implements EventStore {
           + " on psic.trackedentitycommentid = psinote.trackedentitycommentid"
           + " left join userinfo on psinote.lastupdatedby = userinfo.userinfoid ";
 
+  private static final String EVENT_GEOMETRY = "geometry";
+  private static final String EVENT_DELETED = "deleted";
+  private static final String EVENT_ATTRIBUTE_OPTION_COMBO_ID = "attributeOptionCombo";
+  private static final String EVENT_PROGRAM_ID = "program";
+  private static final String EVENT_PROGRAM_STAGE_ID = "programStage";
+  private static final String EVENT_STATUS_ID = "status";
+  private static final String EVENT_ORG_UNIT_NAME = "orgUnitName";
+  private static final String EVENT_ORG_UNIT_ID = "orgUnit";
+  private static final String EVENT_OCCURRED_AT_DATE_ID = "occurredAt";
+  private static final String EVENT_SCHEDULED_AT_DATE_ID = "scheduledAt";
+  private static final String EVENT_COMPLETED_AT_ID = "completedAt";
+  private static final String EVENT_COMPLETED_BY_ID = "completedBy";
+  private static final String EVENT_STORED_BY_ID = "storedBy";
+  private static final String EVENT_UPDATED_BY = "updatedBy";
+  private static final String EVENT_UPDATED_AT_ID = "updatedAt";
+  private static final String EVENT_CREATED_BY_ID = "createdBy";
+  private static final String EVENT_CREATED_AT_ID = "createdAt";
+  private static final String EVENT_ENROLLMENT_ID = "enrollment";
+  private static final String EVENT_ID = "event";
   private static final String EVENT_STATUS = "psi_status";
 
   private static final String EVENT_STATUS_EQ = " psi.status = ";
@@ -167,32 +167,36 @@ public class JdbcEventStore implements EventStore {
 
   private static final String AND = " AND ";
 
-  public static final Map<String, String> QUERY_PARAM_COL_MAP =
+  /**
+   * Events can be ordered by given fields which correspond to fields on {@link
+   * org.hisp.dhis.program.Event}. Maps fields to DB columns.
+   */
+  private static final Map<String, String> ORDERABLE_FIELDS =
       Map.ofEntries(
-          entry(EVENT_ID, "psi_uid"),
-          entry(EVENT_PROGRAM_ID, "p_uid"),
-          entry(EVENT_PROGRAM_STAGE_ID, "ps_uid"),
-          entry(EVENT_ENROLLMENT_ID, "pi_uid"),
-          entry("enrollmentStatus", "pi_status"),
-          entry("enrolledAt", "pi_enrollmentdate"),
-          entry(EVENT_ORG_UNIT_ID, "ou_uid"),
-          entry(EVENT_ORG_UNIT_NAME, "ou_name"),
-          entry("trackedEntity", "tei_uid"),
-          entry(EVENT_OCCURRED_AT_DATE_ID, "psi_executiondate"),
-          entry("followup", "pi_followup"),
-          entry(EVENT_STATUS_ID, EVENT_STATUS),
-          entry(EVENT_SCHEDULE_AT_DATE_ID, "psi_duedate"),
-          entry(EVENT_STORED_BY_ID, "psi_storedby"),
-          entry(EVENT_UPDATED_BY, "psi_lastupdatedbyuserinfo"),
-          entry(EVENT_CREATED_BY_ID, "psi_createdbyuserinfo"),
-          entry(EVENT_CREATED_AT_ID, "psi_created"),
-          entry(EVENT_UPDATED_AT_ID, "psi_lastupdated"),
-          entry(EVENT_COMPLETED_BY_ID, "psi_completedby"),
-          entry(EVENT_ATTRIBUTE_OPTION_COMBO_ID, "psi_aoc"),
-          entry(EVENT_COMPLETED_AT_ID, "psi_completeddate"),
-          entry(EVENT_DELETED, "psi_deleted"),
+          entry("uid", "psi_uid"),
+          entry("enrollment.program.uid", "p_uid"),
+          entry("programStage.uid", "ps_uid"),
+          entry("enrollment.uid", "pi_uid"),
+          entry("enrollment.status", "pi_status"),
+          entry("enrollment.enrollmentDate", "pi_enrollmentdate"),
+          entry("organisationUnit.uid", "ou_uid"),
+          entry("organisationUnit.name", "ou_name"),
+          entry("enrollment.trackedEntity.uid", "tei_uid"),
+          entry("executionDate", "psi_executiondate"),
+          entry("enrollment.followup", "pi_followup"),
+          entry("status", EVENT_STATUS),
+          entry("dueDate", "psi_duedate"),
+          entry("storedBy", "psi_storedby"),
+          entry("lastUpdatedBy", "psi_lastupdatedbyuserinfo"),
+          entry("createdBy", "psi_createdbyuserinfo"),
+          entry("created", "psi_created"),
+          entry("lastUpdated", "psi_lastupdated"),
+          entry("completedBy", "psi_completedby"),
+          entry("attributeOptionCombo.uid", "psi_aoc"),
+          entry("completedDate", "psi_completeddate"),
+          entry("deleted", "psi_deleted"),
           entry("assignedUser", "user_assigned_username"),
-          entry("assignedUserDisplayName", "user_assigned_name"));
+          entry("assignedUser.displayName", "user_assigned_name"));
 
   private static final Map<String, String> COLUMNS_ALIAS_MAP =
       ImmutableMap.<String, String>builder()
@@ -209,7 +213,7 @@ public class JdbcEventStore implements EventStore {
               EVENT_COMPLETED_AT_ID)
           .put(
               EventQuery.COLUMNS.DUE_DATE.getQueryElement().useInSelect(),
-              EVENT_SCHEDULE_AT_DATE_ID)
+              EVENT_SCHEDULED_AT_DATE_ID)
           .put(
               EventQuery.COLUMNS.EXECUTION_DATE.getQueryElement().useInSelect(),
               EVENT_OCCURRED_AT_DATE_ID)
@@ -236,7 +240,7 @@ public class JdbcEventStore implements EventStore {
           EVENT_COMPLETED_BY_ID,
           EVENT_COMPLETED_AT_ID,
           EVENT_OCCURRED_AT_DATE_ID,
-          EVENT_SCHEDULE_AT_DATE_ID,
+          EVENT_SCHEDULED_AT_DATE_ID,
           EVENT_ORG_UNIT_ID,
           EVENT_ORG_UNIT_NAME,
           EVENT_STATUS_ID,
@@ -459,6 +463,11 @@ public class JdbcEventStore implements EventStore {
 
           return events;
         });
+  }
+
+  @Override
+  public Set<String> getOrderableFields() {
+    return ORDERABLE_FIELDS.keySet();
   }
 
   private String getIdSqlBasedOnIdScheme(
@@ -1513,8 +1522,8 @@ public class JdbcEventStore implements EventStore {
     ArrayList<String> orderFields = new ArrayList<>();
 
     for (OrderParam order : params.getOrders()) {
-      if (QUERY_PARAM_COL_MAP.containsKey(order.getField())) {
-        String orderText = QUERY_PARAM_COL_MAP.get(order.getField());
+      if (ORDERABLE_FIELDS.containsKey(order.getField())) {
+        String orderText = ORDERABLE_FIELDS.get(order.getField());
         orderText += " " + (order.getDirection().isAscending() ? "asc" : "desc");
         orderFields.add(orderText);
       } else if (params.getAttributeOrders().contains(order)) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
@@ -84,7 +84,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class EventOperationMapperTest {
+class EventOperationParamsMapperTest {
   private static final String DE_1_UID = "OBzmpRP6YUh";
 
   private static final String DE_2_UID = "KSd4PejqBf9";

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
@@ -90,7 +90,7 @@ import org.mockito.quality.Strictness;
 
 @MockitoSettings(strictness = Strictness.LENIENT) // common setup
 @ExtendWith(MockitoExtension.class)
-class OperationParamsMapperTest {
+class TrackedEntityOperationParamsMapperTest {
   public static final String TEA_1_UID = "TvjwTPToKHO";
 
   public static final String TEA_2_UID = "cy2oRh2sNr6";

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/TrackerExportTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/TrackerExportTests.java
@@ -53,7 +53,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matcher;
 import org.hisp.dhis.Constants;
 import org.hisp.dhis.dto.ApiResponse;
@@ -437,19 +436,6 @@ public class TrackerExportTests extends TrackerApiTest {
         .statusCode(200)
         .rootPath("instances[0]")
         .body("event", equalTo("ZwwuwNp6gVd"));
-  }
-
-  @Test
-  // TODO(tracker): remove with old tracker
-  void shouldReturnInvalidPropertyWhenOrderOnLegacyCreatedField() {
-    ApiResponse response = trackerImportExportActions.get("events?order=created:desc");
-    response
-        .validate()
-        .statusCode(400)
-        .body("status", CoreMatchers.equalTo("ERROR"))
-        .body(
-            "message",
-            CoreMatchers.containsString("Order by property `created` is not supported."));
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -191,7 +191,7 @@ class EventExporterTest extends TrackerTest {
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
             .events(Set.of("pTzf9KYMk72", "D9PbzJY8bJM"))
-            .orders(List.of(new OrderParam("occurredAt", SortDirection.DESC)));
+            .orders(List.of(new OrderParam("executionDate", SortDirection.DESC)));
 
     EventOperationParams params = paramsBuilder.page(1).pageSize(1).build();
 
@@ -441,7 +441,7 @@ class EventExporterTest extends TrackerTest {
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
             .programUid(program.getUid())
-            .orders(List.of(new OrderParam("occurredAt", SortDirection.DESC)));
+            .orders(List.of(new OrderParam("executionDate", SortDirection.DESC)));
 
     EventOperationParams params = paramsBuilder.page(1).pageSize(3).build();
 
@@ -480,7 +480,7 @@ class EventExporterTest extends TrackerTest {
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
             .programUid(program.getUid())
-            .orders(List.of(new OrderParam("occurredAt", SortDirection.DESC)))
+            .orders(List.of(new OrderParam("executionDate", SortDirection.DESC)))
             .page(1)
             .pageSize(2)
             .totalPages(true)
@@ -1149,7 +1149,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .orders(List.of(new OrderParam("enrolledAt", SortDirection.DESC)))
+            .orders(List.of(new OrderParam("enrollment.enrollmentDate", SortDirection.DESC)))
             .build();
 
     List<String> enrollments =
@@ -1165,7 +1165,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .orders(List.of(new OrderParam("enrolledAt", SortDirection.ASC)))
+            .orders(List.of(new OrderParam("enrollment.enrollmentDate", SortDirection.ASC)))
             .build();
 
     List<String> enrollments =
@@ -1181,7 +1181,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .orders(List.of(new OrderParam("occurredAt", SortDirection.DESC)))
+            .orders(List.of(new OrderParam("executionDate", SortDirection.DESC)))
             .build();
 
     Events events = eventService.getEvents(params);
@@ -1194,7 +1194,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .orders(List.of(new OrderParam("occurredAt", SortDirection.ASC)))
+            .orders(List.of(new OrderParam("executionDate", SortDirection.ASC)))
             .build();
 
     Events events = eventService.getEvents(params);
@@ -1269,7 +1269,7 @@ class EventExporterTest extends TrackerTest {
             .orders(
                 List.of(
                     new OrderParam("toUpdate000", SortDirection.ASC),
-                    new OrderParam("enrolledAt", SortDirection.ASC)))
+                    new OrderParam("enrollment.enrollmentDate", SortDirection.ASC)))
             .build();
 
     List<String> trackedEntities =
@@ -1290,7 +1290,7 @@ class EventExporterTest extends TrackerTest {
             .attributeOrders(List.of(OrderCriteria.of("toUpdate000", SortDirection.DESC)))
             .orders(
                 List.of(
-                    new OrderParam("enrolledAt", SortDirection.DESC),
+                    new OrderParam("enrollment.enrollmentDate", SortDirection.DESC),
                     new OrderParam("toUpdate000", SortDirection.DESC)))
             .build();
 
@@ -1312,7 +1312,7 @@ class EventExporterTest extends TrackerTest {
                 List.of(
                     new OrderParam("dueDate", SortDirection.DESC),
                     new OrderParam("DATAEL00006", SortDirection.DESC),
-                    new OrderParam("enrolledAt", SortDirection.DESC)))
+                    new OrderParam("enrollment.enrollmentDate", SortDirection.DESC)))
             .build();
 
     List<String> trackedEntities =
@@ -1331,7 +1331,7 @@ class EventExporterTest extends TrackerTest {
             .orgUnitUid(orgUnit.getUid())
             .orders(
                 List.of(
-                    new OrderParam("enrolledAt", SortDirection.DESC),
+                    new OrderParam("enrollment.enrollmentDate", SortDirection.DESC),
                     new OrderParam("DATAEL00006", SortDirection.DESC)))
             .build();
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerUnitTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerUnitTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.export.event;
+
+import static org.hisp.dhis.utils.Assertions.assertContains;
+import static org.hisp.dhis.utils.Assertions.assertStartsWith;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.hisp.dhis.fieldfiltering.FieldFilterService;
+import org.hisp.dhis.webapi.controller.tracker.export.CsvService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EventsExportControllerUnitTest {
+
+  @Mock private org.hisp.dhis.tracker.export.event.EventService eventService;
+
+  @Mock private EventRequestParamsMapper eventParamsMapper;
+
+  @Mock private CsvService<org.hisp.dhis.webapi.controller.tracker.view.Event> csvEventService;
+
+  @Mock private FieldFilterService fieldFilterService;
+
+  @Mock private EventFieldsParamMapper eventsMapper;
+
+  @Test
+  void shouldFailInstantiatingControllerIfAnyOrderableFieldIsUnsupported() {
+    // pretend the service does not support 2 of the orderable fields the web advocates
+    Iterator<Entry<String, String>> iterator =
+        EventMapper.ORDERABLE_FIELDS.entrySet().stream().iterator();
+    Entry<String, String> missing1 = iterator.next();
+    Entry<String, String> missing2 = iterator.next();
+    Map<String, String> orderableFields = new HashMap<>(EventMapper.ORDERABLE_FIELDS);
+    orderableFields.remove(missing1.getKey());
+    orderableFields.remove(missing2.getKey());
+    when(eventService.getOrderableFields()).thenReturn(new HashSet<>(orderableFields.values()));
+
+    Exception exception =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                new EventsExportController(
+                    eventService,
+                    eventParamsMapper,
+                    csvEventService,
+                    fieldFilterService,
+                    eventsMapper));
+
+    assertAll(
+        () -> assertStartsWith("event controller supports ordering by", exception.getMessage()),
+        () -> assertContains(missing1.getKey(), exception.getMessage()),
+        () -> assertContains(missing2.getKey(), exception.getMessage()));
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventMapper.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.event;
 
+import static java.util.Map.entry;
+
+import java.util.Map;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.webapi.controller.tracker.export.DataValueMapper;
 import org.hisp.dhis.webapi.controller.tracker.export.NoteMapper;
@@ -48,6 +51,43 @@ import org.mapstruct.Mapping;
     })
 public interface EventMapper
     extends ViewMapper<Event, org.hisp.dhis.webapi.controller.tracker.view.Event> {
+
+  /**
+   * Events can be ordered by given fields which correspond to fields on {@link
+   * org.hisp.dhis.program.Event}.
+   */
+  static final Map<String, String> ORDERABLE_FIELDS =
+      Map.ofEntries(
+          entry("assignedUser", "assignedUser"),
+          entry("assignedUserDisplayName", "assignedUser.displayName"),
+          entry("attributeOptionCombo", "attributeOptionCombo.uid"),
+          entry("completedAt", "completedDate"),
+          entry("completedBy", "completedBy"),
+          entry("createdAt", "created"),
+          entry("createdBy", "createdBy"),
+          entry("deleted", "deleted"),
+          entry("enrolledAt", "enrollment.enrollmentDate"),
+          entry("enrollment", "enrollment.uid"),
+          entry("enrollmentStatus", "enrollment.status"),
+          entry("event", "uid"),
+          entry("followup", "enrollment.followup"),
+          entry("occurredAt", "executionDate"),
+          entry("orgUnit", "organisationUnit.uid"),
+          entry("orgUnitName", "organisationUnit.name"),
+          entry(
+              "program",
+              "enrollment.program.uid"), // TODO(TECH-1606) this is what we do in the export. I
+          // assume we
+          // can also get the program via event.programStage.program
+          // right? Which one is more accurate
+          entry("programStage", "programStage.uid"),
+          entry("scheduledAt", "dueDate"),
+          entry("status", "status"),
+          entry("storedBy", "storedBy"),
+          entry("trackedEntity", "enrollment.trackedEntity.uid"),
+          entry("updatedAt", "lastUpdated"),
+          entry("updatedBy", "lastUpdatedBy"));
+
   @Mapping(target = "event", source = "uid")
   @Mapping(target = "program", source = "enrollment.program.uid")
   @Mapping(target = "programStage", source = "programStage.uid")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
@@ -35,8 +35,10 @@ import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.v
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
@@ -46,7 +48,6 @@ import org.hisp.dhis.common.UID;
 import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.tracker.export.event.EventOperationParams;
-import org.hisp.dhis.tracker.export.event.JdbcEventStore;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper;
@@ -60,8 +61,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 class EventRequestParamsMapper {
-  private static final Set<String> SORTABLE_PROPERTIES =
-      JdbcEventStore.QUERY_PARAM_COL_MAP.keySet();
+  private static final Set<String> ORDERABLE_FIELD_NAMES = EventMapper.ORDERABLE_FIELDS.keySet();
 
   public EventOperationParams map(RequestParams requestParams) throws BadRequestException {
     OrganisationUnitSelectionMode orgUnitMode =
@@ -160,22 +160,54 @@ class EventRequestParamsMapper {
     }
     validateOrderParams(order);
 
-    return OrderParamsHelper.toOrderParams(order);
+    return OrderParamsHelper.toOrderParams(
+        order.stream()
+            .map(
+                orderCriteria -> {
+                  if (EventMapper.ORDERABLE_FIELDS.containsKey(orderCriteria.getField())) {
+                    return OrderCriteria.of(
+                        EventMapper.ORDERABLE_FIELDS.get(orderCriteria.getField()),
+                        orderCriteria.getDirection());
+                  }
+
+                  return orderCriteria;
+                })
+            .toList());
   }
 
   private void validateOrderParams(List<OrderCriteria> order) throws BadRequestException {
-    Set<String> requestProperties =
-        order.stream()
-            .map(OrderCriteria::getField)
-            .filter(field -> !CodeGenerator.isValidUid(field))
+    Set<String> invalidOrderComponents =
+        order.stream().map(OrderCriteria::getField).collect(Collectors.toSet());
+    invalidOrderComponents.removeAll(ORDERABLE_FIELD_NAMES);
+    Set<String> uids =
+        invalidOrderComponents.stream()
+            .filter(CodeGenerator::isValidUid)
             .collect(Collectors.toSet());
+    invalidOrderComponents.removeAll(uids);
 
-    requestProperties.removeAll(SORTABLE_PROPERTIES);
-    if (!requestProperties.isEmpty()) {
+    if (!invalidOrderComponents.isEmpty()) {
       throw new BadRequestException(
           String.format(
-              "Order by property `%s` is not supported. Supported are `%s`",
-              String.join(", ", requestProperties), String.join(", ", SORTABLE_PROPERTIES)));
+              "order parameter is invalid. `%s` are either unsupported fields and/or invalid UID(s). Supported are data element and attribute UIDs and fields `%s`",
+              String.join(", ", invalidOrderComponents),
+              String.join(", ", ORDERABLE_FIELD_NAMES.stream().sorted().toList())));
+    }
+
+    Set<String> duplicateOrderComponents =
+        order.stream()
+            .map(OrderCriteria::getField)
+            .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()))
+            .entrySet()
+            .stream()
+            .filter(e -> e.getValue() > 1)
+            .map(Entry::getKey)
+            .collect(Collectors.toSet());
+
+    if (!duplicateOrderComponents.isEmpty()) {
+      throw new BadRequestException(
+          String.format(
+              "order parameter is invalid. `%s` are repeated. Data element and attribute UIDs and fields should only be specified once.",
+              String.join(", ", duplicateOrderComponents)));
     }
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -38,12 +38,15 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.zip.GZIPOutputStream;
 import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.UID;
@@ -54,6 +57,7 @@ import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.tracker.export.event.EventOperationParams;
 import org.hisp.dhis.tracker.export.event.EventParams;
+import org.hisp.dhis.tracker.export.event.EventService;
 import org.hisp.dhis.tracker.export.event.Events;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
 import org.hisp.dhis.webapi.controller.tracker.export.CsvService;
@@ -75,7 +79,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping(value = RESOURCE_PATH + "/" + EventsExportController.EVENTS)
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
-@RequiredArgsConstructor
 class EventsExportController {
   protected static final String EVENTS = "events";
 
@@ -91,6 +94,45 @@ class EventsExportController {
   @Nonnull private final FieldFilterService fieldFilterService;
 
   private final EventFieldsParamMapper eventsMapper;
+
+  public EventsExportController(
+      EventService eventService,
+      EventRequestParamsMapper eventParamsMapper,
+      CsvService<Event> csvEventService,
+      FieldFilterService fieldFilterService,
+      EventFieldsParamMapper eventsMapper) {
+    this.eventService = eventService;
+    this.eventParamsMapper = eventParamsMapper;
+    this.csvEventService = csvEventService;
+    this.fieldFilterService = fieldFilterService;
+    this.eventsMapper = eventsMapper;
+
+    assertUserOrderableFieldsAreSupported();
+  }
+
+  /**
+   * Ensures that all fields advocated by {@link
+   * org.hisp.dhis.webapi.controller.tracker.export.event} as orderable are in fact orderable by the
+   * service. Web is responsible for mapping from the language users use (our API) to our internal
+   * representation used in our services. This is to prevent web and service (store) from getting
+   * out of sync.
+   */
+  private void assertUserOrderableFieldsAreSupported() {
+    Set<String> orderableFields = eventService.getOrderableFields();
+    Set<String> unsupportedFields = new HashSet<>(EventMapper.ORDERABLE_FIELDS.values());
+    unsupportedFields.removeAll(orderableFields);
+    if (!unsupportedFields.isEmpty()) {
+      Set<String> unsupportedFieldNames =
+          EventMapper.ORDERABLE_FIELDS.entrySet().stream()
+              .filter(e -> unsupportedFields.contains(e.getValue()))
+              .map(Entry::getKey)
+              .collect(Collectors.toSet());
+      throw new IllegalStateException(
+          "event controller supports ordering by "
+              + String.join(", ", unsupportedFieldNames)
+              + " while event service does not.");
+    }
+  }
 
   @OpenApi.Response(status = Status.OK, value = OpenApiExport.ListResponse.class)
   @GetMapping(produces = APPLICATION_JSON_VALUE)


### PR DESCRIPTION
Note that this is the first in many order related PRs. We will have more possibilities in refactoring some of the methods/reuse them in RequestParamUtils, ...

## dhis-web-api

- Validate (EventsExportController): all orderable fields can be ordered by our service  
- Validate (EventRequestParamsMapper): the fields in the users order request parameter can be ordered by   
- Validate (EventRequestParamsMapper): UIDs are valid. /tracker/events allows ordering by data elements and attributes by passing UIDs in the order request parameter   
- Validate (EventRequestParamsMapper): the fields in the users order request parameter are not repeated like order=createdAt,createdAt:desc order=createdAt,createdAt   
- Map (EventMapper): from org.hisp.dhis.webapi.controller.tracker.view models representing the JSON API (known to users) to org.hisp.dhis (dhis-api) models used to persist into the DB like org.hisp.dhis.program.Event   

## Store

- Map: from org.hisp.dhis (dhis-api) models used to persist into to DB columns.

## Additional changes

* Added tests for OrderCriteriaTest to understand its current behavior. We might want to change it in a later issue. Notice that an invalid sort direction like `foo` is turned into `asc`. We should never hide any such issues but fail instead.

## Next PR

### Service

- Validate: attributes, data elements exist
- Validate: ACL attributes, data elements (access denied if user does not have it instead of filtering the attribute from the order components)

### Store

- Validate: fields can be ordered by (maybe only for now as a last safety net; until we know for sure no one else than tracker can directly use our stores).
