### PR TITLE
chore: simplify new tracked entities store TECH-1611

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -702,7 +702,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
 
   private void checkIfMaxTeiLimitIsReached(TrackedEntityQueryParams params, int maxTeiLimit) {
     if (maxTeiLimit > 0) {
-      int teCount = trackedEntityStore.getTrackedEntityCountForGridWithMaxTeiLimit(params);
+      int teCount = trackedEntityStore.getTrackedEntityCountForWithMaxTeiLimit(params);
 
       if (teCount > maxTeiLimit) {
         throw new IllegalQueryException("maxteicountreached");
@@ -726,7 +726,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
 
     // using countForGrid here to leverage the better performant rewritten
     // sql query
-    return trackedEntityStore.getTrackedEntityCountForGrid(params);
+    return trackedEntityStore.getTrackedEntityCount(params);
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
@@ -35,7 +35,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -74,10 +73,6 @@ public class TrackedEntityQueryParams {
   public static final String INACTIVE_ID = "inactive";
 
   public static final String DELETED = "deleted";
-
-  public static final String META_DATA_NAMES_KEY = "names";
-
-  public static final String PAGER_META_KEY = "pager";
 
   public static final String POTENTIAL_DUPLICATE = "potentialduplicate";
 
@@ -240,35 +235,6 @@ public class TrackedEntityQueryParams {
   public TrackedEntityQueryParams addOrganisationUnit(OrganisationUnit unit) {
     this.orgUnits.add(unit);
     return this;
-  }
-
-  /**
-   * Performs a set of operations on this params.
-   *
-   * <ul>
-   *   <li>If a query item is specified as an attribute item as well as a filter item, the filter
-   *       item will be removed. In that case, if the attribute item does not have any filters and
-   *       the filter item has one or more filters, these will be applied to the attribute item.
-   * </ul>
-   */
-  public void conform() {
-    Iterator<QueryItem> filterIter = filters.iterator();
-
-    while (filterIter.hasNext()) {
-      QueryItem filter = filterIter.next();
-
-      int index = attributes.indexOf(filter); // Filter present as attr
-
-      if (index >= 0) {
-        QueryItem attribute = attributes.get(index);
-
-        if (!attribute.hasFilter() && filter.hasFilter()) {
-          attribute.getFilters().addAll(filter.getFilters());
-        }
-
-        filterIter.remove();
-      }
-    }
   }
 
   /**
@@ -498,11 +464,6 @@ public class TrackedEntityQueryParams {
   /** Indicates whether this parameters specifies an event end date. */
   public boolean hasEventEndDate() {
     return eventEndDate != null;
-  }
-
-  /** Indicates whether this parameters specifies a user. */
-  public boolean hasUser() {
-    return user != null;
   }
 
   /** Check whether we are filtering for potential duplicate property. */

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityStore.java
@@ -36,7 +36,7 @@ interface TrackedEntityStore extends IdentifiableObjectStore<TrackedEntity> {
 
   List<Long> getTrackedEntityIds(TrackedEntityQueryParams params);
 
-  int getTrackedEntityCountForGrid(TrackedEntityQueryParams params);
+  int getTrackedEntityCount(TrackedEntityQueryParams params);
 
-  int getTrackedEntityCountForGridWithMaxTeiLimit(TrackedEntityQueryParams params);
+  int getTrackedEntityCountForWithMaxTeiLimit(TrackedEntityQueryParams params);
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
@@ -61,7 +61,9 @@ import org.hisp.dhis.tracker.export.event.EventOperationParams;
 import org.hisp.dhis.tracker.export.event.EventOperationParams.EventOperationParamsBuilder;
 import org.hisp.dhis.tracker.export.event.EventService;
 import org.hisp.dhis.tracker.export.event.Events;
+import org.hisp.dhis.tracker.export.trackedentity.TrackedEntities;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityOperationParams;
+import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityOperationParams.TrackedEntityOperationParamsBuilder;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityService;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
 import org.hisp.dhis.user.User;
@@ -107,6 +109,89 @@ class OrderAndPaginationExporterTest extends TrackerTest {
     // needed as some tests are run using another user (injectSecurityContext) while most tests
     // expect to be run by admin
     injectAdminUser();
+  }
+
+  @Test
+  void shouldReturnPaginatedTrackedEntitiesGivenNonDefaultPageSize()
+      throws ForbiddenException, BadRequestException, NotFoundException {
+    TrackedEntityOperationParamsBuilder builder =
+        TrackedEntityOperationParams.builder()
+            .organisationUnits(Set.of(orgUnit.getUid()))
+            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .orders(List.of(OrderCriteria.of("numericAttr", SortDirection.ASC)));
+
+    TrackedEntityOperationParams params = builder.page(1).pageSize(3).build();
+
+    TrackedEntities firstPage = trackedEntityService.getTrackedEntities(params);
+
+    assertAll(
+        "first page",
+        // TODO(tracker): fix in TECH-1601. I assume this was recently introduced (only on master)
+        // when
+        // handleLastPageFlag was copied from the event service which works in conjunction with the
+        // event store
+        // that fetches pageSize + 1 when totalCount=false. This split of logic between
+        // service/store is
+        // error prone and hard to follow. We will fix/refactor it for all entities so this is
+        // purely a concern
+        // of the store.
+        () -> assertSlimPager(1, 3, true, firstPage.getPager()),
+        () ->
+            assertEquals(
+                List.of("dUE514NMOlo", "mHWCacsGYYn", "QS6w44flWAf"),
+                uids(firstPage.getTrackedEntities())));
+
+    params = builder.page(2).pageSize(3).build();
+
+    TrackedEntities secondPage = trackedEntityService.getTrackedEntities(params);
+
+    assertAll(
+        "second (last) page",
+        () -> assertSlimPager(2, 3, true, secondPage.getPager()),
+        () ->
+            assertEquals(
+                List.of("QesgJkTyTCk", "guVNoAerxWo"), uids(secondPage.getTrackedEntities())));
+
+    params = builder.page(3).pageSize(3).build();
+
+    assertIsEmpty(getTrackedEntities(params));
+  }
+
+  @Test
+  void shouldReturnPaginatedTrackedEntitiesGivenNonDefaultPageSizeAndTotalPages()
+      throws ForbiddenException, BadRequestException, NotFoundException {
+    TrackedEntityOperationParamsBuilder builder =
+        TrackedEntityOperationParams.builder()
+            .organisationUnits(Set.of(orgUnit.getUid()))
+            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .orders(List.of(OrderCriteria.of("numericAttr", SortDirection.ASC)));
+
+    TrackedEntityOperationParams params = builder.page(1).pageSize(3).totalPages(true).build();
+
+    TrackedEntities firstPage = trackedEntityService.getTrackedEntities(params);
+
+    assertAll(
+        "first page",
+        () -> assertPager(1, 3, 5, firstPage.getPager()),
+        () ->
+            assertEquals(
+                List.of("dUE514NMOlo", "mHWCacsGYYn", "QS6w44flWAf"),
+                uids(firstPage.getTrackedEntities())));
+
+    params = builder.page(2).pageSize(3).totalPages(true).build();
+
+    TrackedEntities secondPage = trackedEntityService.getTrackedEntities(params);
+
+    assertAll(
+        "second (last) page",
+        () -> assertPager(2, 3, 5, secondPage.getPager()),
+        () ->
+            assertEquals(
+                List.of("QesgJkTyTCk", "guVNoAerxWo"), uids(secondPage.getTrackedEntities())));
+
+    params = builder.page(3).pageSize(3).totalPages(true).build();
+
+    assertIsEmpty(getTrackedEntities(params));
   }
 
   @Test
@@ -213,6 +298,25 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
+  void shouldOrderTrackedEntitiesByFieldAndAttribute()
+      throws ForbiddenException, BadRequestException, NotFoundException {
+    TrackedEntityOperationParams params =
+        TrackedEntityOperationParams.builder()
+            .organisationUnits(Set.of(orgUnit.getUid()))
+            .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
+            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .orders(
+                List.of(
+                    OrderCriteria.of("toDelete000", SortDirection.ASC),
+                    OrderCriteria.of("enrolledAt", SortDirection.ASC)))
+            .build();
+
+    List<String> trackedEntities = getTrackedEntities(params);
+
+    assertEquals(List.of("QS6w44flWAf", "dUE514NMOlo"), trackedEntities);
+  }
+
+  @Test
   void shouldOrderTrackedEntitiesByAttributeAsc()
       throws ForbiddenException, BadRequestException, NotFoundException {
     TrackedEntityOperationParams params =
@@ -241,6 +345,59 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     List<String> trackedEntities = getTrackedEntities(params);
 
+    assertEquals(List.of("QS6w44flWAf", "dUE514NMOlo"), trackedEntities);
+  }
+
+  @Test
+  void shouldOrderTrackedEntitiesByAttributeWhenFiltered()
+      throws ForbiddenException, BadRequestException, NotFoundException {
+    TrackedEntityOperationParams params =
+        TrackedEntityOperationParams.builder()
+            .organisationUnits(Set.of(orgUnit.getUid()))
+            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .orders(List.of(OrderCriteria.of("toUpdate000", SortDirection.ASC)))
+            .filters("numericAttr:lt:75")
+            .build();
+
+    List<String> trackedEntities = getTrackedEntities(params);
+
+    assertEquals(List.of("dUE514NMOlo", "mHWCacsGYYn"), trackedEntities);
+  }
+
+  @Test
+  void shouldOrderTrackedEntitiesByAttributeWhenFilteredOnSameAttribute()
+      throws ForbiddenException, BadRequestException, NotFoundException {
+    TrackedEntityOperationParams params =
+        TrackedEntityOperationParams.builder()
+            .organisationUnits(Set.of(orgUnit.getUid()))
+            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .orders(List.of(OrderCriteria.of("numericAttr", SortDirection.DESC)))
+            .filters("numericAttr:lt:75")
+            .build();
+
+    List<String> trackedEntities = getTrackedEntities(params);
+
+    assertEquals(List.of("mHWCacsGYYn", "dUE514NMOlo"), trackedEntities);
+  }
+
+  @Test
+  void shouldOrderTrackedEntitiesByAttributeAndNotFilterOutATrackedEntityWithoutThatAttribute()
+      throws ForbiddenException, BadRequestException, NotFoundException {
+    TrackedEntityOperationParams params =
+        TrackedEntityOperationParams.builder()
+            .organisationUnits(Set.of(orgUnit.getUid()))
+            .trackedEntityTypeUid(trackedEntityType.getUid())
+            .trackedEntityUids(
+                Set.of(
+                    "dUE514NMOlo", "QS6w44flWAf")) // TE QS6w44flWAf without attribute notUpdated0
+            .orders(List.of(OrderCriteria.of("notUpdated0", SortDirection.DESC)))
+            .build();
+
+    List<String> trackedEntities = getTrackedEntities(params);
+
+    // https://www.postgresql.org/docs/current/queries-order.html
+    // By default, null values sort as if larger than any non-null value
+    // => TE QS6w44flWAf without attribute notUpdated0 will come first when DESC
     assertEquals(List.of("QS6w44flWAf", "dUE514NMOlo"), trackedEntities);
   }
 
@@ -297,7 +454,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "first page",
-        () -> assertSlimPager(1, 1, false, firstPage),
+        () -> assertSlimPager(1, 1, false, firstPage.getPager()),
         () -> assertEquals(List.of("D9PbzJY8bJM"), eventUids(firstPage)));
 
     params = paramsBuilder.page(2).pageSize(1).build();
@@ -306,7 +463,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "second (last) page",
-        () -> assertSlimPager(2, 1, true, secondPage),
+        () -> assertSlimPager(2, 1, true, secondPage.getPager()),
         () -> assertEquals(List.of("pTzf9KYMk72"), eventUids(secondPage)));
 
     params = paramsBuilder.page(3).pageSize(3).build();
@@ -315,7 +472,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldReturnEventsWithTotalPages() throws ForbiddenException, BadRequestException {
+  void shouldReturnPaginatedEventsWithTotalPages() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         EventOperationParams.builder()
             .orgUnitUid(orgUnit.getUid())
@@ -346,7 +503,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "first page",
-        () -> assertSlimPager(1, 3, false, firstPage),
+        () -> assertSlimPager(1, 3, false, firstPage.getPager()),
         () ->
             assertEquals(
                 List.of("ck7DzdxqLqA", "OTmjvJDn0Fu", "kWjSezkXHVp"), eventUids(firstPage)));
@@ -357,7 +514,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "second (last) page",
-        () -> assertSlimPager(2, 3, true, secondPage),
+        () -> assertSlimPager(2, 3, true, secondPage.getPager()),
         () ->
             assertEquals(
                 List.of("lumVtWwwy0O", "QRYjLTiJTrA", "cadc5eGj0j7"), eventUids(secondPage)));
@@ -387,7 +544,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "first page",
-        () -> assertPager(1, 2, 6, events),
+        () -> assertPager(1, 2, 6, events.getPager()),
         () -> assertEquals(List.of("ck7DzdxqLqA", "OTmjvJDn0Fu"), eventUids(events)));
   }
 
@@ -420,7 +577,6 @@ class OrderAndPaginationExporterTest extends TrackerTest {
             .sorted(Comparator.comparing(event -> event.getEnrollment().getProgram().getUid()))
             .map(Event::getUid)
             .toList();
-    System.out.println(expected);
 
     EventOperationParams params =
         EventOperationParams.builder()
@@ -460,6 +616,25 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
+  void shouldOrderEventsByAttributeAndFilterOutEventsWithATrackedEntityWithoutThatAttribute()
+      throws ForbiddenException, BadRequestException {
+    EventOperationParams params =
+        EventOperationParams.builder()
+            .orgUnitUid(orgUnit.getUid())
+            .events(
+                Set.of(
+                    "pTzf9KYMk72",
+                    "D9PbzJY8bJM")) // EV pTzf9KYMk72 => TE QS6w44flWAf without attribute
+            // notUpdated0
+            .orderBy(UID.of("notUpdated0"), SortDirection.ASC)
+            .build();
+
+    List<String> events = getEvents(params);
+
+    assertEquals(List.of("D9PbzJY8bJM"), events);
+  }
+
+  @Test
   void shouldOrderEventsByMultipleAttributesDesc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         EventOperationParams.builder()
@@ -493,7 +668,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldOrderEventsByMultipleAttributesAndPaginateWhenGivenNonDefaultPageSize()
+  void shouldReturnPaginatedEventsOrderedByMultipleAttributesWhenGivenNonDefaultPageSize()
       throws ForbiddenException, BadRequestException {
     EventOperationParamsBuilder paramsBuilder =
         EventOperationParams.builder()
@@ -507,7 +682,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "first page",
-        () -> assertSlimPager(1, 1, false, firstPage),
+        () -> assertSlimPager(1, 1, false, firstPage.getPager()),
         () -> assertEquals(List.of("D9PbzJY8bJM"), eventUids(firstPage)));
 
     params = paramsBuilder.page(2).pageSize(1).build();
@@ -516,7 +691,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "second (last) page",
-        () -> assertSlimPager(2, 1, true, secondPage),
+        () -> assertSlimPager(2, 1, true, secondPage.getPager()),
         () -> assertEquals(List.of("pTzf9KYMk72"), eventUids(secondPage)));
 
     params = paramsBuilder.page(3).pageSize(3).build();
@@ -637,6 +812,28 @@ class OrderAndPaginationExporterTest extends TrackerTest {
     assertEquals(List.of("D9PbzJY8bJM", "pTzf9KYMk72"), events);
   }
 
+  @Test
+  void shouldOrderEventsByDataElementAndNotFilterOutEventsWithoutThatDataElement()
+      throws ForbiddenException, BadRequestException {
+    EventOperationParams params =
+        EventOperationParams.builder()
+            .orgUnitUid(orgUnit.getUid())
+            .events(
+                Set.of(
+                    "pTzf9KYMk72", // EV pTzf9KYMk72 without data element DATAEL00002
+                    "D9PbzJY8bJM"))
+            // notUpdated0
+            .orderBy(UID.of("DATAEL00002"), SortDirection.DESC)
+            .build();
+
+    List<String> events = getEvents(params);
+
+    // https://www.postgresql.org/docs/current/queries-order.html
+    // By default, null values sort as if larger than any non-null value
+    // => EV pTzf9KYMk72 without data element DATAEL00002 will come first when DESC
+    assertEquals(List.of("pTzf9KYMk72", "D9PbzJY8bJM"), events);
+  }
+
   private <T extends IdentifiableObject> T get(Class<T> type, String uid) {
     T t = manager.get(type, uid);
     assertNotNull(
@@ -647,28 +844,26 @@ class OrderAndPaginationExporterTest extends TrackerTest {
     return t;
   }
 
-  private static void assertSlimPager(int pageNumber, int pageSize, boolean isLast, Events events) {
-    assertInstanceOf(
-        SlimPager.class, events.getPager(), "SlimPager should be returned if totalPages=false");
-    SlimPager pager = (SlimPager) events.getPager();
+  private static void assertSlimPager(int pageNumber, int pageSize, boolean isLast, Pager pager) {
+    assertInstanceOf(SlimPager.class, pager, "SlimPager should be returned if totalPages=false");
+    SlimPager slimPager = (SlimPager) pager;
     assertAll(
         "pagination details",
-        () -> assertEquals(pageNumber, pager.getPage(), "number of current page"),
-        () -> assertEquals(pageSize, pager.getPageSize(), "page size"),
+        () -> assertEquals(pageNumber, slimPager.getPage(), "number of current page"),
+        () -> assertEquals(pageSize, slimPager.getPageSize(), "page size"),
         () ->
             assertEquals(
                 isLast,
-                pager.isLastPage(),
+                slimPager.isLastPage(),
                 isLast ? "should be the last page" : "should NOT be the last page"));
   }
 
-  private static void assertPager(int pageNumber, int pageSize, int totalCount, Events events) {
-    Pager pager = events.getPager();
+  private static void assertPager(int pageNumber, int pageSize, int totalCount, Pager pager) {
     assertAll(
         "pagination details",
         () -> assertEquals(pageNumber, pager.getPage(), "number of current page"),
         () -> assertEquals(pageSize, pager.getPageSize(), "page size"),
-        () -> assertEquals(totalCount, pager.getTotal(), "total page count"));
+        () -> assertEquals(totalCount, pager.getTotal(), "total count of items"));
   }
 
   private List<String> getTrackedEntities(TrackedEntityOperationParams params)

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
@@ -37,8 +37,6 @@
         "idScheme": "UID",
         "identifier": "ja8NY4PW7Xm"
       },
-      "createdAt": "2020-02-20T12:09:21.844",
-      "updatedAt": "2020-02-20T12:09:21.844",
       "orgUnit": {
         "idScheme": "UID",
         "identifier": "h4w96yEMlzO"
@@ -81,8 +79,6 @@
         "idScheme": "UID",
         "identifier": "ja8NY4PW7Xm"
       },
-      "createdAt": "2020-02-20T12:09:21.844",
-      "updatedAt": "2020-02-20T12:09:21.844",
       "orgUnit": {
         "idScheme": "UID",
         "identifier": "h4w96yEMlzO"
@@ -133,8 +129,6 @@
         "idScheme": "UID",
         "identifier": "ja8NY4PW7Xm"
       },
-      "createdAt": "2020-02-20T12:09:21.844",
-      "updatedAt": "2020-02-20T12:09:21.844",
       "orgUnit": {
         "idScheme": "UID",
         "identifier": "h4w96yEMlzO"
@@ -166,7 +160,7 @@
             "idScheme": "UID",
             "identifier": "numericAttr"
           },
-          "value": 88
+          "value": 72
         }
       ],
       "enrollments": []
@@ -177,8 +171,6 @@
         "idScheme": "UID",
         "identifier": "ja8NY4PW7Xm"
       },
-      "createdAt": "2020-02-20T12:09:21.844",
-      "updatedAt": "2020-02-20T12:09:21.844",
       "orgUnit": {
         "idScheme": "UID",
         "identifier": "h4w96yEMlzO"
@@ -210,7 +202,7 @@
             "idScheme": "UID",
             "identifier": "numericAttr"
           },
-          "value": 88
+          "value": 89
         }
       ],
       "enrollments": []
@@ -221,8 +213,6 @@
         "idScheme": "UID",
         "identifier": "ja8NY4PW7Xm"
       },
-      "createdAt": "2020-02-20T12:09:21.844",
-      "updatedAt": "2020-02-20T12:09:21.844",
       "orgUnit": {
         "idScheme": "UID",
         "identifier": "tSsGrtfRzjY"
@@ -254,7 +244,7 @@
             "idScheme": "UID",
             "identifier": "numericAttr"
           },
-          "value": 88
+          "value": 90
         }
       ],
       "enrollments": []


### PR DESCRIPTION
New tracker does not support grid queries. Once we remove the grid query code from the new tracker store we can simplify the SQL query to get TE ids.

The grid query returns data as row/column format using `Map<String,String>`.

https://github.com/dhis2/dhis2-core/blob/98be48af4bb6fe2b83cd2a45fdbd53b271fd861c/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java#L227-L255

In case there is any attribute present in a `filter` and maybe `attribute` and `order` (thus join) it would add an aggregation for `string_agg(TEA.uid || ':' || TEAV.value, ';@//@;') AS tea_values`. This aggregation required us to group by every column we wanted to return. This is obviously not needed for new tracker queries.


* Removed unused code.
* Removed createdAt/updatedAt from test fixture as they are automatically set by our code and have no effect other than to cause confusion.

I added additional tests for
* ordering by field name and attribute together with filtering
* ordering by the same attribute we also filter on
* pagination (which shows that we recently introduced a bug we will fix in https://dhis2.atlassian.net/browse/TECH-1601 see comment).

If you are curious you can read the following on the SQL we generate in the store.

## Details on the SQL query

The SQL query for getting tracked entity ids has at least these similarities to the one we do for events:
* inner sub-query to get TEs in correct order and paginated (limit/offset)
* order also specified on outer select as we cannot rely on ordering of the sub-query

### Attributes

#### Order by

```java
TrackedEntityOperationParams params =
    TrackedEntityOperationParams.builder()
        .orders(List.of(OrderCriteria.of("toUpdate000", SortDirection.ASC)))
```

turns into select in sub-query

```sql
"toUpdate000".value AS "toUpdate000"
```

adds a **LEFT** join (opposite to INNER join in events ordering by attributes). So here we do not filter out TEs when ordering by attributes they don't have.

```sql
LEFT JOIN trackedentityattributevalue AS "toUpdate000"
            ON "toUpdate000".trackedentityid = TE.trackedentityid AND
            "toUpdate000".trackedentityattributeid = 67
```

We add an additional left join on the trackedentityattribute table

```sql
LEFT JOIN trackedentityattributevalue TEAV ON TEAV.trackedentityid = TE.trackedentityid AND
                                            TEAV.trackedentityattributeid IN (67)
LEFT JOIN trackedentityattribute TEA
        ON TEA.trackedentityattributeid = TEAV.trackedentityattributeid
```

The sub-query gets an order by

```sql
ORDER BY "toUpdate000".value ASC
```

as well as the outer query

```sql
ORDER BY TE."toUpdate000" ASC
```

Previously we also added a

```sql
GROUP BY TE.trackedentityid, TE.uid, TE.created, TE.lastupdated, TE.ou, TE.ouname, TET.uid,
         TE.potentialduplicate, TE.inactive, TE."toUpdate000"
```

due to the grid aggregation of TEAV. Note that even though we in new tracker did not make a grid query the aggregation and group by were still present.
