### PR TITLE
chore: e2e code cleanup - automatic refactorings only

### DIFF
--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/TestRunStorage.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/TestRunStorage.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -63,7 +64,7 @@ public class TestRunStorage {
 
     return getCreatedEntities().entrySet().stream()
         .filter(entrySet -> resource.equals(entrySet.getValue()))
-        .map(entry -> entry.getKey())
+        .map(Entry::getKey)
         .collect(toList());
   }
 

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/IdGenerator.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/IdGenerator.java
@@ -38,13 +38,10 @@ public class IdGenerator extends RestApiActions {
   }
 
   public String generateUniqueId() {
-    String id =
-        get("id.json", new QueryParamsBuilder().add("limit=1"))
-            .validate()
-            .statusCode(200)
-            .extract()
-            .path("codes[0]");
-
-    return id;
+    return get("id.json", new QueryParamsBuilder().add("limit=1"))
+        .validate()
+        .statusCode(200)
+        .extract()
+        .path("codes[0]");
   }
 }

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/LoginActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/LoginActions.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.actions;
 
-import static io.restassured.RestAssured.oauth2;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 import io.restassured.RestAssured;
@@ -41,9 +40,6 @@ public class LoginActions {
   /**
    * Makes sure user with given name is logged in. Will throw assertion exception if authentication
    * is not successful.
-   *
-   * @param username
-   * @param password
    */
   public void loginAsUser(final String username, final String password) {
     ApiResponse loggedInUser = getLoggedInUserInfo();
@@ -87,28 +83,14 @@ public class LoginActions {
     return getLoggedInUserInfo().extractString("id");
   }
 
-  /**
-   * Adds authentication header that is used in all consecutive requests
-   *
-   * @param username
-   * @param password
-   */
-  public void addAuthenticationHeader(final String username, final String password) {
+  /** Adds authentication header that is used in all consecutive requests */
+  public static void addAuthenticationHeader(final String username, final String password) {
     RestAssured.authentication = RestAssured.preemptive().basic(username, password);
   }
 
   /** Removes authentication header */
-  public void removeAuthenticationHeader() {
+  public static void removeAuthenticationHeader() {
     RestAssured.authentication = RestAssured.DEFAULT_AUTH;
-  }
-
-  /**
-   * Logs in with oAuth2 token
-   *
-   * @param token
-   */
-  public void loginWithToken(String token) {
-    RestAssured.authentication = oauth2(token);
   }
 
   public void loginAsAdmin() {

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/MaintenanceActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/MaintenanceActions.java
@@ -37,7 +37,7 @@ import org.hisp.dhis.helpers.QueryParamsBuilder;
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */
 public class MaintenanceActions extends RestApiActions {
-  private Logger logger = LogManager.getLogger(MaintenanceActions.class.getName());
+  private final Logger logger = LogManager.getLogger(MaintenanceActions.class.getName());
 
   public MaintenanceActions() {
     super("/maintenance");

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/RestApiActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/RestApiActions.java
@@ -232,14 +232,7 @@ public class RestApiActions {
     return new ApiResponse(response);
   }
 
-  /**
-   * Sends PATCH request to specified resource
-   *
-   * @param resourceId
-   * @param object
-   * @param paramsBuilder
-   * @return
-   */
+  /** Sends PATCH request to specified resource */
   public ApiResponse patch(String resourceId, Object object, QueryParamsBuilder paramsBuilder) {
     Response response =
         this.given()
@@ -252,13 +245,7 @@ public class RestApiActions {
     return new ApiResponse(response);
   }
 
-  /**
-   * Sends PATCH request to specified resource. Uses importReportMode=ERRORS
-   *
-   * @param resourceId
-   * @param object
-   * @return
-   */
+  /** Sends PATCH request to specified resource. Uses importReportMode=ERRORS */
   public ApiResponse patch(String resourceId, Object object) {
     return this.patch(
         resourceId, object, new QueryParamsBuilder().add("importReportMode", "ERRORS"));

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/SchemasActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/SchemasActions.java
@@ -45,9 +45,7 @@ public class SchemasActions extends RestApiActions {
   public List<SchemaProperty> getRequiredProperties(String resource) {
     List<SchemaProperty> list = get(resource).extractList("properties", SchemaProperty.class);
 
-    return list.stream()
-        .filter((schemaProperty -> schemaProperty.isRequired()))
-        .collect(Collectors.toList());
+    return list.stream().filter((SchemaProperty::isRequired)).collect(Collectors.toList());
   }
 
   public Schema getSchema(String resource) {

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/UserActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/UserActions.java
@@ -40,7 +40,7 @@ import org.hisp.dhis.helpers.JsonObjectBuilder;
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */
 public class UserActions extends RestApiActions {
-  private IdGenerator idGenerator = new IdGenerator();
+  private final IdGenerator idGenerator = new IdGenerator();
 
   public UserActions() {
     super("/users");
@@ -153,20 +153,6 @@ public class UserActions extends RestApiActions {
     response.validate().statusCode(200).body("status", equalTo("OK"));
   }
 
-  public void grantUserDataViewAccessToOrgUnit(String userId, String orgUnitId) {
-    JsonObject object =
-        this.get(userId)
-            .getBodyAsJsonBuilder()
-            .addOrAppendToArray(
-                "dataViewOrganisationUnits",
-                new JsonObjectBuilder().addProperty("id", orgUnitId).build())
-            .build();
-
-    ApiResponse response = this.update(userId, object);
-
-    response.validate().statusCode(200).body("status", equalTo("OK"));
-  }
-
   public void grantUserCaptureAccessToOrgUnit(String userId, String orgUnitId) {
     JsonObject object =
         this.get(userId)
@@ -183,8 +169,6 @@ public class UserActions extends RestApiActions {
   /**
    * Grants user access to all org units imported before the tests.
    * /test/resources/setup/metadata.json
-   *
-   * @param userId
    */
   public void grantUserAccessToTAOrgUnits(String userId) {
     for (String orgUnitId : Constants.ORG_UNIT_IDS) {

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/analytics/AnalyticsEnrollmentsActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/analytics/AnalyticsEnrollmentsActions.java
@@ -53,11 +53,6 @@ public class AnalyticsEnrollmentsActions extends RestApiActions {
     return new AnalyticsEnrollmentsActions("/aggregate");
   }
 
-  public ApiResponse getDimensions(String programId) {
-    return this.get("/dimensions", new QueryParamsBuilder().add("programId", programId))
-        .validateStatus(200);
-  }
-
   public ApiResponse getDimensions(String programId, QueryParamsBuilder queryParamsBuilder) {
     queryParamsBuilder.add("programId", programId);
     return this.get("/dimensions", queryParamsBuilder).validateStatus(200);

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/analytics/AnalyticsEventActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/analytics/AnalyticsEventActions.java
@@ -63,13 +63,4 @@ public class AnalyticsEventActions extends RestApiActions {
 
     return this.get("/dimensions", queryParamsBuilder).validateStatus(200);
   }
-
-  public ApiResponse getDimensionsByDimensionType(String programStage, String dimensionType) {
-    return this.get(
-            "/dimensions",
-            new QueryParamsBuilder()
-                .add("programStageId", programStage)
-                .add("filter", "dimensionType:eq:" + dimensionType))
-        .validateStatus(200);
-  }
 }

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/analytics/AnalyticsTeiActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/analytics/AnalyticsTeiActions.java
@@ -50,10 +50,6 @@ public class AnalyticsTeiActions extends RestApiActions {
     return new AnalyticsTeiActions("/query");
   }
 
-  public ApiResponse getDimensions(String trackedEntityType) {
-    return getDimensions(trackedEntityType, null);
-  }
-
   public ApiResponse getDimensions(String trackedEntityType, QueryParamsBuilder queryParams) {
     if (queryParams == null) {
       queryParams = new QueryParamsBuilder();

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/deprecated/tracker/EventActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/deprecated/tracker/EventActions.java
@@ -44,12 +44,7 @@ public class EventActions extends RestApiActions {
     super("/events");
   }
 
-  /**
-   * Hard deletes event.
-   *
-   * @param eventId
-   * @return
-   */
+  /** Hard deletes event. */
   @Override
   public ApiResponse delete(String eventId) {
     ApiResponse response = super.delete(eventId);

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/deprecated/tracker/RelationshipActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/deprecated/tracker/RelationshipActions.java
@@ -71,20 +71,17 @@ public class RelationshipActions extends RestApiActions {
       String fromEntityId,
       String toEntity,
       String toEntityId) {
-    JsonObject relationship =
-        new JsonObjectBuilder()
-            .addProperty("relationshipType", relationshipTypeId)
-            .addObject(
-                "from",
-                new JsonObjectBuilder()
-                    .addObject(
-                        fromEntity, new JsonObjectBuilder().addProperty(fromEntity, fromEntityId)))
-            .addObject(
-                "to",
-                new JsonObjectBuilder()
-                    .addObject(toEntity, new JsonObjectBuilder().addProperty(toEntity, toEntityId)))
-            .build();
-
-    return relationship;
+    return new JsonObjectBuilder()
+        .addProperty("relationshipType", relationshipTypeId)
+        .addObject(
+            "from",
+            new JsonObjectBuilder()
+                .addObject(
+                    fromEntity, new JsonObjectBuilder().addProperty(fromEntity, fromEntityId)))
+        .addObject(
+            "to",
+            new JsonObjectBuilder()
+                .addObject(toEntity, new JsonObjectBuilder().addProperty(toEntity, toEntityId)))
+        .build();
   }
 }

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/metadata/MetadataPaginationActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/metadata/MetadataPaginationActions.java
@@ -43,12 +43,12 @@ import org.hisp.dhis.helpers.config.TestConfiguration;
  * @author Luciano Fiandesio
  */
 public class MetadataPaginationActions extends RestApiActions {
-  public static String DEFAULT_METADATA_FIELDS =
+  public static final String DEFAULT_METADATA_FIELDS =
       "displayName,shortName,id,lastUpdated,created,displayDescription,code,publicAccess,access,href,level,displayName,publicAccess,lastUpdated,order";
 
-  public static String DEFAULT_METADATA_FILTER = "name:ne:default";
+  public static final String DEFAULT_METADATA_FILTER = "name:ne:default";
 
-  public static String DEFAULT_METADATA_SORT = "displayName:ASC";
+  public static final String DEFAULT_METADATA_SORT = "displayName:ASC";
 
   public MetadataPaginationActions(String endpoint) {
     super(endpoint);

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/tracker/PotentialDuplicatesActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/tracker/PotentialDuplicatesActions.java
@@ -62,16 +62,7 @@ public class PotentialDuplicatesActions extends RestApiActions {
   }
 
   public String createAndValidatePotentialDuplicate(String teiA, String teiB) {
-    String openStatus = "OPEN";
-
-    JsonObject object =
-        new JsonObjectBuilder()
-            .addProperty("original", teiA)
-            .addProperty("duplicate", teiB)
-            .addProperty("status", "OPEN")
-            .build();
-
-    return createAndValidatePotentialDuplicate(teiA, teiB, openStatus);
+    return createAndValidatePotentialDuplicate(teiA, teiB, "OPEN");
   }
 
   public ApiResponse postPotentialDuplicate(String teiA, String teiB, String status) {

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/tracker/TrackerImportExportActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/tracker/TrackerImportExportActions.java
@@ -32,6 +32,7 @@ import static org.hamcrest.Matchers.notNullValue;
 
 import com.google.gson.JsonObject;
 import java.io.File;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
@@ -45,7 +46,7 @@ import org.hisp.dhis.helpers.QueryParamsBuilder;
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */
 public class TrackerImportExportActions extends RestApiActions {
-  private Logger logger = LogManager.getLogger(TrackerImportExportActions.class.getName());
+  private final Logger logger = LogManager.getLogger(TrackerImportExportActions.class.getName());
 
   public TrackerImportExportActions() {
     super("/tracker");
@@ -61,7 +62,7 @@ public class TrackerImportExportActions extends RestApiActions {
     Callable<Boolean> jobIsCompleted =
         () -> getJob(jobId).validateStatus(200).extractList("completed").contains(true);
 
-    with().atMost(20, TimeUnit.SECONDS).await().until(() -> jobIsCompleted.call());
+    with().atMost(20, TimeUnit.SECONDS).await().until(jobIsCompleted::call);
 
     logger.info("Tracker job is completed. Message: " + getJob(jobId).extract("message"));
   }
@@ -170,11 +171,8 @@ public class TrackerImportExportActions extends RestApiActions {
 
       if (response.extractList(path) != null) {
         response.extractList(path).stream()
-            .filter(o -> o != null)
-            .forEach(
-                id -> {
-                  this.addCreatedEntity(s.split(",")[1], id.toString());
-                });
+            .filter(Objects::nonNull)
+            .forEach(id -> this.addCreatedEntity(s.split(",")[1], id.toString()));
       }
     }
   }

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/dto/ApiResponse.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/dto/ApiResponse.java
@@ -27,9 +27,6 @@
  */
 package org.hisp.dhis.dto;
 
-import static org.hamcrest.core.IsNot.not;
-import static org.hamcrest.text.IsEmptyString.emptyOrNullString;
-
 import com.google.gson.JsonObject;
 import io.restassured.path.json.config.JsonParserType;
 import io.restassured.path.json.config.JsonPathConfig;
@@ -78,12 +75,6 @@ public class ApiResponse {
   }
 
   public String extractString(String path) {
-    return raw.jsonPath().getString(path);
-  }
-
-  public String extractStringFailIfEmpty(String path) {
-    this.validate().body(path, not(emptyOrNullString()));
-
     return raw.jsonPath().getString(path);
   }
 
@@ -149,11 +140,13 @@ public class ApiResponse {
 
     if (this.extract(pathToImportSummaries + "responseType") != null) {
       switch (this.extract(pathToImportSummaries + "responseType").toString()) {
-        case "ImportSummaries":
+        case "ImportSummaries" -> {
           return this.extractList(pathToImportSummaries + "importSummaries", ImportSummary.class);
-        case "ImportSummary":
+        }
+        case "ImportSummary" -> {
           return Collections.singletonList(
               this.raw.jsonPath().getObject(pathToImportSummaries, ImportSummary.class));
+        }
       }
     }
 

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/dto/schemas/Schema.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/dto/schemas/Schema.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.dto.schemas;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -37,7 +36,7 @@ import java.util.stream.Collectors;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Schema {
-  private ArrayList<SchemaProperty> properties;
+  private List<SchemaProperty> properties;
 
   private String plural;
 
@@ -49,17 +48,15 @@ public class Schema {
     this.plural = plural;
   }
 
-  public ArrayList<SchemaProperty> getProperties() {
+  public List<SchemaProperty> getProperties() {
     return properties;
   }
 
-  public void setProperties(ArrayList<SchemaProperty> properties) {
+  public void setProperties(List<SchemaProperty> properties) {
     this.properties = properties;
   }
 
   public List<SchemaProperty> getRequiredProperties() {
-    return properties.stream()
-        .filter((schemaProperty -> schemaProperty.isRequired()))
-        .collect(Collectors.toList());
+    return properties.stream().filter((SchemaProperty::isRequired)).collect(Collectors.toList());
   }
 }

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/helpers/JsonObjectBuilder.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/helpers/JsonObjectBuilder.java
@@ -42,9 +42,9 @@ import org.hisp.dhis.utils.SharingUtils;
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */
 public class JsonObjectBuilder {
-  private JsonObject jsonObject;
+  private final JsonObject jsonObject;
 
-  private Configuration jsonPathConfiguration =
+  private final Configuration jsonPathConfiguration =
       Configuration.builder()
           .jsonProvider(new GsonJsonProvider())
           .options(
@@ -80,8 +80,6 @@ public class JsonObjectBuilder {
    *
    * @param path eg "events[0]
    * @param propertyName eg "event"
-   * @param value
-   * @return
    */
   public JsonObjectBuilder addPropertyByJsonPath(String path, String propertyName, String value) {
     JsonPath.using(jsonPathConfiguration).parse(jsonObject).put(path, propertyName, value);
@@ -134,8 +132,8 @@ public class JsonObjectBuilder {
 
   public JsonObjectBuilder addArray(String property, JsonObject... objects) {
     JsonArray array = new JsonArray();
-    for (int i = 0; i < objects.length; i++) {
-      array.add(objects[i]);
+    for (JsonObject object : objects) {
+      array.add(object);
     }
 
     jsonObject.add(property, array);
@@ -171,8 +169,8 @@ public class JsonObjectBuilder {
 
   public JsonObjectBuilder addOrAppendToArray(String property, JsonObject... objects) {
     if (jsonObject.has(property)) {
-      for (int i = 0; i < objects.length; i++) {
-        jsonObject.getAsJsonArray(property).add(objects[i]);
+      for (JsonObject object : objects) {
+        jsonObject.getAsJsonArray(property).add(object);
       }
     } else {
       addArray(property, objects);

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/helpers/JsonParserUtils.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/helpers/JsonParserUtils.java
@@ -35,15 +35,13 @@ import com.google.gson.JsonParser;
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */
 public class JsonParserUtils {
-  private static JsonParser parser = new JsonParser();
+  private static final JsonParser parser = new JsonParser();
 
   public static JsonObject toJsonObject(Object object) {
-    if (object instanceof String) {
-      return parser.parse((String) object).getAsJsonObject();
+    if (object instanceof String s) {
+      return parser.parse(s).getAsJsonObject();
     }
 
-    JsonObject jsonObject = parser.parse(new Gson().toJson(object)).getAsJsonObject();
-
-    return jsonObject;
+    return parser.parse(new Gson().toJson(object)).getAsJsonObject();
   }
 }

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/helpers/PeriodHelper.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/helpers/PeriodHelper.java
@@ -62,17 +62,12 @@ public class PeriodHelper {
   }
 
   public static String getRelativePeriodDate(Period relativePeriod) {
-    switch (relativePeriod) {
-      case LAST_YEAR:
-        return now().plusYears(1).format(BASIC_ISO_DATE);
-      case LAST_5_YEARS:
-        return now().plusYears(5).format(BASIC_ISO_DATE);
-      case LAST_12_MONTHS:
-        return now().plusMonths(12).format(BASIC_ISO_DATE);
-      case LAST_6_MONTHS:
-        return now().plusMonths(6).format(BASIC_ISO_DATE);
-      default:
-        return EMPTY;
-    }
+    return switch (relativePeriod) {
+      case LAST_YEAR -> now().plusYears(1).format(BASIC_ISO_DATE);
+      case LAST_5_YEARS -> now().plusYears(5).format(BASIC_ISO_DATE);
+      case LAST_12_MONTHS -> now().plusMonths(12).format(BASIC_ISO_DATE);
+      case LAST_6_MONTHS -> now().plusMonths(6).format(BASIC_ISO_DATE);
+      default -> EMPTY;
+    };
   }
 }

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/helpers/QueryParamsBuilder.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/helpers/QueryParamsBuilder.java
@@ -45,12 +45,7 @@ public class QueryParamsBuilder {
     return this.add(param + "=" + value);
   }
 
-  /**
-   * Adds or updates the query param. Format: key=value
-   *
-   * @param param
-   * @return
-   */
+  /** Adds or updates the query param. Format: key=value */
   public QueryParamsBuilder add(String param) {
     String[] split = param.split("=");
     MutablePair pair = getByKey(split[0]);
@@ -78,7 +73,7 @@ public class QueryParamsBuilder {
   }
 
   public String build() {
-    if (queryParams.size() == 0) {
+    if (queryParams.isEmpty()) {
       return "";
     }
 

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/utils/DataGenerator.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/utils/DataGenerator.java
@@ -48,7 +48,7 @@ import org.hisp.dhis.dto.schemas.SchemaProperty;
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */
 public class DataGenerator {
-  private static Faker faker = new Faker();
+  private static final Faker faker = new Faker();
 
   public static String randomString() {
     return RandomStringUtils.randomAlphabetic(6);
@@ -62,54 +62,33 @@ public class DataGenerator {
     return "AutoTest entity " + randomString();
   }
 
-  /**
-   * Generates random data for simple type schema properties;
-   *
-   * @param property
-   * @return
-   */
+  /** Generates random data for simple type schema properties; */
   public static JsonElement generateRandomValueMatchingSchema(SchemaProperty property) {
     JsonElement jsonElement;
     switch (property.getPropertyType()) {
-      case STRING:
-        jsonElement =
-            new JsonPrimitive(
-                generateStringByFieldName(
-                    property.getName(),
-                    property.getMin().intValue(),
-                    property.getMax().intValue()));
-        break;
-
-      case DATE:
+      case STRING -> jsonElement =
+          new JsonPrimitive(
+              generateStringByFieldName(
+                  property.getName(), property.getMin().intValue(), property.getMax().intValue()));
+      case DATE -> {
         Date date = faker.date().past(1000, TimeUnit.DAYS);
         jsonElement =
             new JsonPrimitive(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS").format(date));
-        break;
-
-      case BOOLEAN:
+      }
+      case BOOLEAN -> {
         if (property.getName().equalsIgnoreCase("external")) {
           jsonElement = new JsonPrimitive(true);
           break;
         }
-
         jsonElement = new JsonPrimitive(String.valueOf(faker.bool().bool()));
-        break;
-
-      case CONSTANT:
-        jsonElement = generateConstantValue(property);
-        break;
-
-      case NUMBER:
-        jsonElement =
-            new JsonPrimitive(
-                faker
-                    .number()
-                    .numberBetween(property.getMin().intValue(), property.getMax().intValue()));
-        break;
-
-      default:
-        jsonElement = new JsonPrimitive("Conversion not defined.");
-        break;
+      }
+      case CONSTANT -> jsonElement = generateConstantValue(property);
+      case NUMBER -> jsonElement =
+          new JsonPrimitive(
+              faker
+                  .number()
+                  .numberBetween(property.getMin().intValue(), property.getMax().intValue()));
+      default -> jsonElement = new JsonPrimitive("Conversion not defined.");
     }
 
     return jsonElement;
@@ -161,27 +140,26 @@ public class DataGenerator {
 
   private static String generateStringByFieldName(String name, int minLength, int maxLength) {
     switch (name) {
-      case "url":
+      case "url" -> {
         return "http://" + faker.internet().url();
-
-      case "cronExpression":
+      }
+      case "cronExpression" -> {
         return "* * * * * *";
-
-      case "periodType":
+      }
+      case "periodType" -> {
         List<String> periodTypes =
             new RestApiActions("/periodTypes").get().extractList("periodTypes.name");
         return periodTypes.get(faker.number().numberBetween(0, periodTypes.size() - 1));
-
-      default:
+      }
+      default -> {
         if (minLength < 1) {
           return faker.lorem().characters(6);
         }
-
         if (maxLength == minLength) {
           return faker.lorem().characters(maxLength);
         }
-
         return faker.lorem().characters(minLength, maxLength);
+      }
     }
   }
 

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/LoginTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/LoginTests.java
@@ -30,7 +30,6 @@ package org.hisp.dhis;
 import static org.hamcrest.Matchers.*;
 
 import org.hisp.dhis.actions.LoginActions;
-import org.hisp.dhis.actions.UaaActions;
 import org.hisp.dhis.actions.UserActions;
 import org.hisp.dhis.utils.DataGenerator;
 import org.junit.jupiter.api.BeforeAll;
@@ -39,23 +38,17 @@ import org.junit.jupiter.api.BeforeAll;
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */
 public class LoginTests extends ApiTest {
-  private LoginActions loginActions;
 
-  private UaaActions uaaActions;
-
-  private UserActions userActions;
-
-  private String userName = ("LoginTestsUser" + DataGenerator.randomString()).toLowerCase();
-
-  private String password = Constants.USER_PASSWORD;
+  private final String userName = ("LoginTestsUser" + DataGenerator.randomString()).toLowerCase();
 
   @BeforeAll
   public void preconditions() {
-    loginActions = new LoginActions();
-    userActions = new UserActions();
+    LoginActions loginActions = new LoginActions();
+    UserActions userActions = new UserActions();
 
     loginActions.loginAsSuperUser();
 
+    String password = Constants.USER_PASSWORD;
     userActions.addUser(userName, password);
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/helpers/TestCleanUp.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/helpers/TestCleanUp.java
@@ -40,7 +40,7 @@ import org.hisp.dhis.dto.ApiResponse;
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */
 public class TestCleanUp {
-  private Logger logger = LogManager.getLogger(TestCleanUp.class.getName());
+  private final Logger logger = LogManager.getLogger(TestCleanUp.class.getName());
 
   private int deleteCount = 0;
 
@@ -53,10 +53,7 @@ public class TestCleanUp {
     List<String> reverseOrderedKeys = new ArrayList<>(createdEntities.keySet());
     Collections.reverse(reverseOrderedKeys);
 
-    Iterator<String> iterator = reverseOrderedKeys.iterator();
-
-    while (iterator.hasNext()) {
-      String key = iterator.next();
+    for (String key : reverseOrderedKeys) {
       boolean deleted = deleteEntity(createdEntities.get(key), key);
       if (deleted) {
         TestRunStorage.removeEntity(createdEntities.get(key), key);
@@ -97,11 +94,8 @@ public class TestCleanUp {
   }
 
   public void deleteCreatedEntities(LinkedHashMap<String, String> entitiesToDelete) {
-    Iterator<String> iterator = entitiesToDelete.keySet().iterator();
 
-    while (iterator.hasNext()) {
-      String key = iterator.next();
-
+    for (String key : entitiesToDelete.keySet()) {
       deleteEntity(entitiesToDelete.get(key), key);
     }
   }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/helpers/extensions/AnalyticsSetupExtension.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/helpers/extensions/AnalyticsSetupExtension.java
@@ -57,7 +57,7 @@ public class AnalyticsSetupExtension implements BeforeAllCallback {
   /** Max limit, in minutes, until the process is timed-out. */
   private static final long TIMEOUT = minutes(25);
 
-  private static AtomicBoolean run = new AtomicBoolean(false);
+  private static final AtomicBoolean run = new AtomicBoolean(false);
 
   @Override
   public void beforeAll(ExtensionContext context) {

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/helpers/extensions/AuthFilter.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/helpers/extensions/AuthFilter.java
@@ -33,6 +33,7 @@ import io.restassured.filter.FilterContext;
 import io.restassured.response.Response;
 import io.restassured.specification.FilterableRequestSpecification;
 import io.restassured.specification.FilterableResponseSpecification;
+import java.util.Objects;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -57,10 +58,12 @@ public class AuthFilter implements io.restassured.spi.AuthFilter {
     }
 
     if (requestSpec.getAuthenticationScheme() instanceof PreemptiveBasicAuthScheme
-        && (((PreemptiveBasicAuthScheme) requestSpec.getAuthenticationScheme()).getUserName()
-                != lastLoggedInUser
-            || ((PreemptiveBasicAuthScheme) requestSpec.getAuthenticationScheme()).getPassword()
-                != lastLoggedInUserPsw)) {
+        && (!Objects.equals(
+                ((PreemptiveBasicAuthScheme) requestSpec.getAuthenticationScheme()).getUserName(),
+                lastLoggedInUser)
+            || !Objects.equals(
+                ((PreemptiveBasicAuthScheme) requestSpec.getAuthenticationScheme()).getPassword(),
+                lastLoggedInUserPsw))) {
       if (hasSessionCookie(requestSpec)) {
         requestSpec.removeCookies();
       }
@@ -71,8 +74,7 @@ public class AuthFilter implements io.restassured.spi.AuthFilter {
           ((PreemptiveBasicAuthScheme) requestSpec.getAuthenticationScheme()).getPassword();
     }
 
-    final Response response = ctx.next(requestSpec, responseSpec);
-    return response;
+    return ctx.next(requestSpec, responseSpec);
   }
 
   private boolean hasSessionCookie(FilterableRequestSpecification requestSpec) {

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/helpers/extensions/CoverageLoggerExtension.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/helpers/extensions/CoverageLoggerExtension.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  */
 public class CoverageLoggerExtension
     implements BeforeAllCallback, ExtensionContext.Store.CloseableResource {
-  private static Logger logger = Logger.getLogger(CoverageLoggerExtension.class.getName());
+  private static final Logger logger = Logger.getLogger(CoverageLoggerExtension.class.getName());
 
   @Override
   public void beforeAll(ExtensionContext context) throws Exception {

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/helpers/extensions/MetadataSetupExtension.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/helpers/extensions/MetadataSetupExtension.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.helpers.extensions;
 import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.GLOBAL;
 
 import java.io.File;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -53,9 +52,9 @@ public class MetadataSetupExtension
     implements BeforeAllCallback, ExtensionContext.Store.CloseableResource {
   private static boolean started = false;
 
-  private static Map<String, String> createdData = new LinkedHashMap<>();
+  private static final Map<String, String> createdData = new LinkedHashMap<>();
 
-  private static Logger logger = LogManager.getLogger(MetadataSetupExtension.class.getName());
+  private static final Logger logger = LogManager.getLogger(MetadataSetupExtension.class.getName());
 
   @Override
   public void beforeAll(ExtensionContext context) {
@@ -120,10 +119,8 @@ public class MetadataSetupExtension
   }
 
   private void iterateCreatedData(Consumer<String> stringConsumer) {
-    Iterator<String> iterator = createdData.keySet().iterator();
 
-    while (iterator.hasNext()) {
-      String id = iterator.next();
+    for (String id : createdData.keySet()) {
       stringConsumer.accept(id);
     }
   }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/helpers/file/FileReaderUtils.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/helpers/file/FileReaderUtils.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.helpers.file;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import java.io.File;
-import java.io.IOException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hisp.dhis.actions.IdGenerator;
@@ -40,7 +39,7 @@ import org.hisp.dhis.utils.DataGenerator;
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */
 public class FileReaderUtils {
-  private Logger logger = LogManager.getLogger(FileReaderUtils.class.getName());
+  private final Logger logger = LogManager.getLogger(FileReaderUtils.class.getName());
 
   public FileReader read(File file) throws Exception {
 
@@ -67,10 +66,6 @@ public class FileReaderUtils {
   /**
    * Reads json file and generates data where needed. Json file should indicate what data should be
    * generated. Format: %string%, %id%
-   *
-   * @param file
-   * @return
-   * @throws IOException
    */
   public JsonObject readJsonAndGenerateData(File file) throws Exception {
     return read(file)

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/helpers/file/JsonFileReader.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/helpers/file/JsonFileReader.java
@@ -66,9 +66,6 @@ public class JsonFileReader implements FileReader {
 
   /***
    * Replaces all occurrences of a string with unique generated id
-   *
-   * @param strToReplace
-   * @return
    */
   public JsonFileReader replaceStringsWithIds(String... strToReplace) {
     String replacedJson = obj.toString();

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/helpers/matchers/MatchesJson.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/helpers/matchers/MatchesJson.java
@@ -43,7 +43,7 @@ public class MatchesJson extends TypeSafeDiagnosingMatcher<Object> {
 
   private final String expectedJSON;
 
-  private JSONCompareMode jsonCompareMode;
+  private final JSONCompareMode jsonCompareMode;
 
   private String mismatch;
 

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/helpers/models/User.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/helpers/models/User.java
@@ -36,11 +36,11 @@ import org.apache.commons.collections4.ListUtils;
  * @author Stian Sandvold
  */
 public class User {
-  private String username;
+  private final String username;
 
-  private String uid;
+  private final String uid;
 
-  private String password;
+  private final String password;
 
   private Map<String, List<String>> dataRead;
 


### PR DESCRIPTION
I noticed that e2e code had a few dozen sonar warnings and automatic refactorings suggested by the IDE so I went ahead and applied them. Only manual thing was removing "empty" javadoc lines.