### PR TITLE
chore: Put index back in objects report [DHIS2-15596] 2.39

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/AbstractTrackerPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/AbstractTrackerPersister.java
@@ -102,7 +102,8 @@ public abstract class AbstractTrackerPersister<
     Set<String> updatedTeiList = bundle.getUpdatedTeis();
 
     for (T trackerDto : dtos) {
-      TrackerObjectReport objectReport = new TrackerObjectReport(getType(), trackerDto.getUid());
+      TrackerObjectReport objectReport =
+          new TrackerObjectReport(getType(), trackerDto.getUid(), dtos.indexOf(trackerDto));
 
       try {
         //

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/DefaultTrackerObjectsDeletionService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/DefaultTrackerObjectsDeletionService.java
@@ -78,7 +78,8 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
     for (Enrollment enrollment : enrollments) {
       String uid = enrollment.getEnrollment();
 
-      TrackerObjectReport objectReport = new TrackerObjectReport(TrackerType.ENROLLMENT, uid);
+      TrackerObjectReport objectReport =
+          new TrackerObjectReport(TrackerType.ENROLLMENT, uid, enrollments.indexOf(enrollment));
 
       ProgramInstance programInstance = programInstanceService.getProgramInstance(uid);
 
@@ -116,7 +117,8 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
     for (Event event : events) {
       String uid = event.getEvent();
 
-      TrackerObjectReport objectReport = new TrackerObjectReport(TrackerType.EVENT, uid);
+      TrackerObjectReport objectReport =
+          new TrackerObjectReport(TrackerType.EVENT, uid, events.indexOf(event));
 
       ProgramStageInstance programStageInstance =
           programStageInstanceService.getProgramStageInstance(uid);
@@ -149,7 +151,9 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
     for (TrackedEntity trackedEntity : trackedEntities) {
       String uid = trackedEntity.getTrackedEntity();
 
-      TrackerObjectReport objectReport = new TrackerObjectReport(TrackerType.TRACKED_ENTITY, uid);
+      TrackerObjectReport objectReport =
+          new TrackerObjectReport(
+              TrackerType.TRACKED_ENTITY, uid, trackedEntities.indexOf(trackedEntity));
 
       org.hisp.dhis.trackedentity.TrackedEntityInstance daoEntityInstance =
           teiService.getTrackedEntityInstance(uid);
@@ -186,7 +190,8 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
     for (Relationship rel : relationships) {
       String uid = rel.getRelationship();
 
-      TrackerObjectReport objectReport = new TrackerObjectReport(TrackerType.RELATIONSHIP, uid);
+      TrackerObjectReport objectReport =
+          new TrackerObjectReport(TrackerType.RELATIONSHIP, uid, relationships.indexOf(rel));
 
       org.hisp.dhis.relationship.Relationship relationship =
           relationshipService.getRelationship(uid);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerObjectReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerObjectReport.java
@@ -44,6 +44,9 @@ public class TrackerObjectReport {
   /** Type of object this {@link TrackerObjectReport} represents. */
   @JsonProperty private final TrackerType trackerType;
 
+  /** Index into list. */
+  @JsonProperty private Integer index;
+
   /** UID of object (if object is id object). */
   @JsonProperty private String uid;
 
@@ -53,18 +56,21 @@ public class TrackerObjectReport {
     this.trackerType = trackerType;
   }
 
-  public TrackerObjectReport(TrackerType trackerType, String uid) {
+  public TrackerObjectReport(TrackerType trackerType, String uid, Integer index) {
     this.trackerType = trackerType;
     this.uid = uid;
+    this.index = index;
   }
 
   @JsonCreator
   public TrackerObjectReport(
       @JsonProperty("trackerType") TrackerType trackerType,
       @JsonProperty("uid") String uid,
+      @JsonProperty("index") Integer index,
       @JsonProperty("errorReports") List<TrackerErrorReport> errorReports) {
     this.trackerType = trackerType;
     this.uid = uid;
+    this.index = index;
     if (errorReports != null) {
       List<TrackerErrorReport> errorCodeReportList;
       for (TrackerErrorReport errorReport : errorReports) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerBundleImportReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerBundleImportReportTest.java
@@ -331,7 +331,7 @@ class TrackerBundleImportReportTest {
   private TrackerBundleReport createBundleReport() {
     TrackerBundleReport bundleReport = new TrackerBundleReport();
     TrackerTypeReport typeReport = new TrackerTypeReport(TRACKED_ENTITY);
-    TrackerObjectReport objectReport = new TrackerObjectReport(TRACKED_ENTITY, "TEI_UID");
+    TrackerObjectReport objectReport = new TrackerObjectReport(TRACKED_ENTITY, "TEI_UID", 1);
     typeReport.addObjectReport(objectReport);
     typeReport.getStats().incCreated();
     bundleReport.getTypeReportMap().put(TRACKED_ENTITY, typeReport);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAssertions.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAssertions.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -37,6 +38,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
@@ -193,6 +195,14 @@ public class JsonAssertions {
         jsonTypeReport.getEntityReport().stream()
             .map(JsonEntity::getUid)
             .collect(Collectors.toList());
-    assertEquals(expectedEntityUids, reportEntityUids);
+    List<Integer> reportEntityIndexes =
+        jsonTypeReport.getEntityReport().stream()
+            .map(JsonEntity::getIndex)
+            .collect(Collectors.toList());
+    List<Integer> expectedIndexes =
+        IntStream.range(0, expectedEntityUids.size()).boxed().collect(Collectors.toList());
+    assertAll(
+        () -> assertEquals(expectedEntityUids, reportEntityUids),
+        () -> assertEquals(expectedIndexes, reportEntityIndexes));
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonEntity.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonEntity.java
@@ -40,4 +40,8 @@ public interface JsonEntity extends JsonObject {
   default String getUid() {
     return getString("uid").string();
   }
+
+  default Integer getIndex() {
+    return getNumber("index").intValue();
+  }
 }


### PR DESCRIPTION
Removing index from `objectsReport` section in tracker report is going to be a breaking change in next release but we need to maintain it in older versions.