### PR TITLE
chore: make it hard to misuse the EventSearchParams API TECH-1606

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/Order.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/Order.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker;
+
+import lombok.Value;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
+
+/**
+ * Tracker exporter APIs allow ordering by different types. For example events can be ordered by
+ * field names, {@link DataElement} and {@link TrackedEntityAttribute}. It is crucial for the order
+ * values to stay in one collection as their order needs to be kept as provided by the user. We
+ * cannot come up with a type-safe type that captures the above order features and that can be used
+ * in a generic collection such as a List (see typesafe heterogeneous container). We therefore use
+ * {@link Order} with a field of type {@link Object}. We get compile time type safety via such as
+ * {@link org.hisp.dhis.tracker.export.event.EventSearchParams#orderBy(DataElement, SortDirection)}.
+ * This allows us to advocate the types that can be ordered by while storing the order in a single
+ * {@code List} of {@link Order}. Runtime type checks are then used to ensure users (and developers)
+ * get meaningful error messages in case they order by unsupported fields or types.
+ */
+@Value
+public class Order {
+  Object field;
+  SortDirection direction;
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/Order.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/Order.java
@@ -38,11 +38,12 @@ import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
  * values to stay in one collection as their order needs to be kept as provided by the user. We
  * cannot come up with a type-safe type that captures the above order features and that can be used
  * in a generic collection such as a List (see typesafe heterogeneous container). We therefore use
- * {@link Order} with a field of type {@link Object}. We get compile time type safety via such as
- * {@link org.hisp.dhis.tracker.export.event.EventSearchParams#orderBy(DataElement, SortDirection)}.
- * This allows us to advocate the types that can be ordered by while storing the order in a single
- * {@code List} of {@link Order}. Runtime type checks are then used to ensure users (and developers)
- * get meaningful error messages in case they order by unsupported fields or types.
+ * {@link Order} with a field of type {@link Object}. We get compile time type safety via methods
+ * such as {@link org.hisp.dhis.tracker.export.event.EventSearchParams#orderBy(DataElement,
+ * SortDirection)}. This allows us to advocate the types that can be ordered by while storing the
+ * order in a single {@code List} of {@link Order}. Runtime type checks are then used to ensure
+ * users (and developers) get meaningful error messages in case they order by unsupported fields or
+ * types.
  */
 @Value
 public class Order {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
@@ -41,11 +41,12 @@ import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.AssignedUserSelectionMode;
 import org.hisp.dhis.common.IdSchemes;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.ProgramType;
-import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
-import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
+import org.hisp.dhis.tracker.Order;
+import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 
 @Getter
 @Builder(toBuilder = true)
@@ -118,9 +119,17 @@ public class EventOperationParams {
 
   private boolean includeRelationships;
 
-  @Builder.Default private List<OrderParam> orders = new ArrayList<>();
-
-  @Builder.Default private List<OrderCriteria> attributeOrders = new ArrayList<>();
+  /**
+   * Events can be ordered by field names (given as {@link String}), data element (given as {@link
+   * UID}) and tracked entity attribute (given as {@link UID}). It is crucial for the order values
+   * to stay in one collection as their order needs to be kept as provided by the user. We cannot
+   * come up with a type-safe type that captures the above order features and that can be used in a
+   * generic collection such as a List (see typesafe heterogeneous container). We therefore provide
+   * {@link EventOperationParamsBuilder#orderBy(String, SortDirection)} and {@link
+   * EventOperationParamsBuilder#orderBy(UID, SortDirection)} to advocate the types that can be
+   * ordered by while storing the order in a single List of {@link Order}.
+   */
+  private List<Order> order;
 
   private boolean includeAttributes;
 
@@ -131,10 +140,10 @@ public class EventOperationParams {
   private Boolean skipEventId;
 
   /** Comma separated list of data element filters */
-  private String filters;
+  private String dataElementFilters;
 
   /** Comma separated list of attribute filters */
-  private String filterAttributes;
+  private String attributeFilters;
 
   private boolean includeDeleted;
 
@@ -149,9 +158,28 @@ public class EventOperationParams {
 
   private Set<String> enrollments;
 
-  // -------------------------------------------------------------------------
-  // Logic
-  // -------------------------------------------------------------------------
+  public static class EventOperationParamsBuilder {
+
+    private List<Order> order = new ArrayList<>();
+
+    // Do not remove this unused method. This hides the order field from the builder which Lombok
+    // does not support. The repeated order field and private order method prevent access to order
+    // via the builder.
+    // Order should be added via the orderBy builder methods.
+    private EventOperationParamsBuilder order(List<Order> order) {
+      return this;
+    }
+
+    public EventOperationParamsBuilder orderBy(String field, SortDirection direction) {
+      this.order.add(new Order(field, direction));
+      return this;
+    }
+
+    public EventOperationParamsBuilder orderBy(UID uid, SortDirection direction) {
+      this.order.add(new Order(uid, direction));
+      return this;
+    }
+  }
 
   public boolean isPaging() {
     return page != null || pageSize != null;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
@@ -143,8 +143,8 @@ public class EventOperationParamsMapper {
             operationParams.getDataElementFilters(), this::dataElementToQueryItem);
     mapDataElementFilters(searchParams, dataElementFilters);
 
-    List<QueryItem> attributeFilters = parseFilterAttributes(operationParams.getAttributeFilters());
-    validateFilterAttributes(attributeFilters);
+    List<QueryItem> attributeFilters = parseAttributeFilters(operationParams.getAttributeFilters());
+    validateAttributeFilters(attributeFilters);
     mapAttributeFilters(searchParams, attributeFilters);
 
     mapOrderParam(searchParams, operationParams.getOrder());
@@ -334,19 +334,20 @@ public class EventOperationParamsMapper {
         || user.isAuthorized(Authorities.F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS.name());
   }
 
-  private List<QueryItem> parseFilterAttributes(String filterAttributes)
+  private List<QueryItem> parseAttributeFilters(String attributeFilters)
       throws BadRequestException {
     Map<String, TrackedEntityAttribute> attributes =
         attributeService.getAllTrackedEntityAttributes().stream()
             .collect(Collectors.toMap(TrackedEntityAttribute::getUid, att -> att));
 
-    return parseAttributeQueryItems(filterAttributes, attributes);
+    return parseAttributeQueryItems(attributeFilters, attributes);
   }
 
-  private void validateFilterAttributes(List<QueryItem> queryItems) throws BadRequestException {
+  private void validateAttributeFilters(List<QueryItem> attributeFilters)
+      throws BadRequestException {
     Set<String> attributes = new HashSet<>();
     Set<String> duplicates = new HashSet<>();
-    for (QueryItem item : queryItems) {
+    for (QueryItem item : attributeFilters) {
       if (!attributes.add(item.getItemId())) {
         duplicates.add(item.getItemId());
       }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
@@ -31,16 +31,12 @@ import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.SELECTED;
 import static org.hisp.dhis.tracker.export.OperationParamUtils.parseAttributeQueryItems;
 import static org.hisp.dhis.tracker.export.OperationParamUtils.parseDataElementQueryItems;
-import static org.hisp.dhis.tracker.export.OperationParamUtils.parseQueryItem;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -50,7 +46,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.AssignedUserQueryParam;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
+import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.feedback.BadRequestException;
@@ -68,11 +66,9 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
+import org.hisp.dhis.tracker.Order;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
-import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
-import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -107,8 +103,6 @@ public class EventOperationParamsMapper {
 
   private final DataElementService dataElementService;
 
-  // For now this maps to EventSearchParams. We should create a new EventQueryParams class that
-  // should be used in the persistence layer
   @Transactional(readOnly = true)
   public EventSearchParams map(EventOperationParams operationParams)
       throws BadRequestException, ForbiddenException {
@@ -143,28 +137,17 @@ public class EventOperationParamsMapper {
 
     validateOrgUnitMode(operationParams, user, program);
 
-    Map<String, SortDirection> attributeOrders =
-        getAttributesFromOrder(operationParams.getAttributeOrders());
-    List<OrderParam> attributeOrderParams = mapToOrderParams(attributeOrders);
-
-    List<QueryItem> filterAttributes =
-        parseFilterAttributes(operationParams.getFilterAttributes(), attributeOrderParams);
-    validateFilterAttributes(filterAttributes);
-
-    Map<String, SortDirection> dataElementOrders =
-        getDataElementsFromOrder(operationParams.getOrders());
-
-    List<QueryItem> dataElements = new ArrayList<>();
-    for (String order : dataElementOrders.keySet()) {
-      dataElements.add(parseQueryItem(order, this::dataElementToQueryItem));
-    }
-
-    List<OrderParam> dataElementOrderParams = mapToOrderParams(dataElementOrders);
-
-    List<QueryItem> filters =
-        parseDataElementQueryItems(operationParams.getFilters(), this::dataElementToQueryItem);
-
     EventSearchParams searchParams = new EventSearchParams();
+    List<QueryItem> dataElementFilters =
+        parseDataElementQueryItems(
+            operationParams.getDataElementFilters(), this::dataElementToQueryItem);
+    mapDataElementFilters(searchParams, dataElementFilters);
+
+    List<QueryItem> attributeFilters = parseFilterAttributes(operationParams.getAttributeFilters());
+    validateFilterAttributes(attributeFilters);
+    mapAttributeFilters(searchParams, attributeFilters);
+
+    mapOrderParam(searchParams, operationParams.getOrder());
 
     return searchParams
         .setProgram(program)
@@ -198,12 +181,6 @@ public class EventOperationParamsMapper {
         .setSkipEventId(operationParams.getSkipEventId())
         .setIncludeAttributes(false)
         .setIncludeAllDataElements(false)
-        .addDataElements(new LinkedHashSet<>(dataElements))
-        .addFilters(filters)
-        .addFilterAttributes(filterAttributes)
-        .addOrders(operationParams.getOrders())
-        .addGridOrders(dataElementOrderParams)
-        .addAttributeOrders(attributeOrderParams)
         .setEvents(operationParams.getEvents())
         .setEnrollments(operationParams.getEnrollments())
         .setIncludeDeleted(operationParams.isIncludeDeleted())
@@ -357,41 +334,13 @@ public class EventOperationParamsMapper {
         || user.isAuthorized(Authorities.F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS.name());
   }
 
-  private List<QueryItem> parseFilterAttributes(
-      String filterAttributes, List<OrderParam> attributeOrderParams) throws BadRequestException {
+  private List<QueryItem> parseFilterAttributes(String filterAttributes)
+      throws BadRequestException {
     Map<String, TrackedEntityAttribute> attributes =
         attributeService.getAllTrackedEntityAttributes().stream()
             .collect(Collectors.toMap(TrackedEntityAttribute::getUid, att -> att));
 
-    List<QueryItem> filterItems = parseAttributeQueryItems(filterAttributes, attributes);
-    List<QueryItem> orderItems =
-        attributeQueryItemsFromOrder(filterItems, attributes, attributeOrderParams);
-
-    return Stream.concat(filterItems.stream(), orderItems.stream()).toList();
-  }
-
-  private List<QueryItem> attributeQueryItemsFromOrder(
-      List<QueryItem> filterAttributes,
-      Map<String, TrackedEntityAttribute> attributes,
-      List<OrderParam> attributeOrderParams) {
-    return attributeOrderParams.stream()
-        .map(OrderParam::getField)
-        .filter(att -> !containsAttributeFilter(filterAttributes, att))
-        .map(attributes::get)
-        .map(
-            at ->
-                new QueryItem(
-                    at, null, at.getValueType(), at.getAggregationType(), at.getOptionSet()))
-        .toList();
-  }
-
-  private boolean containsAttributeFilter(List<QueryItem> attributeFilters, String attributeUid) {
-    for (QueryItem item : attributeFilters) {
-      if (Objects.equals(item.getItem().getUid(), attributeUid)) {
-        return true;
-      }
-    }
-    return false;
+    return parseAttributeQueryItems(filterAttributes, attributes);
   }
 
   private void validateFilterAttributes(List<QueryItem> queryItems) throws BadRequestException {
@@ -409,41 +358,6 @@ public class EventOperationParamsMapper {
               "filterAttributes contains duplicate tracked entity attribute (TEA): %s. Multiple filters for the same TEA can be specified like 'uid:gt:2:lt:10'",
               String.join(", ", duplicates)));
     }
-  }
-
-  private Map<String, SortDirection> getAttributesFromOrder(List<OrderCriteria> allOrders) {
-    if (allOrders == null) {
-      return Collections.emptyMap();
-    }
-
-    Map<String, SortDirection> attributes = new HashMap<>();
-    for (OrderCriteria orderCriteria : allOrders) {
-      TrackedEntityAttribute attribute =
-          trackedEntityAttributeService.getTrackedEntityAttribute(orderCriteria.getField());
-      if (attribute != null) {
-        attributes.put(orderCriteria.getField(), orderCriteria.getDirection());
-      }
-    }
-    return attributes;
-  }
-
-  private List<OrderParam> mapToOrderParams(Map<String, SortDirection> orders) {
-    return orders.entrySet().stream().map(e -> new OrderParam(e.getKey(), e.getValue())).toList();
-  }
-
-  private Map<String, SortDirection> getDataElementsFromOrder(List<OrderParam> allOrders) {
-    if (allOrders == null) {
-      return Collections.emptyMap();
-    }
-
-    Map<String, SortDirection> dataElements = new HashMap<>();
-    for (OrderParam orderParam : allOrders) {
-      DataElement de = dataElementService.getDataElement(orderParam.getField());
-      if (de != null) {
-        dataElements.put(orderParam.getField(), orderParam.getDirection());
-      }
-    }
-    return dataElements;
   }
 
   private QueryItem dataElementToQueryItem(String item) throws BadRequestException {
@@ -586,5 +500,60 @@ public class EventOperationParamsMapper {
 
   private static boolean isProgramAccessRestricted(Program program) {
     return program != null && (program.isClosed() || program.isProtected());
+  }
+
+  private void mapDataElementFilters(EventSearchParams params, List<QueryItem> dataElementFilters) {
+    for (QueryItem item : dataElementFilters) {
+      for (QueryFilter filter : item.getFilters()) {
+        params.addDataElementFilter((DataElement) item.getItem(), filter);
+      }
+    }
+  }
+
+  private void mapAttributeFilters(EventSearchParams params, List<QueryItem> attributeFilters) {
+    for (QueryItem item : attributeFilters) {
+      if (item.getFilters().isEmpty()) {
+        params.addAttribute((TrackedEntityAttribute) item.getItem());
+      }
+
+      for (QueryFilter filter : item.getFilters()) {
+        params.addAttributeFilter((TrackedEntityAttribute) item.getItem(), filter);
+      }
+    }
+  }
+
+  private void mapOrderParam(EventSearchParams params, List<Order> orders)
+      throws BadRequestException {
+    if (orders == null || orders.isEmpty()) {
+      return;
+    }
+
+    for (Order order : orders) {
+      if (order.getField() instanceof String field) {
+        params.orderBy(field, order.getDirection());
+      } else if (order.getField() instanceof UID uid) {
+        DataElement de = dataElementService.getDataElement(uid.getValue());
+        if (de != null) {
+          params.orderBy(de, order.getDirection());
+          continue;
+        }
+
+        TrackedEntityAttribute tea =
+            trackedEntityAttributeService.getTrackedEntityAttribute(uid.getValue());
+        if (tea == null) {
+          throw new BadRequestException(
+              "Cannot order by '"
+                  + uid.getValue()
+                  + "' as its neither a data element nor a tracked entity attribute. Events can be ordered by event fields, data elements and tracked entity attributes.");
+        }
+
+        params.orderBy(tea, order.getDirection());
+      } else {
+        throw new IllegalArgumentException(
+            "Cannot order by '"
+                + order.getField()
+                + "'. Events can be ordered by event fields, data elements and tracked entity attributes.");
+      }
+    }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
@@ -41,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -48,12 +49,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.AssignedUserSelectionMode;
+import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.QueryFilter;
-import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryOperator;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.feedback.BadRequestException;
@@ -69,16 +70,14 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
+import org.hisp.dhis.tracker.Order;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
-import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.function.Executable;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -292,7 +291,7 @@ class EventOperationParamsMapperTest {
   }
 
   @Test
-  void testFilterAttributes() throws BadRequestException, ForbiddenException {
+  void shouldMapAttributeFilters() throws BadRequestException, ForbiddenException {
     TrackedEntityAttribute tea1 = new TrackedEntityAttribute();
     tea1.setUid(TEA_1_UID);
     TrackedEntityAttribute tea2 = new TrackedEntityAttribute();
@@ -301,98 +300,61 @@ class EventOperationParamsMapperTest {
         .thenReturn(List.of(tea1, tea2));
     EventOperationParams requestParams =
         EventOperationParams.builder()
-            .filterAttributes(TEA_1_UID + ":eq:2," + TEA_2_UID + ":like:foo")
+            .attributeFilters(TEA_1_UID + ":eq:2," + TEA_2_UID + ":like:foo")
             .build();
 
     EventSearchParams searchParams = mapper.map(requestParams);
 
-    List<QueryItem> items = searchParams.getFilterAttributes();
-    assertNotNull(items);
-    // mapping to UIDs as the error message by just relying on QueryItem
-    // equals() is not helpful
-    assertContainsOnly(
-        List.of(TEA_1_UID, TEA_2_UID),
-        items.stream().map(i -> i.getItem().getUid()).collect(Collectors.toList()));
-
-    // QueryItem equals() does not take the QueryFilter into account so
-    // assertContainsOnly alone does not ensure operators and filter value
-    // are correct
-    // the following block is needed because of that
-    // assertion is order independent as the order of QueryItems is not
-    // guaranteed
-    Map<String, QueryFilter> expectedFilters =
+    Map<TrackedEntityAttribute, List<QueryFilter>> attributes = searchParams.getAttributes();
+    assertNotNull(attributes);
+    Map<TrackedEntityAttribute, List<QueryFilter>> expected =
         Map.of(
-            TEA_1_UID,
-            new QueryFilter(QueryOperator.EQ, "2"),
-            TEA_2_UID,
-            new QueryFilter(QueryOperator.LIKE, "foo"));
-    assertAll(
-        items.stream()
-            .map(
-                i ->
-                    (Executable)
-                        () -> {
-                          String uid = i.getItem().getUid();
-                          QueryFilter expected = expectedFilters.get(uid);
-                          assertEquals(
-                              expected.getOperator().getValue() + " " + expected.getFilter(),
-                              i.getFiltersAsString(),
-                              () -> String.format("QueryFilter mismatch for TEA with UID %s", uid));
-                        })
-            .collect(Collectors.toList()));
+            tea1,
+            List.of(new QueryFilter(QueryOperator.EQ, "2")),
+            tea2,
+            List.of(new QueryFilter(QueryOperator.LIKE, "foo")));
+    assertEquals(expected, attributes);
   }
 
   @Test
-  void testFilterAttributesWhenTEAHasMultipleFilters()
+  void shouldMapAttributeFiltersWhenAttributeHasMultipleFilters()
       throws BadRequestException, ForbiddenException {
     TrackedEntityAttribute tea1 = new TrackedEntityAttribute();
     tea1.setUid(TEA_1_UID);
     when(trackedEntityAttributeService.getAllTrackedEntityAttributes()).thenReturn(List.of(tea1));
     EventOperationParams operationParams =
-        EventOperationParams.builder().filterAttributes(TEA_1_UID + ":gt:10:lt:20").build();
+        EventOperationParams.builder().attributeFilters(TEA_1_UID + ":gt:10:lt:20").build();
 
     EventSearchParams searchParams = mapper.map(operationParams);
 
-    List<QueryItem> items = searchParams.getFilterAttributes();
-    assertNotNull(items);
-    // mapping to UIDs as the error message by just relying on QueryItem
-    // equals() is not helpful
-    assertContainsOnly(
-        List.of(TEA_1_UID),
-        items.stream().map(i -> i.getItem().getUid()).collect(Collectors.toList()));
-
-    // QueryItem equals() does not take the QueryFilter into account so
-    // assertContainsOnly alone does not ensure operators and filter value
-    // are correct
-    assertContainsOnly(
-        Set.of(new QueryFilter(QueryOperator.GT, "10"), new QueryFilter(QueryOperator.LT, "20")),
-        items.get(0).getFilters());
+    Map<TrackedEntityAttribute, List<QueryFilter>> attributes = searchParams.getAttributes();
+    assertNotNull(attributes);
+    Map<TrackedEntityAttribute, List<QueryFilter>> expected =
+        Map.of(
+            tea1,
+            List.of(
+                new QueryFilter(QueryOperator.GT, "10"), new QueryFilter(QueryOperator.LT, "20")));
+    assertEquals(expected, attributes);
   }
 
   @Test
-  void testFilterAttributesUsingOnlyUID() throws BadRequestException, ForbiddenException {
+  void shouldMapAttributeFiltersWhenOnlyGivenUID() throws BadRequestException, ForbiddenException {
     TrackedEntityAttribute tea1 = new TrackedEntityAttribute();
     tea1.setUid(TEA_1_UID);
     when(trackedEntityAttributeService.getAllTrackedEntityAttributes()).thenReturn(List.of(tea1));
     EventOperationParams operationParams =
-        EventOperationParams.builder().filterAttributes(TEA_1_UID).build();
+        EventOperationParams.builder().attributeFilters(TEA_1_UID).build();
 
     EventSearchParams params = mapper.map(operationParams);
 
-    assertContainsOnly(
-        List.of(
-            new QueryItem(
-                tea1,
-                null,
-                tea1.getValueType(),
-                tea1.getAggregationType(),
-                tea1.getOptionSet(),
-                tea1.isUnique())),
-        params.getFilterAttributes());
+    Map<TrackedEntityAttribute, List<QueryFilter>> attributes = params.getAttributes();
+    assertNotNull(attributes);
+    Map<TrackedEntityAttribute, List<QueryFilter>> expected = Map.of(tea1, List.of());
+    assertEquals(expected, attributes);
   }
 
   @Test
-  void testFilterAttributesWhenTEAUidIsDuplicated() {
+  void shouldFailToMapAttributeFiltersWhenUIDIsDuplicated() {
     TrackedEntityAttribute tea1 = new TrackedEntityAttribute();
     tea1.setUid(TEA_1_UID);
     TrackedEntityAttribute tea2 = new TrackedEntityAttribute();
@@ -401,7 +363,7 @@ class EventOperationParamsMapperTest {
         .thenReturn(List.of(tea1, tea2));
     EventOperationParams operationParams =
         EventOperationParams.builder()
-            .filterAttributes(
+            .attributeFilters(
                 "TvjwTPToKHO:lt:20,"
                     + "cy2oRh2sNr6:lt:20,"
                     + "TvjwTPToKHO:gt:30,"
@@ -422,31 +384,74 @@ class EventOperationParamsMapperTest {
   }
 
   @Test
-  void testMappingAttributeOrdering() throws BadRequestException, ForbiddenException {
+  void shouldMapOrderInGivenOrder() throws BadRequestException, ForbiddenException {
     TrackedEntityAttribute tea1 = new TrackedEntityAttribute();
     tea1.setUid(TEA_1_UID);
     when(trackedEntityAttributeService.getAllTrackedEntityAttributes()).thenReturn(List.of(tea1));
-    when(trackedEntityAttributeService.getTrackedEntityAttribute("TvjwTPToKHO")).thenReturn(tea1);
+    when(trackedEntityAttributeService.getTrackedEntityAttribute(TEA_1_UID)).thenReturn(tea1);
+
+    DataElement de1 = new DataElement();
+    de1.setUid(DE_1_UID);
+    when(dataElementService.getDataElement(DE_1_UID)).thenReturn(de1);
+    when(dataElementService.getDataElement(TEA_1_UID)).thenReturn(null);
+
     EventOperationParams operationParams =
         EventOperationParams.builder()
-            .attributeOrders(
-                List.of(
-                    OrderCriteria.of(TEA_1_UID, SortDirection.ASC),
-                    OrderCriteria.of("unknownAtt1", SortDirection.ASC)))
-            .filterAttributes(TEA_1_UID)
+            .orderBy("created", SortDirection.ASC)
+            .orderBy(UID.of(TEA_1_UID), SortDirection.ASC)
+            .orderBy("programStage.uid", SortDirection.DESC)
+            .orderBy(UID.of(DE_1_UID), SortDirection.DESC)
+            .orderBy("dueDate", SortDirection.ASC)
             .build();
 
     EventSearchParams params = mapper.map(operationParams);
 
-    assertAll(
-        () ->
-            assertContainsOnly(
-                params.getAttributeOrders(),
-                List.of(new OrderParam(TEA_1_UID, SortDirection.ASC))));
+    assertEquals(
+        List.of(
+            new Order("created", SortDirection.ASC),
+            new Order(tea1, SortDirection.ASC),
+            new Order("programStage.uid", SortDirection.DESC),
+            new Order(de1, SortDirection.DESC),
+            new Order("dueDate", SortDirection.ASC)),
+        params.getOrder());
   }
 
   @Test
-  void testFilter() throws BadRequestException, ForbiddenException {
+  void shouldFailToMapOrderIfUIDIsNeitherDataElementNorAttribute() {
+    TrackedEntityAttribute tea1 = new TrackedEntityAttribute();
+    tea1.setUid(TEA_1_UID);
+    when(trackedEntityAttributeService.getAllTrackedEntityAttributes()).thenReturn(List.of(tea1));
+    when(trackedEntityAttributeService.getTrackedEntityAttribute(TEA_1_UID)).thenReturn(null);
+
+    DataElement de1 = new DataElement();
+    de1.setUid(DE_1_UID);
+    when(dataElementService.getDataElement(TEA_1_UID)).thenReturn(null);
+
+    EventOperationParams operationParams =
+        EventOperationParams.builder().orderBy(UID.of(TEA_1_UID), SortDirection.ASC).build();
+
+    Exception exception =
+        assertThrows(BadRequestException.class, () -> mapper.map(operationParams));
+    assertStartsWith("Cannot order by '" + TEA_1_UID, exception.getMessage());
+  }
+
+  @Test
+  void shouldFailToMapGivenInvalidOrderNameWhichIsAValidUID() {
+    // This test case shows that some field names are valid UIDs. Previous stages (web) can thus not
+    // rule out all
+    // invalid field names and UIDs. Such invalid order values will be caught in this mapper.
+    assertTrue(CodeGenerator.isValidUid("lastUpdated"));
+
+    EventOperationParams operationParams =
+        EventOperationParams.builder().orderBy(UID.of("lastUpdated"), SortDirection.ASC).build();
+
+    Exception exception =
+        assertThrows(BadRequestException.class, () -> mapper.map(operationParams));
+    assertStartsWith("Cannot order by 'lastUpdated'", exception.getMessage());
+  }
+
+  @Test
+  void shouldMapDataElementFilters() throws BadRequestException, ForbiddenException {
     DataElement de1 = new DataElement();
     de1.setUid(DE_1_UID);
     when(dataElementService.getDataElement(DE_1_UID)).thenReturn(de1);
@@ -456,77 +461,48 @@ class EventOperationParamsMapperTest {
 
     EventOperationParams requestParams =
         EventOperationParams.builder()
-            .filters(DE_1_UID + ":eq:2," + DE_2_UID + ":like:foo")
+            .dataElementFilters(DE_1_UID + ":eq:2," + DE_2_UID + ":like:foo")
             .build();
     EventSearchParams params = mapper.map(requestParams);
 
-    List<QueryItem> items = params.getFilters();
-    assertNotNull(items);
-    // mapping to UIDs as the error message by just relying on QueryItem
-    // equals() is not helpful
-    assertContainsOnly(
-        List.of(DE_1_UID, DE_2_UID),
-        items.stream().map(i -> i.getItem().getUid()).collect(Collectors.toList()));
-
-    // QueryItem equals() does not take the QueryFilter into account so
-    // assertContainsOnly alone does not ensure operators and filter value
-    // are correct
-    // the following block is needed because of that
-    // assertion is order independent as the order of QueryItems is not
-    // guaranteed
-    Map<String, QueryFilter> expectedFilters =
+    Map<DataElement, List<QueryFilter>> dataElements = params.getDataElements();
+    assertNotNull(dataElements);
+    Map<DataElement, List<QueryFilter>> expected =
         Map.of(
-            DE_1_UID,
-            new QueryFilter(QueryOperator.EQ, "2"),
-            DE_2_UID,
-            new QueryFilter(QueryOperator.LIKE, "foo"));
-    assertAll(
-        items.stream()
-            .map(
-                i ->
-                    (Executable)
-                        () -> {
-                          String uid = i.getItem().getUid();
-                          QueryFilter expected = expectedFilters.get(uid);
-                          assertEquals(
-                              expected.getOperator().getValue() + " " + expected.getFilter(),
-                              i.getFiltersAsString(),
-                              () -> String.format("QueryFilter mismatch for DE with UID %s", uid));
-                        })
-            .collect(Collectors.toList()));
+            de1,
+            List.of(new QueryFilter(QueryOperator.EQ, "2")),
+            de2,
+            List.of(new QueryFilter(QueryOperator.LIKE, "foo")));
+    assertEquals(expected, dataElements);
   }
 
   @Test
-  void testFilterWhenDEHasMultipleFilters() throws BadRequestException, ForbiddenException {
+  void shouldMapDataElementFiltersWhenDataElementHasMultipleFilters()
+      throws BadRequestException, ForbiddenException {
     DataElement de1 = new DataElement();
     de1.setUid(DE_1_UID);
     when(dataElementService.getDataElement(DE_1_UID)).thenReturn(de1);
 
     EventOperationParams requestParams =
-        EventOperationParams.builder().filters(DE_1_UID + ":gt:10:lt:20").build();
+        EventOperationParams.builder().dataElementFilters(DE_1_UID + ":gt:10:lt:20").build();
 
     EventSearchParams params = mapper.map(requestParams);
 
-    List<QueryItem> items = params.getFilters();
-    assertNotNull(items);
-    // mapping to UIDs as the error message by just relying on QueryItem
-    // equals() is not helpful
-    assertContainsOnly(
-        List.of(DE_1_UID),
-        items.stream().map(i -> i.getItem().getUid()).collect(Collectors.toList()));
-
-    // QueryItem equals() does not take the QueryFilter into account so
-    // assertContainsOnly alone does not ensure operators and filter value
-    // are correct
-    assertContainsOnly(
-        Set.of(new QueryFilter(QueryOperator.GT, "10"), new QueryFilter(QueryOperator.LT, "20")),
-        items.get(0).getFilters());
+    Map<DataElement, List<QueryFilter>> dataElements = params.getDataElements();
+    assertNotNull(dataElements);
+    Map<DataElement, List<QueryFilter>> expected =
+        Map.of(
+            de1,
+            List.of(
+                new QueryFilter(QueryOperator.GT, "10"), new QueryFilter(QueryOperator.LT, "20")));
+    assertEquals(expected, dataElements);
   }
 
   @Test
-  void shouldFailWithBadRequestExceptionWhenCriteriaDataElementDoesNotExist() {
+  void shouldFailWhenDataElementInGivenDataElementFilterDoesNotExist() {
     String filterName = "filter";
-    EventOperationParams requestParams = EventOperationParams.builder().filters(filterName).build();
+    EventOperationParams requestParams =
+        EventOperationParams.builder().dataElementFilters(filterName).build();
 
     when(dataElementService.getDataElement(filterName)).thenReturn(null);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventSearchParamsTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventSearchParamsTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.export.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import org.hisp.dhis.DhisConvenienceTest;
+import org.hisp.dhis.common.QueryFilter;
+import org.hisp.dhis.common.QueryOperator;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.tracker.Order;
+import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class EventSearchParamsTest extends DhisConvenienceTest {
+
+  private TrackedEntityAttribute tea1;
+
+  private DataElement de1;
+
+  @BeforeEach
+  void setUp() {
+    tea1 = createTrackedEntityAttribute('a');
+    de1 = createDataElement('a');
+  }
+
+  @Test
+  void shouldAddAttributeToOrderAndAttributesWhenOrderingByAttribute() {
+    EventSearchParams params = new EventSearchParams();
+
+    params.orderBy(tea1, SortDirection.DESC);
+
+    assertEquals(List.of(new Order(tea1, SortDirection.DESC)), params.getOrder());
+    assertEquals(Map.of(tea1, List.of()), params.getAttributes());
+  }
+
+  @Test
+  void shouldKeepExistingAttributeFiltersWhenOrderingByAttribute() {
+    EventSearchParams params = new EventSearchParams();
+
+    QueryFilter filter = new QueryFilter(QueryOperator.EQ, "summer day");
+    params.addAttributeFilter(tea1, filter);
+
+    assertEquals(Map.of(tea1, List.of(filter)), params.getAttributes());
+
+    params.orderBy(tea1, SortDirection.DESC);
+
+    assertEquals(Map.of(tea1, List.of(filter)), params.getAttributes());
+  }
+
+  @Test
+  void shouldAddDataElementToOrderAndDataElementsWhenOrderingByDataElement() {
+    EventSearchParams params = new EventSearchParams();
+
+    params.orderBy(de1, SortDirection.ASC);
+
+    assertEquals(List.of(new Order(de1, SortDirection.ASC)), params.getOrder());
+    assertEquals(Map.of(de1, List.of()), params.getDataElements());
+    assertFalse(params.hasDataElementFilter());
+  }
+
+  @Test
+  void shouldKeepExistingDataElementFiltersWhenOrderingByDataElement() {
+    EventSearchParams params = new EventSearchParams();
+
+    QueryFilter filter = new QueryFilter(QueryOperator.EQ, "summer day");
+    params.addDataElementFilter(de1, filter);
+
+    assertTrue(params.hasDataElementFilter());
+    assertEquals(Map.of(de1, List.of(filter)), params.getDataElements());
+
+    params.orderBy(de1, SortDirection.ASC);
+
+    assertTrue(params.hasDataElementFilter());
+    assertEquals(Map.of(de1, List.of(filter)), params.getDataElements());
+  }
+}

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -59,6 +59,7 @@ import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.SlimPager;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
@@ -80,9 +81,7 @@ import org.hisp.dhis.tracker.export.event.EventOperationParams.EventOperationPar
 import org.hisp.dhis.tracker.imports.TrackerImportService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;
-import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
-import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -197,7 +196,7 @@ class EventExporterTest extends TrackerTest {
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
             .events(Set.of("pTzf9KYMk72", "D9PbzJY8bJM"))
-            .orders(List.of(new OrderParam("executionDate", SortDirection.DESC)));
+            .orderBy("executionDate", SortDirection.DESC);
 
     EventOperationParams params = paramsBuilder.page(1).pageSize(1).build();
 
@@ -364,7 +363,7 @@ class EventExporterTest extends TrackerTest {
             .orgUnitUid(orgUnit.getUid())
             .enrollments(Set.of("nxP7UnKhomJ"))
             .programStageUid(programStage.getUid())
-            .filters("DATAEL00001:like:%val%")
+            .dataElementFilters("DATAEL00001:like:%val%")
             .build();
 
     List<String> events = getEvents(params);
@@ -385,7 +384,7 @@ class EventExporterTest extends TrackerTest {
             .enrollments(Set.of("nxP7UnKhomJ"))
             .programStageUid(programStage.getUid())
             .programStatus(ProgramStatus.ACTIVE)
-            .filters(dataElement.getUid() + ":like:%val%")
+            .dataElementFilters(dataElement.getUid() + ":like:%val%")
             .build();
 
     List<String> events = getEvents(params);
@@ -404,7 +403,7 @@ class EventExporterTest extends TrackerTest {
             .enrollments(Set.of("nxP7UnKhomJ"))
             .programStageUid(programStage.getUid())
             .programType(ProgramType.WITH_REGISTRATION)
-            .filters(dataElement.getUid() + ":like:%val%")
+            .dataElementFilters(dataElement.getUid() + ":like:%val%")
             .build();
 
     List<String> events = getEvents(params);
@@ -422,7 +421,7 @@ class EventExporterTest extends TrackerTest {
             .orgUnitUid(orgUnit.getUid())
             .enrollments(Set.of("nxP7UnKhomJ"))
             .programStageUid(programStage.getUid())
-            .filters(dataElement.getUid() + ":like:%value00001%")
+            .dataElementFilters(dataElement.getUid() + ":like:%value00001%")
             .build();
 
     List<String> events = getEvents(params);
@@ -440,7 +439,7 @@ class EventExporterTest extends TrackerTest {
             .orgUnitUid(orgUnit.getUid())
             .enrollments(Set.of("nxP7UnKhomJ", "TvctPPhpD8z"))
             .programStageUid(programStage.getUid())
-            .filters(datael00001.getUid() + ":in:value00001;value00002")
+            .dataElementFilters(datael00001.getUid() + ":in:value00001;value00002")
             .build();
 
     List<String> events = getEvents(params);
@@ -461,7 +460,7 @@ class EventExporterTest extends TrackerTest {
             .programUid(program.getUid())
             .attributeCategoryCombo("bjDvmb4bfuf")
             .attributeCategoryOptions(Set.of("xYerKDKCefk"))
-            .filters(dataElement.getUid() + ":eq:value00001")
+            .dataElementFilters(dataElement.getUid() + ":eq:value00001")
             .build();
 
     List<String> events = getEvents(params);
@@ -479,7 +478,7 @@ class EventExporterTest extends TrackerTest {
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
             .programUid(program.getUid())
-            .orders(List.of(new OrderParam("executionDate", SortDirection.DESC)));
+            .orderBy("executionDate", SortDirection.DESC);
 
     EventOperationParams params = paramsBuilder.page(1).pageSize(3).build();
 
@@ -518,7 +517,7 @@ class EventExporterTest extends TrackerTest {
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
             .programUid(program.getUid())
-            .orders(List.of(new OrderParam("executionDate", SortDirection.DESC)))
+            .orderBy("executionDate", SortDirection.DESC)
             .page(1)
             .pageSize(2)
             .totalPages(true)
@@ -703,7 +702,7 @@ class EventExporterTest extends TrackerTest {
             .programUid(program.getUid())
             .attributeCategoryCombo("bjDvmb4bfuf")
             .attributeCategoryOptions(Set.of("xYerKDKCefk"))
-            .filters(dataElement.getUid() + ":eq:value00002")
+            .dataElementFilters(dataElement.getUid() + ":eq:value00002")
             .build();
 
     List<String> events = getEvents(params);
@@ -720,7 +719,7 @@ class EventExporterTest extends TrackerTest {
             .orgUnitUid(orgUnit.getUid())
             .enrollments(Set.of("nxP7UnKhomJ"))
             .programStageUid(programStage.getUid())
-            .filters(dataElement.getUid() + ":eq:option1")
+            .dataElementFilters(dataElement.getUid() + ":eq:option1")
             .build();
 
     List<String> events = getEvents(params);
@@ -737,7 +736,7 @@ class EventExporterTest extends TrackerTest {
             .orgUnitUid(orgUnit.getUid())
             .enrollments(Set.of("nxP7UnKhomJ", "TvctPPhpD8z"))
             .programStageUid(programStage.getUid())
-            .filters(dataElement.getUid() + ":in:option1;option2")
+            .dataElementFilters(dataElement.getUid() + ":in:option1;option2")
             .build();
 
     List<String> events = getEvents(params);
@@ -754,7 +753,7 @@ class EventExporterTest extends TrackerTest {
             .orgUnitUid(orgUnit.getUid())
             .enrollments(Set.of("nxP7UnKhomJ"))
             .programStageUid(programStage.getUid())
-            .filters(dataElement.getUid() + ":like:%opt%")
+            .dataElementFilters(dataElement.getUid() + ":like:%opt%")
             .build();
 
     List<String> events = getEvents(params);
@@ -776,7 +775,7 @@ class EventExporterTest extends TrackerTest {
             .orgUnitUid(orgUnit.getUid())
             .enrollments(Set.of("nxP7UnKhomJ", "TvctPPhpD8z"))
             .programStageUid(programStage.getUid())
-            .filters(dataElement.getUid() + ":lt:77:gt:8")
+            .dataElementFilters(dataElement.getUid() + ":lt:77:gt:8")
             .build();
 
     List<String> events = getEvents(params);
@@ -976,7 +975,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .filterAttributes("numericAttr:lt:77:gt:8")
+            .attributeFilters("numericAttr:lt:77:gt:8")
             .build();
 
     List<String> trackedEntities =
@@ -992,7 +991,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .filterAttributes("toUpdate000:eq:summer day")
+            .attributeFilters("toUpdate000:eq:summer day")
             .build();
 
     List<String> trackedEntities =
@@ -1009,7 +1008,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .filterAttributes("toUpdate000:eq:rainy day,notUpdated0:eq:winter day")
+            .attributeFilters("toUpdate000:eq:rainy day,notUpdated0:eq:winter day")
             .build();
 
     List<String> trackedEntities =
@@ -1029,7 +1028,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .filterAttributes("toUpdate000:like:day:like:in")
+            .attributeFilters("toUpdate000:like:day:like:in")
             .build();
 
     List<String> trackedEntities =
@@ -1045,9 +1044,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .filterAttributes("toUpdate000")
-            .attributeOrders(List.of(OrderCriteria.of("toUpdate000", SortDirection.ASC)))
-            .orders(List.of(new OrderParam("toUpdate000", SortDirection.ASC)))
+            .orderBy(UID.of("toUpdate000"), SortDirection.ASC)
             .build();
 
     List<String> trackedEntities =
@@ -1063,9 +1060,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .filterAttributes("toUpdate000")
-            .attributeOrders(List.of(OrderCriteria.of("toUpdate000", SortDirection.DESC)))
-            .orders(List.of(new OrderParam("toUpdate000", SortDirection.DESC)))
+            .orderBy(UID.of("toUpdate000"), SortDirection.DESC)
             .build();
 
     List<String> trackedEntities =
@@ -1081,15 +1076,8 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .filterAttributes("toUpdate000,toDelete000")
-            .attributeOrders(
-                List.of(
-                    OrderCriteria.of("toDelete000", SortDirection.DESC),
-                    OrderCriteria.of("toUpdate000", SortDirection.DESC)))
-            .orders(
-                List.of(
-                    new OrderParam("toDelete000", SortDirection.DESC),
-                    new OrderParam("toUpdate000", SortDirection.DESC)))
+            .orderBy(UID.of("toDelete000"), SortDirection.DESC)
+            .orderBy(UID.of("toUpdate000"), SortDirection.DESC)
             .build();
 
     List<String> trackedEntities =
@@ -1105,15 +1093,8 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .filterAttributes("toUpdate000,toDelete000")
-            .attributeOrders(
-                List.of(
-                    OrderCriteria.of("toDelete000", SortDirection.DESC),
-                    OrderCriteria.of("toUpdate000", SortDirection.ASC)))
-            .orders(
-                List.of(
-                    new OrderParam("toDelete000", SortDirection.DESC),
-                    new OrderParam("toUpdate000", SortDirection.ASC)))
+            .orderBy(UID.of("toDelete000"), SortDirection.DESC)
+            .orderBy(UID.of("toUpdate000"), SortDirection.ASC)
             .build();
 
     List<Event> events = eventService.getEvents(params).getEvents();
@@ -1132,15 +1113,8 @@ class EventExporterTest extends TrackerTest {
     EventOperationParamsBuilder paramsBuilder =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .filterAttributes("toUpdate000,toDelete000")
-            .attributeOrders(
-                List.of(
-                    OrderCriteria.of("toDelete000", SortDirection.DESC),
-                    OrderCriteria.of("toUpdate000", SortDirection.ASC)))
-            .orders(
-                List.of(
-                    new OrderParam("toDelete000", SortDirection.DESC),
-                    new OrderParam("toUpdate000", SortDirection.ASC)));
+            .orderBy(UID.of("toDelete000"), SortDirection.DESC)
+            .orderBy(UID.of("toUpdate000"), SortDirection.ASC);
 
     EventOperationParams params = paramsBuilder.page(1).pageSize(1).build();
 
@@ -1187,7 +1161,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .orders(List.of(new OrderParam("enrollment.enrollmentDate", SortDirection.DESC)))
+            .orderBy("enrollment.enrollmentDate", SortDirection.DESC)
             .build();
 
     List<String> enrollments =
@@ -1203,7 +1177,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .orders(List.of(new OrderParam("enrollment.enrollmentDate", SortDirection.ASC)))
+            .orderBy("enrollment.enrollmentDate", SortDirection.ASC)
             .build();
 
     List<String> enrollments =
@@ -1219,7 +1193,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .orders(List.of(new OrderParam("executionDate", SortDirection.DESC)))
+            .orderBy("executionDate", SortDirection.DESC)
             .build();
 
     Events events = eventService.getEvents(params);
@@ -1232,7 +1206,7 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .orders(List.of(new OrderParam("executionDate", SortDirection.ASC)))
+            .orderBy("executionDate", SortDirection.ASC)
             .build();
 
     Events events = eventService.getEvents(params);
@@ -1302,12 +1276,8 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .filterAttributes("toUpdate000")
-            .attributeOrders(List.of(OrderCriteria.of("toUpdate000", SortDirection.ASC)))
-            .orders(
-                List.of(
-                    new OrderParam("toUpdate000", SortDirection.ASC),
-                    new OrderParam("enrollment.enrollmentDate", SortDirection.ASC)))
+            .orderBy(UID.of("toUpdate000"), SortDirection.ASC)
+            .orderBy("enrollment.enrollmentDate", SortDirection.ASC)
             .build();
 
     List<String> trackedEntities =
@@ -1324,12 +1294,8 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .filterAttributes("toUpdate000")
-            .attributeOrders(List.of(OrderCriteria.of("toUpdate000", SortDirection.DESC)))
-            .orders(
-                List.of(
-                    new OrderParam("enrollment.enrollmentDate", SortDirection.DESC),
-                    new OrderParam("toUpdate000", SortDirection.DESC)))
+            .orderBy("enrollment.enrollmentDate", SortDirection.DESC)
+            .orderBy(UID.of("toUpdate000"), SortDirection.DESC)
             .build();
 
     List<String> trackedEntities =
@@ -1346,11 +1312,9 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .orders(
-                List.of(
-                    new OrderParam("dueDate", SortDirection.DESC),
-                    new OrderParam("DATAEL00006", SortDirection.DESC),
-                    new OrderParam("enrollment.enrollmentDate", SortDirection.DESC)))
+            .orderBy("dueDate", SortDirection.DESC)
+            .orderBy(UID.of("DATAEL00006"), SortDirection.DESC)
+            .orderBy("enrollment.enrollmentDate", SortDirection.DESC)
             .build();
 
     List<String> trackedEntities =
@@ -1367,10 +1331,8 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .orders(
-                List.of(
-                    new OrderParam("enrollment.enrollmentDate", SortDirection.DESC),
-                    new OrderParam("DATAEL00006", SortDirection.DESC)))
+            .orderBy("enrollment.enrollmentDate", SortDirection.DESC)
+            .orderBy(UID.of("DATAEL00006"), SortDirection.DESC)
             .build();
 
     List<String> trackedEntities =

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
@@ -41,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -66,10 +67,10 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
+import org.hisp.dhis.tracker.Order;
 import org.hisp.dhis.tracker.export.event.EventOperationParams;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.junit.jupiter.api.BeforeEach;
@@ -196,7 +197,7 @@ class EventRequestParamsMapperTest {
   }
 
   @Test
-  void shouldThrowIfDeprecatedAndNewOrgUnitModeParameterIsSet() {
+  void shouldFailIfDeprecatedAndNewOrgUnitModeParameterIsSet() {
     RequestParams requestParams = new RequestParams();
     requestParams.setOuMode(OrganisationUnitSelectionMode.SELECTED);
     requestParams.setOrgUnitMode(OrganisationUnitSelectionMode.SELECTED);
@@ -407,23 +408,25 @@ class EventRequestParamsMapperTest {
   }
 
   @Test
-  void shouldMapOrderParameterToOrderCriteriaWhenFieldsAreOrderable() throws BadRequestException {
+  void shouldMapOrderParameterInGivenOrderWhenFieldsAreOrderable() throws BadRequestException {
     RequestParams requestParams = new RequestParams();
     requestParams.setOrder(
-        OrderCriteria.fromOrderString("createdAt:asc,programStage:desc,scheduledAt:asc"));
+        OrderCriteria.fromOrderString(
+            "createdAt:asc,zGlzbfreTOH,programStage:desc,scheduledAt:asc"));
 
     EventOperationParams params = mapper.map(requestParams);
 
-    assertContainsOnly(
+    assertEquals(
         List.of(
-            new OrderParam("created", SortDirection.ASC),
-            new OrderParam("programStage.uid", SortDirection.DESC),
-            new OrderParam("dueDate", SortDirection.ASC)),
-        params.getOrders());
+            new Order("created", SortDirection.ASC),
+            new Order(UID.of("zGlzbfreTOH"), SortDirection.ASC),
+            new Order("programStage.uid", SortDirection.DESC),
+            new Order("dueDate", SortDirection.ASC)),
+        params.getOrder());
   }
 
   @Test
-  void shouldThrowWhenOrderParameterContainsInvalidOrderComponents() {
+  void shouldFailGivenInvalidOrderComponents() {
     String invalidUID = "Cogn34Del";
     assertFalse(CodeGenerator.isValidUid(invalidUID));
 
@@ -444,7 +447,23 @@ class EventRequestParamsMapperTest {
   }
 
   @Test
-  void shouldThrowWhenOrderParameterContainsRepeatedOrderComponents() {
+  void shouldMapGivenInvalidOrderNameWhichIsAValidUIDToUID() throws BadRequestException {
+    // This test case shows that some field names are valid UIDs. We can thus not rule out all
+    // invalid field names and UIDs at this stage as we do not have access to data element/attribute
+    // services. Such invalid order values will be caught in the
+    // service (mapper).
+    assertTrue(CodeGenerator.isValidUid("lastUpdated"));
+
+    RequestParams requestParams = new RequestParams();
+    requestParams.setOrder(OrderCriteria.fromOrderString("lastUpdated:desc"));
+
+    EventOperationParams params = mapper.map(requestParams);
+
+    assertEquals(List.of(new Order(UID.of("lastUpdated"), SortDirection.DESC)), params.getOrder());
+  }
+
+  @Test
+  void shouldFailWhenOrderParameterContainsRepeatedOrderComponents() {
     RequestParams requestParams = new RequestParams();
     requestParams.setOrder(
         OrderCriteria.fromOrderString(


### PR DESCRIPTION
`/tracker/events` is the endpoint with the most "order features" of all tracker exporter endpoints. Users can order by event fields, data elements and tracked entities as in `/tracker/events?order=createdAt:desc,TvjwTPToKHO,scheduledAt,OBzmpRP6YUh:asc`.

Its essential that we preserve the user provided order in whatever data structure we use to represent the order.

Challenges:
* You can see from the example request that a UID might be a data element or a tracked entity attribute. In case we do not find a UID as one of the above we cannot be sure what the user meant.
* Certain field names are considered valid UIDs. For example: `completedAt, scheduledAt, completedBy, orgUnitName, lastUpdated, completedBy` are all valid UIDs. We thus need to be careful with checks like `isValidUid`.
* The requirement to preserve order and support 3 different types that do not all have something useful in common in a generic collection such as a `List` is hard (see typesafe heterogeneous container).

## Goal

The goal of this PR is to implement most tasks in https://dhis2.atlassian.net/browse/TECH-1606. In addition we want to ["make it easy to do the right thing and almost impossible to do the wrong thing"](https://www.infoq.com/articles/API-Design-Joshua-Bloch/).

Ordering by attributes (and data elements) turned from 

```java
EventOperationParams params =
    EventOperationParams.builder()
        .filterAttributes("toUpdate000")
        .attributeOrders(List.of(OrderCriteria.of("toUpdate000", SortDirection.DESC)))
        .orders(List.of(new OrderParam("toUpdate000", SortDirection.DESC)))
        .build();
```

to

```java
EventOperationParams params =
    EventOperationParams.builder()
        .orderBy(UID.of("toUpdate000"), SortDirection.DESC)
        .build();
```

EventOperationParams(EventSearchParams) will make sure to update internal structures necessary for the JdbcEventStore to create the query. Users do not have to remember that.

## Types

This is to illustrate how the types/information gets richer from the request to the store. Note that this is a pseudo notation as there is no union.

1. A request like
`order=createdAt:desc,TvjwTPToKHO,scheduledAt,OBzmpRP6YUh:asc` starts out as => `List<OrderCriteria<String>>`
2. EventRequestParamsMapper => `List<Order<String|UID>>`
3. EventOperationParamsMapper => `List<Order<String|DataElement|TrackedEntityAttribute>>`

Each stage makes sure that the types at runtime are one of the supported ones.

## Events SQL Query (JdbcEventStore)

### Attributes

#### Filter

Filtering by attributes like

```java
EventOperationParams.builder()
    .attributeFilters("toUpdate000:eq:summer day")
```

turns into join

```sql
INNER JOIN trackedentityattributevalue "toUpdate000"
            ON "toUpdate000".trackedentityid = TEI.trackedentityid
INNER JOIN trackedentityattribute "toUpdate000ATT"
            ON "toUpdate000".trackedentityattributeid =
                "toUpdate000ATT".trackedentityattributeid AND
                "toUpdate000ATT".UID = 'toUpdate000' AND
                lower("toUpdate000".value) = 'summer day'
```

#### Order

Ordering by attributes

```java
EventOperationParams.builder()
    .orderBy(UID.of("toUpdate000"), SortDirection.ASC)
```

turns into

```sql
"toUpdate000".value AS toUpdate000_value,
```

in the select and join (as when filtering)

```sql
INNER JOIN trackedentityattributevalue "toUpdate000"
            ON "toUpdate000".trackedentityid = TEI.trackedentityid
INNER JOIN trackedentityattribute "toUpdate000ATT"
            ON "toUpdate000".trackedentityattributeid =
                "toUpdate000ATT".trackedentityattributeid AND
                "toUpdate000ATT".UID = 'toUpdate000'
```

An `order by toUpdate000_value ASC` is added to the event subquery. This is so that pagination is correct as the pagination using limit/offset is applied in the event subquery. Additionally, we add another `order by toUpdate000_value ASC` in the outer query as we cannot rely on ordering by simply ordering the subquery.

### Data elements

Data elements have to be treated differently than attributes as they are stored as JSONB in the event table itself.

An example JSONB

```json
{
    "D7m8vpzxHDJ": {"value": "P+", "created": "2014-11-02T22:55:17.849", "storedBy": null,
"lastUpdated": "2014-11-02T22:55:17.849", "providedElsewhere": false},
    "HmkXnHJxcD1": {"value": "TAI", "created": "2014-11-02T22:55:19.225", "storedBy": null, "lastUpdated":
    "2014-11-02T22:55:19.225", "providedElsewhere": false}
}
```

#### Filter

Filtering by data elements like

```java
EventOperationParams.builder()
  .dataElementFilters("DATAEL00001:like:%val%")
```

turns into select

```sql
lower(psi.eventdatavalues #>> '{DATAEL00001, value}') as DATAEL00001
```

and where clause in the event subquery

```sql
where lower(psi.eventdatavalues #>> '{DATAEL00001, value}') like :parameter_2
```

#### Ordering by data element

```java
EventOperationParams.builder()
    .orderBy(UID.of("DATAEL00006"), SortDirection.ASC)
```

turns into select

```sql
cast(psi.eventdatavalues #>> '{DATAEL00006, value}' as numeric) as DATAEL00006
```

in the event subquery.

Note that the cast is due to this data element being of a numeric value type.

An order by clause is added in the events subquery and the outer query

```sql
order by DATAEL00006 DESC
```
