### PR TITLE
chore: implement /tracker/relationships?order consistently with other endpoints TECH-1619

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParams.java
@@ -27,13 +27,15 @@
  */
 package org.hisp.dhis.tracker.export.relationship;
 
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.hisp.dhis.tracker.TrackerType;
-import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
+import org.hisp.dhis.tracker.export.Order;
+import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 
 @Getter
 @Builder(toBuilder = true)
@@ -56,5 +58,23 @@ public class RelationshipOperationParams {
 
   private boolean skipPaging;
 
-  private List<OrderCriteria> order;
+  private List<Order> order;
+
+  public static class RelationshipOperationParamsBuilder {
+
+    private List<Order> order = new ArrayList<>();
+
+    // Do not remove this unused method. This hides the order field from the builder which Lombok
+    // does not support. The repeated order field and private order method prevent access to order
+    // via the builder.
+    // Order should be added via the orderBy builder methods.
+    private RelationshipOperationParamsBuilder order(List<Order> order) {
+      return this;
+    }
+
+    public RelationshipOperationParamsBuilder orderBy(String field, SortDirection direction) {
+      this.order.add(new Order(field, direction));
+      return this;
+    }
+  }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapper.java
@@ -82,6 +82,7 @@ class RelationshipOperationParamsMapper {
         .pageSize(params.getPageSize())
         .totalPages(params.isTotalPages())
         .skipPaging(params.isSkipPaging())
+        .order(params.getOrder())
         .build();
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipQueryParams.java
@@ -27,23 +27,43 @@
  */
 package org.hisp.dhis.tracker.export.relationship;
 
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
+import org.hisp.dhis.tracker.export.Order;
 
+@Getter
 @Builder
-public class RelationshipQueryParams extends PagingAndSortingCriteriaAdapter {
+class RelationshipQueryParams {
+  public static final int DEFAULT_PAGE = 1;
 
-  public static final RelationshipQueryParams EMPTY = RelationshipQueryParams.builder().build();
+  public static final int DEFAULT_PAGE_SIZE = 50;
 
-  @Getter private final IdentifiableObject entity;
+  private final IdentifiableObject entity;
 
-  @Getter private Integer page;
+  private Integer page;
 
-  @Getter private Integer pageSize;
+  private Integer pageSize;
 
-  @Getter private boolean totalPages;
+  private boolean totalPages;
 
-  @Getter private Boolean skipPaging;
+  private boolean skipPaging;
+
+  private List<Order> order;
+
+  /** Returns the page number, falls back to default value of 1 if not specified. */
+  public int getPageWithDefault() {
+    return page != null && page > 0 ? page : DEFAULT_PAGE;
+  }
+
+  /** Returns the page size, falls back to default value of 50 if not specified. */
+  public int getPageSizeWithDefault() {
+    return pageSize != null && pageSize >= 0 ? pageSize : DEFAULT_PAGE_SIZE;
+  }
+
+  /** Returns the offset based on the page number and page size. */
+  public int getOffset() {
+    return (getPageWithDefault() - 1) * getPageSizeWithDefault();
+  }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
@@ -27,35 +27,23 @@
  */
 package org.hisp.dhis.tracker.export.relationship;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.Set;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
-import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.Event;
 import org.hisp.dhis.relationship.Relationship;
-import org.hisp.dhis.trackedentity.TrackedEntity;
-import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
 
 public interface RelationshipService {
 
   Relationships getRelationships(RelationshipOperationParams params)
       throws ForbiddenException, NotFoundException;
 
+  /**
+   * Fields the {@link #getRelationships(RelationshipOperationParams)} can order relationships by.
+   * Ordering by fields other than these is considered a programmer error. Validation of user
+   * provided field names should occur before calling {@link
+   * #getRelationships(RelationshipOperationParams)}.
+   */
+  Set<String> getOrderableFields();
+
   Relationship getRelationship(String id) throws ForbiddenException, NotFoundException;
-
-  Optional<Relationship> findRelationshipByUid(String id)
-      throws ForbiddenException, NotFoundException;
-
-  List<Relationship> getRelationshipsByTrackedEntity(
-      TrackedEntity te, PagingAndSortingCriteriaAdapter criteria)
-      throws ForbiddenException, NotFoundException;
-
-  List<Relationship> getRelationshipsByEnrollment(
-      Enrollment enrollment, PagingAndSortingCriteriaAdapter criteria)
-      throws ForbiddenException, NotFoundException;
-
-  List<Relationship> getRelationshipsByEvent(
-      Event event, PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter)
-      throws ForbiddenException, NotFoundException;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipStore.java
@@ -28,22 +28,27 @@
 package org.hisp.dhis.tracker.export.relationship;
 
 import java.util.List;
+import java.util.Set;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.trackedentity.TrackedEntity;
-import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
 
 public interface RelationshipStore extends IdentifiableObjectStore<Relationship> {
   String ID = RelationshipStore.class.getName();
 
   List<Relationship> getByTrackedEntity(
-      TrackedEntity trackedEntity, PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter);
+      TrackedEntity trackedEntity, RelationshipQueryParams queryParams);
 
-  List<Relationship> getByEnrollment(
-      Enrollment enrollment, PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter);
+  List<Relationship> getByEnrollment(Enrollment enrollment, RelationshipQueryParams queryParams);
 
-  List<Relationship> getByEvent(
-      Event event, PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter);
+  List<Relationship> getByEvent(Event event, RelationshipQueryParams queryParams);
+
+  /**
+   * Fields the store can order relationships by. Ordering by fields other than these is considered
+   * a programmer error. Validation of user provided field names should occur before calling any
+   * store method.
+   */
+  Set<String> getOrderableFields();
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapperTest.java
@@ -256,7 +256,7 @@ class EnrollmentOperationParamsMapperTest {
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder()
             .orderBy("enrollmentDate", SortDirection.ASC)
-            .orderBy("createdAt", SortDirection.DESC)
+            .orderBy("created", SortDirection.DESC)
             .build();
 
     EnrollmentQueryParams params = mapper.map(operationParams);
@@ -264,7 +264,7 @@ class EnrollmentOperationParamsMapperTest {
     assertEquals(
         List.of(
             new Order("enrollmentDate", SortDirection.ASC),
-            new Order("createdAt", SortDirection.DESC)),
+            new Order("created", SortDirection.DESC)),
         params.getOrder());
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
@@ -57,9 +57,11 @@ import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.tracker.TrackerTest;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams.EnrollmentOperationParamsBuilder;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
@@ -68,6 +70,10 @@ import org.hisp.dhis.tracker.export.event.EventOperationParams;
 import org.hisp.dhis.tracker.export.event.EventOperationParams.EventOperationParamsBuilder;
 import org.hisp.dhis.tracker.export.event.EventService;
 import org.hisp.dhis.tracker.export.event.Events;
+import org.hisp.dhis.tracker.export.relationship.RelationshipOperationParams;
+import org.hisp.dhis.tracker.export.relationship.RelationshipOperationParams.RelationshipOperationParamsBuilder;
+import org.hisp.dhis.tracker.export.relationship.RelationshipService;
+import org.hisp.dhis.tracker.export.relationship.Relationships;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntities;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityOperationParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityOperationParams.TrackedEntityOperationParamsBuilder;
@@ -87,6 +93,8 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   @Autowired private EnrollmentService enrollmentService;
 
   @Autowired private EventService eventService;
+
+  @Autowired private RelationshipService relationshipService;
 
   @Autowired private TrackerImportService trackerImportService;
 
@@ -962,6 +970,172 @@ class OrderAndPaginationExporterTest extends TrackerTest {
     assertEquals(List.of("pTzf9KYMk72", "D9PbzJY8bJM"), events);
   }
 
+  @Test
+  void shouldOrderRelationshipsByPrimaryKeyDescByDefault()
+      throws ForbiddenException, NotFoundException {
+    Relationship oLT07jKRu9e = get(Relationship.class, "oLT07jKRu9e");
+    Relationship yZxjxJli9mO = get(Relationship.class, "yZxjxJli9mO");
+    List<String> expected =
+        Stream.of(oLT07jKRu9e, yZxjxJli9mO)
+            .sorted(Comparator.comparing(Relationship::getId).reversed()) // reversed = desc
+            .map(Relationship::getUid)
+            .toList();
+
+    RelationshipOperationParams params =
+        RelationshipOperationParams.builder()
+            .type(TrackerType.EVENT)
+            .identifier("pTzf9KYMk72")
+            .build();
+
+    List<String> relationships = getRelationships(params);
+
+    assertEquals(expected, relationships);
+  }
+
+  @Test
+  void shouldReturnPaginatedRelationshipsGivenNonDefaultPageSize()
+      throws ForbiddenException, NotFoundException {
+    // relationships can only be ordered by created date which is not under our control during
+    // testing
+    // pagination is tested using default order by primary key desc. We thus need to get the
+    // expected order of the pages beforehand.
+    Relationship oLT07jKRu9e = get(Relationship.class, "oLT07jKRu9e");
+    Relationship yZxjxJli9mO = get(Relationship.class, "yZxjxJli9mO");
+    List<String> expected =
+        Stream.of(oLT07jKRu9e, yZxjxJli9mO)
+            .sorted(Comparator.comparing(Relationship::getId).reversed()) // reversed = desc
+            .map(Relationship::getUid)
+            .toList();
+    String expectedOnPage1 = expected.get(0);
+    String expectedOnPage2 = expected.get(1);
+
+    RelationshipOperationParamsBuilder builder =
+        RelationshipOperationParams.builder().type(TrackerType.EVENT).identifier("pTzf9KYMk72");
+
+    RelationshipOperationParams params = builder.page(1).pageSize(1).build();
+
+    Relationships firstPage = relationshipService.getRelationships(params);
+
+    assertAll(
+        "first page",
+        () -> assertSlimPager(1, 1, false, firstPage.getPager()),
+        () -> assertEquals(List.of(expectedOnPage1), uids(firstPage.getRelationships())));
+
+    params = builder.page(2).pageSize(1).build();
+
+    Relationships secondPage = relationshipService.getRelationships(params);
+
+    assertAll(
+        "second (last) page",
+        () -> assertSlimPager(2, 1, true, secondPage.getPager()),
+        () -> assertEquals(List.of(expectedOnPage2), uids(secondPage.getRelationships())));
+
+    params = builder.page(3).pageSize(1).build();
+
+    assertIsEmpty(getRelationships(params));
+  }
+
+  @Test
+  void shouldReturnPaginatedRelationshipsGivenNonDefaultPageSizeAndTotalPages()
+      throws ForbiddenException, NotFoundException {
+    // relationships can only be ordered by created date which is not under our control during
+    // testing
+    // pagination is tested using default order by primary key desc. We thus need to get the
+    // expected order of the pages beforehand.
+    Relationship oLT07jKRu9e = get(Relationship.class, "oLT07jKRu9e");
+    Relationship yZxjxJli9mO = get(Relationship.class, "yZxjxJli9mO");
+    List<String> expected =
+        Stream.of(oLT07jKRu9e, yZxjxJli9mO)
+            .sorted(Comparator.comparing(Relationship::getId).reversed()) // reversed = desc
+            .map(Relationship::getUid)
+            .toList();
+    String expectedOnPage1 = expected.get(0);
+    String expectedOnPage2 = expected.get(1);
+
+    RelationshipOperationParamsBuilder builder =
+        RelationshipOperationParams.builder().type(TrackerType.EVENT).identifier("pTzf9KYMk72");
+
+    RelationshipOperationParams params = builder.page(1).pageSize(1).totalPages(true).build();
+
+    Relationships firstPage = relationshipService.getRelationships(params);
+
+    assertAll(
+        "first page",
+        () -> assertPager(1, 1, 2, firstPage.getPager()),
+        () -> assertEquals(List.of(expectedOnPage1), uids(firstPage.getRelationships())));
+
+    params = builder.page(2).pageSize(1).totalPages(true).build();
+
+    Relationships secondPage = relationshipService.getRelationships(params);
+
+    assertAll(
+        "second (last) page",
+        () -> assertPager(2, 1, 2, secondPage.getPager()),
+        () -> assertEquals(List.of(expectedOnPage2), uids(secondPage.getRelationships())));
+
+    params = builder.page(3).pageSize(1).totalPages(true).build();
+
+    assertIsEmpty(getRelationships(params));
+  }
+
+  @Test
+  void shouldOrderRelationshipsByCreatedAsc() throws ForbiddenException, NotFoundException {
+    Relationship oLT07jKRu9e = get(Relationship.class, "oLT07jKRu9e");
+    Relationship yZxjxJli9mO = get(Relationship.class, "yZxjxJli9mO");
+
+    RelationshipOperationParams params =
+        RelationshipOperationParams.builder()
+            .type(TrackerType.EVENT)
+            .identifier("pTzf9KYMk72")
+            .orderBy("created", SortDirection.ASC)
+            .build();
+
+    List<String> relationships = getRelationships(params);
+
+    boolean isSameCreatedDate = oLT07jKRu9e.getCreated().equals(yZxjxJli9mO.getCreated());
+    if (isSameCreatedDate) {
+      // the order is non-deterministic if the created date is the same. we can then only assert
+      // the correct entities are in the result. otherwise the test is flaky
+      assertContainsOnly(List.of("oLT07jKRu9e", "yZxjxJli9mO"), relationships);
+    } else {
+      List<String> expected =
+          Stream.of(oLT07jKRu9e, yZxjxJli9mO)
+              .sorted(Comparator.comparing(Relationship::getCreated)) // asc
+              .map(Relationship::getUid)
+              .toList();
+      assertEquals(expected, relationships);
+    }
+  }
+
+  @Test
+  void shouldOrderRelationshipsByCreatedDesc() throws ForbiddenException, NotFoundException {
+    Relationship oLT07jKRu9e = get(Relationship.class, "oLT07jKRu9e");
+    Relationship yZxjxJli9mO = get(Relationship.class, "yZxjxJli9mO");
+
+    RelationshipOperationParams params =
+        RelationshipOperationParams.builder()
+            .type(TrackerType.EVENT)
+            .identifier("pTzf9KYMk72")
+            .orderBy("created", SortDirection.DESC)
+            .build();
+
+    List<String> relationships = getRelationships(params);
+
+    boolean isSameCreatedDate = oLT07jKRu9e.getCreated().equals(yZxjxJli9mO.getCreated());
+    if (isSameCreatedDate) {
+      // the order is non-deterministic if the created date is the same. we can then only assert
+      // the correct entities are in the result. otherwise the test is flaky
+      assertContainsOnly(List.of("oLT07jKRu9e", "yZxjxJli9mO"), relationships);
+    } else {
+      List<String> expected =
+          Stream.of(oLT07jKRu9e, yZxjxJli9mO)
+              .sorted(Comparator.comparing(Relationship::getCreated).reversed()) // reversed = desc
+              .map(Relationship::getUid)
+              .toList();
+      assertEquals(expected, relationships);
+    }
+  }
+
   private <T extends IdentifiableObject> T get(Class<T> type, String uid) {
     T t = manager.get(type, uid);
     assertNotNull(
@@ -1007,6 +1181,11 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   private List<String> getEvents(EventOperationParams params)
       throws ForbiddenException, BadRequestException {
     return uids(eventService.getEvents(params).getEvents());
+  }
+
+  private List<String> getRelationships(RelationshipOperationParams params)
+      throws ForbiddenException, NotFoundException {
+    return uids(relationshipService.getRelationships(params).getRelationships());
   }
 
   private static List<String> eventUids(Events events) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerUnitTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerUnitTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.export.relationship;
+
+import static org.hisp.dhis.utils.Assertions.assertContains;
+import static org.hisp.dhis.utils.Assertions.assertStartsWith;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.hisp.dhis.fieldfiltering.FieldFilterService;
+import org.hisp.dhis.tracker.export.relationship.RelationshipService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RelationshipsExportControllerUnitTest {
+
+  @Mock private RelationshipService relationshipService;
+
+  @Mock private RelationshipRequestParamsMapper paramsMapper;
+
+  @Mock private FieldFilterService fieldFilterService;
+
+  @Test
+  void shouldFailInstantiatingControllerIfAnyOrderableFieldIsUnsupported() {
+    // pretend the service does not support 2 of the orderable fields the web advocates
+    Iterator<Entry<String, String>> iterator =
+        RelationshipMapper.ORDERABLE_FIELDS.entrySet().stream().iterator();
+    Entry<String, String> missing1 = iterator.next();
+    Map<String, String> orderableFields = new HashMap<>(RelationshipMapper.ORDERABLE_FIELDS);
+    orderableFields.remove(missing1.getKey());
+    when(relationshipService.getOrderableFields())
+        .thenReturn(new HashSet<>(orderableFields.values()));
+
+    Exception exception =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                new RelationshipsExportController(
+                    relationshipService, paramsMapper, fieldFilterService));
+
+    assertAll(
+        () ->
+            assertStartsWith(
+                "relationship controller supports ordering by", exception.getMessage()),
+        () -> assertContains(missing1.getKey(), exception.getMessage()));
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipMapper.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.relationship;
 
+import static java.util.Map.entry;
+
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.hisp.dhis.webapi.controller.tracker.view.InstantMapper;
@@ -38,6 +41,13 @@ import org.mapstruct.Mapping;
 @Mapper(uses = {RelationshipItemMapper.class, InstantMapper.class})
 public interface RelationshipMapper
     extends ViewMapper<org.hisp.dhis.relationship.Relationship, Relationship> {
+
+  /**
+   * Relationships can be ordered by given fields which correspond to fields on {@link
+   * org.hisp.dhis.relationship.Relationship}.
+   */
+  Map<String, String> ORDERABLE_FIELDS = Map.ofEntries(entry("createdAt", "created"));
+
   @Mapping(target = "relationship", source = "uid")
   @Mapping(target = "relationshipType", source = "relationshipType.uid")
   @Mapping(target = "relationshipName", source = "relationshipType.name")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
@@ -29,12 +29,12 @@ package org.hisp.dhis.webapi.controller.tracker.export.relationship;
 
 import static org.hisp.dhis.common.OpenApi.Response.Status;
 import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.RESOURCE_PATH;
+import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.assertUserOrderableFieldsAreSupported;
 import static org.hisp.dhis.webapi.controller.tracker.export.relationship.RequestParams.DEFAULT_FIELDS_PARAM;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.UID;
@@ -65,7 +65,6 @@ import org.springframework.web.bind.annotation.RestController;
     produces = APPLICATION_JSON_VALUE,
     value = RESOURCE_PATH + "/" + RelationshipsExportController.RELATIONSHIPS)
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
-@RequiredArgsConstructor
 class RelationshipsExportController {
 
   protected static final String RELATIONSHIPS = "relationships";
@@ -78,6 +77,20 @@ class RelationshipsExportController {
   private final RelationshipRequestParamsMapper mapper;
 
   private final FieldFilterService fieldFilterService;
+
+  public RelationshipsExportController(
+      RelationshipService relationshipService,
+      RelationshipRequestParamsMapper mapper,
+      FieldFilterService fieldFilterService) {
+    this.relationshipService = relationshipService;
+    this.mapper = mapper;
+    this.fieldFilterService = fieldFilterService;
+
+    assertUserOrderableFieldsAreSupported(
+        "relationship",
+        RelationshipMapper.ORDERABLE_FIELDS,
+        relationshipService.getOrderableFields());
+  }
 
   @OpenApi.Response(status = Status.OK, value = OpenApiExport.ListResponse.class)
   @GetMapping

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/RelationshipsExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/RelationshipsExportController.md
@@ -18,7 +18,8 @@ Get a relationship with the given UID.
 
 ### `getRelationshipByUid.parameter.fields`
 
-Get only the specified fields in the JSON response. This query parameter allows you to remove unnecessary fields from
+Get only the specified fields in the JSON response. This query parameter allows you to remove
+unnecessary fields from
 the response and in some cases decrease the response time. Refer to
 https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_metadata_field_filter
 for how to use it.
@@ -43,9 +44,25 @@ Get the relationships of the given enrollment.
 
 Get relationships of the given event.
 
+### `*.parameter.RelationshipRequestParams.order`
+
+`<propertyName1:sortDirection>[,<propertyName2:sortDirection>...]`
+
+Get relationships in given order. Relationships can be ordered by the following case-sensitive
+properties
+
+* `createdAt`
+
+Valid `sortDirection`s are `asc` and `desc`. `sortDirection` is case-insensitive. `sortDirection`
+defaults to `asc` for properties without explicit `sortDirection` as in `order=createdAt`.
+
+Relationships are ordered by newest (internal id desc) by default meaning when no `order` parameter
+is provided.
+
 ### `*.parameter.RelationshipRequestParams.fields`
 
-Get only the specified fields in the JSON response. This query parameter allows you to remove unnecessary fields from
+Get only the specified fields in the JSON response. This query parameter allows you to remove
+unnecessary fields from
 the JSON response and in some cases decrease the response time. Refer to
 https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_metadata_field_filter
 for how to use it.

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipRequestParamsMapperTest.java
@@ -30,13 +30,20 @@ package org.hisp.dhis.webapi.controller.tracker.export.relationship;
 import static org.hisp.dhis.tracker.TrackerType.ENROLLMENT;
 import static org.hisp.dhis.tracker.TrackerType.EVENT;
 import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
+import static org.hisp.dhis.utils.Assertions.assertContains;
+import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.utils.Assertions.assertStartsWith;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.List;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.tracker.export.relationship.RelationshipOperationParams;
+import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
+import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.junit.jupiter.api.Test;
 
 class RelationshipRequestParamsMapperTest {
@@ -181,5 +188,38 @@ class RelationshipRequestParamsMapperTest {
     RelationshipOperationParams operationParams = mapper.map(requestParams);
 
     assertEquals(EVENT, operationParams.getType());
+  }
+
+  @Test
+  void shouldMapOrderParameterInGivenOrderWhenFieldsAreOrderable() throws BadRequestException {
+    RequestParams requestParams = new RequestParams();
+    requestParams.setTrackedEntity(UID.of("Hq3Kc6HK4OZ"));
+    requestParams.setOrder(OrderCriteria.fromOrderString("createdAt:asc"));
+
+    RelationshipOperationParams operationParams = mapper.map(requestParams);
+
+    assertEquals(List.of(new Order("created", SortDirection.ASC)), operationParams.getOrder());
+  }
+
+  @Test
+  void shouldFailGivenInvalidOrderFieldName() {
+    RequestParams requestParams = new RequestParams();
+    requestParams.setTrackedEntity(UID.of("Hq3Kc6HK4OZ"));
+    requestParams.setOrder(OrderCriteria.fromOrderString("unsupportedProperty1:asc,createdAt:asc"));
+
+    Exception exception = assertThrows(BadRequestException.class, () -> mapper.map(requestParams));
+    assertAll(
+        () -> assertStartsWith("order parameter is invalid", exception.getMessage()),
+        () -> assertContains("unsupportedProperty1", exception.getMessage()));
+  }
+
+  @Test
+  void testMappingOrderParamsNoOrder() throws BadRequestException {
+    RequestParams requestParams = new RequestParams();
+    requestParams.setTrackedEntity(UID.of("Hq3Kc6HK4OZ"));
+
+    RelationshipOperationParams operationParams = mapper.map(requestParams);
+
+    assertIsEmpty(operationParams.getOrder());
   }
 }


### PR DESCRIPTION
* validate field names are supported and not repeated in web layer
* validate fields advocated by web are actually supported by service/store
* map to List<Order> and map field names to Java field names (dhis-api org.hisp.dhis.relationship.Relationship class) in web layer
* stores do not need to handle order differently as we use hibernate to
  map from Java field names to DB columns
* add order and pagination tests
* hide classes if possible. Devs should depend on our services not stores and not any particular implementation
* order by primary key desc by default
* document order in OpenAPI spec
* only expose from our service whats used outside of the package (currently the only consumer is our exporter endpoint)
* service should have operation params in the signature, while stores should have the query params in their signature
