### PR TITLE
fix: Misleading message about password requirements 

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -195,7 +195,7 @@ public enum ErrorCode {
   E4002("Allowed length range for property `{0}` is [{1} to {2}], but given length was {3}"),
   E4003("Property `{0}` requires a valid email address, was given `{1}`"),
   E4004("Property `{0}` requires a valid URL, was given `{1}`"),
-  E4005("Property `{0}` requires a valid password, was given `{1}`"),
+  E4005("Property `{0}` requires a valid password, `{1}`"),
   E4006("Property `{0}` requires a valid HEX color, was given `{1}`"),
   E4007("Allowed size range for collection property `{0}` is [{1} to {2}], but size given was {3}"),
   E4008("Allowed range for numeric property `{0}` is [{1} to {2}], but number given was {3}"),

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/validation/DefaultSchemaValidator.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/validation/DefaultSchemaValidator.java
@@ -175,7 +175,8 @@ public class DefaultSchemaValidator implements SchemaValidator {
       errorReports.add(createNameReport(ErrorCode.E4004, klass, property, value));
     } else if (isInvalidPassword(property, value)) {
       PasswordValidationResult result = validatePassword(value);
-      errorReports.add(createNameReport(ErrorCode.E4005, klass, property, result.getErrorMessage()));
+      errorReports.add(
+          createNameReport(ErrorCode.E4005, klass, property, result.getErrorMessage()));
     } else if (isInvalidColor(property, value)) {
       errorReports.add(createNameReport(ErrorCode.E4006, klass, property, value));
     }

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/validation/DefaultSchemaValidator.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/validation/DefaultSchemaValidator.java
@@ -145,8 +145,10 @@ public class DefaultSchemaValidator implements SchemaValidator {
 
     String value = (String) propertyObject;
 
-    // Check column max length
-    if (property.getLength() != null && value.length() > property.getLength()) {
+    // Check column max length, but not if it is a password,
+    // because the password is hashed to a fixed size, hence the input length is irrelevant.
+    if ((property.getLength() != null && value.length() > property.getLength())
+        && !property.getPropertyType().equals(PropertyType.PASSWORD)) {
       return singletonList(
           createReport(
               ErrorCode.E4001,
@@ -159,7 +161,9 @@ public class DefaultSchemaValidator implements SchemaValidator {
 
     List<ErrorReport> errorReports = new ArrayList<>();
 
-    if (value.length() < property.getMin() || value.length() > property.getMax()) {
+    // Only check of min/max length if it's not a password.
+    if ((value.length() < property.getMin() || value.length() > property.getMax())
+        && !property.getPropertyType().equals(PropertyType.PASSWORD)) {
       errorReports.add(createNameMinMaxReport(ErrorCode.E4002, klass, property, value.length()));
     }
 
@@ -170,7 +174,8 @@ public class DefaultSchemaValidator implements SchemaValidator {
     } else if (isInvalidUrl(property, value)) {
       errorReports.add(createNameReport(ErrorCode.E4004, klass, property, value));
     } else if (isInvalidPassword(property, value)) {
-      errorReports.add(createNameReport(ErrorCode.E4005, klass, property, value));
+      PasswordValidationResult result = validatePassword(value);
+      errorReports.add(createNameReport(ErrorCode.E4005, klass, property, result.getErrorMessage()));
     } else if (isInvalidColor(property, value)) {
       errorReports.add(createNameReport(ErrorCode.E4006, klass, property, value));
     }
@@ -195,15 +200,12 @@ public class DefaultSchemaValidator implements SchemaValidator {
   private boolean isInvalidPassword(Property property, String value) {
     return !BCRYPT_PATTERN.matcher(value).matches()
         && PropertyType.PASSWORD == property.getPropertyType()
-        && !passwordIsValid(value);
+        && !validatePassword(value).isValid();
   }
 
-  private boolean passwordIsValid(String value) {
+  private PasswordValidationResult validatePassword(String value) {
     CredentialsInfo credentialsInfo = new CredentialsInfo("USERNAME", value, "", true);
-
-    PasswordValidationResult result = passwordValidationService.validate(credentialsInfo);
-
-    return result.isValid();
+    return passwordValidationService.validate(credentialsInfo);
   }
 
   private boolean isInvalidUsername(Property property, String value) {

--- a/dhis-2/dhis-services/dhis-service-schema/src/test/java/org/hisp/dhis/schema/validation/DefaultSchemaValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/test/java/org/hisp/dhis/schema/validation/DefaultSchemaValidatorTest.java
@@ -165,13 +165,8 @@ class DefaultSchemaValidatorTest {
 
   @BeforeEach
   void setUpSchema() {
-    CredentialsInfo credentialsInfo = new CredentialsInfo("USERNAME", "tooShort", "", true);
-
     schema.setPropertyMap(introspectorService.getPropertiesMap(SimpleFields.class));
     when(schemaService.getDynamicSchema(SimpleFields.class)).thenReturn(schema);
-
-    //        when( passwordValidationService.isV( credentialsInfo ) ).thenReturn( new
-    // PasswordValidationResult( null ) );
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-schema/src/test/java/org/hisp/dhis/schema/validation/DefaultSchemaValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/test/java/org/hisp/dhis/schema/validation/DefaultSchemaValidatorTest.java
@@ -243,7 +243,8 @@ class DefaultSchemaValidatorTest {
     assertError(
         ErrorCode.E4005,
         SimpleFields.builder().string("valid").password("tooShort").build(),
-        "Property `password` requires a valid password, was given `tooShort`");
+        "Property `password` requires a valid password, `Password must have at least %d, and at"
+            + " most %d characters`");
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
@@ -81,12 +81,7 @@ public enum SettingKey {
   EMAIL_SENDER("keyEmailSender", "", String.class),
   EMAIL_PASSWORD("keyEmailPassword", "", String.class, true, false),
   MIN_PASSWORD_LENGTH("minPasswordLength", 8, Integer.class),
-
-  /**
-   * The password max value is set to 60 to match the max value of the password column in the
-   * database, hence it can not be greater than 60.
-   */
-  MAX_PASSWORD_LENGTH("maxPasswordLength", 256, Integer.class),
+  MAX_PASSWORD_LENGTH("maxPasswordLength", 72, Integer.class),
   SMS_CONFIG("keySmsSetting", new SmsConfiguration(), SmsConfiguration.class),
   SMS_MAX_LENGTH("keySmsMaxLength", 1071, Integer.class),
   CACHE_STRATEGY("keyCacheStrategy", CacheStrategy.CACHE_1_MINUTE, CacheStrategy.class),

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
@@ -86,7 +86,7 @@ public enum SettingKey {
    * The password max value is set to 60 to match the max value of the password column in the
    * database, hence it can not be greater than 60.
    */
-  MAX_PASSWORD_LENGTH("maxPasswordLength", 60, Integer.class),
+  MAX_PASSWORD_LENGTH("maxPasswordLength", 256, Integer.class),
   SMS_CONFIG("keySmsSetting", new SmsConfiguration(), SmsConfiguration.class),
   SMS_MAX_LENGTH("keySmsMaxLength", 1071, Integer.class),
   CACHE_STRATEGY("keyCacheStrategy", CacheStrategy.CACHE_1_MINUTE, CacheStrategy.class),

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/users/UserTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/users/UserTest.java
@@ -81,12 +81,12 @@ public class UserTest extends ApiTest {
           Arguments.of(
               password,
               "Test1?",
-              "Password must have at least 8, and at most 256 characters",
+              "Password must have at least 8, and at most 72 characters",
               "newPassword is too short"),
           Arguments.of(
               password,
               DataGenerator.randomString(257) + "1?",
-              "Password must have at least 8, and at most 256 characters",
+              "Password must have at least 8, and at most 72 characters",
               "newPassword is too-long"),
           Arguments.of(
               password, "", "OldPassword and newPassword must be provided", "newPassword is empty"),

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/users/UserTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/users/UserTest.java
@@ -81,12 +81,12 @@ public class UserTest extends ApiTest {
           Arguments.of(
               password,
               "Test1?",
-              "Password must have at least 8, and at most 60 characters",
+              "Password must have at least 8, and at most 256 characters",
               "newPassword is too short"),
           Arguments.of(
               password,
               DataGenerator.randomString(257) + "1?",
-              "Password must have at least 8, and at most 60 characters",
+              "Password must have at least 8, and at most 256 characters",
               "newPassword is too-long"),
           Arguments.of(
               password, "", "OldPassword and newPassword must be provided", "newPassword is empty"),

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/systemsettings/SystemSettingsTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/systemsettings/SystemSettingsTests.java
@@ -57,7 +57,7 @@ public class SystemSettingsTests extends ApiTest {
 
   private static final String MAX_PASSWORD_LENGTH_KEY = "maxPasswordLength";
 
-  private static final int MAX_PASSWORD_LENGTH_DEFAULT_VALUE = 256;
+  private static final int MAX_PASSWORD_LENGTH_DEFAULT_VALUE = 72;
 
   private static final String EMAIL_SENDER_KEY = "keyEmailSender";
 

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/systemsettings/SystemSettingsTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/systemsettings/SystemSettingsTests.java
@@ -57,7 +57,7 @@ public class SystemSettingsTests extends ApiTest {
 
   private static final String MAX_PASSWORD_LENGTH_KEY = "maxPasswordLength";
 
-  private static final int MAX_PASSWORD_LENGTH_DEFAULT_VALUE = 60;
+  private static final int MAX_PASSWORD_LENGTH_DEFAULT_VALUE = 256;
 
   private static final String EMAIL_SENDER_KEY = "keyEmailSender";
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
@@ -138,7 +138,7 @@ class AccountControllerTest extends DhisControllerConvenienceTest {
     assertMessage(
         "response",
         "error",
-        "Password must have at least 8, and at most 256 characters",
+        "Password must have at least 8, and at most 72 characters",
         GET("/account/password?password=xyz").content(HttpStatus.OK));
   }
 
@@ -156,7 +156,7 @@ class AccountControllerTest extends DhisControllerConvenienceTest {
     assertMessage(
         "response",
         "error",
-        "Password must have at least 8, and at most 256 characters",
+        "Password must have at least 8, and at most 72 characters",
         POST("/account/validatePassword?password=xyz").content(HttpStatus.OK));
   }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
@@ -138,7 +138,7 @@ class AccountControllerTest extends DhisControllerConvenienceTest {
     assertMessage(
         "response",
         "error",
-        "Password must have at least 8, and at most 60 characters",
+        "Password must have at least 8, and at most 256 characters",
         GET("/account/password?password=xyz").content(HttpStatus.OK));
   }
 
@@ -156,7 +156,7 @@ class AccountControllerTest extends DhisControllerConvenienceTest {
     assertMessage(
         "response",
         "error",
-        "Password must have at least 8, and at most 60 characters",
+        "Password must have at least 8, and at most 256 characters",
         POST("/account/validatePassword?password=xyz").content(HttpStatus.OK));
   }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MeControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MeControllerTest.java
@@ -229,8 +229,7 @@ class MeControllerTest extends DhisControllerConvenienceTest {
                     + "supersecretsupersecretsupersecretsupersecret"
                     + "supersecretsupersecretsupersecretsupersecret"
                     + "supersecretsupersecretsupersecretsupersecret"
-                    + "supersecretsupersecretsupersecretsupersecret"
-            )
+                    + "supersecretsupersecretsupersecretsupersecret")
             .content()
             .as(JsonPasswordValidation.class);
     assertFalse(result.isValidPassword());

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MeControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MeControllerTest.java
@@ -133,7 +133,7 @@ class MeControllerTest extends DhisControllerConvenienceTest {
   @Test
   void testChangePassword_WrongNew() {
     assertEquals(
-        "Password must have at least 8, and at most 60 characters",
+        "Password must have at least 8, and at most 256 characters",
         PUT("/me/changePassword", "{'oldPassword':'district','newPassword':'secret'}")
             .error(Series.CLIENT_ERROR)
             .getMessage());
@@ -215,7 +215,7 @@ class MeControllerTest extends DhisControllerConvenienceTest {
             .as(JsonPasswordValidation.class);
     assertFalse(result.isValidPassword());
     assertEquals(
-        "Password must have at least 8, and at most 60 characters", result.getErrorMessage());
+        "Password must have at least 8, and at most 256 characters", result.getErrorMessage());
   }
 
   @Test
@@ -224,12 +224,18 @@ class MeControllerTest extends DhisControllerConvenienceTest {
         POST(
                 "/me/validatePassword",
                 "text/plain:supersecretsupersecretsupersecret"
-                    + "supersecretsupersecretsupersecretsupersecret")
+                    + "supersecretsupersecretsupersecretsupersecret"
+                    + "supersecretsupersecretsupersecretsupersecret"
+                    + "supersecretsupersecretsupersecretsupersecret"
+                    + "supersecretsupersecretsupersecretsupersecret"
+                    + "supersecretsupersecretsupersecretsupersecret"
+                    + "supersecretsupersecretsupersecretsupersecret"
+            )
             .content()
             .as(JsonPasswordValidation.class);
     assertFalse(result.isValidPassword());
     assertEquals(
-        "Password must have at least 8, and at most 60 characters", result.getErrorMessage());
+        "Password must have at least 8, and at most 256 characters", result.getErrorMessage());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MeControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MeControllerTest.java
@@ -133,7 +133,7 @@ class MeControllerTest extends DhisControllerConvenienceTest {
   @Test
   void testChangePassword_WrongNew() {
     assertEquals(
-        "Password must have at least 8, and at most 256 characters",
+        "Password must have at least 8, and at most 72 characters",
         PUT("/me/changePassword", "{'oldPassword':'district','newPassword':'secret'}")
             .error(Series.CLIENT_ERROR)
             .getMessage());
@@ -215,7 +215,7 @@ class MeControllerTest extends DhisControllerConvenienceTest {
             .as(JsonPasswordValidation.class);
     assertFalse(result.isValidPassword());
     assertEquals(
-        "Password must have at least 8, and at most 256 characters", result.getErrorMessage());
+        "Password must have at least 8, and at most 72 characters", result.getErrorMessage());
   }
 
   @Test
@@ -223,24 +223,20 @@ class MeControllerTest extends DhisControllerConvenienceTest {
     JsonPasswordValidation result =
         POST(
                 "/me/validatePassword",
-                "text/plain:supersecretsupersecretsupersecret"
-                    + "supersecretsupersecretsupersecretsupersecret"
-                    + "supersecretsupersecretsupersecretsupersecret"
-                    + "supersecretsupersecretsupersecretsupersecret"
-                    + "supersecretsupersecretsupersecretsupersecret"
-                    + "supersecretsupersecretsupersecretsupersecret"
-                    + "supersecretsupersecretsupersecretsupersecret")
+                "text/plain:supersecretsupersecretsupersecretsupersecretsupersecretsupersecretsuperse")
             .content()
             .as(JsonPasswordValidation.class);
     assertFalse(result.isValidPassword());
     assertEquals(
-        "Password must have at least 8, and at most 256 characters", result.getErrorMessage());
+        "Password must have at least 8, and at most 72 characters", result.getErrorMessage());
   }
 
   @Test
   void testValidatePasswordText_NoDigits() {
     JsonPasswordValidation result =
-        POST("/me/validatePassword", "text/plain:supersecret")
+        POST(
+                "/me/validatePassword",
+                "text/plain:supersecretsupersecretsupersecretsupersecretsupersecretsupersecretsupers")
             .content()
             .as(JsonPasswordValidation.class);
     assertFalse(result.isValidPassword());

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -374,7 +374,7 @@ class UserControllerTest extends DhisControllerConvenienceTest {
         "Conflict",
         409,
         "ERROR",
-        "Password must have at least 8, and at most 60 characters",
+        "Password must have at least 8, and at most 256 characters",
         POST("/users/" + peter.getUid() + "/replica", "{'username':'peter2','password':'lame'}")
             .content(HttpStatus.CONFLICT));
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -374,7 +374,7 @@ class UserControllerTest extends DhisControllerConvenienceTest {
         "Conflict",
         409,
         "ERROR",
-        "Password must have at least 8, and at most 256 characters",
+        "Password must have at least 8, and at most 72 characters",
         POST("/users/" + peter.getUid() + "/replica", "{'username':'peter2','password':'lame'}")
             .content(HttpStatus.CONFLICT));
   }


### PR DESCRIPTION
## Summary
Makes the password validation in the SchemaValidator ignore min and max string length validation, since validation now is always done in the PasswordValidationService, and the actual database column length is not relevant to the input string, since we always hash the input string with Bcrypt, that always gives a 60 character length string before it is persisted. 
The actual max input string length is limited by the Bcrypt max input size which is 72 bytes.

Reference: https://security.stackexchange.com/questions/152430/what-maximum-password-length-to-choose-when-using-bcrypt