### PR TITLE
chore: rename EventSearchParams to EventQueryParams TECH-1607

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -64,7 +64,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service("org.hisp.dhis.tracker.export.event.EventService")
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class DefaultEventService implements EventService {
+class DefaultEventService implements EventService {
 
   private final CurrentUserService currentUserService;
 
@@ -171,21 +171,21 @@ public class DefaultEventService implements EventService {
   @Override
   public Events getEvents(EventOperationParams operationParams)
       throws BadRequestException, ForbiddenException {
-    EventSearchParams searchParams = paramsMapper.map(operationParams);
+    EventQueryParams queryParams = paramsMapper.map(operationParams);
 
     if (!operationParams.isPaging() && !operationParams.isSkipPaging()) {
       operationParams.setDefaultPaging();
     }
 
     if (operationParams.isSkipPaging()) {
-      return Events.withoutPagination(eventStore.getEvents(searchParams, emptyMap()));
+      return Events.withoutPagination(eventStore.getEvents(queryParams, emptyMap()));
     }
 
     Pager pager;
-    List<Event> eventList = new ArrayList<>(eventStore.getEvents(searchParams, emptyMap()));
+    List<Event> eventList = new ArrayList<>(eventStore.getEvents(queryParams, emptyMap()));
 
     if (operationParams.isTotalPages()) {
-      int count = eventStore.getEventCount(searchParams);
+      int count = eventStore.getEventCount(queryParams);
       pager =
           new Pager(
               operationParams.getPageWithDefault(),
@@ -205,7 +205,7 @@ public class DefaultEventService implements EventService {
 
   /**
    * This method will apply the logic related to the parameter 'totalPages=false'. This works in
-   * conjunction with the method: {@link EventStore#getEvents(EventSearchParams,
+   * conjunction with the method: {@link EventStore#getEvents(EventQueryParams,
    * Map<String,Set<String>>)}
    *
    * <p>This is needed because we need to query (pageSize + 1) at DB level. The resulting query will

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
@@ -65,13 +65,13 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Maps {@link EventOperationParams} to {@link EventSearchParams} which is used to fetch events from
+ * Maps {@link EventOperationParams} to {@link EventQueryParams} which is used to fetch events from
  * the DB.
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class EventOperationParamsMapper {
+class EventOperationParamsMapper {
 
   private final ProgramService programService;
 
@@ -94,7 +94,7 @@ public class EventOperationParamsMapper {
   private final DataElementService dataElementService;
 
   @Transactional(readOnly = true)
-  public EventSearchParams map(EventOperationParams operationParams)
+  public EventQueryParams map(EventOperationParams operationParams)
       throws BadRequestException, ForbiddenException {
     User user = currentUserService.getCurrentUser();
 
@@ -125,13 +125,13 @@ public class EventOperationParamsMapper {
 
     validateAttributeOptionCombo(attributeOptionCombo, user);
 
-    EventSearchParams searchParams = new EventSearchParams();
+    EventQueryParams queryParams = new EventQueryParams();
 
-    mapDataElementFilters(searchParams, operationParams.getDataElementFilters());
-    mapAttributeFilters(searchParams, operationParams.getAttributeFilters());
-    mapOrderParam(searchParams, operationParams.getOrder());
+    mapDataElementFilters(queryParams, operationParams.getDataElementFilters());
+    mapAttributeFilters(queryParams, operationParams.getAttributeFilters());
+    mapOrderParam(queryParams, operationParams.getOrder());
 
-    return searchParams
+    return queryParams
         .setProgram(program)
         .setProgramStage(programStage)
         .setAccessibleOrgUnits(accessibleOrgUnits)
@@ -418,7 +418,7 @@ public class EventOperationParamsMapper {
   }
 
   private void mapDataElementFilters(
-      EventSearchParams params, Map<String, List<QueryFilter>> dataElementFilters)
+      EventQueryParams params, Map<String, List<QueryFilter>> dataElementFilters)
       throws BadRequestException {
     for (Entry<String, List<QueryFilter>> dataElementFilter : dataElementFilters.entrySet()) {
       DataElement de = dataElementService.getDataElement(dataElementFilter.getKey());
@@ -436,7 +436,7 @@ public class EventOperationParamsMapper {
   }
 
   private void mapAttributeFilters(
-      EventSearchParams params, Map<String, List<QueryFilter>> attributeFilters)
+      EventQueryParams params, Map<String, List<QueryFilter>> attributeFilters)
       throws BadRequestException {
     for (Map.Entry<String, List<QueryFilter>> attributeFilter : attributeFilters.entrySet()) {
       TrackedEntityAttribute tea =
@@ -458,7 +458,7 @@ public class EventOperationParamsMapper {
     }
   }
 
-  private void mapOrderParam(EventSearchParams params, List<Order> orders)
+  private void mapOrderParam(EventQueryParams params, List<Order> orders)
       throws BadRequestException {
     if (orders == null || orders.isEmpty()) {
       return;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventQueryParams.java
@@ -56,7 +56,7 @@ import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 /**
  * @author Lars Helge Overland
  */
-public class EventSearchParams {
+class EventQueryParams {
 
   public static final int DEFAULT_PAGE = 1;
 
@@ -172,7 +172,7 @@ public class EventSearchParams {
   // Constructors
   // -------------------------------------------------------------------------
 
-  public EventSearchParams() {}
+  public EventQueryParams() {}
 
   // -------------------------------------------------------------------------
   // Logic
@@ -241,7 +241,7 @@ public class EventSearchParams {
     return program;
   }
 
-  public EventSearchParams setProgram(Program program) {
+  public EventQueryParams setProgram(Program program) {
     this.program = program;
     return this;
   }
@@ -250,7 +250,7 @@ public class EventSearchParams {
     return programStage;
   }
 
-  public EventSearchParams setProgramStage(ProgramStage programStage) {
+  public EventQueryParams setProgramStage(ProgramStage programStage) {
     this.programStage = programStage;
     return this;
   }
@@ -259,7 +259,7 @@ public class EventSearchParams {
     return programStatus;
   }
 
-  public EventSearchParams setProgramStatus(ProgramStatus programStatus) {
+  public EventQueryParams setProgramStatus(ProgramStatus programStatus) {
     this.programStatus = programStatus;
     return this;
   }
@@ -268,7 +268,7 @@ public class EventSearchParams {
     return programType;
   }
 
-  public EventSearchParams setProgramType(ProgramType programType) {
+  public EventQueryParams setProgramType(ProgramType programType) {
     this.programType = programType;
     return this;
   }
@@ -277,7 +277,7 @@ public class EventSearchParams {
     return followUp;
   }
 
-  public EventSearchParams setFollowUp(Boolean followUp) {
+  public EventQueryParams setFollowUp(Boolean followUp) {
     this.followUp = followUp;
     return this;
   }
@@ -286,7 +286,7 @@ public class EventSearchParams {
     return accessibleOrgUnits;
   }
 
-  public EventSearchParams setAccessibleOrgUnits(List<OrganisationUnit> accessibleOrgUnits) {
+  public EventQueryParams setAccessibleOrgUnits(List<OrganisationUnit> accessibleOrgUnits) {
     this.accessibleOrgUnits = accessibleOrgUnits;
     return this;
   }
@@ -295,7 +295,7 @@ public class EventSearchParams {
     return orgUnitMode;
   }
 
-  public EventSearchParams setOrgUnitMode(OrganisationUnitSelectionMode orgUnitMode) {
+  public EventQueryParams setOrgUnitMode(OrganisationUnitSelectionMode orgUnitMode) {
     this.orgUnitMode = orgUnitMode;
     return this;
   }
@@ -306,8 +306,7 @@ public class EventSearchParams {
    * @param assignedUserQueryParam assigned user query params
    * @return this
    */
-  public EventSearchParams setAssignedUserQueryParam(
-      AssignedUserQueryParam assignedUserQueryParam) {
+  public EventQueryParams setAssignedUserQueryParam(AssignedUserQueryParam assignedUserQueryParam) {
     this.assignedUserQueryParam = assignedUserQueryParam;
     return this;
   }
@@ -316,7 +315,7 @@ public class EventSearchParams {
     return trackedEntity;
   }
 
-  public EventSearchParams setTrackedEntity(TrackedEntity trackedEntity) {
+  public EventQueryParams setTrackedEntity(TrackedEntity trackedEntity) {
     this.trackedEntity = trackedEntity;
     return this;
   }
@@ -325,7 +324,7 @@ public class EventSearchParams {
     return startDate;
   }
 
-  public EventSearchParams setStartDate(Date startDate) {
+  public EventQueryParams setStartDate(Date startDate) {
     this.startDate = startDate;
     return this;
   }
@@ -334,7 +333,7 @@ public class EventSearchParams {
     return endDate;
   }
 
-  public EventSearchParams setEndDate(Date endDate) {
+  public EventQueryParams setEndDate(Date endDate) {
     this.endDate = endDate;
     return this;
   }
@@ -343,7 +342,7 @@ public class EventSearchParams {
     return eventStatus;
   }
 
-  public EventSearchParams setEventStatus(EventStatus eventStatus) {
+  public EventQueryParams setEventStatus(EventStatus eventStatus) {
     this.eventStatus = eventStatus;
     return this;
   }
@@ -352,7 +351,7 @@ public class EventSearchParams {
     return updatedAtStartDate;
   }
 
-  public EventSearchParams setUpdatedAtStartDate(Date updatedAtStartDate) {
+  public EventQueryParams setUpdatedAtStartDate(Date updatedAtStartDate) {
     this.updatedAtStartDate = updatedAtStartDate;
     return this;
   }
@@ -361,7 +360,7 @@ public class EventSearchParams {
     return updatedAtEndDate;
   }
 
-  public EventSearchParams setUpdatedAtEndDate(Date updatedAtEndDate) {
+  public EventQueryParams setUpdatedAtEndDate(Date updatedAtEndDate) {
     this.updatedAtEndDate = updatedAtEndDate;
     return this;
   }
@@ -370,7 +369,7 @@ public class EventSearchParams {
     return updatedAtDuration;
   }
 
-  public EventSearchParams setUpdatedAtDuration(String updatedAtDuration) {
+  public EventQueryParams setUpdatedAtDuration(String updatedAtDuration) {
     this.updatedAtDuration = updatedAtDuration;
     return this;
   }
@@ -379,7 +378,7 @@ public class EventSearchParams {
     return scheduleAtStartDate;
   }
 
-  public EventSearchParams setScheduleAtStartDate(Date scheduleAtStartDate) {
+  public EventQueryParams setScheduleAtStartDate(Date scheduleAtStartDate) {
     this.scheduleAtStartDate = scheduleAtStartDate;
     return this;
   }
@@ -388,7 +387,7 @@ public class EventSearchParams {
     return scheduleAtEndDate;
   }
 
-  public EventSearchParams setScheduleAtEndDate(Date scheduleAtEndDate) {
+  public EventQueryParams setScheduleAtEndDate(Date scheduleAtEndDate) {
     this.scheduleAtEndDate = scheduleAtEndDate;
     return this;
   }
@@ -397,7 +396,7 @@ public class EventSearchParams {
     return enrollmentEnrolledBefore;
   }
 
-  public EventSearchParams setEnrollmentEnrolledBefore(Date enrollmentEnrolledBefore) {
+  public EventQueryParams setEnrollmentEnrolledBefore(Date enrollmentEnrolledBefore) {
     this.enrollmentEnrolledBefore = enrollmentEnrolledBefore;
     return this;
   }
@@ -406,7 +405,7 @@ public class EventSearchParams {
     return enrollmentEnrolledAfter;
   }
 
-  public EventSearchParams setEnrollmentEnrolledAfter(Date enrollmentEnrolledAfter) {
+  public EventQueryParams setEnrollmentEnrolledAfter(Date enrollmentEnrolledAfter) {
     this.enrollmentEnrolledAfter = enrollmentEnrolledAfter;
     return this;
   }
@@ -415,7 +414,7 @@ public class EventSearchParams {
     return enrollmentOccurredBefore;
   }
 
-  public EventSearchParams setEnrollmentOccurredBefore(Date enrollmentOccurredBefore) {
+  public EventQueryParams setEnrollmentOccurredBefore(Date enrollmentOccurredBefore) {
     this.enrollmentOccurredBefore = enrollmentOccurredBefore;
     return this;
   }
@@ -424,7 +423,7 @@ public class EventSearchParams {
     return enrollmentOccurredAfter;
   }
 
-  public EventSearchParams setEnrollmentOccurredAfter(Date enrollmentOccurredAfter) {
+  public EventQueryParams setEnrollmentOccurredAfter(Date enrollmentOccurredAfter) {
     this.enrollmentOccurredAfter = enrollmentOccurredAfter;
     return this;
   }
@@ -433,7 +432,7 @@ public class EventSearchParams {
     return idSchemes;
   }
 
-  public EventSearchParams setIdSchemes(IdSchemes idSchemes) {
+  public EventQueryParams setIdSchemes(IdSchemes idSchemes) {
     this.idSchemes = idSchemes;
     return this;
   }
@@ -442,7 +441,7 @@ public class EventSearchParams {
     return page;
   }
 
-  public EventSearchParams setPage(Integer page) {
+  public EventQueryParams setPage(Integer page) {
     this.page = page;
     return this;
   }
@@ -451,7 +450,7 @@ public class EventSearchParams {
     return pageSize;
   }
 
-  public EventSearchParams setPageSize(Integer pageSize) {
+  public EventQueryParams setPageSize(Integer pageSize) {
     this.pageSize = pageSize;
     return this;
   }
@@ -460,7 +459,7 @@ public class EventSearchParams {
     return totalPages;
   }
 
-  public EventSearchParams setTotalPages(boolean totalPages) {
+  public EventQueryParams setTotalPages(boolean totalPages) {
     this.totalPages = totalPages;
     return this;
   }
@@ -469,7 +468,7 @@ public class EventSearchParams {
     return skipPaging;
   }
 
-  public EventSearchParams setSkipPaging(boolean skipPaging) {
+  public EventQueryParams setSkipPaging(boolean skipPaging) {
     this.skipPaging = skipPaging;
     return this;
   }
@@ -478,7 +477,7 @@ public class EventSearchParams {
     return includeAttributes;
   }
 
-  public EventSearchParams setIncludeAttributes(boolean includeAttributes) {
+  public EventQueryParams setIncludeAttributes(boolean includeAttributes) {
     this.includeAttributes = includeAttributes;
     return this;
   }
@@ -487,7 +486,7 @@ public class EventSearchParams {
     return includeAllDataElements;
   }
 
-  public EventSearchParams setIncludeAllDataElements(boolean includeAllDataElements) {
+  public EventQueryParams setIncludeAllDataElements(boolean includeAllDataElements) {
     this.includeAllDataElements = includeAllDataElements;
     return this;
   }
@@ -497,20 +496,20 @@ public class EventSearchParams {
   }
 
   /** Order by an event field of the given {@code field} name in given sort {@code direction}. */
-  public EventSearchParams orderBy(String field, SortDirection direction) {
+  public EventQueryParams orderBy(String field, SortDirection direction) {
     this.order.add(new Order(field, direction));
     return this;
   }
 
   /** Order by the given data element {@code de} in given sort {@code direction}. */
-  public EventSearchParams orderBy(DataElement de, SortDirection direction) {
+  public EventQueryParams orderBy(DataElement de, SortDirection direction) {
     this.order.add(new Order(de, direction));
     this.dataElements.putIfAbsent(de, new ArrayList<>());
     return this;
   }
 
   /** Order by the given tracked entity attribute {@code tea} in given sort {@code direction}. */
-  public EventSearchParams orderBy(TrackedEntityAttribute tea, SortDirection direction) {
+  public EventQueryParams orderBy(TrackedEntityAttribute tea, SortDirection direction) {
     this.order.add(new Order(tea, direction));
     this.attributes.putIfAbsent(tea, new ArrayList<>());
     return this;
@@ -520,7 +519,7 @@ public class EventSearchParams {
     return categoryOptionCombo;
   }
 
-  public EventSearchParams setCategoryOptionCombo(CategoryOptionCombo categoryOptionCombo) {
+  public EventQueryParams setCategoryOptionCombo(CategoryOptionCombo categoryOptionCombo) {
     this.categoryOptionCombo = categoryOptionCombo;
     return this;
   }
@@ -529,7 +528,7 @@ public class EventSearchParams {
     return events;
   }
 
-  public EventSearchParams setEvents(Set<String> events) {
+  public EventQueryParams setEvents(Set<String> events) {
     this.events = events;
     return this;
   }
@@ -538,7 +537,7 @@ public class EventSearchParams {
     return skipEventId;
   }
 
-  public EventSearchParams setSkipEventId(Boolean skipEventId) {
+  public EventQueryParams setSkipEventId(Boolean skipEventId) {
     this.skipEventId = skipEventId;
     return this;
   }
@@ -551,25 +550,25 @@ public class EventSearchParams {
     return this.dataElements;
   }
 
-  public EventSearchParams filterBy(TrackedEntityAttribute tea, QueryFilter filter) {
+  public EventQueryParams filterBy(TrackedEntityAttribute tea, QueryFilter filter) {
     this.attributes.putIfAbsent(tea, new ArrayList<>());
     this.attributes.get(tea).add(filter);
     return this;
   }
 
-  public EventSearchParams filterBy(TrackedEntityAttribute tea) {
+  public EventQueryParams filterBy(TrackedEntityAttribute tea) {
     this.attributes.putIfAbsent(tea, new ArrayList<>());
     return this;
   }
 
-  public EventSearchParams filterBy(DataElement de, QueryFilter filter) {
+  public EventQueryParams filterBy(DataElement de, QueryFilter filter) {
     this.dataElements.putIfAbsent(de, new ArrayList<>());
     this.dataElements.get(de).add(filter);
     this.hasDataElementFilter = true;
     return this;
   }
 
-  public EventSearchParams setIncludeDeleted(boolean includeDeleted) {
+  public EventQueryParams setIncludeDeleted(boolean includeDeleted) {
     this.includeDeleted = includeDeleted;
     return this;
   }
@@ -582,7 +581,7 @@ public class EventSearchParams {
     return accessiblePrograms;
   }
 
-  public EventSearchParams setAccessiblePrograms(Set<String> accessiblePrograms) {
+  public EventQueryParams setAccessiblePrograms(Set<String> accessiblePrograms) {
     this.accessiblePrograms = accessiblePrograms;
     return this;
   }
@@ -591,7 +590,7 @@ public class EventSearchParams {
     return accessibleProgramStages;
   }
 
-  public EventSearchParams setAccessibleProgramStages(Set<String> accessibleProgramStages) {
+  public EventQueryParams setAccessibleProgramStages(Set<String> accessibleProgramStages) {
     this.accessibleProgramStages = accessibleProgramStages;
     return this;
   }
@@ -604,7 +603,7 @@ public class EventSearchParams {
     return synchronizationQuery;
   }
 
-  public EventSearchParams setSynchronizationQuery(boolean synchronizationQuery) {
+  public EventQueryParams setSynchronizationQuery(boolean synchronizationQuery) {
     this.synchronizationQuery = synchronizationQuery;
     return this;
   }
@@ -613,7 +612,7 @@ public class EventSearchParams {
     return skipChangedBefore;
   }
 
-  public EventSearchParams setSkipChangedBefore(Date skipChangedBefore) {
+  public EventQueryParams setSkipChangedBefore(Date skipChangedBefore) {
     this.skipChangedBefore = skipChangedBefore;
     return this;
   }
@@ -622,7 +621,7 @@ public class EventSearchParams {
     return enrollments;
   }
 
-  public EventSearchParams setEnrollments(Set<String> enrollments) {
+  public EventQueryParams setEnrollments(Set<String> enrollments) {
     this.enrollments = enrollments;
     return this;
   }
@@ -631,7 +630,7 @@ public class EventSearchParams {
     return includeRelationships;
   }
 
-  public EventSearchParams setIncludeRelationships(boolean includeRelationships) {
+  public EventQueryParams setIncludeRelationships(boolean includeRelationships) {
     this.includeRelationships = includeRelationships;
     return this;
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventStore.java
@@ -36,9 +36,9 @@ import org.hisp.dhis.program.Event;
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 public interface EventStore {
-  List<Event> getEvents(EventSearchParams params, Map<String, Set<String>> psdesWithSkipSyncTrue);
+  List<Event> getEvents(EventQueryParams params, Map<String, Set<String>> psdesWithSkipSyncTrue);
 
   Set<String> getOrderableFields();
 
-  int getEventCount(EventSearchParams params);
+  int getEventCount(EventQueryParams params);
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -112,7 +112,7 @@ import org.springframework.stereotype.Repository;
 @Slf4j
 @Repository("org.hisp.dhis.tracker.export.event.EventStore")
 @RequiredArgsConstructor
-public class JdbcEventStore implements EventStore {
+class JdbcEventStore implements EventStore {
   private static final String DEFAULT_ORDER = "ev_id desc";
 
   private static final String RELATIONSHIP_IDS_QUERY =
@@ -215,7 +215,7 @@ public class JdbcEventStore implements EventStore {
 
   @Override
   public List<Event> getEvents(
-      EventSearchParams params, Map<String, Set<String>> psdesWithSkipSyncTrue) {
+      EventQueryParams params, Map<String, Set<String>> psdesWithSkipSyncTrue) {
     User user = currentUserService.getCurrentUser();
 
     setAccessiblePrograms(user, params);
@@ -446,7 +446,7 @@ public class JdbcEventStore implements EventStore {
     }
   }
 
-  private String getEventSelectIdentifiersByIdScheme(EventSearchParams params) {
+  private String getEventSelectIdentifiersByIdScheme(EventQueryParams params) {
     IdSchemes idSchemes = params.getIdSchemes();
 
     StringBuilder sqlBuilder = new StringBuilder();
@@ -485,7 +485,7 @@ public class JdbcEventStore implements EventStore {
   }
 
   @Override
-  public int getEventCount(EventSearchParams params) {
+  public int getEventCount(EventQueryParams params) {
     User user = currentUserService.getCurrentUser();
     setAccessiblePrograms(user, params);
 
@@ -512,7 +512,7 @@ public class JdbcEventStore implements EventStore {
    * on events.
    */
   private String buildSql(
-      EventSearchParams params, MapSqlParameterSource mapSqlParameterSource, User user) {
+      EventQueryParams params, MapSqlParameterSource mapSqlParameterSource, User user) {
     StringBuilder sqlBuilder = new StringBuilder().append("select * from (");
 
     sqlBuilder.append(getEventSelectQuery(params, mapSqlParameterSource, user));
@@ -630,7 +630,7 @@ public class JdbcEventStore implements EventStore {
   }
 
   private String getEventSelectQuery(
-      EventSearchParams params, MapSqlParameterSource mapSqlParameterSource, User user) {
+      EventQueryParams params, MapSqlParameterSource mapSqlParameterSource, User user) {
     SqlHelper hlp = new SqlHelper();
 
     StringBuilder selectBuilder =
@@ -680,7 +680,7 @@ public class JdbcEventStore implements EventStore {
         .toString();
   }
 
-  private boolean checkForOwnership(EventSearchParams params) {
+  private boolean checkForOwnership(EventQueryParams params) {
     return Optional.ofNullable(params.getProgram())
         .filter(
             p ->
@@ -689,12 +689,12 @@ public class JdbcEventStore implements EventStore {
         .isPresent();
   }
 
-  private String getOuTableName(EventSearchParams params) {
+  private String getOuTableName(EventQueryParams params) {
     return checkForOwnership(params) ? " evou" : " ou";
   }
 
   private StringBuilder getFromWhereClause(
-      EventSearchParams params,
+      EventQueryParams params,
       MapSqlParameterSource mapSqlParameterSource,
       User user,
       SqlHelper hlp,
@@ -946,7 +946,7 @@ public class JdbcEventStore implements EventStore {
     return fromBuilder;
   }
 
-  private String getOrgUnitSql(EventSearchParams params, String ouTable) {
+  private String getOrgUnitSql(EventQueryParams params, String ouTable) {
     return switch (params.getOrgUnitMode()) {
       case SELECTED -> getSelectedOrgUnitPath(params.getAccessibleOrgUnits(), ouTable);
       case CHILDREN -> getChildrenOrgUnitsPath(params.getAccessibleOrgUnits(), ouTable);
@@ -960,7 +960,7 @@ public class JdbcEventStore implements EventStore {
    * in where clause.
    */
   private StringBuilder dataElementAndFiltersSql(
-      EventSearchParams params,
+      EventQueryParams params,
       MapSqlParameterSource mapSqlParameterSource,
       SqlHelper hlp,
       StringBuilder selectBuilder) {
@@ -1100,7 +1100,7 @@ public class JdbcEventStore implements EventStore {
   }
 
   private String eventStatusSql(
-      EventSearchParams params, MapSqlParameterSource mapSqlParameterSource, SqlHelper hlp) {
+      EventQueryParams params, MapSqlParameterSource mapSqlParameterSource, SqlHelper hlp) {
     StringBuilder stringBuilder = new StringBuilder();
 
     if (params.getEventStatus() != null) {
@@ -1135,7 +1135,7 @@ public class JdbcEventStore implements EventStore {
   }
 
   private String addLastUpdatedFilters(
-      EventSearchParams params, MapSqlParameterSource mapSqlParameterSource, SqlHelper hlp) {
+      EventQueryParams params, MapSqlParameterSource mapSqlParameterSource, SqlHelper hlp) {
     StringBuilder sqlBuilder = new StringBuilder();
 
     if (params.hasUpdatedAtDuration()) {
@@ -1217,7 +1217,7 @@ public class JdbcEventStore implements EventStore {
     return joinCondition + ") as coc_agg on coc_agg.id = ev.attributeoptioncomboid ";
   }
 
-  private String getEventPagingQuery(final EventSearchParams params) {
+  private String getEventPagingQuery(final EventQueryParams params) {
     final StringBuilder sqlBuilder = new StringBuilder().append(" ");
     int pageSize = params.getPageSizeWithDefault();
 
@@ -1241,7 +1241,7 @@ public class JdbcEventStore implements EventStore {
     return sqlBuilder.toString();
   }
 
-  private String getOrderQuery(EventSearchParams params) {
+  private String getOrderQuery(EventQueryParams params) {
     ArrayList<String> orderFields = new ArrayList<>();
 
     for (Order order : params.getOrder()) {
@@ -1295,7 +1295,7 @@ public class JdbcEventStore implements EventStore {
     }
   }
 
-  private void setAccessiblePrograms(User user, EventSearchParams params) {
+  private void setAccessiblePrograms(User user, EventQueryParams params) {
     if (!isSuper(user)) {
       params.setAccessiblePrograms(
           manager.getDataReadAll(Program.class).stream()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -85,9 +85,7 @@ import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
 import org.hisp.dhis.tracker.export.event.EventParams;
-import org.hisp.dhis.tracker.export.event.EventSearchParams;
 import org.hisp.dhis.tracker.export.event.EventService;
-import org.hisp.dhis.tracker.export.event.EventStore;
 import org.hisp.dhis.tracker.export.trackedentity.aggregates.TrackedEntityAggregate;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
@@ -821,7 +819,8 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
 
   /**
    * This method will apply the logic related to the parameter 'totalPages=false'. This works in
-   * conjunction with the method: {@link EventStore#getEvents(EventSearchParams, Map)}
+   * conjunction with the method: {@link
+   * TrackedEntityStore#getTrackedEntityIds(TrackedEntityQueryParams)}
    *
    * <p>This is needed because we need to query (pageSize + 1) at DB level. The resulting query will
    * allow us to evaluate if we are in the last page or not. And this is what his method does,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
@@ -269,9 +269,9 @@ class EventOperationParamsMapperTest {
         .thenReturn(combo);
     when(aclService.canDataRead(any(User.class), any(CategoryOptionCombo.class))).thenReturn(true);
 
-    EventSearchParams searchParams = mapper.map(operationParams);
+    EventQueryParams queryParams = mapper.map(operationParams);
 
-    assertEquals(combo, searchParams.getCategoryOptionCombo());
+    assertEquals(combo, queryParams.getCategoryOptionCombo());
   }
 
   @Test
@@ -282,13 +282,13 @@ class EventOperationParamsMapperTest {
             .assignedUserMode(AssignedUserSelectionMode.PROVIDED)
             .build();
 
-    EventSearchParams searchParams = mapper.map(operationParams);
+    EventQueryParams queryParams = mapper.map(operationParams);
 
     assertContainsOnly(
         Set.of("IsdLBTOBzMi", "l5ab8q5skbB"),
-        searchParams.getAssignedUserQueryParam().getAssignedUsers());
+        queryParams.getAssignedUserQueryParam().getAssignedUsers());
     assertEquals(
-        AssignedUserSelectionMode.PROVIDED, searchParams.getAssignedUserQueryParam().getMode());
+        AssignedUserSelectionMode.PROVIDED, queryParams.getAssignedUserQueryParam().getMode());
   }
 
   @Test
@@ -310,9 +310,9 @@ class EventOperationParamsMapperTest {
                     List.of(new QueryFilter(QueryOperator.LIKE, "foo"))))
             .build();
 
-    EventSearchParams searchParams = mapper.map(operationParams);
+    EventQueryParams queryParams = mapper.map(operationParams);
 
-    Map<TrackedEntityAttribute, List<QueryFilter>> attributes = searchParams.getAttributes();
+    Map<TrackedEntityAttribute, List<QueryFilter>> attributes = queryParams.getAttributes();
     assertNotNull(attributes);
     Map<TrackedEntityAttribute, List<QueryFilter>> expected =
         Map.of(
@@ -358,7 +358,7 @@ class EventOperationParamsMapperTest {
             .orderBy("dueDate", SortDirection.ASC)
             .build();
 
-    EventSearchParams params = mapper.map(operationParams);
+    EventQueryParams params = mapper.map(operationParams);
 
     assertEquals(
         List.of(
@@ -422,9 +422,9 @@ class EventOperationParamsMapperTest {
                     List.of(new QueryFilter(QueryOperator.LIKE, "foo"))))
             .build();
 
-    EventSearchParams searchParams = mapper.map(operationParams);
+    EventQueryParams queryParams = mapper.map(operationParams);
 
-    Map<DataElement, List<QueryFilter>> dataElements = searchParams.getDataElements();
+    Map<DataElement, List<QueryFilter>> dataElements = queryParams.getDataElements();
     assertNotNull(dataElements);
     Map<DataElement, List<QueryFilter>> expected =
         Map.of(
@@ -473,9 +473,9 @@ class EventOperationParamsMapperTest {
             .orgUnitMode(DESCENDANTS)
             .build();
 
-    EventSearchParams searchParams = mapper.map(operationParams);
+    EventQueryParams queryParams = mapper.map(operationParams);
 
-    assertContainsOnly(List.of(captureScopeOrgUnit), searchParams.getAccessibleOrgUnits());
+    assertContainsOnly(List.of(captureScopeOrgUnit), queryParams.getAccessibleOrgUnits());
   }
 
   @Test
@@ -499,9 +499,9 @@ class EventOperationParamsMapperTest {
             .orgUnitMode(DESCENDANTS)
             .build();
 
-    EventSearchParams searchParams = mapper.map(operationParams);
+    EventQueryParams queryParams = mapper.map(operationParams);
 
-    assertContainsOnly(List.of(searchScopeOrgUnit), searchParams.getAccessibleOrgUnits());
+    assertContainsOnly(List.of(searchScopeOrgUnit), queryParams.getAccessibleOrgUnits());
   }
 
   @Test
@@ -581,9 +581,9 @@ class EventOperationParamsMapperTest {
     when(currentUserService.getCurrentUser()).thenReturn(user);
     when(organisationUnitService.getOrganisationUnit(orgUnit.getUid())).thenReturn(orgUnit);
 
-    EventSearchParams searchParams = mapper.map(operationParams);
+    EventQueryParams queryParams = mapper.map(operationParams);
 
-    assertContainsOnly(List.of(captureScopeOrgUnit), searchParams.getAccessibleOrgUnits());
+    assertContainsOnly(List.of(captureScopeOrgUnit), queryParams.getAccessibleOrgUnits());
   }
 
   @Test
@@ -605,9 +605,9 @@ class EventOperationParamsMapperTest {
     when(currentUserService.getCurrentUser()).thenReturn(user);
     when(organisationUnitService.getOrganisationUnit(orgUnit.getUid())).thenReturn(orgUnit);
 
-    EventSearchParams searchParams = mapper.map(operationParams);
+    EventQueryParams queryParams = mapper.map(operationParams);
 
-    assertContainsOnly(List.of(searchScopeOrgUnit), searchParams.getAccessibleOrgUnits());
+    assertContainsOnly(List.of(searchScopeOrgUnit), queryParams.getAccessibleOrgUnits());
   }
 
   @Test
@@ -674,9 +674,9 @@ class EventOperationParamsMapperTest {
     EventOperationParams operationParams =
         EventOperationParams.builder().programUid(program.getUid()).orgUnitMode(CAPTURE).build();
 
-    EventSearchParams searchParams = mapper.map(operationParams);
+    EventQueryParams queryParams = mapper.map(operationParams);
 
-    assertContainsOnly(List.of(captureScopeOrgUnit), searchParams.getAccessibleOrgUnits());
+    assertContainsOnly(List.of(captureScopeOrgUnit), queryParams.getAccessibleOrgUnits());
   }
 
   @Test
@@ -692,9 +692,9 @@ class EventOperationParamsMapperTest {
 
     EventOperationParams operationParams = eventBuilder.programUid(program.getUid()).build();
 
-    EventSearchParams searchParams = mapper.map(operationParams);
+    EventQueryParams queryParams = mapper.map(operationParams);
 
-    assertContainsOnly(List.of(searchScopeOrgUnit), searchParams.getAccessibleOrgUnits());
+    assertContainsOnly(List.of(searchScopeOrgUnit), queryParams.getAccessibleOrgUnits());
   }
 
   @Test
@@ -719,9 +719,9 @@ class EventOperationParamsMapperTest {
             .orgUnitMode(SELECTED)
             .build();
 
-    EventSearchParams searchParams = mapper.map(operationParams);
+    EventQueryParams queryParams = mapper.map(operationParams);
 
-    assertContainsOnly(List.of(orgUnit), searchParams.getAccessibleOrgUnits());
+    assertContainsOnly(List.of(orgUnit), queryParams.getAccessibleOrgUnits());
   }
 
   @Test
@@ -737,10 +737,10 @@ class EventOperationParamsMapperTest {
 
     EventOperationParams operationParams = eventBuilder.programUid(program.getUid()).build();
 
-    EventSearchParams searchParams = mapper.map(operationParams);
+    EventQueryParams queryParams = mapper.map(operationParams);
 
-    assertEquals(ACCESSIBLE, searchParams.getOrgUnitMode());
-    assertContainsOnly(List.of(searchScopeOrgUnit), searchParams.getAccessibleOrgUnits());
+    assertEquals(ACCESSIBLE, queryParams.getOrgUnitMode());
+    assertContainsOnly(List.of(searchScopeOrgUnit), queryParams.getAccessibleOrgUnits());
   }
 
   private OrganisationUnit createOrgUnit(String name, String uid) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventQueryParamsTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventQueryParamsTest.java
@@ -43,7 +43,7 @@ import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class EventSearchParamsTest extends DhisConvenienceTest {
+class EventQueryParamsTest extends DhisConvenienceTest {
 
   private TrackedEntityAttribute tea1;
 
@@ -57,7 +57,7 @@ class EventSearchParamsTest extends DhisConvenienceTest {
 
   @Test
   void shouldAddAttributeToOrderAndAttributesWhenOrderingByAttribute() {
-    EventSearchParams params = new EventSearchParams();
+    EventQueryParams params = new EventQueryParams();
 
     params.orderBy(tea1, SortDirection.DESC);
 
@@ -67,7 +67,7 @@ class EventSearchParamsTest extends DhisConvenienceTest {
 
   @Test
   void shouldKeepExistingAttributeFiltersWhenOrderingByAttribute() {
-    EventSearchParams params = new EventSearchParams();
+    EventQueryParams params = new EventQueryParams();
 
     QueryFilter filter = new QueryFilter(QueryOperator.EQ, "summer day");
     params.filterBy(tea1, filter);
@@ -81,7 +81,7 @@ class EventSearchParamsTest extends DhisConvenienceTest {
 
   @Test
   void shouldAddDataElementToOrderAndDataElementsWhenOrderingByDataElement() {
-    EventSearchParams params = new EventSearchParams();
+    EventQueryParams params = new EventQueryParams();
 
     params.orderBy(de1, SortDirection.ASC);
 
@@ -92,7 +92,7 @@ class EventSearchParamsTest extends DhisConvenienceTest {
 
   @Test
   void shouldKeepExistingDataElementFiltersWhenOrderingByDataElement() {
-    EventSearchParams params = new EventSearchParams();
+    EventQueryParams params = new EventQueryParams();
 
     QueryFilter filter = new QueryFilter(QueryOperator.EQ, "summer day");
     params.filterBy(de1, filter);


### PR DESCRIPTION
since all other parameters to store have the QueryParams suffix

Make them and the store package private as they are only used within the package. This should also force devs to go via our service"

This will be backported so that future backports will at least not be hindered by the difference in naming.