### PR TITLE
chore: Put index back in objects report [DHIS2-15596] 2.40

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/AbstractTrackerPersister.java
@@ -102,7 +102,7 @@ public abstract class AbstractTrackerPersister<
     Set<String> updatedTeiList = bundle.getUpdatedTeis();
 
     for (T trackerDto : dtos) {
-      Entity objectReport = new Entity(getType(), trackerDto.getUid());
+      Entity objectReport = new Entity(getType(), trackerDto.getUid(), dtos.indexOf(trackerDto));
 
       try {
         //

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/DefaultTrackerObjectsDeletionService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/DefaultTrackerObjectsDeletionService.java
@@ -78,7 +78,8 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
     for (Enrollment enrollment : enrollments) {
       String uid = enrollment.getEnrollment();
 
-      Entity objectReport = new Entity(TrackerType.ENROLLMENT, uid);
+      Entity objectReport =
+          new Entity(TrackerType.ENROLLMENT, uid, enrollments.indexOf(enrollment));
 
       ProgramInstance programInstance = programInstanceService.getProgramInstance(uid);
 
@@ -116,7 +117,7 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
     for (Event event : events) {
       String uid = event.getEvent();
 
-      Entity objectReport = new Entity(TrackerType.EVENT, uid);
+      Entity objectReport = new Entity(TrackerType.EVENT, uid, events.indexOf(event));
 
       ProgramStageInstance programStageInstance =
           programStageInstanceService.getProgramStageInstance(uid);
@@ -149,7 +150,8 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
     for (TrackedEntity trackedEntity : trackedEntities) {
       String uid = trackedEntity.getTrackedEntity();
 
-      Entity objectReport = new Entity(TrackerType.TRACKED_ENTITY, uid);
+      Entity objectReport =
+          new Entity(TrackerType.TRACKED_ENTITY, uid, trackedEntities.indexOf(trackedEntity));
 
       org.hisp.dhis.trackedentity.TrackedEntityInstance daoEntityInstance =
           teiService.getTrackedEntityInstance(uid);
@@ -186,7 +188,7 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
     for (Relationship rel : relationships) {
       String uid = rel.getRelationship();
 
-      Entity objectReport = new Entity(TrackerType.RELATIONSHIP, uid);
+      Entity objectReport = new Entity(TrackerType.RELATIONSHIP, uid, relationships.indexOf(rel));
 
       org.hisp.dhis.relationship.Relationship relationship =
           relationshipService.getRelationship(uid);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/Entity.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/Entity.java
@@ -42,6 +42,9 @@ public class Entity {
   /** Type of object this {@link Entity} represents. */
   @JsonProperty private final TrackerType trackerType;
 
+  /** Index into list. */
+  @JsonProperty private Integer index;
+
   /** UID of entity (if object is id object). */
   @JsonProperty private String uid;
 
@@ -51,18 +54,21 @@ public class Entity {
     this.trackerType = trackerType;
   }
 
-  public Entity(TrackerType trackerType, String uid) {
+  public Entity(TrackerType trackerType, String uid, Integer index) {
     this.trackerType = trackerType;
     this.uid = uid;
+    this.index = index;
   }
 
   @JsonCreator
   public Entity(
       @JsonProperty("trackerType") TrackerType trackerType,
       @JsonProperty("uid") String uid,
+      @JsonProperty("index") Integer index,
       @JsonProperty("errorReports") List<Error> errorReports) {
     this.trackerType = trackerType;
     this.uid = uid;
+    this.index = index;
     if (errorReports != null) {
       this.errorReports = errorReports;
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerBundleImportReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerBundleImportReportTest.java
@@ -310,7 +310,7 @@ class TrackerBundleImportReportTest {
   private PersistenceReport createBundleReport() {
     PersistenceReport persistenceReport = PersistenceReport.emptyReport();
     TrackerTypeReport typeReport = new TrackerTypeReport(TRACKED_ENTITY);
-    Entity objectReport = new Entity(TRACKED_ENTITY, "TEI_UID");
+    Entity objectReport = new Entity(TRACKED_ENTITY, "TEI_UID", 1);
     typeReport.addEntity(objectReport);
     typeReport.getStats().incCreated();
     persistenceReport.getTypeReportMap().put(TRACKED_ENTITY, typeReport);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAssertions.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAssertions.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -37,6 +38,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
@@ -193,6 +195,14 @@ public class JsonAssertions {
         jsonTypeReport.getEntityReport().stream()
             .map(JsonEntity::getUid)
             .collect(Collectors.toList());
-    assertEquals(expectedEntityUids, reportEntityUids);
+    List<Integer> reportEntityIndexes =
+        jsonTypeReport.getEntityReport().stream()
+            .map(JsonEntity::getIndex)
+            .collect(Collectors.toList());
+    List<Integer> expectedIndexes =
+        IntStream.range(0, expectedEntityUids.size()).boxed().collect(Collectors.toList());
+    assertAll(
+        () -> assertEquals(expectedEntityUids, reportEntityUids),
+        () -> assertEquals(expectedIndexes, reportEntityIndexes));
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonEntity.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonEntity.java
@@ -40,4 +40,8 @@ public interface JsonEntity extends JsonObject {
   default String getUid() {
     return getString("uid").string();
   }
+
+  default Integer getIndex() {
+    return getNumber("index").intValue();
+  }
 }


### PR DESCRIPTION
Removing index from `objectsReport` section in tracker report is going to be a breaking change in next release but we need to maintain it in older versions.