### PR TITLE
fix: add metadata info in error message for duplicate translation

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -47,7 +47,7 @@ public enum ErrorCode {
   E1103("Category option combo not found or not accessible: `{0}`"),
   E1104("Attribute option combo not found or not accessible: `{0}`"),
   E1105("Data set not found or not accessible: `{0}`"),
-  E1106("There are duplicate translation record for property `{0}` and locale `{1}`"),
+  E1106("There are duplicate translation records for property `{0}` and locale `{1}` on {2} `{3}`"),
   E1107("Object type `{0}` is not translatable"),
   E1108("Could not add item to collection: {0}"),
   E1109("Could not remove item from collection: {0}"),

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/TranslationsCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/TranslationsCheck.java
@@ -106,7 +106,9 @@ public class TranslationsCheck implements ObjectValidationCheck {
                     Translation.class,
                     ErrorCode.E1106,
                     translation.getProperty(),
-                    translation.getLocale())
+                    translation.getLocale(),
+                    klass.getSimpleName(),
+                    object.getUid())
                 .setErrorKlass(klass));
       } else {
         setPropertyLocales.add(key);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
@@ -259,7 +259,9 @@ class AbstractCrudControllerTest extends DhisControllerConvenienceTest {
     JsonErrorReport error =
         message.find(JsonErrorReport.class, report -> report.getErrorCode() == ErrorCode.E1106);
     assertEquals(
-        "There are duplicate translation record for property `name` and locale `sv`",
+        String.format(
+            "There are duplicate translation records for property `name` and locale `sv` on DataSet `%s`",
+            id),
         error.getMessage());
     assertEquals("name", error.getErrorProperties().get(0));
   }


### PR DESCRIPTION
cherry-pick from https://github.com/dhis2/dhis2-core/pull/12910
https://dhis2.atlassian.net/browse/DHIS2-13159
- This PR add metadata class name and metadata object uid to the error message of `E1106`