### PR TITLE
fix: Period object in /analytics [DHIS2-15684] (#14884)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodType.java
@@ -75,8 +75,17 @@ public abstract class PeriodType implements Serializable {
     return getCalendar().name() + getName() + date.getTime();
   }
 
+  private String getCacheKey(Date date, String customKey) {
+    return getCalendar().name() + getName() + date.getTime() + customKey;
+  }
+
   private String getCacheKey(org.hisp.dhis.calendar.Calendar calendar, Date date) {
     return calendar.name() + getName() + date.getTime();
+  }
+
+  private String getCacheKey(
+      org.hisp.dhis.calendar.Calendar calendar, Date date, String customKey) {
+    return calendar.name() + getName() + date.getTime() + customKey;
   }
 
   /**
@@ -279,8 +288,21 @@ public abstract class PeriodType implements Serializable {
    * @param date the date which is contained by the created period.
    * @return the valid Period based on the given date
    */
-  public Period createPeriod(final Date date) {
+  public Period createPeriod(Date date) {
     return PERIOD_CACHE.get(getCacheKey(date), s -> createPeriod(date, getCalendar()));
+  }
+
+  /**
+   * Creates a valid Period based on the given date and "dateField". E.g. the given date is February
+   * 10. 2007, a monthly PeriodType should return February 2007.
+   *
+   * @param date the date which is contained by the created period.
+   * @param dateField the date field of the returned {@link Period}.
+   * @return the valid Period based on the given date.
+   */
+  public Period createPeriod(Date date, String dateField) {
+    return PERIOD_CACHE.get(
+        getCacheKey(date, dateField), s -> createPeriod(date, getCalendar(), dateField));
   }
 
   public Period createPeriod(Calendar cal) {
@@ -291,16 +313,35 @@ public abstract class PeriodType implements Serializable {
 
   /**
    * Creates a valid Period based on the given date. E.g. the given date is February 10. 2007, a
-   * monthly PeriodType should return February 2007. This method is intended for use in situations
-   * where a huge number of of periods will be generated and its desirable to re-use the calendar.
+   * monthly {@link PeriodType} should return February 2007. This method is intended for use in
+   * situations where a huge number of periods will be generated and its desirable to re-use the
+   * calendar.
    *
    * @param date the date which is contained by the created period.
    * @param calendar the calendar implementation to use.
    * @return the valid Period based on the given date
    */
-  public Period createPeriod(final Date date, final org.hisp.dhis.calendar.Calendar calendar) {
+  public Period createPeriod(Date date, org.hisp.dhis.calendar.Calendar calendar) {
     return PERIOD_CACHE.get(
         getCacheKey(calendar, date),
+        p -> createPeriod(calendar.fromIso(DateTimeUnit.fromJdkDate(date)), calendar));
+  }
+
+  /**
+   * Creates a valid {@link Period} based on the given date. E.g. the given date is February 10.
+   * 2007, a monthly {@link PeriodType} should return February 2007. This method is intended for use
+   * in situations where a huge number of periods will be generated and its desirable to re-use the
+   * calendar.
+   *
+   * @param date the date which is contained by the created period.
+   * @param calendar the calendar implementation to use.
+   * @param dateField the date field of the returned {@link Period}.
+   * @return the valid Period based on the given date.
+   */
+  public Period createPeriod(
+      Date date, org.hisp.dhis.calendar.Calendar calendar, String dateField) {
+    return PERIOD_CACHE.get(
+        getCacheKey(calendar, date, dateField),
         p -> createPeriod(calendar.fromIso(DateTimeUnit.fromJdkDate(date)), calendar));
   }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -839,7 +839,10 @@ public class DataQueryParams {
 
     if (dataPeriodType != null) {
       for (DimensionalItemObject aggregatePeriod : getDimensionOrFilterItems(PERIOD_DIM_ID)) {
-        Period dataPeriod = dataPeriodType.createPeriod(((Period) aggregatePeriod).getStartDate());
+        Period dataPeriod =
+            dataPeriodType.createPeriod(
+                ((Period) aggregatePeriod).getStartDate(),
+                ((Period) aggregatePeriod).getDateField());
 
         map.putValue(dataPeriod, aggregatePeriod);
 
@@ -849,7 +852,10 @@ public class DataQueryParams {
           // corresponding to the second part of the financial year so
           // that the query will count both years.
 
-          Period endYear = dataPeriodType.createPeriod(((Period) aggregatePeriod).getEndDate());
+          Period endYear =
+              dataPeriodType.createPeriod(
+                  ((Period) aggregatePeriod).getEndDate(),
+                  ((Period) aggregatePeriod).getDateField());
           map.putValue(endYear, aggregatePeriod);
         }
       }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManager.java
@@ -231,7 +231,7 @@ public class JdbcAnalyticsManager implements AnalyticsManager {
             periods,
             String.format(
                 "Period list cannot be null, key: '%s', map: '%s'",
-                key, dataPeriodAggregationPeriodMap.toString()));
+                key, dataPeriodAggregationPeriodMap));
 
         Object value = dataValueMap.get(key);
 


### PR DESCRIPTION
**_[Backport from master/2.41]_**

There is an issue with the Period handling in the “/analytics” endpoint.
The problem only shows up when we first execute the “/analytics/tei” endpoint specifying the type of the date period.

This will cause subsequent requests of “/analytics” to fail because it might try to use the Period object previously cached (that contains the attribute “dateField” set).

The “/analytics” endpoint should never have that attribute set, otherwise, we can face undesirable behavior throughout the flow.

#14884