### PR TITLE
chore: no need for QueryItem in handling filters TECH-1606

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/OperationParamUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/OperationParamUtils.java
@@ -65,7 +65,7 @@ public class OperationParamUtils {
    * Negative lookahead to avoid wrong split when filter value contains colon. It skips colon
    * escaped by slash
    */
-  private static final Pattern FILTER_ITEM_SPLIT =
+  public static final Pattern FILTER_ITEM_SPLIT =
       Pattern.compile("(?<!" + ESCAPE + ")" + DIMENSION_NAME_SEP);
 
   private static final String COMMA_STRING = Character.toString(COMMA_SEPARATOR);
@@ -167,7 +167,7 @@ public class OperationParamUtils {
     return operatorValueQueryFilter(operatorValue[0], operatorValue[1], filter);
   }
 
-  private static QueryFilter operatorValueQueryFilter(String operator, String value, String filter)
+  public static QueryFilter operatorValueQueryFilter(String operator, String value, String filter)
       throws BadRequestException {
     if (StringUtils.isEmpty(operator) || StringUtils.isEmpty(value)) {
       throw new BadRequestException("Query item or filter is invalid: " + filter);
@@ -192,31 +192,6 @@ public class OperationParamUtils {
   }
 
   /**
-   * Parse request parameter to filter data elements using UID, operator and values. Refer to {@link
-   * #parseQueryItem(String, CheckedFunction)} for details on the expected item format.
-   *
-   * @param filterItem query item strings each composed of UID, operator and value
-   * @param uidToQueryItem function to translate the data element UID to a QueryItem
-   * @return query items each of a data element with attached query filters
-   */
-  public static List<QueryItem> parseDataElementQueryItems(
-      String filterItem, CheckedFunction<String, QueryItem> uidToQueryItem)
-      throws BadRequestException {
-    if (StringUtils.isEmpty(filterItem)) {
-      return List.of();
-    }
-
-    List<String> uidOperatorValues = filterList(filterItem);
-
-    List<QueryItem> itemList = new ArrayList<>();
-    for (String uidOperatorValue : uidOperatorValues) {
-      itemList.add(parseQueryItem(uidOperatorValue, uidToQueryItem));
-    }
-
-    return itemList;
-  }
-
-  /**
    * Given an attribute filter list, first, it removes the escape chars in order to be able to split
    * by comma and collect the filter list. Then, it recreates the original filters by restoring the
    * escapes chars if any.
@@ -224,7 +199,7 @@ public class OperationParamUtils {
    * @param filterItem
    * @return a filter list split by comma
    */
-  private static List<String> filterList(String filterItem) {
+  public static List<String> filterList(String filterItem) {
     Map<Integer, Boolean> escapesToRestore = new HashMap<>();
 
     StringBuilder filterListToEscape = new StringBuilder(filterItem);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
@@ -30,8 +30,10 @@ package org.hisp.dhis.tracker.export.event;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -41,6 +43,7 @@ import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.AssignedUserSelectionMode;
 import org.hisp.dhis.common.IdSchemes;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
+import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.program.ProgramStatus;
@@ -139,11 +142,11 @@ public class EventOperationParams {
 
   private Boolean skipEventId;
 
-  /** Comma separated list of data element filters */
-  private String dataElementFilters;
+  /** Data element filters per data element UID. */
+  @Builder.Default private Map<String, List<QueryFilter>> dataElementFilters = new HashMap<>();
 
-  /** Comma separated list of attribute filters */
-  private String attributeFilters;
+  /** Tracked entity attribute filters per attribute UID. */
+  @Builder.Default private Map<String, List<QueryFilter>> attributeFilters = new HashMap<>();
 
   private boolean includeDeleted;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventSearchParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventSearchParams.java
@@ -225,8 +225,8 @@ public class EventSearchParams {
   }
 
   /**
-   * Returns true if any data element filter has been added using {@link
-   * #addDataElementFilter(DataElement, QueryFilter)}.
+   * Returns true if any data element filter has been added using {@link #filterBy(DataElement,
+   * QueryFilter)}.
    */
   public boolean hasDataElementFilter() {
     return this.hasDataElementFilter;
@@ -551,18 +551,18 @@ public class EventSearchParams {
     return this.dataElements;
   }
 
-  public EventSearchParams addAttributeFilter(TrackedEntityAttribute tea, QueryFilter filter) {
+  public EventSearchParams filterBy(TrackedEntityAttribute tea, QueryFilter filter) {
     this.attributes.putIfAbsent(tea, new ArrayList<>());
     this.attributes.get(tea).add(filter);
     return this;
   }
 
-  public EventSearchParams addAttribute(TrackedEntityAttribute tea) {
+  public EventSearchParams filterBy(TrackedEntityAttribute tea) {
     this.attributes.putIfAbsent(tea, new ArrayList<>());
     return this;
   }
 
-  public EventSearchParams addDataElementFilter(DataElement de, QueryFilter filter) {
+  public EventSearchParams filterBy(DataElement de, QueryFilter filter) {
     this.dataElements.putIfAbsent(de, new ArrayList<>());
     this.dataElements.get(de).add(filter);
     this.hasDataElementFilter = true;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventSearchParamsTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventSearchParamsTest.java
@@ -70,7 +70,7 @@ class EventSearchParamsTest extends DhisConvenienceTest {
     EventSearchParams params = new EventSearchParams();
 
     QueryFilter filter = new QueryFilter(QueryOperator.EQ, "summer day");
-    params.addAttributeFilter(tea1, filter);
+    params.filterBy(tea1, filter);
 
     assertEquals(Map.of(tea1, List.of(filter)), params.getAttributes());
 
@@ -95,7 +95,7 @@ class EventSearchParamsTest extends DhisConvenienceTest {
     EventSearchParams params = new EventSearchParams();
 
     QueryFilter filter = new QueryFilter(QueryOperator.EQ, "summer day");
-    params.addDataElementFilter(de1, filter);
+    params.filterBy(de1, filter);
 
     assertTrue(params.hasDataElementFilter());
     assertEquals(Map.of(de1, List.of(filter)), params.getDataElements());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -46,9 +46,9 @@ import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdSchemes;
@@ -60,7 +60,6 @@ import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.SlimPager;
 import org.hisp.dhis.common.UID;
-import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.feedback.BadRequestException;
@@ -74,7 +73,6 @@ import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.trackedentity.TrackedEntity;
-import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.export.event.EventOperationParams.EventOperationParamsBuilder;
@@ -363,7 +361,8 @@ class EventExporterTest extends TrackerTest {
             .orgUnitUid(orgUnit.getUid())
             .enrollments(Set.of("nxP7UnKhomJ"))
             .programStageUid(programStage.getUid())
-            .dataElementFilters("DATAEL00001:like:%val%")
+            .dataElementFilters(
+                Map.of("DATAEL00001", List.of(new QueryFilter(QueryOperator.LIKE, "%val%"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -384,7 +383,8 @@ class EventExporterTest extends TrackerTest {
             .enrollments(Set.of("nxP7UnKhomJ"))
             .programStageUid(programStage.getUid())
             .programStatus(ProgramStatus.ACTIVE)
-            .dataElementFilters(dataElement.getUid() + ":like:%val%")
+            .dataElementFilters(
+                Map.of(dataElement.getUid(), List.of(new QueryFilter(QueryOperator.LIKE, "%val%"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -403,7 +403,8 @@ class EventExporterTest extends TrackerTest {
             .enrollments(Set.of("nxP7UnKhomJ"))
             .programStageUid(programStage.getUid())
             .programType(ProgramType.WITH_REGISTRATION)
-            .dataElementFilters(dataElement.getUid() + ":like:%val%")
+            .dataElementFilters(
+                Map.of(dataElement.getUid(), List.of(new QueryFilter(QueryOperator.LIKE, "%val%"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -421,7 +422,10 @@ class EventExporterTest extends TrackerTest {
             .orgUnitUid(orgUnit.getUid())
             .enrollments(Set.of("nxP7UnKhomJ"))
             .programStageUid(programStage.getUid())
-            .dataElementFilters(dataElement.getUid() + ":like:%value00001%")
+            .dataElementFilters(
+                Map.of(
+                    dataElement.getUid(),
+                    List.of(new QueryFilter(QueryOperator.LIKE, "%value00001%"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -439,7 +443,10 @@ class EventExporterTest extends TrackerTest {
             .orgUnitUid(orgUnit.getUid())
             .enrollments(Set.of("nxP7UnKhomJ", "TvctPPhpD8z"))
             .programStageUid(programStage.getUid())
-            .dataElementFilters(datael00001.getUid() + ":in:value00001;value00002")
+            .dataElementFilters(
+                Map.of(
+                    datael00001.getUid(),
+                    List.of(new QueryFilter(QueryOperator.IN, "value00001;value00002"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -460,7 +467,9 @@ class EventExporterTest extends TrackerTest {
             .programUid(program.getUid())
             .attributeCategoryCombo("bjDvmb4bfuf")
             .attributeCategoryOptions(Set.of("xYerKDKCefk"))
-            .dataElementFilters(dataElement.getUid() + ":eq:value00001")
+            .dataElementFilters(
+                Map.of(
+                    dataElement.getUid(), List.of(new QueryFilter(QueryOperator.EQ, "value00001"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -702,7 +711,9 @@ class EventExporterTest extends TrackerTest {
             .programUid(program.getUid())
             .attributeCategoryCombo("bjDvmb4bfuf")
             .attributeCategoryOptions(Set.of("xYerKDKCefk"))
-            .dataElementFilters(dataElement.getUid() + ":eq:value00002")
+            .dataElementFilters(
+                Map.of(
+                    dataElement.getUid(), List.of(new QueryFilter(QueryOperator.EQ, "value00002"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -719,7 +730,8 @@ class EventExporterTest extends TrackerTest {
             .orgUnitUid(orgUnit.getUid())
             .enrollments(Set.of("nxP7UnKhomJ"))
             .programStageUid(programStage.getUid())
-            .dataElementFilters(dataElement.getUid() + ":eq:option1")
+            .dataElementFilters(
+                Map.of(dataElement.getUid(), List.of(new QueryFilter(QueryOperator.EQ, "option1"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -736,7 +748,10 @@ class EventExporterTest extends TrackerTest {
             .orgUnitUid(orgUnit.getUid())
             .enrollments(Set.of("nxP7UnKhomJ", "TvctPPhpD8z"))
             .programStageUid(programStage.getUid())
-            .dataElementFilters(dataElement.getUid() + ":in:option1;option2")
+            .dataElementFilters(
+                Map.of(
+                    dataElement.getUid(),
+                    List.of(new QueryFilter(QueryOperator.IN, "option1;option2"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -753,7 +768,8 @@ class EventExporterTest extends TrackerTest {
             .orgUnitUid(orgUnit.getUid())
             .enrollments(Set.of("nxP7UnKhomJ"))
             .programStageUid(programStage.getUid())
-            .dataElementFilters(dataElement.getUid() + ":like:%opt%")
+            .dataElementFilters(
+                Map.of(dataElement.getUid(), List.of(new QueryFilter(QueryOperator.LIKE, "%opt%"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -765,17 +781,17 @@ class EventExporterTest extends TrackerTest {
   void testExportEventsWhenFilteringByNumericDataElements()
       throws ForbiddenException, BadRequestException {
     DataElement dataElement = dataElement("DATAEL00006");
-    QueryItem queryItem =
-        new QueryItem(
-            dataElement, null, dataElement.getValueType(), null, dataElement.getOptionSet());
-    queryItem.addFilter(new QueryFilter(QueryOperator.LT, "77"));
-    queryItem.addFilter(new QueryFilter(QueryOperator.GT, "8"));
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
             .enrollments(Set.of("nxP7UnKhomJ", "TvctPPhpD8z"))
             .programStageUid(programStage.getUid())
-            .dataElementFilters(dataElement.getUid() + ":lt:77:gt:8")
+            .dataElementFilters(
+                Map.of(
+                    dataElement.getUid(),
+                    List.of(
+                        new QueryFilter(QueryOperator.LT, "77"),
+                        new QueryFilter(QueryOperator.GT, "8"))))
             .build();
 
     List<String> events = getEvents(params);
@@ -975,7 +991,12 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .attributeFilters("numericAttr:lt:77:gt:8")
+            .attributeFilters(
+                Map.of(
+                    "numericAttr",
+                    List.of(
+                        new QueryFilter(QueryOperator.LT, "77"),
+                        new QueryFilter(QueryOperator.GT, "8"))))
             .build();
 
     List<String> trackedEntities =
@@ -991,7 +1012,8 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .attributeFilters("toUpdate000:eq:summer day")
+            .attributeFilters(
+                Map.of("toUpdate000", List.of(new QueryFilter(QueryOperator.EQ, "summer day"))))
             .build();
 
     List<String> trackedEntities =
@@ -1008,7 +1030,12 @@ class EventExporterTest extends TrackerTest {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .attributeFilters("toUpdate000:eq:rainy day,notUpdated0:eq:winter day")
+            .attributeFilters(
+                Map.of(
+                    "toUpdate000",
+                    List.of(new QueryFilter(QueryOperator.EQ, "rainy day")),
+                    "notUpdated0",
+                    List.of(new QueryFilter(QueryOperator.EQ, "winter day"))))
             .build();
 
     List<String> trackedEntities =
@@ -1022,13 +1049,15 @@ class EventExporterTest extends TrackerTest {
   @Test
   void testEnrollmentFilterAttributesWithMultipleFiltersOnTheSameAttribute()
       throws ForbiddenException, BadRequestException {
-    QueryItem item = queryItem("toUpdate000", QueryOperator.LIKE, "day");
-    item.addFilter(new QueryFilter(QueryOperator.LIKE, "in"));
-
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
-            .attributeFilters("toUpdate000:like:day:like:in")
+            .attributeFilters(
+                Map.of(
+                    "toUpdate000",
+                    List.of(
+                        new QueryFilter(QueryOperator.LIKE, "day"),
+                        new QueryFilter(QueryOperator.LIKE, "in"))))
             .build();
 
     List<String> trackedEntities =
@@ -1351,25 +1380,6 @@ class EventExporterTest extends TrackerTest {
 
   private DataElement dataElement(String uid) {
     return dataElementService.getDataElement(uid);
-  }
-
-  private static QueryItem queryItem(String teaUid, QueryOperator operator, String filter) {
-    QueryItem item = queryItem(teaUid);
-    item.addFilter(new QueryFilter(operator, filter));
-    return item;
-  }
-
-  private static QueryItem queryItem(String teaUid) {
-    return queryItem(teaUid, ValueType.TEXT);
-  }
-
-  private static QueryItem queryItem(String teaUid, ValueType valueType) {
-    TrackedEntityAttribute at = new TrackedEntityAttribute();
-    at.setUid(teaUid);
-    at.setValueType(valueType);
-    at.setAggregationType(AggregationType.NONE);
-    return new QueryItem(
-        at, null, at.getValueType(), at.getAggregationType(), at.getOptionSet(), at.isUnique());
   }
 
   private <T extends IdentifiableObject> T get(Class<T> type, String uid) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
@@ -27,17 +27,24 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export;
 
+import static org.hisp.dhis.common.DimensionalObject.DIMENSION_NAME_SEP;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
+import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.tracker.export.OperationParamUtils;
 
 /**
  * RequestParamUtils are functions used to parse and transform tracker request parameters. This
@@ -156,6 +163,63 @@ public class RequestParamUtils {
           String.format(
               "orgUnitMode %s cannot be used with orgUnits. Please remove the orgUnit parameter and try again.",
               orgUnitMode));
+    }
+  }
+
+  /**
+   * Parse given {@code input} string representing a filter for an object referenced by a UID like a
+   * tracked entity attribute or data element. Refer to {@link #parseSanitizedFilters(Map, String)}}
+   * for details on the expected input format.
+   */
+  public static void parseFilters(Map<String, List<QueryFilter>> result, String input)
+      throws BadRequestException {
+    if (StringUtils.isBlank(input)) {
+      return;
+    }
+
+    for (String uidOperatorValue : OperationParamUtils.filterList(input)) {
+      parseSanitizedFilters(result, uidOperatorValue);
+    }
+  }
+
+  /**
+   * Accumulate {@link QueryFilter}s per UID by parsing given input string of format
+   * {uid}:{operator}:{value}[:{operator}:{value}]. Only the UID is mandatory. Multiple
+   * operator:value pairs are allowed. A {@link QueryFilter} for each operator:value pair is added
+   * to the corresponding UID.
+   *
+   * @throws BadRequestException filter is neither multiple nor single operator:value format
+   */
+  private static void parseSanitizedFilters(Map<String, List<QueryFilter>> result, String input)
+      throws BadRequestException {
+    int uidIndex = input.indexOf(DIMENSION_NAME_SEP) + 1;
+
+    if (uidIndex == 0 || input.length() == uidIndex) {
+      String uid = input.replace(DIMENSION_NAME_SEP, "");
+      result.putIfAbsent(uid, new ArrayList<>());
+      return;
+    }
+
+    String uid = input.substring(0, uidIndex - 1);
+    result.putIfAbsent(uid, new ArrayList<>());
+
+    String[] filters = OperationParamUtils.FILTER_ITEM_SPLIT.split(input.substring(uidIndex));
+
+    // single operator
+    if (filters.length == 2) {
+      result
+          .get(uid)
+          .add(OperationParamUtils.operatorValueQueryFilter(filters[0], filters[1], input));
+    }
+    // multiple operator
+    else if (filters.length == 4) {
+      for (int i = 0; i < filters.length; i += 2) {
+        result
+            .get(uid)
+            .add(OperationParamUtils.operatorValueQueryFilter(filters[i], filters[i + 1], input));
+      }
+    } else {
+      throw new BadRequestException("Query item or filter is invalid: " + input);
     }
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
@@ -32,10 +32,13 @@ import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
 import static org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams.DEFAULT_PAGE;
 import static org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams.DEFAULT_PAGE_SIZE;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseFilters;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedUidsParameter;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
@@ -45,6 +48,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
+import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.feedback.BadRequestException;
@@ -88,6 +92,11 @@ class EventRequestParamsMapper {
             "event", requestParams.getEvent(), "events", requestParams.getEvents());
 
     validateFilter(requestParams.getFilter(), eventUids);
+    Map<String, List<QueryFilter>> dataElementFilters = new HashMap<>();
+    parseFilters(dataElementFilters, requestParams.getFilter());
+
+    Map<String, List<QueryFilter>> attributeFilters = new HashMap<>();
+    parseFilters(attributeFilters, requestParams.getFilterAttributes());
 
     Set<UID> assignedUsers =
         validateDeprecatedUidsParameter(
@@ -141,8 +150,8 @@ class EventRequestParamsMapper {
             .skipEventId(requestParams.getSkipEventId())
             .includeAttributes(false)
             .includeAllDataElements(false)
-            .dataElementFilters(requestParams.getFilter())
-            .attributeFilters(requestParams.getFilterAttributes())
+            .dataElementFilters(dataElementFilters)
+            .attributeFilters(attributeFilters)
             .events(UID.toValueSet(eventUids))
             .enrollments(UID.toValueSet(requestParams.getEnrollments()))
             .includeDeleted(requestParams.isIncludeDeleted());

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/EventsExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/EventsExportController.md
@@ -151,15 +151,38 @@ Get events with given UID(s).
 
 `<propertyName1:sortDirection>[,<propertyName2:sortDirection>...]`
 
-Get events in given order. Valid `sortDirection`s are `asc` and `desc`. `propName` is
-case-sensitive, `sortDirection`
-is case-insensitive.
+Get events in given order. Events can be ordered by data elements and tracked entity attributes by
+passing a UID instead of a property name. This will order events by the values of the specified
+attribute and data element not their UIDs. Events can also be ordered by the following
+case-sensitive properties
 
-Supported properties
-are `assignedUser`, `assignedUserDisplayName`, `attributeOptionCombo`, `completedAt`,
-`completedBy`, `createdAt`, `createdBy`, `deleted`, `enrolledAt`, `enrollment`, `enrollmentStatus`, `event`, `followup`,
-`occurredAt`, `orgUnit`, `orgUnitName`, `program`, `programStage`, `scheduleAt`, `status`, `storedBy`, `trackedEntity`,
-`updatedAt`, `updatedBy`.
+* `assignedUser`
+* `assignedUserDisplayName`
+* `attributeOptionCombo`
+* `completedAt`
+* `completedBy`
+* `createdAt`
+* `createdBy`
+* `deleted`
+* `enrolledAt`
+* `enrollment`
+* `enrollmentStatus`
+* `event`
+* `followup`
+* `occurredAt`
+* `orgUnit`
+* `orgUnitName`
+* `program`
+* `programStage`
+* `scheduledAt`
+* `status`
+* `storedBy`
+* `trackedEntity`
+* `updatedAt`
+* `updatedBy`
+
+Valid `sortDirection`s are `asc` and `desc`. `sortDirection` is case-insensitive. `sortDirection`
+defaults to `asc` for properties or UIDs without explicit `sortDirection` as in `order=scheduledAt`.
 
 ### `*.parameter.EventRequestParams.fields`
 
@@ -176,16 +199,12 @@ NOTE: this query parameter has no effect on a CSV response!
 `<filter1>[,<filter2>...]`
 
 Get events matching given filters on data values. A filter is a colon separated data element UID
-with operator and value
-pairs. Example: `filter=H9IlTX2X6SL:sw:A` with operator starts with `sw` followed by a value.
-Special characters
-like `+` need to be percent-encoded so `%2B` instead of `+`. Multiple operator/value pairs for the
-same data element
-like `filter=AuPLng5hLbE:gt:438901703:lt:448901704` are allowed. Repeating the same data element UID
-is not allowed.
-Operator and values are case-insensitive. A user needs metadata read access to the data element and
-data read access to
-the program (if the program is without registration) or the program stage (if the program is with
+with operator and value pairs. Example: `filter=H9IlTX2X6SL:sw:A` with operator starts with `sw`
+followed by a value. Special characters like `+` need to be percent-encoded so `%2B` instead of `+`.
+Multiple operator/value pairs for the same data element
+as `filter=AuPLng5hLbE:gt:438901703:lt:448901704` are allowed. Operator and values are
+case-insensitive. A user needs metadata read access to the data element and data read access to the
+program (if the program is without registration) or the program stage (if the program is with
 registration).
 
 Valid operators are:
@@ -212,17 +231,12 @@ Valid operators are:
 `<filter1>[,<filter2>...]`
 
 Get events matching given filters on tracked entity attributes. A filter is a colon separated
-attribute UID with
-optional operator and value pairs. Example: `filter=H9IlTX2X6SL:sw:A` with operator starts with `sw`
-followed by a
-value. Special characters like `+` need to be percent-encoded so `%2B` instead of `+`. Multiple
-operator/value pairs for
-the same attribute like `filter=AuPLng5hLbE:gt:438901703:lt:448901704` are allowed. Repeating the
-same attribute UID is
-not allowed. Operator and values are case-insensitive. A user needs metadata read access to the
-attribute and data
-read access to the program (if the program is without registration) or to the program stage (if the
-program is with
+attribute UID with optional operator and value pairs. Example: `filter=H9IlTX2X6SL:sw:A` with
+operator starts with `sw` followed by a value. Special characters like `+` need to be
+percent-encoded so `%2B` instead of `+`. Multiple operator/value pairs for the same attribute
+as `filter=AuPLng5hLbE:gt:438901703:lt:448901704` are allowed. Operator and values are
+case-insensitive. A user needs metadata read access to the attribute and data read access to the
+program (if the program is without registration) or to the program stage (if the program is with
 registration).
 
 Valid operators are:


### PR DESCRIPTION
We found that our stores don't profit from using QueryItem. In addition, our APIs become simpler. We should therefore remove the use of QueryItem entirely.

Filters (attribute and data element ones) are now parsed in the web layer. This is the approach we are establishing for all parameters. The further down you go in our layers (web, service, repo) the more structured, easy to use the data should be. As we should take advantage of the knowledge we gain and the validations we've already done.

`filter=uid:op:value` transitions from `String` to `Map<String,List<QueryFilter>>` in the web and then `Map<TrackedEntityAttribute|DataElement,List<QueryFilter>>` in the service layer. (note this is pseudo-code).

`parseFilters` is replacing the tracked entity attribute, data element specific parse functions (currently in `OperationParamsUtils`). I had to make a few helpers public in `OperationParamsUtils` that will be moved to `RequestParamUtils` once the same changes are also made to `/tracker/trackedEntities?order=`.

* update OpenAPI spec on `order`, `filter` and  `filterAttributes`