### PR TITLE
chore: implement /tracker/enrollment?order consistently with other endpointsTECH-1617

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -368,4 +368,9 @@ class DefaultEnrollmentService
 
     return enrollmentList;
   }
+
+  @Override
+  public Set<String> getOrderableFields() {
+    return enrollmentStore.getOrderableFields();
+  }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -69,7 +69,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @RequiredArgsConstructor
 @Service("org.hisp.dhis.tracker.export.enrollment.EnrollmentService")
-public class DefaultEnrollmentService
+class DefaultEnrollmentService
     implements org.hisp.dhis.tracker.export.enrollment.EnrollmentService {
   private final EnrollmentStore enrollmentStore;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParams.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.export.enrollment;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -37,7 +38,8 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.program.ProgramStatus;
-import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
+import org.hisp.dhis.tracker.export.Order;
+import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 
 @Getter
 @Builder(toBuilder = true)
@@ -102,8 +104,7 @@ public class EnrollmentOperationParams {
   /** Indicates whether to include soft-deleted enrollments */
   private final boolean includeDeleted;
 
-  /** List of order params */
-  private final List<OrderParam> order;
+  private final List<Order> order;
 
   /** Indicates whether paging is enabled. */
   public boolean isPaging() {
@@ -118,5 +119,23 @@ public class EnrollmentOperationParams {
   /** Returns the page size, falls back to default value of 50 if not specified. */
   public int getPageSizeWithDefault() {
     return pageSize != null && pageSize >= 0 ? pageSize : DEFAULT_PAGE_SIZE;
+  }
+
+  public static class EnrollmentOperationParamsBuilder {
+
+    private List<Order> order = new ArrayList<>();
+
+    // Do not remove this unused method. This hides the order field from the builder which Lombok
+    // does not support. The repeated order field and private order method prevent access to order
+    // via the builder.
+    // Order should be added via the orderBy builder methods.
+    private EnrollmentOperationParamsBuilder order(List<Order> order) {
+      return this;
+    }
+
+    public EnrollmentOperationParamsBuilder orderBy(String field, SortDirection direction) {
+      this.order.add(new Order(field, direction));
+      return this;
+    }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentQueryParams.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.export.enrollment;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -40,15 +41,16 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
+import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @Data
 @Accessors(chain = true)
-public class EnrollmentQueryParams {
+class EnrollmentQueryParams {
   public static final int DEFAULT_PAGE = 1;
 
   public static final int DEFAULT_PAGE_SIZE = 50;
@@ -106,8 +108,7 @@ public class EnrollmentQueryParams {
   /** Indicates whether to include soft-deleted enrollments */
   private boolean includeDeleted;
 
-  /** List of order params */
-  private List<OrderParam> order;
+  private List<Order> order;
 
   // -------------------------------------------------------------------------
   // Transient properties
@@ -222,5 +223,17 @@ public class EnrollmentQueryParams {
 
   public boolean isSorting() {
     return !CollectionUtils.emptyIfNull(order).isEmpty();
+  }
+
+  public List<Order> getOrder() {
+    return Collections.unmodifiableList(this.order);
+  }
+
+  /**
+   * Order by an enrollment field of the given {@code field} name in given sort {@code direction}.
+   */
+  public EnrollmentQueryParams orderBy(String field, SortDirection direction) {
+    this.order.add(new Order(field, direction));
+    return this;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentQueryParams.java
@@ -27,14 +27,12 @@
  */
 package org.hisp.dhis.tracker.export.enrollment;
 
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import lombok.Data;
 import lombok.experimental.Accessors;
-import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
@@ -219,14 +217,6 @@ class EnrollmentQueryParams {
     this.page = DEFAULT_PAGE;
     this.pageSize = DEFAULT_PAGE_SIZE;
     this.skipPaging = false;
-  }
-
-  public boolean isSorting() {
-    return !CollectionUtils.emptyIfNull(order).isEmpty();
-  }
-
-  public List<Order> getOrder() {
-    return Collections.unmodifiableList(this.order);
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.export.enrollment;
 
+import java.util.Set;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
@@ -41,4 +42,12 @@ public interface EnrollmentService {
 
   Enrollments getEnrollments(EnrollmentOperationParams params)
       throws ForbiddenException, BadRequestException;
+
+  /**
+   * Fields the {@link #getEnrollments(EnrollmentOperationParams)} can order enrollments by.
+   * Ordering by fields other than these is considered a programmer error. Validation of user
+   * provided field names should occur before calling {@link
+   * #getEnrollments(EnrollmentOperationParams)}.
+   */
+  Set<String> getOrderableFields();
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentStore.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.tracker.export.enrollment;
 
 import java.util.List;
+import java.util.Set;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 import org.hisp.dhis.program.Enrollment;
 
@@ -49,4 +50,11 @@ interface EnrollmentStore extends IdentifiableObjectStore<Enrollment> {
    * @return Enrollments matching params
    */
   List<Enrollment> getEnrollments(EnrollmentQueryParams params);
+
+  /**
+   * Fields the {@link #getEnrollments(EnrollmentQueryParams)} can order enrollments by. Ordering by
+   * fields other than these is considered a programmer error. Validation of user provided field
+   * names should occur before calling {@link #getEnrollments(EnrollmentQueryParams)}.
+   */
+  Set<String> getOrderableFields();
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/HibernateEnrollmentStore.java
@@ -35,6 +35,7 @@ import static org.hisp.dhis.util.DateUtils.nowMinusDuration;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -61,6 +62,19 @@ import org.springframework.stereotype.Repository;
 class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enrollment>
     implements EnrollmentStore {
   private static final String STATUS = "status";
+
+  /**
+   * Enrollments can be ordered by given fields which correspond to fields on {@link
+   * org.hisp.dhis.program.Enrollment}.
+   */
+  private static final Set<String> ORDERABLE_FIELDS =
+      Set.of(
+          "endDate",
+          "created",
+          "createdAtClient",
+          "enrollmentDate",
+          "lastUpdated",
+          "lastUpdatedAtClient");
 
   public HibernateEnrollmentStore(
       SessionFactory sessionFactory,
@@ -243,5 +257,10 @@ class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enrollment
   @Override
   protected Enrollment postProcessObject(Enrollment enrollment) {
     return (enrollment == null || enrollment.isDeleted()) ? null : enrollment;
+  }
+
+  @Override
+  public Set<String> getOrderableFields() {
+    return ORDERABLE_FIELDS;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -97,7 +97,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @Service("org.hisp.dhis.tracker.export.trackedentity.TrackedEntityService")
 @RequiredArgsConstructor
-public class DefaultTrackedEntityService implements TrackedEntityService {
+class DefaultTrackedEntityService implements TrackedEntityService {
 
   private final TrackedEntityStore trackedEntityStore;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParams.java
@@ -46,9 +46,9 @@ import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 
+@Getter
 @Builder(toBuilder = true)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Getter
 public class TrackedEntityOperationParams {
   public static final int DEFAULT_PAGE = 1;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
@@ -56,7 +56,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 
 @ToString
-public class TrackedEntityQueryParams {
+class TrackedEntityQueryParams {
 
   public static final int DEFAULT_PAGE = 1;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
@@ -56,7 +56,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 
 @ToString
-class TrackedEntityQueryParams {
+public class TrackedEntityQueryParams {
 
   public static final int DEFAULT_PAGE = 1;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapperTest.java
@@ -28,8 +28,8 @@
 package org.hisp.dhis.tracker.export.enrollment;
 
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -47,9 +47,9 @@ import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
+import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -252,19 +252,19 @@ class EnrollmentOperationParamsMapperTest {
   }
 
   @Test
-  void shouldMapOrderingParamsWhenOrderingParamsAreSpecified()
-      throws BadRequestException, ForbiddenException {
-    OrderParam order1 = new OrderParam("field1", SortDirection.ASC);
-    OrderParam order2 = new OrderParam("field2", SortDirection.DESC);
+  void shouldMapOrderInGivenOrder() throws BadRequestException, ForbiddenException {
     EnrollmentOperationParams operationParams =
-        EnrollmentOperationParams.builder().order(List.of(order1, order2)).build();
+        EnrollmentOperationParams.builder()
+            .orderBy("enrollmentDate", SortDirection.ASC)
+            .orderBy("createdAt", SortDirection.DESC)
+            .build();
 
     EnrollmentQueryParams params = mapper.map(operationParams);
 
     assertEquals(
         List.of(
-            new OrderParam("field1", SortDirection.ASC),
-            new OrderParam("field2", SortDirection.DESC)),
+            new Order("enrollmentDate", SortDirection.ASC),
+            new Order("createdAt", SortDirection.DESC)),
         params.getOrder());
   }
 
@@ -275,6 +275,6 @@ class EnrollmentOperationParamsMapperTest {
 
     EnrollmentQueryParams params = mapper.map(requestParams);
 
-    assertNull(params.getOrder());
+    assertIsEmpty(params.getOrder());
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
@@ -55,6 +55,7 @@ import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
@@ -494,6 +495,25 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
+  void shouldOrderEnrollmentsByPrimaryKeyDescByDefault()
+      throws ForbiddenException, BadRequestException {
+    Enrollment nxP7UnKhomJ = get(Enrollment.class, "nxP7UnKhomJ");
+    Enrollment TvctPPhpD8z = get(Enrollment.class, "TvctPPhpD8z");
+    List<String> expected =
+        Stream.of(nxP7UnKhomJ, TvctPPhpD8z)
+            .sorted(Comparator.comparing(Enrollment::getId).reversed()) // reversed = desc
+            .map(Enrollment::getUid)
+            .toList();
+
+    EnrollmentOperationParams params =
+        EnrollmentOperationParams.builder().orgUnitUids(Set.of(orgUnit.getUid())).build();
+
+    List<String> enrollments = getEnrollments(params);
+
+    assertEquals(expected, enrollments);
+  }
+
+  @Test
   void shouldOrderEnrollmentsByEnrolledAtAsc() throws ForbiddenException, BadRequestException {
     EnrollmentOperationParams params =
         EnrollmentOperationParams.builder()
@@ -507,7 +527,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldOrderEnrollmentsByOccurredAtDesc() throws ForbiddenException, BadRequestException {
+  void shouldOrderEnrollmentsByEnrolledAtDesc() throws ForbiddenException, BadRequestException {
     EnrollmentOperationParams params =
         EnrollmentOperationParams.builder()
             .orgUnitUids(Set.of(orgUnit.getUid()))

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.tracker.export;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.SELECTED;
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
+import static org.hisp.dhis.tracker.Assertions.assertSlimPager;
+import static org.hisp.dhis.tracker.TrackerTestUtils.uids;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -59,6 +61,10 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.tracker.TrackerTest;
+import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
+import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams.EnrollmentOperationParamsBuilder;
+import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
+import org.hisp.dhis.tracker.export.enrollment.Enrollments;
 import org.hisp.dhis.tracker.export.event.EventOperationParams;
 import org.hisp.dhis.tracker.export.event.EventOperationParams.EventOperationParamsBuilder;
 import org.hisp.dhis.tracker.export.event.EventService;
@@ -78,6 +84,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 class OrderAndPaginationExporterTest extends TrackerTest {
 
   @Autowired private TrackedEntityService trackedEntityService;
+
+  @Autowired private EnrollmentService enrollmentService;
 
   @Autowired private EventService eventService;
 
@@ -451,6 +459,64 @@ class OrderAndPaginationExporterTest extends TrackerTest {
     List<String> trackedEntities = getTrackedEntities(params);
 
     assertEquals(List.of("QS6w44flWAf", "dUE514NMOlo"), trackedEntities);
+  }
+
+  @Test
+  void shouldReturnPaginatedEnrollmentsGivenNonDefaultPageSize()
+      throws ForbiddenException, BadRequestException {
+
+    EnrollmentOperationParamsBuilder builder =
+        EnrollmentOperationParams.builder()
+            .orgUnitUids(Set.of(orgUnit.getUid()))
+            .orderBy("enrollmentDate", SortDirection.ASC);
+
+    EnrollmentOperationParams params = builder.page(1).pageSize(1).build();
+
+    Enrollments firstPage = enrollmentService.getEnrollments(params);
+
+    assertAll(
+        "first page",
+        () -> assertSlimPager(1, 1, false, firstPage.getPager()),
+        () -> assertEquals(List.of("nxP7UnKhomJ"), uids(firstPage.getEnrollments())));
+
+    params = builder.page(2).pageSize(1).build();
+
+    Enrollments secondPage = enrollmentService.getEnrollments(params);
+
+    assertAll(
+        "second (last) page",
+        () -> assertSlimPager(2, 1, true, secondPage.getPager()),
+        () -> assertEquals(List.of("TvctPPhpD8z"), uids(secondPage.getEnrollments())));
+
+    params = builder.page(3).pageSize(1).build();
+
+    assertIsEmpty(uids(enrollmentService.getEnrollments(params).getEnrollments()));
+  }
+
+  @Test
+  void shouldOrderEnrollmentsByEnrolledAtAsc() throws ForbiddenException, BadRequestException {
+    EnrollmentOperationParams params =
+        EnrollmentOperationParams.builder()
+            .orgUnitUids(Set.of(orgUnit.getUid()))
+            .orderBy("enrollmentDate", SortDirection.ASC)
+            .build();
+
+    List<String> enrollments = getEnrollments(params);
+
+    assertEquals(List.of("nxP7UnKhomJ", "TvctPPhpD8z"), enrollments);
+  }
+
+  @Test
+  void shouldOrderEnrollmentsByOccurredAtDesc() throws ForbiddenException, BadRequestException {
+    EnrollmentOperationParams params =
+        EnrollmentOperationParams.builder()
+            .orgUnitUids(Set.of(orgUnit.getUid()))
+            .orderBy("enrollmentDate", SortDirection.DESC)
+            .build();
+
+    List<String> enrollments = getEnrollments(params);
+
+    assertEquals(List.of("TvctPPhpD8z", "nxP7UnKhomJ"), enrollments);
   }
 
   @Test
@@ -883,6 +949,11 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   private List<String> getTrackedEntities(TrackedEntityOperationParams params)
       throws ForbiddenException, BadRequestException, NotFoundException {
     return uids(trackedEntityService.getTrackedEntities(params).getTrackedEntities());
+  }
+
+  private List<String> getEnrollments(EnrollmentOperationParams params)
+      throws ForbiddenException, BadRequestException {
+    return uids(enrollmentService.getEnrollments(params).getEnrollments());
   }
 
   private List<String> getEvents(EventOperationParams params)

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerUnitTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerUnitTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.export.enrollment;
+
+import static org.hisp.dhis.utils.Assertions.assertContains;
+import static org.hisp.dhis.utils.Assertions.assertStartsWith;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.hisp.dhis.fieldfiltering.FieldFilterService;
+import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EnrollmentsExportControllerUnitTest {
+
+  @Mock private EnrollmentService enrollmentService;
+
+  @Mock private EnrollmentRequestParamsMapper paramsMapper;
+
+  @Mock private FieldFilterService fieldFilterService;
+
+  @Mock private EnrollmentFieldsParamMapper fieldsMapper;
+
+  @Test
+  void shouldFailInstantiatingControllerIfAnyOrderableFieldIsUnsupported() {
+    // pretend the service does not support 2 of the orderable fields the web advocates
+    Iterator<Entry<String, String>> iterator =
+        EnrollmentMapper.ORDERABLE_FIELDS.entrySet().stream().iterator();
+    Entry<String, String> missing1 = iterator.next();
+    Entry<String, String> missing2 = iterator.next();
+    Map<String, String> orderableFields = new HashMap<>(EnrollmentMapper.ORDERABLE_FIELDS);
+    orderableFields.remove(missing1.getKey());
+    orderableFields.remove(missing2.getKey());
+    when(enrollmentService.getOrderableFields())
+        .thenReturn(new HashSet<>(orderableFields.values()));
+
+    Exception exception =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                new EnrollmentsExportController(
+                    enrollmentService, paramsMapper, fieldFilterService, fieldsMapper));
+
+    assertAll(
+        () ->
+            assertStartsWith("enrollment controller supports ordering by", exception.getMessage()),
+        () -> assertContains(missing1.getKey(), exception.getMessage()),
+        () -> assertContains(missing2.getKey(), exception.getMessage()));
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
@@ -231,7 +231,7 @@ public class RequestParamUtils {
    * {@code supportedFieldNames}. Every field name can be specified at most once. If the endpoint
    * supports field names and UIDs use {@link #validateOrderParams(List, Set, String)}.
    */
-  public static void validateOrderParams(Set<String> supportedFieldNames, List<OrderCriteria> order)
+  public static void validateOrderParams(List<OrderCriteria> order, Set<String> supportedFieldNames)
       throws BadRequestException {
     if (order == null || order.isEmpty()) {
       return;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
@@ -223,9 +223,10 @@ public class RequestParamUtils {
 
   /**
    * Validate the {@code order} request parameter in tracker exporters. Allowed order values are
-   * {@code supportedFieldNames}. Every field name can be specified at most once. If the endpoint supports field names and UIDs use {@link #validateOrderParams(Set, String, List)}.
+   * {@code supportedFieldNames}. Every field name can be specified at most once. If the endpoint
+   * supports field names and UIDs use {@link #validateOrderParams(Set, String, List)}.
    */
-  public static void validateOrderParams( Set<String> supportedFieldNames, List<OrderCriteria> order)
+  public static void validateOrderParams(Set<String> supportedFieldNames, List<OrderCriteria> order)
       throws BadRequestException {
     if (order == null || order.isEmpty()) {
       return;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentMapper.java
@@ -57,7 +57,14 @@ public interface EnrollmentMapper
    * Enrollments can be ordered by given fields which correspond to fields on {@link
    * org.hisp.dhis.program.Enrollment}.
    */
-  Map<String, String> ORDERABLE_FIELDS = Map.ofEntries( entry("enrolledAt", "enrollmentDate"));
+  Map<String, String> ORDERABLE_FIELDS =
+      Map.ofEntries(
+          entry("completedAt", "endDate"),
+          entry("createdAt", "created"),
+          entry("createdAtClient", "createdAtClient"),
+          entry("enrolledAt", "enrollmentDate"),
+          entry("updatedAt", "lastUpdated"),
+          entry("updatedAtClient", "lastUpdatedAtClient"));
 
   @Mapping(target = "enrollment", source = "uid")
   @Mapping(target = "createdAt", source = "created")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentMapper.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.enrollment;
 
+import static java.util.Map.entry;
+
+import java.util.Map;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.webapi.controller.tracker.export.AttributeMapper;
 import org.hisp.dhis.webapi.controller.tracker.export.NoteMapper;
@@ -49,6 +52,13 @@ import org.mapstruct.Mapping;
     })
 public interface EnrollmentMapper
     extends ViewMapper<Enrollment, org.hisp.dhis.webapi.controller.tracker.view.Enrollment> {
+
+  /**
+   * Enrollments can be ordered by given fields which correspond to fields on {@link
+   * org.hisp.dhis.program.Enrollment}.
+   */
+  Map<String, String> ORDERABLE_FIELDS = Map.ofEntries( entry("enrolledAt", "enrollmentDate"));
+
   @Mapping(target = "enrollment", source = "uid")
   @Mapping(target = "createdAt", source = "created")
   @Mapping(target = "createdAtClient", source = "createdAtClient")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
@@ -71,7 +71,7 @@ class EnrollmentRequestParamsMapper {
 
     validateOrgUnitParams(orgUnits, orgUnitMode);
 
-    validateOrderParams(requestParams.getOrder(), ORDERABLE_FIELD_NAMES, "");
+    validateOrderParams(requestParams.getOrder(), ORDERABLE_FIELD_NAMES);
 
     EnrollmentOperationParamsBuilder builder =
         EnrollmentOperationParams.builder()

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
@@ -71,7 +71,7 @@ class EnrollmentRequestParamsMapper {
 
     validateOrgUnitParams(orgUnits, orgUnitMode);
 
-    validateOrderParams(ORDERABLE_FIELD_NAMES, "", requestParams.getOrder());
+    validateOrderParams(requestParams.getOrder(), ORDERABLE_FIELD_NAMES, "");
 
     EnrollmentOperationParamsBuilder builder =
         EnrollmentOperationParams.builder()

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
@@ -33,6 +33,7 @@ import static org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams.
 import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedUidsParameter;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateOrderParams;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateOrgUnitParams;
 
 import java.util.Objects;
@@ -52,6 +53,8 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 class EnrollmentRequestParamsMapper {
+  private static final Set<String> ORDERABLE_FIELD_NAMES = EnrollmentMapper.ORDERABLE_FIELDS.keySet();
+
   private final EnrollmentFieldsParamMapper fieldsParamMapper;
 
   public EnrollmentOperationParams map(RequestParams requestParams) throws BadRequestException {
@@ -64,6 +67,9 @@ class EnrollmentRequestParamsMapper {
             "ouMode", requestParams.getOuMode(), "orgUnitMode", requestParams.getOrgUnitMode());
 
     validateOrgUnitParams(orgUnits, orgUnitMode);
+
+    validateOrderParams(
+        ORDERABLE_FIELD_NAMES, "", requestParams.getOrder());
 
     return EnrollmentOperationParams.builder()
         .programUid(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
@@ -30,12 +30,12 @@ package org.hisp.dhis.webapi.controller.tracker.export.enrollment;
 import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
 import static org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams.DEFAULT_PAGE;
 import static org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams.DEFAULT_PAGE_SIZE;
-import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedUidsParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateOrderParams;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateOrgUnitParams;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -43,6 +43,8 @@ import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
+import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams.EnrollmentOperationParamsBuilder;
+import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.springframework.stereotype.Component;
 
 /**
@@ -53,7 +55,8 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 class EnrollmentRequestParamsMapper {
-  private static final Set<String> ORDERABLE_FIELD_NAMES = EnrollmentMapper.ORDERABLE_FIELDS.keySet();
+  private static final Set<String> ORDERABLE_FIELD_NAMES =
+      EnrollmentMapper.ORDERABLE_FIELDS.keySet();
 
   private final EnrollmentFieldsParamMapper fieldsParamMapper;
 
@@ -68,35 +71,50 @@ class EnrollmentRequestParamsMapper {
 
     validateOrgUnitParams(orgUnits, orgUnitMode);
 
-    validateOrderParams(
-        ORDERABLE_FIELD_NAMES, "", requestParams.getOrder());
+    validateOrderParams(ORDERABLE_FIELD_NAMES, "", requestParams.getOrder());
 
-    return EnrollmentOperationParams.builder()
-        .programUid(
-            requestParams.getProgram() != null ? requestParams.getProgram().getValue() : null)
-        .programStatus(requestParams.getProgramStatus())
-        .followUp(requestParams.getFollowUp())
-        .lastUpdated(requestParams.getUpdatedAfter())
-        .lastUpdatedDuration(requestParams.getUpdatedWithin())
-        .programStartDate(requestParams.getEnrolledAfter())
-        .programEndDate(requestParams.getEnrolledBefore())
-        .trackedEntityTypeUid(
-            requestParams.getTrackedEntityType() != null
-                ? requestParams.getTrackedEntityType().getValue()
-                : null)
-        .trackedEntityUid(
-            requestParams.getTrackedEntity() != null
-                ? requestParams.getTrackedEntity().getValue()
-                : null)
-        .orgUnitUids(UID.toValueSet(orgUnits))
-        .orgUnitMode(orgUnitMode)
-        .page(Objects.requireNonNullElse(requestParams.getPage(), DEFAULT_PAGE))
-        .pageSize(Objects.requireNonNullElse(requestParams.getPageSize(), DEFAULT_PAGE_SIZE))
-        .totalPages(toBooleanDefaultIfNull(requestParams.isTotalPages(), false))
-        .skipPaging(toBooleanDefaultIfNull(requestParams.isSkipPaging(), false))
-        .includeDeleted(requestParams.isIncludeDeleted())
-        .order(toOrderParams(requestParams.getOrder()))
-        .enrollmentParams(fieldsParamMapper.map(requestParams.getFields()))
-        .build();
+    EnrollmentOperationParamsBuilder builder =
+        EnrollmentOperationParams.builder()
+            .programUid(
+                requestParams.getProgram() != null ? requestParams.getProgram().getValue() : null)
+            .programStatus(requestParams.getProgramStatus())
+            .followUp(requestParams.getFollowUp())
+            .lastUpdated(requestParams.getUpdatedAfter())
+            .lastUpdatedDuration(requestParams.getUpdatedWithin())
+            .programStartDate(requestParams.getEnrolledAfter())
+            .programEndDate(requestParams.getEnrolledBefore())
+            .trackedEntityTypeUid(
+                requestParams.getTrackedEntityType() != null
+                    ? requestParams.getTrackedEntityType().getValue()
+                    : null)
+            .trackedEntityUid(
+                requestParams.getTrackedEntity() != null
+                    ? requestParams.getTrackedEntity().getValue()
+                    : null)
+            .orgUnitUids(UID.toValueSet(orgUnits))
+            .orgUnitMode(orgUnitMode)
+            .page(Objects.requireNonNullElse(requestParams.getPage(), DEFAULT_PAGE))
+            .pageSize(Objects.requireNonNullElse(requestParams.getPageSize(), DEFAULT_PAGE_SIZE))
+            .totalPages(toBooleanDefaultIfNull(requestParams.isTotalPages(), false))
+            .skipPaging(toBooleanDefaultIfNull(requestParams.isSkipPaging(), false))
+            .includeDeleted(requestParams.isIncludeDeleted())
+            .enrollmentParams(fieldsParamMapper.map(requestParams.getFields()));
+
+    mapOrderParam(builder, requestParams.getOrder());
+
+    return builder.build();
+  }
+
+  private void mapOrderParam(EnrollmentOperationParamsBuilder builder, List<OrderCriteria> orders) {
+    if (orders == null || orders.isEmpty()) {
+      return;
+    }
+
+    for (OrderCriteria order : orders) {
+      if (EnrollmentMapper.ORDERABLE_FIELDS.containsKey(order.getField())) {
+        builder.orderBy(
+            EnrollmentMapper.ORDERABLE_FIELDS.get(order.getField()), order.getDirection());
+      }
+    }
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller.tracker.export.enrollment;
 
 import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.RESOURCE_PATH;
+import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.assertUserOrderableFieldsAreSupported;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateDeprecatedUidsParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.enrollment.RequestParams.DEFAULT_FIELDS_PARAM;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -36,7 +37,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.OpenApi.Response.Status;
@@ -67,20 +67,33 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping(value = RESOURCE_PATH + "/" + EnrollmentsExportController.ENROLLMENTS)
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
-@RequiredArgsConstructor
 class EnrollmentsExportController {
   protected static final String ENROLLMENTS = "enrollments";
 
   private static final EnrollmentMapper ENROLLMENT_MAPPER =
       Mappers.getMapper(EnrollmentMapper.class);
 
-  private final EnrollmentRequestParamsMapper operationParamsMapper;
-
   private final EnrollmentService enrollmentService;
+
+  private final EnrollmentRequestParamsMapper paramsMapper;
 
   private final FieldFilterService fieldFilterService;
 
   private final EnrollmentFieldsParamMapper fieldsMapper;
+
+  public EnrollmentsExportController(
+      EnrollmentService enrollmentService,
+      EnrollmentRequestParamsMapper paramsMapper,
+      FieldFilterService fieldFilterService,
+      EnrollmentFieldsParamMapper fieldsMapper) {
+    this.enrollmentService = enrollmentService;
+    this.paramsMapper = paramsMapper;
+    this.fieldFilterService = fieldFilterService;
+    this.fieldsMapper = fieldsMapper;
+
+    assertUserOrderableFieldsAreSupported(
+        "enrollment", EnrollmentMapper.ORDERABLE_FIELDS, enrollmentService.getOrderableFields());
+  }
 
   @OpenApi.Response(status = Status.OK, value = OpenApiExport.ListResponse.class)
   @GetMapping(produces = APPLICATION_JSON_VALUE)
@@ -90,7 +103,7 @@ class EnrollmentsExportController {
 
     List<org.hisp.dhis.program.Enrollment> enrollmentList;
 
-    EnrollmentOperationParams operationParams = operationParamsMapper.map(requestParams);
+    EnrollmentOperationParams operationParams = paramsMapper.map(requestParams);
 
     Set<UID> enrollmentUids =
         validateDeprecatedUidsParameter(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
@@ -110,7 +110,7 @@ class EventRequestParamsMapper {
 
     validateUpdateDurationParams(requestParams);
     validateOrderParams(
-        ORDERABLE_FIELD_NAMES, "data element and attribute", requestParams.getOrder());
+        requestParams.getOrder(), ORDERABLE_FIELD_NAMES, "data element and attribute");
 
     EventOperationParamsBuilder builder =
         EventOperationParams.builder()

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
@@ -103,7 +103,7 @@ class TrackedEntityRequestParamsMapper {
             requestParams.getTrackedEntity(),
             "trackedEntities",
             requestParams.getTrackedEntities());
-    validateOrderParams(ORDERABLE_FIELD_NAMES, "attribute", requestParams.getOrder());
+    validateOrderParams(requestParams.getOrder(), ORDERABLE_FIELD_NAMES, "attribute");
 
     TrackedEntityOperationParamsBuilder builder =
         TrackedEntityOperationParams.builder()

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/EnrollmentsExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/EnrollmentsExportController.md
@@ -105,6 +105,23 @@ Get enrollments updated after given date.
 
 Get enrollments updated since given ISO-8601 duration.
 
+### `*.parameter.EnrollmentRequestParams.order`
+
+`<propertyName1:sortDirection>[,<propertyName2:sortDirection>...]`
+
+Get enrollments in given order. Enrollments can be ordered by the following case-sensitive
+properties
+
+* `completedAt`
+* `createdAt`
+* `createdAtClient`
+* `enrolledAt`
+* `updatedAt`
+* `updatedAtClient`
+
+Valid `sortDirection`s are `asc` and `desc`. `sortDirection` is case-insensitive. `sortDirection`
+defaults to `asc` for properties without explicit `sortDirection` as in `order=enrolledAt`.
+
 ### `*.parameter.EnrollmentRequestParams.fields`
 
 Get only the specified fields in the JSON response. This query parameter allows you to remove

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/EnrollmentsExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/EnrollmentsExportController.md
@@ -122,6 +122,9 @@ properties
 Valid `sortDirection`s are `asc` and `desc`. `sortDirection` is case-insensitive. `sortDirection`
 defaults to `asc` for properties without explicit `sortDirection` as in `order=enrolledAt`.
 
+Enrollments are ordered by newest (internal id desc) by default meaning when no `order` parameter is
+provided.
+
 ### `*.parameter.EnrollmentRequestParams.fields`
 
 Get only the specified fields in the JSON response. This query parameter allows you to remove

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtilsTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtilsTest.java
@@ -87,7 +87,7 @@ class RequestParamUtilsTest {
   void shouldPassOrderParamsValidationWhenGivenOrderIsOrderable() throws BadRequestException {
     Set<String> supportedFieldNames = Set.of("createdAt", "scheduledAt");
 
-    validateOrderParams(supportedFieldNames, "", fromOrderString("createdAt:asc,scheduledAt:asc"));
+    validateOrderParams(fromOrderString("createdAt:asc,scheduledAt:asc"), supportedFieldNames, "");
   }
 
   @Test
@@ -101,12 +101,12 @@ class RequestParamUtilsTest {
             BadRequestException.class,
             () ->
                 validateOrderParams(
-                    supportedFieldNames,
-                    "data element and attribute",
                     fromOrderString(
                         "unsupportedProperty1:asc,enrolledAt:asc,"
                             + invalidUID
-                            + ",unsupportedProperty2:desc")));
+                            + ",unsupportedProperty2:desc"),
+                    supportedFieldNames,
+                    "data element and attribute"));
     assertAll(
         () -> assertStartsWith("order parameter is invalid", exception.getMessage()),
         () ->
@@ -127,7 +127,7 @@ class RequestParamUtilsTest {
     // services. Such invalid order values will be caught in the service (mapper).
     assertTrue(CodeGenerator.isValidUid("lastUpdated"));
 
-    validateOrderParams(supportedFieldNames, "", fromOrderString("lastUpdated:desc"));
+    validateOrderParams(fromOrderString("lastUpdated:desc"), supportedFieldNames, "");
   }
 
   @Test
@@ -139,14 +139,15 @@ class RequestParamUtilsTest {
             BadRequestException.class,
             () ->
                 validateOrderParams(
-                    supportedFieldNames,
-                    "",
                     fromOrderString(
-                        "zGlzbfreTOH,createdAt:asc,enrolledAt:asc,enrolledAt,zGlzbfreTOH")));
+                        "zGlzbfreTOH,createdAt:asc,enrolledAt:asc,enrolledAt,zGlzbfreTOH"),
+                    supportedFieldNames,
+                    ""));
 
     assertAll(
         () -> assertStartsWith("order parameter is invalid", exception.getMessage()),
         // order of fields might not always be the same; therefore using contains
+        () -> assertContains("repeated", exception.getMessage()),
         () -> assertContains("enrolledAt", exception.getMessage()),
         () -> assertContains("zGlzbfreTOH", exception.getMessage()));
   }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapperTest.java
@@ -46,9 +46,9 @@ import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.fieldfiltering.FieldFilterParser;
+import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentParams;
-import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.junit.jupiter.api.BeforeEach;
@@ -177,26 +177,17 @@ class EnrollmentRequestParamsMapperTest {
   }
 
   @Test
-  void testMappingOrderParams() throws BadRequestException {
+  void shouldMapOrderParameterInGivenOrderWhenFieldsAreOrderable() throws BadRequestException {
     RequestParams requestParams = new RequestParams();
-    OrderCriteria order1 = OrderCriteria.of("enrolledAt", SortDirection.ASC);
-    requestParams.setOrder(List.of(order1));
+    requestParams.setOrder(OrderCriteria.fromOrderString("enrolledAt:desc,createdAt:asc"));
 
     EnrollmentOperationParams params = mapper.map(requestParams);
 
     assertEquals(
         List.of(
-            new OrderParam("enrolledAt", SortDirection.ASC)),
+            new Order("enrollmentDate", SortDirection.DESC),
+            new Order("created", SortDirection.ASC)),
         params.getOrder());
-  }
-
-  @Test
-  void testMappingOrderParamsNoOrder() throws BadRequestException {
-    RequestParams requestParams = new RequestParams();
-
-    EnrollmentOperationParams params = mapper.map(requestParams);
-
-    assertIsEmpty(params.getOrder());
   }
 
   @Test
@@ -209,5 +200,14 @@ class EnrollmentRequestParamsMapperTest {
     assertAll(
         () -> assertStartsWith("order parameter is invalid", exception.getMessage()),
         () -> assertContains("unsupportedProperty1", exception.getMessage()));
+  }
+
+  @Test
+  void testMappingOrderParamsNoOrder() throws BadRequestException {
+    RequestParams requestParams = new RequestParams();
+
+    EnrollmentOperationParams params = mapper.map(requestParams);
+
+    assertIsEmpty(params.getOrder());
   }
 }


### PR DESCRIPTION
* validate field names are supported and not repeated in web layer
* validate fields advocated by web are actually supported by service/store
* map to List<Order> and map field names to Java field names (dhis-api org.hisp.dhis.program.Enrollment class) in web layer
* stores do not need to handle order differently as we use hibernate to
  map from Java field names to DB columns
* add order and pagination test
* hide classes if possible. Devs should depend on our services not stores and not any particular implementation
* order by primary key desc by default
* document order in OpenAPI spec
