### PR TITLE
fix: wrong alias for category option combo UID in JdbcEventStore TECH-1606

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -168,7 +168,7 @@ class JdbcEventStore implements EventStore {
   private static final String COLUMN_EVENT_CREATED = "ev_created";
   private static final String COLUMN_EVENT_LAST_UPDATED = "ev_lastupdated";
   private static final String COLUMN_EVENT_COMPLETED_BY = "ev_completedby";
-  private static final String COLUMN_EVENT_ATTRIBUTE_OPTION_COMBO_UID = "ev_aoc";
+  private static final String COLUMN_EVENT_ATTRIBUTE_OPTION_COMBO_UID = "coc_uid";
   private static final String COLUMN_EVENT_COMPLETED_DATE = "ev_completeddate";
   private static final String COLUMN_EVENT_DELETED = "ev_deleted";
   private static final String COLUMN_EVENT_ASSIGNED_USER_USERNAME = "user_assigned_username";
@@ -465,7 +465,8 @@ class JdbcEventStore implements EventStore {
       throw new IllegalStateException(
           String.format(
               "CategoryOptionCombo %s does not have a value assigned for idScheme %s",
-              rowSet.getString("coc_uid"), idSchemes.getCategoryOptionComboIdScheme().name()));
+              rowSet.getString(COLUMN_EVENT_ATTRIBUTE_OPTION_COMBO_UID),
+              idSchemes.getCategoryOptionComboIdScheme().name()));
     }
   }
 
@@ -703,7 +704,9 @@ class JdbcEventStore implements EventStore {
             .append("au.username as ")
             .append(COLUMN_EVENT_ASSIGNED_USER_USERNAME)
             .append(",")
-            .append("coc.uid as coc_uid, ")
+            .append("coc.uid as ")
+            .append(COLUMN_EVENT_ATTRIBUTE_OPTION_COMBO_UID)
+            .append(", ")
             .append("coc_agg.co_uids AS co_uids, ")
             .append("coc_agg.co_count AS option_size, ");
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
@@ -898,6 +898,36 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
+  void shouldOrderEventsByAttributeOptionComboUidDesc()
+      throws ForbiddenException, BadRequestException {
+    EventOperationParams params =
+        eventParamsBuilder
+            .orgUnitUid("DiszpKrYNg8")
+            .events(Set.of("ck7DzdxqLqA", "lumVtWwwy0O", "cadc5eGj0j7"))
+            .orderBy("attributeOptionCombo.uid", SortDirection.DESC)
+            .build();
+
+    List<String> events = getEvents(params);
+
+    assertEquals(List.of("ck7DzdxqLqA", "cadc5eGj0j7", "lumVtWwwy0O"), events);
+  }
+
+  @Test
+  void shouldOrderEventsByAttributeOptionComboUidAsc()
+      throws ForbiddenException, BadRequestException {
+    EventOperationParams params =
+        eventParamsBuilder
+            .orgUnitUid("DiszpKrYNg8")
+            .events(Set.of("ck7DzdxqLqA", "lumVtWwwy0O", "cadc5eGj0j7"))
+            .orderBy("attributeOptionCombo.uid", SortDirection.ASC)
+            .build();
+
+    List<String> events = getEvents(params);
+
+    assertEquals(List.of("lumVtWwwy0O", "cadc5eGj0j7", "ck7DzdxqLqA"), events);
+  }
+
+  @Test
   void shouldOrderEventsByOccurredAtDesc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder


### PR DESCRIPTION
Wrong alias for category option combo UID in JdbcEventStore causes a SQL exception when trying to order by it.

