### PR TITLE
fix: Exp. analytics crash due to invalid date/year [DHIS2-15573]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/resourcetable/ResourceTableStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/resourcetable/ResourceTableStore.java
@@ -35,18 +35,6 @@ import java.util.List;
 public interface ResourceTableStore {
   String ID = ResourceTableStore.class.getName();
 
-  String TABLE_NAME_CATEGORY_OPTION_COMBO_NAME = "_categoryoptioncomboname";
-
-  String TABLE_NAME_DATA_ELEMENT_STRUCTURE = "_dataelementstructure";
-
-  String TABLE_NAME_PERIOD_STRUCTURE = "_periodstructure";
-
-  String TABLE_NAME_DATE_PERIOD_STRUCTURE = "_dateperiodstructure";
-
-  String TABLE_NAME_DATA_ELEMENT_CATEGORY_OPTION_COMBO = "_dataelementcategoryoptioncombo";
-
-  String TABLE_NAME_DATA_APPROVAL_MIN_LEVEL = "_dataapprovalminlevel";
-
   /**
    * Generates the given resource table.
    *

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/DefaultResourceTableService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/DefaultResourceTableService.java
@@ -27,10 +27,12 @@
  */
 package org.hisp.dhis.resourcetable;
 
+import static java.time.temporal.ChronoUnit.YEARS;
 import static java.util.Comparator.reverseOrder;
 import static java.util.stream.Collectors.toList;
 
 import com.google.common.collect.Lists;
+import java.time.Year;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -67,6 +69,7 @@ import org.hisp.dhis.resourcetable.table.OrganisationUnitGroupSetResourceTable;
 import org.hisp.dhis.resourcetable.table.OrganisationUnitStructureResourceTable;
 import org.hisp.dhis.resourcetable.table.PeriodResourceTable;
 import org.hisp.dhis.scheduling.JobProgress;
+import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.sqlview.SqlView;
 import org.hisp.dhis.sqlview.SqlViewService;
 import org.springframework.stereotype.Service;
@@ -179,9 +182,48 @@ public class DefaultResourceTableService implements ResourceTableService {
 
   @Override
   public void generateDatePeriodTable() {
+    List<Integer> availableYears = periodDataProvider.getAvailableYears();
+    checkYearsOffset(availableYears);
+
     resourceTableStore.generateResourceTable(
-        new DatePeriodResourceTable(
-            periodDataProvider.getAvailableYears(), analyticsExportSettings.getTableType()));
+        new DatePeriodResourceTable(availableYears, analyticsExportSettings.getTableType()));
+  }
+
+  /**
+   * This method checks if any of the year in the given list is within the offset defined in system
+   * settings. The constant where the offset is defined can be seen at {@link
+   * SettingKey.ANALYTICS_MAX_PERIOD_YEARS_OFFSET}.
+   *
+   * <p>Based on the current year YYYY and the defined offset X. This method allows a range of X
+   * years in the past and X years in the future. Including also the current year YYYY. So, for
+   * YYYY=2023 and offset=2, the valid range would be [2021,2022,2023,2024,2025].
+   *
+   * @param yearsToCheck the list of years to be checked.
+   */
+  private void checkYearsOffset(List<Integer> yearsToCheck) {
+    int maxYearsOffset = analyticsExportSettings.getMaxPeriodYearsOffset();
+    int minRangeAllowed = Year.now().minus(maxYearsOffset, YEARS).getValue();
+    int maxRangeAllowed = Year.now().plus(maxYearsOffset, YEARS).getValue();
+
+    boolean yearsOutOfRange =
+        yearsToCheck.stream().anyMatch(year -> year < minRangeAllowed || year > maxRangeAllowed);
+
+    if (yearsOutOfRange) {
+      String errorMessage = "Your database contains years out of the allowed offset.";
+      errorMessage +=
+          "\n Range of years allowed (based on your system settings and existing data): "
+              + yearsToCheck.stream()
+                  .filter(year -> year >= minRangeAllowed && year <= maxRangeAllowed)
+                  .collect(toList())
+              + ".";
+      errorMessage +=
+          "\n Years are out of range found: "
+              + yearsToCheck.stream()
+                  .filter(year -> year < minRangeAllowed || year > maxRangeAllowed)
+                  .collect(toList())
+              + ".";
+      throw new RuntimeException(errorMessage);
+    }
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DatePeriodResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DatePeriodResourceTable.java
@@ -27,13 +27,13 @@
  */
 package org.hisp.dhis.resourcetable.table;
 
+import static java.util.stream.Collectors.toList;
 import static org.hisp.dhis.system.util.SqlUtils.quote;
 
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.hisp.dhis.calendar.Calendar;
 import org.hisp.dhis.commons.collection.UniqueArrayList;
 import org.hisp.dhis.period.Cal;
@@ -49,8 +49,14 @@ import org.hisp.dhis.resourcetable.ResourceTableType;
 public class DatePeriodResourceTable extends ResourceTable<Integer> {
   private final String tableType;
 
-  public DatePeriodResourceTable(List<Integer> objects, String tableType) {
-    super(objects);
+  /**
+   * Constructor method.
+   *
+   * @param years the list of years that periods will be generated for.
+   * @param tableType the table type.
+   */
+  public DatePeriodResourceTable(List<Integer> years, String tableType) {
+    super(years);
     this.tableType = tableType;
   }
 
@@ -97,15 +103,14 @@ public class DatePeriodResourceTable extends ResourceTable<Integer> {
     List<Period> dailyPeriods = new DailyPeriodType().generatePeriods(startDate, endDate);
 
     List<Date> days =
-        new UniqueArrayList<>(
-            dailyPeriods.stream().map(Period::getStartDate).collect(Collectors.toList()));
+        new UniqueArrayList<>(dailyPeriods.stream().map(Period::getStartDate).collect(toList()));
 
     Calendar calendar = PeriodType.getCalendar();
 
     for (Date day : days) {
       List<Object> values = new ArrayList<>();
 
-      final int year = PeriodType.getCalendar().fromIso(day).getYear();
+      int year = PeriodType.getCalendar().fromIso(day).getYear();
 
       values.add(day);
       values.add(year);

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/resourcetable/DefaultResourceTableServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/resourcetable/DefaultResourceTableServiceTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.resourcetable;
+
+import static java.time.temporal.ChronoUnit.YEARS;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+import java.time.Year;
+import java.util.List;
+import org.hisp.dhis.analytics.AnalyticsExportSettings;
+import org.hisp.dhis.period.PeriodDataProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultResourceTableServiceTest {
+
+  @InjectMocks private DefaultResourceTableService defaultResourceTableService;
+
+  @Mock private PeriodDataProvider periodDataProvider;
+
+  @Mock private AnalyticsExportSettings analyticsExportSettings;
+
+  @Mock private ResourceTableStore resourceTableStore;
+
+  @Test
+  void generateDatePeriodTableWhenYearIsOutOfRange() {
+    // Given
+    List<Integer> yearsToCheck = List.of(2000, 2001, 2002, 2003, 2004);
+    int defaultOffset = 22;
+
+    // When
+    when(periodDataProvider.getAvailableYears()).thenReturn(yearsToCheck);
+    when(analyticsExportSettings.getMaxPeriodYearsOffset()).thenReturn(defaultOffset);
+
+    // Then
+    RuntimeException exception =
+        assertThrows(
+            RuntimeException.class, () -> defaultResourceTableService.generateDatePeriodTable());
+
+    assertTrue(
+        exception.getMessage().contains("Your database contains years out of the allowed offset"));
+  }
+
+  @Test
+  void generateDatePeriodTableWhenOffsetIsZeroWithPreviousYears() {
+    // Given
+    List<Integer> yearsToCheck = List.of(2000, 2001, 2002, 2003, 2004);
+    int zeroOffset = 0;
+
+    // When
+    when(periodDataProvider.getAvailableYears()).thenReturn(yearsToCheck);
+    when(analyticsExportSettings.getMaxPeriodYearsOffset()).thenReturn(zeroOffset);
+
+    // Then
+    RuntimeException exception =
+        assertThrows(
+            RuntimeException.class, () -> defaultResourceTableService.generateDatePeriodTable());
+
+    assertTrue(
+        exception.getMessage().contains("Your database contains years out of the allowed offset"));
+  }
+
+  @Test
+  void generateDatePeriodTableWhenOffsetIsZeroWithCurrentYear() {
+    // Given
+    List<Integer> yearsToCheck = List.of(Year.now().getValue());
+    int zeroOffset = 0;
+
+    // When
+    when(periodDataProvider.getAvailableYears()).thenReturn(yearsToCheck);
+    when(analyticsExportSettings.getMaxPeriodYearsOffset()).thenReturn(zeroOffset);
+    doNothing().when(resourceTableStore).generateResourceTable(any());
+
+    // Then
+    assertDoesNotThrow(() -> defaultResourceTableService.generateDatePeriodTable());
+  }
+
+  @Test
+  void generateDatePeriodTableWhenYearsAreInExpectedRange() {
+    // Given
+    List<Integer> yearsToCheck =
+        List.of(
+            Year.now().getValue(),
+            Year.now().plus(1, YEARS).getValue(),
+            Year.now().plus(2, YEARS).getValue());
+    int defaultOffset = 2;
+
+    // When
+    when(periodDataProvider.getAvailableYears()).thenReturn(yearsToCheck);
+    when(analyticsExportSettings.getMaxPeriodYearsOffset()).thenReturn(defaultOffset);
+    doNothing().when(resourceTableStore).generateResourceTable(any());
+
+    // Then
+    assertDoesNotThrow(() -> defaultResourceTableService.generateDatePeriodTable());
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/analytics/AnalyticsExportSettings.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/analytics/AnalyticsExportSettings.java
@@ -29,9 +29,11 @@ package org.hisp.dhis.analytics;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_TABLE_UNLOGGED;
+import static org.hisp.dhis.setting.SettingKey.ANALYTICS_MAX_PERIOD_YEARS_OFFSET;
 
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.setting.SystemSettingManager;
 import org.springframework.stereotype.Component;
 
 /**
@@ -44,6 +46,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class AnalyticsExportSettings {
   private final DhisConfigurationProvider dhisConfigurationProvider;
+
+  private final SystemSettingManager systemSettingManager;
 
   private static final String UNLOGGED = "unlogged";
 
@@ -59,5 +63,15 @@ public class AnalyticsExportSettings {
     }
 
     return EMPTY;
+  }
+
+  /**
+   * Returns the years' offset defined for the period generation. See {@link
+   * ANALYTICS_MAX_PERIOD_YEARS_OFFSET}.
+   *
+   * @return the offset defined in system settings.
+   */
+  public int getMaxPeriodYearsOffset() {
+    return systemSettingManager.getIntSetting(ANALYTICS_MAX_PERIOD_YEARS_OFFSET);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
@@ -240,7 +240,10 @@ public enum SettingKey {
 
   /** The cache time to live value for the analytics API. */
   ANALYTICS_CACHE_TTL_MODE(
-      "keyAnalyticsCacheTtlMode", AnalyticsCacheTtlMode.FIXED, AnalyticsCacheTtlMode.class);
+      "keyAnalyticsCacheTtlMode", AnalyticsCacheTtlMode.FIXED, AnalyticsCacheTtlMode.class),
+
+  /** The offset of years used during period generation during the analytics export process. */
+  ANALYTICS_MAX_PERIOD_YEARS_OFFSET("keyAnalyticsPeriodYearsOffset", 22, Integer.class);
 
   private final String name;
 


### PR DESCRIPTION
**_[Backport from master/2.41]_** (#15039)

This fix is related to the analytics offset dates problem that happens during the Analytics Export process.

After internal discussion, we decided to add a new variable in "System Settings" representing a single number/offset to be used in the export process.

So, let’s suppose that the user/admin sets the offset value to “5”, and we are in the year 2023.

It means that analytics will accept dates from 2018 (inclusive) to 2028 (inclusive). Which translates to: [2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026, 2027, 2028].

If dates out of that year’s range are found the system sends back a warning message and also aborts the export process (through the job progress component).
