### PR TITLE
fix: wrong alias for program stage UID in JdbcEventStore TECH-1606

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -113,8 +113,6 @@ import org.springframework.stereotype.Repository;
 @Repository("org.hisp.dhis.tracker.export.event.EventStore")
 @RequiredArgsConstructor
 class JdbcEventStore implements EventStore {
-  private static final String DEFAULT_ORDER = "ev_id desc";
-
   private static final String RELATIONSHIP_IDS_QUERY =
       " left join (select ri.eventid as ri_ev_id, json_agg(ri.relationshipid) as ev_rl FROM relationshipitem ri"
           + " GROUP by ri_ev_id)  as fgh on fgh.ri_ev_id=event.ev_id ";
@@ -150,8 +148,10 @@ class JdbcEventStore implements EventStore {
 
   private static final String AND = " AND ";
 
+  private static final String COLUMN_EVENT_ID = "ev_id";
   private static final String COLUMN_EVENT_UID = "ev_uid";
   private static final String COLUMN_PROGRAM_UID = "p_uid";
+  private static final String COLUMN_PROGRAM_STAGE_UID = "ps_uid";
   private static final String COLUMN_ENROLLMENT_UID = "en_uid";
   private static final String COLUMN_ENROLLMENT_STATUS = "en_status";
   private static final String COLUMN_ENROLLMENT_DATE = "en_enrollmentdate";
@@ -174,6 +174,8 @@ class JdbcEventStore implements EventStore {
   private static final String COLUMN_EVENT_ASSIGNED_USER_USERNAME = "user_assigned_username";
   private static final String COLUMN_EVENT_ASSIGNED_USER_DISPLAY_NAME = "user_assigned_name";
 
+  private static final String DEFAULT_ORDER = COLUMN_EVENT_ID + " desc";
+
   /**
    * Events can be ordered by given fields which correspond to fields on {@link
    * org.hisp.dhis.program.Event}. Maps fields to DB columns.
@@ -182,7 +184,7 @@ class JdbcEventStore implements EventStore {
       Map.ofEntries(
           entry("uid", COLUMN_EVENT_UID),
           entry("enrollment.program.uid", COLUMN_PROGRAM_UID),
-          entry("programStage.uid", COLUMN_ENROLLMENT_UID),
+          entry("programStage.uid", COLUMN_PROGRAM_STAGE_UID),
           entry("enrollment.uid", COLUMN_ENROLLMENT_UID),
           entry("enrollment.status", COLUMN_ENROLLMENT_STATUS),
           entry("enrollment.enrollmentDate", COLUMN_ENROLLMENT_DATE),
@@ -451,7 +453,8 @@ class JdbcEventStore implements EventStore {
       throw new IllegalStateException(
           String.format(
               "ProgramStage %s does not have a value assigned for idScheme %s",
-              rowSet.getString("ps_uid"), idSchemes.getProgramStageIdScheme().name()));
+              rowSet.getString(COLUMN_PROGRAM_STAGE_UID),
+              idSchemes.getProgramStageIdScheme().name()));
     }
 
     if (StringUtils.isEmpty(rowSet.getString("ou_identifier"))) {
@@ -554,7 +557,9 @@ class JdbcEventStore implements EventStore {
 
     sqlBuilder.append(EVENT_COMMENT_QUERY);
 
-    sqlBuilder.append(") as cm on event.ev_id=cm.evc_id ");
+    sqlBuilder.append(") as cm on event.");
+    sqlBuilder.append(COLUMN_EVENT_ID);
+    sqlBuilder.append("=cm.evc_id ");
 
     if (params.isIncludeRelationships()) {
       sqlBuilder.append(RELATIONSHIP_IDS_QUERY);
@@ -667,8 +672,12 @@ class JdbcEventStore implements EventStore {
             .append(COLUMN_ORG_UNIT_UID)
             .append(", p.uid as ")
             .append(COLUMN_PROGRAM_UID)
-            .append(", ps.uid as ps_uid, ")
-            .append("ev.eventid as ev_id, ev.status as ")
+            .append(", ps.uid as ")
+            .append(COLUMN_PROGRAM_STAGE_UID)
+            .append(", ")
+            .append("ev.eventid as ")
+            .append(COLUMN_EVENT_ID)
+            .append(", ev.status as ")
             .append(COLUMN_EVENT_STATUS)
             .append(", ev.executiondate as ")
             .append(COLUMN_EVENT_EXECUTION_DATE)
@@ -727,7 +736,7 @@ class JdbcEventStore implements EventStore {
                 + ", en.enrollmentdate as "
                 + COLUMN_ENROLLMENT_DATE
                 + ", en.incidentdate as en_incidentdate, ")
-        .append("p.type as p_type, ps.uid as ps_uid, ou.name as ")
+        .append("p.type as p_type, ou.name as ")
         .append(COLUMN_ORG_UNIT_NAME)
         .append(", ")
         .append("te.trackedentityid as te_id, te.uid as ")

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
@@ -878,6 +878,32 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
+  void shouldOrderEventsByProgramStageUidDesc() throws ForbiddenException, BadRequestException {
+    EventOperationParams params =
+        eventParamsBuilder
+            .orgUnitUid("uoNW0E3xXUy")
+            .orderBy("programStage.uid", SortDirection.DESC)
+            .build();
+
+    List<String> events = getEvents(params);
+
+    assertEquals(List.of("JaRDIvcEcEx", "jxgFyJEMUPf"), events);
+  }
+
+  @Test
+  void shouldOrderEventsByProgramStageUidAsc() throws ForbiddenException, BadRequestException {
+    EventOperationParams params =
+        eventParamsBuilder
+            .orgUnitUid("uoNW0E3xXUy")
+            .orderBy("programStage.uid", SortDirection.ASC)
+            .build();
+
+    List<String> events = getEvents(params);
+
+    assertEquals(List.of("jxgFyJEMUPf", "JaRDIvcEcEx"), events);
+  }
+
+  @Test
   void shouldOrderEventsByTrackedEntityUidDesc() throws ForbiddenException, BadRequestException {
     EventOperationParams params =
         eventParamsBuilder
@@ -887,11 +913,6 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     List<String> events = getEvents(params);
 
-    // TODO(tracker): TECH-1620 the order is reversed
-    // EV D9PbzJY8bJM EN TvctPPhpD8z TE dUE514NMOlo
-    // EV pTzf9KYMk72 EN nxP7UnKhomJ TE QS6w44flWAf
-    // We would therefore expect the TE order to be QS6w44flWAf, dUE514NMOlo
-    // and thus the EV order to be pTzf9KYMk72, D9PbzJY8bJM
     assertEquals(List.of("D9PbzJY8bJM", "pTzf9KYMk72"), events);
   }
 
@@ -905,11 +926,6 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     List<String> events = getEvents(params);
 
-    // TODO(tracker): TECH-1620 the order is reversed
-    // EV D9PbzJY8bJM EN TvctPPhpD8z TE dUE514NMOlo
-    // EV pTzf9KYMk72 EN nxP7UnKhomJ TE QS6w44flWAf
-    // We would therefore expect the TE order to be dUE514NMOlo, QS6w44flWAf
-    // and thus the EV order to be D9PbzJY8bJM, pTzf9KYMk72
     assertEquals(List.of("pTzf9KYMk72", "D9PbzJY8bJM"), events);
   }
 


### PR DESCRIPTION
Wrong alias for program stage UID in JdbcEventStore orders by the wrong column. Removed the duplicate declaration of `ps_uid` in the select as this leads to a SQL exception for ordering by an ambiguous column.

Removed the TODOs for a bug as its actually not a bug but the expected order https://dhis2.atlassian.net/browse/DHIS2-15675
