### PR TITLE
ci: get latest IM tag instead of using master [skip ci]

### DIFF
--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -191,6 +191,7 @@ pipeline {
         stage('Update IM Play dev instance') {
             environment {
                 HTTP = "http --check-status"
+                IM_REPO_URL = "https://github.com/dhis2-sre/im-manager"
                 IM_HOST = "https://api.im.prod.test.c.dhis2.org"
                 INSTANCE_URL = "https://play.im.prod.test.c.dhis2.org/dev"
                 IMAGE_REPOSITORY = "core-dev"
@@ -203,12 +204,13 @@ pipeline {
                 LIVENESS_PROBE_TIMEOUT_SECONDS = "3"
                 READINESS_PROBE_TIMEOUT_SECONDS = "3"
             }
+
             steps {
                 script {
                     if (env.GIT_BRANCH == 'master') {
                         withCredentials([usernamePassword(credentialsId: 'dhis2-im-bot', passwordVariable: 'PASSWORD', usernameVariable: 'USER_EMAIL')]) {
                             dir('im-manager') {
-                                gitHelper.sparseCheckout('https://github.com/dhis2-sre/im-manager', 'master', '/scripts')
+                                gitHelper.sparseCheckout(IM_REPO_URL, "${gitHelper.getLatestTag(IM_REPO_URL)}", '/scripts')
 
                                 dir('scripts/databases') {
                                     env.DATABASE_ID = sh(


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DEVOPS-274

Sometimes using `master` to clone the `im-manager` user scripts leads to version discrepancies with breaking changes between the scripts and the API version deployed on the targeted production environment.

Using the "latest" available tag for the IM would make sure that we're using user scripts from the same version as deployed on the prod environment. 

