### PR TITLE
chore: Order objects in tracker import report [DHIS2-15596]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -101,13 +101,9 @@ public abstract class AbstractTrackerPersister<
 
     Set<String> updatedTeiList = bundle.getUpdatedTeis();
 
-    for (int idx = 0; idx < dtos.size(); idx++) {
-      //
-      // Create the Report for the entity being persisted
-      //
-      final T trackerDto = dtos.get(idx);
+    for (T trackerDto : dtos) {
 
-      Entity objectReport = new Entity(getType(), trackerDto.getUid(), idx);
+      Entity objectReport = new Entity(getType(), trackerDto.getUid(), trackerDto.getIndex());
 
       try {
         //

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Enrollment.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Enrollment.java
@@ -83,10 +83,15 @@ public class Enrollment implements TrackerDto {
   @JsonProperty private User updatedBy;
 
   @JsonProperty int index;
+
   @JsonProperty private Geometry geometry;
+
   @JsonProperty @Builder.Default private List<Event> events = new ArrayList<>();
+
   @JsonProperty @Builder.Default private List<Relationship> relationships = new ArrayList<>();
+
   @JsonProperty @Builder.Default private List<Attribute> attributes = new ArrayList<>();
+
   @JsonProperty @Builder.Default private List<Note> notes = new ArrayList<>();
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Enrollment.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Enrollment.java
@@ -82,14 +82,11 @@ public class Enrollment implements TrackerDto {
 
   @JsonProperty private User updatedBy;
 
+  @JsonProperty int index;
   @JsonProperty private Geometry geometry;
-
   @JsonProperty @Builder.Default private List<Event> events = new ArrayList<>();
-
   @JsonProperty @Builder.Default private List<Relationship> relationships = new ArrayList<>();
-
   @JsonProperty @Builder.Default private List<Attribute> attributes = new ArrayList<>();
-
   @JsonProperty @Builder.Default private List<Note> notes = new ArrayList<>();
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Event.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Event.java
@@ -94,10 +94,15 @@ public class Event implements TrackerDto {
   @JsonProperty private Geometry geometry;
 
   @JsonProperty int index;
+
   @JsonProperty private User assignedUser;
+
   @JsonProperty private User createdBy;
+
   @JsonProperty private User updatedBy;
+
   @JsonProperty @Builder.Default private Set<DataValue> dataValues = new HashSet<>();
+
   @JsonProperty @Builder.Default private List<Note> notes = new ArrayList<>();
 
   @JsonIgnore

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Event.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Event.java
@@ -93,14 +93,11 @@ public class Event implements TrackerDto {
 
   @JsonProperty private Geometry geometry;
 
+  @JsonProperty int index;
   @JsonProperty private User assignedUser;
-
   @JsonProperty private User createdBy;
-
   @JsonProperty private User updatedBy;
-
   @JsonProperty @Builder.Default private Set<DataValue> dataValues = new HashSet<>();
-
   @JsonProperty @Builder.Default private List<Note> notes = new ArrayList<>();
 
   @JsonIgnore

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Relationship.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Relationship.java
@@ -52,10 +52,15 @@ public class Relationship implements TrackerDto {
   @JsonProperty private Instant createdAt;
 
   @JsonProperty int index;
+
   @JsonProperty private Instant updatedAt;
+
   @JsonProperty private boolean bidirectional;
+
   @JsonProperty private boolean deleted;
+
   @JsonProperty private RelationshipItem from;
+
   @JsonProperty private RelationshipItem to;
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Relationship.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Relationship.java
@@ -51,14 +51,11 @@ public class Relationship implements TrackerDto {
 
   @JsonProperty private Instant createdAt;
 
+  @JsonProperty int index;
   @JsonProperty private Instant updatedAt;
-
   @JsonProperty private boolean bidirectional;
-
   @JsonProperty private boolean deleted;
-
   @JsonProperty private RelationshipItem from;
-
   @JsonProperty private RelationshipItem to;
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/TrackedEntity.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/TrackedEntity.java
@@ -71,10 +71,15 @@ public class TrackedEntity implements TrackerDto {
   @JsonProperty private String storedBy;
 
   @JsonProperty int index;
+
   @JsonProperty private User createdBy;
+
   @JsonProperty private User updatedBy;
+
   @JsonProperty @Builder.Default private List<Relationship> relationships = new ArrayList<>();
+
   @JsonProperty @Builder.Default private List<Attribute> attributes = new ArrayList<>();
+
   @JsonProperty @Builder.Default private List<Enrollment> enrollments = new ArrayList<>();
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/TrackedEntity.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/TrackedEntity.java
@@ -70,14 +70,11 @@ public class TrackedEntity implements TrackerDto {
 
   @JsonProperty private String storedBy;
 
+  @JsonProperty int index;
   @JsonProperty private User createdBy;
-
   @JsonProperty private User updatedBy;
-
   @JsonProperty @Builder.Default private List<Relationship> relationships = new ArrayList<>();
-
   @JsonProperty @Builder.Default private List<Attribute> attributes = new ArrayList<>();
-
   @JsonProperty @Builder.Default private List<Enrollment> enrollments = new ArrayList<>();
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/TrackerDto.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/TrackerDto.java
@@ -33,7 +33,10 @@ import org.hisp.dhis.tracker.TrackerType;
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 public interface TrackerDto {
+
   String getUid();
 
   TrackerType getTrackerType();
+
+  int getIndex();
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/report/Entity.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/report/Entity.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.tracker.imports.report;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,13 +40,10 @@ import org.hisp.dhis.tracker.TrackerType;
  */
 @Data
 public class Entity {
-  /** Type of object this {@link Entity} represents. */
   @JsonProperty private final TrackerType trackerType;
 
-  /** Index into list. */
-  @JsonProperty private Integer index;
+  @JsonIgnore private int index;
 
-  /** UID of entity (if object is id object). */
   @JsonProperty private String uid;
 
   private List<Error> errorReports = new ArrayList<>();
@@ -54,7 +52,7 @@ public class Entity {
     this.trackerType = trackerType;
   }
 
-  public Entity(TrackerType trackerType, String uid, Integer index) {
+  public Entity(TrackerType trackerType, String uid, int index) {
     this.trackerType = trackerType;
     this.uid = uid;
     this.index = index;
@@ -64,7 +62,7 @@ public class Entity {
   public Entity(
       @JsonProperty("trackerType") TrackerType trackerType,
       @JsonProperty("uid") String uid,
-      @JsonProperty("index") Integer index,
+      @JsonProperty("index") int index,
       @JsonProperty("errorReports") List<Error> errorReports) {
     this.trackerType = trackerType;
     this.uid = uid;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/report/TrackerTypeReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/report/TrackerTypeReport.java
@@ -90,10 +90,7 @@ public class TrackerTypeReport {
   }
 
   private List<Error> getErrorReports() {
-    List<Error> errorReports = new ArrayList<>();
-    entityReport.forEach(entity -> errorReports.addAll(entity.getErrorReports()));
-
-    return errorReports;
+    return entityReport.stream().flatMap(e -> e.getErrorReports().stream()).toList();
   }
 
   public List<TrackerSideEffectDataBundle> getSideEffectDataBundles() {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/report/TrackerTypeReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/report/TrackerTypeReport.java
@@ -31,9 +31,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import lombok.Data;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.imports.job.TrackerSideEffectDataBundle;
@@ -49,7 +48,7 @@ public class TrackerTypeReport {
 
   @JsonIgnore private List<TrackerSideEffectDataBundle> sideEffectDataBundles = new ArrayList<>();
 
-  private Map<Integer, Entity> entityReport = new HashMap<>();
+  private List<Entity> entityReport = new ArrayList<>();
 
   public TrackerTypeReport(TrackerType trackerType) {
     this.trackerType = trackerType;
@@ -65,17 +64,12 @@ public class TrackerTypeReport {
     this.trackerType = trackerType;
     this.stats = stats;
     this.sideEffectDataBundles = sideEffectDataBundles;
-
-    if (entityReport != null) {
-      for (Entity entity : entityReport) {
-        this.entityReport.put(entity.getIndex(), entity);
-      }
-    }
+    this.entityReport = entityReport;
   }
 
   @JsonProperty("objectReports")
   public List<Entity> getEntityReport() {
-    return new ArrayList<>(entityReport.values());
+    return entityReport.stream().sorted(Comparator.comparingInt(Entity::getIndex)).toList();
   }
 
   // -----------------------------------------------------------------------------------
@@ -92,18 +86,14 @@ public class TrackerTypeReport {
   }
 
   public void addEntity(Entity entity) {
-    this.entityReport.put(entity.getIndex(), entity);
+    this.entityReport.add(entity);
   }
 
   private List<Error> getErrorReports() {
     List<Error> errorReports = new ArrayList<>();
-    entityReport.values().forEach(entity -> errorReports.addAll(entity.getErrorReports()));
+    entityReport.forEach(entity -> errorReports.addAll(entity.getErrorReports()));
 
     return errorReports;
-  }
-
-  public Map<Integer, Entity> getEntityReportMap() {
-    return entityReport;
   }
 
   public List<TrackerSideEffectDataBundle> getSideEffectDataBundles() {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/DefaultValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/DefaultValidationService.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.tracker.imports.validation;
 import static org.hisp.dhis.tracker.imports.validation.PersistablesFilter.filter;
 
 import java.util.HashSet;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.ListUtils;
@@ -70,7 +71,13 @@ public class DefaultValidationService implements ValidationService {
           "Skipping validation for metadata import by user '"
               + bundle.getUsername()
               + "'. Not recommended.");
-      return Result.empty();
+      return new Result(
+          bundle.getTrackedEntities(),
+          bundle.getEnrollments(),
+          bundle.getEvents(),
+          bundle.getRelationships(),
+          Set.of(),
+          Set.of());
     }
 
     Reporter reporter =

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/report/TrackerBundleImportReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/report/TrackerBundleImportReportTest.java
@@ -214,8 +214,8 @@ class TrackerBundleImportReportTest {
         serializedReportTrackerTypeReport.getTrackerType(),
         deserializedReportTrackerTypeReport.getTrackerType());
     assertEquals(
-        serializedReportTrackerTypeReport.getEntityReportMap(),
-        deserializedReportTrackerTypeReport.getEntityReportMap());
+        serializedReportTrackerTypeReport.getEntityReport(),
+        deserializedReportTrackerTypeReport.getEntityReport());
     assertEquals(
         serializedReportTrackerTypeReport.getEntityReport(),
         deserializedReportTrackerTypeReport.getEntityReport());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/PersistablesFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/PersistablesFilterTest.java
@@ -865,6 +865,11 @@ class PersistablesFilterTest {
       public String getUid() {
         return uid;
       }
+
+      @Override
+      public int getIndex() {
+        return 0;
+      }
     };
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/SeqTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/SeqTest.java
@@ -263,6 +263,11 @@ class SeqTest {
       public TrackerType getTrackerType() {
         return TrackerType.TRACKED_ENTITY;
       }
+
+      @Override
+      public int getIndex() {
+        return 0;
+      }
     };
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/ReportSummaryDeleteIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/ReportSummaryDeleteIntegrationTest.java
@@ -150,7 +150,7 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest {
         persistenceReport.getTypeReportMap().get(trackedEntityType).getStats().getCreated());
     assertEquals(
         expected,
-        persistenceReport.getTypeReportMap().get(trackedEntityType).getEntityReportMap().size());
+        persistenceReport.getTypeReportMap().get(trackedEntityType).getEntityReport().size());
   }
 
   private void assertDeletedObjects(
@@ -161,6 +161,6 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest {
         persistenceReport.getTypeReportMap().get(trackedEntityType).getStats().getDeleted());
     assertEquals(
         expected,
-        persistenceReport.getTypeReportMap().get(trackedEntityType).getEntityReportMap().size());
+        persistenceReport.getTypeReportMap().get(trackedEntityType).getEntityReport().size());
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentImportValidationTest.java
@@ -146,8 +146,7 @@ class EnrollmentImportValidationTest extends TrackerTest {
             .getPersistenceReport()
             .getTypeReportMap()
             .get(TrackerType.ENROLLMENT)
-            .getEntityReportMap()
-            .values()
+            .getEntityReport()
             .size());
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
@@ -417,7 +417,7 @@ class EventImportValidationTest extends TrackerTest {
   private Event getEventFromReport(ImportReport importReport) {
     final Map<TrackerType, TrackerTypeReport> typeReportMap =
         importReport.getPersistenceReport().getTypeReportMap();
-    String newEvent = typeReportMap.get(TrackerType.EVENT).getEntityReportMap().get(0).getUid();
+    String newEvent = typeReportMap.get(TrackerType.EVENT).getEntityReport().get(0).getUid();
     return programStageServiceInstance.getEvent(newEvent);
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAssertions.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAssertions.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import org.hisp.dhis.jsontree.JsonArray;
@@ -43,6 +44,7 @@ import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.tracker.TrackerType;
 
 public class JsonAssertions {
 
@@ -163,5 +165,20 @@ public class JsonAssertions {
     assertTrue(
         actual.containsAll(toValue, expected),
         () -> String.format("expected %s instead got %s", expected, actual));
+  }
+
+  public static void assertReportEntities(
+      List<String> expectedEntityUids, JsonImportReport importReport, TrackerType trackerType) {
+    JsonTypeReport jsonTypeReport =
+        switch (trackerType) {
+          case TRACKED_ENTITY -> importReport.getBundleReport().getTrackedEntities();
+          case ENROLLMENT -> importReport.getBundleReport().getEnrollments();
+          case EVENT -> importReport.getBundleReport().getEvents();
+          case RELATIONSHIP -> importReport.getBundleReport().getRelationships();
+        };
+
+    List<String> reportEntityUids =
+        jsonTypeReport.getEntityReport().stream().map(JsonEntity::getUid).toList();
+    assertEquals(expectedEntityUids, reportEntityUids);
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAssertions.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAssertions.java
@@ -168,7 +168,7 @@ public class JsonAssertions {
   }
 
   public static void assertReportEntities(
-      List<String> expectedEntityUids, JsonImportReport importReport, TrackerType trackerType) {
+      List<String> expectedEntityUids, TrackerType trackerType, JsonImportReport importReport) {
     JsonTypeReport jsonTypeReport =
         switch (trackerType) {
           case TRACKED_ENTITY -> importReport.getBundleReport().getTrackedEntities();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonBundleReport.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonBundleReport.java
@@ -25,48 +25,32 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.tracker.view;
+package org.hisp.dhis.webapi.controller.tracker;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.Instant;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.common.OpenApi.Shared.Pattern;
-import org.hisp.dhis.relationship.RelationshipType;
-import org.hisp.dhis.webapi.common.UID;
+import org.hisp.dhis.jsontree.JsonMap;
+import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.tracker.imports.report.PersistenceReport;
 
-/**
- * @author Morten Olav Hansen <mortenoh@gmail.com>
- */
-@OpenApi.Shared(pattern = Pattern.TRACKER)
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Relationship {
-  @OpenApi.Property({UID.class, Relationship.class})
-  @JsonProperty
-  private String relationship;
+/** Web API equivalent of a {@link PersistenceReport}. */
+public interface JsonBundleReport extends JsonObject {
 
-  @JsonProperty private String relationshipName;
+  default JsonTypeReport getTrackedEntities() {
+    JsonMap<JsonTypeReport> typeReportMap = getMap("typeReportMap", JsonTypeReport.class);
+    return typeReportMap.get("TRACKED_ENTITY");
+  }
 
-  @OpenApi.Property({UID.class, RelationshipType.class})
-  @JsonProperty
-  private String relationshipType;
+  default JsonTypeReport getEnrollments() {
+    JsonMap<JsonTypeReport> typeReportMap = getMap("typeReportMap", JsonTypeReport.class);
+    return typeReportMap.get("ENROLLMENT");
+  }
 
-  @JsonProperty private Instant createdAt;
+  default JsonTypeReport getEvents() {
+    JsonMap<JsonTypeReport> typeReportMap = getMap("typeReportMap", JsonTypeReport.class);
+    return typeReportMap.get("EVENT");
+  }
 
-  @JsonProperty private Instant updatedAt;
-
-  @JsonProperty private boolean bidirectional;
-
-  @JsonProperty private RelationshipItem from;
-
-  @JsonProperty private RelationshipItem to;
-
-  @JsonIgnore private int index;
+  default JsonTypeReport getRelationships() {
+    JsonMap<JsonTypeReport> typeReportMap = getMap("typeReportMap", JsonTypeReport.class);
+    return typeReportMap.get("RELATIONSHIP");
+  }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonEntity.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonEntity.java
@@ -25,48 +25,23 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.tracker.view;
+package org.hisp.dhis.webapi.controller.tracker;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.Instant;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.common.OpenApi.Shared.Pattern;
-import org.hisp.dhis.relationship.RelationshipType;
-import org.hisp.dhis.webapi.common.UID;
+import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.tracker.imports.report.Entity;
 
-/**
- * @author Morten Olav Hansen <mortenoh@gmail.com>
- */
-@OpenApi.Shared(pattern = Pattern.TRACKER)
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Relationship {
-  @OpenApi.Property({UID.class, Relationship.class})
-  @JsonProperty
-  private String relationship;
+/** Web API equivalent of an {@link Entity}. */
+public interface JsonEntity extends JsonObject {
 
-  @JsonProperty private String relationshipName;
+  default String getTrackerType() {
+    return getString("trackerType").string();
+  }
 
-  @OpenApi.Property({UID.class, RelationshipType.class})
-  @JsonProperty
-  private String relationshipType;
+  default String getUid() {
+    return getString("uid").string();
+  }
 
-  @JsonProperty private Instant createdAt;
-
-  @JsonProperty private Instant updatedAt;
-
-  @JsonProperty private boolean bidirectional;
-
-  @JsonProperty private RelationshipItem from;
-
-  @JsonProperty private RelationshipItem to;
-
-  @JsonIgnore private int index;
+  default String getIndex() {
+    return getString("index").string();
+  }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonEntity.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonEntity.java
@@ -40,8 +40,4 @@ public interface JsonEntity extends JsonObject {
   default String getUid() {
     return getString("uid").string();
   }
-
-  default String getIndex() {
-    return getString("index").string();
-  }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonImportReport.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonImportReport.java
@@ -25,48 +25,27 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.tracker.view;
+package org.hisp.dhis.webapi.controller.tracker;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.Instant;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.common.OpenApi.Shared.Pattern;
-import org.hisp.dhis.relationship.RelationshipType;
-import org.hisp.dhis.webapi.common.UID;
+import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.tracker.imports.report.ImportReport;
+import org.hisp.dhis.webapi.json.domain.JsonStats;
 
-/**
- * @author Morten Olav Hansen <mortenoh@gmail.com>
- */
-@OpenApi.Shared(pattern = Pattern.TRACKER)
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Relationship {
-  @OpenApi.Property({UID.class, Relationship.class})
-  @JsonProperty
-  private String relationship;
+/** Web API equivalent of an {@link ImportReport}. */
+public interface JsonImportReport extends JsonObject {
+  default String getMessage() {
+    return getString("message").string();
+  }
 
-  @JsonProperty private String relationshipName;
+  default String getStatus() {
+    return getString("status").string();
+  }
 
-  @OpenApi.Property({UID.class, RelationshipType.class})
-  @JsonProperty
-  private String relationshipType;
+  default JsonStats getStats() {
+    return get("stats", JsonStats.class);
+  }
 
-  @JsonProperty private Instant createdAt;
-
-  @JsonProperty private Instant updatedAt;
-
-  @JsonProperty private boolean bidirectional;
-
-  @JsonProperty private RelationshipItem from;
-
-  @JsonProperty private RelationshipItem to;
-
-  @JsonIgnore private int index;
+  default JsonBundleReport getBundleReport() {
+    return get("bundleReport", JsonBundleReport.class);
+  }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonTypeReport.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonTypeReport.java
@@ -25,48 +25,16 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.tracker.view;
+package org.hisp.dhis.webapi.controller.tracker;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.Instant;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.common.OpenApi.Shared.Pattern;
-import org.hisp.dhis.relationship.RelationshipType;
-import org.hisp.dhis.webapi.common.UID;
+import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
 
-/**
- * @author Morten Olav Hansen <mortenoh@gmail.com>
- */
-@OpenApi.Shared(pattern = Pattern.TRACKER)
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Relationship {
-  @OpenApi.Property({UID.class, Relationship.class})
-  @JsonProperty
-  private String relationship;
+/** Web API equivalent of a {@link TrackerTypeReport}. */
+public interface JsonTypeReport extends JsonObject {
 
-  @JsonProperty private String relationshipName;
-
-  @OpenApi.Property({UID.class, RelationshipType.class})
-  @JsonProperty
-  private String relationshipType;
-
-  @JsonProperty private Instant createdAt;
-
-  @JsonProperty private Instant updatedAt;
-
-  @JsonProperty private boolean bidirectional;
-
-  @JsonProperty private RelationshipItem from;
-
-  @JsonProperty private RelationshipItem to;
-
-  @JsonIgnore private int index;
+  default JsonList<JsonEntity> getEntityReport() {
+    return getList("objectReports", JsonEntity.class);
+  }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
@@ -27,15 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.imports;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.util.List;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
-import org.hisp.dhis.webapi.controller.tracker.JsonEntity;
-import org.hisp.dhis.webapi.controller.tracker.JsonImportReport;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -45,49 +38,6 @@ import org.junit.jupiter.api.Test;
  * @author Jan Bernitt
  */
 class TrackerImportControllerTest extends DhisControllerConvenienceTest {
-
-  @Test
-  void shouldReturnOrderedReport() {
-    TrackedEntityType type = createTrackedEntityType('A');
-    manager.save(type);
-    OrganisationUnit organisationUnit = createOrganisationUnit('A');
-    manager.save(organisationUnit);
-
-    String body =
-        """
-        {
-         "trackedEntities": [
-             {
-               "trackedEntity": "IybbQIQt6rn",
-               "trackedEntityType": "%s",
-               "orgUnit": "%s"
-             },
-             {
-               "trackedEntity": "daMwzsKN3oJ",
-               "trackedEntityType": "%s",
-               "orgUnit": "%s"
-             }
-           ]
-        }"""
-            .formatted(
-                type.getUid(), organisationUnit.getUid(), type.getUid(), organisationUnit.getUid());
-    JsonImportReport importReport =
-        POST(
-                "/tracker?async=false&reportMode=FULL"
-                    + "&validationMode=SKIP"
-                    + "&atomicMode=OBJECT",
-                body)
-            .content(HttpStatus.OK)
-            .as(JsonImportReport.class);
-
-    assertEquals(
-        List.of("IybbQIQt6rn", "daMwzsKN3oJ"),
-        importReport.getBundleReport().getTrackedEntities().getEntityReport().stream()
-            .map(JsonEntity::getUid)
-            .toList());
-    assertEquals("OK", importReport.getStatus());
-  }
-
   @Test
   void shouldSuccessWhenAllValidParametersArePassed() {
     assertWebMessage(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.Test;
  */
 class TrackerImportControllerTest extends DhisControllerConvenienceTest {
   @Test
-  void shouldSuccessWhenAllValidParametersArePassed() {
+  void shouldSucceedWhenAllValidParametersArePassed() {
     assertWebMessage(
         "OK",
         200,

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportReportTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportReportTest.java
@@ -27,6 +27,10 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.imports;
 
+import static org.hisp.dhis.tracker.TrackerType.ENROLLMENT;
+import static org.hisp.dhis.tracker.TrackerType.EVENT;
+import static org.hisp.dhis.tracker.TrackerType.RELATIONSHIP;
+import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertReportEntities;
 
 import java.util.List;
@@ -36,7 +40,6 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.web.WebClient;
@@ -99,14 +102,10 @@ class TrackerImportReportTest extends DhisControllerConvenienceTest {
             .as(JsonImportReport.class);
 
     assertReportEntities(
-        List.of("IybbQIQt6te", "daMwzsKN3te", "FRM97UKN8te"),
-        importReport,
-        TrackerType.TRACKED_ENTITY);
-    assertReportEntities(
-        List.of("IybbQIQt6en", "daMwzsKN3en"), importReport, TrackerType.ENROLLMENT);
-    assertReportEntities(List.of("IybbQIQt6ev", "daMwzsKN3ev"), importReport, TrackerType.EVENT);
-    assertReportEntities(
-        List.of("IybbQIQtrel", "daMwzsKNrel"), importReport, TrackerType.RELATIONSHIP);
+        List.of("IybbQIQt6te", "daMwzsKN3te", "FRM97UKN8te"), TRACKED_ENTITY, importReport);
+    assertReportEntities(List.of("IybbQIQt6en", "daMwzsKN3en"), ENROLLMENT, importReport);
+    assertReportEntities(List.of("IybbQIQt6ev", "daMwzsKN3ev"), EVENT, importReport);
+    assertReportEntities(List.of("IybbQIQtrel", "daMwzsKNrel"), RELATIONSHIP, importReport);
   }
 
   @Test
@@ -122,13 +121,9 @@ class TrackerImportReportTest extends DhisControllerConvenienceTest {
             .as(JsonImportReport.class);
 
     assertReportEntities(
-        List.of("IybbQIQt6te", "daMwzsKN3te", "FRM97UKN8te"),
-        importReport,
-        TrackerType.TRACKED_ENTITY);
-    assertReportEntities(
-        List.of("IybbQIQt6en", "daMwzsKN3en"), importReport, TrackerType.ENROLLMENT);
-    assertReportEntities(List.of("IybbQIQt6ev", "daMwzsKN3ev"), importReport, TrackerType.EVENT);
-    assertReportEntities(
-        List.of("IybbQIQtrel", "daMwzsKNrel"), importReport, TrackerType.RELATIONSHIP);
+        List.of("IybbQIQt6te", "daMwzsKN3te", "FRM97UKN8te"), TRACKED_ENTITY, importReport);
+    assertReportEntities(List.of("IybbQIQt6en", "daMwzsKN3en"), ENROLLMENT, importReport);
+    assertReportEntities(List.of("IybbQIQt6ev", "daMwzsKN3ev"), EVENT, importReport);
+    assertReportEntities(List.of("IybbQIQtrel", "daMwzsKNrel"), RELATIONSHIP, importReport);
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportReportTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportReportTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.imports;
+
+import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertReportEntities;
+
+import java.util.List;
+import java.util.Set;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.relationship.RelationshipType;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.tracker.TrackerType;
+import org.hisp.dhis.tracker.imports.report.ImportReport;
+import org.hisp.dhis.web.HttpStatus;
+import org.hisp.dhis.web.WebClient;
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.webapi.controller.tracker.JsonImportReport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link ImportReport} behavior through {@link TrackerImportController} using (mocked) REST
+ * requests
+ */
+class TrackerImportReportTest extends DhisControllerConvenienceTest {
+
+  private static final String ORG_UNIT_UID = "PSeMWi7rBgb";
+
+  private static final String TE_TYPE_UID = "PrZMWi7rBga";
+
+  private static final String PROGRAM_UID = "XrZRFi7rU9e";
+
+  private static final String PS_UID = "I8RRFi7rUps";
+
+  private static final String REL_TYPE_UID = "A4ORFi7rReL";
+
+  @BeforeEach
+  void setUp() {
+    TrackedEntityType type = createTrackedEntityType('A');
+    type.setUid(TE_TYPE_UID);
+    manager.save(type);
+
+    OrganisationUnit orgUnit = createOrganisationUnit('A');
+    orgUnit.setUid(ORG_UNIT_UID);
+    manager.save(orgUnit);
+
+    Program program = createProgram('A');
+    program.setOrganisationUnits(Set.of(orgUnit));
+    program.setTrackedEntityType(type);
+    program.setUid(PROGRAM_UID);
+    manager.save(program);
+
+    ProgramStage programStage = createProgramStage('A', program);
+    programStage.setUid(PS_UID);
+    manager.save(programStage);
+
+    RelationshipType relType = createPersonToPersonRelationshipType('A', program, type, false);
+    relType.setUid(REL_TYPE_UID);
+    manager.save(relType);
+  }
+
+  @Test
+  void shouldReturnOrderedEntitiesInReportWhenFlatPayloadImportIsSuccessful() {
+    JsonImportReport importReport =
+        POST(
+                "/tracker?async=false&reportMode=FULL"
+                    + "&validationMode=SKIP"
+                    + "&atomicMode=OBJECT"
+                    + "&skipRuleEngine=true",
+                WebClient.Body("tracker/import_flatten_payload.json"))
+            .content(HttpStatus.OK)
+            .as(JsonImportReport.class);
+
+    assertReportEntities(
+        List.of("IybbQIQt6te", "daMwzsKN3te", "FRM97UKN8te"),
+        importReport,
+        TrackerType.TRACKED_ENTITY);
+    assertReportEntities(
+        List.of("IybbQIQt6en", "daMwzsKN3en"), importReport, TrackerType.ENROLLMENT);
+    assertReportEntities(List.of("IybbQIQt6ev", "daMwzsKN3ev"), importReport, TrackerType.EVENT);
+    assertReportEntities(
+        List.of("IybbQIQtrel", "daMwzsKNrel"), importReport, TrackerType.RELATIONSHIP);
+  }
+
+  @Test
+  void shouldReturnOrderedEntitiesInReportWhenNestedPayloadImportIsSuccessful() {
+    JsonImportReport importReport =
+        POST(
+                "/tracker?async=false&reportMode=FULL"
+                    + "&validationMode=SKIP"
+                    + "&atomicMode=OBJECT"
+                    + "&skipRuleEngine=true",
+                WebClient.Body("tracker/import_nested_payload.json"))
+            .content(HttpStatus.OK)
+            .as(JsonImportReport.class);
+
+    assertReportEntities(
+        List.of("IybbQIQt6te", "daMwzsKN3te", "FRM97UKN8te"),
+        importReport,
+        TrackerType.TRACKED_ENTITY);
+    assertReportEntities(
+        List.of("IybbQIQt6en", "daMwzsKN3en"), importReport, TrackerType.ENROLLMENT);
+    assertReportEntities(List.of("IybbQIQt6ev", "daMwzsKN3ev"), importReport, TrackerType.EVENT);
+    assertReportEntities(
+        List.of("IybbQIQtrel", "daMwzsKNrel"), importReport, TrackerType.RELATIONSHIP);
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/resources/tracker/import_flatten_payload.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/tracker/import_flatten_payload.json
@@ -1,0 +1,79 @@
+{
+  "trackedEntities": [
+    {
+      "trackedEntity": "IybbQIQt6te",
+      "trackedEntityType": "PrZMWi7rBga",
+      "orgUnit": "PSeMWi7rBgb"
+    },
+    {
+      "trackedEntity": "daMwzsKN3te",
+      "trackedEntityType": "PrZMWi7rBga",
+      "orgUnit": "PSeMWi7rBgb"
+    },
+    {
+      "trackedEntity": "FRM97UKN8te",
+      "trackedEntityType": "PrZMWi7rBga",
+      "orgUnit": "PSeMWi7rBgb"
+    }
+  ],
+  "enrollments": [{
+    "enrollment": "IybbQIQt6en",
+    "trackedEntity": "IybbQIQt6te",
+    "orgUnit": "PSeMWi7rBgb",
+    "program": "XrZRFi7rU9e",
+    "enrolledAt": "2016-03-17T01:51:39.609+0000"
+    },
+    {
+      "enrollment": "daMwzsKN3en",
+      "trackedEntity": "daMwzsKN3te",
+      "orgUnit": "PSeMWi7rBgb",
+      "program": "XrZRFi7rU9e",
+      "enrolledAt": "2016-03-17T01:51:39.609+0000"
+    }
+  ],
+  "events": [
+    {
+      "event": "IybbQIQt6ev",
+      "enrollment": "IybbQIQt6en",
+      "orgUnit": "PSeMWi7rBgb",
+      "programStage": "I8RRFi7rUps"
+    },
+    {
+      "event": "daMwzsKN3ev",
+      "enrollment": "daMwzsKN3en",
+      "orgUnit": "PSeMWi7rBgb",
+      "programStage": "I8RRFi7rUps"
+    }
+  ],
+  "relationships": [
+    {
+      "relationshipType": "A4ORFi7rReL",
+      "relationship": "IybbQIQtrel",
+      "from": {
+        "trackedEntity": {
+          "trackedEntity": "IybbQIQt6te"
+        }
+      },
+      "to": {
+        "trackedEntity": {
+          "trackedEntity":"daMwzsKN3te"
+        }
+      }
+    },
+    {
+      "relationshipType": "A4ORFi7rReL",
+      "relationship": "daMwzsKNrel",
+      "from": {
+        "trackedEntity": {
+          "trackedEntity": "IybbQIQt6te"
+        }
+      },
+      "to": {
+        "trackedEntity": {
+          "trackedEntity": "FRM97UKN8te"
+        }
+      }
+    }
+  ]
+
+}

--- a/dhis-2/dhis-test-web-api/src/test/resources/tracker/import_nested_payload.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/tracker/import_nested_payload.json
@@ -1,0 +1,78 @@
+{
+  "trackedEntities": [
+    {
+      "trackedEntity": "IybbQIQt6te",
+      "trackedEntityType": "PrZMWi7rBga",
+      "orgUnit": "PSeMWi7rBgb",
+      "enrollments": [
+        {
+          "enrollment": "IybbQIQt6en",
+          "orgUnit": "PSeMWi7rBgb",
+          "program": "XrZRFi7rU9e",
+          "enrolledAt": "2016-03-17T01:51:39.609+0000",
+          "events": [
+            {
+              "event": "IybbQIQt6ev",
+              "orgUnit": "PSeMWi7rBgb",
+              "programStage": "I8RRFi7rUps"
+            }]
+        }
+      ],
+      "relationships": [
+        {
+          "relationshipType": "A4ORFi7rReL",
+          "relationship": "IybbQIQtrel",
+          "from": {
+            "trackedEntity": {
+              "trackedEntity": "IybbQIQt6te"
+            }
+          },
+          "to": {
+            "trackedEntity": {
+              "trackedEntity":"daMwzsKN3te"
+            }
+          }
+        },
+        {
+          "relationshipType": "A4ORFi7rReL",
+          "relationship": "daMwzsKNrel",
+          "from": {
+            "trackedEntity": {
+              "trackedEntity": "IybbQIQt6te"
+            }
+          },
+          "to": {
+            "trackedEntity": {
+              "trackedEntity": "FRM97UKN8te"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "trackedEntity": "daMwzsKN3te",
+      "trackedEntityType": "PrZMWi7rBga",
+      "orgUnit": "PSeMWi7rBgb",
+      "enrollments": [
+        {
+          "enrollment": "daMwzsKN3en",
+          "orgUnit": "PSeMWi7rBgb",
+          "program": "XrZRFi7rU9e",
+          "enrolledAt": "2016-03-17T01:51:39.609+0000",
+          "events": [
+            {
+              "event": "daMwzsKN3ev",
+              "orgUnit": "PSeMWi7rBgb",
+              "programStage": "I8RRFi7rUps"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "trackedEntity": "FRM97UKN8te",
+      "trackedEntityType": "PrZMWi7rBga",
+      "orgUnit": "PSeMWi7rBgb"
+    }
+  ]
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Enrollment.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Enrollment.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.view;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -100,4 +101,6 @@ public class Enrollment {
   @JsonProperty @Builder.Default private List<Attribute> attributes = new ArrayList<>();
 
   @JsonProperty @Builder.Default private List<Note> notes = new ArrayList<>();
+
+  @JsonIgnore private int index;
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Event.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Event.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.view;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -113,4 +114,6 @@ public class Event {
   @JsonProperty @Builder.Default private Set<DataValue> dataValues = new HashSet<>();
 
   @JsonProperty @Builder.Default private List<Note> notes = new ArrayList<>();
+
+  @JsonIgnore private int index;
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/TrackedEntity.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/TrackedEntity.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.view;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -86,4 +87,6 @@ public class TrackedEntity {
   @JsonProperty @Builder.Default private List<Enrollment> enrollments = new ArrayList<>();
 
   @JsonProperty @Builder.Default private List<ProgramOwner> programOwners = new ArrayList<>();
+
+  @JsonIgnore private int index;
 }


### PR DESCRIPTION
Entities imported using tracker endpoint were presented out of order in the response.
It is essential to preserve the order because the client is allowed to not specify the `UID` of the entities in case they are being created and then it is the server's responsibility to create those `UID`s.

The request payload can present the entities in a flattened or nested way (or any mix of the two), the order that is preserved is exactly the order in which the entities appear in the payload.

*Side fixes*
- `Index` field is not present anymore in `bundleReport.typeReportMap."TRACKER_TYPE".objectsReport` as the order of the entities is just the one in the response
- `validationMode=SKIP` is now working when calling the import endpoint. Before, that option was skipping validation and persistence.