### PR TITLE
chore: do not allow disabling Java formatter [2.39]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/orgunit/handler/DataOrgUnitMergeHandler.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/orgunit/handler/DataOrgUnitMergeHandler.java
@@ -93,32 +93,34 @@ public class DataOrgUnitMergeHandler {
   }
 
   private String getMergeDataValuesLastUpdatedSql(OrgUnitMergeRequest request) {
-    // @formatter:off
     return String.format(
         // Delete existing target data values
-        "delete from datavalue where sourceid = :target_id; " +
-        // Insert target data values for last modified source data values
-        "with dv_rank as ( " +
+        "delete from datavalue where sourceid = :target_id; "
+            +
+            // Insert target data values for last modified source data values
+            "with dv_rank as ( "
+            +
             // Window over data value sources ranked by last modification
-            "select dv.*, row_number() over (" +
-                "partition by dv.dataelementid, dv.periodid, dv.categoryoptioncomboid, dv.attributeoptioncomboid " +
-                "order by dv.lastupdated desc, dv.created desc) as lastupdated_rank " +
-            "from datavalue dv " +
-            "where dv.sourceid in (:source_ids) " +
-            "and dv.deleted is false" +
-        ") " +
-        // Insert target data values
-        "insert into datavalue (" +
-            "dataelementid, periodid, sourceid, categoryoptioncomboid, attributeoptioncomboid, " +
-            "value, storedby, created, lastupdated, comment, followup, deleted) " +
-        "select dataelementid, periodid, %s, categoryoptioncomboid, attributeoptioncomboid, " +
-            "value, storedby, created, lastupdated, comment, followup, false " +
-        "from dv_rank " +
-        "where dv_rank.lastupdated_rank = 1; " +
-        // Delete source data values
-        "delete from datavalue where sourceid in (:source_ids);",
-        request.getTarget().getId() );
-    // @formatter:on
+            "select dv.*, row_number() over ("
+            + "partition by dv.dataelementid, dv.periodid, dv.categoryoptioncomboid, dv.attributeoptioncomboid "
+            + "order by dv.lastupdated desc, dv.created desc) as lastupdated_rank "
+            + "from datavalue dv "
+            + "where dv.sourceid in (:source_ids) "
+            + "and dv.deleted is false"
+            + ") "
+            +
+            // Insert target data values
+            "insert into datavalue ("
+            + "dataelementid, periodid, sourceid, categoryoptioncomboid, attributeoptioncomboid, "
+            + "value, storedby, created, lastupdated, comment, followup, deleted) "
+            + "select dataelementid, periodid, %s, categoryoptioncomboid, attributeoptioncomboid, "
+            + "value, storedby, created, lastupdated, comment, followup, false "
+            + "from dv_rank "
+            + "where dv_rank.lastupdated_rank = 1; "
+            +
+            // Delete source data values
+            "delete from datavalue where sourceid in (:source_ids);",
+        request.getTarget().getId());
   }
 
   public void mergeDataApprovalAudits(OrgUnitMergeRequest request) {
@@ -145,7 +147,6 @@ public class DataOrgUnitMergeHandler {
   }
 
   private String getMergeDataApprovalsLastUpdatedSql(OrgUnitMergeRequest request) {
-    // @formatter:off
     return String.format(
         // Delete existing target data approvals
         "delete from dataapproval where organisationunitid = :target_id; "
@@ -173,7 +174,6 @@ public class DataOrgUnitMergeHandler {
             // Delete source data approvals
             "delete from dataapproval where organisationunitid in (:source_ids);",
         request.getTarget().getId());
-    // @formatter:on
   }
 
   public void mergeLockExceptions(OrgUnitMergeRequest request) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/PersistablesFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/PersistablesFilterTest.java
@@ -66,20 +66,17 @@ import org.junit.jupiter.api.Test;
 class PersistablesFilterTest {
   @Test
   void testCreateAndUpdateValidEntitiesCanBePersisted() {
-    // @formatter:off
-    Setup setup = new Setup.Builder()
-        .trackedEntity( "xK7H53f4Hc2" )
-            .enrollment( "t1zaUjKgT3p" )
-                .event( "Qck4PQ7TMun" )
-        .trackedEntity( "QxGbKYwChDM" )
-            .enrollment( "Ok4Fe5moc3N" )
-                .event( "Ox1qBWsnVwE" )
-                .event( "jNyGqnwryNi" )
-        .relationship("Te3IC6TpnBB",
-            trackedEntity("xK7H53f4Hc2"),
-            trackedEntity("QxGbKYwChDM") )
-        .build();
-    // @formatter:on
+    Setup setup =
+        new Setup.Builder()
+            .trackedEntity("xK7H53f4Hc2")
+            .enrollment("t1zaUjKgT3p")
+            .event("Qck4PQ7TMun")
+            .trackedEntity("QxGbKYwChDM")
+            .enrollment("Ok4Fe5moc3N")
+            .event("Ox1qBWsnVwE")
+            .event("jNyGqnwryNi")
+            .relationship("Te3IC6TpnBB", trackedEntity("xK7H53f4Hc2"), trackedEntity("QxGbKYwChDM"))
+            .build();
 
     PersistablesFilter.Result persistable =
         filter(setup.bundle, setup.invalidEntities, TrackerImportStrategy.CREATE_AND_UPDATE);
@@ -96,17 +93,18 @@ class PersistablesFilterTest {
 
   @Test
   void testCreateAndUpdateValidEntitiesReferencingParentsNotInPayload() {
-    // @formatter:off
-    Setup setup = new Setup.Builder()
-            .trackedEntity( "xK7H53f4Hc2" ).isInDB().isNotInPayload()
-                .enrollment( "t1zaUjKgT3p")
-            .enrollment( "Ok4Fe5moc3N").isInDB().isNotInPayload()
-                .event( "Ox1qBWsnVwE" )
-            .relationship("Te3IC6TpnBB",
-                    trackedEntity("xK7H53f4Hc2"),
-                    enrollment("Ok4Fe5moc3N") )
+    Setup setup =
+        new Setup.Builder()
+            .trackedEntity("xK7H53f4Hc2")
+            .isInDB()
+            .isNotInPayload()
+            .enrollment("t1zaUjKgT3p")
+            .enrollment("Ok4Fe5moc3N")
+            .isInDB()
+            .isNotInPayload()
+            .event("Ox1qBWsnVwE")
+            .relationship("Te3IC6TpnBB", trackedEntity("xK7H53f4Hc2"), enrollment("Ok4Fe5moc3N"))
             .build();
-    // @formatter:on
 
     PersistablesFilter.Result persistable =
         filter(setup.bundle, setup.invalidEntities, TrackerImportStrategy.CREATE_AND_UPDATE);
@@ -121,13 +119,15 @@ class PersistablesFilterTest {
 
   @Test
   void testCreateAndUpdateValidEntitiesCanBePersistedIfTheyExist() {
-    // @formatter:off
-    Setup setup = new Setup.Builder()
-        .trackedEntity( "xK7H53f4Hc2" ).isInDB()
-        .enrollment( "t1zaUjKgT3p" ).isInDB()
-        .event( "Qck4PQ7TMun" ).isInDB()
-        .build();
-    // @formatter:on
+    Setup setup =
+        new Setup.Builder()
+            .trackedEntity("xK7H53f4Hc2")
+            .isInDB()
+            .enrollment("t1zaUjKgT3p")
+            .isInDB()
+            .event("Qck4PQ7TMun")
+            .isInDB()
+            .build();
 
     PersistablesFilter.Result persistable =
         filter(setup.bundle, setup.invalidEntities, TrackerImportStrategy.CREATE_AND_UPDATE);
@@ -141,12 +141,13 @@ class PersistablesFilterTest {
 
   @Test
   void testCreateAndUpdateValidEnrollmentOfInvalidTeiCanBeUpdatedIfTeiExists() {
-    // @formatter:off
-    Setup setup = new Setup.Builder()
-        .trackedEntity( "xK7H53f4Hc2" ).isNotValid().isInDB()
-            .enrollment( "t1zaUjKgT3p" )
-        .build();
-    // @formatter:on
+    Setup setup =
+        new Setup.Builder()
+            .trackedEntity("xK7H53f4Hc2")
+            .isNotValid()
+            .isInDB()
+            .enrollment("t1zaUjKgT3p")
+            .build();
 
     PersistablesFilter.Result persistable =
         filter(setup.bundle, setup.invalidEntities, TrackerImportStrategy.CREATE_AND_UPDATE);
@@ -159,12 +160,12 @@ class PersistablesFilterTest {
 
   @Test
   void testCreateAndUpdateValidEnrollmentOfInvalidTeiCannotBeUpdatedIfTeiDoesNotExist() {
-    // @formatter:off
-    Setup setup = new Setup.Builder()
-        .trackedEntity( "xK7H53f4Hc2" ).isNotValid()
-            .enrollment( "t1zaUjKgT3p" )
-        .build();
-    // @formatter:on
+    Setup setup =
+        new Setup.Builder()
+            .trackedEntity("xK7H53f4Hc2")
+            .isNotValid()
+            .enrollment("t1zaUjKgT3p")
+            .build();
 
     PersistablesFilter.Result persistable =
         filter(setup.bundle, setup.invalidEntities, TrackerImportStrategy.CREATE_AND_UPDATE);
@@ -183,13 +184,14 @@ class PersistablesFilterTest {
 
   @Test
   void testCreateAndUpdateValidEventOfInvalidEnrollmentCanBeUpdatedIfEnrollmentExists() {
-    // @formatter:off
-    Setup setup = new Setup.Builder()
-        .trackedEntity( "xK7H53f4Hc2" )
-            .enrollment( "t1zaUjKgT3p" ).isNotValid().isInDB()
-                .event( "Qck4PQ7TMun" )
-        .build();
-    // @formatter:on
+    Setup setup =
+        new Setup.Builder()
+            .trackedEntity("xK7H53f4Hc2")
+            .enrollment("t1zaUjKgT3p")
+            .isNotValid()
+            .isInDB()
+            .event("Qck4PQ7TMun")
+            .build();
 
     PersistablesFilter.Result persistable =
         filter(setup.bundle, setup.invalidEntities, TrackerImportStrategy.CREATE_AND_UPDATE);
@@ -203,13 +205,13 @@ class PersistablesFilterTest {
 
   @Test
   void testCreateAndUpdateValidEventOfInvalidEnrollmentCannotBeCreatedIfEnrollmentDoesNotExist() {
-    // @formatter:off
-    Setup setup = new Setup.Builder()
-        .trackedEntity( "xK7H53f4Hc2" )
-            .enrollment( "t1zaUjKgT3p" ).isNotValid()
-                .event( "Qck4PQ7TMun" )
-        .build();
-    // @formatter:on
+    Setup setup =
+        new Setup.Builder()
+            .trackedEntity("xK7H53f4Hc2")
+            .enrollment("t1zaUjKgT3p")
+            .isNotValid()
+            .event("Qck4PQ7TMun")
+            .build();
 
     PersistablesFilter.Result persistable =
         filter(setup.bundle, setup.invalidEntities, TrackerImportStrategy.CREATE_AND_UPDATE);
@@ -225,13 +227,13 @@ class PersistablesFilterTest {
 
   @Test
   void testCreateAndUpdateInvalidEventOfValidEnrollmentCannotBePersisted() {
-    // @formatter:off
-    Setup setup = new Setup.Builder()
-        .trackedEntity( "xK7H53f4Hc2" )
-            .enrollment( "t1zaUjKgT3p" )
-                .event( "Qck4PQ7TMun" ).isNotValid()
-        .build();
-    // @formatter:on
+    Setup setup =
+        new Setup.Builder()
+            .trackedEntity("xK7H53f4Hc2")
+            .enrollment("t1zaUjKgT3p")
+            .event("Qck4PQ7TMun")
+            .isNotValid()
+            .build();
 
     PersistablesFilter.Result persistable =
         filter(setup.bundle, setup.invalidEntities, TrackerImportStrategy.CREATE_AND_UPDATE);
@@ -245,16 +247,13 @@ class PersistablesFilterTest {
 
   @Test
   void testCreateAndUpdateInvalidRelationshipCannotBePersisted() {
-    // @formatter:off
-    Setup setup = new Setup.Builder()
-            .trackedEntity( "xK7H53f4Hc2" )
-            .trackedEntity( "QxGbKYwChDM" )
-            .relationship("Te3IC6TpnBB",
-                    trackedEntity("xK7H53f4Hc2"),
-                    trackedEntity("QxGbKYwChDM")
-                ).isNotValid()
+    Setup setup =
+        new Setup.Builder()
+            .trackedEntity("xK7H53f4Hc2")
+            .trackedEntity("QxGbKYwChDM")
+            .relationship("Te3IC6TpnBB", trackedEntity("xK7H53f4Hc2"), trackedEntity("QxGbKYwChDM"))
+            .isNotValid()
             .build();
-    // @formatter:on
 
     PersistablesFilter.Result persistable =
         filter(setup.bundle, setup.invalidEntities, TrackerImportStrategy.CREATE_AND_UPDATE);
@@ -267,15 +266,14 @@ class PersistablesFilterTest {
 
   @Test
   void testCreateAndUpdateValidRelationshipWithInvalidButExistingFrom() {
-    // @formatter:off
-    Setup setup = new Setup.Builder()
-        .trackedEntity( "xK7H53f4Hc2" ).isNotValid().isInDB()
-        .trackedEntity( "QxGbKYwChDM" )
-        .relationship("Te3IC6TpnBB",
-            trackedEntity("xK7H53f4Hc2"),
-            trackedEntity("QxGbKYwChDM") )
-        .build();
-    // @formatter:on
+    Setup setup =
+        new Setup.Builder()
+            .trackedEntity("xK7H53f4Hc2")
+            .isNotValid()
+            .isInDB()
+            .trackedEntity("QxGbKYwChDM")
+            .relationship("Te3IC6TpnBB", trackedEntity("xK7H53f4Hc2"), trackedEntity("QxGbKYwChDM"))
+            .build();
 
     PersistablesFilter.Result persistable =
         filter(setup.bundle, setup.invalidEntities, TrackerImportStrategy.CREATE_AND_UPDATE);
@@ -288,15 +286,13 @@ class PersistablesFilterTest {
 
   @Test
   void testCreateAndUpdateValidRelationshipWithInvalidFromCannotBeCreated() {
-    // @formatter:off
-    Setup setup = new Setup.Builder()
-            .trackedEntity( "xK7H53f4Hc2" )
-                .enrollment( "QxGbKYwChDM" ).isNotValid()
-            .relationship("Te3IC6TpnBB",
-                enrollment("QxGbKYwChDM"),
-                trackedEntity("xK7H53f4Hc2") )
+    Setup setup =
+        new Setup.Builder()
+            .trackedEntity("xK7H53f4Hc2")
+            .enrollment("QxGbKYwChDM")
+            .isNotValid()
+            .relationship("Te3IC6TpnBB", enrollment("QxGbKYwChDM"), trackedEntity("xK7H53f4Hc2"))
             .build();
-    // @formatter:on
 
     PersistablesFilter.Result persistable =
         filter(setup.bundle, setup.invalidEntities, TrackerImportStrategy.CREATE_AND_UPDATE);
@@ -315,16 +311,14 @@ class PersistablesFilterTest {
 
   @Test
   void testCreateAndUpdateValidRelationshipWithInvalidToCannotBeCreated() {
-    // @formatter:off
-    Setup setup = new Setup.Builder()
-            .trackedEntity( "xK7H53f4Hc2" )
-                .enrollment( "QxGbKYwChDM" )
-                    .event( "QxGbKYwChDM" ).isNotValid()
-            .relationship("Te3IC6TpnBB",
-                trackedEntity("xK7H53f4Hc2"),
-                event("QxGbKYwChDM") )
+    Setup setup =
+        new Setup.Builder()
+            .trackedEntity("xK7H53f4Hc2")
+            .enrollment("QxGbKYwChDM")
+            .event("QxGbKYwChDM")
+            .isNotValid()
+            .relationship("Te3IC6TpnBB", trackedEntity("xK7H53f4Hc2"), event("QxGbKYwChDM"))
             .build();
-    // @formatter:on
 
     PersistablesFilter.Result persistable =
         filter(setup.bundle, setup.invalidEntities, TrackerImportStrategy.CREATE_AND_UPDATE);
@@ -349,16 +343,15 @@ class PersistablesFilterTest {
     // validation report. Only add errors if it would not be clear why an entity cannot be
     // persisted.
 
-    // @formatter:off
-    Setup setup = new Setup.Builder()
-        .trackedEntity( "xK7H53f4Hc2" ).isNotValid()
-        .enrollment( "t1zaUjKgT3p" ).isNotValid()
-        .relationship("Te3IC6TpnBB",
-            trackedEntity("xK7H53f4Hc2"),
-            enrollment("t1zaUjKgT3p")
-        ).isNotValid()
-        .build();
-    // @formatter:on
+    Setup setup =
+        new Setup.Builder()
+            .trackedEntity("xK7H53f4Hc2")
+            .isNotValid()
+            .enrollment("t1zaUjKgT3p")
+            .isNotValid()
+            .relationship("Te3IC6TpnBB", trackedEntity("xK7H53f4Hc2"), enrollment("t1zaUjKgT3p"))
+            .isNotValid()
+            .build();
 
     PersistablesFilter.Result persistable =
         filter(setup.bundle, setup.invalidEntities, TrackerImportStrategy.CREATE_AND_UPDATE);
@@ -372,20 +365,17 @@ class PersistablesFilterTest {
 
   @Test
   void testDeleteValidEntitiesCanBeDeleted() {
-    // @formatter:off
-    Setup setup = new Setup.Builder()
-            .trackedEntity( "xK7H53f4Hc2" )
-                .enrollment( "t1zaUjKgT3p" )
-                    .event( "Qck4PQ7TMun" )
-            .trackedEntity( "QxGbKYwChDM" )
-                .enrollment( "Ok4Fe5moc3N" )
-                    .event( "Ox1qBWsnVwE" )
-                    .event( "jNyGqnwryNi" )
-            .relationship("Te3IC6TpnBB",
-                trackedEntity("xK7H53f4Hc2"),
-                trackedEntity("QxGbKYwChDM") )
+    Setup setup =
+        new Setup.Builder()
+            .trackedEntity("xK7H53f4Hc2")
+            .enrollment("t1zaUjKgT3p")
+            .event("Qck4PQ7TMun")
+            .trackedEntity("QxGbKYwChDM")
+            .enrollment("Ok4Fe5moc3N")
+            .event("Ox1qBWsnVwE")
+            .event("jNyGqnwryNi")
+            .relationship("Te3IC6TpnBB", trackedEntity("xK7H53f4Hc2"), trackedEntity("QxGbKYwChDM"))
             .build();
-    // @formatter:on
 
     PersistablesFilter.Result persistable =
         filter(setup.bundle, setup.invalidEntities, TrackerImportStrategy.DELETE);
@@ -402,14 +392,14 @@ class PersistablesFilterTest {
 
   @Test
   void testDeleteInvalidTrackedEntityCannotBeDeletedButItsChildrenCan() {
-    // @formatter:off
-    Setup setup = new Setup.Builder()
-            .trackedEntity( "xK7H53f4Hc2" ).isNotValid()
-                .enrollment( "t1zaUjKgT3p" )
-                    .event( "Qck4PQ7TMun" )
-                    .event( "Ox1qBWsnVwE" )
+    Setup setup =
+        new Setup.Builder()
+            .trackedEntity("xK7H53f4Hc2")
+            .isNotValid()
+            .enrollment("t1zaUjKgT3p")
+            .event("Qck4PQ7TMun")
+            .event("Ox1qBWsnVwE")
             .build();
-    // @formatter:on
 
     PersistablesFilter.Result persistable =
         filter(setup.bundle, setup.invalidEntities, TrackerImportStrategy.DELETE);
@@ -428,16 +418,15 @@ class PersistablesFilterTest {
     // validation report. Only add errors if it would not be clear why an entity cannot be
     // persisted.
 
-    // @formatter:off
-    Setup setup = new Setup.Builder()
-            .trackedEntity( "xK7H53f4Hc2" ).isNotValid()
-                .enrollment( "t1zaUjKgT3p" ).isNotValid()
-            .relationship("Te3IC6TpnBB",
-                    trackedEntity("xK7H53f4Hc2"),
-                    enrollment("t1zaUjKgT3p")
-                ).isNotValid()
+    Setup setup =
+        new Setup.Builder()
+            .trackedEntity("xK7H53f4Hc2")
+            .isNotValid()
+            .enrollment("t1zaUjKgT3p")
+            .isNotValid()
+            .relationship("Te3IC6TpnBB", trackedEntity("xK7H53f4Hc2"), enrollment("t1zaUjKgT3p"))
+            .isNotValid()
             .build();
-    // @formatter:on
 
     PersistablesFilter.Result persistable =
         filter(setup.bundle, setup.invalidEntities, TrackerImportStrategy.DELETE);
@@ -451,19 +440,16 @@ class PersistablesFilterTest {
 
   @Test
   void testDeleteInvalidRelationshipPreventsDeletionOfTrackedEntityAndEvent() {
-    // @formatter:off
-    Setup setup = new Setup.Builder()
-            .trackedEntity( "xK7H53f4Hc2" )
-                .enrollment( "t1zaUjKgT3p" )
-                    .event( "Qck4PQ7TMun" )
-            .trackedEntity( "QxGbKYwChDM" )
-                .enrollment( "Ok4Fe5moc3N" )
-            .relationship("Te3IC6TpnBB",
-                    trackedEntity("xK7H53f4Hc2"),
-                    event("Qck4PQ7TMun")
-                ).isNotValid()
+    Setup setup =
+        new Setup.Builder()
+            .trackedEntity("xK7H53f4Hc2")
+            .enrollment("t1zaUjKgT3p")
+            .event("Qck4PQ7TMun")
+            .trackedEntity("QxGbKYwChDM")
+            .enrollment("Ok4Fe5moc3N")
+            .relationship("Te3IC6TpnBB", trackedEntity("xK7H53f4Hc2"), event("Qck4PQ7TMun"))
+            .isNotValid()
             .build();
-    // @formatter:on
 
     PersistablesFilter.Result persistable =
         filter(setup.bundle, setup.invalidEntities, TrackerImportStrategy.DELETE);
@@ -494,19 +480,16 @@ class PersistablesFilterTest {
 
   @Test
   void testDeleteInvalidRelationshipPreventsDeletionOfEnrollmentAndEvent() {
-    // @formatter:off
-    Setup setup = new Setup.Builder()
-            .trackedEntity( "xK7H53f4Hc2" )
-                .enrollment( "t1zaUjKgT3p" )
-                    .event( "QxGbKYwChDM" )
-                    .event( "Ox1qBWsnVwE" )
-                .enrollment( "Ok4Fe5moc3N" )
-            .relationship("Te3IC6TpnBB",
-                    event("QxGbKYwChDM"),
-                    enrollment("t1zaUjKgT3p")
-                ).isNotValid()
+    Setup setup =
+        new Setup.Builder()
+            .trackedEntity("xK7H53f4Hc2")
+            .enrollment("t1zaUjKgT3p")
+            .event("QxGbKYwChDM")
+            .event("Ox1qBWsnVwE")
+            .enrollment("Ok4Fe5moc3N")
+            .relationship("Te3IC6TpnBB", event("QxGbKYwChDM"), enrollment("t1zaUjKgT3p"))
+            .isNotValid()
             .build();
-    // @formatter:on
 
     PersistablesFilter.Result persistable =
         filter(setup.bundle, setup.invalidEntities, TrackerImportStrategy.DELETE);
@@ -534,16 +517,14 @@ class PersistablesFilterTest {
 
   @Test
   void testDeleteValidRelationshipWithInvalidFrom() {
-    // @formatter:off
-    Setup setup = new Setup.Builder()
-            .trackedEntity( "QxGbKYwChDM" )
-            .trackedEntity( "xK7H53f4Hc2" )
-                .enrollment( "t1zaUjKgT3p" ).isNotValid()
-            .relationship("Te3IC6TpnBB",
-                    enrollment("t1zaUjKgT3p"),
-                    trackedEntity("QxGbKYwChDM") )
+    Setup setup =
+        new Setup.Builder()
+            .trackedEntity("QxGbKYwChDM")
+            .trackedEntity("xK7H53f4Hc2")
+            .enrollment("t1zaUjKgT3p")
+            .isNotValid()
+            .relationship("Te3IC6TpnBB", enrollment("t1zaUjKgT3p"), trackedEntity("QxGbKYwChDM"))
             .build();
-    // @formatter:on
 
     PersistablesFilter.Result persistable =
         filter(setup.bundle, setup.invalidEntities, TrackerImportStrategy.DELETE);
@@ -556,17 +537,18 @@ class PersistablesFilterTest {
 
   @Test
   void testDeleteValidEntitiesReferencingParentsNotInPayload() {
-    // @formatter:off
-    Setup setup = new Setup.Builder()
-            .trackedEntity( "xK7H53f4Hc2").isInDB().isNotInPayload()
-            .enrollment( "t1zaUjKgT3p")
-            .enrollment( "Ok4Fe5moc3N").isInDB().isNotInPayload()
-            .event( "Ox1qBWsnVwE" )
-            .relationship("Te3IC6TpnBB",
-                    trackedEntity("xK7H53f4Hc2"),
-                    enrollment("Ok4Fe5moc3N") )
+    Setup setup =
+        new Setup.Builder()
+            .trackedEntity("xK7H53f4Hc2")
+            .isInDB()
+            .isNotInPayload()
+            .enrollment("t1zaUjKgT3p")
+            .enrollment("Ok4Fe5moc3N")
+            .isInDB()
+            .isNotInPayload()
+            .event("Ox1qBWsnVwE")
+            .relationship("Te3IC6TpnBB", trackedEntity("xK7H53f4Hc2"), enrollment("Ok4Fe5moc3N"))
             .build();
-    // @formatter:on
 
     PersistablesFilter.Result persistable =
         filter(setup.bundle, setup.invalidEntities, TrackerImportStrategy.DELETE);

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/dataanalysis/jdbc/JdbcDataAnalysisStore.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/dataanalysis/jdbc/JdbcDataAnalysisStore.java
@@ -157,29 +157,37 @@ public class JdbcDataAnalysisStore implements DataAnalysisStore {
     String periodIds = getCommaDelimitedString(getIdentifiers(periods));
     String categoryOptionComboIds = getCommaDelimitedString(getIdentifiers(categoryOptionCombos));
 
-    // @formatter:off
     String sql =
-        "select dv.dataelementid, dv.periodid, dv.sourceid, dv.categoryoptioncomboid, dv.attributeoptioncomboid, " +
-            "dv.value, dv.storedby, dv.lastupdated, " +
-            "dv.created, dv.comment, dv.followup, ou.name as sourcename, de.name as dataelementname, " +
-            "pt.name as periodtypename, pe.startdate, pe.enddate, coc.name as categoryoptioncomboname, " +
-            "mm.minimumvalue, mm.maximumvalue " +
-        "from datavalue dv " +
-        "left join minmaxdataelement mm on dv.dataelementid = mm.dataelementid " +
-            "and dv.categoryoptioncomboid = mm.categoryoptioncomboid and dv.sourceid = mm.sourceid " +
-        "inner join dataelement de on dv.dataelementid = de.dataelementid " +
-        "inner join period pe on dv.periodid = pe.periodid " +
-        "inner join periodtype pt on pe.periodtypeid = pt.periodtypeid " +
-        "inner join organisationunit ou on dv.sourceid = ou.organisationunitid " +
-        "inner join categoryoptioncombo coc on dv.categoryoptioncomboid = coc.categoryoptioncomboid " +
-        "where dv.dataelementid in (" + dataElementIds + ") " +
-        "and dv.categoryoptioncomboid in (" + categoryOptionComboIds + ") " +
-        "and dv.periodid in (" + periodIds + ") " +
-        "and (" +
-            "cast(dv.value as " + statementBuilder.getDoubleColumnType() + ") < mm.minimumvalue " +
-            "or cast(dv.value as " + statementBuilder.getDoubleColumnType() + ") > mm.maximumvalue) " +
-        "and (";
-    // @formatter:on
+        "select dv.dataelementid, dv.periodid, dv.sourceid, dv.categoryoptioncomboid, dv.attributeoptioncomboid, "
+            + "dv.value, dv.storedby, dv.lastupdated, "
+            + "dv.created, dv.comment, dv.followup, ou.name as sourcename, de.name as dataelementname, "
+            + "pt.name as periodtypename, pe.startdate, pe.enddate, coc.name as categoryoptioncomboname, "
+            + "mm.minimumvalue, mm.maximumvalue "
+            + "from datavalue dv "
+            + "left join minmaxdataelement mm on dv.dataelementid = mm.dataelementid "
+            + "and dv.categoryoptioncomboid = mm.categoryoptioncomboid and dv.sourceid = mm.sourceid "
+            + "inner join dataelement de on dv.dataelementid = de.dataelementid "
+            + "inner join period pe on dv.periodid = pe.periodid "
+            + "inner join periodtype pt on pe.periodtypeid = pt.periodtypeid "
+            + "inner join organisationunit ou on dv.sourceid = ou.organisationunitid "
+            + "inner join categoryoptioncombo coc on dv.categoryoptioncomboid = coc.categoryoptioncomboid "
+            + "where dv.dataelementid in ("
+            + dataElementIds
+            + ") "
+            + "and dv.categoryoptioncomboid in ("
+            + categoryOptionComboIds
+            + ") "
+            + "and dv.periodid in ("
+            + periodIds
+            + ") "
+            + "and ("
+            + "cast(dv.value as "
+            + statementBuilder.getDoubleColumnType()
+            + ") < mm.minimumvalue "
+            + "or cast(dv.value as "
+            + statementBuilder.getDoubleColumnType()
+            + ") > mm.maximumvalue) "
+            + "and (";
 
     for (OrganisationUnit parent : parents) {
       sql += "ou.path like '" + parent.getPath() + "%' or ";
@@ -229,20 +237,25 @@ public class JdbcDataAnalysisStore implements DataAnalysisStore {
       Map<Long, Integer> upperBoundMap) {
     String periodIds = TextUtils.getCommaDelimitedString(getIdentifiers(periods));
 
-    // @formatter:off
-    String sql = "select dv.dataelementid, dv.periodid, dv.sourceid, " +
-        "dv.categoryoptioncomboid, dv.attributeoptioncomboid, dv.value, dv.storedby, dv.lastupdated, " +
-        "dv.created, dv.comment, dv.followup, ou.name as sourcename, " +
-        "? as dataelementname, pt.name as periodtypename, pe.startdate, pe.enddate, " +
-        "? as categoryoptioncomboname " +
-        "from datavalue dv " +
-        "inner join period pe on dv.periodid = pe.periodid " +
-        "inner join periodtype pt on pe.periodtypeid = pt.periodtypeid " +
-        "inner join organisationunit ou on dv.sourceid = ou.organisationunitid " +
-        "where dv.dataelementid = " + dataElement.getId() + " " +
-        "and dv.categoryoptioncomboid = " + categoryOptionCombo.getId() + " " +
-        "and dv.periodid in (" + periodIds + ") and (";
-    // @formatter:on
+    String sql =
+        "select dv.dataelementid, dv.periodid, dv.sourceid, "
+            + "dv.categoryoptioncomboid, dv.attributeoptioncomboid, dv.value, dv.storedby, dv.lastupdated, "
+            + "dv.created, dv.comment, dv.followup, ou.name as sourcename, "
+            + "? as dataelementname, pt.name as periodtypename, pe.startdate, pe.enddate, "
+            + "? as categoryoptioncomboname "
+            + "from datavalue dv "
+            + "inner join period pe on dv.periodid = pe.periodid "
+            + "inner join periodtype pt on pe.periodtypeid = pt.periodtypeid "
+            + "inner join organisationunit ou on dv.sourceid = ou.organisationunitid "
+            + "where dv.dataelementid = "
+            + dataElement.getId()
+            + " "
+            + "and dv.categoryoptioncomboid = "
+            + categoryOptionCombo.getId()
+            + " "
+            + "and dv.periodid in ("
+            + periodIds
+            + ") and (";
 
     for (Long orgUnitUid : organisationUnits) {
       sql +=
@@ -292,25 +305,30 @@ public class JdbcDataAnalysisStore implements DataAnalysisStore {
     String periodIds = getCommaDelimitedString(getIdentifiers(periods));
     String categoryOptionComboIds = getCommaDelimitedString(getIdentifiers(categoryOptionCombos));
 
-    // @formatter:off
     String sql =
-        "select dv.dataelementid, dv.periodid, dv.sourceid, " +
-            "dv.categoryoptioncomboid, dv.attributeoptioncomboid, dv.value, dv.storedby, dv.lastupdated, " +
-            "dv.created, dv.comment, dv.followup, ou.name as sourcename, de.name as dataelementname, " +
-        "pt.name as periodtypename, pe.startdate, pe.enddate, coc.name as categoryoptioncomboname, " +
-        "mm.minimumvalue, mm.maximumvalue " +
-        "from datavalue dv " +
-        "left join minmaxdataelement mm on dv.dataelementid = mm.dataelementid " +
-        "and dv.categoryoptioncomboid = mm.categoryoptioncomboid and dv.sourceid = mm.sourceid " +
-        "inner join dataelement de on dv.dataelementid = de.dataelementid " +
-        "inner join period pe on dv.periodid = pe.periodid " +
-        "inner join periodtype pt on pe.periodtypeid = pt.periodtypeid " +
-        "inner join organisationunit ou on dv.sourceid = ou.organisationunitid " +
-        "inner join categoryoptioncombo coc on dv.categoryoptioncomboid = coc.categoryoptioncomboid " +
-        "where dv.dataelementid in (" + dataElementIds + ") " +
-        "and dv.categoryoptioncomboid in (" + categoryOptionComboIds + ") " +
-        "and dv.periodid in (" + periodIds + ") " + "and (";
-    // @formatter:on
+        "select dv.dataelementid, dv.periodid, dv.sourceid, "
+            + "dv.categoryoptioncomboid, dv.attributeoptioncomboid, dv.value, dv.storedby, dv.lastupdated, "
+            + "dv.created, dv.comment, dv.followup, ou.name as sourcename, de.name as dataelementname, "
+            + "pt.name as periodtypename, pe.startdate, pe.enddate, coc.name as categoryoptioncomboname, "
+            + "mm.minimumvalue, mm.maximumvalue "
+            + "from datavalue dv "
+            + "left join minmaxdataelement mm on dv.dataelementid = mm.dataelementid "
+            + "and dv.categoryoptioncomboid = mm.categoryoptioncomboid and dv.sourceid = mm.sourceid "
+            + "inner join dataelement de on dv.dataelementid = de.dataelementid "
+            + "inner join period pe on dv.periodid = pe.periodid "
+            + "inner join periodtype pt on pe.periodtypeid = pt.periodtypeid "
+            + "inner join organisationunit ou on dv.sourceid = ou.organisationunitid "
+            + "inner join categoryoptioncombo coc on dv.categoryoptioncomboid = coc.categoryoptioncomboid "
+            + "where dv.dataelementid in ("
+            + dataElementIds
+            + ") "
+            + "and dv.categoryoptioncomboid in ("
+            + categoryOptionComboIds
+            + ") "
+            + "and dv.periodid in ("
+            + periodIds
+            + ") "
+            + "and (";
 
     for (OrganisationUnit parent : parents) {
       sql += "ou.path like '" + parent.getPath() + "%' or ";

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/outlierdetection/service/MinMaxOutlierDetectionManager.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/outlierdetection/service/MinMaxOutlierDetectionManager.java
@@ -68,37 +68,40 @@ public class MinMaxOutlierDetectionManager {
   public List<OutlierValue> getOutlierValues(OutlierDetectionRequest request) {
     final String ouPathClause = getOrgUnitPathClause(request.getOrgUnits());
 
-    // @formatter:off
     final String sql =
-        "select de.uid as de_uid, ou.uid as ou_uid, coc.uid as coc_uid, aoc.uid as aoc_uid, " +
-            "de.name as de_name, ou.name as ou_name, coc.name as coc_name, aoc.name as aoc_name, " +
-            "pe.startdate as pe_start_date, pt.name as pt_name, " +
-            "dv.value::double precision as value, dv.followup as follow_up, " +
-            "least(abs(dv.value::double precision - mm.minimumvalue), " +
-            "abs(dv.value::double precision - mm.maximumvalue)) as bound_abs_dev, " +
-            "mm.minimumvalue as lower_bound, " +
-            "mm.maximumvalue as upper_bound " +
-        "from datavalue dv " +
-        "inner join dataelement de on dv.dataelementid = de.dataelementid " +
-        "inner join categoryoptioncombo coc on dv.categoryoptioncomboid = coc.categoryoptioncomboid " +
-        "inner join categoryoptioncombo aoc on dv.attributeoptioncomboid = aoc.categoryoptioncomboid " +
-        "inner join period pe on dv.periodid = pe.periodid " +
-        "inner join periodtype pt on pe.periodtypeid = pt.periodtypeid " +
-        "inner join organisationunit ou on dv.sourceid = ou.organisationunitid " +
-        // Min-max value join
-        "inner join minmaxdataelement mm on (dv.dataelementid = mm.dataelementid " +
-        "and dv.sourceid = mm.sourceid and dv.categoryoptioncomboid = mm.categoryoptioncomboid) " +
-        "where dv.dataelementid in (:data_element_ids) " +
-        "and pe.startdate >= :start_date " +
-        "and pe.enddate <= :end_date " +
-        "and " + ouPathClause + " " +
-        "and dv.deleted is false " +
-        // Filter for values outside the min-max range
-        "and (dv.value::double precision < mm.minimumvalue or dv.value::double precision > mm.maximumvalue) " +
-        // Order and limit
-        "order by bound_abs_dev desc " +
-        "limit :max_results;";
-    // @formatter:on
+        "select de.uid as de_uid, ou.uid as ou_uid, coc.uid as coc_uid, aoc.uid as aoc_uid, "
+            + "de.name as de_name, ou.name as ou_name, coc.name as coc_name, aoc.name as aoc_name, "
+            + "pe.startdate as pe_start_date, pt.name as pt_name, "
+            + "dv.value::double precision as value, dv.followup as follow_up, "
+            + "least(abs(dv.value::double precision - mm.minimumvalue), "
+            + "abs(dv.value::double precision - mm.maximumvalue)) as bound_abs_dev, "
+            + "mm.minimumvalue as lower_bound, "
+            + "mm.maximumvalue as upper_bound "
+            + "from datavalue dv "
+            + "inner join dataelement de on dv.dataelementid = de.dataelementid "
+            + "inner join categoryoptioncombo coc on dv.categoryoptioncomboid = coc.categoryoptioncomboid "
+            + "inner join categoryoptioncombo aoc on dv.attributeoptioncomboid = aoc.categoryoptioncomboid "
+            + "inner join period pe on dv.periodid = pe.periodid "
+            + "inner join periodtype pt on pe.periodtypeid = pt.periodtypeid "
+            + "inner join organisationunit ou on dv.sourceid = ou.organisationunitid "
+            +
+            // Min-max value join
+            "inner join minmaxdataelement mm on (dv.dataelementid = mm.dataelementid "
+            + "and dv.sourceid = mm.sourceid and dv.categoryoptioncomboid = mm.categoryoptioncomboid) "
+            + "where dv.dataelementid in (:data_element_ids) "
+            + "and pe.startdate >= :start_date "
+            + "and pe.enddate <= :end_date "
+            + "and "
+            + ouPathClause
+            + " "
+            + "and dv.deleted is false "
+            +
+            // Filter for values outside the min-max range
+            "and (dv.value::double precision < mm.minimumvalue or dv.value::double precision > mm.maximumvalue) "
+            +
+            // Order and limit
+            "order by bound_abs_dev desc "
+            + "limit :max_results;";
 
     final SqlParameterSource params =
         new MapSqlParameterSource()

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/outlierdetection/service/ZScoreOutlierDetectionManager.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/outlierdetection/service/ZScoreOutlierDetectionManager.java
@@ -90,67 +90,77 @@ public class ZScoreOutlierDetectionManager {
             ? "middle_value_abs_dev"
             : request.getOrderBy().getKey();
 
-    // @formatter:off
     final String sql =
-        "select dvs.de_uid, dvs.ou_uid, dvs.coc_uid, dvs.aoc_uid, " +
-            "dvs.de_name, dvs.ou_name, dvs.coc_name, dvs.aoc_name, dvs.value, dvs.follow_up, " +
-            "dvs.pe_start_date, dvs.pt_name, " +
-            "stats.middle_value as middle_value, " +
-            "stats.std_dev as std_dev, " +
-            "abs(dvs.value::double precision - stats.middle_value) as middle_value_abs_dev, " +
-            "abs(dvs.value::double precision - stats.middle_value) / stats.std_dev as z_score, " +
-            "stats.middle_value - (stats.std_dev * :threshold) as lower_bound, " +
-            "stats.middle_value + (stats.std_dev * :threshold) as upper_bound " +
-        // Data value query
-        "from (" +
-            "select dv.dataelementid, dv.sourceid, dv.periodid, " +
-            "dv.categoryoptioncomboid, dv.attributeoptioncomboid, " +
-            "de.uid as de_uid, ou.uid as ou_uid, coc.uid as coc_uid, aoc.uid as aoc_uid, " +
-            "de.name as de_name, ou.name as ou_name, coc.name as coc_name, aoc.name as aoc_name, " +
-            "pe.startdate as pe_start_date, pt.name as pt_name, " +
-            "dv.value as value, dv.followup as follow_up " +
-            "from datavalue dv " +
-            "inner join dataelement de on dv.dataelementid = de.dataelementid " +
-            "inner join categoryoptioncombo coc on dv.categoryoptioncomboid = coc.categoryoptioncomboid " +
-            "inner join categoryoptioncombo aoc on dv.attributeoptioncomboid = aoc.categoryoptioncomboid " +
-            "inner join period pe on dv.periodid = pe.periodid " +
-            "inner join periodtype pt on pe.periodtypeid = pt.periodtypeid " +
-            "inner join organisationunit ou on dv.sourceid = ou.organisationunitid " +
-            "where dv.dataelementid in (:data_element_ids) " +
-            "and pe.startdate >= :start_date " +
-            "and pe.enddate <= :end_date " +
-            "and " + ouPathClause + " " +
-            "and dv.deleted is false" +
-        ") as dvs " +
-        // Mean or Median and std dev mapping query
-        "inner join (" +
-            "select dv.dataelementid as dataelementid, dv.sourceid as sourceid, " +
-            "dv.categoryoptioncomboid as categoryoptioncomboid, " +
-            "dv.attributeoptioncomboid as attributeoptioncomboid, " +
-            middle_stats_calc +" as middle_value, "+
-            "stddev_pop(dv.value::double precision) as std_dev " +
-            "from datavalue dv " +
-            "inner join period pe on dv.periodid = pe.periodid " +
-            "inner join organisationunit ou on dv.sourceid = ou.organisationunitid " +
-            "where dv.dataelementid in (:data_element_ids) " +
-            dataStartDateClause +
-            dataEndDateClause +
-            "and " + ouPathClause + " " +
-            "and dv.deleted is false " +
-            "group by dv.dataelementid, dv.sourceid, dv.categoryoptioncomboid, dv.attributeoptioncomboid" +
-        ") as stats " +
-        // Query join
-        "on dvs.dataelementid = stats.dataelementid " +
-        "and dvs.sourceid = stats.sourceid " +
-        "and dvs.categoryoptioncomboid = stats.categoryoptioncomboid " +
-        "and dvs.attributeoptioncomboid = stats.attributeoptioncomboid " +
-        "where stats.std_dev != 0.0 " +
-        // Filter on z-score threshold
-        "and (abs(dvs.value::double precision - stats.middle_value) / stats.std_dev) >= :threshold " +
-        // Order and limit
-        "order by " + order + " desc " +
-        "limit :max_results;";
-    // @formatter:on
+        "select dvs.de_uid, dvs.ou_uid, dvs.coc_uid, dvs.aoc_uid, "
+            + "dvs.de_name, dvs.ou_name, dvs.coc_name, dvs.aoc_name, dvs.value, dvs.follow_up, "
+            + "dvs.pe_start_date, dvs.pt_name, "
+            + "stats.middle_value as middle_value, "
+            + "stats.std_dev as std_dev, "
+            + "abs(dvs.value::double precision - stats.middle_value) as middle_value_abs_dev, "
+            + "abs(dvs.value::double precision - stats.middle_value) / stats.std_dev as z_score, "
+            + "stats.middle_value - (stats.std_dev * :threshold) as lower_bound, "
+            + "stats.middle_value + (stats.std_dev * :threshold) as upper_bound "
+            +
+            // Data value query
+            "from ("
+            + "select dv.dataelementid, dv.sourceid, dv.periodid, "
+            + "dv.categoryoptioncomboid, dv.attributeoptioncomboid, "
+            + "de.uid as de_uid, ou.uid as ou_uid, coc.uid as coc_uid, aoc.uid as aoc_uid, "
+            + "de.name as de_name, ou.name as ou_name, coc.name as coc_name, aoc.name as aoc_name, "
+            + "pe.startdate as pe_start_date, pt.name as pt_name, "
+            + "dv.value as value, dv.followup as follow_up "
+            + "from datavalue dv "
+            + "inner join dataelement de on dv.dataelementid = de.dataelementid "
+            + "inner join categoryoptioncombo coc on dv.categoryoptioncomboid = coc.categoryoptioncomboid "
+            + "inner join categoryoptioncombo aoc on dv.attributeoptioncomboid = aoc.categoryoptioncomboid "
+            + "inner join period pe on dv.periodid = pe.periodid "
+            + "inner join periodtype pt on pe.periodtypeid = pt.periodtypeid "
+            + "inner join organisationunit ou on dv.sourceid = ou.organisationunitid "
+            + "where dv.dataelementid in (:data_element_ids) "
+            + "and pe.startdate >= :start_date "
+            + "and pe.enddate <= :end_date "
+            + "and "
+            + ouPathClause
+            + " "
+            + "and dv.deleted is false"
+            + ") as dvs "
+            +
+            // Mean or Median and std dev mapping query
+            "inner join ("
+            + "select dv.dataelementid as dataelementid, dv.sourceid as sourceid, "
+            + "dv.categoryoptioncomboid as categoryoptioncomboid, "
+            + "dv.attributeoptioncomboid as attributeoptioncomboid, "
+            + middle_stats_calc
+            + " as middle_value, "
+            + "stddev_pop(dv.value::double precision) as std_dev "
+            + "from datavalue dv "
+            + "inner join period pe on dv.periodid = pe.periodid "
+            + "inner join organisationunit ou on dv.sourceid = ou.organisationunitid "
+            + "where dv.dataelementid in (:data_element_ids) "
+            + dataStartDateClause
+            + dataEndDateClause
+            + "and "
+            + ouPathClause
+            + " "
+            + "and dv.deleted is false "
+            + "group by dv.dataelementid, dv.sourceid, dv.categoryoptioncomboid, dv.attributeoptioncomboid"
+            + ") as stats "
+            +
+            // Query join
+            "on dvs.dataelementid = stats.dataelementid "
+            + "and dvs.sourceid = stats.sourceid "
+            + "and dvs.categoryoptioncomboid = stats.categoryoptioncomboid "
+            + "and dvs.attributeoptioncomboid = stats.attributeoptioncomboid "
+            + "where stats.std_dev != 0.0 "
+            +
+            // Filter on z-score threshold
+            "and (abs(dvs.value::double precision - stats.middle_value) / stats.std_dev) >= :threshold "
+            +
+            // Order and limit
+            "order by "
+            + order
+            + " desc "
+            + "limit :max_results;";
 
     final SqlParameterSource params =
         new MapSqlParameterSource()

--- a/dhis-2/dhis-test-e2e/pom.xml
+++ b/dhis-2/dhis-test-e2e/pom.xml
@@ -159,10 +159,6 @@
               <enabled>true</enabled>
             </upToDateChecking>
             <java>
-              <toggleOffOn>
-                <off>@formatter:off</off>
-                <on>@formatter:on</on>
-              </toggleOffOn>
               <googleJavaFormat/>
               <trimTrailingWhitespace/>
               <licenseHeader>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1963,10 +1963,6 @@ jasperreports.version=${jasperreports.version}
               <enabled>true</enabled>
             </upToDateChecking>
             <java>
-              <toggleOffOn>
-                <off>@formatter:off</off>
-                <on>@formatter:on</on>
-              </toggleOffOn>
               <googleJavaFormat/>
               <trimTrailingWhitespace/>
               <licenseHeader>


### PR DESCRIPTION
The code formatting is not consistent when formatting directly in an IDE (Eclipse/Intellij) using the xml formatter config then compared with formatting via the Spotless plugin. The formatter xml configs that are provided even in the google formatter project are not reliable. Seems like the suggestion is that they should actually be removed from the google java formatter project. The google formatter cannot be turned of by design. Removing the ability to turn it off via spotless allows us to use the google java formatter plugin in Intellij.