### PR TITLE
chore: Remove index to order objects in tracker report [DHIS2-15596]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/AbstractTrackerPersister.java
@@ -103,7 +103,7 @@ public abstract class AbstractTrackerPersister<
 
     for (T trackerDto : dtos) {
 
-      Entity objectReport = new Entity(getType(), trackerDto.getUid(), trackerDto.getIndex());
+      Entity objectReport = new Entity(getType(), trackerDto.getUid());
 
       try {
         //

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/DefaultTrackerObjectsDeletionService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/DefaultTrackerObjectsDeletionService.java
@@ -72,10 +72,10 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
 
     List<org.hisp.dhis.tracker.imports.domain.Enrollment> enrollments = bundle.getEnrollments();
 
-    for (int idx = 0; idx < enrollments.size(); idx++) {
-      String uid = enrollments.get(idx).getEnrollment();
+    for (org.hisp.dhis.tracker.imports.domain.Enrollment value : enrollments) {
+      String uid = value.getEnrollment();
 
-      Entity objectReport = new Entity(TrackerType.ENROLLMENT, uid, idx);
+      Entity objectReport = new Entity(TrackerType.ENROLLMENT, uid);
 
       Enrollment enrollment = enrollmentService.getEnrollment(uid);
 
@@ -110,10 +110,10 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
 
     List<org.hisp.dhis.tracker.imports.domain.Event> events = bundle.getEvents();
 
-    for (int idx = 0; idx < events.size(); idx++) {
-      String uid = events.get(idx).getEvent();
+    for (org.hisp.dhis.tracker.imports.domain.Event value : events) {
+      String uid = value.getEvent();
 
-      Entity objectReport = new Entity(TrackerType.EVENT, uid, idx);
+      Entity objectReport = new Entity(TrackerType.EVENT, uid);
 
       Event event = eventService.getEvent(uid);
 
@@ -142,10 +142,10 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
     List<org.hisp.dhis.tracker.imports.domain.TrackedEntity> trackedEntities =
         bundle.getTrackedEntities();
 
-    for (int idx = 0; idx < trackedEntities.size(); idx++) {
-      String uid = trackedEntities.get(idx).getTrackedEntity();
+    for (org.hisp.dhis.tracker.imports.domain.TrackedEntity trackedEntity : trackedEntities) {
+      String uid = trackedEntity.getTrackedEntity();
 
-      Entity objectReport = new Entity(TrackerType.TRACKED_ENTITY, uid, idx);
+      Entity objectReport = new Entity(TrackerType.TRACKED_ENTITY, uid);
 
       TrackedEntity daoEntityInstance = teiService.getTrackedEntity(uid);
 
@@ -176,10 +176,10 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
 
     List<Relationship> relationships = bundle.getRelationships();
 
-    for (int idx = 0; idx < relationships.size(); idx++) {
-      String uid = relationships.get(idx).getRelationship();
+    for (Relationship value : relationships) {
+      String uid = value.getRelationship();
 
-      Entity objectReport = new Entity(TrackerType.RELATIONSHIP, uid, idx);
+      Entity objectReport = new Entity(TrackerType.RELATIONSHIP, uid);
 
       org.hisp.dhis.relationship.Relationship relationship =
           relationshipService.getRelationship(uid);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Enrollment.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Enrollment.java
@@ -82,8 +82,6 @@ public class Enrollment implements TrackerDto {
 
   @JsonProperty private User updatedBy;
 
-  @JsonProperty int index;
-
   @JsonProperty private Geometry geometry;
 
   @JsonProperty @Builder.Default private List<Event> events = new ArrayList<>();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Event.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Event.java
@@ -93,8 +93,6 @@ public class Event implements TrackerDto {
 
   @JsonProperty private Geometry geometry;
 
-  @JsonProperty int index;
-
   @JsonProperty private User assignedUser;
 
   @JsonProperty private User createdBy;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Relationship.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Relationship.java
@@ -51,8 +51,6 @@ public class Relationship implements TrackerDto {
 
   @JsonProperty private Instant createdAt;
 
-  @JsonProperty int index;
-
   @JsonProperty private Instant updatedAt;
 
   @JsonProperty private boolean bidirectional;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/TrackedEntity.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/TrackedEntity.java
@@ -70,8 +70,6 @@ public class TrackedEntity implements TrackerDto {
 
   @JsonProperty private String storedBy;
 
-  @JsonProperty int index;
-
   @JsonProperty private User createdBy;
 
   @JsonProperty private User updatedBy;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/TrackerDto.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/TrackerDto.java
@@ -37,6 +37,4 @@ public interface TrackerDto {
   String getUid();
 
   TrackerType getTrackerType();
-
-  int getIndex();
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preprocess/DuplicateRelationshipsPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preprocess/DuplicateRelationshipsPreProcessor.java
@@ -123,12 +123,20 @@ public class DuplicateRelationshipsPreProcessor implements BundlePreProcessor {
     // sort the Relationship Items
     bundle.getRelationships().stream()
         .filter(validRelationship)
-        .forEach(rel -> map.put(rel.getRelationship(), hash(rel, bundle)));
+        .forEach(
+            rel -> {
+              String hash = hash(rel, bundle);
+              if (!map.containsKey(rel.getRelationship()) && !map.containsValue(hash)) {
+                map.put(rel.getRelationship(), hash);
+              }
+            });
 
     // Remove duplicated Relationships from the bundle, if any
     bundle
         .getRelationships()
         .removeIf(rel -> validRelationship.test(rel) && !map.containsKey(rel.getRelationship()));
+
+    bundle.setRelationships(bundle.getRelationships().stream().distinct().toList());
   }
 
   private String hash(Relationship rel, TrackerBundle bundle) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preprocess/DuplicateRelationshipsPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preprocess/DuplicateRelationshipsPreProcessor.java
@@ -113,7 +113,7 @@ public class DuplicateRelationshipsPreProcessor implements BundlePreProcessor {
     for (Relationship relationship : bundle.getRelationships()) {
       RelationshipType relationshipType =
           bundle.getPreheat().getRelationshipType(relationship.getRelationshipType());
-      if (relationshipType == null
+      if (isInvalidRelationship(relationship, relationshipType)
           || !isDuplicate(relationship, relationshipType, distinctRelationships)) {
         distinctRelationships.add(relationship);
       }
@@ -128,17 +128,19 @@ public class DuplicateRelationshipsPreProcessor implements BundlePreProcessor {
       List<Relationship> distinctRelationships) {
     List<RelationshipKey> relationshipKeys =
         distinctRelationships.stream().map(r -> getRelationshipKey(r, relationshipType)).toList();
-    if (hasRelationshipKey(relationship, relationshipType)) {
-      RelationshipKey relationshipKey = getRelationshipKey(relationship, relationshipType);
+    RelationshipKey relationshipKey = getRelationshipKey(relationship, relationshipType);
 
-      RelationshipKey inverseKey = null;
-      if (relationshipType.isBidirectional()) {
-        inverseKey = relationshipKey.inverseKey();
-      }
-      return Stream.of(relationshipKey, inverseKey)
-          .filter(Objects::nonNull)
-          .anyMatch(relationshipKeys::contains);
+    RelationshipKey inverseKey = null;
+    if (relationshipType.isBidirectional()) {
+      inverseKey = relationshipKey.inverseKey();
     }
-    return false;
+    return Stream.of(relationshipKey, inverseKey)
+        .filter(Objects::nonNull)
+        .anyMatch(relationshipKeys::contains);
+  }
+
+  public boolean isInvalidRelationship(
+      Relationship relationship, RelationshipType relationshipType) {
+    return relationshipType == null || !hasRelationshipKey(relationship, relationshipType);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preprocess/DuplicateRelationshipsPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preprocess/DuplicateRelationshipsPreProcessor.java
@@ -27,12 +27,14 @@
  */
 package org.hisp.dhis.tracker.imports.preprocess;
 
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
+import static org.hisp.dhis.tracker.imports.util.RelationshipKeySupport.getRelationshipKey;
+import static org.hisp.dhis.tracker.imports.util.RelationshipKeySupport.hasRelationshipKey;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
-import org.apache.commons.collections4.BidiMap;
-import org.apache.commons.collections4.bidimap.DualHashBidiMap;
-import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.relationship.RelationshipKey;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.Relationship;
@@ -48,9 +50,10 @@ import org.springframework.stereotype.Component;
 public class DuplicateRelationshipsPreProcessor implements BundlePreProcessor {
 
   /**
-   * Process the bundle's relationships collection and remove relationships that are duplicated.
+   * Process the bundle's relationships collection and remove relationships that are duplicated. to
+   * preserve the order, always the second one to appear is removed.
    *
-   * <p>There are 5 cases (all cases assume the same relationship type):
+   * <p>There are 4 cases (all cases assume the same relationship type):
    *
    * <pre>
    * case 1:
@@ -63,7 +66,7 @@ public class DuplicateRelationshipsPreProcessor implements BundlePreProcessor {
    *
    * TYPE  --- bi = false
    *
-   * result:  REL 1 or REL 2 has to be removed (does not matter which one)
+   * result:  REL 2 has to be removed
    *
    * case 2:
    *
@@ -87,7 +90,7 @@ public class DuplicateRelationshipsPreProcessor implements BundlePreProcessor {
    *
    * TYPE  --- bi = true
    *
-   * result:  REL 1 or REL 2 has to be removed (does not matter which one)
+   * result:  REL 2 has to be removed
    *
    *
    * case 4:
@@ -100,57 +103,42 @@ public class DuplicateRelationshipsPreProcessor implements BundlePreProcessor {
    *
    * TYPE  --- bi = true
    *
-   * result:  REL 1 or REL 2 has to be removed (does not matter which one)
+   * result:  REL 2 has to be removed
    *
    * </pre>
    */
   @Override
   public void process(TrackerBundle bundle) {
-    Predicate<Relationship> validRelationship =
-        rel ->
-            StringUtils.isNotEmpty(rel.getRelationship())
-                && rel.getRelationshipType().isNotBlank()
-                && rel.getFrom() != null
-                && rel.getTo() != null
-                && bundle.getPreheat().getRelationshipType(rel.getRelationshipType()) != null;
+    List<Relationship> distinctRelationships = new ArrayList<>();
+    for (Relationship relationship : bundle.getRelationships()) {
+      RelationshipType relationshipType =
+          bundle.getPreheat().getRelationshipType(relationship.getRelationshipType());
+      if (relationshipType == null
+          || !isDuplicate(relationship, relationshipType, distinctRelationships)) {
+        distinctRelationships.add(relationship);
+      }
+    }
 
-    // Create a map where both key and value must be unique
-    BidiMap<String, String> map = new DualHashBidiMap<>();
-
-    // Add a pseudo hash of all relationships to the map. If the
-    // relationship is
-    // bidirectional, first
-    // sort the Relationship Items
-    bundle.getRelationships().stream()
-        .filter(validRelationship)
-        .forEach(
-            rel -> {
-              String hash = hash(rel, bundle);
-              if (!map.containsKey(rel.getRelationship()) && !map.containsValue(hash)) {
-                map.put(rel.getRelationship(), hash);
-              }
-            });
-
-    // Remove duplicated Relationships from the bundle, if any
-    bundle
-        .getRelationships()
-        .removeIf(rel -> validRelationship.test(rel) && !map.containsKey(rel.getRelationship()));
-
-    bundle.setRelationships(bundle.getRelationships().stream().distinct().toList());
+    bundle.setRelationships(distinctRelationships);
   }
 
-  private String hash(Relationship rel, TrackerBundle bundle) {
-    RelationshipType relationshipType =
-        bundle.getPreheat().getRelationshipType(rel.getRelationshipType());
-    return rel.getRelationshipType()
-        + "-"
-        + (relationshipType.isBidirectional() ? sortItems(rel) : rel.getFrom() + "-" + rel.getTo())
-        + relationshipType.isBidirectional();
-  }
+  public boolean isDuplicate(
+      Relationship relationship,
+      RelationshipType relationshipType,
+      List<Relationship> distinctRelationships) {
+    List<RelationshipKey> relationshipKeys =
+        distinctRelationships.stream().map(r -> getRelationshipKey(r, relationshipType)).toList();
+    if (hasRelationshipKey(relationship, relationshipType)) {
+      RelationshipKey relationshipKey = getRelationshipKey(relationship, relationshipType);
 
-  private String sortItems(Relationship rel) {
-    return Stream.of(rel.getFrom().toString(), rel.getTo().toString())
-        .sorted()
-        .collect(Collectors.joining("-"));
+      RelationshipKey inverseKey = null;
+      if (relationshipType.isBidirectional()) {
+        inverseKey = relationshipKey.inverseKey();
+      }
+      return Stream.of(relationshipKey, inverseKey)
+          .filter(Objects::nonNull)
+          .anyMatch(relationshipKeys::contains);
+    }
+    return false;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/report/Entity.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/report/Entity.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.tracker.imports.report;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,8 +41,6 @@ import org.hisp.dhis.tracker.TrackerType;
 public class Entity {
   @JsonProperty private final TrackerType trackerType;
 
-  @JsonIgnore private int index;
-
   @JsonProperty private String uid;
 
   private List<Error> errorReports = new ArrayList<>();
@@ -52,21 +49,18 @@ public class Entity {
     this.trackerType = trackerType;
   }
 
-  public Entity(TrackerType trackerType, String uid, int index) {
+  public Entity(TrackerType trackerType, String uid) {
     this.trackerType = trackerType;
     this.uid = uid;
-    this.index = index;
   }
 
   @JsonCreator
   public Entity(
       @JsonProperty("trackerType") TrackerType trackerType,
       @JsonProperty("uid") String uid,
-      @JsonProperty("index") int index,
       @JsonProperty("errorReports") List<Error> errorReports) {
     this.trackerType = trackerType;
     this.uid = uid;
-    this.index = index;
     if (errorReports != null) {
       this.errorReports = errorReports;
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/report/TrackerTypeReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/report/TrackerTypeReport.java
@@ -31,7 +31,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import lombok.Data;
 import org.hisp.dhis.tracker.TrackerType;
@@ -69,7 +68,7 @@ public class TrackerTypeReport {
 
   @JsonProperty("objectReports")
   public List<Entity> getEntityReport() {
-    return entityReport.stream().sorted(Comparator.comparingInt(Entity::getIndex)).toList();
+    return entityReport;
   }
 
   // -----------------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/DuplicateRelationshipsPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/DuplicateRelationshipsPreProcessorTest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.tracker.imports.preprocess;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.Lists;
 import org.hisp.dhis.common.CodeGenerator;
@@ -104,13 +105,43 @@ class DuplicateRelationshipsPreProcessorTest {
    * - one is removed
    */
   @Test
-  void test_on_identical_rels_1_is_removed() {
+  void shouldRemoveRelationshipFromBundleWhenThereAreTwoIdenticalRelationships() {
     String relType = REL_TYPE_NONBIDIRECTIONAL_UID;
+    String relUid = CodeGenerator.generateUid();
     String fromTeiUid = CodeGenerator.generateUid();
     String toTeiUid = CodeGenerator.generateUid();
     Relationship relationship1 =
         Relationship.builder()
-            .relationship(CodeGenerator.generateUid())
+            .relationship(relUid)
+            .relationshipType(MetadataIdentifier.ofUid(relType))
+            .from(trackedEntityRelationshipItem(fromTeiUid))
+            .to(trackedEntityRelationshipItem(toTeiUid))
+            .build();
+    Relationship relationship2 =
+        Relationship.builder()
+            .relationship(relUid)
+            .relationshipType(MetadataIdentifier.ofUid(relType))
+            .from(trackedEntityRelationshipItem(fromTeiUid))
+            .to(trackedEntityRelationshipItem(toTeiUid))
+            .build();
+    TrackerBundle bundle =
+        TrackerBundle.builder()
+            .preheat(this.preheat)
+            .relationships(Lists.newArrayList(relationship1, relationship2))
+            .build();
+    preProcessor.process(bundle);
+    assertThat(bundle.getRelationships(), hasSize(1));
+  }
+
+  @Test
+  void shouldRemoveRelationshipFromBundleWhenThereAreTwoIdenticalRelationshipsWithDifferentUids() {
+    String relType = REL_TYPE_NONBIDIRECTIONAL_UID;
+    String fromTeiUid = CodeGenerator.generateUid();
+    String toTeiUid = CodeGenerator.generateUid();
+    String relationship1Uid = CodeGenerator.generateUid();
+    Relationship relationship1 =
+        Relationship.builder()
+            .relationship(relationship1Uid)
             .relationshipType(MetadataIdentifier.ofUid(relType))
             .from(trackedEntityRelationshipItem(fromTeiUid))
             .to(trackedEntityRelationshipItem(toTeiUid))
@@ -129,6 +160,7 @@ class DuplicateRelationshipsPreProcessorTest {
             .build();
     preProcessor.process(bundle);
     assertThat(bundle.getRelationships(), hasSize(1));
+    assertEquals(relationship1Uid, bundle.getRelationships().get(0).getRelationship());
   }
 
   /*

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/report/TrackerBundleImportReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/report/TrackerBundleImportReportTest.java
@@ -134,7 +134,6 @@ class TrackerBundleImportReportTest {
     TrackerTypeReport typeReport = new TrackerTypeReport(TRACKED_ENTITY);
     Entity entity = new Entity(TRACKED_ENTITY);
 
-    entity.setIndex(0);
     entity.setUid("BltTZV9HvEZ");
     typeReport.addEntity(entity);
     typeReport.getStats().setCreated(1);
@@ -314,7 +313,7 @@ class TrackerBundleImportReportTest {
   private PersistenceReport createBundleReport() {
     PersistenceReport persistenceReport = PersistenceReport.emptyReport();
     TrackerTypeReport typeReport = new TrackerTypeReport(TRACKED_ENTITY);
-    Entity objectReport = new Entity(TRACKED_ENTITY, "TEI_UID", 1);
+    Entity objectReport = new Entity(TRACKED_ENTITY, "TEI_UID");
     typeReport.addEntity(objectReport);
     typeReport.getStats().incCreated();
     persistenceReport.getTypeReportMap().put(TRACKED_ENTITY, typeReport);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/PersistablesFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/PersistablesFilterTest.java
@@ -865,11 +865,6 @@ class PersistablesFilterTest {
       public String getUid() {
         return uid;
       }
-
-      @Override
-      public int getIndex() {
-        return 0;
-      }
     };
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/SeqTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/SeqTest.java
@@ -263,11 +263,6 @@ class SeqTest {
       public TrackerType getTrackerType() {
         return TrackerType.TRACKED_ENTITY;
       }
-
-      @Override
-      public int getIndex() {
-        return 0;
-      }
     };
   }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportReportTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportReportTest.java
@@ -126,4 +126,24 @@ class TrackerImportReportTest extends DhisControllerConvenienceTest {
     assertReportEntities(List.of("IybbQIQt6ev", "daMwzsKN3ev"), EVENT, importReport);
     assertReportEntities(List.of("IybbQIQtrel", "daMwzsKNrel"), RELATIONSHIP, importReport);
   }
+
+  @Test
+  void
+      shouldReturnOrderedEntitiesInReportWhenNestedPayloadWithRepeatedRelationshipsImportIsSuccessful() {
+    JsonImportReport importReport =
+        POST(
+                "/tracker?async=false&reportMode=FULL"
+                    + "&validationMode=SKIP"
+                    + "&atomicMode=OBJECT"
+                    + "&skipRuleEngine=true",
+                WebClient.Body("tracker/import_nested_payload_repeated_relationships.json"))
+            .content(HttpStatus.OK)
+            .as(JsonImportReport.class);
+
+    assertReportEntities(
+        List.of("IybbQIQt6te", "daMwzsKN3te", "FRM97UKN8te"), TRACKED_ENTITY, importReport);
+    assertReportEntities(List.of("IybbQIQt6en", "daMwzsKN3en"), ENROLLMENT, importReport);
+    assertReportEntities(List.of("IybbQIQt6ev", "daMwzsKN3ev"), EVENT, importReport);
+    assertReportEntities(List.of("IybbQIQtrel", "daMwzsKNrel"), RELATIONSHIP, importReport);
+  }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportReportTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportReportTest.java
@@ -46,7 +46,8 @@ import org.hisp.dhis.web.WebClient;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.webapi.controller.tracker.JsonImportReport;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests {@link ImportReport} behavior through {@link TrackerImportController} using (mocked) REST
@@ -89,54 +90,21 @@ class TrackerImportReportTest extends DhisControllerConvenienceTest {
     manager.save(relType);
   }
 
-  @Test
-  void shouldReturnOrderedEntitiesInReportWhenFlatPayloadImportIsSuccessful() {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "import_flatten_payload.json",
+        "import_nested_payload.json",
+        "import_nested_payload_repeated_relationships.json"
+      })
+  void shouldReturnOrderedEntitiesInReportWhenImportIsSuccessful(String fileName) {
     JsonImportReport importReport =
         POST(
                 "/tracker?async=false&reportMode=FULL"
                     + "&validationMode=SKIP"
                     + "&atomicMode=OBJECT"
                     + "&skipRuleEngine=true",
-                WebClient.Body("tracker/import_flatten_payload.json"))
-            .content(HttpStatus.OK)
-            .as(JsonImportReport.class);
-
-    assertReportEntities(
-        List.of("IybbQIQt6te", "daMwzsKN3te", "FRM97UKN8te"), TRACKED_ENTITY, importReport);
-    assertReportEntities(List.of("IybbQIQt6en", "daMwzsKN3en"), ENROLLMENT, importReport);
-    assertReportEntities(List.of("IybbQIQt6ev", "daMwzsKN3ev"), EVENT, importReport);
-    assertReportEntities(List.of("IybbQIQtrel", "daMwzsKNrel"), RELATIONSHIP, importReport);
-  }
-
-  @Test
-  void shouldReturnOrderedEntitiesInReportWhenNestedPayloadImportIsSuccessful() {
-    JsonImportReport importReport =
-        POST(
-                "/tracker?async=false&reportMode=FULL"
-                    + "&validationMode=SKIP"
-                    + "&atomicMode=OBJECT"
-                    + "&skipRuleEngine=true",
-                WebClient.Body("tracker/import_nested_payload.json"))
-            .content(HttpStatus.OK)
-            .as(JsonImportReport.class);
-
-    assertReportEntities(
-        List.of("IybbQIQt6te", "daMwzsKN3te", "FRM97UKN8te"), TRACKED_ENTITY, importReport);
-    assertReportEntities(List.of("IybbQIQt6en", "daMwzsKN3en"), ENROLLMENT, importReport);
-    assertReportEntities(List.of("IybbQIQt6ev", "daMwzsKN3ev"), EVENT, importReport);
-    assertReportEntities(List.of("IybbQIQtrel", "daMwzsKNrel"), RELATIONSHIP, importReport);
-  }
-
-  @Test
-  void
-      shouldReturnOrderedEntitiesInReportWhenNestedPayloadWithRepeatedRelationshipsImportIsSuccessful() {
-    JsonImportReport importReport =
-        POST(
-                "/tracker?async=false&reportMode=FULL"
-                    + "&validationMode=SKIP"
-                    + "&atomicMode=OBJECT"
-                    + "&skipRuleEngine=true",
-                WebClient.Body("tracker/import_nested_payload_repeated_relationships.json"))
+                WebClient.Body("tracker/" + fileName))
             .content(HttpStatus.OK)
             .as(JsonImportReport.class);
 

--- a/dhis-2/dhis-test-web-api/src/test/resources/tracker/import_nested_payload_repeated_relationships.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/tracker/import_nested_payload_repeated_relationships.json
@@ -1,0 +1,94 @@
+{
+  "trackedEntities": [
+    {
+      "trackedEntity": "IybbQIQt6te",
+      "trackedEntityType": "PrZMWi7rBga",
+      "orgUnit": "PSeMWi7rBgb",
+      "enrollments": [
+        {
+          "enrollment": "IybbQIQt6en",
+          "orgUnit": "PSeMWi7rBgb",
+          "program": "XrZRFi7rU9e",
+          "enrolledAt": "2016-03-17T01:51:39.609+0000",
+          "events": [
+            {
+              "event": "IybbQIQt6ev",
+              "orgUnit": "PSeMWi7rBgb",
+              "programStage": "I8RRFi7rUps"
+            }]
+        }
+      ],
+      "relationships": [
+        {
+          "relationshipType": "A4ORFi7rReL",
+          "relationship": "IybbQIQtrel",
+          "from": {
+            "trackedEntity": {
+              "trackedEntity": "IybbQIQt6te"
+            }
+          },
+          "to": {
+            "trackedEntity": {
+              "trackedEntity":"daMwzsKN3te"
+            }
+          }
+        },
+        {
+          "relationshipType": "A4ORFi7rReL",
+          "relationship": "daMwzsKNrel",
+          "from": {
+            "trackedEntity": {
+              "trackedEntity": "IybbQIQt6te"
+            }
+          },
+          "to": {
+            "trackedEntity": {
+              "trackedEntity": "FRM97UKN8te"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "trackedEntity": "daMwzsKN3te",
+      "trackedEntityType": "PrZMWi7rBga",
+      "orgUnit": "PSeMWi7rBgb",
+      "enrollments": [
+        {
+          "enrollment": "daMwzsKN3en",
+          "orgUnit": "PSeMWi7rBgb",
+          "program": "XrZRFi7rU9e",
+          "enrolledAt": "2016-03-17T01:51:39.609+0000",
+          "events": [
+            {
+              "event": "daMwzsKN3ev",
+              "orgUnit": "PSeMWi7rBgb",
+              "programStage": "I8RRFi7rUps"
+            }
+          ]
+        }
+      ],
+      "relationships": [
+        {
+          "relationshipType": "A4ORFi7rReL",
+          "relationship": "IybbQIQtrel",
+          "from": {
+            "trackedEntity": {
+              "trackedEntity": "IybbQIQt6te"
+            }
+          },
+          "to": {
+            "trackedEntity": {
+              "trackedEntity":"daMwzsKN3te"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "trackedEntity": "FRM97UKN8te",
+      "trackedEntityType": "PrZMWi7rBga",
+      "orgUnit": "PSeMWi7rBgb"
+    }
+  ]
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/BodyConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/BodyConverter.java
@@ -29,11 +29,7 @@ package org.hisp.dhis.webapi.controller.tracker.imports;
 
 import com.fasterxml.jackson.databind.util.StdConverter;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.webapi.controller.tracker.view.Enrollment;
@@ -95,104 +91,65 @@ class BodyConverter extends StdConverter<Body, Body> {
    */
   @Override
   public Body convert(Body body) {
-    Map<String, TrackedEntity> trackedEntityMap = new HashMap<>();
-    Map<String, Enrollment> enrollmentHashMap = new HashMap<>();
-    Map<String, Event> eventHashMap = new HashMap<>();
-    Map<String, Relationship> relationshipHashMap = new HashMap<>();
-    AtomicInteger indexCounter = new AtomicInteger();
+    List<TrackedEntity> trackedEntities = new ArrayList<>();
+    List<Enrollment> enrollments = new ArrayList<>();
+    List<Event> events = new ArrayList<>();
+    List<Relationship> relationships = new ArrayList<>();
 
     // Extract all enrollments and relationships, and set parent reference.
     for (TrackedEntity te : body.getTrackedEntities()) {
-      te.setIndex(indexCounter.getAndIncrement());
       updateTrackedEntityReferences(te);
-      trackedEntityMap.put(te.getTrackedEntity(), te);
+      trackedEntities.add(te);
 
-      extractEnrollments(te)
-          .forEach(
-              enrollment -> {
-                enrollment.setIndex(indexCounter.getAndIncrement());
-                enrollmentHashMap.put(enrollment.getEnrollment(), enrollment);
-              });
+      enrollments.addAll(extractEnrollments(te));
 
-      extractRelationships(te)
-          .forEach(
-              relationship -> {
-                relationship.setIndex(indexCounter.getAndIncrement());
-                relationshipHashMap.put(relationship.getRelationship(), relationship);
-              });
+      relationships.addAll(extractRelationships(te));
     }
 
     // Set UID for all enrollments and notes
     body.getEnrollments().stream()
         .map(enrollment -> updateEnrollmentReferences(enrollment, enrollment.getTrackedEntity()))
-        .forEach(
-            enrollment -> {
-              enrollment.setIndex(indexCounter.getAndIncrement());
-              enrollmentHashMap.put(enrollment.getEnrollment(), enrollment);
-            });
+        .forEach(enrollments::add);
 
     // Extract all events and relationships, and set parent references
-    for (Enrollment enrollment : enrollmentHashMap.values()) {
-      extractEvents(enrollment)
-          .forEach(
-              event -> {
-                event.setIndex(indexCounter.getAndIncrement());
-                eventHashMap.put(event.getEvent(), event);
-              });
+    for (Enrollment enrollment : enrollments) {
+      events.addAll(extractEvents(enrollment));
 
-      extractRelationships(enrollment)
-          .forEach(
-              relationship -> {
-                relationship.setIndex(indexCounter.getAndIncrement());
-                relationshipHashMap.put(relationship.getRelationship(), relationship);
-              });
+      relationships.addAll(extractRelationships(enrollment));
 
       enrollment.setNotes(
           enrollment.getNotes().stream()
               .filter(note -> !StringUtils.isEmpty(note.getValue()))
               .map(this::updateNoteReferences)
-              .collect(Collectors.toList()));
+              .toList());
     }
 
     // Set UID for all events and notes
     body.getEvents().stream()
         .map(event -> updateEventReferences(event, event.getEnrollment()))
-        .forEach(
-            event -> {
-              event.setIndex(indexCounter.getAndIncrement());
-              eventHashMap.put(event.getEvent(), event);
-            });
+        .forEach(events::add);
 
     // Extract all relationships
-    for (Event event : eventHashMap.values()) {
-      extractRelationships(event)
-          .forEach(
-              relationship -> {
-                relationship.setIndex(indexCounter.getAndIncrement());
-                relationshipHashMap.put(relationship.getRelationship(), relationship);
-              });
+    for (Event event : events) {
+      relationships.addAll(extractRelationships(event));
 
       event.setNotes(
           event.getNotes().stream()
               .filter(note -> !StringUtils.isEmpty(note.getValue()))
               .map(this::updateNoteReferences)
-              .collect(Collectors.toList()));
+              .toList());
     }
 
     // Set UID for all relationships
     body.getRelationships().stream()
         .map(this::updateRelationshipReferences)
-        .forEach(
-            relationship -> {
-              relationship.setIndex(indexCounter.getAndIncrement());
-              relationshipHashMap.put(relationship.getRelationship(), relationship);
-            });
+        .forEach(relationships::add);
 
     return Body.builder()
-        .trackedEntities(new ArrayList<>(trackedEntityMap.values()))
-        .enrollments(new ArrayList<>(enrollmentHashMap.values()))
-        .events(new ArrayList<>(eventHashMap.values()))
-        .relationships(new ArrayList<>(relationshipHashMap.values()))
+        .trackedEntities(trackedEntities)
+        .enrollments(enrollments)
+        .events(events)
+        .relationships(relationships)
         .build();
   }
 
@@ -221,9 +178,7 @@ class BodyConverter extends StdConverter<Body, Body> {
    */
   private List<Relationship> extractRelationships(Enrollment enrollment) {
     List<Relationship> relationships =
-        enrollment.getRelationships().stream()
-            .map(this::updateRelationshipReferences)
-            .collect(Collectors.toList());
+        enrollment.getRelationships().stream().map(this::updateRelationshipReferences).toList();
 
     enrollment.setRelationships(new ArrayList<>());
 
@@ -239,9 +194,7 @@ class BodyConverter extends StdConverter<Body, Body> {
    */
   private List<Relationship> extractRelationships(Event event) {
     List<Relationship> relationships =
-        event.getRelationships().stream()
-            .map(this::updateRelationshipReferences)
-            .collect(Collectors.toList());
+        event.getRelationships().stream().map(this::updateRelationshipReferences).toList();
 
     event.setRelationships(new ArrayList<>());
 
@@ -259,7 +212,7 @@ class BodyConverter extends StdConverter<Body, Body> {
     List<Event> events =
         enrollment.getEvents().stream()
             .map(event -> updateEventReferences(event, enrollment.getEnrollment()))
-            .collect(Collectors.toList());
+            .toList();
 
     enrollment.setEvents(new ArrayList<>());
 
@@ -336,11 +289,9 @@ class BodyConverter extends StdConverter<Body, Body> {
    * Updates uid of references in a trackedEntity
    *
    * @param trackedEntity the trackedEntity to check and update references for
-   * @return
    */
-  private TrackedEntity updateTrackedEntityReferences(TrackedEntity trackedEntity) {
+  private void updateTrackedEntityReferences(TrackedEntity trackedEntity) {
     trackedEntity.setTrackedEntity(updateReference(trackedEntity.getTrackedEntity()));
-    return trackedEntity;
   }
 
   /**

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Enrollment.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Enrollment.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.view;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -101,6 +100,4 @@ public class Enrollment {
   @JsonProperty @Builder.Default private List<Attribute> attributes = new ArrayList<>();
 
   @JsonProperty @Builder.Default private List<Note> notes = new ArrayList<>();
-
-  @JsonIgnore private int index;
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Event.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Event.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.view;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -114,6 +113,4 @@ public class Event {
   @JsonProperty @Builder.Default private Set<DataValue> dataValues = new HashSet<>();
 
   @JsonProperty @Builder.Default private List<Note> notes = new ArrayList<>();
-
-  @JsonIgnore private int index;
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Relationship.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Relationship.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.view;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 import lombok.AllArgsConstructor;
@@ -67,6 +66,4 @@ public class Relationship {
   @JsonProperty private RelationshipItem from;
 
   @JsonProperty private RelationshipItem to;
-
-  @JsonIgnore private int index;
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/TrackedEntity.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/TrackedEntity.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.view;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -87,6 +86,4 @@ public class TrackedEntity {
   @JsonProperty @Builder.Default private List<Enrollment> enrollments = new ArrayList<>();
 
   @JsonProperty @Builder.Default private List<ProgramOwner> programOwners = new ArrayList<>();
-
-  @JsonIgnore private int index;
 }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/BodyConverterTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/BodyConverterTest.java
@@ -92,7 +92,7 @@ class BodyConverterTest {
     assertThat(b2.getTrackedEntities(), hasSize(1));
     assertThat(b2.getEnrollments(), hasSize(2));
     assertThat(b2.getEvents(), hasSize(10));
-    assertThat(b2.getRelationships(), hasSize(4));
+    assertThat(b2.getRelationships(), hasSize(6));
   }
 
   @Test
@@ -152,7 +152,7 @@ class BodyConverterTest {
     assertThat(b2.getEnrollments().get(1).getEnrollment(), is(notNullValue()));
     assertThat(b2.getEvents().get(0).getEvent(), is(notNullValue()));
     assertThat(b2.getEvents().get(1).getEvent(), is(notNullValue()));
-    assertThat(b2.getRelationships(), hasSize(4));
+    assertThat(b2.getRelationships(), hasSize(6));
     b2.getRelationships().stream()
         .forEach(r -> assertThat(r.getRelationship(), is(notNullValue())));
   }


### PR DESCRIPTION
At the moment, the order of entities in the payload is preserved in the report using an index linked to the entity that is created at the beginning of the process and it is in the end used to order the entities.
In this PR we are removing this index and just using `java.util.List` to maintain the order of the entities through the whole process.

This new approach is working for all entities but relationships as in the `BodyConverter` we were not just flattening the payload but also removing the repeated relationships that could be present as a relationship has two ends and it could be included in both of them.

To make everything work the clean-up of repeated relationships was moved to `DuplicateRelationshipsPreProcessor` that is where it was supposed to be in the first place.

*Next PR*
- Validating that the payload is either completely flatten or completely nested, so do not accept any payload with a mix of the two structures