### PR TITLE
fix: refactor query for checking references when deleting User

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectManager.java
@@ -87,6 +87,15 @@ public interface IdentifiableObjectManager {
   <T extends IdentifiableObject> List<T> findByUser(Class<T> type, @Nonnull User user);
 
   /**
+   * Look up objects which have property createdBy or lastUpdatedBy linked to given {@link User}
+   *
+   * @param type the object class type.
+   * @param user the User which is linked to createdBy or lastUpdatedBy property.
+   * @return TRUE if {@link IdentifiableObject} found. FALSE if not found.
+   */
+  <T extends IdentifiableObject> boolean existsByUser(Class<T> type, @Nonnull User user);
+
+  /**
    * Lookup objects of a specific type by database ID.
    *
    * @param type the object class type.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectStore.java
@@ -450,4 +450,13 @@ public interface IdentifiableObjectStore<T> extends GenericStore<T> {
    * @return List of objects found.
    */
   List<T> findByCreatedBy(@Nonnull User user);
+
+  /**
+   * Look up list objects which have property createdBy or lastUpdatedBy linked to given {@link
+   * User}
+   *
+   * @param user the {@link User} for filtering
+   * @return TRUE if objects exist. FALSE otherwise.
+   */
+  boolean existsByUser(@Nonnull User user, final Set<String> checkProperties);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
@@ -73,6 +73,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 @Slf4j
 public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     extends SharingHibernateGenericStoreImpl<T> implements GenericDimensionalObjectStore<T> {
+  private static final Set<String> EXISTS_BY_USER_PROPERTIES = Set.of("createdBy", "lastUpdatedBy");
   @Autowired protected DbmsManager dbmsManager;
 
   protected boolean transientIdentifiableProperties = false;
@@ -897,6 +898,30 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         10000,
         partition ->
             newJpaParameters().addPredicate(root -> builder.equal(root.get("createdBy"), user)));
+  }
+
+  /**
+   * Look up objects which have property createdBy or lastUpdatedBy linked to given {@link User}
+   *
+   * @param user the {@link User} for filtering
+   * @return TRUE of objects found. FALSE otherwise.
+   */
+  @Override
+  public boolean existsByUser(@Nonnull User user, final Set<String> checkProperties) {
+    CriteriaBuilder builder = getCriteriaBuilder();
+    CriteriaQuery<Integer> query = builder.createQuery(Integer.class);
+    Root<T> root = query.from(getClazz());
+    query.select(builder.literal(1));
+    List<Predicate> predicates =
+        checkProperties.stream()
+            .filter(EXISTS_BY_USER_PROPERTIES::contains)
+            .map(p -> builder.equal(root.get(p), user))
+            .toList();
+    if (predicates.isEmpty()) {
+      return false;
+    }
+    query.where(builder.or(predicates.toArray(new Predicate[0])));
+    return !getSession().createQuery(query).setMaxResults(1).getResultList().isEmpty();
   }
 
   /**

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/deletion/IdObjectDeletionHandler.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/deletion/IdObjectDeletionHandler.java
@@ -68,6 +68,6 @@ public abstract class IdObjectDeletionHandler<T extends IdentifiableObject>
   protected abstract void registerHandler();
 
   private DeletionVeto allowDeleteUser(User user) {
-    return idObjectManager.findByUser(klass, user).isEmpty() ? DeletionVeto.ACCEPT : VETO;
+    return idObjectManager.existsByUser(klass, user) ? VETO : DeletionVeto.ACCEPT;
   }
 }


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-14144
### Summary
- While working on DHIS2-14144 I found out that currently when deleting a User,  the query used by `DeletionHandler` for checking User referenced objects is a `select *` query. We can convert it to a `select 1` query in order to improve the performance.

### Fix
- Use `select 1` to improve the performance of the query for checking for User's references when deleting User.
- This PR doesn't change the functionality so existing tests in [UserServiceTest](https://github.com/dhis2/dhis2-core/blob/7da23afd9e7b7a9f939d551e8ea09612d37ca186/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserServiceTest.java#L174) still applicable.
- Added a test to `DataElementStoreTest` to test the new method in `HibernateIdentifiableObjectStore.existsByUser()`