### PR TITLE
fix: Validate query filters for item value type [DHIS2-12152]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryItem.java
@@ -84,7 +84,7 @@ public class QueryItem
     public QueryItem( DimensionalItemObject item, LegendSet legendSet, ValueType valueType,
         AggregationType aggregationType, OptionSet optionSet )
     {
-        this.item = item;
+        this( item );
         this.legendSet = legendSet;
         this.valueType = valueType;
         this.aggregationType = aggregationType;
@@ -94,11 +94,7 @@ public class QueryItem
     public QueryItem( DimensionalItemObject item, LegendSet legendSet, ValueType valueType,
         AggregationType aggregationType, OptionSet optionSet, Boolean unique )
     {
-        this.item = item;
-        this.legendSet = legendSet;
-        this.valueType = valueType;
-        this.aggregationType = aggregationType;
-        this.optionSet = optionSet;
+        this( item, legendSet, valueType, aggregationType, optionSet );
         this.unique = unique;
     }
 
@@ -128,7 +124,7 @@ public class QueryItem
     public QueryItem( DimensionalItemObject item, QueryOperator operator, String filter, ValueType valueType,
         AggregationType aggregationType, OptionSet optionSet )
     {
-        this.item = item;
+        this( item );
         this.valueType = valueType;
         this.aggregationType = aggregationType;
         this.optionSet = optionSet;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.common;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -58,7 +60,7 @@ public enum QueryOperator
 
     public static QueryOperator fromString( String string )
     {
-        if ( string == null || string.isEmpty() )
+        if ( isBlank( string ) )
         {
             return null;
         }
@@ -66,4 +68,8 @@ public enum QueryOperator
         return valueOf( string.toUpperCase() );
     }
 
+    public boolean isIn()
+    {
+        return IN == this;
+    }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -321,7 +321,8 @@ public enum ErrorCode
     E7226( "Dimension is not a valid query item: `{0}`" ),
     E7227( "Relationship entity type not supported: `{0}`" ),
     E7228( "Fallback coordinate field is invalid: `{0}` " ),
-    E7229( "Operator '{0}' does not allow missing value" ),
+    E7229( "Query operator `{0}` does not allow missing values" ),
+    E7234( "Query filter: `{0}` not valid for query item value type: `{1}`" ),
 
     /* Org unit analytics */
     E7300( "At least one organisation unit must be specified" ),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceMetadataTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceMetadataTest.java
@@ -158,6 +158,8 @@ public class EventAnalyticsServiceMetadataTest
     @SuppressWarnings( "unchecked" )
     public void testGetQueryItemDimensionMetadata()
     {
+        deB = createDataElement( 'B', ValueType.TEXT, AggregationType.SUM );
+
         DimensionalObject periods = new BaseDimensionalObject( DimensionalObject.PERIOD_DIM_ID, DimensionType.PERIOD,
             Lists.newArrayList( peA ) );
         DimensionalObject orgUnits = new BaseDimensionalObject( DimensionalObject.ORGUNIT_DIM_ID,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventQueryValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventQueryValidatorTest.java
@@ -29,7 +29,10 @@ package org.hisp.dhis.analytics.event.data;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
 
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.analytics.AggregationType;
@@ -40,7 +43,9 @@ import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.EventQueryValidator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementDomain;
@@ -165,7 +170,99 @@ public class EventQueryValidatorTest
     }
 
     @Test
-    public void validateSuccesA()
+    public void validateValidFilterForValueType()
+    {
+        QueryFilter filter = new QueryFilter( QueryOperator.EQ, "68" );
+        QueryItem item = new QueryItem( deA, deA.getLegendSet(),
+            deA.getValueType(), deA.getAggregationType(), deA.getOptionSet() );
+        item.addFilter( filter );
+
+        EventQueryParams params = new EventQueryParams.Builder()
+            .withProgram( prA )
+            .withStartDate( new DateTime( 2010, 6, 1, 0, 0 ).toDate() )
+            .withEndDate( new DateTime( 2012, 3, 20, 0, 0 ).toDate() )
+            .withOrganisationUnits( Arrays.asList( ouB ) )
+            .addItem( item ).build();
+
+        queryValidator.validate( params );
+    }
+
+    @Test
+    public void validateInvalidFilterForIntegerValueType()
+    {
+        QueryFilter filter = new QueryFilter( QueryOperator.EQ, "male" );
+        QueryItem item = new QueryItem( deA, deA.getLegendSet(),
+            deA.getValueType(), deA.getAggregationType(), deA.getOptionSet() );
+        item.addFilter( filter );
+
+        EventQueryParams params = new EventQueryParams.Builder()
+            .withProgram( prA )
+            .withStartDate( new DateTime( 2010, 6, 1, 0, 0 ).toDate() )
+            .withEndDate( new DateTime( 2012, 3, 20, 0, 0 ).toDate() )
+            .withOrganisationUnits( Arrays.asList( ouB ) )
+            .addItem( item ).build();
+
+        assertValidationError( ErrorCode.E7234, params );
+    }
+
+    @Test
+    public void validateInvalidInFilterForIntegerValueType()
+    {
+        QueryFilter filter = new QueryFilter( QueryOperator.IN, "male;1" );
+        QueryItem item = new QueryItem( deA, deA.getLegendSet(),
+            deA.getValueType(), deA.getAggregationType(), deA.getOptionSet() );
+        item.addFilter( filter );
+
+        EventQueryParams params = new EventQueryParams.Builder()
+            .withProgram( prA )
+            .withStartDate( new DateTime( 2010, 6, 1, 0, 0 ).toDate() )
+            .withEndDate( new DateTime( 2012, 3, 20, 0, 0 ).toDate() )
+            .withOrganisationUnits( Arrays.asList( ouB ) )
+            .addItem( item ).build();
+
+        assertValidationError( ErrorCode.E7234, params );
+    }
+
+    @Test
+    public void validateValidInFilterForIntegerValueType()
+    {
+        QueryFilter filter = new QueryFilter( QueryOperator.IN, "2;1" );
+        QueryItem item = new QueryItem( deA, deA.getLegendSet(),
+            deA.getValueType(), deA.getAggregationType(), deA.getOptionSet() );
+        item.addFilter( filter );
+
+        EventQueryParams params = new EventQueryParams.Builder()
+            .withProgram( prA )
+            .withStartDate( new DateTime( 2010, 6, 1, 0, 0 ).toDate() )
+            .withEndDate( new DateTime( 2012, 3, 20, 0, 0 ).toDate() )
+            .withOrganisationUnits( Arrays.asList( ouB ) )
+            .addItem( item ).build();
+
+        ErrorMessage error = queryValidator.validateForErrorMessage( params );
+
+        assertNull( error );
+    }
+
+    @Test
+    public void validateInvalidFilterForDateTimeValueType()
+    {
+        QueryFilter filter = new QueryFilter( QueryOperator.EQ, "2023-12-01" );
+        QueryItem item = new QueryItem( deC, deC.getLegendSet(),
+            deC.getValueType(), deC.getAggregationType(), deC.getOptionSet() );
+        item.addFilter( filter );
+
+        EventQueryParams params = new EventQueryParams.Builder()
+            .withProgram( prA )
+            .withStartDate( new DateTime( 2010, 6, 1, 0, 0 ).toDate() )
+            .withEndDate( new DateTime( 2012, 3, 20, 0, 0 ).toDate() )
+            .withOrganisationUnits( Arrays.asList( ouB ) )
+            .addItem( item ).build();
+
+        assertValidationError( ErrorCode.E7234, params );
+    }
+
+    @Test
+    public void validateSuccessA()
     {
         EventQueryParams params = new EventQueryParams.Builder()
             .withProgram( prA )
@@ -228,7 +325,7 @@ public class EventQueryValidatorTest
             .withProgram( prA )
             .withOrganisationUnits( Lists.newArrayList( ouB ) ).build();
 
-        assertValidatonError( ErrorCode.E7205, params );
+        assertValidationError( ErrorCode.E7205, params );
     }
 
     @Test
@@ -253,7 +350,7 @@ public class EventQueryValidatorTest
             .withOrganisationUnits( Lists.newArrayList( ouB ) )
             .addItem( new QueryItem( deA, lsA, ValueType.TEXT, AggregationType.NONE, osA ) ).build();
 
-        assertValidatonError( ErrorCode.E7215, params );
+        assertValidationError( ErrorCode.E7215, params );
     }
 
     @Test
@@ -266,7 +363,7 @@ public class EventQueryValidatorTest
             .withOrganisationUnits( Lists.newArrayList( ouA ) )
             .withTimeField( "notAUidOrTimeField" ).build();
 
-        assertValidatonError( ErrorCode.E7210, params );
+        assertValidationError( ErrorCode.E7210, params );
     }
 
     @Test
@@ -279,7 +376,7 @@ public class EventQueryValidatorTest
             .withOrganisationUnits( Lists.newArrayList( ouA ) )
             .withOrgUnitField( "notAUid" ).build();
 
-        assertValidatonError( ErrorCode.E7211, params );
+        assertValidationError( ErrorCode.E7211, params );
     }
 
     @Test
@@ -370,7 +467,7 @@ public class EventQueryValidatorTest
      * @param errorCode the {@link ErrorCode}.
      * @param params the {@link DataQueryParams}.
      */
-    private void assertValidatonError( final ErrorCode errorCode, final EventQueryParams params )
+    private void assertValidationError( final ErrorCode errorCode, final EventQueryParams params )
     {
         ThrowingRunnable runnable = () -> queryValidator.validate( params );
         IllegalQueryException ex = assertThrows( "Error code mismatch", IllegalQueryException.class, runnable );

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
@@ -27,36 +27,52 @@
  */
 package org.hisp.dhis.system.util;
 
-import static org.apache.commons.lang3.StringUtils.trimToEmpty;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.lowerCase;
+import static org.apache.commons.lang3.StringUtils.trim;
+import static org.hisp.dhis.common.CodeGenerator.isValidUid;
+import static org.hisp.dhis.datavalue.DataValue.FALSE;
+import static org.hisp.dhis.datavalue.DataValue.TRUE;
+import static org.hisp.dhis.system.util.MathUtils.isBool;
+import static org.hisp.dhis.system.util.MathUtils.isCoordinate;
+import static org.hisp.dhis.system.util.MathUtils.isInteger;
+import static org.hisp.dhis.system.util.MathUtils.isNegativeInteger;
+import static org.hisp.dhis.system.util.MathUtils.isNumeric;
+import static org.hisp.dhis.system.util.MathUtils.isPercentage;
+import static org.hisp.dhis.system.util.MathUtils.isPositiveInteger;
+import static org.hisp.dhis.system.util.MathUtils.isUnitInterval;
+import static org.hisp.dhis.system.util.MathUtils.isValidDouble;
+import static org.hisp.dhis.system.util.MathUtils.isZeroOrPositiveInteger;
 import static org.hisp.dhis.system.util.MathUtils.parseDouble;
+import static org.hisp.dhis.util.DateUtils.dateIsValid;
+import static org.hisp.dhis.util.DateUtils.dateTimeIsValid;
 
 import java.awt.geom.Point2D;
 import java.util.Date;
-import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.validator.routines.DateValidator;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.hisp.dhis.analytics.AggregationType;
-import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.FileTypeValueOptions;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.common.ValueTypeOptions;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.render.ObjectValueTypeRenderingOption;
 import org.hisp.dhis.render.StaticRenderingConfiguration;
 import org.hisp.dhis.render.type.ValueTypeRenderingType;
 import org.hisp.dhis.user.UserCredentials;
-import org.hisp.dhis.util.DateUtils;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
@@ -108,6 +124,12 @@ public class ValidationUtils
         "commit", "copy", "create", "createdb", "createrole", "createuser", "close", "delete", "destroy", "drop",
         "escape", "insert", "select", "rename", "replace", "restore", "return", "update", "when", "write" );
 
+    private static final Map<String, String> BOOLEAN_VALUES = ImmutableMap.of(
+        "true", TRUE,
+        "false", FALSE,
+        "0", FALSE,
+        "1", TRUE );
+
     /**
      * Validates whether a filter expression contains malicious code such as SQL
      * injection attempts.
@@ -149,29 +171,6 @@ public class ValidationUtils
     public static boolean emailIsValid( String email )
     {
         return EmailValidator.getInstance().isValid( email );
-    }
-
-    /**
-     * Validates whether a date string is valid for the given Locale.
-     *
-     * @param date the date string.
-     * @param locale the Locale
-     * @return true if the date string is valid, false otherwise.
-     */
-    public static boolean dateIsValid( String date, Locale locale )
-    {
-        return DateValidator.getInstance().isValid( date, locale );
-    }
-
-    /**
-     * Validates whether a date string is valid for the default Locale.
-     *
-     * @param date the date string.
-     * @return true if the date string is valid, false otherwise.
-     */
-    public static boolean dateIsValid( String date )
-    {
-        return dateIsValid( date, null );
     }
 
     /**
@@ -477,11 +476,12 @@ public class ValidationUtils
     }
 
     /**
-     * Indicates whether the given data value is valid according to the given
-     * value type.
+     * Indicates whether the given value is valid according to the given value
+     * type.
      *
-     * @param value the data value.
+     * @param value the value.
      * @param valueType the {@link ValueType}.
+     *
      * @return null if the value is valid, a string if not.
      */
     public static String dataValueIsValid( String value, ValueType valueType )
@@ -502,65 +502,100 @@ public class ValidationUtils
         }
 
         // Value type checks
+        switch ( valueType )
+        {
+        case LETTER:
+            return !isValidLetter( value ) ? "value_not_valid_letter" : null;
+        case NUMBER:
+            return !isNumeric( value ) ? "value_not_numeric" : null;
+        case UNIT_INTERVAL:
+            return !isUnitInterval( value ) ? "value_not_unit_interval" : null;
+        case PERCENTAGE:
+            return !isPercentage( value ) ? "value_not_percentage" : null;
+        case INTEGER:
+            return !isInteger( value ) ? "value_not_integer" : null;
+        case INTEGER_POSITIVE:
+            return !isPositiveInteger( value ) ? "value_not_positive_integer" : null;
+        case INTEGER_NEGATIVE:
+            return !isNegativeInteger( value ) ? "value_not_negative_integer" : null;
+        case INTEGER_ZERO_OR_POSITIVE:
+            return !isZeroOrPositiveInteger( value ) ? "value_not_zero_or_positive_integer" : null;
+        case BOOLEAN:
+            return !isBool( value.toLowerCase() ) ? "value_not_bool" : null;
+        case TRUE_ONLY:
+            return !TRUE.equalsIgnoreCase( value ) ? "value_not_true_only" : null;
+        case DATE:
+            return !dateIsValid( value ) ? "value_not_valid_date" : null;
+        case DATETIME:
+            return !dateTimeIsValid( value ) ? "value_not_valid_datetime" : null;
+        case COORDINATE:
+            return !isCoordinate( value ) ? "value_not_coordinate" : null;
+        case URL:
+            return !urlIsValid( value ) ? "value_not_url" : null;
+        case FILE_RESOURCE:
+        case IMAGE:
+            return !isValidUid( value ) ? "value_not_valid_file_resource_uid" : null;
+        default:
+            return null;
+        }
+    }
 
-        if ( ValueType.NUMBER == valueType && !MathUtils.isNumeric( value ) )
+    /**
+     * Indicates whether the given "value" is comparable in relation to the
+     * given {@link ValueType}. Empty/null values are always considered NOT
+     * comparable.
+     *
+     * @param value the value.
+     * @param valueType the {@link ValueType}.
+     *
+     * @return true if the value is comparable, false otherwise.
+     */
+    public static boolean valueIsComparable( String value, ValueType valueType )
+    {
+        if ( isEmpty( value ) || value.length() > VALUE_MAX_LENGTH || valueType == null )
         {
-            return "value_not_numeric";
-        }
-        else if ( ValueType.UNIT_INTERVAL == valueType && !MathUtils.isUnitInterval( value ) )
-        {
-            return "value_not_unit_interval";
-        }
-        else if ( ValueType.PERCENTAGE == valueType && !MathUtils.isPercentage( value ) )
-        {
-            return "value_not_percentage";
-        }
-        else if ( ValueType.INTEGER == valueType && !MathUtils.isInteger( value ) )
-        {
-            return "value_not_integer";
-        }
-        else if ( ValueType.INTEGER_POSITIVE == valueType && !MathUtils.isPositiveInteger( value ) )
-        {
-            return "value_not_positive_integer";
-        }
-        else if ( ValueType.INTEGER_NEGATIVE == valueType && !MathUtils.isNegativeInteger( value ) )
-        {
-            return "value_not_negative_integer";
-        }
-        else if ( ValueType.INTEGER_ZERO_OR_POSITIVE == valueType && !MathUtils.isZeroOrPositiveInteger( value ) )
-        {
-            return "value_not_zero_or_positive_integer";
-        }
-        else if ( ValueType.BOOLEAN == valueType && !MathUtils.isBool( trimToEmpty( value ).toLowerCase() ) )
-        {
-            return "value_not_bool";
-        }
-        else if ( ValueType.TRUE_ONLY == valueType && !DataValue.TRUE.equals( trimToEmpty( value ).toLowerCase() ) )
-        {
-            return "value_not_true_only";
-        }
-        else if ( ValueType.DATE == valueType && !DateUtils.dateIsValid( value ) )
-        {
-            return "value_not_valid_date";
-        }
-        else if ( ValueType.DATETIME == valueType && !DateUtils.dateTimeIsValid( value ) )
-        {
-            return "value_not_valid_datetime";
-        }
-        else if ( ValueType.COORDINATE == valueType && !MathUtils.isCoordinate( value ) )
-        {
-            return "value_not_coordinate";
-        }
-        else if ( ValueType.URL == valueType && !urlIsValid( value ) )
-        {
-            return "value_not_url";
-        }
-        else if ( valueType.isFile() && !CodeGenerator.isValidUid( value ) )
-        {
-            return "value_not_valid_file_resource_uid";
+            return false;
         }
 
-        return null;
+        // Value type grouped checks.
+        switch ( valueType )
+        {
+        case INTEGER:
+        case INTEGER_POSITIVE:
+        case INTEGER_NEGATIVE:
+        case INTEGER_ZERO_OR_POSITIVE:
+            return isInteger( trim( value ) );
+        case NUMBER:
+        case UNIT_INTERVAL:
+        case PERCENTAGE:
+            return isValidDouble( parseDouble( trim( value ) ) );
+        case BOOLEAN:
+        case TRUE_ONLY:
+            return isBool( defaultIfBlank( BOOLEAN_VALUES.get( lowerCase( trim( value ) ) ), EMPTY ) );
+        case DATE:
+            return dateIsValid( trim( value ) );
+        case TIME:
+            return timeIsValid( trim( value ) );
+        case DATETIME:
+            return dateTimeIsValid( trim( value ) );
+        case LONG_TEXT:
+        case PHONE_NUMBER:
+        case EMAIL:
+        case TEXT:
+        case LETTER:
+        case COORDINATE:
+        case URL:
+        case FILE_RESOURCE:
+        case IMAGE:
+        case USERNAME:
+        default:
+            return true;
+        }
+    }
+
+    public static boolean isValidLetter( String value )
+    {
+        return value.length() == 1 && Character.isLetter( value.charAt( 0 ) );
     }
 
     /**
@@ -679,15 +714,15 @@ public class ValidationUtils
      */
     public static String normalizeBoolean( String bool, ValueType valueType )
     {
-        if ( ValueType.BOOLEAN_TYPES.contains( valueType ) )
+        if ( valueType != null && valueType.isBoolean() )
         {
             if ( BOOL_FALSE_VARIANTS.contains( bool ) && valueType != ValueType.TRUE_ONLY )
             {
-                return DataValue.FALSE;
+                return FALSE;
             }
             else if ( BOOL_TRUE_VARIANTS.contains( bool ) )
             {
-                return DataValue.TRUE;
+                return TRUE;
             }
         }
 

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/ValidationUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/ValidationUtilsTest.java
@@ -27,6 +27,28 @@
  */
 package org.hisp.dhis.system.util;
 
+import static org.hisp.dhis.common.ValueType.BOOLEAN;
+import static org.hisp.dhis.common.ValueType.COORDINATE;
+import static org.hisp.dhis.common.ValueType.DATE;
+import static org.hisp.dhis.common.ValueType.DATETIME;
+import static org.hisp.dhis.common.ValueType.EMAIL;
+import static org.hisp.dhis.common.ValueType.FILE_RESOURCE;
+import static org.hisp.dhis.common.ValueType.IMAGE;
+import static org.hisp.dhis.common.ValueType.INTEGER;
+import static org.hisp.dhis.common.ValueType.INTEGER_NEGATIVE;
+import static org.hisp.dhis.common.ValueType.INTEGER_POSITIVE;
+import static org.hisp.dhis.common.ValueType.INTEGER_ZERO_OR_POSITIVE;
+import static org.hisp.dhis.common.ValueType.LETTER;
+import static org.hisp.dhis.common.ValueType.LONG_TEXT;
+import static org.hisp.dhis.common.ValueType.NUMBER;
+import static org.hisp.dhis.common.ValueType.PERCENTAGE;
+import static org.hisp.dhis.common.ValueType.PHONE_NUMBER;
+import static org.hisp.dhis.common.ValueType.TEXT;
+import static org.hisp.dhis.common.ValueType.TIME;
+import static org.hisp.dhis.common.ValueType.TRUE_ONLY;
+import static org.hisp.dhis.common.ValueType.UNIT_INTERVAL;
+import static org.hisp.dhis.common.ValueType.URL;
+import static org.hisp.dhis.common.ValueType.USERNAME;
 import static org.hisp.dhis.system.util.ValidationUtils.bboxIsValid;
 import static org.hisp.dhis.system.util.ValidationUtils.coordinateIsValid;
 import static org.hisp.dhis.system.util.ValidationUtils.dataValueIsValid;
@@ -40,6 +62,7 @@ import static org.hisp.dhis.system.util.ValidationUtils.normalizeBoolean;
 import static org.hisp.dhis.system.util.ValidationUtils.passwordIsValid;
 import static org.hisp.dhis.system.util.ValidationUtils.usernameIsValid;
 import static org.hisp.dhis.system.util.ValidationUtils.uuidIsValid;
+import static org.hisp.dhis.system.util.ValidationUtils.valueIsComparable;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -170,9 +193,9 @@ public class ValidationUtilsTest
     public void testDataValueIsZeroAndInsignificant()
     {
         DataElement de = new DataElement( "DEA" );
-        de.setValueType( ValueType.INTEGER );
-        de.setAggregationType( AggregationType.SUM );
 
+        de.setValueType( INTEGER );
+        de.setAggregationType( AggregationType.SUM );
         assertTrue( dataValueIsZeroAndInsignificant( "0", de ) );
 
         de.setAggregationType( AggregationType.AVERAGE_SUM_ORG_UNIT );
@@ -180,60 +203,279 @@ public class ValidationUtilsTest
     }
 
     @Test
-    public void testDataValueIsValid()
+    public void testValueIsComparableForIntegerTypes()
+    {
+        ValueType valueType = INTEGER;
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "-1 ", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+        assertFalse( valueIsComparable( "a", valueType ) );
+
+        valueType = INTEGER_POSITIVE;
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "-1 ", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+        assertFalse( valueIsComparable( "a", valueType ) );
+
+        valueType = INTEGER_NEGATIVE;
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "-1 ", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+        assertFalse( valueIsComparable( "a", valueType ) );
+
+        valueType = INTEGER_ZERO_OR_POSITIVE;
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "-1 ", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+        assertFalse( valueIsComparable( "a", valueType ) );
+    }
+
+    @Test
+    public void testValueIsComparableForDoubleTypes()
+    {
+        ValueType valueType;
+        valueType = NUMBER;
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "2.45", valueType ) );
+        assertTrue( valueIsComparable( "-2.45", valueType ) );
+        assertTrue( valueIsComparable( "-2.45 ", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+        assertFalse( valueIsComparable( "a", valueType ) );
+
+        valueType = UNIT_INTERVAL;
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "2.45", valueType ) );
+        assertTrue( valueIsComparable( "-2.45", valueType ) );
+        assertTrue( valueIsComparable( "-2.45 ", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+        assertFalse( valueIsComparable( "a", valueType ) );
+
+        valueType = PERCENTAGE;
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "2.45", valueType ) );
+        assertTrue( valueIsComparable( "-2.45", valueType ) );
+        assertTrue( valueIsComparable( "-2.45 ", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+        assertFalse( valueIsComparable( "a", valueType ) );
+    }
+
+    @Test
+    public void testValueIsComparableForBooleanTypes()
+    {
+        ValueType valueType;
+        valueType = BOOLEAN;
+        assertTrue( valueIsComparable( "true", valueType ) );
+        assertTrue( valueIsComparable( "false", valueType ) );
+        assertTrue( valueIsComparable( "false ", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "1 ", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+        assertFalse( valueIsComparable( "a", valueType ) );
+
+        valueType = TRUE_ONLY;
+        assertTrue( valueIsComparable( "true", valueType ) );
+        assertTrue( valueIsComparable( "false", valueType ) );
+        assertTrue( valueIsComparable( "false ", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "1 ", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+        assertFalse( valueIsComparable( "a", valueType ) );
+    }
+
+    @Test
+    public void testValueIsComparableForDateTimeTypes()
+    {
+        ValueType valueType;
+        valueType = DATE;
+        assertTrue( valueIsComparable( "2013-04-01", valueType ) );
+        assertFalse( valueIsComparable( "2013/04/01", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+        assertFalse( valueIsComparable( "a", valueType ) );
+
+        valueType = TIME;
+        assertTrue( valueIsComparable( "12:30", valueType ) );
+        assertFalse( valueIsComparable( "12.30", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+        assertFalse( valueIsComparable( "a", valueType ) );
+
+        valueType = DATETIME;
+        assertTrue( valueIsComparable( "2021-08-30T13:53:33.767412Z", valueType ) );
+        assertTrue( valueIsComparable( "2021-08-30T13:53:33.767412", valueType ) );
+        assertTrue( valueIsComparable( "2013-04-01T11:12:05.5417Z", valueType ) );
+        assertTrue( valueIsComparable( "2013-04-01T11:12:05.5417", valueType ) );
+        assertTrue( valueIsComparable( "2013-04-01T11:12:02.541Z", valueType ) );
+        assertTrue( valueIsComparable( "2021-08-30T13:53:33.741", valueType ) );
+        assertTrue( valueIsComparable( "2013-04-01T11:12:00", valueType ) );
+        assertFalse( valueIsComparable( "2021-08-30T13.53.33.767412Z", valueType ) );
+        assertFalse( valueIsComparable( "2021-08-30T13.53.33.767412", valueType ) );
+        assertFalse( valueIsComparable( "2013-04-01T11.12.05.5417Z", valueType ) );
+        assertFalse( valueIsComparable( "2021-08-30T13.53.33.741", valueType ) );
+        assertFalse( valueIsComparable( "2013-04-01T11.12.00", valueType ) );
+        assertFalse( valueIsComparable( "2013-04-01", valueType ) );
+        assertFalse( valueIsComparable( "abcd", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+    }
+
+    @Test
+    public void testValueIsComparableForStringTypes()
+    {
+        ValueType valueType;
+        valueType = LONG_TEXT;
+        assertTrue( valueIsComparable( "a", valueType ) );
+        assertTrue( valueIsComparable( "abc", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "@", valueType ) );
+
+        valueType = PHONE_NUMBER;
+        assertTrue( valueIsComparable( "a", valueType ) );
+        assertTrue( valueIsComparable( "abc", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "(+355)", valueType ) );
+        assertTrue( valueIsComparable( "5-1234-5", valueType ) );
+        assertTrue( valueIsComparable( "@", valueType ) );
+
+        valueType = EMAIL;
+        assertTrue( valueIsComparable( "a", valueType ) );
+        assertTrue( valueIsComparable( "abc", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "5_1234_5", valueType ) );
+        assertTrue( valueIsComparable( "5-1234-5", valueType ) );
+        assertTrue( valueIsComparable( "@", valueType ) );
+
+        valueType = TEXT;
+        assertTrue( valueIsComparable( "a", valueType ) );
+        assertTrue( valueIsComparable( "abc", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "@", valueType ) );
+        assertTrue( valueIsComparable( " ", valueType ) );
+
+        valueType = LETTER;
+        assertTrue( valueIsComparable( "a", valueType ) );
+        assertTrue( valueIsComparable( "abc", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "@", valueType ) );
+        assertTrue( valueIsComparable( " ", valueType ) );
+
+        valueType = COORDINATE;
+        assertTrue( valueIsComparable( "a", valueType ) );
+        assertTrue( valueIsComparable( "abc", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( ":", valueType ) );
+        assertTrue( valueIsComparable( ".", valueType ) );
+
+        valueType = URL;
+        assertTrue( valueIsComparable( "http", valueType ) );
+        assertTrue( valueIsComparable( "abc", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( ":", valueType ) );
+        assertTrue( valueIsComparable( ".", valueType ) );
+
+        valueType = FILE_RESOURCE;
+        assertTrue( valueIsComparable( "file://", valueType ) );
+        assertTrue( valueIsComparable( "abc", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "@", valueType ) );
+        assertTrue( valueIsComparable( ":", valueType ) );
+        assertTrue( valueIsComparable( ".", valueType ) );
+
+        valueType = IMAGE;
+        assertTrue( valueIsComparable( "file://", valueType ) );
+        assertTrue( valueIsComparable( "abc", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "@", valueType ) );
+        assertTrue( valueIsComparable( ":", valueType ) );
+        assertTrue( valueIsComparable( ".", valueType ) );
+
+        valueType = USERNAME;
+        assertTrue( valueIsComparable( "a", valueType ) );
+        assertTrue( valueIsComparable( "abc", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "@", valueType ) );
+
+        // Applicable for all value types.
+        assertFalse( valueIsComparable( "", valueType ) );
+        assertFalse( valueIsComparable( null, valueType ) );
+    }
+
+    @Test
+    public void testValueIsValid()
     {
         DataElement de = new DataElement( "DEA" );
-        de.setValueType( ValueType.INTEGER );
 
+        de.setValueType( INTEGER );
         assertNull( dataValueIsValid( null, de ) );
         assertNull( dataValueIsValid( "", de ) );
-
         assertNull( dataValueIsValid( "34", de ) );
         assertNotNull( dataValueIsValid( "Yes", de ) );
 
-        de.setValueType( ValueType.NUMBER );
-
+        de.setValueType( NUMBER );
         assertNull( dataValueIsValid( "3.7", de ) );
         assertNotNull( dataValueIsValid( "No", de ) );
 
-        de.setValueType( ValueType.INTEGER_POSITIVE );
-
+        de.setValueType( INTEGER_POSITIVE );
         assertNull( dataValueIsValid( "3", de ) );
         assertNotNull( dataValueIsValid( "-4", de ) );
 
-        de.setValueType( ValueType.INTEGER_ZERO_OR_POSITIVE );
-
+        de.setValueType( INTEGER_ZERO_OR_POSITIVE );
         assertNull( dataValueIsValid( "3", de ) );
         assertNotNull( dataValueIsValid( "-4", de ) );
 
-        de.setValueType( ValueType.INTEGER_NEGATIVE );
-
+        de.setValueType( INTEGER_NEGATIVE );
         assertNull( dataValueIsValid( "-3", de ) );
         assertNotNull( dataValueIsValid( "4", de ) );
 
-        de.setValueType( ValueType.TEXT );
-
+        de.setValueType( TEXT );
         assertNull( dataValueIsValid( "0", de ) );
 
-        de.setValueType( ValueType.BOOLEAN );
-
+        de.setValueType( BOOLEAN );
         assertNull( dataValueIsValid( "true", de ) );
         assertNull( dataValueIsValid( "false", de ) );
         assertNull( dataValueIsValid( "FALSE", de ) );
         assertNotNull( dataValueIsValid( "yes", de ) );
 
-        de.setValueType( ValueType.TRUE_ONLY );
-
+        de.setValueType( TRUE_ONLY );
         assertNull( dataValueIsValid( "true", de ) );
         assertNull( dataValueIsValid( "TRUE", de ) );
         assertNotNull( dataValueIsValid( "false", de ) );
 
-        de.setValueType( ValueType.DATE );
+        de.setValueType( DATE );
         assertNull( dataValueIsValid( "2013-04-01", de ) );
         assertNotNull( dataValueIsValid( "2012304-01", de ) );
         assertNotNull( dataValueIsValid( "Date", de ) );
 
-        de.setValueType( ValueType.DATETIME );
+        de.setValueType( DATETIME );
         assertNull( dataValueIsValid( "2021-08-30T13:53:33.767412Z", de ) );
         assertNull( dataValueIsValid( "2021-08-30T13:53:33.767412", de ) );
         assertNull( dataValueIsValid( "2013-04-01T11:12:05.5417Z", de ) );
@@ -277,19 +519,17 @@ public class ValidationUtilsTest
     @Test
     public void testNormalizeBoolean()
     {
-        assertEquals( "true", normalizeBoolean( "1", ValueType.BOOLEAN ) );
-        assertEquals( "true", normalizeBoolean( "T", ValueType.BOOLEAN ) );
-        assertEquals( "true", normalizeBoolean( "true", ValueType.BOOLEAN ) );
-        assertEquals( "true", normalizeBoolean( "TRUE", ValueType.BOOLEAN ) );
-        assertEquals( "true", normalizeBoolean( "t", ValueType.BOOLEAN ) );
-
-        assertEquals( "test", normalizeBoolean( "test", ValueType.TEXT ) );
-
-        assertEquals( "false", normalizeBoolean( "0", ValueType.BOOLEAN ) );
-        assertEquals( "false", normalizeBoolean( "f", ValueType.BOOLEAN ) );
-        assertEquals( "false", normalizeBoolean( "False", ValueType.BOOLEAN ) );
-        assertEquals( "false", normalizeBoolean( "FALSE", ValueType.BOOLEAN ) );
-        assertEquals( "false", normalizeBoolean( "F", ValueType.BOOLEAN ) );
+        assertEquals( "true", normalizeBoolean( "1", BOOLEAN ) );
+        assertEquals( "true", normalizeBoolean( "T", BOOLEAN ) );
+        assertEquals( "true", normalizeBoolean( "true", BOOLEAN ) );
+        assertEquals( "true", normalizeBoolean( "TRUE", BOOLEAN ) );
+        assertEquals( "true", normalizeBoolean( "t", BOOLEAN ) );
+        assertEquals( "test", normalizeBoolean( "test", TEXT ) );
+        assertEquals( "false", normalizeBoolean( "0", BOOLEAN ) );
+        assertEquals( "false", normalizeBoolean( "f", BOOLEAN ) );
+        assertEquals( "false", normalizeBoolean( "False", BOOLEAN ) );
+        assertEquals( "false", normalizeBoolean( "FALSE", BOOLEAN ) );
+        assertEquals( "false", normalizeBoolean( "F", BOOLEAN ) );
     }
 
     @Test
@@ -298,7 +538,7 @@ public class ValidationUtilsTest
     {
         long oneHundredMegaBytes = 1024 * (1024 * 100L);
 
-        ValueType valueType = ValueType.FILE_RESOURCE;
+        ValueType valueType = FILE_RESOURCE;
 
         FileTypeValueOptions options = new FileTypeValueOptions();
         options.setMaxFileSize( oneHundredMegaBytes );


### PR DESCRIPTION
**_[Backport from 2.40]_**

Fixes related to the event query filter param.
Recently, we introduced a validation for the filters based on the related `ValueType`. (https://github.com/dhis2/dhis2-core/pull/12791)

This was too restrictive as clients might want to use operators like `!=`,  `like`, `not like`, `not null`, etc. We started to face validation errors for common filters that had valid comparisons.

This PR aims to make the validation more "relaxed", so filters that are comparable are always permitted. This will allow a broader set of possible comparisons and at the same time disallow invalid comparisons for the most restrictive types.
The idea is to have a more balanced validation.

I also took some time for small code improvements/clean-up.

