### PR TITLE
 fix: Use search scope to validate org unit [DHIS2-15145][2.39]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/EnrollmentCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/EnrollmentCriteriaMapper.java
@@ -128,9 +128,10 @@ public class EnrollmentCriteriaMapper {
           throw new IllegalQueryException("Organisation unit does not exist: " + orgUnit);
         }
 
-        if ( !organisationUnitService.isInUserHierarchy( organisationUnit.getUid(), user.getTeiSearchOrganisationUnitsWithFallback() ) )
-        {
-          throw new IllegalQueryException( "Organisation unit is not part of the search scope: " + orgUnit );
+        if (!organisationUnitService.isInUserHierarchy(
+            organisationUnit.getUid(), user.getTeiSearchOrganisationUnitsWithFallback())) {
+          throw new IllegalQueryException(
+              "Organisation unit is not part of the search scope: " + orgUnit);
         }
 
         params.getOrganisationUnits().add(organisationUnit);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/EnrollmentCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/EnrollmentCriteriaMapper.java
@@ -49,7 +49,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
-import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
@@ -70,8 +69,6 @@ public class EnrollmentCriteriaMapper {
   private final TrackedEntityTypeService trackedEntityTypeService;
 
   private final TrackedEntityInstanceService trackedEntityInstanceService;
-
-  private final TrackerAccessManager trackerAccessManager;
 
   /**
    * Returns a ProgramInstanceQueryParams based on the given input.
@@ -131,9 +128,9 @@ public class EnrollmentCriteriaMapper {
           throw new IllegalQueryException("Organisation unit does not exist: " + orgUnit);
         }
 
-        if (!trackerAccessManager.canAccess(user, program, organisationUnit)) {
-          throw new IllegalQueryException(
-              "User does not have access to organisation unit: " + organisationUnit.getUid());
+        if ( !organisationUnitService.isInUserHierarchy( organisationUnit.getUid(), user.getTeiSearchOrganisationUnitsWithFallback() ) )
+        {
+          throw new IllegalQueryException( "Organisation unit is not part of the search scope: " + orgUnit );
         }
 
         params.getOrganisationUnits().add(organisationUnit);

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/EnrollmentCriteriaMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/EnrollmentCriteriaMapperTest.java
@@ -114,7 +114,9 @@ class EnrollmentCriteriaMapperTest {
     Set<String> orgUnits = Set.of(ORG_UNIT1);
     when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
     when(organisationUnitService.getOrganisationUnit(ORG_UNIT1)).thenReturn(organisationUnit);
-    when(organisationUnitService.isInUserHierarchy(organisationUnit.getUid(), Set.of(organisationUnit))).thenReturn(true);
+    when(organisationUnitService.isInUserHierarchy(
+            organisationUnit.getUid(), Set.of(organisationUnit)))
+        .thenReturn(true);
     when(trackedEntityTypeService.getTrackedEntityType(ENTITY_TYPE)).thenReturn(trackedEntityType);
     when(trackedEntityInstanceService.getTrackedEntityInstance(ENTITY_INSTANCE))
         .thenReturn(trackedEntityInstance);
@@ -180,7 +182,9 @@ class EnrollmentCriteriaMapperTest {
     Set<String> orgUnits = Set.of(ORG_UNIT1);
     when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
     when(organisationUnitService.getOrganisationUnit(ORG_UNIT1)).thenReturn(organisationUnit);
-    when(organisationUnitService.isInUserHierarchy(organisationUnit.getUid(), Set.of(organisationUnit))).thenReturn(false);
+    when(organisationUnitService.isInUserHierarchy(
+            organisationUnit.getUid(), Set.of(organisationUnit)))
+        .thenReturn(false);
     user.setTeiSearchOrganisationUnits(Set.of(organisationUnit));
 
     Exception exception =

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/EnrollmentCriteriaMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/EnrollmentCriteriaMapperTest.java
@@ -114,10 +114,11 @@ class EnrollmentCriteriaMapperTest {
     Set<String> orgUnits = Set.of(ORG_UNIT1);
     when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
     when(organisationUnitService.getOrganisationUnit(ORG_UNIT1)).thenReturn(organisationUnit);
-    when(trackerAccessManager.canAccess(user, program, organisationUnit)).thenReturn(true);
+    when(organisationUnitService.isInUserHierarchy(organisationUnit.getUid(), Set.of(organisationUnit))).thenReturn(true);
     when(trackedEntityTypeService.getTrackedEntityType(ENTITY_TYPE)).thenReturn(trackedEntityType);
     when(trackedEntityInstanceService.getTrackedEntityInstance(ENTITY_INSTANCE))
         .thenReturn(trackedEntityInstance);
+    user.setTeiSearchOrganisationUnits(Set.of(organisationUnit));
 
     ProgramInstanceQueryParams params =
         mapper.getFromUrl(
@@ -175,11 +176,12 @@ class EnrollmentCriteriaMapperTest {
   }
 
   @Test
-  void shouldThrowExceptionWhenOrgUnitNotInScope() {
+  void shouldThrowExceptionWhenOrgUnitNotInSearchScope() {
     Set<String> orgUnits = Set.of(ORG_UNIT1);
     when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
     when(organisationUnitService.getOrganisationUnit(ORG_UNIT1)).thenReturn(organisationUnit);
-    when(trackerAccessManager.canAccess(user, program, organisationUnit)).thenReturn(false);
+    when(organisationUnitService.isInUserHierarchy(organisationUnit.getUid(), Set.of(organisationUnit))).thenReturn(false);
+    user.setTeiSearchOrganisationUnits(Set.of(organisationUnit));
 
     Exception exception =
         assertThrows(
@@ -204,6 +206,6 @@ class EnrollmentCriteriaMapperTest {
                     false,
                     null));
     assertEquals(
-        "User does not have access to organisation unit: " + ORG_UNIT1, exception.getMessage());
+        "Organisation unit is not part of the search scope: " + ORG_UNIT1, exception.getMessage());
   }
 }


### PR DESCRIPTION
Enrollments need to use the search scope to validate the requested org unit regardless of the program access level

Ticket: https://dhis2.atlassian.net/browse/DHIS2-15145