### PR TITLE
chore: map /tracker/trackedEntities?order as in events TECH-1611

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/Order.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/Order.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker;
+package org.hisp.dhis.tracker.export;
 
 import lombok.Value;
 import org.hisp.dhis.dataelement.DataElement;
@@ -39,11 +39,10 @@ import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
  * cannot come up with a type-safe type that captures the above order features and that can be used
  * in a generic collection such as a List (see typesafe heterogeneous container). We therefore use
  * {@link Order} with a field of type {@link Object}. We get compile time type safety via methods
- * such as {@link org.hisp.dhis.tracker.export.event.EventSearchParams#orderBy(DataElement,
- * SortDirection)}. This allows us to advocate the types that can be ordered by while storing the
- * order in a single {@code List} of {@link Order}. Runtime type checks are then used to ensure
- * users (and developers) get meaningful error messages in case they order by unsupported fields or
- * types.
+ * such as {@code orderBy(DataElement, SortDirection)}. This allows us to advocate the types that
+ * can be ordered by while storing the order in a single {@code List} of {@link Order}. Runtime type
+ * checks are then used to ensure users (and developers) get meaningful error messages in case they
+ * order by unsupported fields or types.
  */
 @Value
 public class Order {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
@@ -48,7 +48,7 @@ import org.hisp.dhis.common.UID;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.ProgramType;
-import org.hisp.dhis.tracker.Order;
+import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 
 @Getter

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
@@ -61,7 +61,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
-import org.hisp.dhis.tracker.Order;
+import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Component;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventSearchParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventSearchParams.java
@@ -50,7 +50,7 @@ import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
-import org.hisp.dhis.tracker.Order;
+import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 
 /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -93,7 +93,7 @@ import org.hisp.dhis.system.util.SqlUtils;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
-import org.hisp.dhis.tracker.Order;
+import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -39,7 +39,6 @@ import static org.hisp.dhis.common.Pager.DEFAULT_PAGE_SIZE;
 import static org.hisp.dhis.common.SlimPager.FIRST_PAGE;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -93,7 +92,6 @@ import org.hisp.dhis.tracker.export.trackedentity.aggregates.TrackedEntityAggreg
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;
-import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -376,31 +374,23 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
   }
 
   /**
-   * This method handles any dynamic sort order columns in the params. These have to be added to the
-   * attribute list if neither are present in the attribute list nor the filter list.
+   * Attributes that are ordered by are added to the attribute list if neither are present in the
+   * attribute list nor the filter list.
    *
    * <p>For example, if attributes or filters don't have a specific trackedentityattribute uid, but
    * sorting has been requested for that tea uid, then we need to add them to the attribute list.
-   *
-   * @param params The TEIQueryParams object
    */
   private void handleSortAttributes(TrackedEntityQueryParams params) {
     List<TrackedEntityAttribute> sortAttributes =
-        params.getOrders().stream()
-            .map(OrderParam::getField)
-            .filter(this::isDynamicColumn)
-            .map(trackedEntityAttributeService::getTrackedEntityAttribute)
+        params.getOrder().stream()
+            .filter(o -> o.getField() instanceof TrackedEntityAttribute)
+            .map(o -> (TrackedEntityAttribute) o.getField())
             .collect(Collectors.toList());
 
     params.addAttributesIfNotExist(
         QueryItem.getQueryItems(sortAttributes).stream()
             .filter(sAtt -> !params.getFilters().contains(sAtt))
             .collect(Collectors.toList()));
-  }
-
-  public boolean isDynamicColumn(String propName) {
-    return Arrays.stream(TrackedEntityQueryParams.OrderColumn.values())
-        .noneMatch(orderColumn -> orderColumn.getPropName().equals(propName));
   }
 
   public void decideAccess(TrackedEntityQueryParams params) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParams.java
@@ -39,10 +39,12 @@ import lombok.Getter;
 import org.hisp.dhis.common.AssignedUserQueryParam;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.program.ProgramStatus;
+import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
+import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 
 @Builder(toBuilder = true)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -167,8 +169,40 @@ public class TrackedEntityOperationParams {
    */
   private Boolean potentialDuplicate;
 
-  /** TE order params */
-  @Builder.Default private List<OrderCriteria> orders = new ArrayList<>();
+  /**
+   * Tracked entities can be ordered by field names (given as {@link String}) and tracked entity
+   * attributes (given as {@link UID}). It is crucial for the order values to stay in one collection
+   * as their order needs to be kept as provided by the user. We cannot come up with a type-safe
+   * type that captures the above order features and that can be used in a generic collection such
+   * as a List (see typesafe heterogeneous container). We therefore provide {@link
+   * TrackedEntityOperationParamsBuilder#orderBy(String, SortDirection)} and {@link
+   * TrackedEntityOperationParamsBuilder#orderBy(UID, SortDirection)} to advocate the types that can
+   * be ordered by while storing the order in a single List of {@link Order}.
+   */
+  private List<Order> order;
 
   private User user;
+
+  public static class TrackedEntityOperationParamsBuilder {
+
+    private List<Order> order = new ArrayList<>();
+
+    // Do not remove this unused method. This hides the order field from the builder which Lombok
+    // does not support. The repeated order field and private order method prevent access to order
+    // via the builder.
+    // Order should be added via the orderBy builder methods.
+    private TrackedEntityOperationParamsBuilder order(List<Order> order) {
+      return this;
+    }
+
+    public TrackedEntityOperationParamsBuilder orderBy(String field, SortDirection direction) {
+      this.order.add(new Order(field, direction));
+      return this;
+    }
+
+    public TrackedEntityOperationParamsBuilder orderBy(UID uid, SortDirection direction) {
+      this.order.add(new Order(uid, direction));
+      return this;
+    }
+  }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
@@ -29,18 +29,14 @@ package org.hisp.dhis.tracker.export.trackedentity;
 
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CHILDREN;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.ToString;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.time.DateUtils;
 import org.hisp.dhis.common.AssignedUserQueryParam;
@@ -53,36 +49,18 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStatus;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
+import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 
+@ToString
 public class TrackedEntityQueryParams {
-  public static final String TRACKED_ENTITY_ID = "instance";
-
-  public static final String CREATED_ID = "created";
-
-  public static final String LAST_UPDATED_ID = "lastupdated";
-
-  public static final String ORG_UNIT_ID = "ou";
-
-  public static final String ORG_UNIT_NAME = "ouname";
-
-  public static final String TRACKED_ENTITY_TYPE_ID = "te";
-
-  public static final String INACTIVE_ID = "inactive";
-
-  public static final String DELETED = "deleted";
-
-  public static final String POTENTIAL_DUPLICATE = "potentialduplicate";
 
   public static final int DEFAULT_PAGE = 1;
 
   public static final int DEFAULT_PAGE_SIZE = 50;
-
-  public static final String MAIN_QUERY_ALIAS = "TE";
-
-  public static final String PROGRAM_INSTANCE_ALIAS = "pi";
 
   /** Query value, will apply to all relevant attributes. */
   private QueryFilter query;
@@ -157,7 +135,7 @@ public class TrackedEntityQueryParams {
   /** End date for event for the given program. */
   private Date eventEndDate;
 
-  /** Indicates whether not to include meta data in the response. */
+  /** Indicates whether not to include metadata in the response. */
   private boolean skipMeta;
 
   /** Page number. */
@@ -199,8 +177,7 @@ public class TrackedEntityQueryParams {
    */
   private Boolean potentialDuplicate;
 
-  /** TE order params */
-  private List<OrderParam> orders = new ArrayList<>();
+  private final List<Order> order = new ArrayList<>();
 
   // -------------------------------------------------------------------------
   // Transient properties
@@ -419,27 +396,27 @@ public class TrackedEntityQueryParams {
     return programEnrollmentEndDate != null;
   }
 
-  /** Indicates whether this parameters specifies a program incident start date. */
+  /** Indicates whether these parameters specify a program incident start date. */
   public boolean hasProgramIncidentStartDate() {
     return programIncidentStartDate != null;
   }
 
-  /** Indicates whether this parameters specifies a program incident end date. */
+  /** Indicates whether these parameters specify a program incident end date. */
   public boolean hasProgramIncidentEndDate() {
     return programIncidentEndDate != null;
   }
 
-  /** Indicates whether this parameters specifies a tracked entity. */
+  /** Indicates whether these parameters specify a tracked entity. */
   public boolean hasTrackedEntityType() {
     return trackedEntityType != null;
   }
 
-  /** Indicates whether this parameters is of the given organisation unit mode. */
+  /** Indicates whether these parameters are of the given organisation unit mode. */
   public boolean isOrganisationUnitMode(OrganisationUnitSelectionMode mode) {
     return orgUnitMode != null && orgUnitMode.equals(mode);
   }
 
-  /** Indicates whether this parameters specifies a programStage. */
+  /** Indicates whether these parameters specify a programStage. */
   public boolean hasProgramStage() {
     return programStage != null;
   }
@@ -456,12 +433,12 @@ public class TrackedEntityQueryParams {
     return this.eventStatus != null && this.eventStatus.equals(eventStatus);
   }
 
-  /** Indicates whether this parameters specifies an event start date. */
+  /** Indicates whether these parameters specify an event start date. */
   public boolean hasEventStartDate() {
     return eventStartDate != null;
   }
 
-  /** Indicates whether this parameters specifies an event end date. */
+  /** Indicates whether these parameters specify an event end date. */
   public boolean hasEventEndDate() {
     return eventEndDate != null;
   }
@@ -516,53 +493,6 @@ public class TrackedEntityQueryParams {
   public int getOffset() {
     return (getPageWithDefault() - 1) * getPageSizeWithDefault();
   }
-
-  // -------------------------------------------------------------------------
-  // toString
-  // -------------------------------------------------------------------------
-
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("query", query)
-        .add("attributes", attributes)
-        .add("filters", filters)
-        .add("orgUnits", orgUnits)
-        .add("program", program)
-        .add("programStatus", programStatus)
-        .add("followUp", followUp)
-        .add("lastUpdatedStartDate", lastUpdatedStartDate)
-        .add("lastUpdatedEndDate", lastUpdatedEndDate)
-        .add("lastUpdatedDuration", lastUpdatedDuration)
-        .add("programEnrollmentStartDate", programEnrollmentStartDate)
-        .add("programEnrollmentEndDate", programEnrollmentEndDate)
-        .add("programIncidentStartDate", programIncidentStartDate)
-        .add("programIncidentEndDate", programIncidentEndDate)
-        .add("trackedEntityType", trackedEntityType)
-        .add("orgUnitMode", orgUnitMode)
-        .add("assignedUserQueryParam", assignedUserQueryParam)
-        .add("eventStatus", eventStatus)
-        .add("eventStartDate", eventStartDate)
-        .add("eventEndDate", eventEndDate)
-        .add("skipMeta", skipMeta)
-        .add("page", page)
-        .add("pageSize", pageSize)
-        .add("totalPages", totalPages)
-        .add("skipPaging", skipPaging)
-        .add("includeDeleted", includeDeleted)
-        .add("includeAllAttributes", includeAllAttributes)
-        .add("internalSearch", internalSearch)
-        .add("synchronizationQuery", synchronizationQuery)
-        .add("skipChangedBefore", skipChangedBefore)
-        .add("orders", orders)
-        .add("user", user)
-        .add("potentialDuplicate", potentialDuplicate)
-        .toString();
-  }
-
-  // -------------------------------------------------------------------------
-  // Getters and setters
-  // -------------------------------------------------------------------------
 
   public QueryFilter getQuery() {
     return query;
@@ -853,39 +783,32 @@ public class TrackedEntityQueryParams {
     return internalSearch;
   }
 
-  public TrackedEntityQueryParams setInternalSearch(boolean internalSearch) {
-    this.internalSearch = internalSearch;
-    return this;
-  }
-
   public boolean isSynchronizationQuery() {
     return synchronizationQuery;
-  }
-
-  public TrackedEntityQueryParams setSynchronizationQuery(boolean synchronizationQuery) {
-    this.synchronizationQuery = synchronizationQuery;
-    return this;
   }
 
   public Date getSkipChangedBefore() {
     return skipChangedBefore;
   }
 
-  public TrackedEntityQueryParams setSkipChangedBefore(Date skipChangedBefore) {
-    this.skipChangedBefore = skipChangedBefore;
-    return this;
-  }
-
   public User getUser() {
     return user;
   }
 
-  public List<OrderParam> getOrders() {
-    return orders;
+  /** Order by an event field of the given {@code field} name in given sort {@code direction}. */
+  public TrackedEntityQueryParams orderBy(String field, SortDirection direction) {
+    this.order.add(new Order(field, direction));
+    return this;
   }
 
-  public void setOrders(List<OrderParam> orders) {
-    this.orders = orders;
+  /** Order by the given tracked entity attribute {@code tea} in given sort {@code direction}. */
+  public TrackedEntityQueryParams orderBy(TrackedEntityAttribute tea, SortDirection direction) {
+    this.order.add(new Order(tea, direction));
+    return this;
+  }
+
+  public List<Order> getOrder() {
+    return order;
   }
 
   public Set<String> getTrackedEntityUids() {
@@ -897,81 +820,11 @@ public class TrackedEntityQueryParams {
     return this;
   }
 
-  /**
-   * Set assigned user selection mode, assigned users and the current user for the query. Non-empty
-   * assigned users are only allowed with mode PROVIDED (or null).
-   *
-   * @param mode assigned user mode
-   * @param current current user with which query is made
-   * @param assignedUsers assigned user uids
-   * @return this
-   */
-  public TrackedEntityQueryParams setUserWithAssignedUsers(
-      AssignedUserSelectionMode mode, User current, Set<String> assignedUsers) {
-    this.assignedUserQueryParam = new AssignedUserQueryParam(mode, current, assignedUsers);
-    this.user = current;
-    return this;
-  }
-
   public List<TrackedEntityType> getTrackedEntityTypes() {
     return trackedEntityTypes;
   }
 
   public void setTrackedEntityTypes(List<TrackedEntityType> trackedEntityTypes) {
     this.trackedEntityTypes = trackedEntityTypes;
-  }
-
-  @Getter
-  @AllArgsConstructor
-  public enum OrderColumn {
-    TRACKEDENTITY("trackedEntity", "uid", MAIN_QUERY_ALIAS),
-    // TODO(tracker): remove with old tracker
-    CREATED("created", CREATED_ID, MAIN_QUERY_ALIAS),
-    CREATED_AT("createdAt", CREATED_ID, MAIN_QUERY_ALIAS),
-    CREATED_AT_CLIENT("createdAtClient", "createdatclient", MAIN_QUERY_ALIAS),
-    UPDATED_AT("updatedAt", "lastupdated", MAIN_QUERY_ALIAS),
-    UPDATED_AT_CLIENT("updatedAtClient", "lastupdatedatclient", MAIN_QUERY_ALIAS),
-    ENROLLED_AT(
-        "enrolledAt",
-        "enrollmentdate",
-        PROGRAM_INSTANCE_ALIAS), // this works only for the new endpoint
-    // ORGUNIT_NAME( "orgUnitName", MAIN_QUERY_ALIAS+".organisationUnit.name" ),
-    INACTIVE(INACTIVE_ID, "inactive", MAIN_QUERY_ALIAS);
-
-    private final String propName;
-
-    private final String column;
-
-    private final String tableAlias;
-
-    public boolean isPropertyEqualTo(String property) {
-      return propName.equalsIgnoreCase(property);
-    }
-
-    /**
-     * @param property
-     * @return an Optional of an OrderColumn matching by property name
-     */
-    public static Optional<OrderColumn> findColumn(String property) {
-      return Arrays.stream(values())
-          .filter(orderColumn -> orderColumn.getPropName().equals(property))
-          .findFirst();
-    }
-
-    /**
-     * @return a Sql string composed by the actual table alias and column. In use for the inner
-     *     query select fields and order by
-     */
-    public String getSqlColumnWithTableAlias() {
-      return tableAlias + "." + column;
-    }
-
-    /**
-     * @return a Sql string composed by the main query alias and column. In use for the outer query
-     *     select fields and order by
-     */
-    public String getSqlColumnWithMainTable() {
-      return MAIN_QUERY_ALIAS + "." + column;
-    }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
@@ -68,7 +68,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
-import org.hisp.dhis.tracker.Order;
+import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventSearchParamsTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventSearchParamsTest.java
@@ -38,7 +38,7 @@ import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
-import org.hisp.dhis.tracker.Order;
+import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
@@ -68,7 +68,6 @@ import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityService;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
-import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -118,7 +117,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
         TrackedEntityOperationParams.builder()
             .organisationUnits(Set.of(orgUnit.getUid()))
             .trackedEntityTypeUid(trackedEntityType.getUid())
-            .orders(List.of(OrderCriteria.of("numericAttr", SortDirection.ASC)));
+            .orderBy(UID.of("numericAttr"), SortDirection.ASC);
 
     TrackedEntityOperationParams params = builder.page(1).pageSize(3).build();
 
@@ -164,7 +163,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
         TrackedEntityOperationParams.builder()
             .organisationUnits(Set.of(orgUnit.getUid()))
             .trackedEntityTypeUid(trackedEntityType.getUid())
-            .orders(List.of(OrderCriteria.of("numericAttr", SortDirection.ASC)));
+            .orderBy(UID.of("numericAttr"), SortDirection.ASC);
 
     TrackedEntityOperationParams params = builder.page(1).pageSize(3).totalPages(true).build();
 
@@ -233,7 +232,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
             .organisationUnits(Set.of(orgUnit.getUid()))
             .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
             .trackedEntityTypeUid(trackedEntityType.getUid())
-            .orders(List.of(OrderCriteria.of("created", SortDirection.ASC)))
+            .orderBy("created", SortDirection.ASC)
             .build();
 
     List<String> trackedEntities = getTrackedEntities(params);
@@ -257,7 +256,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
             .organisationUnits(Set.of(orgUnit.getUid()))
             .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
             .trackedEntityTypeUid(trackedEntityType.getUid())
-            .orders(List.of(OrderCriteria.of("created", SortDirection.DESC)))
+            .orderBy("created", SortDirection.DESC)
             .build();
 
     List<String> trackedEntities = getTrackedEntities(params);
@@ -273,7 +272,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
             .organisationUnits(Set.of(orgUnit.getUid()))
             .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
             .trackedEntityTypeUid(trackedEntityType.getUid())
-            .orders(List.of(OrderCriteria.of("enrolledAt", SortDirection.ASC)))
+            .orderBy("enrollment.enrollmentDate", SortDirection.ASC)
             .build();
 
     List<String> trackedEntities = getTrackedEntities(params);
@@ -289,7 +288,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
             .organisationUnits(Set.of(orgUnit.getUid()))
             .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
             .trackedEntityTypeUid(trackedEntityType.getUid())
-            .orders(List.of(OrderCriteria.of("enrolledAt", SortDirection.DESC)))
+            .orderBy("enrollment.enrollmentDate", SortDirection.DESC)
             .build();
 
     List<String> trackedEntities = getTrackedEntities(params);
@@ -305,10 +304,8 @@ class OrderAndPaginationExporterTest extends TrackerTest {
             .organisationUnits(Set.of(orgUnit.getUid()))
             .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
             .trackedEntityTypeUid(trackedEntityType.getUid())
-            .orders(
-                List.of(
-                    OrderCriteria.of("toDelete000", SortDirection.ASC),
-                    OrderCriteria.of("enrolledAt", SortDirection.ASC)))
+            .orderBy(UID.of("toDelete000"), SortDirection.ASC)
+            .orderBy("enrollment.enrollmentDate", SortDirection.ASC)
             .build();
 
     List<String> trackedEntities = getTrackedEntities(params);
@@ -324,7 +321,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
             .organisationUnits(Set.of(orgUnit.getUid()))
             .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
             .trackedEntityTypeUid(trackedEntityType.getUid())
-            .orders(List.of(OrderCriteria.of("toUpdate000", SortDirection.ASC)))
+            .orderBy(UID.of("toUpdate000"), SortDirection.ASC)
             .build();
 
     List<String> trackedEntities = getTrackedEntities(params);
@@ -340,7 +337,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
             .organisationUnits(Set.of(orgUnit.getUid()))
             .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
             .trackedEntityTypeUid(trackedEntityType.getUid())
-            .orders(List.of(OrderCriteria.of("toUpdate000", SortDirection.DESC)))
+            .orderBy(UID.of("toUpdate000"), SortDirection.DESC)
             .build();
 
     List<String> trackedEntities = getTrackedEntities(params);
@@ -355,7 +352,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
         TrackedEntityOperationParams.builder()
             .organisationUnits(Set.of(orgUnit.getUid()))
             .trackedEntityTypeUid(trackedEntityType.getUid())
-            .orders(List.of(OrderCriteria.of("toUpdate000", SortDirection.ASC)))
+            .orderBy(UID.of("toUpdate000"), SortDirection.ASC)
             .filters("numericAttr:lt:75")
             .build();
 
@@ -371,7 +368,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
         TrackedEntityOperationParams.builder()
             .organisationUnits(Set.of(orgUnit.getUid()))
             .trackedEntityTypeUid(trackedEntityType.getUid())
-            .orders(List.of(OrderCriteria.of("numericAttr", SortDirection.DESC)))
+            .orderBy(UID.of("numericAttr"), SortDirection.DESC)
             .filters("numericAttr:lt:75")
             .build();
 
@@ -390,7 +387,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
             .trackedEntityUids(
                 Set.of(
                     "dUE514NMOlo", "QS6w44flWAf")) // TE QS6w44flWAf without attribute notUpdated0
-            .orders(List.of(OrderCriteria.of("notUpdated0", SortDirection.DESC)))
+            .orderBy(UID.of("notUpdated0"), SortDirection.DESC)
             .build();
 
     List<String> trackedEntities = getTrackedEntities(params);
@@ -409,10 +406,8 @@ class OrderAndPaginationExporterTest extends TrackerTest {
             .organisationUnits(Set.of(orgUnit.getUid()))
             .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
             .trackedEntityTypeUid(trackedEntityType.getUid())
-            .orders(
-                List.of(
-                    OrderCriteria.of("toDelete000", SortDirection.DESC),
-                    OrderCriteria.of("numericAttr", SortDirection.ASC)))
+            .orderBy(UID.of("toDelete000"), SortDirection.DESC)
+            .orderBy(UID.of("numericAttr"), SortDirection.ASC)
             .build();
 
     List<String> trackedEntities = getTrackedEntities(params);
@@ -428,10 +423,8 @@ class OrderAndPaginationExporterTest extends TrackerTest {
             .organisationUnits(Set.of(orgUnit.getUid()))
             .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
             .trackedEntityTypeUid(trackedEntityType.getUid())
-            .orders(
-                List.of(
-                    OrderCriteria.of("toDelete000", SortDirection.DESC),
-                    OrderCriteria.of("numericAttr", SortDirection.DESC)))
+            .orderBy(UID.of("toDelete000"), SortDirection.DESC)
+            .orderBy(UID.of("numericAttr"), SortDirection.DESC)
             .build();
 
     List<String> trackedEntities = getTrackedEntities(params);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
@@ -150,6 +150,7 @@ class EventRequestParamsMapper {
             .events(UID.toValueSet(eventUids))
             .enrollments(UID.toValueSet(requestParams.getEnrollments()))
             .includeDeleted(requestParams.isIncludeDeleted());
+
     mapOrderParam(builder, requestParams.getOrder());
 
     return builder.build();

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
@@ -69,7 +69,7 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
-import org.hisp.dhis.tracker.Order;
+import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.tracker.export.event.EventOperationParams;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;


### PR DESCRIPTION
* use the same `List<Order>` as in events added via typesafe `orderBy` methods
* validate attributes exist in the service layer (mapper)
* remove `List<OrderParam> orders` from `TrackedEntityQueryParams`
* move and hide SQL related constants from `TrackedEntityQueryParams` into `HibernateTrackedEntityStore`

`HibernateTrackedEntityStore` will be improved in follow up PRs (see next PRs). Tests added before this PR in https://github.com/dhis2/dhis2-core/pull/14829 should ensure that ordering, pagination + basic filtering still works.

# Next PR(s)

* simplify `HibernateTrackedEntityStore`. I don't quite get why we need to use different alias in the sub/main query. This adds some extra logic we do not seem to need in /tracker/events. Unless I am missing something. Ideally we could remove OrderColumn and simply rely on ORDERABLE_FIELDS as in events.
* can we move logic in `handleSortAttributes` into `TrackedEntityQueryParams` to follow ideal in https://github.com/dhis2/dhis2-core/pull/14784