### PR TITLE
fix: Use search scope in /events requests [TECH-1630] [2.40]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -304,15 +304,15 @@ public abstract class AbstractEventService implements EventService {
     List<Event> eventList = new ArrayList<>();
 
     if (params.isSkipPaging()) {
-      events.setEvents(eventStore.getEvents(params, params.getAccessibleOrgUnits(), emptyMap()));
+      events.setEvents(eventStore.getEvents(params, emptyMap()));
       return events;
     }
 
     Pager pager;
-    eventList.addAll(eventStore.getEvents(params, params.getAccessibleOrgUnits(), emptyMap()));
+    eventList.addAll(eventStore.getEvents(params, emptyMap()));
 
     if (params.isTotalPages()) {
-      int count = eventStore.getEventCount(params, params.getAccessibleOrgUnits());
+      int count = eventStore.getEventCount(params);
       pager = new Pager(params.getPageWithDefault(), count, params.getPageSizeWithDefault());
     } else {
       pager = handleLastPageFlag(params, eventList);
@@ -415,8 +415,7 @@ public abstract class AbstractEventService implements EventService {
       grid.addHeader(new GridHeader(item.getItem().getUid(), item.getItem().getName()));
     }
 
-    List<Map<String, String>> events =
-        eventStore.getEventsGrid(params, params.getAccessibleOrgUnits());
+    List<Map<String, String>> events = eventStore.getEventsGrid(params);
 
     // ---------------------------------------------------------------------
     // Grid rows
@@ -440,7 +439,7 @@ public abstract class AbstractEventService implements EventService {
       final Pager pager;
 
       if (params.isTotalPages()) {
-        int count = eventStore.getEventCount(params, params.getAccessibleOrgUnits());
+        int count = eventStore.getEventCount(params);
         pager = new Pager(params.getPageWithDefault(), count, params.getPageSizeWithDefault());
       } else {
         pager = handleLastPageFlag(params, grid);
@@ -495,7 +494,7 @@ public abstract class AbstractEventService implements EventService {
             .setSynchronizationQuery(true)
             .setSkipChangedBefore(skipChangedBefore);
 
-    return eventStore.getEventCount(params, null);
+    return eventStore.getEventCount(params);
   }
 
   @Override
@@ -514,7 +513,7 @@ public abstract class AbstractEventService implements EventService {
             .setSkipChangedBefore(skipChangedBefore);
 
     Events anonymousEvents = new Events();
-    List<Event> events = eventStore.getEvents(params, null, psdesWithSkipSyncTrue);
+    List<Event> events = eventStore.getEvents(params, psdesWithSkipSyncTrue);
     anonymousEvents.setEvents(events);
     return anonymousEvents;
   }
@@ -526,7 +525,7 @@ public abstract class AbstractEventService implements EventService {
 
     EventRows eventRows = new EventRows();
 
-    List<EventRow> eventRowList = eventStore.getEventRows(params, params.getAccessibleOrgUnits());
+    List<EventRow> eventRowList = eventStore.getEventRows(params);
 
     EventContext eventContext = eventServiceContextBuilder.build(eventRowList, user);
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventQueryParams.java
@@ -115,9 +115,9 @@ public class EventQueryParams {
   // TODO Default set to DESCENDANTS to replicate master, but this will need to be fixed in
   // https://dhis2.atlassian.net/browse/TECH-1588
   private OrganisationUnitSelectionMode orgUnitSelectionMode =
-      OrganisationUnitSelectionMode.DESCENDANTS;
+      OrganisationUnitSelectionMode.ACCESSIBLE;
 
-  private List<OrganisationUnit> accessibleOrgUnits = new ArrayList<>();
+  private OrganisationUnit orgUnit;
 
   private TrackedEntityInstance trackedEntityInstance;
 
@@ -341,12 +341,12 @@ public class EventQueryParams {
     return this;
   }
 
-  public List<OrganisationUnit> getAccessibleOrgUnits() {
-    return accessibleOrgUnits;
+  public OrganisationUnit getOrgUnit() {
+    return orgUnit;
   }
 
-  public EventQueryParams setAccessibleOrgUnits(List<OrganisationUnit> accessibleOrgUnits) {
-    this.accessibleOrgUnits = accessibleOrgUnits;
+  public EventQueryParams setOrgUnit(OrganisationUnit orgUnit) {
+    this.orgUnit = orgUnit;
     return this;
   }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventStore.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.hisp.dhis.dxf2.events.report.EventRow;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.user.User;
 
@@ -55,17 +54,13 @@ public interface EventStore {
    */
   List<ProgramStageInstance> updateEvents(List<ProgramStageInstance> programStageInstances);
 
-  List<Event> getEvents(
-      EventQueryParams params,
-      List<OrganisationUnit> organisationUnits,
-      Map<String, Set<String>> psdesWithSkipSyncTrue);
+  List<Event> getEvents(EventQueryParams params, Map<String, Set<String>> psdesWithSkipSyncTrue);
 
-  List<Map<String, String>> getEventsGrid(
-      EventQueryParams params, List<OrganisationUnit> organisationUnits);
+  List<Map<String, String>> getEventsGrid(EventQueryParams params);
 
-  List<EventRow> getEventRows(EventQueryParams params, List<OrganisationUnit> organisationUnits);
+  List<EventRow> getEventRows(EventQueryParams params);
 
-  int getEventCount(EventQueryParams params, List<OrganisationUnit> organisationUnits);
+  int getEventCount(EventQueryParams params);
 
   /**
    * Delete list of given events to be removed. This operation also remove comments connected to

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -1367,11 +1367,18 @@ public class JdbcEventStore implements EventStore {
   private String createAccessibleSql(
       User user, EventQueryParams params, MapSqlParameterSource mapSqlParameterSource) {
 
-    if (isProgramRestricted(params.getProgram())) {
+    if (isProgramRestricted(params.getProgram()) || isUserSearchScopeNotSet(user)) {
       return createCaptureSql(user, mapSqlParameterSource);
     }
 
-    return "";
+    mapSqlParameterSource.addValue(COLUMN_USER_UID, user.getUid());
+    return " EXISTS(SELECT ss.organisationunitid "
+        + " FROM userteisearchorgunits ss "
+        + " JOIN organisationunit orgunit ON orgunit.organisationunitid = ss.organisationunitid "
+        + " JOIN userinfo u ON u.userinfoid = ss.userinfoid "
+        + " WHERE u.uid = :"
+        + COLUMN_USER_UID
+        + " AND ou.path like CONCAT(orgunit.path, '%')) ";
   }
 
   private String createDescendantsSql(
@@ -1432,6 +1439,10 @@ public class JdbcEventStore implements EventStore {
 
   private boolean isProgramRestricted(Program program) {
     return program != null && (program.isProtected() || program.isClosed());
+  }
+
+  private boolean isUserSearchScopeNotSet(User user) {
+    return user.getTeiSearchOrganisationUnits().isEmpty();
   }
 
   private String createCaptureScopeQuery(

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -100,7 +100,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.StringJoiner;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -129,7 +128,6 @@ import org.hisp.dhis.hibernate.jsonb.type.JsonEventDataValueSetBinaryType;
 import org.hisp.dhis.jdbc.BatchPreparedStatementSetterWithKeyHolder;
 import org.hisp.dhis.jdbc.JdbcUtils;
 import org.hisp.dhis.jdbc.StatementBuilder;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitStore;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
@@ -337,9 +335,11 @@ public class JdbcEventStore implements EventStore {
             + " where uid = :uid;";
   }
 
-  private static final String PATH_LIKE = "path LIKE";
+  private static final String COLUMN_USER_UID = "u_uid";
 
-  private static final String PATH_EQ = "path =";
+  private static final String COLUMN_ORG_UNIT_PATH = "ou_path";
+
+  private static final String PERCENTAGE_SIGN = ", '%' ";
 
   // -------------------------------------------------------------------------
   // Dependencies
@@ -371,9 +371,7 @@ public class JdbcEventStore implements EventStore {
 
   @Override
   public List<Event> getEvents(
-      EventQueryParams params,
-      List<OrganisationUnit> organisationUnits,
-      Map<String, Set<String>> psdesWithSkipSyncTrue) {
+      EventQueryParams params, Map<String, Set<String>> psdesWithSkipSyncTrue) {
     User user = currentUserService.getCurrentUser();
 
     setAccessiblePrograms(user, params);
@@ -597,15 +595,14 @@ public class JdbcEventStore implements EventStore {
   }
 
   @Override
-  public List<Map<String, String>> getEventsGrid(
-      EventQueryParams params, List<OrganisationUnit> organisationUnits) {
+  public List<Map<String, String>> getEventsGrid(EventQueryParams params) {
     User user = currentUserService.getCurrentUser();
 
     setAccessiblePrograms(user, params);
 
     final MapSqlParameterSource mapSqlParameterSource = new MapSqlParameterSource();
 
-    String sql = buildGridSql(params, mapSqlParameterSource);
+    String sql = buildGridSql(params, mapSqlParameterSource, user);
 
     return jdbcTemplate.query(
         sql,
@@ -634,8 +631,7 @@ public class JdbcEventStore implements EventStore {
   }
 
   @Override
-  public List<EventRow> getEventRows(
-      EventQueryParams params, List<OrganisationUnit> organisationUnits) {
+  public List<EventRow> getEventRows(EventQueryParams params) {
     User user = currentUserService.getCurrentUser();
 
     setAccessiblePrograms(user, params);
@@ -843,7 +839,7 @@ public class JdbcEventStore implements EventStore {
   }
 
   @Override
-  public int getEventCount(EventQueryParams params, List<OrganisationUnit> organisationUnits) {
+  public int getEventCount(EventQueryParams params) {
     User user = currentUserService.getCurrentUser();
     setAccessiblePrograms(user, params);
 
@@ -852,7 +848,7 @@ public class JdbcEventStore implements EventStore {
     MapSqlParameterSource mapSqlParameterSource = new MapSqlParameterSource();
 
     if (params.hasFilters()) {
-      sql = buildGridSql(params, mapSqlParameterSource);
+      sql = buildGridSql(params, mapSqlParameterSource, user);
     } else {
       sql = getEventSelectQuery(params, mapSqlParameterSource, user);
     }
@@ -883,7 +879,7 @@ public class JdbcEventStore implements EventStore {
   }
 
   private String buildGridSql(
-      EventQueryParams params, MapSqlParameterSource mapSqlParameterSource) {
+      EventQueryParams params, MapSqlParameterSource mapSqlParameterSource, User user) {
     SqlHelper hlp = new SqlHelper();
 
     StringBuilder selectBuilder =
@@ -900,7 +896,8 @@ public class JdbcEventStore implements EventStore {
                 params,
                 dataElementAndFiltersSql(params, mapSqlParameterSource, hlp, selectBuilder),
                 mapSqlParameterSource,
-                hlp))
+                hlp,
+                user))
         .append(getGridOrderQuery(params))
         .append(getEventPagingQuery(params))
         .toString();
@@ -1245,7 +1242,7 @@ public class JdbcEventStore implements EventStore {
           .append(" ");
     }
 
-    String orgUnitSql = getOrgUnitSql(params, getOuTableName(params));
+    String orgUnitSql = getOrgUnitSql(params, user, mapSqlParameterSource);
 
     if (!isNullOrEmpty(orgUnitSql)) {
       fromBuilder.append(hlp.whereAnd()).append(" (").append(orgUnitSql).append(") ");
@@ -1345,54 +1342,111 @@ public class JdbcEventStore implements EventStore {
     return fromBuilder;
   }
 
-  private String getOrgUnitSql(EventQueryParams params, String ouTable) {
+  private String getOrgUnitSql(
+      EventQueryParams params, User user, MapSqlParameterSource mapSqlParameterSource) {
     switch (params.getOrgUnitSelectionMode()) {
-      case SELECTED:
-        return getSelectedOrgUnitPath(params.getAccessibleOrgUnits(), ouTable);
+      case CAPTURE:
+        return createCaptureSql(user, mapSqlParameterSource);
+      case ACCESSIBLE:
+        return createAccessibleSql(user, params, mapSqlParameterSource);
+      case DESCENDANTS:
+        return createDescendantsSql(user, params, mapSqlParameterSource);
       case CHILDREN:
-        return getChildrenOrgUnitsPath(params.getAccessibleOrgUnits(), ouTable);
-      case ALL:
-        return null;
+        return createChildrenSql(user, params, mapSqlParameterSource);
+      case SELECTED:
+        return createSelectedSql(user, params, mapSqlParameterSource);
       default:
-        return getOrgUnitsPath(params.getAccessibleOrgUnits(), ouTable);
+        return null;
     }
   }
 
-  private String getChildrenOrgUnitsPath(List<OrganisationUnit> orgUnits, String ouTable) {
-    StringJoiner orgUnitSqlJoiner = new StringJoiner(" or ");
-
-    for (OrganisationUnit orgUnit : orgUnits) {
-      orgUnitSqlJoiner.add(
-          ouTable
-              + "."
-              + PATH_LIKE
-              + " '%"
-              + orgUnit.getPath()
-              + "%' "
-              + " and "
-              + ouTable
-              + "."
-              + "hierarchylevel = "
-              + orgUnit.getLevel());
-    }
-
-    return orgUnitSqlJoiner.toString();
+  private String createCaptureSql(User user, MapSqlParameterSource mapSqlParameterSource) {
+    return createCaptureScopeQuery(user, mapSqlParameterSource, "");
   }
 
-  private String getSelectedOrgUnitPath(List<OrganisationUnit> orgUnits, String ouTable) {
-    return orgUnits.isEmpty()
-        ? null
-        : ouTable + "." + PATH_EQ + " '" + orgUnits.get(0).getPath() + "' ";
-  }
+  private String createAccessibleSql(
+      User user, EventQueryParams params, MapSqlParameterSource mapSqlParameterSource) {
 
-  private String getOrgUnitsPath(List<OrganisationUnit> orgUnits, String ouTable) {
-    StringJoiner orgUnitSqlJoiner = new StringJoiner(" or ");
-
-    for (OrganisationUnit orgUnit : orgUnits) {
-      orgUnitSqlJoiner.add(ouTable + "." + PATH_LIKE + " '%" + orgUnit.getPath() + "%' ");
+    if (isProgramRestricted(params.getProgram())) {
+      return createCaptureSql(user, mapSqlParameterSource);
     }
 
-    return orgUnitSqlJoiner.toString();
+    return "";
+  }
+
+  private String createDescendantsSql(
+      User user, EventQueryParams params, MapSqlParameterSource mapSqlParameterSource) {
+    mapSqlParameterSource.addValue(COLUMN_ORG_UNIT_PATH, params.getOrgUnit().getPath());
+
+    if (isProgramRestricted(params.getProgram())) {
+      return createCaptureScopeQuery(
+          user,
+          mapSqlParameterSource,
+          " AND ou.path like CONCAT(:" + COLUMN_ORG_UNIT_PATH + PERCENTAGE_SIGN + ")");
+    }
+
+    return " ou.path like CONCAT(:" + COLUMN_ORG_UNIT_PATH + PERCENTAGE_SIGN + ") ";
+  }
+
+  private String createChildrenSql(
+      User user, EventQueryParams params, MapSqlParameterSource mapSqlParameterSource) {
+    mapSqlParameterSource.addValue(COLUMN_ORG_UNIT_PATH, params.getOrgUnit().getPath());
+
+    if (isProgramRestricted(params.getProgram())) {
+      String childrenSqlClause =
+          " AND ou.path like CONCAT(:"
+              + COLUMN_ORG_UNIT_PATH
+              + PERCENTAGE_SIGN
+              + ") "
+              + " AND (ou.hierarchylevel = "
+              + params.getOrgUnit().getHierarchyLevel()
+              + " OR ou.hierarchylevel = "
+              + (params.getOrgUnit().getHierarchyLevel() + 1)
+              + " )";
+
+      return createCaptureScopeQuery(user, mapSqlParameterSource, childrenSqlClause);
+    }
+
+    return " ou.path like CONCAT(:"
+        + COLUMN_ORG_UNIT_PATH
+        + PERCENTAGE_SIGN
+        + ") "
+        + " AND (ou.hierarchylevel = "
+        + params.getOrgUnit().getHierarchyLevel()
+        + " OR ou.hierarchylevel = "
+        + (params.getOrgUnit().getHierarchyLevel() + 1)
+        + " ) ";
+  }
+
+  private String createSelectedSql(
+      User user, EventQueryParams params, MapSqlParameterSource mapSqlParameterSource) {
+    mapSqlParameterSource.addValue(COLUMN_ORG_UNIT_PATH, params.getOrgUnit().getPath());
+
+    if (isProgramRestricted(params.getProgram())) {
+      String customSelectedClause = " AND ou.path = :" + COLUMN_ORG_UNIT_PATH + " ";
+      return createCaptureScopeQuery(user, mapSqlParameterSource, customSelectedClause);
+    }
+
+    return " ou.path = :" + COLUMN_ORG_UNIT_PATH + " ";
+  }
+
+  private boolean isProgramRestricted(Program program) {
+    return program != null && (program.isProtected() || program.isClosed());
+  }
+
+  private String createCaptureScopeQuery(
+      User user, MapSqlParameterSource mapSqlParameterSource, String customClause) {
+    mapSqlParameterSource.addValue(COLUMN_USER_UID, user.getUid());
+
+    return " EXISTS(SELECT cs.organisationunitid "
+        + " FROM usermembership cs "
+        + " JOIN organisationunit orgunit ON orgunit.organisationunitid = cs.organisationunitid "
+        + " JOIN userinfo u ON u.userinfoid = cs.userinfoid "
+        + " WHERE u.uid = :"
+        + COLUMN_USER_UID
+        + " AND ou.path like CONCAT(orgunit.path, '%') "
+        + customClause
+        + ") ";
   }
 
   /**
@@ -1536,7 +1590,8 @@ public class JdbcEventStore implements EventStore {
       EventQueryParams params,
       StringBuilder dataElementAndFiltersSql,
       MapSqlParameterSource mapSqlParameterSource,
-      SqlHelper hlp) {
+      SqlHelper hlp,
+      User user) {
     StringBuilder sqlBuilder =
         new StringBuilder()
             .append(
@@ -1562,7 +1617,7 @@ public class JdbcEventStore implements EventStore {
 
     sqlBuilder.append(dataElementAndFiltersSql);
 
-    String orgUnitSql = getOrgUnitSql(params, getOuTableName(params));
+    String orgUnitSql = getOrgUnitSql(params, user, mapSqlParameterSource);
 
     if (orgUnitSql != null) {
       sqlBuilder.append(hlp.whereAnd()).append(" (").append(orgUnitSql).append(") ");

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventStoreTest.java
@@ -117,7 +117,7 @@ class JdbcEventStoreTest {
   void verifyEventDataValuesAreProcessedOnceForEachPSI() throws SQLException {
     EventQueryParams eventQueryParams = new EventQueryParams();
 
-    List<EventRow> rows = subject.getEventRows(eventQueryParams, new ArrayList<>());
+    List<EventRow> rows = subject.getEventRows(eventQueryParams);
     assertThat(rows, hasSize(1));
     verify(rowSet, times(4)).getString("psi_eventdatavalues");
   }
@@ -126,7 +126,7 @@ class JdbcEventStoreTest {
   void verifyNullOrganisationUnitsIsHandled() throws SQLException {
     EventQueryParams eventQueryParams = new EventQueryParams();
 
-    List<EventRow> rows = subject.getEventRows(eventQueryParams, null);
+    List<EventRow> rows = subject.getEventRows(eventQueryParams);
     assertThat(rows, hasSize(1));
     verify(rowSet, times(4)).getString("psi_eventdatavalues");
   }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventStoreTest.java
@@ -53,6 +53,7 @@ import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -116,6 +117,7 @@ class JdbcEventStoreTest {
   @Test
   void verifyEventDataValuesAreProcessedOnceForEachPSI() throws SQLException {
     EventQueryParams eventQueryParams = new EventQueryParams();
+    when(currentUserService.getCurrentUser()).thenReturn(new User());
 
     List<EventRow> rows = subject.getEventRows(eventQueryParams);
     assertThat(rows, hasSize(1));
@@ -125,6 +127,7 @@ class JdbcEventStoreTest {
   @Test
   void verifyNullOrganisationUnitsIsHandled() throws SQLException {
     EventQueryParams eventQueryParams = new EventQueryParams();
+    when(currentUserService.getCurrentUser()).thenReturn(new User());
 
     List<EventRow> rows = subject.getEventRows(eventQueryParams);
     assertThat(rows, hasSize(1));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/EventXmlImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/EventXmlImportTest.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.Set;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.ValueType;
@@ -117,7 +118,7 @@ class EventXmlImportTest extends TransactionalIntegrationTest {
     programA.getProgramStages().add(programStageA);
     manager.update(programStageA);
     manager.update(programA);
-    createUserAndInjectSecurityContext(true);
+    createUserAndInjectSecurityContext(Set.of(organisationUnitA), true);
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/RegistrationMultiEventsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/RegistrationMultiEventsServiceTest.java
@@ -35,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import com.google.common.collect.Lists;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.List;
 import org.hamcrest.CoreMatchers;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -226,7 +225,7 @@ class RegistrationMultiEventsServiceTest extends TransactionalIntegrationTest {
     assertEquals(ImportStatus.SUCCESS, importSummary.getStatus());
     EventQueryParams params = new EventQueryParams();
     params.setProgram(programA);
-    params.setAccessibleOrgUnits(List.of(organisationUnitA));
+    params.setOrgUnit(organisationUnitA);
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
     assertEquals(2, eventService.getEvents(params).getEvents().size());
     event =
@@ -263,7 +262,7 @@ class RegistrationMultiEventsServiceTest extends TransactionalIntegrationTest {
             tei.getEnrollments().get(0).getEnrollment(), EnrollmentParams.FALSE);
     EventQueryParams params = new EventQueryParams();
     params.setProgram(programA);
-    params.setAccessibleOrgUnits(List.of(organisationUnitA));
+    params.setOrgUnit(organisationUnitA);
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
     Event retrievedEvent = enrollment.getEvents().get(0);
     assertNotNull(retrievedEnrlollment);
@@ -303,7 +302,7 @@ class RegistrationMultiEventsServiceTest extends TransactionalIntegrationTest {
     assertEquals(ImportStatus.SUCCESS, importSummary.getStatus());
     EventQueryParams params = new EventQueryParams();
     params.setProgram(programA);
-    params.setAccessibleOrgUnits(List.of(organisationUnitA));
+    params.setOrgUnit(organisationUnitA);
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
     assertEquals(2, eventService.getEvents(params).getEvents().size());
     event =
@@ -335,7 +334,7 @@ class RegistrationMultiEventsServiceTest extends TransactionalIntegrationTest {
     importOptions.setImportStrategy(ImportStrategy.CREATE_AND_UPDATE);
     EventQueryParams params = new EventQueryParams();
     params.setProgram(programA);
-    params.setAccessibleOrgUnits(List.of(organisationUnitA));
+    params.setOrgUnit(organisationUnitA);
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
     Enrollment enrollment =
         createEnrollment(programA.getUid(), trackedEntityInstanceMaleA.getTrackedEntityInstance());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/RegistrationSingleEventServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/RegistrationSingleEventServiceTest.java
@@ -33,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Date;
 import java.util.HashSet;
-import java.util.List;
 import org.hamcrest.CoreMatchers;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
@@ -230,7 +229,7 @@ class RegistrationSingleEventServiceTest extends TransactionalIntegrationTest {
     assertEquals(ImportStatus.SUCCESS, importSummary.getStatus());
     EventQueryParams params = new EventQueryParams();
     params.setProgram(programA);
-    params.setAccessibleOrgUnits(List.of(organisationUnitA));
+    params.setOrgUnit(organisationUnitA);
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
     assertEquals(1, eventService.getEvents(params).getEvents().size());
     event =

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/AclEventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/AclEventExporterTest.java
@@ -44,7 +44,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.poi.ss.formula.functions.T;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/AclEventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/AclEventExporterTest.java
@@ -28,12 +28,14 @@
 package org.hisp.dhis.tracker;
 
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
+import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ALL;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CHILDREN;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.DESCENDANTS;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.SELECTED;
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -42,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.poi.ss.formula.functions.T;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -99,7 +102,7 @@ class AclEventExporterTest extends TrackerTest {
     injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
     EventQueryParams params = new EventQueryParams();
     params.setProgram(get(Program.class, "pcxIanBWlSY"));
-    params.setAccessibleOrgUnits(List.of(get(OrganisationUnit.class, "uoNW0E3xXUy")));
+    params.setOrgUnit(get(OrganisationUnit.class, "uoNW0E3xXUy"));
     params.setOrgUnitSelectionMode(DESCENDANTS);
 
     List<Event> events = eventService.getEvents(params).getEvents();
@@ -121,7 +124,7 @@ class AclEventExporterTest extends TrackerTest {
   void shouldReturnEventsWhenNoProgramSpecifiedOuModeDescendantsAndOrgUnitInSearchScope() {
     injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
     EventQueryParams params = new EventQueryParams();
-    params.setAccessibleOrgUnits(List.of(get(OrganisationUnit.class, orgUnit.getUid())));
+    params.setOrgUnit(get(OrganisationUnit.class, orgUnit.getUid()));
     params.setOrgUnitSelectionMode(DESCENDANTS);
 
     List<Event> events = eventService.getEvents(params).getEvents();
@@ -138,7 +141,7 @@ class AclEventExporterTest extends TrackerTest {
   void shouldReturnEventsWhenNoProgramSpecifiedOuModeDescenadantsAndOrgUnitInSearchScope() {
     injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
     EventQueryParams params = new EventQueryParams();
-    params.setAccessibleOrgUnits(List.of(get(OrganisationUnit.class, "uoNW0E3xXUy")));
+    params.setOrgUnit(get(OrganisationUnit.class, "uoNW0E3xXUy"));
     params.setOrgUnitSelectionMode(DESCENDANTS);
 
     List<Event> events = eventService.getEvents(params).getEvents();
@@ -156,7 +159,7 @@ class AclEventExporterTest extends TrackerTest {
     injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
     EventQueryParams params = new EventQueryParams();
     params.setProgram(get(Program.class, "pcxIanBWlSY"));
-    params.setAccessibleOrgUnits(List.of(get(OrganisationUnit.class, "uoNW0E3xXUy")));
+    params.setOrgUnit(get(OrganisationUnit.class, "uoNW0E3xXUy"));
     params.setOrgUnitSelectionMode(CHILDREN);
 
     List<Event> events = eventService.getEvents(params).getEvents();
@@ -178,10 +181,7 @@ class AclEventExporterTest extends TrackerTest {
   void shouldReturnEventsWhenNoProgramSpecifiedOuModeChildrenAndOrgUnitInSearchScope() {
     injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
     EventQueryParams params = new EventQueryParams();
-    params.setAccessibleOrgUnits(
-        List.of(
-            get(OrganisationUnit.class, orgUnit.getUid()),
-            get(OrganisationUnit.class, "uoNW0E3xXUy")));
+    params.setOrgUnit(get(OrganisationUnit.class, orgUnit.getUid()));
     params.setOrgUnitSelectionMode(CHILDREN);
 
     List<Event> events = eventService.getEvents(params).getEvents();
@@ -199,7 +199,7 @@ class AclEventExporterTest extends TrackerTest {
     injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
     EventQueryParams params = new EventQueryParams();
     params.setProgram(get(Program.class, "pcxIanBWlSY"));
-    params.setAccessibleOrgUnits(List.of(get(OrganisationUnit.class, "uoNW0E3xXUy")));
+    params.setOrgUnit(get(OrganisationUnit.class, "uoNW0E3xXUy"));
     params.setOrgUnitSelectionMode(SELECTED);
 
     List<Event> events = eventService.getEvents(params).getEvents();
@@ -222,7 +222,7 @@ class AclEventExporterTest extends TrackerTest {
     injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
 
     EventQueryParams params = new EventQueryParams();
-    params.setAccessibleOrgUnits(List.of(get(OrganisationUnit.class, orgUnit.getUid())));
+    params.setOrgUnit(get(OrganisationUnit.class, orgUnit.getUid()));
     params.setOrgUnitSelectionMode(SELECTED);
 
     List<Event> events = eventService.getEvents(params).getEvents();
@@ -247,7 +247,7 @@ class AclEventExporterTest extends TrackerTest {
 
     EventQueryParams params = new EventQueryParams();
     params.setProgram(get(Program.class, "shPjYNifvMK"));
-    params.setAccessibleOrgUnits(List.of(get(OrganisationUnit.class, orgUnit.getUid())));
+    params.setOrgUnit(get(OrganisationUnit.class, orgUnit.getUid()));
     params.setOrgUnitSelectionMode(SELECTED);
 
     List<Event> events = eventService.getEvents(params).getEvents();
@@ -319,6 +319,53 @@ class AclEventExporterTest extends TrackerTest {
                 "Expected to find capture org unit uoNW0E3xXUy, but found "
                     + e.getOrgUnit()
                     + " instead"));
+  }
+
+  @Test
+  void shouldReturnEmptyCollectionWhenProgramIsClosedAndOrgUnitNotInSearchScope() {
+    injectSecurityContext(userService.getUser("FIgVWzUCkpw"));
+
+    EventQueryParams params = new EventQueryParams();
+    params.setProgram(get(Program.class, "pcxIanBWlSY"));
+    params.setOrgUnit(get(OrganisationUnit.class, "DiszpKrYNg8"));
+    params.setOrgUnitSelectionMode(DESCENDANTS);
+
+    assertIsEmpty(eventService.getEvents(params).getEvents());
+  }
+
+  @Test
+  void shouldReturnAllOrgUnitEventsWhenOrgUnitModeAllAndNoOrgUnitProvided() {
+    injectSecurityContext(userService.getUser("lPaILkLkgOM"));
+
+    EventQueryParams params = new EventQueryParams();
+    params.setOrgUnitSelectionMode(ALL);
+
+    List<Event> events = eventService.getEvents(params).getEvents();
+
+    assertFalse(
+        events.isEmpty(),
+        "Expected to find events when ou mode ALL no program specified and no org unit provided");
+    assertContainsOnly(
+        List.of("h4w96yEMlzO", "uoNW0E3xXUy", "DiszpKrYNg8", "tSsGrtfRzjY"),
+        events.stream().map(Event::getOrgUnit).collect(Collectors.toSet()));
+  }
+
+  @Test
+  void shouldReturnAllOrgUnitEventsWhenOrgUnitModeAllAndOrgUnitProvided() {
+    injectSecurityContext(userService.getUser("lPaILkLkgOM"));
+
+    EventQueryParams params = new EventQueryParams();
+    params.setOrgUnit(get(OrganisationUnit.class, "uoNW0E3xXUy"));
+    params.setOrgUnitSelectionMode(ALL);
+
+    List<Event> events = eventService.getEvents(params).getEvents();
+
+    assertFalse(
+        events.isEmpty(),
+        "Expected to find events when ou mode ALL no program specified and no org unit provided");
+    assertContainsOnly(
+        List.of("h4w96yEMlzO", "uoNW0E3xXUy", "DiszpKrYNg8", "tSsGrtfRzjY"),
+        events.stream().map(Event::getOrgUnit).collect(Collectors.toSet()));
   }
 
   private <T extends IdentifiableObject> T get(Class<T> type, String uid) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -160,7 +160,7 @@ class EventExporterTest extends TrackerTest {
   @Test
   void shouldReturnEventsWithRelationships() {
     EventQueryParams params = new EventQueryParams();
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setEvents(Set.of("pTzf9KYMk72"));
     params.setIncludeRelationships(true);
 
@@ -177,7 +177,7 @@ class EventExporterTest extends TrackerTest {
   @Test
   void shouldReturnEventsWithNotes() {
     EventQueryParams params = new EventQueryParams();
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setEvents(Set.of("pTzf9KYMk72"));
     params.setIncludeRelationships(true);
 
@@ -196,7 +196,7 @@ class EventExporterTest extends TrackerTest {
   @Test
   void shouldReturnPaginatedEventsWithNotesGivenNonDefaultPageSize() {
     EventQueryParams params = new EventQueryParams();
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setEvents(Set.of("pTzf9KYMk72", "D9PbzJY8bJM"));
     params.addOrders(List.of(new OrderParam("occurredAt", SortDirection.DESC)));
 
@@ -230,7 +230,7 @@ class EventExporterTest extends TrackerTest {
   void testExportEvents(Function<EventQueryParams, List<String>> eventFunction) {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setProgramStage(programStage);
 
     List<String> events = eventFunction.apply(params);
@@ -243,7 +243,7 @@ class EventExporterTest extends TrackerTest {
   void testExportEventsWithTotalPages(Function<EventQueryParams, List<String>> eventFunction) {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setTotalPages(true);
     params.setProgramStage(programStage);
 
@@ -256,7 +256,7 @@ class EventExporterTest extends TrackerTest {
   void testExportEventsWhenFilteringByEnrollment() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setTrackedEntityInstance(trackedEntityInstance);
     params.setProgramInstances(Set.of("TvctPPhpD8z"));
 
@@ -271,7 +271,7 @@ class EventExporterTest extends TrackerTest {
       Function<EventQueryParams, List<String>> eventFunction) {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setProgramInstances(Set.of("TvctPPhpD8z"));
     params.setProgramStage(programStage);
 
@@ -290,7 +290,7 @@ class EventExporterTest extends TrackerTest {
       Function<EventQueryParams, List<String>> eventFunction) {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setProgramInstances(Set.of("TvctPPhpD8z"));
     params.setProgramStage(programStage);
 
@@ -306,7 +306,7 @@ class EventExporterTest extends TrackerTest {
   void testExportEventsWithLastUpdateDates(Function<EventQueryParams, List<String>> eventFunction) {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setProgramInstances(Set.of("TvctPPhpD8z"));
     params.setProgramStage(programStage);
 
@@ -331,7 +331,7 @@ class EventExporterTest extends TrackerTest {
       Function<EventQueryParams, List<String>> eventFunction) {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setProgramInstances(Set.of("nxP7UnKhomJ"));
     params.setProgramStage(programStage);
 
@@ -353,7 +353,7 @@ class EventExporterTest extends TrackerTest {
       Function<EventQueryParams, List<String>> eventFunction) {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setProgramInstances(Set.of("nxP7UnKhomJ"));
     params.setProgramStatus(ProgramStatus.ACTIVE);
     params.setProgramStage(programStage);
@@ -376,7 +376,7 @@ class EventExporterTest extends TrackerTest {
       Function<EventQueryParams, List<String>> eventFunction) {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setProgramInstances(Set.of("nxP7UnKhomJ"));
     params.setProgramType(ProgramType.WITH_REGISTRATION);
     params.setProgramStage(programStage);
@@ -399,7 +399,7 @@ class EventExporterTest extends TrackerTest {
       Function<EventQueryParams, List<String>> eventFunction) {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setProgramInstances(Set.of("nxP7UnKhomJ"));
     params.setProgramStage(programStage);
 
@@ -426,7 +426,7 @@ class EventExporterTest extends TrackerTest {
       Function<EventQueryParams, List<String>> eventFunction) {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setProgramInstances(Set.of("nxP7UnKhomJ", "TvctPPhpD8z"));
     params.setProgramStage(programStage);
 
@@ -451,7 +451,7 @@ class EventExporterTest extends TrackerTest {
   void testExportEventsWhenFilteringByDataElementsWithCategoryOptionSuperUser() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setProgramInstances(Set.of("nxP7UnKhomJ"));
     params.setProgramStage(programStage);
     params.setProgram(program);
@@ -482,7 +482,7 @@ class EventExporterTest extends TrackerTest {
     injectSecurityContext(userService.getUser("o1HMTIzBGo7"));
 
     EventQueryParams params = new EventQueryParams();
-    params.setAccessibleOrgUnits(List.of(get(OrganisationUnit.class, "DiszpKrYNg8")));
+    params.setOrgUnit(get(OrganisationUnit.class, "DiszpKrYNg8"));
     params.setEvents(Set.of("lumVtWwwy0O", "cadc5eGj0j7"));
 
     Events events = eventService.getEvents(params);
@@ -512,7 +512,7 @@ class EventExporterTest extends TrackerTest {
     injectSecurityContext(userService.getUser("CYVgFNKCaUS"));
 
     EventQueryParams params = new EventQueryParams();
-    params.setAccessibleOrgUnits(List.of(get(OrganisationUnit.class, "DiszpKrYNg8")));
+    params.setOrgUnit(get(OrganisationUnit.class, "DiszpKrYNg8"));
     params.setEvents(Set.of("lumVtWwwy0O", "cadc5eGj0j7"));
 
     List<String> events = eventsFunction.apply(params);
@@ -527,7 +527,7 @@ class EventExporterTest extends TrackerTest {
 
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setProgram(program);
 
     params.addOrders(List.of(new OrderParam("occurredAt", SortDirection.DESC)));
@@ -545,7 +545,7 @@ class EventExporterTest extends TrackerTest {
 
     params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setProgram(program);
 
     params.addOrders(List.of(new OrderParam("occurredAt", SortDirection.DESC)));
@@ -563,7 +563,7 @@ class EventExporterTest extends TrackerTest {
 
     params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setProgram(program);
 
     params.addOrders(List.of(new OrderParam("occurredAt", SortDirection.DESC)));
@@ -581,7 +581,7 @@ class EventExporterTest extends TrackerTest {
 
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setProgram(program);
 
     params.addOrders(List.of(new OrderParam("occurredAt", SortDirection.DESC)));
@@ -601,7 +601,7 @@ class EventExporterTest extends TrackerTest {
   void shouldReturnEventsGivenCategoryOptionCombo() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(get(OrganisationUnit.class, "DiszpKrYNg8")));
+    params.setOrgUnit(get(OrganisationUnit.class, "DiszpKrYNg8"));
     params.setCategoryOptionCombo(get(CategoryOptionCombo.class, "cr89ebDZrac"));
 
     Events events = eventService.getEvents(params);
@@ -634,7 +634,7 @@ class EventExporterTest extends TrackerTest {
   void shouldFailIfCategoryOptionComboOfGivenEventDoesNotHaveAValueForGivenIdScheme() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(get(OrganisationUnit.class, "DiszpKrYNg8")));
+    params.setOrgUnit(get(OrganisationUnit.class, "DiszpKrYNg8"));
     IdSchemes idSchemes = new IdSchemes();
     idSchemes.setCategoryOptionComboIdScheme("ATTRIBUTE:GOLswS44mh8");
     params.setIdSchemes(idSchemes);
@@ -650,7 +650,7 @@ class EventExporterTest extends TrackerTest {
   void shouldReturnEventsGivenIdSchemeCode() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(get(OrganisationUnit.class, "DiszpKrYNg8")));
+    params.setOrgUnit(get(OrganisationUnit.class, "DiszpKrYNg8"));
     params.setCategoryOptionCombo(get(CategoryOptionCombo.class, "cr89ebDZrac"));
     IdSchemes idSchemes = new IdSchemes();
     idSchemes.setProgramIdScheme("code");
@@ -691,7 +691,7 @@ class EventExporterTest extends TrackerTest {
   void shouldReturnEventsGivenIdSchemeAttribute() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(get(OrganisationUnit.class, "DiszpKrYNg8")));
+    params.setOrgUnit(get(OrganisationUnit.class, "DiszpKrYNg8"));
     params.setCategoryOptionCombo(get(CategoryOptionCombo.class, "cr89ebDZrac"));
     IdSchemes idSchemes = new IdSchemes();
     idSchemes.setProgramIdScheme("ATTRIBUTE:j45AR9cBQKc");
@@ -739,7 +739,7 @@ class EventExporterTest extends TrackerTest {
 
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setProgramInstances(Set.of("TvctPPhpD8z"));
     params.setProgramStage(programStage);
     params.setProgram(program);
@@ -769,7 +769,7 @@ class EventExporterTest extends TrackerTest {
       Function<EventQueryParams, List<String>> eventFunction) {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setProgramInstances(Set.of("nxP7UnKhomJ"));
     params.setProgramStage(programStage);
 
@@ -796,7 +796,7 @@ class EventExporterTest extends TrackerTest {
       Function<EventQueryParams, List<String>> eventFunction) {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setProgramInstances(Set.of("nxP7UnKhomJ", "TvctPPhpD8z"));
     params.setProgramStage(programStage);
 
@@ -823,7 +823,7 @@ class EventExporterTest extends TrackerTest {
       Function<EventQueryParams, List<String>> eventFunction) {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setProgramInstances(Set.of("nxP7UnKhomJ"));
     params.setProgramStage(programStage);
 
@@ -850,7 +850,7 @@ class EventExporterTest extends TrackerTest {
       Function<EventQueryParams, List<String>> eventFunction) {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setProgramInstances(Set.of("nxP7UnKhomJ", "TvctPPhpD8z"));
     params.setProgramStage(programStage);
 
@@ -872,7 +872,7 @@ class EventExporterTest extends TrackerTest {
   void testEnrollmentEnrolledBeforeSetToBeforeFirstEnrolledAtDate() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setEnrollmentEnrolledBefore(parseDate("2021-02-27T12:05:00.000"));
 
     List<String> enrollments =
@@ -887,7 +887,7 @@ class EventExporterTest extends TrackerTest {
   void testEnrollmentEnrolledBeforeEqualToFirstEnrolledAtDate() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setEnrollmentEnrolledBefore(parseDate("2021-02-28T12:05:00.000"));
 
     List<String> enrollments =
@@ -902,7 +902,7 @@ class EventExporterTest extends TrackerTest {
   void testEnrollmentEnrolledBeforeSetToAfterFirstEnrolledAtDate() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setEnrollmentEnrolledBefore(parseDate("2021-02-28T13:05:00.000"));
 
     List<String> enrollments =
@@ -917,7 +917,7 @@ class EventExporterTest extends TrackerTest {
   void testEnrollmentEnrolledAfterSetToBeforeLastEnrolledAtDate() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setEnrollmentEnrolledAfter(parseDate("2021-03-27T12:05:00.000"));
 
     List<String> enrollments =
@@ -932,7 +932,7 @@ class EventExporterTest extends TrackerTest {
   void testEnrollmentEnrolledAfterEqualToLastEnrolledAtDate() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setEnrollmentEnrolledAfter(parseDate("2021-03-28T12:05:00.000"));
 
     List<String> enrollments =
@@ -947,7 +947,7 @@ class EventExporterTest extends TrackerTest {
   void testEnrollmentEnrolledAfterSetToAfterLastEnrolledAtDate() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setEnrollmentEnrolledAfter(parseDate("2021-03-28T13:05:00.000"));
 
     List<String> enrollments =
@@ -962,7 +962,7 @@ class EventExporterTest extends TrackerTest {
   void testEnrollmentOccurredBeforeSetToBeforeFirstOccurredAtDate() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setEnrollmentOccurredBefore(parseDate("2021-02-27T12:05:00.000"));
 
     List<String> enrollments =
@@ -977,7 +977,7 @@ class EventExporterTest extends TrackerTest {
   void testEnrollmentOccurredBeforeEqualToFirstOccurredAtDate() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setEnrollmentOccurredBefore(parseDate("2021-02-28T12:05:00.000"));
 
     List<String> enrollments =
@@ -992,7 +992,7 @@ class EventExporterTest extends TrackerTest {
   void testEnrollmentOccurredBeforeSetToAfterFirstOccurredAtDate() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setEnrollmentOccurredBefore(parseDate("2021-02-28T13:05:00.000"));
 
     List<String> enrollments =
@@ -1007,7 +1007,7 @@ class EventExporterTest extends TrackerTest {
   void testEnrollmentOccurredAfterSetToBeforeLastOccurredAtDate() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setEnrollmentOccurredAfter(parseDate("2021-03-27T12:05:00.000"));
 
     List<String> enrollments =
@@ -1022,7 +1022,7 @@ class EventExporterTest extends TrackerTest {
   void testEnrollmentOccurredAfterEqualToLastOccurredAtDate() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setEnrollmentOccurredAfter(parseDate("2021-03-28T12:05:00.000"));
 
     List<String> enrollments =
@@ -1037,7 +1037,7 @@ class EventExporterTest extends TrackerTest {
   void testEnrollmentFilterNumericAttributes() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
 
     QueryItem queryItem = numericQueryItem("numericAttr");
     QueryFilter lessThan = new QueryFilter(QueryOperator.LT, "77");
@@ -1058,7 +1058,7 @@ class EventExporterTest extends TrackerTest {
   void testEnrollmentFilterAttributes() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
 
     params.addFilterAttributes(queryItem("toUpdate000", QueryOperator.EQ, "summer day"));
 
@@ -1074,7 +1074,7 @@ class EventExporterTest extends TrackerTest {
   void testEnrollmentFilterAttributesWithMultipleFiltersOnDifferentAttributes() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
 
     params.addFilterAttributes(
         List.of(
@@ -1093,7 +1093,7 @@ class EventExporterTest extends TrackerTest {
   void testEnrollmentFilterAttributesWithMultipleFiltersOnTheSameAttribute() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
 
     QueryItem item = queryItem("toUpdate000", QueryOperator.LIKE, "day");
     item.addFilter(new QueryFilter(QueryOperator.LIKE, "in"));
@@ -1111,7 +1111,7 @@ class EventExporterTest extends TrackerTest {
   void testOrderEventsOnAttributeAsc() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.addFilterAttributes(queryItem("toUpdate000"));
     params.addAttributeOrders(List.of(new OrderParam("toUpdate000", SortDirection.ASC)));
     params.addOrders(params.getAttributeOrders());
@@ -1128,7 +1128,7 @@ class EventExporterTest extends TrackerTest {
   void testOrderEventsOnAttributeDesc() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.addFilterAttributes(queryItem("toUpdate000"));
     params.addAttributeOrders(List.of(new OrderParam("toUpdate000", SortDirection.DESC)));
     params.addOrders(params.getAttributeOrders());
@@ -1145,7 +1145,7 @@ class EventExporterTest extends TrackerTest {
   void testOrderEventsOnMultipleAttributesDesc() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.addFilterAttributes(List.of(queryItem("toUpdate000"), queryItem("toDelete000")));
     params.addAttributeOrders(
         List.of(
@@ -1165,7 +1165,7 @@ class EventExporterTest extends TrackerTest {
   void testOrderEventsOnMultipleAttributesAsc() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.addFilterAttributes(List.of(queryItem("toUpdate000"), queryItem("toDelete000")));
     params.addAttributeOrders(
         List.of(
@@ -1187,7 +1187,7 @@ class EventExporterTest extends TrackerTest {
   @Test
   void shouldOrderEventsByMultipleAttributesAndPaginateWhenGivenNonDefaultPageSize() {
     EventQueryParams params = new EventQueryParams();
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.addFilterAttributes(List.of(queryItem("toUpdate000"), queryItem("toDelete000")));
     params.addAttributeOrders(
         List.of(
@@ -1225,7 +1225,7 @@ class EventExporterTest extends TrackerTest {
   void testEnrollmentOccurredAfterSetToAfterLastOccurredAtDate() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setEnrollmentOccurredAfter(parseDate("2021-03-28T13:05:00.000"));
 
     List<String> enrollments =
@@ -1240,7 +1240,7 @@ class EventExporterTest extends TrackerTest {
   void testOrderByEnrolledAtDesc() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.addOrders(List.of(new OrderParam("enrolledAt", SortDirection.DESC)));
 
     List<String> enrollments =
@@ -1255,7 +1255,7 @@ class EventExporterTest extends TrackerTest {
   void testOrderByEnrolledAtAsc() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.addOrders(List.of(new OrderParam("enrolledAt", SortDirection.ASC)));
 
     List<String> enrollments =
@@ -1270,7 +1270,7 @@ class EventExporterTest extends TrackerTest {
   void testOrderByOccurredAtDesc() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.addOrders(List.of(new OrderParam("occurredAt", SortDirection.DESC)));
 
     Events events = eventService.getEvents(params);
@@ -1282,7 +1282,7 @@ class EventExporterTest extends TrackerTest {
   void testOrderByOccurredAtAsc() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.addOrders(List.of(new OrderParam("occurredAt", SortDirection.ASC)));
 
     Events events = eventService.getEvents(params);
@@ -1294,7 +1294,7 @@ class EventExporterTest extends TrackerTest {
   void shouldReturnNoEventsWhenParamStartDueDateLaterThanEventDueDate() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setDueDateStart(parseDate("2021-02-28T13:05:00.000"));
 
     List<String> events = eventsFunction.apply(params);
@@ -1306,7 +1306,7 @@ class EventExporterTest extends TrackerTest {
   void shouldReturnEventsWhenParamStartDueDateEarlierThanEventsDueDate() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setDueDateStart(parseDate("2018-02-28T13:05:00.000"));
 
     List<String> events = eventsFunction.apply(params);
@@ -1318,7 +1318,7 @@ class EventExporterTest extends TrackerTest {
   void shouldReturnNoEventsWhenParamEndDueDateEarlierThanEventDueDate() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setDueDateEnd(parseDate("2018-02-28T13:05:00.000"));
 
     List<String> events = eventsFunction.apply(params);
@@ -1330,7 +1330,7 @@ class EventExporterTest extends TrackerTest {
   void shouldReturnEventsWhenParamEndDueDateLaterThanEventsDueDate() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.setDueDateEnd(parseDate("2021-02-28T13:05:00.000"));
 
     List<String> events = eventsFunction.apply(params);
@@ -1342,7 +1342,7 @@ class EventExporterTest extends TrackerTest {
   void shouldSortEntitiesRespectingOrderWhenAttributeOrderSuppliedBeforeOrderParam() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.addFilterAttributes(List.of(queryItem("toUpdate000")));
     params.addAttributeOrders(List.of(new OrderParam("toUpdate000", SortDirection.ASC)));
     params.addOrders(
@@ -1362,7 +1362,7 @@ class EventExporterTest extends TrackerTest {
   void shouldSortEntitiesRespectingOrderWhenOrderParamSuppliedBeforeAttributeOrder() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.addFilterAttributes(List.of(queryItem("toUpdate000")));
     params.addAttributeOrders(List.of(new OrderParam("toUpdate000", SortDirection.DESC)));
     params.addOrders(
@@ -1382,7 +1382,7 @@ class EventExporterTest extends TrackerTest {
   void shouldSortEntitiesRespectingOrderWhenDataElementSuppliedBeforeOrderParam() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.addDataElements(List.of(queryItem("DATAEL00006")));
     params.addGridOrders(List.of(new OrderParam("DATAEL00006", SortDirection.DESC)));
 
@@ -1404,7 +1404,7 @@ class EventExporterTest extends TrackerTest {
   void shouldSortEntitiesRespectingOrderWhenOrderParamSuppliedBeforeDataElement() {
     EventQueryParams params = new EventQueryParams();
     params.setOrgUnitSelectionMode(OrganisationUnitSelectionMode.SELECTED);
-    params.setAccessibleOrgUnits(List.of(orgUnit));
+    params.setOrgUnit(orgUnit);
     params.addDataElements(List.of(queryItem("DATAEL00006")));
     params.addGridOrders(List.of(new OrderParam("DATAEL00006", SortDirection.DESC)));
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventRequestToSearchParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventRequestToSearchParamsMapper.java
@@ -262,6 +262,7 @@ class EventRequestToSearchParamsMapper {
     }
 
     if (requestedOrgUnit != null
+        && !user.isSuper()
         && !organisationUnitService.isInUserHierarchy(
             requestedOrgUnit.getUid(), user.getTeiSearchOrganisationUnitsWithFallback())) {
       throw new ForbiddenException(

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/EventRequestToSearchParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/EventRequestToSearchParamsMapperTest.java
@@ -412,10 +412,12 @@ class EventRequestToSearchParamsMapperTest {
       names = {"SELECTED", "ACCESSIBLE", "DESCENDANTS", "CHILDREN"})
   void shouldFailWhenOuModeRequiresUserScopeOrgUnitAndUserHasNoOrgUnitsAssigned(
       OrganisationUnitSelectionMode orgUnitMode) {
+    User user = new User();
+    Program program = new Program();
     Exception exception =
         assertThrows(
             IllegalQueryException.class,
-            () -> validateOrgUnitMode(orgUnitMode, new User(), new Program(), null));
+            () -> validateOrgUnitMode(orgUnitMode, user, program, null));
 
     assertEquals(
         "User needs to be assigned either search or data capture org units",

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/EventRequestToSearchParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/EventRequestToSearchParamsMapperTest.java
@@ -32,12 +32,11 @@ import static org.hisp.dhis.common.AccessLevel.OPEN;
 import static org.hisp.dhis.common.AccessLevel.PROTECTED;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CHILDREN;
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.DESCENDANTS;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.SELECTED;
-import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.hisp.dhis.webapi.controller.tracker.export.TrackerEventCriteriaMapperUtils.validateOrgUnitMode;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -156,8 +155,11 @@ class EventRequestToSearchParamsMapperTest {
             createOrgUnit("searchScopeChild", "searchScopeChildUid")));
   }
 
-  @Test
-  void shouldMapCaptureScopeOrgUnitWhenProgramProtectedAndOuModeDescendants()
+  @ParameterizedTest
+  @EnumSource(
+      value = OrganisationUnitSelectionMode.class,
+      names = {"SELECTED", "DESCENDANTS", "CHILDREN", "ACCESSIBLE", "CAPTURE"})
+  void shouldMapRequestedOrgUnitWhenProgramProtected(OrganisationUnitSelectionMode orgUnitMode)
       throws ForbiddenException {
     Program program = new Program();
     program.setAccessLevel(PROTECTED);
@@ -173,138 +175,57 @@ class EventRequestToSearchParamsMapperTest {
     when(organisationUnitService.getOrganisationUnitWithChildren(orgUnitId))
         .thenReturn(orgUnitDescendants);
 
+    when(organisationUnitService.isInUserHierarchy(
+            orgUnitId, user.getTeiSearchOrganisationUnitsWithFallback()))
+        .thenReturn(true);
+
     EventCriteria eventCriteria = new EventCriteria();
     eventCriteria.setProgram(program.getUid());
     eventCriteria.setOrgUnit(orgUnitId);
-    eventCriteria.setOuMode(DESCENDANTS);
+    eventCriteria.setOuMode(orgUnitMode);
 
     EventQueryParams queryParams = mapper.map(eventCriteria);
 
-    assertContainsOnly(List.of(captureScopeOrgUnit), queryParams.getAccessibleOrgUnits());
+    assertEquals(orgUnitId, queryParams.getOrgUnit().getUid());
   }
 
-  @Test
-  void shouldMapSearchScopeOrgUnitWhenProgramOpenAndOuModeDescendants() throws ForbiddenException {
-    Program program = new Program();
-    program.setAccessLevel(OPEN);
-    OrganisationUnit searchScopeOrgUnit = createOrgUnit("searchScopeOrgUnit", "uid4");
-    User user = new User();
-    user.setTeiSearchOrganisationUnits(Set.of(searchScopeOrgUnit));
-
-    when(currentUserService.getCurrentUser()).thenReturn(user);
-    when(organisationUnitService.getOrganisationUnit(orgUnit.getUid())).thenReturn(orgUnit);
-    when(organisationUnitService.getOrganisationUnitWithChildren(orgUnitId))
-        .thenReturn(orgUnitDescendants);
-
-    EventCriteria eventCriteria = new EventCriteria();
-    eventCriteria.setProgram(program.getUid());
-    eventCriteria.setOrgUnit(orgUnit.getUid());
-    eventCriteria.setOuMode(DESCENDANTS);
-
-    EventQueryParams queryParams = mapper.map(eventCriteria);
-
-    assertContainsOnly(List.of(searchScopeOrgUnit), queryParams.getAccessibleOrgUnits());
-  }
-
-  @Test
-  void shouldFailWhenProgramProtectedAndOuModeDescendantsAndUserHasNoAccessToCaptureScopeOrgUnit() {
-    Program program = new Program();
-    program.setUid(PROGRAM_UID);
-    program.setAccessLevel(PROTECTED);
-    OrganisationUnit captureScopeOrgUnit = createOrgUnit("made up org unit", "made up uid");
-    User user = new User();
-    user.setOrganisationUnits(Set.of(captureScopeOrgUnit));
-
-    when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
-    when(currentUserService.getCurrentUser()).thenReturn(user);
-    when(organisationUnitService.getOrganisationUnit(orgUnit.getUid())).thenReturn(orgUnit);
-    when(organisationUnitService.getOrganisationUnitWithChildren(orgUnitId))
-        .thenReturn(orgUnitDescendants);
-
-    EventCriteria eventCriteria = new EventCriteria();
-    eventCriteria.setProgram(program.getUid());
-    eventCriteria.setOrgUnit(orgUnit.getUid());
-    eventCriteria.setOuMode(DESCENDANTS);
-
-    ForbiddenException exception =
-        assertThrows(ForbiddenException.class, () -> mapper.map(eventCriteria));
-    assertEquals(
-        "User does not have access to orgUnit: " + orgUnit.getUid(), exception.getMessage());
-  }
-
-  @Test
-  void shouldFailWhenProgramOpenAndOuModeDescendantsAndUserHasNoAccessToSearchScopeOrgUnit() {
-    Program program = new Program();
-    program.setAccessLevel(OPEN);
-    OrganisationUnit searchScopeOrgUnit = createOrgUnit("made up org unit", "made up uid");
-    User user = new User();
-    user.setTeiSearchOrganisationUnits(Set.of(searchScopeOrgUnit));
-
-    EventCriteria eventCriteria = new EventCriteria();
-    eventCriteria.setProgram(program.getUid());
-    eventCriteria.setOrgUnit(orgUnit.getUid());
-    eventCriteria.setOuMode(DESCENDANTS);
-
-    when(currentUserService.getCurrentUser()).thenReturn(user);
-    when(organisationUnitService.getOrganisationUnit(orgUnit.getUid())).thenReturn(orgUnit);
-    when(organisationUnitService.getOrganisationUnitWithChildren(orgUnitId))
-        .thenReturn(orgUnitDescendants);
-
-    ForbiddenException exception =
-        assertThrows(ForbiddenException.class, () -> mapper.map(eventCriteria));
-    assertEquals(
-        "User does not have access to orgUnit: " + orgUnit.getUid(), exception.getMessage());
-  }
-
-  @Test
-  void shouldMapCaptureScopeOrgUnitWhenProgramProtectedAndOuModeChildren()
+  @ParameterizedTest
+  @EnumSource(
+      value = OrganisationUnitSelectionMode.class,
+      names = {"SELECTED", "DESCENDANTS", "CHILDREN", "ACCESSIBLE", "CAPTURE"})
+  void shouldMapRequestedOrgUnitWhenProgramOpen(OrganisationUnitSelectionMode orgUnitMode)
       throws ForbiddenException {
     Program program = new Program();
-    program.setUid(PROGRAM_UID);
-    program.setAccessLevel(PROTECTED);
-    OrganisationUnit captureScopeOrgUnit =
-        createOrgUnit("captureScopeChild", "captureScopeChildUid");
-    User user = new User();
-    user.setOrganisationUnits(Set.of(captureScopeOrgUnit));
-
-    EventCriteria eventCriteria = new EventCriteria();
-    eventCriteria.setProgram(program.getUid());
-    eventCriteria.setOrgUnit(orgUnit.getUid());
-    eventCriteria.setOuMode(CHILDREN);
-
-    when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
-    when(currentUserService.getCurrentUser()).thenReturn(user);
-    when(organisationUnitService.getOrganisationUnit(orgUnit.getUid())).thenReturn(orgUnit);
-
-    EventQueryParams queryParams = mapper.map(eventCriteria);
-
-    assertContainsOnly(List.of(captureScopeOrgUnit), queryParams.getAccessibleOrgUnits());
-  }
-
-  @Test
-  void shouldMapSearchScopeOrgUnitWhenProgramOpenAndOuModeChildren() throws ForbiddenException {
-    Program program = new Program();
     program.setAccessLevel(OPEN);
-    OrganisationUnit searchScopeOrgUnit = createOrgUnit("searchScopeChild", "searchScopeChildUid");
+    OrganisationUnit searchScopeOrgUnit = createOrgUnit("searchScopeOrgUnit", "uid4");
     User user = new User();
     user.setTeiSearchOrganisationUnits(Set.of(searchScopeOrgUnit));
+    user.setOrganisationUnits(Set.of(searchScopeOrgUnit));
+
+    when(currentUserService.getCurrentUser()).thenReturn(user);
+    when(organisationUnitService.getOrganisationUnit(orgUnit.getUid())).thenReturn(orgUnit);
+    when(organisationUnitService.getOrganisationUnitWithChildren(orgUnitId))
+        .thenReturn(orgUnitDescendants);
+    when(organisationUnitService.isInUserHierarchy(
+            orgUnitId, user.getTeiSearchOrganisationUnitsWithFallback()))
+        .thenReturn(true);
 
     EventCriteria eventCriteria = new EventCriteria();
     eventCriteria.setProgram(program.getUid());
     eventCriteria.setOrgUnit(orgUnit.getUid());
-    eventCriteria.setOuMode(CHILDREN);
-
-    when(currentUserService.getCurrentUser()).thenReturn(user);
-    when(organisationUnitService.getOrganisationUnit(orgUnit.getUid())).thenReturn(orgUnit);
+    eventCriteria.setOuMode(orgUnitMode);
 
     EventQueryParams queryParams = mapper.map(eventCriteria);
 
-    assertContainsOnly(List.of(searchScopeOrgUnit), queryParams.getAccessibleOrgUnits());
+    assertEquals(orgUnitId, queryParams.getOrgUnit().getUid());
   }
 
-  @Test
-  void shouldFailWhenProgramProtectedAndOuModeChildrenAndUserHasNoAccessToCaptureScopeOrgUnit() {
+  @ParameterizedTest
+  @EnumSource(
+      value = OrganisationUnitSelectionMode.class,
+      names = {"SELECTED", "DESCENDANTS", "CHILDREN", "ACCESSIBLE", "CAPTURE"})
+  void shouldFailWhenProgramProtectedAndUserHasNoAccessToCaptureScopeOrgUnit(
+      OrganisationUnitSelectionMode orgUnitMode) {
     Program program = new Program();
     program.setUid(PROGRAM_UID);
     program.setAccessLevel(PROTECTED);
@@ -315,102 +236,50 @@ class EventRequestToSearchParamsMapperTest {
     when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
     when(currentUserService.getCurrentUser()).thenReturn(user);
     when(organisationUnitService.getOrganisationUnit(orgUnit.getUid())).thenReturn(orgUnit);
+    when(organisationUnitService.getOrganisationUnitWithChildren(orgUnitId))
+        .thenReturn(orgUnitDescendants);
+    when(aclService.canDataRead(user, program)).thenReturn(true);
 
     EventCriteria eventCriteria = new EventCriteria();
     eventCriteria.setProgram(program.getUid());
     eventCriteria.setOrgUnit(orgUnit.getUid());
-    eventCriteria.setOuMode(CHILDREN);
+    eventCriteria.setOuMode(orgUnitMode);
 
     ForbiddenException exception =
         assertThrows(ForbiddenException.class, () -> mapper.map(eventCriteria));
     assertEquals(
-        "User does not have access to orgUnit: " + orgUnit.getUid(), exception.getMessage());
+        "Organisation unit is not part of the search scope: " + orgUnit.getUid(),
+        exception.getMessage());
   }
 
-  @Test
-  void shouldFailWhenProgramOpenAndOuModeChildrenAndUserHasNoAccessToSearchScopeOrgUnit() {
+  @ParameterizedTest
+  @EnumSource(
+      value = OrganisationUnitSelectionMode.class,
+      names = {"SELECTED", "DESCENDANTS", "CHILDREN", "ACCESSIBLE", "CAPTURE"})
+  void shouldFailWhenProgramOpenAndUserHasNoAccessToSearchScopeOrgUnit(
+      OrganisationUnitSelectionMode orgUnitMode) {
     Program program = new Program();
     program.setAccessLevel(OPEN);
     OrganisationUnit searchScopeOrgUnit = createOrgUnit("made up org unit", "made up uid");
     User user = new User();
     user.setTeiSearchOrganisationUnits(Set.of(searchScopeOrgUnit));
-
-    when(currentUserService.getCurrentUser()).thenReturn(user);
-    when(organisationUnitService.getOrganisationUnit(orgUnit.getUid())).thenReturn(orgUnit);
+    user.setOrganisationUnits(Set.of(searchScopeOrgUnit));
 
     EventCriteria eventCriteria = new EventCriteria();
     eventCriteria.setProgram(program.getUid());
     eventCriteria.setOrgUnit(orgUnit.getUid());
-    eventCriteria.setOuMode(CHILDREN);
+    eventCriteria.setOuMode(orgUnitMode);
+
+    when(currentUserService.getCurrentUser()).thenReturn(user);
+    when(organisationUnitService.getOrganisationUnit(orgUnit.getUid())).thenReturn(orgUnit);
+    when(organisationUnitService.getOrganisationUnitWithChildren(orgUnitId))
+        .thenReturn(orgUnitDescendants);
 
     ForbiddenException exception =
         assertThrows(ForbiddenException.class, () -> mapper.map(eventCriteria));
     assertEquals(
-        "User does not have access to orgUnit: " + orgUnit.getUid(), exception.getMessage());
-  }
-
-  @Test
-  void shouldMapCaptureScopeOrgUnitWhenOuModeCapture() throws ForbiddenException {
-    Program program = new Program();
-    program.setAccessLevel(OPEN);
-    OrganisationUnit captureScopeOrgUnit = createOrgUnit("captureScopeOrgUnit", "uid4");
-    User user = new User();
-    user.setOrganisationUnits(Set.of(captureScopeOrgUnit));
-
-    when(currentUserService.getCurrentUser()).thenReturn(user);
-    when(organisationUnitService.getOrganisationUnit(orgUnit.getUid())).thenReturn(orgUnit);
-
-    EventCriteria eventCriteria = new EventCriteria();
-    eventCriteria.setProgram(program.getUid());
-    eventCriteria.setOuMode(CAPTURE);
-
-    EventQueryParams queryParams = mapper.map(eventCriteria);
-
-    assertContainsOnly(List.of(captureScopeOrgUnit), queryParams.getAccessibleOrgUnits());
-  }
-
-  @Test
-  void shouldMapSearchScopeOrgUnitWhenOuModeAccessible() throws ForbiddenException {
-    Program program = new Program();
-    program.setAccessLevel(OPEN);
-    OrganisationUnit searchScopeOrgUnit = createOrgUnit("searchScopeOrgUnit", "uid4");
-    User user = new User();
-    user.setOrganisationUnits(Set.of(searchScopeOrgUnit));
-
-    when(currentUserService.getCurrentUser()).thenReturn(user);
-    when(organisationUnitService.getOrganisationUnit(orgUnit.getUid())).thenReturn(orgUnit);
-
-    EventCriteria eventCriteria = new EventCriteria();
-    eventCriteria.setProgram(program.getUid());
-    eventCriteria.setOuMode(ACCESSIBLE);
-
-    EventQueryParams queryParams = mapper.map(eventCriteria);
-
-    assertContainsOnly(List.of(searchScopeOrgUnit), queryParams.getAccessibleOrgUnits());
-  }
-
-  @Test
-  void shouldMapRequestedOrgUnitWhenOuModeSelected() throws ForbiddenException {
-    Program program = new Program();
-    program.setUid(PROGRAM_UID);
-    OrganisationUnit searchScopeOrgUnit = createOrgUnit("searchScopeOrgUnit", "uid4");
-    User user = new User();
-    user.setOrganisationUnits(Set.of(searchScopeOrgUnit));
-
-    when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
-    when(aclService.canDataRead(user, program)).thenReturn(true);
-    when(currentUserService.getCurrentUser()).thenReturn(user);
-    when(organisationUnitService.getOrganisationUnit(orgUnit.getUid())).thenReturn(orgUnit);
-    when(trackerAccessManager.canAccess(user, program, orgUnit)).thenReturn(true);
-
-    EventCriteria eventCriteria = new EventCriteria();
-    eventCriteria.setProgram(program.getUid());
-    eventCriteria.setOrgUnit(orgUnit.getUid());
-    eventCriteria.setOuMode(SELECTED);
-
-    EventQueryParams queryParams = mapper.map(eventCriteria);
-
-    assertContainsOnly(List.of(orgUnit), queryParams.getAccessibleOrgUnits());
+        "Organisation unit is not part of the search scope: " + orgUnit.getUid(),
+        exception.getMessage());
   }
 
   @Test
@@ -418,15 +287,17 @@ class EventRequestToSearchParamsMapperTest {
       throws ForbiddenException {
     Program program = new Program();
     program.setUid(PROGRAM_UID);
-    OrganisationUnit searchScopeOrgUnit = createOrgUnit("searchScopeOrgUnit", "uid4");
     User user = new User();
-    user.setOrganisationUnits(Set.of(searchScopeOrgUnit));
+    user.setOrganisationUnits(Set.of(orgUnit));
 
     when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
     when(aclService.canDataRead(user, program)).thenReturn(true);
     when(currentUserService.getCurrentUser()).thenReturn(user);
     when(organisationUnitService.getOrganisationUnit(orgUnit.getUid())).thenReturn(orgUnit);
     when(trackerAccessManager.canAccess(user, program, orgUnit)).thenReturn(true);
+    when(organisationUnitService.isInUserHierarchy(
+            orgUnitId, user.getTeiSearchOrganisationUnitsWithFallback()))
+        .thenReturn(true);
 
     EventCriteria eventCriteria = new EventCriteria();
     eventCriteria.setProgram(program.getUid());
@@ -435,11 +306,11 @@ class EventRequestToSearchParamsMapperTest {
     EventQueryParams queryParams = mapper.map(eventCriteria);
 
     assertEquals(SELECTED, queryParams.getOrgUnitSelectionMode());
-    assertContainsOnly(List.of(orgUnit), queryParams.getAccessibleOrgUnits());
+    assertEquals(orgUnit, queryParams.getOrgUnit());
   }
 
   @Test
-  void shouldMapRequestedOrgUnitAsAccessibleWhenNoOrgUnitProvidedAndNoOrgUnitModeProvided()
+  void shouldMapOrgUnitModeAccessibleWhenNoOrgUnitProvidedAndNoOrgUnitModeProvided()
       throws ForbiddenException {
     Program program = new Program();
     program.setAccessLevel(OPEN);
@@ -456,7 +327,7 @@ class EventRequestToSearchParamsMapperTest {
     EventQueryParams queryParams = mapper.map(eventCriteria);
 
     assertEquals(ACCESSIBLE, queryParams.getOrgUnitSelectionMode());
-    assertContainsOnly(List.of(searchScopeOrgUnit), queryParams.getAccessibleOrgUnits());
+    assertNull(queryParams.getOrgUnit());
   }
 
   @Test
@@ -477,7 +348,8 @@ class EventRequestToSearchParamsMapperTest {
     ForbiddenException exception =
         assertThrows(ForbiddenException.class, () -> mapper.map(eventCriteria));
     assertEquals(
-        "User does not have access to orgUnit: " + orgUnit.getUid(), exception.getMessage());
+        "Organisation unit is not part of the search scope: " + orgUnit.getUid(),
+        exception.getMessage());
   }
 
   @ParameterizedTest
@@ -490,7 +362,8 @@ class EventRequestToSearchParamsMapperTest {
 
     IllegalQueryException exception =
         assertThrows(IllegalQueryException.class, () -> mapper.map(eventCriteria));
-    assertEquals("Organisation unit is required for ouMode: " + mode, exception.getMessage());
+    assertEquals(
+        "Organisation unit is required for org unit mode: " + mode, exception.getMessage());
   }
 
   @ParameterizedTest
@@ -507,6 +380,48 @@ class EventRequestToSearchParamsMapperTest {
     assertDoesNotThrow(() -> mapper.map(eventCriteria));
   }
 
+  @Test
+  void shouldFailWhenModeAccessibleAndUserScopeNotSet() {
+    when(currentUserService.getCurrentUser()).thenReturn(new User());
+
+    EventCriteria eventCriteria = new EventCriteria();
+    eventCriteria.setOuMode(ACCESSIBLE);
+
+    Exception exception =
+        assertThrows(IllegalQueryException.class, () -> mapper.map(eventCriteria));
+    assertEquals(
+        "User needs to be assigned either search or data capture org units",
+        exception.getMessage());
+  }
+
+  @Test
+  void shouldFailWhenModeCaptureAndUserCaptureScopeNotSet() {
+    when(currentUserService.getCurrentUser()).thenReturn(new User());
+
+    EventCriteria eventCriteria = new EventCriteria();
+    eventCriteria.setOuMode(CAPTURE);
+
+    Exception exception =
+        assertThrows(IllegalQueryException.class, () -> mapper.map(eventCriteria));
+    assertEquals("User needs to be assigned data capture org units", exception.getMessage());
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = OrganisationUnitSelectionMode.class,
+      names = {"SELECTED", "ACCESSIBLE", "DESCENDANTS", "CHILDREN"})
+  void shouldFailWhenOuModeRequiresUserScopeOrgUnitAndUserHasNoOrgUnitsAssigned(
+      OrganisationUnitSelectionMode orgUnitMode) {
+    Exception exception =
+        assertThrows(
+            IllegalQueryException.class,
+            () -> validateOrgUnitMode(orgUnitMode, new User(), new Program(), null));
+
+    assertEquals(
+        "User needs to be assigned either search or data capture org units",
+        exception.getMessage());
+  }
+
   private OrganisationUnit createOrgUnit(String name, String uid) {
     OrganisationUnit orgUnit = new OrganisationUnit(name);
     orgUnit.setUid(uid);
@@ -519,6 +434,7 @@ class EventRequestToSearchParamsMapperTest {
     userRole.setAuthorities(
         Set.of(Authorities.F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS.name()));
     user.setUserRoles(Set.of(userRole));
+    user.setOrganisationUnits(Set.of(orgUnit));
 
     return user;
   }


### PR DESCRIPTION
`/events` need to use the search scope to validate the org unit in any incoming requests, regardless of the program access level.
This means that we will consider a request to be valid as long as the org unit in the request is in the user's search scope.
If the program is restricted (protected or closed), we will make sure to use the capture scope when we run the sql query, and worst case we would return an empty collection when no org units are present in the user capture scope, but we would not return an exception, as we did so far.

Ticket: https://dhis2.atlassian.net/browse/TECH-1630