### PR TITLE
chore: move handleSortAttributes into TrackedEntityQueryParams  TECH-1611

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -670,7 +670,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
 
   private void checkIfMaxTeiLimitIsReached(TrackedEntityQueryParams params, int maxTeiLimit) {
     if (maxTeiLimit > 0) {
-      int teCount = trackedEntityStore.getTrackedEntityCountForWithMaxTeiLimit(params);
+      int teCount = trackedEntityStore.getTrackedEntityCountWithMaxTrackedEntityLimit(params);
 
       if (teCount > maxTeiLimit) {
         throw new IllegalQueryException("maxteicountreached");

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -356,8 +356,6 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
       params.addFiltersIfNotExist(QueryItem.getQueryItems(attributes));
     }
 
-    handleSortAttributes(params);
-
     decideAccess(params);
 
     // AccessValidation should be skipped only and only if it is internal
@@ -371,26 +369,6 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
     }
 
     return trackedEntityStore.getTrackedEntityIds(params);
-  }
-
-  /**
-   * Attributes that are ordered by are added to the attribute list if neither are present in the
-   * attribute list nor the filter list.
-   *
-   * <p>For example, if attributes or filters don't have a specific trackedentityattribute uid, but
-   * sorting has been requested for that tea uid, then we need to add them to the attribute list.
-   */
-  private void handleSortAttributes(TrackedEntityQueryParams params) {
-    List<TrackedEntityAttribute> sortAttributes =
-        params.getOrder().stream()
-            .filter(o -> o.getField() instanceof TrackedEntityAttribute)
-            .map(o -> (TrackedEntityAttribute) o.getField())
-            .collect(Collectors.toList());
-
-    params.addAttributesIfNotExist(
-        QueryItem.getQueryItems(sortAttributes).stream()
-            .filter(sAtt -> !params.getFilters().contains(sAtt))
-            .collect(Collectors.toList()));
   }
 
   public void decideAccess(TrackedEntityQueryParams params) {
@@ -550,7 +528,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
       List<String> uniqueAttributeIds =
           trackedEntityAttributeService.getAllSystemWideUniqueTrackedEntityAttributes().stream()
               .map(TrackedEntityAttribute::getUid)
-              .collect(Collectors.toList());
+              .toList();
 
       for (String att : params.getAttributeAndFilterIds()) {
         if (!uniqueAttributeIds.contains(att)) {
@@ -587,7 +565,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
           searchableAttributeIds.addAll(
               trackedEntityAttributeService.getAllSystemWideUniqueTrackedEntityAttributes().stream()
                   .map(TrackedEntityAttribute::getUid)
-                  .collect(Collectors.toList()));
+                  .toList());
         }
 
         List<String> violatingAttributes = new ArrayList<>();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -106,7 +106,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
 
   private static final String PROGRAM_INSTANCE_ALIAS = "en";
 
-  private static final String DEFAULT_ORDER = "TE.te_id ASC";
+  private static final String DEFAULT_ORDER = "TE.trackedentityid desc";
 
   private static final String OFFSET = "OFFSET";
 
@@ -132,7 +132,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
 
   private static final String EV_STATUS = "EV.status";
 
-  private static final String SELECT_COUNT_INSTANCE_FROM = "SELECT count(te_id) FROM ( ";
+  private static final String SELECT_COUNT_INSTANCE_FROM = "SELECT count(trackedentityid) FROM ( ";
 
   /**
    * Tracked entities can be ordered by given fields which correspond to fields on {@link
@@ -192,7 +192,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     List<Long> ids = new ArrayList<>();
 
     while (rowSet.next()) {
-      ids.add(rowSet.getLong("te_id"));
+      ids.add(rowSet.getLong("trackedentityid"));
     }
 
     return ids;
@@ -341,7 +341,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     LinkedHashSet<String> select =
         new LinkedHashSet<>(
             List.of(
-                "te_id",
+                "TE.trackedentityid",
                 "te_uid",
                 "te_created",
                 "te_lastupdated",
@@ -415,7 +415,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     LinkedHashSet<String> columns =
         new LinkedHashSet<>(
             List.of(
-                "TE.trackedentityid as te_id",
+                "TE.trackedentityid as trackedentityid",
                 "TE.trackedentitytypeid as te_type_id",
                 "TE.uid as te_uid",
                 "TE.created as te_created",
@@ -1013,7 +1013,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
 
       relatedTables
           .append("LEFT JOIN trackedentityattributevalue TEAV ")
-          .append("ON TEAV.trackedentityid = TE.te_id ")
+          .append("ON TEAV.trackedentityid = TE.trackedentityid ")
           .append("AND TEAV.trackedentityattributeid IN (")
           .append(attributeString)
           .append(") ");
@@ -1073,6 +1073,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
 
     if (params.getAttributesAndFilters().stream()
         .noneMatch(qi -> qi.hasFilter() && qi.isUnique())) {
+      // TODO(ivo) in an inner query it should use TE.trackedentityid and not the alias
       return "ORDER BY " + DEFAULT_ORDER + " ";
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapper.java
@@ -101,14 +101,15 @@ class TrackedEntityOperationParamsMapper {
         attributeService.getAllTrackedEntityAttributes().stream()
             .collect(Collectors.toMap(TrackedEntityAttribute::getUid, att -> att));
 
+    TrackedEntityQueryParams params = new TrackedEntityQueryParams();
+
     List<QueryItem> attributeItems =
         parseAttributeQueryItems(operationParams.getAttributes(), attributes);
+    params.setAttributes(attributeItems);
 
     List<QueryItem> filters = parseAttributeQueryItems(operationParams.getFilters(), attributes);
-
     validateDuplicatedAttributeFilters(filters);
-
-    TrackedEntityQueryParams params = new TrackedEntityQueryParams();
+    params.setFilters(filters);
 
     mapOrderParam(params, operationParams.getOrder());
 
@@ -134,8 +135,6 @@ class TrackedEntityOperationParamsMapper {
         .setAssignedUserQueryParam(operationParams.getAssignedUserQueryParam())
         .setUser(user)
         .setTrackedEntityUids(operationParams.getTrackedEntityUids())
-        .setAttributes(attributeItems)
-        .setFilters(filters)
         .setSkipMeta(operationParams.isSkipMeta())
         .setPage(operationParams.getPage())
         .setPageSize(operationParams.getPageSize())

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
@@ -192,22 +192,6 @@ public class TrackedEntityQueryParams {
 
   public TrackedEntityQueryParams() {}
 
-  // -------------------------------------------------------------------------
-  // Logic
-  // -------------------------------------------------------------------------
-
-  /** Adds a query item as attribute to the parameters. */
-  public TrackedEntityQueryParams addAttribute(QueryItem attribute) {
-    this.attributes.add(attribute);
-    return this;
-  }
-
-  /** Adds a query item as filter to the parameters. */
-  public TrackedEntityQueryParams addFilter(QueryItem filter) {
-    this.filters.add(filter);
-    return this;
-  }
-
   /** Adds an organisation unit to the parameters. */
   public TrackedEntityQueryParams addOrganisationUnit(OrganisationUnit unit) {
     this.orgUnits.add(unit);
@@ -801,9 +785,17 @@ public class TrackedEntityQueryParams {
     return this;
   }
 
-  /** Order by the given tracked entity attribute {@code tea} in given sort {@code direction}. */
+  /**
+   * Order by the given tracked entity attribute {@code tea} in given sort {@code direction}.
+   * Attributes are added to the attribute list if neither are present in the attribute list nor the
+   * filter list.
+   */
   public TrackedEntityQueryParams orderBy(TrackedEntityAttribute tea, SortDirection direction) {
     this.order.add(new Order(tea, direction));
+    this.addAttributesIfNotExist(
+        QueryItem.getQueryItems(List.of(tea)).stream()
+            .filter(sAtt -> !this.getFilters().contains(sAtt))
+            .collect(Collectors.toList()));
     return this;
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
@@ -795,7 +795,7 @@ public class TrackedEntityQueryParams {
     this.addAttributesIfNotExist(
         QueryItem.getQueryItems(List.of(tea)).stream()
             .filter(sAtt -> !this.getFilters().contains(sAtt))
-            .collect(Collectors.toList()));
+            .toList());
     return this;
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityStore.java
@@ -38,5 +38,5 @@ interface TrackedEntityStore extends IdentifiableObjectStore<TrackedEntity> {
 
   int getTrackedEntityCount(TrackedEntityQueryParams params);
 
-  int getTrackedEntityCountForWithMaxTeiLimit(TrackedEntityQueryParams params);
+  int getTrackedEntityCountWithMaxTrackedEntityLimit(TrackedEntityQueryParams params);
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
@@ -201,13 +201,13 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldOrderTrackedEntitiesByPrimaryKeyAscByDefault()
+  void shouldOrderTrackedEntitiesByPrimaryKeyDescByDefault()
       throws ForbiddenException, BadRequestException, NotFoundException {
     TrackedEntity QS6w44flWAf = get(TrackedEntity.class, "QS6w44flWAf");
     TrackedEntity dUE514NMOlo = get(TrackedEntity.class, "dUE514NMOlo");
     List<String> expected =
         Stream.of(QS6w44flWAf, dUE514NMOlo)
-            .sorted(Comparator.comparing(TrackedEntity::getId)) // asc
+            .sorted(Comparator.comparing(TrackedEntity::getId).reversed()) // reversed = desc
             .map(TrackedEntity::getUid)
             .toList();
 

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
@@ -131,6 +131,29 @@ if `assignedUserMode` is either `PROVIDED` or not specified.
 
 ### `*.parameter.TrackedEntityRequestParams.potentialDuplicate`
 
+### `*.parameter.TrackedEntityRequestParams.order`
+
+`<propertyName1:sortDirection>[,<propertyName2:sortDirection>...]`
+
+Get tracked entities in given order. Tracked entities can be ordered by tracked entity attributes by
+passing a UID instead of a property name. This will order tracked entities by the values of the
+specified attribute not their UIDs. Tracked entities can also be ordered by the following
+case-sensitive properties
+
+* `createdAt`
+* `createdAtClient`
+* `enrolledAt`
+* `inactive`
+* `trackedEntity`
+* `updatedAt`
+* `updatedAtClient`
+
+Valid `sortDirection`s are `asc` and `desc`. `sortDirection` is case-insensitive. `sortDirection`
+defaults to `asc` for properties or UIDs without explicit `sortDirection` as in `order=createdAt`.
+
+Tracked entities are ordered by newest (internal id desc) by default meaning when no `order`
+parameter is provided.
+
 ### `*.parameter.TrackedEntityRequestParams.fields`
 
 Get only the specified fields in the JSON response. This query parameter allows you to remove


### PR DESCRIPTION
* test `attribute` and `filter`. It's interesting that `attribute=uid` does not seem to have an effect. It adds a left join on the attribute. This is different than `/tracker/events?filterAttribute=uid` which filters out events of TE without such attribute. Not clear what `attribute=uid` is actually for.
* remove unused methods in `TrackedEntityQueryParams`
* move handleSortAttributes into `TrackedEntityQueryParams` similar to [EventSearchParams](https://github.com/dhis2/dhis2-core/pull/14784). It should be hard to misuse TrackedEntityQueryParams. User of it should not have to remember to add the order tea into attributes with all the conditions of when to do it.
* document ordering capabilities of `/tracker/trackedEntities`
* order by default by primary key desc as we now also do for events