### PR TITLE
fix: Use search scope to validate org unit [DHIS2-15021][2.40]

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/TrackedEntityCriteriaMapperTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/TrackedEntityCriteriaMapperTest.java
@@ -276,7 +276,7 @@ class TrackedEntityCriteriaMapperTest extends DhisWebSpringTest {
   }
 
   @Test
-  void shouldThrowExceptionWhenProgramIsProtectedAndUserNotInCaptureScope() {
+  void shouldThrowExceptionWhenProgramIsProtectedSearchScopeIsEmptyAndUserNotInCaptureScope() {
     clearSecurityContext();
     User mockUser = createUserWithAuth("testUser2");
     mockUser.setOrganisationUnits(Set.of(organisationUnit));
@@ -290,7 +290,7 @@ class TrackedEntityCriteriaMapperTest extends DhisWebSpringTest {
         assertThrows(IllegalQueryException.class, () -> trackedEntityCriteriaMapper.map(criteria));
 
     assertEquals(
-        "User does not have access to organisation unit: " + organisationUnitB.getUid(),
+        "Organisation unit is not part of the search scope: " + organisationUnitB.getUid(),
         e.getMessage());
   }
 
@@ -309,7 +309,7 @@ class TrackedEntityCriteriaMapperTest extends DhisWebSpringTest {
         assertThrows(IllegalQueryException.class, () -> trackedEntityCriteriaMapper.map(criteria));
 
     assertEquals(
-        "User does not have access to organisation unit: " + organisationUnitB.getUid(),
+        "Organisation unit is not part of the search scope: " + organisationUnitB.getUid(),
         e.getMessage());
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceCriteriaMapper.java
@@ -149,9 +149,12 @@ public class TrackedEntityInstanceCriteriaMapper {
         throw new IllegalQueryException("Organisation unit does not exist: " + orgUnit);
       }
 
-      if (!trackerAccessManager.canAccess(user, program, organisationUnit)) {
+      if (user != null
+          && !user.isSuper()
+          && !organisationUnitService.isInUserHierarchy(
+              organisationUnit.getUid(), user.getTeiSearchOrganisationUnitsWithFallback())) {
         throw new IllegalQueryException(
-            "User does not have access to organisation unit: " + orgUnit);
+            "Organisation unit is not part of the search scope: " + orgUnit);
       }
 
       params.getOrganisationUnits().add(organisationUnit);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceCriteriaMapper.java
@@ -58,7 +58,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
-import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
@@ -81,15 +80,12 @@ public class TrackedEntityInstanceCriteriaMapper {
 
   private final TrackedEntityAttributeService attributeService;
 
-  private final TrackerAccessManager trackerAccessManager;
-
   public TrackedEntityInstanceCriteriaMapper(
       CurrentUserService currentUserService,
       OrganisationUnitService organisationUnitService,
       ProgramService programService,
       TrackedEntityAttributeService attributeService,
-      TrackedEntityTypeService trackedEntityTypeService,
-      TrackerAccessManager trackerAccessManager) {
+      TrackedEntityTypeService trackedEntityTypeService) {
     checkNotNull(currentUserService);
     checkNotNull(organisationUnitService);
     checkNotNull(programService);
@@ -101,7 +97,6 @@ public class TrackedEntityInstanceCriteriaMapper {
     this.programService = programService;
     this.attributeService = attributeService;
     this.trackedEntityTypeService = trackedEntityTypeService;
-    this.trackerAccessManager = trackerAccessManager;
   }
 
   @Transactional(readOnly = true)

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapperTest.java
@@ -495,7 +495,7 @@ class TrackerTrackedEntityCriteriaMapperTest {
   }
 
   @Test
-  void shouldThrowExceptionWhenOrgUnitNotInScope() {
+  void shouldThrowExceptionWhenOrgUnitNotInSearchScope() {
     when(organisationUnitService.isInUserHierarchy(
             orgUnit1.getUid(), user.getTeiSearchOrganisationUnitsWithFallback()))
         .thenReturn(false);
@@ -504,7 +504,7 @@ class TrackerTrackedEntityCriteriaMapperTest {
 
     ForbiddenException e = assertThrows(ForbiddenException.class, () -> mapper.map(criteria));
     assertEquals(
-        "User does not have access to organisation unit: " + ORG_UNIT_1_UID, e.getMessage());
+        "Organisation unit is not part of the search scope: " + ORG_UNIT_1_UID, e.getMessage());
   }
 
   @Test


### PR DESCRIPTION
Tracked entities needs to use the search scope to validate the requested org unit regardless of the program access level

Ticket: https://dhis2.atlassian.net/browse/DHIS2-15021