### PR TITLE
fix: VisualizationController getEntityList not show nested filters [DHIS2-15322]

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/VisualizationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/VisualizationControllerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.jsontree.JsonMixed;
+import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.web.HttpStatus;
+import org.hisp.dhis.web.WebClient;
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.webapi.json.domain.JsonImportSummary;
+import org.junit.jupiter.api.Test;
+
+class VisualizationControllerTest extends DhisControllerConvenienceTest {
+
+  @Test
+  void testGetVisualizationWithNestedFilters() {
+    JsonImportSummary report =
+        POST("/metadata", WebClient.Body("metadata/metadata_with_visualization.json"))
+            .content(HttpStatus.OK)
+            .get("response")
+            .as(JsonImportSummary.class);
+    assertEquals("OK", report.getStatus());
+
+    JsonMixed response =
+        GET("/visualizations.json?filter=id:eq:qD72aBqsHvt&fields=filters").content();
+    JsonList<JsonObject> visualizations = response.getList("visualizations", JsonObject.class);
+    assertEquals(1, visualizations.size());
+    assertEquals(1, visualizations.get(0).getList("filters", JsonObject.class).size());
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/resources/metadata/metadata_with_visualization.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/metadata/metadata_with_visualization.json
@@ -1,0 +1,1093 @@
+{
+  "categories": [
+    {
+      "lastUpdated": "2016-03-17T01:53:56.098+0000",
+      "code": "Gender",
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "dataDimensionType": "DISAGGREGATION",
+      "userGroupAccesses": [],
+      "id": "XFgfIO1qQmd",
+      "name": "Gender",
+      "shortName": "Gender",
+      "created": "2016-03-17T01:53:56.097+0000",
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "categoryOptions": [
+        {
+          "id": "DRs8ZFxNOpW"
+        },
+        {
+          "id": "x3Owjhq9G7K"
+        }
+      ],
+      "dataDimension": true
+    }
+  ],
+  "userRoles": [
+    {
+      "description": "Superuser",
+      "name": "Superuser",
+      "created": "2016-03-17T01:51:26.775+0000",
+      "id": "yrB6vc5Ip3r",
+      "userGroupAccesses": [ ],
+      "programs": [ ],
+      "code": "Superuser",
+      "lastUpdated": "2016-03-17T01:51:26.775+0000",
+      "authorities": [
+        "F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS",
+        "ALL",
+        "F_USERGROUP_MANAGING_RELATIONSHIPS_ADD",
+        "F_DATAELEMENTGROUP_PUBLIC_ADD",
+        "F_USER_GROUPS_READ_ONLY_ADD_MEMBERS",
+        "F_DATAELEMENT_DELETE",
+        "F_CATEGORY_OPTION_GROUP_SET_PRIVATE_ADD",
+        "F_MAP_PUBLIC_ADD",
+        "F_CATEGORY_OPTION_GROUP_SET_DELETE",
+        "F_CATEGORY_PRIVATE_ADD",
+        "F_INDICATORGROUPSET_PUBLIC_ADD",
+        "F_USER_ADD_WITHIN_MANAGED_GROUP",
+        "F_PROGRAM_ENROLLMENT",
+        "F_CATEGORY_OPTION_PRIVATE_ADD",
+        "F_GIS_ADMIN",
+        "F_CATEGORY_OPTION_GROUP_PUBLIC_ADD",
+        "F_REPLICATE_USER",
+        "F_INSERT_CUSTOM_JS_CSS",
+        "F_DATAELEMENTGROUPSET_DELETE",
+        "F_INDICATOR_DELETE",
+        "F_INDICATORTYPE_ADD",
+        "F_VIEW_UNAPPROVED_DATA",
+        "F_INDICATOR_PUBLIC_ADD",
+        "F_INDICATORGROUP_PUBLIC_ADD",
+        "F_USERGROUP_MANAGING_RELATIONSHIPS_VIEW",
+        "F_INDICATOR_PRIVATE_ADD",
+        "F_TRACKED_ENTITY_INSTANCE_ADD",
+        "F_USERGROUP_PUBLIC_ADD",
+        "F_OAUTH2_CLIENT_MANAGE",
+        "F_PROGRAM_DASHBOARD_CONFIG_ADMIN",
+        "F_APPROVE_DATA_LOWER_LEVELS",
+        "F_CATEGORY_OPTION_PUBLIC_ADD",
+        "F_CATEGORY_OPTION_DELETE",
+        "F_CATEGORY_COMBO_PRIVATE_ADD",
+        "F_TRACKED_ENTITY_INSTANCE_DELETE",
+        "F_DATAELEMENT_PUBLIC_ADD",
+        "F_INDICATORGROUP_DELETE",
+        "F_CATEGORY_OPTION_GROUP_DELETE",
+        "F_TRACKED_ENTITY_INSTANCE_SEARCH",
+        "F_SQLVIEW_EXTERNAL",
+        "F_DATAELEMENTGROUPSET_PRIVATE_ADD",
+        "F_CATEGORY_COMBO_DELETE",
+        "F_CATEGORY_OPTION_GROUP_PRIVATE_ADD",
+        "F_DASHBOARD_PUBLIC_ADD",
+        "F_METADATA_IMPORT",
+        "F_INDICATORGROUPSET_PRIVATE_ADD",
+        "F_CATEGORY_PUBLIC_ADD",
+        "F_VISUALIZATION_PUBLIC_ADD",
+        "F_EVENT_VISUALIZATION_PUBLIC_ADD",
+        "F_EVENT_VISUALIZATION_EXTERNAL",
+        "F_CATEGORY_COMBO_PUBLIC_ADD",
+        "F_VISUALIZATION_EXTERNAL",
+        "F_METADATA_EXPORT",
+        "F_PROGRAM_UNENROLLMENT",
+        "F_DATAELEMENTGROUP_PRIVATE_ADD",
+        "F_INDICATORGROUPSET_DELETE",
+        "F_APPROVE_DATA",
+        "F_ACCEPT_DATA_LOWER_LEVELS",
+        "F_CATEGORY_DELETE",
+        "F_TRACKED_ENTITY_DATAVALUE_ADD",
+        "F_INDICATORTYPE_DELETE",
+        "F_CATEGORY_OPTION_GROUP_SET_PUBLIC_ADD",
+        "F_MAP_EXTERNAL",
+        "F_INDICATORGROUP_PRIVATE_ADD",
+        "F_DATAELEMENT_PRIVATE_ADD",
+        "F_TRACKED_ENTITY_DATAVALUE_DELETE",
+        "F_DATAELEMENTGROUP_DELETE",
+        "F_DATAELEMENTGROUPSET_PUBLIC_ADD"
+      ],
+      "dataSets": [ ],
+      "sharing": {
+        "public": "--------",
+        "external": false
+      }
+    }
+  ],
+  "organisationUnitGroups": [
+    {
+      "code": "OrgUnitGroupA",
+      "lastUpdated": "2016-03-17T01:52:11.966+0000",
+      "organisationUnits": [
+        {
+          "id": "uyHni0GvBpD"
+        }
+      ],
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "created": "2016-03-17T01:52:11.957+0000",
+      "name": "OrgUnitGroupA",
+      "id": "K82vX2wgq6j",
+      "userGroupAccesses": [ ],
+      "attributeValues": [ ],
+      "shortName": "OrgUnitGroupA"
+    }
+  ],
+  "categoryOptions": [
+    {
+      "userGroupAccesses": [ ],
+      "id": "DRs8ZFxNOpW",
+      "name": "Female",
+      "created": "2016-03-17T01:53:41.459+0000",
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "shortName": "Female",
+      "attributeValues": [ ],
+      "lastUpdated": "2016-03-17T01:53:41.461+0000",
+      "code": "Female",
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "organisationUnits": [ ]
+    },
+    {
+      "code": "Male",
+      "lastUpdated": "2016-03-17T01:53:34.526+0000",
+      "organisationUnits": [ ],
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "name": "Male",
+      "created": "2016-03-17T01:53:34.525+0000",
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "id": "x3Owjhq9G7K",
+      "userGroupAccesses": [ ],
+      "attributeValues": [ ],
+      "shortName": "Male"
+    }
+  ],
+  "organisationUnitLevels": [
+    {
+      "level": 1,
+      "name": "Country",
+      "created": "2016-03-17T01:51:45.201+0000",
+      "id": "knxIFcPUBz2",
+      "lastUpdated": "2016-03-17T01:51:45.201+0000"
+    }
+  ],
+  "categoryOptionCombos": [
+    {
+      "categoryCombo": {
+        "id": "v7n8H4aj8Cg"
+      },
+      "categoryOptions": [
+        {
+          "id": "DRs8ZFxNOpW"
+        }
+      ],
+      "name": "Female",
+      "created": "2016-03-17T01:54:04.952+0000",
+      "lastUpdated": "2016-03-17T01:54:04.952+0000",
+      "ignoreApproval": false,
+      "id": "c8yQa2ZIqhL"
+    },
+    {
+      "name": "Male",
+      "created": "2016-03-17T01:54:04.954+0000",
+      "lastUpdated": "2016-03-17T01:54:04.954+0000",
+      "ignoreApproval": false,
+      "id": "O9ZA0CUVVmL",
+      "categoryOptions": [
+        {
+          "id": "x3Owjhq9G7K"
+        }
+      ],
+      "categoryCombo": {
+        "id": "v7n8H4aj8Cg"
+      }
+    }
+  ],
+  "trackedEntityTypes": [
+    {
+      "created": "2016-03-16T17:00:00.000+0000",
+      "name": "Person",
+      "description": "Person",
+      "code": "Person",
+      "lastUpdated": "2016-03-16T17:00:00.000+0000",
+      "id": "MCPQUTHX1Ze",
+      "attributeValues": [ ]
+    }
+  ],
+  "visualizations": [
+    {
+      "completedOnly": false,
+      "externalAccess": false,
+      "showData": true,
+      "organisationUnits": [
+        {
+          "id": "uyHni0GvBpD"
+        }
+      ],
+      "dataDimensionItems": [
+        {
+          "dataDimensionItemType": "AGGREGATE_DATA_ELEMENT",
+          "dataElement": {
+            "id": "JXWenbITNIR"
+          }
+        },
+        {
+          "dataDimensionItemType": "AGGREGATE_DATA_ELEMENT",
+          "dataElement": {
+            "id": "Kvv6LltZuOd"
+          }
+        }
+      ],
+      "filterDimensions": [
+        "ou"
+      ],
+      "series": [
+        {
+          "dimensionItem": "JXWenbITNIR",
+          "visualizationType": "LINE",
+          "axis": 1
+        },
+        {
+          "dimensionItem": "Kvv6LltZuOd",
+          "visualizationType": "LINE"
+        }
+      ],
+      "organisationUnitLevels": [ ],
+      "id": "gyYXi0rXAIc",
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "userOrganisationUnitChildren": false,
+      "hideEmptyRows": false,
+      "organisationUnitGroups": [ ],
+      "name": "ChartA",
+      "sortOrder": 0,
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "category": "pe",
+      "categoryOptionGroups": [ ],
+      "dataElementGroups": [ ],
+      "relativePeriods": {
+        "lastSixMonth": false,
+        "last5Years": false,
+        "thisSixMonth": false,
+        "thisWeek": false,
+        "last4Weeks": false,
+        "last4Quarters": false,
+        "monthsThisYear": false,
+        "lastWeek": false,
+        "monthsLastYear": false,
+        "thisQuarter": false,
+        "last6BiMonths": false,
+        "thisBimonth": false,
+        "quartersThisYear": false,
+        "lastQuarter": false,
+        "thisFinancialYear": false,
+        "quartersLastYear": false,
+        "last3Months": false,
+        "thisYear": false,
+        "lastBimonth": false,
+        "thisMonth": false,
+        "last12Weeks": false,
+        "last5FinancialYears": false,
+        "last12Months": true,
+        "lastYear": false,
+        "last2SixMonths": false,
+        "lastFinancialYear": false,
+        "last52Weeks": false,
+        "lastMonth": false,
+        "last6Months": false
+      },
+      "categoryDimensions": [ ],
+      "userOrganisationUnit": false,
+      "userGroupAccesses": [ ],
+      "hideSubtitle": false,
+      "hideTitle": false,
+      "regression": false,
+      "type": "COLUMN",
+      "aggregationType": "SUM",
+      "created": "2016-03-17T01:56:51.847+0000",
+      "periods": [ ],
+      "hideLegend": false,
+      "itemOrganisationUnitGroups": [ ],
+      "lastUpdated": "2016-03-17T01:56:51.847+0000",
+      "userOrganisationUnitGrandChildren": false,
+      "fontStyle": {
+        "visualizationTitle": {
+          "font": "VERDANA",
+          "fontSize": 16,
+          "bold": true,
+          "italic": false,
+          "underline": false,
+          "textColor": "#3a3a3a",
+          "textAlign": "LEFT"
+        },
+        "horizontalAxisTitle": {
+          "font": "ROBOTO",
+          "fontSize": 12,
+          "bold": false,
+          "italic": true,
+          "underline": false,
+          "textColor": "#2a2a2a",
+          "textAlign": "CENTER"
+        },
+        "categoryAxisLabel": {
+          "font": "ROBOTO",
+          "fontSize": 12,
+          "bold": false,
+          "italic": true,
+          "underline": false,
+          "textColor": "#dedede",
+          "textAlign": "CENTER"
+        },
+        "targetLineLabel": {
+          "font": "ARIAL",
+          "fontSize": 12,
+          "bold": false,
+          "italic": true,
+          "underline": false,
+          "textColor": "#dedede",
+          "textAlign": "CENTER"
+        }
+      },
+      "colorSet": "color_set_01",
+      "rangeAxisMinValue": -10,
+      "rangeAxisMaxValue": 20,
+      "baseLineValue": -5,
+      "targetLineValue": 15,
+      "legend": {
+        "label": {
+          "fontStyle": {
+            "textColor": "#G"
+          }
+        },
+        "hidden": false
+      },
+      "seriesKey": {
+        "hidden": true
+      },
+      "axes": [
+        {
+          "index": 0,
+          "type": "RANGE",
+          "label": {
+            "fontStyle": {
+              "textColor": "#C"
+            }
+          },
+          "title": {
+            "text": "Range axis title",
+            "fontStyle": {
+              "textColor": "#D"
+            }
+          },
+          "decimals": 1,
+          "maxValue": 100,
+          "minValue": 20,
+          "steps": 5,
+          "baseLine": {
+            "value": 50,
+            "title": {
+              "text": "My baseline",
+              "fontStyle": {
+                "textColor": "#A"
+              }
+            }
+          },
+          "targetLine": {
+            "value": 80,
+            "title": {
+              "text": "My targetline",
+              "fontStyle": {
+                "textColor": "#B"
+              }
+            }
+          }
+        },
+        {
+          "index": 1,
+          "type": "DOMAIN",
+          "label": {
+            "fontStyle": {
+              "textColor": "#E"
+            }
+          },
+          "title": {
+            "text": "Domain axis title",
+            "fontStyle": {
+              "textColor": "#F"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "organisationUnits": [
+        {
+          "id": "uyHni0GvBpD"
+        }
+      ],
+      "showData": true,
+      "filterDimensions": [
+        "ou"
+      ],
+      "dataDimensionItems": [
+        {
+          "dataElementOperand": {
+            "dataElement": {
+              "id": "JrpFZgTcp5m"
+            },
+            "categoryOptionCombo": {
+              "id": "c8yQa2ZIqhL"
+            }
+          },
+          "dataDimensionItemType": "DATA_ELEMENT_OPERAND"
+        },
+        {
+          "dataDimensionItemType": "DATA_ELEMENT_OPERAND",
+          "dataElementOperand": {
+            "dataElement": {
+              "id": "Dy2uRmhOKbJ"
+            },
+            "categoryOptionCombo": {
+              "id": "c8yQa2ZIqhL"
+            }
+          }
+        }
+      ],
+      "series": [
+        {
+          "dimensionItem": "JrpFZgTcp5m",
+          "visualizationType": "LINE",
+          "axis": 1
+        },
+        {
+          "dimensionItem": "Dy2uRmhOKbJ",
+          "visualizationType": "LINE"
+        }
+      ],
+      "completedOnly": false,
+      "externalAccess": false,
+      "publicAccess": "rw------",
+      "sortOrder": 0,
+      "relativePeriods": {
+        "lastYear": false,
+        "last2SixMonths": false,
+        "last52Weeks": false,
+        "lastMonth": false,
+        "last6Months": false,
+        "lastFinancialYear": false,
+        "lastBimonth": false,
+        "last5FinancialYears": false,
+        "last12Months": true,
+        "thisMonth": false,
+        "last12Weeks": false,
+        "thisBimonth": false,
+        "last6BiMonths": false,
+        "thisYear": false,
+        "quartersThisYear": false,
+        "lastQuarter": false,
+        "quartersLastYear": false,
+        "last3Months": false,
+        "thisFinancialYear": false,
+        "last4Weeks": false,
+        "last5Years": false,
+        "thisWeek": false,
+        "thisSixMonth": false,
+        "last4Quarters": false,
+        "lastSixMonth": false,
+        "monthsThisYear": false,
+        "lastWeek": false,
+        "thisQuarter": false,
+        "monthsLastYear": false
+      },
+      "dataElementGroups": [ ],
+      "categoryOptionGroups": [ ],
+      "category": "pe",
+      "organisationUnitLevels": [ ],
+      "organisationUnitGroups": [ ],
+      "name": "ChartB",
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "userOrganisationUnitChildren": false,
+      "hideEmptyRows": false,
+      "id": "qD72aBqsHvt",
+      "regression": false,
+      "type": "COLUMN",
+      "hideTitle": false,
+      "hideSubtitle": false,
+      "aggregationType": "SUM",
+      "userGroupAccesses": [ ],
+      "categoryDimensions": [ ],
+      "userOrganisationUnit": false,
+      "itemOrganisationUnitGroups": [ ],
+      "hideLegend": false,
+      "userOrganisationUnitGrandChildren": false,
+      "lastUpdated": "2016-03-17T01:57:13.118+0000",
+      "periods": [ ],
+      "created": "2016-03-17T01:57:13.118+0000",
+      "fontStyle": {
+        "visualizationTitle": {
+          "font": "VERDANA",
+          "fontSize": 16,
+          "bold": true,
+          "italic": false,
+          "underline": false,
+          "textColor": "#3a3a3a",
+          "textAlign": "LEFT"
+        },
+        "horizontalAxisTitle": {
+          "font": "ROBOTO",
+          "fontSize": 12,
+          "bold": false,
+          "italic": true,
+          "underline": false,
+          "textColor": "#2a2a2a",
+          "textAlign": "CENTER"
+        },
+        "categoryAxisLabel": {
+          "font": "ROBOTO",
+          "fontSize": 12,
+          "bold": false,
+          "italic": true,
+          "underline": false,
+          "textColor": "#dedede",
+          "textAlign": "CENTER"
+        },
+        "targetLineLabel": {
+          "font": "ARIAL",
+          "fontSize": 12,
+          "bold": false,
+          "italic": true,
+          "underline": false,
+          "textColor": "#dedede",
+          "textAlign": "CENTER"
+        }
+      },
+      "colorSet": "color_set_01",
+      "rangeAxisMinValue": -10,
+      "rangeAxisMaxValue": 20,
+      "baseLineValue": -5,
+      "targetLineValue": 15,
+      "legend": {
+        "label": {
+          "fontStyle": {
+            "textColor": "#G"
+          }
+        },
+        "hidden": false
+      },
+      "seriesKey": {
+        "hidden": true
+      },
+      "axes": [
+        {
+          "index": 0,
+          "type": "RANGE",
+          "label": {
+            "fontStyle": {
+              "textColor": "#C"
+            }
+          },
+          "title": {
+            "text": "Range axis title",
+            "fontStyle": {
+              "textColor": "#D"
+            }
+          },
+          "decimals": 1,
+          "maxValue": 100,
+          "minValue": 20,
+          "steps": 5,
+          "baseLine": {
+            "value": 50,
+            "title": {
+              "text": "My baseline",
+              "fontStyle": {
+                "textColor": "#A"
+              }
+            }
+          },
+          "targetLine": {
+            "value": 80,
+            "title": {
+              "text": "My targetline",
+              "fontStyle": {
+                "textColor": "#B"
+              }
+            }
+          }
+        },
+        {
+          "index": 1,
+          "type": "DOMAIN",
+          "label": {
+            "fontStyle": {
+              "textColor": "#E"
+            }
+          },
+          "title": {
+            "text": "Domain axis title",
+            "fontStyle": {
+              "textColor": "#F"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "aggregationType": "SUM",
+      "hideTitle": false,
+      "hideSubtitle": false,
+      "type": "COLUMN",
+      "regression": false,
+      "userOrganisationUnit": false,
+      "categoryDimensions": [ ],
+      "userGroupAccesses": [ ],
+      "lastUpdated": "2016-03-17T01:57:32.354+0000",
+      "userOrganisationUnitGrandChildren": false,
+      "hideLegend": false,
+      "itemOrganisationUnitGroups": [ ],
+      "created": "2016-03-17T01:57:32.354+0000",
+      "periods": [ ],
+      "dataDimensionItems": [
+        {
+          "dataDimensionItemType": "DATA_ELEMENT_OPERAND",
+          "dataElementOperand": {
+            "categoryOptionCombo": {
+              "id": "O9ZA0CUVVmL"
+            },
+            "dataElement": {
+              "id": "JrpFZgTcp5m"
+            }
+          }
+        },
+        {
+          "dataElementOperand": {
+            "dataElement": {
+              "id": "Dy2uRmhOKbJ"
+            },
+            "categoryOptionCombo": {
+              "id": "O9ZA0CUVVmL"
+            }
+          },
+          "dataDimensionItemType": "DATA_ELEMENT_OPERAND"
+        }
+      ],
+      "filterDimensions": [
+        "ou"
+      ],
+      "series": [
+        {
+          "dimensionItem": "JrpFZgTcp5m",
+          "visualizationType": "LINE",
+          "axis": 1
+        },
+        {
+          "dimensionItem": "Dy2uRmhOKbJ",
+          "visualizationType": "LINE"
+        }
+      ],
+      "showData": true,
+      "organisationUnits": [
+        {
+          "id": "uyHni0GvBpD"
+        }
+      ],
+      "externalAccess": false,
+      "completedOnly": false,
+      "category": "pe",
+      "categoryOptionGroups": [ ],
+      "dataElementGroups": [ ],
+      "relativePeriods": {
+        "quartersLastYear": false,
+        "thisFinancialYear": false,
+        "last3Months": false,
+        "lastQuarter": false,
+        "quartersThisYear": false,
+        "thisYear": false,
+        "last6BiMonths": false,
+        "thisBimonth": false,
+        "thisQuarter": false,
+        "lastWeek": false,
+        "monthsLastYear": false,
+        "monthsThisYear": false,
+        "lastSixMonth": false,
+        "last4Quarters": false,
+        "last5Years": false,
+        "thisWeek": false,
+        "thisSixMonth": false,
+        "last4Weeks": false,
+        "lastFinancialYear": false,
+        "lastMonth": false,
+        "last6Months": false,
+        "last52Weeks": false,
+        "last2SixMonths": false,
+        "lastYear": false,
+        "thisMonth": false,
+        "last12Weeks": false,
+        "last5FinancialYears": false,
+        "last12Months": true,
+        "lastBimonth": false
+      },
+      "sortOrder": 0,
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "id": "z3zvnIJYQ4J",
+      "hideEmptyRows": false,
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "userOrganisationUnitChildren": false,
+      "organisationUnitGroups": [ ],
+      "name": "ChartC",
+      "organisationUnitLevels": [ ],
+      "legend": {
+        "label": {
+          "fontStyle": {
+            "textColor": "#G"
+          }
+        },
+        "hidden": false
+      },
+      "seriesKey": {
+        "hidden": true
+      },
+      "axes": [
+        {
+          "index": 0,
+          "type": "RANGE",
+          "label": {
+            "fontStyle": {
+              "textColor": "#C"
+            }
+          },
+          "title": {
+            "text": "Range axis title",
+            "fontStyle": {
+              "textColor": "#D"
+            }
+          },
+          "decimals": 1,
+          "maxValue": 100,
+          "minValue": 20,
+          "steps": 5,
+          "baseLine": {
+            "value": 50,
+            "title": {
+              "text": "My baseline",
+              "fontStyle": {
+                "textColor": "#A"
+              }
+            }
+          },
+          "targetLine": {
+            "value": 80,
+            "title": {
+              "text": "My targetline",
+              "fontStyle": {
+                "textColor": "#B"
+              }
+            }
+          }
+        },
+        {
+          "index": 1,
+          "type": "DOMAIN",
+          "label": {
+            "fontStyle": {
+              "textColor": "#E"
+            }
+          },
+          "title": {
+            "text": "Domain axis title",
+            "fontStyle": {
+              "textColor": "#F"
+            }
+          }
+        }
+      ],
+      "fontStyle": {
+        "visualizationTitle": {
+          "font": "VERDANA",
+          "fontSize": 16,
+          "bold": true,
+          "italic": false,
+          "underline": false,
+          "textColor": "#3a3a3a",
+          "textAlign": "LEFT"
+        },
+        "horizontalAxisTitle": {
+          "font": "ROBOTO",
+          "fontSize": 12,
+          "bold": false,
+          "italic": true,
+          "underline": false,
+          "textColor": "#2a2a2a",
+          "textAlign": "CENTER"
+        },
+        "categoryAxisLabel": {
+          "font": "ROBOTO",
+          "fontSize": 12,
+          "bold": false,
+          "italic": true,
+          "underline": false,
+          "textColor": "#dedede",
+          "textAlign": "CENTER"
+        },
+        "targetLineLabel": {
+          "font": "ARIAL",
+          "fontSize": 12,
+          "bold": false,
+          "italic": true,
+          "underline": false,
+          "textColor": "#dedede",
+          "textAlign": "CENTER"
+        }
+      },
+      "colorSet": "color_set_01",
+      "rangeAxisMinValue": -10,
+      "rangeAxisMaxValue": 20,
+      "baseLineValue": -5,
+      "targetLineValue": 15
+    }
+  ],
+  "categoryCombos": [
+    {
+      "publicAccess": "rw------",
+      "lastUpdated": "2016-03-17T01:54:04.956+0000",
+      "code": "Gender",
+      "skipTotal": false,
+      "id": "v7n8H4aj8Cg",
+      "categories": [
+        {
+          "id": "XFgfIO1qQmd"
+        }
+      ],
+      "userGroupAccesses": [ ],
+      "created": "2016-03-17T01:54:04.875+0000",
+      "name": "Gender",
+      "dataDimensionType": "DISAGGREGATION",
+      "user": {
+        "id": "M5zQapPyTZI"
+      }
+    }
+  ],
+  "users": [
+    {
+      "firstName": "admin",
+        "userRoles": [
+          {
+            "id": "yrB6vc5Ip3r"
+          }
+        ],
+        "selfRegistered": false,
+        "externalAuth": false,
+        "invitation": false,
+        "catDimensionConstraints": [ ],
+        "cogsDimensionConstraints": [ ],
+        "passwordLastUpdated": "2016-03-17T01:51:26.795+0000",
+        "username": "admin",
+        "disabled": false,
+        "lastLogin": "2016-03-17T01:51:26.794+0000",
+      "organisationUnits": [
+        {
+          "id": "uyHni0GvBpD"
+        }
+      ],
+      "lastUpdated": "2016-03-17T01:51:26.764+0000",
+      "code": "admin",
+      "teiSearchOrganisationUnits": [ ],
+      "attributeValues": [ ],
+      "id": "M5zQapPyTZI",
+      "surname": "admin",
+      "dataViewOrganisationUnits": [ ],
+      "created": "2016-03-17T01:51:26.764+0000"
+    }
+  ],
+  "dataElements": [
+    {
+      "code": "DataElementCodeA",
+      "zeroIsSignificant": false,
+      "domainType": "AGGREGATE",
+      "aggregationType": "AVERAGE",
+      "aggregationLevels": [ ],
+      "userGroupAccesses": [ ],
+      "valueType": "NUMBER",
+      "lastUpdated": "2016-03-17T01:52:56.021+0000",
+      "publicAccess": "rw------",
+      "created": "2016-03-17T01:52:56.017+0000",
+      "name": "DataElementA",
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "id": "JXWenbITNIR",
+      "attributeValues": [ ],
+      "shortName": "DataElementShortA"
+    },
+    {
+      "lastUpdated": "2016-03-17T01:53:21.549+0000",
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "id": "Kvv6LltZuOd",
+      "name": "DataElementB",
+      "created": "2016-03-17T01:53:21.548+0000",
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "shortName": "DataElementShortB",
+      "attributeValues": [ ],
+      "aggregationType": "AVERAGE",
+      "domainType": "AGGREGATE",
+      "code": "DataElementCodeB",
+      "zeroIsSignificant": false,
+      "aggregationLevels": [ ],
+      "userGroupAccesses": [ ],
+      "valueType": "NUMBER"
+    },
+    {
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "name": "DataElementC",
+      "created": "2016-03-17T01:54:39.781+0000",
+      "id": "JrpFZgTcp5m",
+      "attributeValues": [ ],
+      "shortName": "DataElementShortC",
+      "lastUpdated": "2016-03-17T01:54:39.782+0000",
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "valueType": "NUMBER",
+      "userGroupAccesses": [ ],
+      "code": "DataElementCodeC",
+      "zeroIsSignificant": false,
+      "aggregationType": "AVERAGE",
+      "domainType": "AGGREGATE",
+      "categoryCombo": {
+        "id": "v7n8H4aj8Cg"
+      },
+      "aggregationLevels": [ ]
+    },
+    {
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "created": "2016-03-17T01:55:00.723+0000",
+      "name": "DataElementD",
+      "id": "Dy2uRmhOKbJ",
+      "attributeValues": [ ],
+      "shortName": "DataElementShortD",
+      "lastUpdated": "2016-03-17T01:55:00.724+0000",
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "valueType": "NUMBER",
+      "userGroupAccesses": [ ],
+      "zeroIsSignificant": false,
+      "code": "DataElementCodeD",
+      "domainType": "AGGREGATE",
+      "aggregationType": "AVERAGE",
+      "categoryCombo": {
+        "id": "v7n8H4aj8Cg"
+      },
+      "aggregationLevels": [ ]
+    }
+  ],
+  "date": "2016-03-17T01:57:49.262+0000",
+  "dataSets": [
+    {
+      "created": "2016-03-17T01:55:31.495+0000",
+      "name": "DataSetA",
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "skipOffline": false,
+      "id": "f1OijtLnf8a",
+      "renderHorizontally": false,
+      "openFuturePeriods": 0,
+      "attributeValues": [ ],
+      "shortName": "DataSetShortA",
+      "version": 1,
+      "timelyDays": 15,
+      "indicators": [ ],
+      "notifyCompletingUser": false,
+      "dataElementDecoration": false,
+      "lastUpdated": "2016-03-17T01:55:35.911+0000",
+      "renderAsTabs": false,
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "fieldCombinationRequired": false,
+      "mobile": false,
+      "userGroupAccesses": [ ],
+      "compulsoryDataElementOperands": [ ],
+      "periodType": "Monthly",
+      "expiryDays": 0,
+      "noValueRequiresComment": false,
+      "dataElements": [
+        {
+          "id": "JXWenbITNIR"
+        },
+        {
+          "id": "Kvv6LltZuOd"
+        },
+        {
+          "id": "Dy2uRmhOKbJ"
+        },
+        {
+          "id": "JrpFZgTcp5m"
+        }
+      ],
+      "code": "DataSetCodeA",
+      "organisationUnits": [
+        {
+          "id": "uyHni0GvBpD"
+        }
+      ],
+      "validCompleteOnly": false
+    }
+  ],
+  "organisationUnits": [
+    {
+      "path": "/uyHni0GvBpD",
+      "featureType": "NONE",
+      "uuid": "eb380b08-6cc6-4aca-9b67-e1247e02db33",
+      "lastUpdated": "2016-03-17T01:51:39.609+0000",
+      "shortName": "Country",
+      "attributeValues": [ ],
+      "openingDate": "2016-03-17",
+      "id": "uyHni0GvBpD",
+      "description": "",
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "name": "Country",
+      "created": "2016-03-17T01:51:39.597+0000"
+    }
+  ]
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationController.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
+import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.DataDimensionItem;
 import org.hisp.dhis.common.DimensionService;
@@ -117,6 +118,33 @@ public class VisualizationController extends AbstractCrudController<Visualizatio
               legendSetService.getLegendSet(
                   visualization.getLegendDefinitions().getLegendSet().getUid()));
     }
+  }
+
+  @Override
+  public void postProcessResponseEntities(
+      List<Visualization> entityList, WebOptions options, Map<String, String> parameters) {
+    if (CollectionUtils.isEmpty(entityList)) return;
+    Set<OrganisationUnit> organisationUnits =
+        currentUserService.getCurrentUser().getDataViewOrganisationUnitsWithFallback();
+    I18nFormat i18nFormat = i18nManager.getI18nFormat();
+    entityList.forEach(
+        visualization -> {
+          visualization.populateAnalyticalProperties();
+
+          for (OrganisationUnit organisationUnit : visualization.getOrganisationUnits()) {
+            visualization
+                .getParentGraphMap()
+                .put(organisationUnit.getUid(), organisationUnit.getParentGraph(organisationUnits));
+          }
+
+          if (isNotEmpty(visualization.getPeriods())) {
+            for (Period period : visualization.getPeriods()) {
+              period.setName(i18nFormat.formatPeriod(period));
+            }
+          }
+
+          addExpressionDimensionItemElementsToDataDimensionItems(visualization);
+        });
   }
 
   @Override


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-15322
### Summary
- `VisualizationController` has a custom handler in `postProcessResponseEntity()` but it's not added to `postProcessResponseEntities()`. Therefore the api returns different results for `api/visualizations?filter=id:eq:{id}` and `api/visualizations/{id}`

### Fix
- This PR copies the custom handler from `postProcessResponseEntity` to `postProcessResponseEntities` and added unit test

### Test
- Can manually test by sending GET request to `api/visualizations.json?filter=id:eq:UlfTKWZWV4u&fields=id,rows,columns,filters` the results should look like below. Notice that the arrays `columns`, `rows`, `filters` should have one item.

```
{
  "pager": {
    "page": 1,
    "total": 1,
    "pageSize": 50,
    "pageCount": 1
  },
  "visualizations": [
    {
      "columns": [
        {
          "id": "dx"
        }
      ],
      "rows": [
        {
          "id": "ou"
        }
      ],
      "filters": [
        {
          "id": "pe"
        }
      ],
      "id": "UlfTKWZWV4u"
    }
  ]
}
```