### PR TITLE
fix: use default Locale.ENGLISH for PdfUtils

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/GridUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/GridUtils.java
@@ -171,8 +171,11 @@ public class GridUtils {
 
   private static final String DECIMAL_DIGITS_MASK = "#.##########";
 
+  private static final Locale DEFAULT_LOCALE = Locale.ENGLISH;
+
   /** Writes a PDF representation of the given Grid to the given OutputStream. */
   public static void toPdf(Locale locale, Grid grid, OutputStream out) {
+    locale = locale != null ? locale : DEFAULT_LOCALE;
     if (isNonEmptyGrid(grid)) {
       Document document = openDocument(out);
 
@@ -186,6 +189,7 @@ public class GridUtils {
 
   /** Writes a PDF representation of the given list of Grids to the given OutputStream. */
   public static void toPdf(Locale locale, List<Grid> grids, OutputStream out) {
+    locale = locale != null ? locale : DEFAULT_LOCALE;
     if (hasNonEmptyGrid(grids)) {
       Document document = openDocument(out);
 


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-13013

### Summary
- Backend throws below error when current DB_LOCALE is null due to User doesn't set it in System Setting app.
- Fix by using `Locale.ENGLISH` as default locale.
- 
### Test
- Can test in Data Quality App > export a report to PDF.
