### PR TITLE
fix: update createdby when replicating users [DHIS2-15595]

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -294,9 +294,32 @@ class UserControllerTest extends DhisControllerConvenienceTest {
         "OK",
         "User replica created",
         POST(
-                "/users/" + peter.getUid() + "/replica",
-                "{'username':'peter2','password':'Saf€sEcre1'}")
+            "/users/" + peter.getUid() + "/replica",
+            "{'username':'peter2','password':'Saf€sEcre1'}")
             .content());
+  }
+
+  @Test
+  void testReplicateUserCreatedByUpdated() throws JsonProcessingException {
+    User newUser = createUserWithAuth("test", "ALL");
+
+    switchToNewUser(newUser);
+
+    String replicatedUsername = "peter2";
+
+    assertWebMessage(
+        "Created",
+        201,
+        "OK",
+        "User replica created",
+        POST(
+            "/users/" + peter.getUid() + "/replica",
+            "{'username':'" + replicatedUsername + "','password':'Saf€sEcre1'}")
+            .content());
+
+    User replicatedUser = userService.getUserByUsername(replicatedUsername);
+
+    assertEquals(newUser.getUsername(), replicatedUser.getCreatedBy().getUsername());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -294,8 +294,8 @@ class UserControllerTest extends DhisControllerConvenienceTest {
         "OK",
         "User replica created",
         POST(
-            "/users/" + peter.getUid() + "/replica",
-            "{'username':'peter2','password':'Saf€sEcre1'}")
+                "/users/" + peter.getUid() + "/replica",
+                "{'username':'peter2','password':'Saf€sEcre1'}")
             .content());
   }
 
@@ -313,8 +313,8 @@ class UserControllerTest extends DhisControllerConvenienceTest {
         "OK",
         "User replica created",
         POST(
-            "/users/" + peter.getUid() + "/replica",
-            "{'username':'" + replicatedUsername + "','password':'Saf€sEcre1'}")
+                "/users/" + peter.getUid() + "/replica",
+                "{'username':'" + replicatedUsername + "','password':'Saf€sEcre1'}")
             .content());
 
     User replicatedUser = userService.getUserByUsername(replicatedUsername);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -484,6 +484,7 @@ public class UserController extends AbstractCrudController<User> {
     userReplica.setUid(CodeGenerator.generateUid());
     userReplica.setCode(null);
     userReplica.setCreated(new Date());
+    userReplica.setCreatedBy( currentUser );
     userReplica.setLdapId(null);
     userReplica.setOpenId(null);
     userReplica.setUsername(username);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -484,7 +484,7 @@ public class UserController extends AbstractCrudController<User> {
     userReplica.setUid(CodeGenerator.generateUid());
     userReplica.setCode(null);
     userReplica.setCreated(new Date());
-    userReplica.setCreatedBy( currentUser );
+    userReplica.setCreatedBy(currentUser);
     userReplica.setLdapId(null);
     userReplica.setOpenId(null);
     userReplica.setUsername(username);


### PR DESCRIPTION
## Summary
Adds an update with the current user's ID to the createdBy field on the replicated user in the UserController's replicateUser method.

### Automatic test
UserControllerTest#testReplicateUserCreatedByUpdated()

### Manual test
Replicate a user in the context menu in the user management app, then investigate the userinfo table and observe that the "creatoruserid" has the same ID as the user performing the replicate. 

Jira: [DHIS2-15595](https://dhis2.atlassian.net/browse/DHIS2-15595)