### PR TITLE
fix: scheduler disabled state transition and system jobs [DHIS2-15027]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
@@ -212,7 +212,8 @@ public class JobConfiguration extends BaseIdentifiableObject implements Secondar
   }
 
   public JobStatus getJobStatus() {
-    if (jobStatus != null) return jobStatus;
+    if (jobStatus != null)
+      return enabled && jobStatus == JobStatus.DISABLED ? JobStatus.SCHEDULED : jobStatus;
     if (getSchedulingType() == SchedulingType.ONCE_ASAP) return JobStatus.NOT_STARTED;
     return JobStatus.SCHEDULED;
   }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
@@ -87,9 +87,7 @@ public enum JobType {
   MATERIALIZED_SQL_VIEW_UPDATE(SqlViewUpdateParameters.class),
   DISABLE_INACTIVE_USERS(DisableInactiveUsersJobParameters.class),
   TEST(TestJobParameters.class),
-  LOCK_EXCEPTION_CLEANUP(
-      LockExceptionCleanupJobParameters.class,
-      daily2am("OQ9KeLgqy20", "Remove lock exceptions older than 6 months")),
+  LOCK_EXCEPTION_CLEANUP(LockExceptionCleanupJobParameters.class),
 
   /*
   Programmatically used Jobs

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobConfigurationTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobConfigurationTest.java
@@ -156,4 +156,12 @@ class JobConfigurationTest {
         tomorrow8_40am.toInstant(),
         config.nextExecutionTime(today10_41am.toInstant(), maxCronDelay));
   }
+
+  @Test
+  void jobStatusIsScheduledWhenJobStatusIsDisabledButEnabled() {
+    JobConfiguration config = new JobConfiguration(JobType.DATA_INTEGRITY);
+    config.setJobStatus(JobStatus.DISABLED);
+
+    assertEquals(JobStatus.SCHEDULED, config.getJobStatus());
+  }
 }


### PR DESCRIPTION
Fixes two smaller issues that were inconsistent loose ends after the scheduling refactor:
1. when enabling a job the `jobStatus` automatically gets back to `SCHEDULED` 
2. the `LOCK_EXCEPTION_CLEANUP` job is no longer considered a system job with a pre-setup because otherwise it would be impossible to delete as it would be recreated with the next run of the scheduler loop. The reasoning it is not a system job is because it has a parameter that the user should be able to change. It was only added as a system job as previously we could have something half/half which did fit the bill of this job at the time.