### PR TITLE
fix: rename job queue by just providing a new name [DHIS2-15699]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfigurationStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfigurationStore.java
@@ -125,6 +125,17 @@ public interface JobConfigurationStore extends GenericDimensionalObjectStore<Job
   Set<JobType> getCompletedTypes();
 
   /**
+   * @return a set of all queue names
+   */
+  Set<String> getAllQueueNames();
+
+  /**
+   * @param queue of the queue to list
+   * @return All jobs in a queue ordered by their position
+   */
+  List<JobConfiguration> getJobsInQueue(@Nonnull String queue);
+
+  /**
    * @param queue name of the queue
    * @param fromPosition current position in the queue (executed last)
    * @return the job next in line if exists or null otherwise

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobQueueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobQueueService.java
@@ -27,15 +27,12 @@
  */
 package org.hisp.dhis.scheduling;
 
-import static java.util.Comparator.comparing;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
-import static java.util.stream.Collectors.toUnmodifiableSet;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -62,20 +59,13 @@ public class DefaultJobQueueService implements JobQueueService {
   @Override
   @Transactional(readOnly = true)
   public Set<String> getQueueNames() {
-    return jobConfigurationStore.getAll().stream()
-        .map(JobConfiguration::getQueueName)
-        .filter(Objects::nonNull)
-        .collect(toUnmodifiableSet());
+    return jobConfigurationStore.getAllQueueNames();
   }
 
   @Override
   @Transactional(readOnly = true)
   public List<JobConfiguration> getQueue(@Nonnull String name) throws NotFoundException {
-    List<JobConfiguration> sequence =
-        jobConfigurationStore.getAll().stream()
-            .filter(config -> name.equals(config.getQueueName()))
-            .sorted(comparing(JobConfiguration::getQueuePosition))
-            .collect(toList());
+    List<JobConfiguration> sequence = jobConfigurationStore.getJobsInQueue(name);
     if (sequence.isEmpty()) {
       throw new NotFoundException(ErrorCode.E7020, name);
     }
@@ -101,18 +91,23 @@ public class DefaultJobQueueService implements JobQueueService {
   public void updateQueue(
       @Nonnull String name,
       @CheckForNull String newName,
-      @Nonnull String newCronExpression,
+      @CheckForNull String newCronExpression,
       @Nonnull List<String> newSequence)
       throws NotFoundException, ConflictException {
     if (newName != null && !newName.isEmpty() && !newName.equals(name)) {
+      if (newCronExpression == null || newSequence.isEmpty()) {
+        List<JobConfiguration> queue = jobConfigurationStore.getJobsInQueue(name);
+        if (queue.isEmpty()) throw new NotFoundException(ErrorCode.E7020, name);
+        if (isEmpty(newCronExpression)) newCronExpression = queue.get(0).getCronExpression();
+        if (newSequence.isEmpty())
+          newSequence = queue.stream().map(JobConfiguration::getUid).toList();
+      }
       deleteQueue(name);
       createQueue(newName, newCronExpression, newSequence);
       return;
     }
     Map<String, JobConfiguration> oldQueueJobs = getQueueJobsByQueueName(name);
-    if (oldQueueJobs.isEmpty()) {
-      throw new NotFoundException(ErrorCode.E7020, name);
-    }
+    if (oldQueueJobs.isEmpty()) throw new NotFoundException(ErrorCode.E7020, name);
     Map<String, JobConfiguration> newQueueJobs = getQueueJobsByIds(newSequence);
     validateCronExpression(newCronExpression);
     validateQueue(name, newQueueJobs.values());
@@ -198,8 +193,7 @@ public class DefaultJobQueueService implements JobQueueService {
   }
 
   private Map<String, JobConfiguration> getQueueJobsByQueueName(String name) {
-    return jobConfigurationStore.getAll().stream()
-        .filter(c -> name.equals(c.getQueueName()))
+    return jobConfigurationStore.getJobsInQueue(name).stream()
         .collect(toMap(IdentifiableObject::getUid, Function.identity()));
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HibernateJobConfigurationStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HibernateJobConfigurationStore.java
@@ -138,6 +138,23 @@ public class HibernateJobConfigurationStore
   }
 
   @Override
+  public Set<String> getAllQueueNames() {
+    // language=SQL
+    String sql = "select distinct queuename from jobconfiguration where queuename is not null";
+    return getResultSet(nativeQuery(sql), Object::toString);
+  }
+
+  @Override
+  public List<JobConfiguration> getJobsInQueue(@Nonnull String queue) {
+    // language=SQL
+    String sql = "select * from jobconfiguration where queuename = :queue order by queueposition;";
+    return getSession()
+        .createNativeQuery(sql, JobConfiguration.class)
+        .setParameter("queue", queue)
+        .list();
+  }
+
+  @Override
   @CheckForNull
   public JobConfiguration getNextInQueue(@Nonnull String queue, int fromPosition) {
     // language=SQL

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobSchedulerControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobSchedulerControllerTest.java
@@ -210,6 +210,9 @@ class JobSchedulerControllerTest extends DhisControllerConvenienceTest {
                 "{'cronExpression':'0 0 1 ? * *','sequence':['%s','%s','%s']}",
                 jobIdA, jobIdB, jobIdC)));
 
+    // we use SQL to find queue names so we have to make sure the creation is visible
+    dbmsManager.flushSession();
+
     assertEquals(List.of("testQueue"), GET("/scheduler/queues/").content().stringValues());
   }
 


### PR DESCRIPTION
### Summary
When a queue is renamed the other fields are extracted from the existing queue if needed.

Since the new scheduling might have much more entries I also eliminated any use of `getAll()` and used dedicated SQL queries instead. 

### Automatic Testing
Was adjusted

### Manual Testing 
See Jira