### PR TITLE
chore: remove grid remnant from new tracker events store TECH-1606

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -69,6 +69,7 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.relationship.Relationship;
+import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
@@ -162,7 +163,9 @@ class EventExporterTest extends TrackerTest {
 
     assertContainsOnly(List.of("pTzf9KYMk72"), uids(events));
     List<Relationship> relationships =
-        events.get(0).getRelationshipItems().stream().map(i -> i.getRelationship()).toList();
+        events.get(0).getRelationshipItems().stream()
+            .map(RelationshipItem::getRelationship)
+            .toList();
     assertContainsOnly(List.of("oLT07jKRu9e", "yZxjxJli9mO"), uids(relationships));
   }
 


### PR DESCRIPTION
When we copied the JdbcEventStore to new tracker we removed the getEventsGrid() as this is only used in old tracker /events/query. We forgot to remove buildGridSql(params, mapSqlParameterSource) which is used in getting the event count in case there are filters. We should remove this logic as the count should be applied on exactly the same query as the one returning the actual events. getEventSelectQuery is used in buildSql.

We have a test for getting the pager with the total count.

This will simplify the following changes for https://dhis2.atlassian.net/browse/TECH-1606