### PR TITLE
fix: drop foreign key [ TECH-1597 ]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_26__DropUnusedTables.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_26__DropUnusedTables.sql
@@ -5,5 +5,38 @@ drop table if exists programstage_programindicators;
 drop table if exists programinstance_outboundsms;
 drop table if exists trackedentityinstancereminder;
 drop table if exists trackedentityattributegroup;
+-- in Sierra Leone Db trackedentityattribute has a foreign key to trackedentitymobilesetting
+do $$
+declare
+
+dyn_sql text;
+stat text;
+
+begin
+dyn_sql :=
+'select ''ALTER TABLE '' || tc.table_name || '' DROP CONSTRAINT '' || tc.constraint_name
+from
+	information_schema.table_constraints as tc
+join information_schema.key_column_usage as kcu
+on
+	tc.constraint_name = kcu.constraint_name
+	and tc.table_schema = kcu.table_schema
+join information_schema.constraint_column_usage as ccu
+on
+	ccu.constraint_name = tc.constraint_name
+	and ccu.table_schema = tc.table_schema
+where
+	tc.constraint_type = ''FOREIGN KEY''
+	and tc.table_name = ''trackedentityattribute''
+	and ccu.table_name = ''trackedentitymobilesetting''';
+
+execute dyn_sql into stat;
+
+if stat != '' then
+execute stat;
+end if;
+
+end $$;
+
 drop table if exists trackedentitymobilesetting;
 drop table if exists programvalidation;


### PR DESCRIPTION
following https://github.com/dhis2/dhis2-core/pull/14803
We need to drop a foreign key before dropping `trackedentitymobilesetting`. This foreign key is in Sierra Leone but does not appear in the metadata