### PR TITLE
test: test ordering events by enrollment program UID TECH-1606

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventExporterTest.java
@@ -1089,6 +1089,30 @@ class EventExporterTest extends TrackerTest {
   }
 
   @Test
+  void shouldOrderEventsByEnrollmentProgramUIDAsc() throws ForbiddenException, BadRequestException {
+    Event pTzf9KYMk72 =
+        get(Event.class, "pTzf9KYMk72"); // enrolled in program BFcipDERJnf with registration
+    Event QRYjLTiJTrA =
+        get(Event.class, "QRYjLTiJTrA"); // enrolled in program BFcipDERJne without registration
+    List<String> expected =
+        Stream.of(pTzf9KYMk72, QRYjLTiJTrA)
+            .sorted(Comparator.comparing(event -> event.getEnrollment().getProgram().getUid()))
+            .map(Event::getUid)
+            .toList();
+    System.out.println(expected);
+
+    EventOperationParams params =
+        EventOperationParams.builder()
+            .events(Set.of("pTzf9KYMk72", "QRYjLTiJTrA"))
+            .orderBy("enrollment.program.uid", SortDirection.ASC)
+            .build();
+
+    List<String> events = getEvents(params);
+
+    assertEquals(expected, events);
+  }
+
+  @Test
   void shouldOrderEventsByAttributeAsc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         EventOperationParams.builder()

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventMapper.java
@@ -74,12 +74,7 @@ public interface EventMapper
           entry("occurredAt", "executionDate"),
           entry("orgUnit", "organisationUnit.uid"),
           entry("orgUnitName", "organisationUnit.name"),
-          entry(
-              "program",
-              "enrollment.program.uid"), // TODO(TECH-1606) this is what we do in the export. I
-          // assume we
-          // can also get the program via event.programStage.program
-          // right? Which one is more accurate
+          entry("program", "enrollment.program.uid"),
           entry("programStage", "programStage.uid"),
           entry("scheduledAt", "dueDate"),
           entry("status", "status"),


### PR DESCRIPTION
Adds a test to show behavior we discussed in https://github.com/dhis2/dhis2-core/pull/14728#discussion_r1276034720

The code relevant for events by `/tracker/events?order=program` is

https://github.com/dhis2/dhis2-core/blob/886e090b15812e9e021959860d7f8d4a9a08330b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventMapper.java#L77-L79

https://github.com/dhis2/dhis2-core/blob/886e090b15812e9e021959860d7f8d4a9a08330b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java#L162

https://github.com/dhis2/dhis2-core/blob/886e090b15812e9e021959860d7f8d4a9a08330b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java#L641

https://github.com/dhis2/dhis2-core/blob/886e090b15812e9e021959860d7f8d4a9a08330b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java#L704-L705

