### PR TITLE
fix: Ignore org unit if org unit mode does not use it [TECH-1628][2.40]

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/TrackedEntityCriteriaMapperTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/TrackedEntityCriteriaMapperTest.java
@@ -31,12 +31,10 @@ import static com.google.common.collect.Sets.newHashSet;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CHILDREN;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.DESCENDANTS;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.SELECTED;
-import static org.hisp.dhis.utils.Assertions.assertStartsWith;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -50,6 +48,7 @@ import org.hisp.dhis.common.AccessLevel;
 import org.hisp.dhis.common.AssignedUserSelectionMode;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -71,6 +70,8 @@ import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.hisp.dhis.webapi.controller.event.webrequest.TrackedEntityInstanceCriteria;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -325,28 +326,18 @@ class TrackedEntityCriteriaMapperTest extends DhisWebSpringTest {
         e.getMessage());
   }
 
-  @Test
-  void shouldFailWhenOrgUnitSuppliedAndOrgUnitModeAccessible() {
+  @ParameterizedTest
+  @EnumSource(
+      value = OrganisationUnitSelectionMode.class,
+      names = {"CAPTURE", "ACCESSIBLE", "ALL"})
+  void shouldPassWhenOuModeDoesNotNeedOrgUnitAndOrgUnitProvided(
+      OrganisationUnitSelectionMode mode) {
     TrackedEntityInstanceCriteria criteria = new TrackedEntityInstanceCriteria();
+
     criteria.setOu(organisationUnit.getUid());
-    criteria.setOuMode(ACCESSIBLE);
+    criteria.setOuMode(mode);
 
-    Exception exception =
-        assertThrows(IllegalQueryException.class, () -> trackedEntityCriteriaMapper.map(criteria));
-
-    assertStartsWith("ouMode ACCESSIBLE cannot be used with orgUnits.", exception.getMessage());
-  }
-
-  @Test
-  void shouldFailWhenOrgUnitSuppliedAndOrgUnitModeCapture() {
-    TrackedEntityInstanceCriteria criteria = new TrackedEntityInstanceCriteria();
-    criteria.setOu(organisationUnit.getUid());
-    criteria.setOuMode(CAPTURE);
-
-    Exception exception =
-        assertThrows(IllegalQueryException.class, () -> trackedEntityCriteriaMapper.map(criteria));
-
-    assertStartsWith("ouMode CAPTURE cannot be used with orgUnits.", exception.getMessage());
+    assertDoesNotThrow(() -> trackedEntityCriteriaMapper.map(criteria));
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentCriteriaMapper.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.event;
 
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
 import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
 
 import java.util.Date;
@@ -125,13 +123,6 @@ public class EnrollmentCriteriaMapper {
     }
 
     if (ou != null) {
-      if (!ou.isEmpty() && (ouMode == ACCESSIBLE || ouMode == CAPTURE)) {
-        throw new IllegalQueryException(
-            String.format(
-                "ouMode %s cannot be used with orgUnits. Please remove the ou parameter and try again.",
-                ouMode));
-      }
-
       for (String orgUnit : ou) {
         OrganisationUnit organisationUnit = organisationUnitService.getOrganisationUnit(orgUnit);
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventRequestToSearchParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventRequestToSearchParamsMapper.java
@@ -30,8 +30,8 @@ package org.hisp.dhis.webapi.controller.event;
 import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
 import static org.hisp.dhis.webapi.controller.tracker.export.TrackerEventCriteriaMapperUtils.getOrgUnitMode;
 import static org.hisp.dhis.webapi.controller.tracker.export.TrackerEventCriteriaMapperUtils.validateAccessibleOrgUnits;
+import static org.hisp.dhis.webapi.controller.tracker.export.TrackerEventCriteriaMapperUtils.validateOrgUnitMode;
 
-import com.google.common.base.Strings;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -73,7 +73,6 @@ import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.query.QueryUtils;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
-import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
@@ -249,7 +248,7 @@ class EventRequestToSearchParamsMapper {
     }
 
     if (orgUnitSelectionMode != null) {
-      validateOrgUnitMode(orgUnitSelectionMode, orgUnit, user);
+      validateOrgUnitMode(orgUnitSelectionMode, ou, user);
     }
 
     OrganisationUnitSelectionMode orgUnitMode = getOrgUnitMode(ou, orgUnitSelectionMode);
@@ -466,54 +465,5 @@ class EventRequestToSearchParamsMapper {
       }
     }
     return dataElements;
-  }
-
-  private void validateOrgUnitMode(
-      OrganisationUnitSelectionMode selectedOuMode, String orgUnit, User user) {
-
-    String violation = null;
-
-    switch (selectedOuMode) {
-      case ALL:
-        violation =
-            userCanSearchOuModeALL(user)
-                ? null
-                : "Current user is not authorized to query across all organisation units";
-        break;
-      case ACCESSIBLE:
-      case CAPTURE:
-        if (user == null) {
-          violation = "User is required for ouMode: " + selectedOuMode;
-        }
-        if (orgUnit != null) {
-          violation =
-              String.format(
-                  "ouMode %s cannot be used with orgUnits. Please remove the orgUnit parameter and try again.",
-                  selectedOuMode);
-        }
-        break;
-      case CHILDREN:
-      case SELECTED:
-      case DESCENDANTS:
-        violation =
-            orgUnit == null ? "Organisation unit is required for ouMode: " + selectedOuMode : null;
-        break;
-      default:
-        violation = "Invalid ouMode:  " + selectedOuMode;
-        break;
-    }
-
-    if (!Strings.isNullOrEmpty(violation)) {
-      throw new IllegalQueryException(violation);
-    }
-  }
-
-  private boolean userCanSearchOuModeALL(User user) {
-    if (user == null) {
-      return false;
-    }
-
-    return user.isSuper()
-        || user.isAuthorized(Authorities.F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS.name());
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceCriteriaMapper.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.webapi.controller.event;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
 import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.OrderColumn.findColumn;
 import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
@@ -38,13 +37,11 @@ import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toO
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.ObjectUtils;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.IllegalQueryException;
-import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryOperator;
@@ -139,8 +136,6 @@ public class TrackedEntityInstanceCriteriaMapper {
         params.getFilters().add(it);
       }
     }
-
-    validateOrgUnitParams(criteria.getOrgUnits(), criteria.getOuMode());
 
     for (String orgUnit : criteria.getOrgUnits()) {
       OrganisationUnit organisationUnit = organisationUnitService.getOrganisationUnit(orgUnit);
@@ -332,15 +327,6 @@ public class TrackedEntityInstanceCriteriaMapper {
           throw new IllegalQueryException("Invalid order property: " + orderParam.getField());
         }
       }
-    }
-  }
-
-  private void validateOrgUnitParams(Set<String> orgUnits, OrganisationUnitSelectionMode ouMode) {
-    if (!orgUnits.isEmpty() && (ouMode == ACCESSIBLE || ouMode == CAPTURE)) {
-      throw new IllegalQueryException(
-          String.format(
-              "ouMode %s cannot be used with orgUnits. Please remove the ou parameter and try again.",
-              ouMode));
     }
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
@@ -28,8 +28,6 @@
 package org.hisp.dhis.webapi.controller.tracker.export;
 
 import static org.hisp.dhis.common.DimensionalObject.DIMENSION_NAME_SEP;
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -45,7 +43,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DimensionalObject;
-import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryOperator;
@@ -349,23 +346,5 @@ class RequestParamUtils {
    */
   private static String escapedFilterValue(String value) {
     return value.replace(ESCAPE_COMMA, COMMA_STRING).replace(ESCAPE_COLON, DIMENSION_NAME_SEP);
-  }
-
-  /**
-   * Validates that no org unit is present if the ou mode is ACCESSIBLE or CAPTURE. If it is, an
-   * exception will be thrown.
-   *
-   * @param orgUnits
-   * @param orgUnitMode
-   * @throws BadRequestException
-   */
-  public static void validateOrgUnitParams(
-      Set<String> orgUnits, OrganisationUnitSelectionMode orgUnitMode) throws BadRequestException {
-    if (!orgUnits.isEmpty() && (orgUnitMode == ACCESSIBLE || orgUnitMode == CAPTURE)) {
-      throw new BadRequestException(
-          String.format(
-              "orgUnitMode %s cannot be used with orgUnits. Please remove the orgUnit parameter and try again.",
-              orgUnitMode));
-    }
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteriaMapper.java
@@ -32,7 +32,6 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.applyIfNonEmpty;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseUids;
-import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateOrgUnitParams;
 
 import java.util.HashSet;
 import java.util.Optional;
@@ -40,7 +39,6 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -97,8 +95,7 @@ public class TrackerEnrollmentCriteriaMapper {
 
     User user = currentUserService.getCurrentUser();
     Set<String> orgUnitIds = parseUids(criteria.getOrgUnit());
-    Set<OrganisationUnit> orgUnits =
-        validateOrgUnits(user, orgUnitIds, criteria.getOuMode(), program);
+    Set<OrganisationUnit> orgUnits = validateOrgUnits(user, orgUnitIds, program);
 
     ProgramInstanceQueryParams params = new ProgramInstanceQueryParams();
     params.setProgram(program);
@@ -145,13 +142,11 @@ public class TrackerEnrollmentCriteriaMapper {
     }
   }
 
-  private Set<OrganisationUnit> validateOrgUnits(
-      User user, Set<String> orgUnitIds, OrganisationUnitSelectionMode orgUnitMode, Program program)
+  private Set<OrganisationUnit> validateOrgUnits(User user, Set<String> orgUnitIds, Program program)
       throws BadRequestException, ForbiddenException {
 
     Set<OrganisationUnit> orgUnits = new HashSet<>();
     if (orgUnitIds != null) {
-      validateOrgUnitParams(orgUnitIds, orgUnitMode);
 
       for (String orgUnitId : orgUnitIds) {
         OrganisationUnit organisationUnit = organisationUnitService.getOrganisationUnit(orgUnitId);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapper.java
@@ -35,6 +35,7 @@ import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.p
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseQueryItem;
 import static org.hisp.dhis.webapi.controller.tracker.export.TrackerEventCriteriaMapperUtils.getOrgUnitMode;
 import static org.hisp.dhis.webapi.controller.tracker.export.TrackerEventCriteriaMapperUtils.validateAccessibleOrgUnits;
+import static org.hisp.dhis.webapi.controller.tracker.export.TrackerEventCriteriaMapperUtils.validateOrgUnitMode;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -150,6 +151,11 @@ class TrackerEventCriteriaMapper {
     OrganisationUnit requestedOrgUnit =
         applyIfNonEmpty(organisationUnitService::getOrganisationUnit, criteria.getOrgUnit());
     validateOrgUnit(criteria.getOrgUnit(), requestedOrgUnit);
+
+    if (criteria.getOuMode() != null) {
+      validateOrgUnitMode(criteria.getOuMode(), requestedOrgUnit, user);
+    }
+
     OrganisationUnitSelectionMode orgUnitMode =
         getOrgUnitMode(requestedOrgUnit, criteria.getOuMode());
     List<OrganisationUnit> accessibleOrgUnits =

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapperUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapperUtils.java
@@ -194,7 +194,7 @@ public class TrackerEventCriteriaMapperUtils {
 
     switch (selectedOuMode) {
       case ALL:
-        if (userCanSearchOuModeALL(user)) {
+        if (!userCanSearchOuModeALL(user)) {
           throw new IllegalQueryException(
               "Current user is not authorized to query across all organisation units");
         }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapper.java
@@ -36,7 +36,6 @@ import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.p
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseAttributeQueryItems;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseQueryFilter;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseUids;
-import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateOrgUnitParams;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -110,7 +109,6 @@ public class TrackerTrackedEntityCriteriaMapper {
 
     User user = currentUserService.getCurrentUser();
     Set<String> orgUnitIds = parseUids(criteria.getOrgUnit());
-    validateOrgUnitParams(orgUnitIds, criteria.getOuMode());
 
     Set<OrganisationUnit> orgUnits = validateOrgUnits(user, orgUnitIds, program);
     if (criteria.getOuMode() == OrganisationUnitSelectionMode.CAPTURE && user != null) {

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtilsTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtilsTest.java
@@ -27,17 +27,9 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export;
 
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CHILDREN;
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.DESCENDANTS;
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.SELECTED;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
-import static org.hisp.dhis.utils.Assertions.assertStartsWith;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseQueryItem;
-import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.validateOrgUnitParams;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -45,7 +37,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryOperator;
@@ -166,42 +157,6 @@ class RequestParamUtilsTest {
     assertEquals(
         new QueryFilter(QueryOperator.LIKE, "project:x"),
         RequestParamUtils.parseQueryFilter("like:project/:x"));
-  }
-
-  @Test
-  void shouldFailWhenOrgUnitSuppliedAndOrgUnitModeAccessible() {
-    Exception exception =
-        assertThrows(
-            BadRequestException.class,
-            () -> validateOrgUnitParams(Set.of(orgUnit.getUid()), ACCESSIBLE));
-
-    assertStartsWith(
-        "orgUnitMode ACCESSIBLE cannot be used with orgUnits.", exception.getMessage());
-  }
-
-  @Test
-  void shouldFailWhenOrgUnitSuppliedAndOrgUnitModeCapture() {
-    Exception exception =
-        assertThrows(
-            BadRequestException.class,
-            () -> validateOrgUnitParams(Set.of(orgUnit.getUid()), CAPTURE));
-
-    assertStartsWith("orgUnitMode CAPTURE cannot be used with orgUnits.", exception.getMessage());
-  }
-
-  @Test
-  void shouldPassWhenOrgUnitSuppliedAndOrgUnitModeSelected() {
-    assertDoesNotThrow(() -> validateOrgUnitParams(Set.of(orgUnit.getUid()), SELECTED));
-  }
-
-  @Test
-  void shouldPassWhenOrgUnitSuppliedAndOrgUnitModeDescendants() {
-    assertDoesNotThrow(() -> validateOrgUnitParams(Set.of(orgUnit.getUid()), DESCENDANTS));
-  }
-
-  @Test
-  void shouldPassWhenOrgUnitSuppliedAndOrgUnitModeChildren() {
-    assertDoesNotThrow(() -> validateOrgUnitParams(Set.of(orgUnit.getUid()), CHILDREN));
   }
 
   private TrackedEntityAttribute trackedEntityAttribute(String uid) {

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapperTest.java
@@ -76,6 +76,7 @@ import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
@@ -84,6 +85,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserRole;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
@@ -1136,6 +1138,8 @@ class TrackerEventCriteriaMapperTest {
       names = {"CAPTURE", "ACCESSIBLE", "ALL"})
   void shouldPassWhenOuModeDoesNotNeedOrgUnitAndOrgUnitProvided(
       OrganisationUnitSelectionMode mode) {
+    when(currentUserService.getCurrentUser()).thenReturn(createSearchInAllOrgUnitsUser());
+
     TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
     eventCriteria.setOuMode(mode);
 
@@ -1146,5 +1150,15 @@ class TrackerEventCriteriaMapperTest {
     OrganisationUnit orgUnit = new OrganisationUnit(name);
     orgUnit.setUid(uid);
     return orgUnit;
+  }
+
+  private User createSearchInAllOrgUnitsUser() {
+    User user = new User();
+    UserRole userRole = new UserRole();
+    userRole.setAuthorities(
+        Set.of(Authorities.F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS.name()));
+    user.setUserRoles(Set.of(userRole));
+
+    return user;
   }
 }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapperTest.java
@@ -77,10 +77,13 @@ import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -651,5 +654,18 @@ class TrackerTrackedEntityCriteriaMapperTest {
             new QueryFilter(QueryOperator.LIKE, "value1:"),
             new QueryFilter(QueryOperator.LIKE, "value2")),
         actualFilters);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = OrganisationUnitSelectionMode.class,
+      names = {"CAPTURE", "ACCESSIBLE", "ALL"})
+  void shouldPassWhenOuModeDoesNotNeedOrgUnitAndOrgUnitProvided(
+      OrganisationUnitSelectionMode mode) {
+    when(trackerAccessManager.canAccess(user, null, orgUnit1)).thenReturn(true);
+
+    criteria.setOrgUnit(orgUnit1.getUid());
+    criteria.setOuMode(mode);
+    Assertions.assertDoesNotThrow(() -> mapper.map(criteria));
   }
 }

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -204,7 +204,7 @@
 
     <!-- Monitoring -->
     <micrometer-spring-legacy.version>1.3.20</micrometer-spring-legacy.version>
-    <micrometer.version>1.11.2</micrometer.version>
+    <micrometer.version>1.11.3</micrometer.version>
 
     <!-- Logging -->
     <log4j.version>2.20.0</log4j.version>


### PR DESCRIPTION
In order not to break the API in older versions, instead of throwing an exception, we will just ignore the requested org unit if the org unit mode is ACCESSIBLE, CAPTURE or ALL.

Ticket: https://dhis2.atlassian.net/browse/TECH-1628 