### PR TITLE
feat: Add sorting into EventVisualization [DHIS2-14956]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/Sorting.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/Sorting.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.eventvisualization;
+
+import static org.hisp.dhis.common.DxfNamespaces.DXF_2_0;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import java.io.Serializable;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.hisp.dhis.analytics.SortOrder;
+
+/** This class is responsible for the encapsulation of objects and attributes related to sorting. */
+@Data
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@NoArgsConstructor
+public class Sorting implements Serializable {
+  /** A dimension can have the format "uid", "uid.uid1", "uid.uid1.uid2" or "uid[-2].uid1". */
+  @EqualsAndHashCode.Include
+  @JsonProperty(required = true)
+  @JacksonXmlProperty(namespace = DXF_2_0)
+  private String dimension;
+
+  @JsonProperty(required = true)
+  @JacksonXmlProperty(namespace = DXF_2_0)
+  private SortOrder direction;
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -451,6 +451,8 @@ public enum ErrorCode {
   E7231("Legacy `{0}` can be updated only through event visualizations"),
   E7232("Fallback coordinate field is invalid: `{0}`"),
   E7234("Query filter: `{0}` not valid for query item value type: `{1}`"),
+  E7237("Sorting must have a valid dimension and a direction"),
+  E7238("Sorting dimension ‘{0}’ is not a column"),
 
   /* TEI analytics */
   E7250("Dimension is not a fully qualified: `{0}`"),

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventvisualization/hibernate/EventVisualization.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventvisualization/hibernate/EventVisualization.hbm.xml
@@ -309,6 +309,8 @@
 
         <property name="simpleDimensions" type="jblSimpleEventDimensions"/>
 
+        <property name="sorting" type="jblSorting"/>
+
         <property name="eventRepetitions" type="jblEventRepetition"/>
 
         <!-- Dynamic attribute values -->

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.40/V2_40_26__Add_sorting_to_eventvisualization.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.40/V2_40_26__Add_sorting_to_eventvisualization.sql
@@ -1,0 +1,4 @@
+-- https://dhis2.atlassian.net/browse/DHIS2-14956
+-- Adds a new column "sorting" into EventVisualization table.
+
+alter table eventvisualization add column if not exists "sorting" jsonb default '[]'::jsonb;

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/org/hisp/dhis/usertype/UserTypes.hbm.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/org/hisp/dhis/usertype/UserTypes.hbm.xml
@@ -65,6 +65,10 @@
     <param name="clazz">org.hisp.dhis.eventvisualization.EventRepetition</param>
   </typedef>
 
+  <typedef class="org.hisp.dhis.hibernate.jsonb.type.JsonListBinaryType" name="jblSorting">
+    <param name="clazz">org.hisp.dhis.eventvisualization.Sorting</param>
+  </typedef>
+
   <typedef class="org.hisp.dhis.hibernate.jsonb.type.JsonBinaryType" name="jblDashboardLayout">
     <param name="clazz">org.hisp.dhis.dashboard.design.Layout</param>
   </typedef>

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/EnrollmentQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/EnrollmentQueryTest.java
@@ -35,7 +35,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hisp.dhis.analytics.ValidationHelper.validateHeader;
 import static org.hisp.dhis.analytics.ValidationHelper.validateRow;
-import static org.hisp.dhis.analytics.ValidationHelper.validateRowContext;
 
 import java.util.List;
 import org.hisp.dhis.AnalyticsApiTest;
@@ -221,81 +220,5 @@ public class EnrollmentQueryTest extends AnalyticsApiTest {
             "COMPLETED",
             "DiszpKrYNg8",
             "2313.0"));
-  }
-
-  @Test
-  public void queryWithProgramAndRepeatableProgramStage() {
-    // Given
-    QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add(
-                "dimension=edqlbukwRfQ[-2].vANAXwtLwcT,edqlbukwRfQ[10].vANAXwtLwcT,pe:LAST_12_MONTHS,ou:ImspTQPwCqd")
-            .add(
-                "headers=ou,ounamehierarchy,edqlbukwRfQ[-2].vANAXwtLwcT,edqlbukwRfQ[10].vANAXwtLwcT")
-            .add("stage=edqlbukwRfQ")
-            .add("displayProperty=NAME")
-            .add("outputType=ENROLLMENT")
-            .add("desc=edqlbukwRfQ[-2].vANAXwtLwcT,ounamehierarchy,enrollmentdate")
-            .add("totalPages=false")
-            .add("pageSize=2")
-            .add("page=4")
-            .add("rowContext=true")
-            .add("relativePeriodDate=2023-06-27");
-
-    // When
-    ApiResponse response = enrollmentsActions.query().get("WSGAb5XwJ3Y", JSON, JSON, params);
-    response
-        .validate()
-        .statusCode(200)
-        .body("headers", hasSize(equalTo(4)))
-        .body("rows", hasSize(equalTo(2)));
-    validateHeader(response, 0, "ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
-    validateHeader(
-        response,
-        1,
-        "ounamehierarchy",
-        "Organisation unit name hierarchy",
-        "TEXT",
-        "java.lang.String",
-        false,
-        true);
-    validateHeader(
-        response,
-        2,
-        "edqlbukwRfQ[-2].vANAXwtLwcT",
-        "WHOMCH Hemoglobin value",
-        "NUMBER",
-        "java.lang.Double",
-        false,
-        true,
-        "edqlbukwRfQ",
-        "startIndex:-2 count:1 startDate:null endDate: null",
-        -2);
-    validateHeader(
-        response,
-        3,
-        "edqlbukwRfQ[10].vANAXwtLwcT",
-        "WHOMCH Hemoglobin value",
-        "NUMBER",
-        "java.lang.Double",
-        false,
-        true,
-        "edqlbukwRfQ",
-        "startIndex:10 count:1 startDate:null endDate: null",
-        10);
-    validateRowContext(response, 0, 3, "ND");
-    validateRowContext(response, 1, 3, "ND");
-    validateRow(
-        response,
-        0,
-        List.of("fmkqsEx6MRo", "Sierra Leone / Port Loko / Koya / Mabora MCHP", "25.0", ""));
-    validateRow(
-        response,
-        1,
-        List.of(
-            "GCbYmPqcOOP",
-            "Sierra Leone / Port Loko / Bureh Kasseh Maconteh / Romeni MCHP",
-            "25.0",
-            ""));
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/EnrollmentQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/EnrollmentQueryTest.java
@@ -221,4 +221,80 @@ public class EnrollmentQueryTest extends AnalyticsApiTest {
             "DiszpKrYNg8",
             "2313.0"));
   }
+
+  @Test
+  public void queryWithProgramAndRepeatableProgramStage() {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add(
+                "dimension=edqlbukwRfQ[-2].vANAXwtLwcT,edqlbukwRfQ[10].vANAXwtLwcT,pe:LAST_12_MONTHS,ou:ImspTQPwCqd")
+            .add(
+                "headers=ou,ounamehierarchy,edqlbukwRfQ[-2].vANAXwtLwcT,edqlbukwRfQ[10].vANAXwtLwcT")
+            .add("stage=edqlbukwRfQ")
+            .add("displayProperty=NAME")
+            .add("outputType=ENROLLMENT")
+            .add("desc=edqlbukwRfQ[-2].vANAXwtLwcT,ounamehierarchy,enrollmentdate")
+            .add("totalPages=false")
+            .add("pageSize=2")
+            .add("page=4")
+            .add("rowContext=true")
+            .add("relativePeriodDate=2023-06-27");
+
+    // When
+    ApiResponse response = enrollmentsActions.query().get("WSGAb5XwJ3Y", JSON, JSON, params);
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(4)))
+        .body("rows", hasSize(equalTo(2)));
+    validateHeader(response, 0, "ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
+    validateHeader(
+        response,
+        1,
+        "ounamehierarchy",
+        "Organisation unit name hierarchy",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+    validateHeader(
+        response,
+        2,
+        "edqlbukwRfQ[-2].vANAXwtLwcT",
+        "WHOMCH Hemoglobin value",
+        "NUMBER",
+        "java.lang.Double",
+        false,
+        true,
+        "edqlbukwRfQ",
+        "startIndex:-2 count:1 startDate:null endDate: null",
+        -2);
+    validateHeader(
+        response,
+        3,
+        "edqlbukwRfQ[10].vANAXwtLwcT",
+        "WHOMCH Hemoglobin value",
+        "NUMBER",
+        "java.lang.Double",
+        false,
+        true,
+        "edqlbukwRfQ",
+        "startIndex:10 count:1 startDate:null endDate: null",
+        10);
+    validateRowContext(response, 0, 3, "ND");
+    validateRowContext(response, 1, 3, "ND");
+    validateRow(
+        response,
+        0,
+        List.of("fmkqsEx6MRo", "Sierra Leone / Port Loko / Koya / Mabora MCHP", "25.0", ""));
+    validateRow(
+        response,
+        1,
+        List.of(
+            "GCbYmPqcOOP",
+            "Sierra Leone / Port Loko / Bureh Kasseh Maconteh / Romeni MCHP",
+            "25.0",
+            ""));
+  }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/EnrollmentQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/EnrollmentQueryTest.java
@@ -35,6 +35,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hisp.dhis.analytics.ValidationHelper.validateHeader;
 import static org.hisp.dhis.analytics.ValidationHelper.validateRow;
+import static org.hisp.dhis.analytics.ValidationHelper.validateRowContext;
 
 import java.util.List;
 import org.hisp.dhis.AnalyticsApiTest;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/EventVisualizationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/EventVisualizationControllerTest.java
@@ -31,15 +31,20 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hisp.dhis.web.HttpStatus.BAD_REQUEST;
+import static org.hisp.dhis.web.HttpStatus.CONFLICT;
 import static org.hisp.dhis.web.HttpStatus.CREATED;
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
-import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.jsontree.JsonNode;
+import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramIndicator;
+import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,25 +56,38 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @author maikel arabori
  */
 class EventVisualizationControllerTest extends DhisControllerConvenienceTest {
-  @Autowired private IdentifiableObjectManager manager;
+  @Autowired private ObjectMapper jsonMapper;
 
   private Program mockProgram;
 
+  private ProgramStage mockProgramStage;
+
+  private ProgramIndicator mockProgramIndicator;
+
   @BeforeEach
-  public void beforeEach() {
+  public void beforeEach() throws JsonProcessingException {
     mockProgram = createProgram('A');
-    manager.save(mockProgram);
+    POST("/programs", jsonMapper.writeValueAsString(mockProgram)).content(CREATED);
+
+    mockProgramIndicator = createProgramIndicator('A', mockProgram, "exp", "filter");
+    mockProgramIndicator.setUid("deabcdefghB");
+    POST("/programIndicators", jsonMapper.writeValueAsString(mockProgramIndicator))
+        .content(CREATED);
+
+    mockProgramStage = createProgramStage('A', mockProgram);
+    mockProgramStage.setUid("deabcdefghA");
+    POST("/programStages", jsonMapper.writeValueAsString(mockProgramStage)).content(CREATED);
   }
 
   @Test
   @SuppressWarnings("unchecked")
   void testPostForSingleEventDate() {
     // Given
-    final String eventDateDimension = "eventDate";
-    final String eventDate = "2021-07-21_2021-08-01";
-    final String dimensionBody =
+    String eventDateDimension = "eventDate";
+    String eventDate = "2021-07-21_2021-08-01";
+    String dimensionBody =
         "{'dimension': '" + eventDateDimension + "', 'items': [{'id': '" + eventDate + "'}]}";
-    final String body =
+    String body =
         "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
             + mockProgram.getUid()
             + "'}, 'columns': ["
@@ -77,11 +95,11 @@ class EventVisualizationControllerTest extends DhisControllerConvenienceTest {
             + "]}";
 
     // When
-    final String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
+    String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
 
     // Then
-    final JsonResponse response = GET("/eventVisualizations/" + uid).content();
-    final Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
+    JsonResponse response = GET("/eventVisualizations/" + uid).content();
+    Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
 
     assertThat(nodeMap.get("simpleDimensions").toString(), containsString("COLUMN"));
     assertThat(nodeMap.get("simpleDimensions").toString(), containsString(eventDateDimension));
@@ -95,15 +113,15 @@ class EventVisualizationControllerTest extends DhisControllerConvenienceTest {
   @SuppressWarnings("unchecked")
   void testPostForMultiEventDates() {
     // Given
-    final String eventDateDimension = "eventDate";
-    final String incidentDateDimension = "incidentDate";
-    final String eventDate = "2021-07-21_2021-08-01";
-    final String incidentDate = "2021-07-21_2021-08-01";
-    final String eventDateBody =
+    String eventDateDimension = "eventDate";
+    String incidentDateDimension = "incidentDate";
+    String eventDate = "2021-07-21_2021-08-01";
+    String incidentDate = "2021-07-21_2021-08-01";
+    String eventDateBody =
         "{'dimension': '" + eventDateDimension + "', 'items': [{'id': '" + eventDate + "'}]}";
-    final String incidentDateBody =
+    String incidentDateBody =
         "{'dimension': '" + incidentDateDimension + "', 'items': [{'id': '" + incidentDate + "'}]}";
-    final String body =
+    String body =
         "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
             + mockProgram.getUid()
             + "'}, 'rows': ["
@@ -113,11 +131,11 @@ class EventVisualizationControllerTest extends DhisControllerConvenienceTest {
             + "]}";
 
     // When
-    final String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
+    String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
 
     // Then
-    final JsonResponse response = GET("/eventVisualizations/" + uid).content();
-    final Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
+    JsonResponse response = GET("/eventVisualizations/" + uid).content();
+    Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
 
     assertThat(nodeMap.get("simpleDimensions").toString(), containsString("ROW"));
     assertThat(nodeMap.get("simpleDimensions").toString(), containsString(eventDate));
@@ -133,11 +151,11 @@ class EventVisualizationControllerTest extends DhisControllerConvenienceTest {
   @Test
   void testPostForInvalidEventDimension() {
     // Given
-    final String invalidDimension = "invalidDimension";
-    final String eventDate = "2021-07-21_2021-08-01";
-    final String dimensionBody =
+    String invalidDimension = "invalidDimension";
+    String eventDate = "2021-07-21_2021-08-01";
+    String dimensionBody =
         "{'dimension': '" + invalidDimension + "', 'items': [{'id': '" + eventDate + "'}]}";
-    final String body =
+    String body =
         "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
             + mockProgram.getUid()
             + "'}, 'columns': ["
@@ -145,7 +163,7 @@ class EventVisualizationControllerTest extends DhisControllerConvenienceTest {
             + "]}";
 
     // When
-    final String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
+    String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
 
     // Then
     assertEquals(
@@ -157,10 +175,10 @@ class EventVisualizationControllerTest extends DhisControllerConvenienceTest {
   @SuppressWarnings("unchecked")
   void testPostRepetitionForFilter() {
     // Given
-    final String dimension = "ou";
-    final String indexes = "[1,2,3,-2,-1,0]";
-    final String repetition = "'repetition': {'indexes': " + indexes + "}";
-    final String body =
+    String dimension = "ou";
+    String indexes = "[1,2,3,-2,-1,0]";
+    String repetition = "'repetition': {'indexes': " + indexes + "}";
+    String body =
         "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
             + mockProgram.getUid()
             + "'}, 'filters': [{'dimension': '"
@@ -170,12 +188,12 @@ class EventVisualizationControllerTest extends DhisControllerConvenienceTest {
             + "}]}";
 
     // When
-    final String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
+    String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
 
     // Then
-    final String getParams = "?fields=:all,filters[:all,items,repetitions]";
-    final JsonResponse response = GET("/eventVisualizations/" + uid + getParams).content();
-    final Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
+    String getParams = "?fields=:all,filters[:all,items,repetitions]";
+    JsonResponse response = GET("/eventVisualizations/" + uid + getParams).content();
+    Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
 
     assertThat(nodeMap.get("repetitions").toString(), containsString("FILTER"));
     assertThat(nodeMap.get("repetitions").toString(), containsString(indexes));
@@ -189,10 +207,10 @@ class EventVisualizationControllerTest extends DhisControllerConvenienceTest {
   @SuppressWarnings("unchecked")
   void testPostRepetitionForRow() {
     // Given
-    final String dimension = "pe";
-    final String indexes = "[1,2,0]";
-    final String repetition = "'repetition': {'indexes': " + indexes + "}";
-    final String body =
+    String dimension = "pe";
+    String indexes = "[1,2,0]";
+    String repetition = "'repetition': {'indexes': " + indexes + "}";
+    String body =
         "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
             + mockProgram.getUid()
             + "'}, 'rows': [{'dimension': '"
@@ -202,12 +220,12 @@ class EventVisualizationControllerTest extends DhisControllerConvenienceTest {
             + "}]}";
 
     // When
-    final String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
+    String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
 
     // Then
-    final String getParams = "?fields=:all,rows[:all,items,repetitions]";
-    final JsonResponse response = GET("/eventVisualizations/" + uid + getParams).content();
-    final Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
+    String getParams = "?fields=:all,rows[:all,items,repetitions]";
+    JsonResponse response = GET("/eventVisualizations/" + uid + getParams).content();
+    Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
 
     assertThat(nodeMap.get("repetitions").toString(), containsString("ROW"));
     assertThat(nodeMap.get("repetitions").toString(), containsString(indexes));
@@ -221,10 +239,10 @@ class EventVisualizationControllerTest extends DhisControllerConvenienceTest {
   @SuppressWarnings("unchecked")
   void testPostRepetitionForColumn() {
     // Given
-    final String dimension = "pe";
-    final String indexes = "[1,0,-1]";
-    final String repetition = "'repetition': {'indexes': " + indexes + "}";
-    final String body =
+    String dimension = "pe";
+    String indexes = "[1,0,-1]";
+    String repetition = "'repetition': {'indexes': " + indexes + "}";
+    String body =
         "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
             + mockProgram.getUid()
             + "'}, 'columns': [{'dimension': '"
@@ -234,12 +252,12 @@ class EventVisualizationControllerTest extends DhisControllerConvenienceTest {
             + "}]}";
 
     // When
-    final String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
+    String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
 
     // Then
-    final String getParams = "?fields=:all,columns[:all,items,repetitions]";
-    final JsonResponse response = GET("/eventVisualizations/" + uid + getParams).content();
-    final Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
+    String getParams = "?fields=:all,columns[:all,items,repetitions]";
+    JsonResponse response = GET("/eventVisualizations/" + uid + getParams).content();
+    Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
 
     assertThat(nodeMap.get("repetitions").toString(), containsString("COLUMN"));
     assertThat(nodeMap.get("repetitions").toString(), containsString(indexes));
@@ -247,5 +265,233 @@ class EventVisualizationControllerTest extends DhisControllerConvenienceTest {
     assertThat(nodeMap.get("columns").toString(), containsString(indexes));
     assertThat(nodeMap.get("rows").toString(), not(containsString(indexes)));
     assertThat(nodeMap.get("filters").toString(), not(containsString(indexes)));
+  }
+
+  @Test
+  void testPostSortingObject() {
+    // Given
+    String dimension = "pe";
+    String sorting = "'sorting': [{'dimension': '" + dimension + "', 'direction':'ASC'}]";
+    String body =
+        "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
+            + mockProgram.getUid()
+            + "'}, 'columns': [{'dimension': '"
+            + dimension
+            + "'}],"
+            + sorting
+            + "}";
+
+    // When
+    String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
+
+    // Then
+    String getParams = "?fields=:all,columns[:all,items,sorting]";
+    JsonObject response = GET("/eventVisualizations/" + uid + getParams).content();
+
+    assertThat(response.get("sorting").toString(), containsString("pe"));
+    assertThat(response.get("sorting").toString(), containsString("ASC"));
+  }
+
+  @Test
+  void testPostSortingObjectWithPrefixedColumn() {
+    // Given
+    String programStageUid = mockProgramStage.getUid();
+    String dimensionUid = mockProgramIndicator.getUid();
+    String sorting =
+        "'sorting': [{'dimension': '"
+            + programStageUid
+            + "."
+            + dimensionUid
+            + "', 'direction':'ASC'}]";
+    String body =
+        "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
+            + mockProgram.getUid()
+            + "'}, 'columns': [{'dimension': '"
+            + dimensionUid
+            + "',"
+            + "'programStage': {'id':'"
+            + programStageUid
+            + "'}"
+            + "}],"
+            + sorting
+            + "}";
+
+    // When
+    String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
+
+    // Then
+    String getParams = "?fields=:all,columns[:all,items,sorting]";
+    JsonObject response = GET("/eventVisualizations/" + uid + getParams).content();
+
+    assertThat(
+        response.get("sorting").toString(), containsString(programStageUid + "." + dimensionUid));
+    assertThat(response.get("sorting").toString(), containsString("ASC"));
+  }
+
+  @Test
+  void testPostSortingObjectWithPrefixedColumnWithIndex() {
+    // Given
+    String programStageUid = mockProgramStage.getUid() + "[-2]";
+    String dimensionUid = mockProgramIndicator.getUid();
+    String sorting =
+        "'sorting': [{'dimension': '"
+            + programStageUid
+            + "."
+            + dimensionUid
+            + "', 'direction':'ASC'}]";
+    String body =
+        "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
+            + mockProgram.getUid()
+            + "'}, 'columns': [{'dimension': '"
+            + dimensionUid
+            + "',"
+            + "'programStage': {'id':'"
+            + programStageUid
+            + "'}"
+            + "}],"
+            + sorting
+            + "}";
+
+    // When
+    String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
+
+    // Then
+    String getParams = "?fields=:all,columns[:all,items,sorting]";
+    JsonObject response = GET("/eventVisualizations/" + uid + getParams).content();
+
+    assertThat(
+        response.get("sorting").toString(), containsString(programStageUid + "." + dimensionUid));
+    assertThat(response.get("sorting").toString(), containsString("ASC"));
+  }
+
+  @Test
+  void testPostMultipleSortingObject() {
+    // Given
+    String dimension1 = "pe";
+    String dimension2 = "ou";
+    String sorting =
+        "'sorting': [{'dimension': '"
+            + dimension1
+            + "', 'direction':'ASC'},"
+            + "{'dimension': '"
+            + dimension2
+            + "', 'direction':'DESC'}]";
+    String body =
+        "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
+            + mockProgram.getUid()
+            + "'}, 'columns': [{'dimension': '"
+            + dimension1
+            + "'}, {'dimension': '"
+            + dimension2
+            + "'}],"
+            + sorting
+            + "}";
+
+    // When
+    String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
+
+    // Then
+    String getParams = "?fields=:all,columns[:all,items,sorting]";
+    JsonObject response = GET("/eventVisualizations/" + uid + getParams).content();
+
+    assertThat(response.get("sorting").toString(), containsString("pe"));
+    assertThat(response.get("sorting").toString(), containsString("ASC"));
+    assertThat(response.get("sorting").toString(), containsString("ou"));
+    assertThat(response.get("sorting").toString(), containsString("DESC"));
+  }
+
+  @Test
+  void testPostSortingObjectWithDuplication() {
+    // Given
+    String dimension = "pe";
+    String sorting =
+        "'sorting': [{'dimension': '"
+            + dimension
+            + "', 'direction':'ASC'},"
+            + "{'dimension': '"
+            + dimension
+            + "', 'direction':'DESC'}]";
+    String body =
+        "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
+            + mockProgram.getUid()
+            + "'}, 'columns': [{'dimension': '"
+            + dimension
+            + "'}],"
+            + sorting
+            + "}";
+
+    // When
+    String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
+
+    // Then
+    String getParams = "?fields=:all,columns[:all,items,sorting]";
+    JsonObject response = GET("/eventVisualizations/" + uid + getParams).content();
+
+    assertThat(response.get("sorting").toString(), containsString("pe"));
+    assertThat(response.get("sorting").toString(), containsString("ASC"));
+    assertThat(response.get("sorting").toString(), not(containsString("DESC")));
+  }
+
+  @Test
+  void testPostInvalidSortingObject() {
+    // Given
+    String invalidDimension = "invalidOne";
+    String sorting = "'sorting': [{'dimension': '" + invalidDimension + "', 'direction':'ASC'}]";
+    String body =
+        "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
+            + mockProgram.getUid()
+            + "'}, 'columns': [{'dimension': 'pe'}],"
+            + sorting
+            + "}";
+
+    // When
+    HttpResponse response = POST("/eventVisualizations/", body);
+
+    // Then
+    assertEquals(
+        "Sorting dimension ‘" + invalidDimension + "’ is not a column",
+        response.error(CONFLICT).getMessage());
+  }
+
+  @Test
+  void testPostBlankSortingObject() {
+    // Given
+    String blankDimension = " ";
+    String sorting = "'sorting': [{'dimension': '" + blankDimension + "', 'direction':'ASC'}]";
+    String body =
+        "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
+            + mockProgram.getUid()
+            + "'}, 'columns': [{'dimension': 'pe'}],"
+            + sorting
+            + "}";
+
+    // When
+    HttpResponse response = POST("/eventVisualizations/", body);
+
+    // Then
+    assertEquals(
+        "Sorting must have a valid dimension and a direction",
+        response.error(CONFLICT).getMessage());
+  }
+
+  @Test
+  void testPostNullSortingObject() {
+    // Given
+    String blankDimension = " ";
+    String sorting = "'sorting': [{'dimension': '" + blankDimension + "', 'direction':'ASC'}]";
+    String body =
+        "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
+            + mockProgram.getUid()
+            + "'}, 'columns': [{'dimension': 'pe'}],"
+            + sorting
+            + "}";
+
+    // When
+    HttpResponse response = POST("/eventVisualizations/", body);
+
+    // Then
+    assertEquals(
+        "Sorting must have a valid dimension and a direction",
+        response.error(CONFLICT).getMessage());
   }
 }


### PR DESCRIPTION
**_[Backport from  master/2.41]_** #14195 #14520

Adding a Sorting object into EventVisualization.
The sorting direction has to be consistent with the dimensions (columns) defined in the EventVisualization object.
Only dimension columns can be sorted.

In the Line Listing app, this will allow users to save the sorting direction they want for a particular EventVisualization.