### PR TITLE
chore: validate web and store are in sync on orderable fields  TECH-1611

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
@@ -43,5 +43,10 @@ public interface EventService {
 
   Events getEvents(EventOperationParams params) throws BadRequestException, ForbiddenException;
 
+  /**
+   * Fields the {@link #getEvents(EventOperationParams)} can order events by. Ordering by fields
+   * other than these is considered a programmer error. Validation of user provided field names
+   * should occur before calling {@link #getEvents(EventOperationParams)}.
+   */
   Set<String> getOrderableFields();
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventStore.java
@@ -38,6 +38,11 @@ import org.hisp.dhis.program.Event;
 public interface EventStore {
   List<Event> getEvents(EventSearchParams params, Map<String, Set<String>> psdesWithSkipSyncTrue);
 
+  /**
+   * Fields the {@link #getEvents(EventSearchParams, Map)} can order events by. Ordering by fields
+   * other than these is considered a programmer error. Validation of user provided field names
+   * should occur before calling {@link #getEvents(EventSearchParams, Map)}.
+   */
   Set<String> getOrderableFields();
 
   int getEventCount(EventSearchParams params);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -847,4 +847,9 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
 
     return new SlimPager(originalPage, originalPageSize, isLastPage);
   }
+
+  @Override
+  public Set<String> getOrderableFields() {
+    return trackedEntityStore.getOrderableFields();
+  }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -372,16 +372,14 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
   }
 
   public void decideAccess(TrackedEntityQueryParams params) {
-    User user = params.isInternalSearch() ? null : params.getUser();
-
     if (params.isOrganisationUnitMode(ALL)
         && !currentUserService.currentUserIsAuthorized(
-            Authorities.F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS.name())
-        && !params.isInternalSearch()) {
+            Authorities.F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS.name())) {
       throw new IllegalQueryException(
           "Current user is not authorized to query across all organisation units");
     }
 
+    User user = params.getUser();
     if (params.hasProgram()) {
       if (!aclService.canDataRead(user, params.getProgram())) {
         throw new IllegalQueryException(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -506,15 +506,6 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
             .append(SINGLE_QUOTE);
       }
     }
-    if (params.isSynchronizationQuery()) {
-      trackedEntity.append(whereAnd.whereAnd()).append(" TE.lastupdated >= TE.lastsynchronized ");
-      if (params.getSkipChangedBefore() != null) {
-        trackedEntity
-            .append(" AND TE.lastupdated >= '")
-            .append(getMediumDateString(params.getSkipChangedBefore()))
-            .append(SINGLE_QUOTE);
-      }
-    }
 
     if (!params.isIncludeDeleted()) {
       trackedEntity.append(whereAnd.whereAnd()).append("TE.deleted IS FALSE ");

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -180,6 +180,11 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     return ids;
   }
 
+  @Override
+  public Set<String> getOrderableFields() {
+    return ORDERABLE_FIELDS.keySet();
+  }
+
   private String encodeAndQuote(Collection<String> elements) {
     return getQuotedCommaDelimitedString(
         elements.stream()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
@@ -160,18 +160,6 @@ public class TrackedEntityQueryParams {
   private boolean includeAllAttributes;
 
   /**
-   * Indicates whether the search is internal triggered by the system. The system should trigger
-   * superuser search to detect duplicates.
-   */
-  private boolean internalSearch;
-
-  /** Indicates whether the search is for synchronization purposes (for Program Data sync job). */
-  private boolean synchronizationQuery;
-
-  /** Indicates a point in the time used to decide the data that should not be synchronized */
-  private Date skipChangedBefore;
-
-  /**
    * Potential Duplicate query parameter value. If null, we don't check whether a TE is a
    * potentialDuplicate or not
    */
@@ -250,7 +238,7 @@ public class TrackedEntityQueryParams {
     return this;
   }
 
-  /** Adds the given filters to this parameters if they are not already present. */
+  /** Adds the given filters to these parameters if they are not already present. */
   public TrackedEntityQueryParams addFiltersIfNotExist(List<QueryItem> filtrs) {
     for (QueryItem filter : filtrs) {
       if (filters != null && !filters.contains(filter)) {
@@ -271,7 +259,7 @@ public class TrackedEntityQueryParams {
     return hasQuery();
   }
 
-  /** Indicates whether this parameters specifies a query. */
+  /** Indicates whether these parameters specify a query. */
   public boolean hasQuery() {
     return query != null && query.isFilter();
   }
@@ -317,65 +305,65 @@ public class TrackedEntityQueryParams {
     return duplicates;
   }
 
-  /** Indicates whether this parameters specifies any attributes and/or filters. */
+  /** Indicates whether these parameters specify any attributes and/or filters. */
   public boolean hasAttributesOrFilters() {
     return hasAttributes() || hasFilters();
   }
 
-  /** Indicates whether this parameters specifies any attributes. */
+  /** Indicates whether these parameters specify any attributes. */
   public boolean hasAttributes() {
     return attributes != null && !attributes.isEmpty();
   }
 
-  /** Indicates whether this parameters specifies any filters. */
+  /** Indicates whether these parameters specify any filters. */
   public boolean hasFilters() {
     return filters != null && !filters.isEmpty();
   }
 
-  /** Indicates whether this parameters specifies any organisation units. */
+  /** Indicates whether these parameters specify any organisation units. */
   public boolean hasOrganisationUnits() {
     return orgUnits != null && !orgUnits.isEmpty();
   }
 
-  /** Indicates whether this parameters specifies a program. */
+  /** Indicates whether these parameters specify a program. */
   public boolean hasProgram() {
     return program != null;
   }
 
-  /** Indicates whether this parameters specifies a program status. */
+  /** Indicates whether these parameters specify a program status. */
   public boolean hasProgramStatus() {
     return programStatus != null;
   }
 
   /**
-   * Indicates whether this parameters specifies follow up for the given program. Follow up can be
+   * Indicates whether these parameters specify follow up for the given program. Follow up can be
    * specified as true or false.
    */
   public boolean hasFollowUp() {
     return followUp != null;
   }
 
-  /** Indicates whether this parameters specifies a last updated start date. */
+  /** Indicates whether these parameters specify a last updated start date. */
   public boolean hasLastUpdatedStartDate() {
     return lastUpdatedStartDate != null;
   }
 
-  /** Indicates whether this parameters specifies a last updated end date. */
+  /** Indicates whether these parameters specify a last updated end date. */
   public boolean hasLastUpdatedEndDate() {
     return lastUpdatedEndDate != null;
   }
 
-  /** Indicates whether this parameters has a lastUpdatedDuration filter. */
+  /** Indicates whether these parameters have a lastUpdatedDuration filter. */
   public boolean hasLastUpdatedDuration() {
     return lastUpdatedDuration != null;
   }
 
-  /** Indicates whether this parameters specifies a program enrollment start date. */
+  /** Indicates whether these parameters specify a program enrollment start date. */
   public boolean hasProgramEnrollmentStartDate() {
     return programEnrollmentStartDate != null;
   }
 
-  /** Indicates whether this parameters specifies a program enrollment end date. */
+  /** Indicates whether these parameters specify a program enrollment end date. */
   public boolean hasProgramEnrollmentEndDate() {
     return programEnrollmentEndDate != null;
   }
@@ -433,10 +421,9 @@ public class TrackedEntityQueryParams {
   }
 
   /**
-   * Checks if there is atleast one unique filter in the params. In attributes or filters.
+   * Checks if there is at least one unique filter in the params. In attributes or filters.
    *
-   * @return true if there is exist atlesast one unique filter in filters/attributes, false
-   *     otherwise.
+   * @return true if there is at least one unique filter in filters/attributes, false otherwise.
    */
   public boolean hasUniqueFilter() {
     if (!hasFilters() && !hasAttributes()) {
@@ -761,18 +748,6 @@ public class TrackedEntityQueryParams {
   public TrackedEntityQueryParams setIncludeAllAttributes(boolean includeAllAttributes) {
     this.includeAllAttributes = includeAllAttributes;
     return this;
-  }
-
-  public boolean isInternalSearch() {
-    return internalSearch;
-  }
-
-  public boolean isSynchronizationQuery() {
-    return synchronizationQuery;
-  }
-
-  public Date getSkipChangedBefore() {
-    return skipChangedBefore;
   }
 
   public User getUser() {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.export.trackedentity;
 
+import java.util.Set;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
@@ -54,4 +55,12 @@ public interface TrackedEntityService {
    */
   TrackedEntities getTrackedEntities(TrackedEntityOperationParams operationParams)
       throws ForbiddenException, NotFoundException, BadRequestException;
+
+  /**
+   * Fields the {@link #getTrackedEntities(TrackedEntityOperationParams)} can order tracked entities
+   * by. Ordering by fields other than these is considered a programmer error. Validation of user
+   * provided field names should occur before calling {@link
+   * #getTrackedEntities(TrackedEntityOperationParams)}.
+   */
+  Set<String> getOrderableFields();
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityStore.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.tracker.export.trackedentity;
 
 import java.util.List;
+import java.util.Set;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 
@@ -35,6 +36,14 @@ interface TrackedEntityStore extends IdentifiableObjectStore<TrackedEntity> {
   String ID = TrackedEntityStore.class.getName();
 
   List<Long> getTrackedEntityIds(TrackedEntityQueryParams params);
+
+  /**
+   * Fields the {@link #getTrackedEntityIds(TrackedEntityQueryParams)})} can order tracked entities
+   * by. Ordering by fields other than these is considered a programmer error. Validation of user
+   * provided field names should occur before calling {@link
+   * #getTrackedEntityIds(TrackedEntityQueryParams)}.
+   */
+  Set<String> getOrderableFields();
 
   int getTrackedEntityCount(TrackedEntityQueryParams params);
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerUnitTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerUnitTest.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.tracker.export.event;
+package org.hisp.dhis.webapi.controller.tracker.export.trackedentity;
 
 import static org.hisp.dhis.utils.Assertions.assertContains;
 import static org.hisp.dhis.utils.Assertions.assertStartsWith;
@@ -39,52 +39,55 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
-import org.hisp.dhis.tracker.export.event.EventService;
+import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityService;
 import org.hisp.dhis.webapi.controller.tracker.export.CsvService;
-import org.hisp.dhis.webapi.controller.tracker.view.Event;
+import org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class EventsExportControllerUnitTest {
+class TrackedEntitiesExportControllerUnitTest {
 
-  @Mock private EventService eventService;
+  @Mock private TrackedEntityService trackedEntityService;
 
-  @Mock private EventRequestParamsMapper eventParamsMapper;
+  @Mock private TrackedEntityRequestParamsMapper requestParamsMapper;
 
-  @Mock private CsvService<Event> csvEventService;
+  @Mock private CsvService<TrackedEntity> csvService;
 
   @Mock private FieldFilterService fieldFilterService;
 
-  @Mock private EventFieldsParamMapper eventsMapper;
+  @Mock private TrackedEntityFieldsParamMapper fieldsParamMapper;
 
   @Test
   void shouldFailInstantiatingControllerIfAnyOrderableFieldIsUnsupported() {
     // pretend the service does not support 2 of the orderable fields the web advocates
     Iterator<Entry<String, String>> iterator =
-        EventMapper.ORDERABLE_FIELDS.entrySet().stream().iterator();
+        TrackedEntityMapper.ORDERABLE_FIELDS.entrySet().stream().iterator();
     Entry<String, String> missing1 = iterator.next();
     Entry<String, String> missing2 = iterator.next();
-    Map<String, String> orderableFields = new HashMap<>(EventMapper.ORDERABLE_FIELDS);
+    Map<String, String> orderableFields = new HashMap<>(TrackedEntityMapper.ORDERABLE_FIELDS);
     orderableFields.remove(missing1.getKey());
     orderableFields.remove(missing2.getKey());
-    when(eventService.getOrderableFields()).thenReturn(new HashSet<>(orderableFields.values()));
+    when(trackedEntityService.getOrderableFields())
+        .thenReturn(new HashSet<>(orderableFields.values()));
 
     Exception exception =
         assertThrows(
             IllegalStateException.class,
             () ->
-                new EventsExportController(
-                    eventService,
-                    eventParamsMapper,
-                    csvEventService,
+                new TrackedEntitiesExportController(
+                    trackedEntityService,
+                    requestParamsMapper,
+                    csvService,
                     fieldFilterService,
-                    eventsMapper));
+                    fieldsParamMapper));
 
     assertAll(
-        () -> assertStartsWith("event controller supports ordering by", exception.getMessage()),
+        () ->
+            assertStartsWith(
+                "tracked entity controller supports ordering by", exception.getMessage()),
         () -> assertContains(missing1.getKey(), exception.getMessage()),
         () -> assertContains(missing2.getKey(), exception.getMessage()));
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -84,12 +84,11 @@ class EventsExportController {
 
   private static final EventMapper EVENTS_MAPPER = Mappers.getMapper(EventMapper.class);
 
-  @Nonnull private final org.hisp.dhis.tracker.export.event.EventService eventService;
+  @Nonnull private final EventService eventService;
 
   @Nonnull private final EventRequestParamsMapper eventParamsMapper;
 
-  @Nonnull
-  private final CsvService<org.hisp.dhis.webapi.controller.tracker.view.Event> csvEventService;
+  @Nonnull private final CsvService<Event> csvEventService;
 
   @Nonnull private final FieldFilterService fieldFilterService;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.trackedentity;
 
+import static java.util.Map.*;
 import static org.hisp.dhis.common.OpenApi.Response.Status;
 import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.RESOURCE_PATH;
 import static org.hisp.dhis.webapi.controller.tracker.export.trackedentity.RequestParams.DEFAULT_FIELDS_PARAM;
@@ -39,14 +40,16 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.UID;
@@ -83,7 +86,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping(value = RESOURCE_PATH + "/" + TrackedEntitiesExportController.TRACKED_ENTITIES)
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
-@RequiredArgsConstructor
 class TrackedEntitiesExportController {
 
   protected static final String TRACKED_ENTITIES = "trackedEntities";
@@ -92,7 +94,7 @@ class TrackedEntitiesExportController {
    * Fields we need to fetch from the DB to fulfill requests for CSV. CSV cannot be filtered using
    * the {@link FieldFilterService} so <code>fields</code> query parameter is ignored when CSV is
    * requested. Make sure this is kept in sync with the columns we promise to return in the CSV. See
-   * {@link org.hisp.dhis.webapi.controller.tracker.export.trackedentity.CsvTrackedEntity}.
+   * {@link CsvTrackedEntity}.
    */
   private static final List<FieldPath> CSV_FIELDS =
       FieldFilterParser.parse(
@@ -101,15 +103,54 @@ class TrackedEntitiesExportController {
   private static final TrackedEntityMapper TRACKED_ENTITY_MAPPER =
       Mappers.getMapper(TrackedEntityMapper.class);
 
-  @Nonnull private final TrackedEntityRequestParamsMapper paramsMapper;
-
   @Nonnull private final TrackedEntityService trackedEntityService;
 
-  @Nonnull private final FieldFilterService fieldFilterService;
+  @Nonnull private final TrackedEntityRequestParamsMapper paramsMapper;
 
   @Nonnull private final CsvService<TrackedEntity> csvEventService;
 
+  @Nonnull private final FieldFilterService fieldFilterService;
+
   private final TrackedEntityFieldsParamMapper fieldsMapper;
+
+  public TrackedEntitiesExportController(
+      TrackedEntityService trackedEntityService,
+      TrackedEntityRequestParamsMapper paramsMapper,
+      CsvService<TrackedEntity> csvEventService,
+      FieldFilterService fieldFilterService,
+      TrackedEntityFieldsParamMapper fieldsMapper) {
+    this.trackedEntityService = trackedEntityService;
+    this.paramsMapper = paramsMapper;
+    this.csvEventService = csvEventService;
+    this.fieldFilterService = fieldFilterService;
+    this.fieldsMapper = fieldsMapper;
+
+    assertUserOrderableFieldsAreSupported();
+  }
+
+  /**
+   * Ensures that all fields advocated by {@link
+   * org.hisp.dhis.webapi.controller.tracker.export.trackedentity} as orderable are in fact
+   * orderable by the service. Web is responsible for mapping from the language users use (our API)
+   * to our internal representation used in our services. This is to prevent web and service (store)
+   * from getting out of sync.
+   */
+  private void assertUserOrderableFieldsAreSupported() {
+    Set<String> orderableFields = trackedEntityService.getOrderableFields();
+    Set<String> unsupportedFields = new HashSet<>(TrackedEntityMapper.ORDERABLE_FIELDS.values());
+    unsupportedFields.removeAll(orderableFields);
+    if (!unsupportedFields.isEmpty()) {
+      Set<String> unsupportedFieldNames =
+          TrackedEntityMapper.ORDERABLE_FIELDS.entrySet().stream()
+              .filter(e -> unsupportedFields.contains(e.getValue()))
+              .map(Entry::getKey)
+              .collect(Collectors.toSet());
+      throw new IllegalStateException(
+          "tracked entity controller supports ordering by "
+              + String.join(", ", unsupportedFieldNames)
+              + " while tracked entity service does not.");
+    }
+  }
 
   @OpenApi.Response(status = Status.OK, value = OpenApiExport.ListResponse.class)
   @GetMapping(produces = APPLICATION_JSON_VALUE)


### PR DESCRIPTION
* validate web and store are in sync on orderable fields: this ensures that if a programmer changes what the web advocates as orderable to the user is actually supported by the store
* chore: remove fields that are never written to: The fields where only read from. Since they are booleans their default of false was always used. Inline false in the consuming code and simplify.