### PR TITLE
chore: validate /trackedEntities?order in web layer TECH-1611

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapper.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.export.trackedentity;
 
-import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.OrderColumn.findColumn;
 import static org.hisp.dhis.tracker.export.OperationParamUtils.parseAttributeQueryItems;
 import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
 
@@ -111,7 +110,6 @@ class TrackedEntityOperationParamsMapper {
     validateDuplicatedAttributeFilters(filters);
 
     List<OrderParam> orderParams = toOrderParams(operationParams.getOrders());
-    validateOrderParams(orderParams, attributes);
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
     params
@@ -266,18 +264,5 @@ class TrackedEntityOperationParamsMapper {
         .filter(ps -> ps.getUid().equals(programStage))
         .findFirst()
         .orElse(null);
-  }
-
-  private void validateOrderParams(
-      List<OrderParam> orderParams, Map<String, TrackedEntityAttribute> attributes)
-      throws BadRequestException {
-    if (orderParams != null && !orderParams.isEmpty()) {
-      for (OrderParam orderParam : orderParams) {
-        if (findColumn(orderParam.getField()).isEmpty()
-            && !attributes.containsKey(orderParam.getField())) {
-          throw new BadRequestException("Invalid order property: " + orderParam.getField());
-        }
-      }
-    }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
@@ -584,17 +584,6 @@ class TrackedEntityOperationParamsMapperTest {
   }
 
   @Test
-  void testMappingOrderParamsGivenInvalidField() {
-    OrderCriteria order1 = OrderCriteria.of("invalid", SortDirection.DESC);
-    TrackedEntityOperationParams operationParams =
-        TrackedEntityOperationParams.builder().orders(List.of(order1)).build();
-
-    BadRequestException e =
-        assertThrows(BadRequestException.class, () -> mapper.map(operationParams));
-    assertEquals("Invalid order property: invalid", e.getMessage());
-  }
-
-  @Test
   void shouldCreateCriteriaFiltersWithFirstOperatorWhenMultipleValidOperandAreNotValid()
       throws BadRequestException, ForbiddenException {
     TrackedEntityOperationParams operationParams =

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventMapper.java
@@ -56,7 +56,7 @@ public interface EventMapper
    * Events can be ordered by given fields which correspond to fields on {@link
    * org.hisp.dhis.program.Event}.
    */
-  static final Map<String, String> ORDERABLE_FIELDS =
+  Map<String, String> ORDERABLE_FIELDS =
       Map.ofEntries(
           entry("assignedUser", "assignedUser"),
           entry("assignedUserDisplayName", "assignedUser.displayName"),

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityMapper.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.trackedentity;
 
+import static java.util.Map.entry;
+
+import java.util.Map;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.webapi.controller.tracker.export.AttributeMapper;
 import org.hisp.dhis.webapi.controller.tracker.export.ProgramOwnerMapper;
@@ -49,6 +52,21 @@ import org.mapstruct.Mapping;
     })
 interface TrackedEntityMapper
     extends ViewMapper<TrackedEntity, org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity> {
+
+  /**
+   * Tracked entities can be ordered by given fields which correspond to fields on {@link
+   * org.hisp.dhis.trackedentity.TrackedEntity}.
+   */
+  Map<String, String> ORDERABLE_FIELDS =
+      Map.ofEntries(
+          entry("trackedEntity", "uid"),
+          entry("createdAt", "created"),
+          entry("createdAtClient", "createdAtClient"),
+          entry("updatedAt", "lastUpdated"),
+          entry("updatedAtClient", "lastUpdatedAtClient"),
+          entry("enrolledAt", "enrollment.enrollmentDate"),
+          entry("inactive", "inactive"));
+
   @Mapping(target = "trackedEntity", source = "uid")
   @Mapping(target = "trackedEntityType", source = "trackedEntityType.uid")
   @Mapping(target = "createdAt", source = "created")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
@@ -33,6 +33,7 @@ import static org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams.
 import static org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams.DEFAULT_PAGE_SIZE;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedUidsParameter;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateOrderParams;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateOrgUnitParams;
 
 import java.util.List;
@@ -56,6 +57,10 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 class TrackedEntityRequestParamsMapper {
+
+  private static final Set<String> ORDERABLE_FIELD_NAMES =
+      TrackedEntityMapper.ORDERABLE_FIELDS.keySet();
+
   private final TrackedEntityFieldsParamMapper fieldsParamMapper;
 
   public TrackedEntityOperationParams map(RequestParams requestParams, User user)
@@ -96,6 +101,7 @@ class TrackedEntityRequestParamsMapper {
             requestParams.getTrackedEntity(),
             "trackedEntities",
             requestParams.getTrackedEntities());
+    validateOrderParams(ORDERABLE_FIELD_NAMES, "attribute", requestParams.getOrder());
 
     return TrackedEntityOperationParams.builder()
         .query(queryFilter)

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtilsTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtilsTest.java
@@ -33,13 +33,17 @@ import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CHILDREN;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.DESCENDANTS;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.SELECTED;
 import static org.hisp.dhis.tracker.export.OperationParamUtils.parseQueryItem;
+import static org.hisp.dhis.utils.Assertions.assertContains;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.utils.Assertions.assertStartsWith;
+import static org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria.fromOrderString;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseFilters;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateOrderParams;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateOrgUnitParams;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -48,6 +52,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryOperator;
@@ -76,6 +81,74 @@ class RequestParamUtilsTest {
         Map.of(
             TEA_1_UID, trackedEntityAttribute(TEA_1_UID),
             TEA_2_UID, trackedEntityAttribute(TEA_2_UID));
+  }
+
+  @Test
+  void shouldPassOrderParamsValidationWhenGivenOrderIsOrderable() throws BadRequestException {
+    Set<String> supportedFieldNames = Set.of("createdAt", "scheduledAt");
+
+    validateOrderParams(supportedFieldNames, "", fromOrderString("createdAt:asc,scheduledAt:asc"));
+  }
+
+  @Test
+  void shouldFailOrderParamsValidationWhenGivenInvalidOrderComponents() {
+    Set<String> supportedFieldNames = Set.of("enrolledAt");
+    String invalidUID = "Cogn34Del";
+    assertFalse(CodeGenerator.isValidUid(invalidUID));
+
+    Exception exception =
+        assertThrows(
+            BadRequestException.class,
+            () ->
+                validateOrderParams(
+                    supportedFieldNames,
+                    "data element and attribute",
+                    fromOrderString(
+                        "unsupportedProperty1:asc,enrolledAt:asc,"
+                            + invalidUID
+                            + ",unsupportedProperty2:desc")));
+    assertAll(
+        () -> assertStartsWith("order parameter is invalid", exception.getMessage()),
+        () ->
+            assertContains(
+                "Supported are data element and attribute UIDs and fields", exception.getMessage()),
+        // order of fields might not always be the same; therefore using contains
+        () -> assertContains(invalidUID, exception.getMessage()),
+        () -> assertContains("unsupportedProperty1", exception.getMessage()),
+        () -> assertContains("unsupportedProperty2", exception.getMessage()));
+  }
+
+  @Test
+  void shouldPassOrderParamsValidationWhenGivenInvalidOrderNameWhichIsAValidUID()
+      throws BadRequestException {
+    Set<String> supportedFieldNames = Set.of("enrolledAt");
+    // This test case shows that some field names are valid UIDs. We can thus not rule out all
+    // invalid field names and UIDs at this stage as we do not have access to data element/attribute
+    // services. Such invalid order values will be caught in the service (mapper).
+    assertTrue(CodeGenerator.isValidUid("lastUpdated"));
+
+    validateOrderParams(supportedFieldNames, "", fromOrderString("lastUpdated:desc"));
+  }
+
+  @Test
+  void shouldFailOrderParamsValidationWhenGivenRepeatedOrderComponents() {
+    Set<String> supportedFieldNames = Set.of("createdAt", "enrolledAt");
+
+    Exception exception =
+        assertThrows(
+            BadRequestException.class,
+            () ->
+                validateOrderParams(
+                    supportedFieldNames,
+                    "",
+                    fromOrderString(
+                        "zGlzbfreTOH,createdAt:asc,enrolledAt:asc,enrolledAt,zGlzbfreTOH")));
+
+    assertAll(
+        () -> assertStartsWith("order parameter is invalid", exception.getMessage()),
+        // order of fields might not always be the same; therefore using contains
+        () -> assertContains("enrolledAt", exception.getMessage()),
+        () -> assertContains("zGlzbfreTOH", exception.getMessage()));
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
@@ -39,7 +39,6 @@ import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.utils.Assertions.assertStartsWith;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -52,7 +51,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.hisp.dhis.common.AssignedUserSelectionMode;
-import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryOperator;
@@ -537,55 +535,15 @@ class EventRequestParamsMapperTest {
   }
 
   @Test
-  void shouldFailGivenInvalidOrderComponents() {
-    String invalidUID = "Cogn34Del";
-    assertFalse(CodeGenerator.isValidUid(invalidUID));
-
+  void shouldFailGivenInvalidOrderFieldName() {
     RequestParams requestParams = new RequestParams();
     requestParams.setOrder(
-        OrderCriteria.fromOrderString(
-            "unsupportedProperty1:asc,enrolledAt:asc,"
-                + invalidUID
-                + ",unsupportedProperty2:desc"));
+        OrderCriteria.fromOrderString("unsupportedProperty1:asc,enrolledAt:asc"));
 
     Exception exception = assertThrows(BadRequestException.class, () -> mapper.map(requestParams));
     assertAll(
         () -> assertStartsWith("order parameter is invalid", exception.getMessage()),
-        // order of fields might not always be the same; therefore using contains
-        () -> assertContains(invalidUID, exception.getMessage()),
-        () -> assertContains("unsupportedProperty1", exception.getMessage()),
-        () -> assertContains("unsupportedProperty2", exception.getMessage()));
-  }
-
-  @Test
-  void shouldMapGivenInvalidOrderNameWhichIsAValidUIDToUID() throws BadRequestException {
-    // This test case shows that some field names are valid UIDs. We can thus not rule out all
-    // invalid field names and UIDs at this stage as we do not have access to data element/attribute
-    // services. Such invalid order values will be caught in the
-    // service (mapper).
-    assertTrue(CodeGenerator.isValidUid("lastUpdated"));
-
-    RequestParams requestParams = new RequestParams();
-    requestParams.setOrder(OrderCriteria.fromOrderString("lastUpdated:desc"));
-
-    EventOperationParams params = mapper.map(requestParams);
-
-    assertEquals(List.of(new Order(UID.of("lastUpdated"), SortDirection.DESC)), params.getOrder());
-  }
-
-  @Test
-  void shouldFailWhenOrderParameterContainsRepeatedOrderComponents() {
-    RequestParams requestParams = new RequestParams();
-    requestParams.setOrder(
-        OrderCriteria.fromOrderString(
-            "zGlzbfreTOH,createdAt:asc,enrolledAt:asc,enrolledAt,zGlzbfreTOH"));
-
-    Exception exception = assertThrows(BadRequestException.class, () -> mapper.map(requestParams));
-    assertAll(
-        () -> assertStartsWith("order parameter is invalid", exception.getMessage()),
-        // order of fields might not always be the same; therefore using contains
-        () -> assertContains("enrolledAt", exception.getMessage()),
-        () -> assertContains("zGlzbfreTOH", exception.getMessage()));
+        () -> assertContains("unsupportedProperty1", exception.getMessage()));
   }
 
   @Test


### PR DESCRIPTION
This is the first PR in https://dhis2.atlassian.net/browse/TECH-1611

* move validation of `order` request parameter to web layer

## Next PR(s)

* map names from user language (view model) to internal language (dhis-api/DB).
https://github.com/dhis2/dhis2-core/blob/271e60c8281a045befd6ad13a224252489c5f871/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityQueryParams.java#L971-L984
* validate attribute UIDs in `order` actually exist
* adding order tests
* move `filter` parsing to web layer
* improvements to params APIs similar to work on /tracker/events