### PR TITLE
chore: order events by primary key desc by default TECH-1606

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -113,6 +113,8 @@ import org.springframework.stereotype.Repository;
 @Repository("org.hisp.dhis.tracker.export.event.EventStore")
 @RequiredArgsConstructor
 public class JdbcEventStore implements EventStore {
+  private static final String DEFAULT_ORDER = "ev_id desc";
+
   private static final String RELATIONSHIP_IDS_QUERY =
       " left join (select ri.eventid as ri_ev_id, json_agg(ri.relationshipid) as ev_rl FROM relationshipitem ri"
           + " GROUP by ri_ev_id)  as fgh on fgh.ri_ev_id=event.ev_id ";
@@ -1268,7 +1270,7 @@ public class JdbcEventStore implements EventStore {
     if (!orderFields.isEmpty()) {
       return "order by " + StringUtils.join(orderFields, ',') + " ";
     } else {
-      return "order by ev_lastupdated desc ";
+      return "order by " + DEFAULT_ORDER + " ";
     }
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -44,11 +44,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.IOException;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdSchemes;
@@ -1069,7 +1071,25 @@ class EventExporterTest extends TrackerTest {
   }
 
   @Test
-  void testOrderEventsOnAttributeAsc() throws ForbiddenException, BadRequestException {
+  void shouldOrderEventsOnPrimaryKeyDescByDefault() throws ForbiddenException, BadRequestException {
+    Event d9PbzJY8bJM = get(Event.class, "D9PbzJY8bJM");
+    Event pTzf9KYMk72 = get(Event.class, "pTzf9KYMk72");
+    List<String> expected =
+        Stream.of(d9PbzJY8bJM, pTzf9KYMk72)
+            .sorted(Comparator.comparing(Event::getId).reversed())
+            .map(Event::getUid)
+            .toList();
+
+    EventOperationParams params =
+        EventOperationParams.builder().orgUnitUid(orgUnit.getUid()).build();
+
+    List<String> events = getEvents(params);
+
+    assertEquals(expected, events);
+  }
+
+  @Test
+  void shouldOrderEventsByAttributeAsc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
@@ -1082,7 +1102,7 @@ class EventExporterTest extends TrackerTest {
   }
 
   @Test
-  void testOrderEventsOnAttributeDesc() throws ForbiddenException, BadRequestException {
+  void shouldOrderEventsByAttributeDesc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
@@ -1095,7 +1115,7 @@ class EventExporterTest extends TrackerTest {
   }
 
   @Test
-  void testOrderEventsOnMultipleAttributesDesc() throws ForbiddenException, BadRequestException {
+  void shouldOrderEventsByMultipleAttributesDesc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
@@ -1109,7 +1129,7 @@ class EventExporterTest extends TrackerTest {
   }
 
   @Test
-  void testOrderEventsOnMultipleAttributesAsc() throws ForbiddenException, BadRequestException {
+  void shouldOrderEventsByMultipleAttributesAsc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
@@ -1357,7 +1377,11 @@ class EventExporterTest extends TrackerTest {
 
   private <T extends IdentifiableObject> T get(Class<T> type, String uid) {
     T t = manager.get(type, uid);
-    assertNotNull(t, () -> String.format("metadata with uid '%s' should have been created", uid));
+    assertNotNull(
+        t,
+        () ->
+            String.format(
+                "'%s' with uid '%s' should have been created", type.getSimpleName(), uid));
     return t;
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -1076,12 +1076,9 @@ class EventExporterTest extends TrackerTest {
             .orderBy(UID.of("toUpdate000"), SortDirection.ASC)
             .build();
 
-    List<String> trackedEntities =
-        eventService.getEvents(params).getEvents().stream()
-            .map(event -> event.getEnrollment().getTrackedEntity().getUid())
-            .collect(Collectors.toList());
+    List<String> events = getEvents(params);
 
-    assertEquals(List.of("dUE514NMOlo", "QS6w44flWAf"), trackedEntities);
+    assertEquals(List.of("D9PbzJY8bJM", "pTzf9KYMk72"), events);
   }
 
   @Test
@@ -1092,12 +1089,9 @@ class EventExporterTest extends TrackerTest {
             .orderBy(UID.of("toUpdate000"), SortDirection.DESC)
             .build();
 
-    List<String> trackedEntities =
-        eventService.getEvents(params).getEvents().stream()
-            .map(event -> event.getEnrollment().getTrackedEntity().getUid())
-            .collect(Collectors.toList());
+    List<String> events = getEvents(params);
 
-    assertEquals(List.of("QS6w44flWAf", "dUE514NMOlo"), trackedEntities);
+    assertEquals(List.of("pTzf9KYMk72", "D9PbzJY8bJM"), events);
   }
 
   @Test
@@ -1109,12 +1103,9 @@ class EventExporterTest extends TrackerTest {
             .orderBy(UID.of("toUpdate000"), SortDirection.DESC)
             .build();
 
-    List<String> trackedEntities =
-        eventService.getEvents(params).getEvents().stream()
-            .map(event -> event.getEnrollment().getTrackedEntity().getUid())
-            .collect(Collectors.toList());
+    List<String> events = getEvents(params);
 
-    assertEquals(List.of("QS6w44flWAf", "dUE514NMOlo"), trackedEntities);
+    assertEquals(List.of("pTzf9KYMk72", "D9PbzJY8bJM"), events);
   }
 
   @Test
@@ -1193,12 +1184,9 @@ class EventExporterTest extends TrackerTest {
             .orderBy("enrollment.enrollmentDate", SortDirection.DESC)
             .build();
 
-    List<String> enrollments =
-        eventService.getEvents(params).getEvents().stream()
-            .map(event -> event.getEnrollment().getUid())
-            .collect(Collectors.toList());
+    List<String> events = getEvents(params);
 
-    assertEquals(List.of("TvctPPhpD8z", "nxP7UnKhomJ"), enrollments);
+    assertEquals(List.of("D9PbzJY8bJM", "pTzf9KYMk72"), events);
   }
 
   @Test
@@ -1209,12 +1197,9 @@ class EventExporterTest extends TrackerTest {
             .orderBy("enrollment.enrollmentDate", SortDirection.ASC)
             .build();
 
-    List<String> enrollments =
-        eventService.getEvents(params).getEvents().stream()
-            .map(event -> event.getEnrollment().getUid())
-            .collect(Collectors.toList());
+    List<String> events = getEvents(params);
 
-    assertEquals(List.of("nxP7UnKhomJ", "TvctPPhpD8z"), enrollments);
+    assertEquals(List.of("pTzf9KYMk72", "D9PbzJY8bJM"), events);
   }
 
   @Test
@@ -1225,9 +1210,9 @@ class EventExporterTest extends TrackerTest {
             .orderBy("executionDate", SortDirection.DESC)
             .build();
 
-    Events events = eventService.getEvents(params);
+    List<String> events = getEvents(params);
 
-    assertEquals(List.of("D9PbzJY8bJM", "pTzf9KYMk72"), eventUids(events));
+    assertEquals(List.of("D9PbzJY8bJM", "pTzf9KYMk72"), events);
   }
 
   @Test
@@ -1238,9 +1223,9 @@ class EventExporterTest extends TrackerTest {
             .orderBy("executionDate", SortDirection.ASC)
             .build();
 
-    Events events = eventService.getEvents(params);
+    List<String> events = getEvents(params);
 
-    assertEquals(List.of("pTzf9KYMk72", "D9PbzJY8bJM"), eventUids(events));
+    assertEquals(List.of("pTzf9KYMk72", "D9PbzJY8bJM"), events);
   }
 
   @Test
@@ -1309,12 +1294,9 @@ class EventExporterTest extends TrackerTest {
             .orderBy("enrollment.enrollmentDate", SortDirection.ASC)
             .build();
 
-    List<String> trackedEntities =
-        eventService.getEvents(params).getEvents().stream()
-            .map(event -> event.getEnrollment().getTrackedEntity().getUid())
-            .collect(Collectors.toList());
+    List<String> events = getEvents(params);
 
-    assertEquals(List.of("dUE514NMOlo", "QS6w44flWAf"), trackedEntities);
+    assertEquals(List.of("D9PbzJY8bJM", "pTzf9KYMk72"), events);
   }
 
   @Test
@@ -1327,12 +1309,9 @@ class EventExporterTest extends TrackerTest {
             .orderBy(UID.of("toUpdate000"), SortDirection.DESC)
             .build();
 
-    List<String> trackedEntities =
-        eventService.getEvents(params).getEvents().stream()
-            .map(event -> event.getEnrollment().getTrackedEntity().getUid())
-            .collect(Collectors.toList());
+    List<String> events = getEvents(params);
 
-    assertEquals(List.of("dUE514NMOlo", "QS6w44flWAf"), trackedEntities);
+    assertEquals(List.of("D9PbzJY8bJM", "pTzf9KYMk72"), events);
   }
 
   @Test
@@ -1346,12 +1325,9 @@ class EventExporterTest extends TrackerTest {
             .orderBy("enrollment.enrollmentDate", SortDirection.DESC)
             .build();
 
-    List<String> trackedEntities =
-        eventService.getEvents(params).getEvents().stream()
-            .map(event -> event.getEnrollment().getTrackedEntity().getUid())
-            .collect(Collectors.toList());
+    List<String> events = getEvents(params);
 
-    assertEquals(List.of("QS6w44flWAf", "dUE514NMOlo"), trackedEntities);
+    assertEquals(List.of("pTzf9KYMk72", "D9PbzJY8bJM"), events);
   }
 
   @Test
@@ -1364,12 +1340,9 @@ class EventExporterTest extends TrackerTest {
             .orderBy(UID.of("DATAEL00006"), SortDirection.DESC)
             .build();
 
-    List<String> trackedEntities =
-        eventService.getEvents(params).getEvents().stream()
-            .map(event -> event.getEnrollment().getTrackedEntity().getUid())
-            .collect(Collectors.toList());
+    List<String> events = getEvents(params);
 
-    assertEquals(List.of("dUE514NMOlo", "QS6w44flWAf"), trackedEntities);
+    assertEquals(List.of("D9PbzJY8bJM", "pTzf9KYMk72"), events);
   }
 
   private void assertNote(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -1076,7 +1076,7 @@ class EventExporterTest extends TrackerTest {
     Event pTzf9KYMk72 = get(Event.class, "pTzf9KYMk72");
     List<String> expected =
         Stream.of(d9PbzJY8bJM, pTzf9KYMk72)
-            .sorted(Comparator.comparing(Event::getId).reversed())
+            .sorted(Comparator.comparing(Event::getId).reversed()) // reversed = desc
             .map(Event::getUid)
             .toList();
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -170,16 +171,20 @@ public class RequestParamUtils {
    * Parse given {@code input} string representing a filter for an object referenced by a UID like a
    * tracked entity attribute or data element. Refer to {@link #parseSanitizedFilters(Map, String)}}
    * for details on the expected input format.
+   *
+   * @return filters by UIDs
    */
-  public static void parseFilters(Map<String, List<QueryFilter>> result, String input)
+  public static Map<String, List<QueryFilter>> parseFilters(String input)
       throws BadRequestException {
+    Map<String, List<QueryFilter>> result = new HashMap<>();
     if (StringUtils.isBlank(input)) {
-      return;
+      return result;
     }
 
     for (String uidOperatorValue : OperationParamUtils.filterList(input)) {
       parseSanitizedFilters(result, uidOperatorValue);
     }
+    return result;
   }
 
   /**

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
@@ -36,7 +36,6 @@ import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.p
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedUidsParameter;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -92,11 +91,9 @@ class EventRequestParamsMapper {
             "event", requestParams.getEvent(), "events", requestParams.getEvents());
 
     validateFilter(requestParams.getFilter(), eventUids);
-    Map<String, List<QueryFilter>> dataElementFilters = new HashMap<>();
-    parseFilters(dataElementFilters, requestParams.getFilter());
-
-    Map<String, List<QueryFilter>> attributeFilters = new HashMap<>();
-    parseFilters(attributeFilters, requestParams.getFilterAttributes());
+    Map<String, List<QueryFilter>> dataElementFilters = parseFilters(requestParams.getFilter());
+    Map<String, List<QueryFilter>> attributeFilters =
+        parseFilters(requestParams.getFilterAttributes());
 
     Set<UID> assignedUsers =
         validateDeprecatedUidsParameter(

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/EventsExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/EventsExportController.md
@@ -184,6 +184,9 @@ case-sensitive properties
 Valid `sortDirection`s are `asc` and `desc`. `sortDirection` is case-insensitive. `sortDirection`
 defaults to `asc` for properties or UIDs without explicit `sortDirection` as in `order=scheduledAt`.
 
+Events are ordered by newest (internal id desc) by default meaning when no `order` parameter is
+provided.
+
 ### `*.parameter.EventRequestParams.fields`
 
 Get only the specified fields in the JSON response. This query parameter allows you to remove

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtilsTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtilsTest.java
@@ -45,7 +45,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -167,9 +166,8 @@ class RequestParamUtilsTest {
 
   @Test
   void shouldParseFilters() throws BadRequestException {
-    Map<String, List<QueryFilter>> filters = new HashMap<>();
-
-    parseFilters(filters, TEA_1_UID + ":lt:20:gt:10," + TEA_2_UID + ":like:foo");
+    Map<String, List<QueryFilter>> filters =
+        parseFilters(TEA_1_UID + ":lt:20:gt:10," + TEA_2_UID + ":like:foo");
 
     assertEquals(
         Map.of(
@@ -183,9 +181,8 @@ class RequestParamUtilsTest {
 
   @Test
   void shouldParseFiltersGivenRepeatedUID() throws BadRequestException {
-    Map<String, List<QueryFilter>> filters = new HashMap<>();
-
-    parseFilters(filters, TEA_1_UID + ":lt:20," + TEA_2_UID + ":like:foo," + TEA_1_UID + ":gt:10");
+    Map<String, List<QueryFilter>> filters =
+        parseFilters(TEA_1_UID + ":lt:20," + TEA_2_UID + ":like:foo," + TEA_1_UID + ":gt:10");
 
     assertEquals(
         Map.of(
@@ -199,46 +196,36 @@ class RequestParamUtilsTest {
 
   @Test
   void shouldParseFiltersOnlyContainingAnIdentifier() throws BadRequestException {
-    Map<String, List<QueryFilter>> filters = new HashMap<>();
-
-    parseFilters(filters, TEA_1_UID);
+    Map<String, List<QueryFilter>> filters = parseFilters(TEA_1_UID);
 
     assertEquals(Map.of(TEA_1_UID, List.of()), filters);
   }
 
   @Test
   void shouldParseFiltersWithIdentifierAndTrailingColon() throws BadRequestException {
-    Map<String, List<QueryFilter>> filters = new HashMap<>();
-
-    parseFilters(filters, TEA_1_UID + ":");
+    Map<String, List<QueryFilter>> filters = parseFilters(TEA_1_UID + ":");
 
     assertEquals(Map.of(TEA_1_UID, List.of()), filters);
   }
 
   @Test
   void shouldParseFiltersGivenBlankInput() throws BadRequestException {
-    Map<String, List<QueryFilter>> filters = new HashMap<>();
-
-    parseFilters(filters, " ");
+    Map<String, List<QueryFilter>> filters = parseFilters(" ");
 
     assertTrue(filters.isEmpty());
   }
 
   @Test
   void shouldFailParsingFiltersMissingAValue() {
-    Map<String, List<QueryFilter>> filters = new HashMap<>();
-
     Exception exception =
-        assertThrows(BadRequestException.class, () -> parseFilters(filters, TEA_1_UID + ":lt"));
+        assertThrows(BadRequestException.class, () -> parseFilters(TEA_1_UID + ":lt"));
     assertEquals("Query item or filter is invalid: " + TEA_1_UID + ":lt", exception.getMessage());
   }
 
   @Test
   void shouldFailParsingFiltersWithMissingValueAndTrailingColon() {
-    Map<String, List<QueryFilter>> filters = new HashMap<>();
-
     Exception exception =
-        assertThrows(BadRequestException.class, () -> parseFilters(filters, TEA_1_UID + ":lt:"));
+        assertThrows(BadRequestException.class, () -> parseFilters(TEA_1_UID + ":lt:"));
     assertEquals("Query item or filter is invalid: " + TEA_1_UID + ":lt:", exception.getMessage());
   }
 


### PR DESCRIPTION
depends on https://github.com/dhis2/dhis2-core/pull/14801

* order events by primary key desc by default
* assert on event order when testing event order. That is what we want to guarantee in the end. It is more obvious and safe than asserting on any of the parents (tracked entity, enrollment).
* let `parseFilters` return a map instead of accepting one. I passed in a map as it fit with the previous implementation where we passed in the function fetching the data element/attribute. This is no longer needed so we can make it a pure function.