### PR TITLE
fix: Drop FK before creation [TECH-1612]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_2__Create_table_custom_icon.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_2__Create_table_custom_icon.sql
@@ -1,15 +1,22 @@
-CREATE TABLE IF NOT EXISTS customicon (
-    customiconid int8 GENERATED ALWAYS AS IDENTITY,
-    "key" varchar(100) NOT NULL,
-    fileresourceid int8 NOT NULL,
-    description text NULL,
-    keywords text[] NULL,
-    created TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
-    createdby bigint NOT NULL,
+CREATE TABLE IF NOT EXISTS customicon
+(
+    customiconid   int8 GENERATED ALWAYS AS IDENTITY,
+    "key"          varchar(100) NOT NULL,
+    fileresourceid int8         NOT NULL,
+    description    text         NULL,
+    keywords       text[]       NULL,
+    created        TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    createdby      bigint       NOT NULL,
     CONSTRAINT customicon_pkey PRIMARY KEY (customiconid),
     CONSTRAINT customicon_ukey UNIQUE ("key"),
     CONSTRAINT customicon_fileresource_ukey UNIQUE (fileresourceid)
 );
 
-ALTER TABLE customicon ADD CONSTRAINT fk_customicon_file_resource FOREIGN KEY (fileresourceid) REFERENCES fileresource(fileresourceid) ON DELETE CASCADE;
-ALTER TABLE customicon ADD CONSTRAINT fk_createdby_userid FOREIGN KEY (createdby) REFERENCES userinfo(userinfoid);
+ALTER TABLE customicon
+    DROP CONSTRAINT IF EXISTS fk_customicon_file_resource;
+ALTER TABLE customicon
+    ADD CONSTRAINT fk_customicon_file_resource FOREIGN KEY (fileresourceid) REFERENCES fileresource (fileresourceid) ON DELETE CASCADE;
+ALTER TABLE customicon
+    DROP CONSTRAINT IF EXISTS fk_createdby_userid;
+ALTER TABLE customicon
+    ADD CONSTRAINT fk_createdby_userid FOREIGN KEY (createdby) REFERENCES userinfo (userinfoid);


### PR DESCRIPTION
Play dev is down from time to time because a migration script tries to create a foreign key that already exists.
This PR aims to solve the problem by deleting it first.

Ticket: https://dhis2.atlassian.net/browse/TECH-1612