### PR TITLE
fix: Drop unused DB tables [ TECH-1597 ]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Enrollment.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Enrollment.hbm.xml
@@ -69,13 +69,6 @@
       <one-to-many class="org.hisp.dhis.relationship.RelationshipItem" />
     </set>
 
-    <list name="messageConversations" table="enrollment_messageconversation">
-      <key column="enrollmentid" />
-      <list-index column="sort_order" base="1" />
-      <many-to-many class="org.hisp.dhis.message.MessageConversation"
-        column="messageconversationid" />
-    </list>
-
     <list name="comments" table="enrollmentcomments" cascade="all-delete-orphan">
       <key column="enrollmentid" foreign-key="fk_programinstancecomments_programinstanceid" />
       <list-index column="sort_order" base="1" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Event.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Event.hbm.xml
@@ -51,13 +51,6 @@
     <many-to-one name="organisationUnit" class="org.hisp.dhis.organisationunit.OrganisationUnit" column="organisationunitid"
       foreign-key="fk_programstageinstance_organisationunitid" index="programstageinstance_organisationunitid" />
 
-    <list name="messageConversations" table="event_messageconversation">
-      <key column="eventid" />
-      <list-index column="sort_order" base="1" />
-      <many-to-many class="org.hisp.dhis.message.MessageConversation"
-        column="messageconversationid" />
-    </list>
-
     <property name="status" column="status" type="org.hisp.dhis.program.EventStatusUserType" not-null="true" />
 
     <property name="completedBy" />

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_26__DropUnusedTables.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_26__DropUnusedTables.sql
@@ -1,0 +1,9 @@
+-- drop unused table. Some of them have been caught in the Sierra Leone Db so they might not exists in other instances
+drop table if exists enrollment_messageconversation;
+drop table if exists event_messageconversation;
+drop table if exists programstage_programindicators;
+drop table if exists programinstance_outboundsms;
+drop table if exists trackedentityinstancereminder;
+drop table if exists trackedentityattributegroup;
+drop table if exists trackedentitymobilesetting;
+drop table if exists programvalidation;

--- a/dhis-2/dhis-test-integration/src/test/resources/dxf2/program_noreg_sections.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/dxf2/program_noreg_sections.json
@@ -1,18 +1,4 @@
 {
-  "trackedEntityAttributeGroups": [
-    {
-      "created": "2016-03-10T07:26:43.664+0000",
-      "lastUpdated": "2016-03-10T07:26:43.665+0000",
-      "id": "VUd5jP8cbjQ",
-      "trackedEntityAttributes": [
-        {
-          "id": "CXsesjOaSzr"
-        }
-      ],
-      "name": "TrackedEntityAttributeGroupA",
-      "description": "TrackedEntityAttributeGroupA"
-    }
-  ],
   "date": "2016-03-10T08:32:51.523+0000",
   "dataElements": [
     {

--- a/dhis-2/dhis-test-integration/src/test/resources/dxf2/program_reg1.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/dxf2/program_reg1.json
@@ -363,22 +363,6 @@
       }
     }
   ],
-  "trackedEntityAttributeGroups": [
-    {
-      "name": "TrackedEntityAttributeGroupA",
-      "trackedEntityAttributes": [
-        {
-          "id": "QhEcRpLZwMb"
-        },
-        {
-          "id": "cpaMZredRXb"
-        }
-      ],
-      "created": "2016-03-11T07:00:02.917+0000",
-      "lastUpdated": "2016-03-11T07:00:02.917+0000",
-      "id": "TLxOGInNoVL"
-    }
-  ],
   "users": [
     {
       "dataViewOrganisationUnits": [],

--- a/dhis-2/dhis-test-integration/src/test/resources/dxf2/program_reg1_invalid_nextschedule.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/dxf2/program_reg1_invalid_nextschedule.json
@@ -366,22 +366,6 @@
       }
     }
   ],
-  "trackedEntityAttributeGroups": [
-    {
-      "name": "TrackedEntityAttributeGroupA",
-      "trackedEntityAttributes": [
-        {
-          "id": "QhEcRpLZwMb"
-        },
-        {
-          "id": "cpaMZredRXb"
-        }
-      ],
-      "created": "2016-03-11T07:00:02.917+0000",
-      "lastUpdated": "2016-03-11T07:00:02.917+0000",
-      "id": "TLxOGInNoVL"
-    }
-  ],
   "users": [
     {
       "dataViewOrganisationUnits": [],

--- a/dhis-2/dhis-test-integration/src/test/resources/dxf2/program_reg1_valid_nextschedule.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/dxf2/program_reg1_valid_nextschedule.json
@@ -366,22 +366,6 @@
       }
     }
   ],
-  "trackedEntityAttributeGroups": [
-    {
-      "name": "TrackedEntityAttributeGroupA",
-      "trackedEntityAttributes": [
-        {
-          "id": "QhEcRpLZwMb"
-        },
-        {
-          "id": "cpaMZredRXb"
-        }
-      ],
-      "created": "2016-03-11T07:00:02.917+0000",
-      "lastUpdated": "2016-03-11T07:00:02.917+0000",
-      "id": "TLxOGInNoVL"
-    }
-  ],
   "users": [
     {
       "dataViewOrganisationUnits": [],

--- a/dhis-2/dhis-test-integration/src/test/resources/dxf2/program_tea_not_shared.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/dxf2/program_tea_not_shared.json
@@ -363,22 +363,6 @@
       }
     }
   ],
-  "trackedEntityAttributeGroups": [
-    {
-      "name": "TrackedEntityAttributeGroupA",
-      "trackedEntityAttributes": [
-        {
-          "id": "QhEcRpLZwMb"
-        },
-        {
-          "id": "cpaMZredRXb"
-        }
-      ],
-      "created": "2016-03-11T07:00:02.917+0000",
-      "lastUpdated": "2016-03-11T07:00:02.917+0000",
-      "id": "TLxOGInNoVL"
-    }
-  ],
   "users": [
     {
       "dataViewOrganisationUnits": [],


### PR DESCRIPTION
Drop tables that are no longer in use. Some appear in the Sierra Leone DB and they might not exist in other instances.
Only `enrollment_messageconversation` and `event_messageconversation` had a reference in the hibernate schema.

Great if people with longer experience in the project could double check @zubaira @stian-sandvold @abyot 