### PR TITLE
fix: Remove skipEventId and skipMeta parameters [DHIS2-15349]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParams.java
@@ -140,8 +140,6 @@ public class EventOperationParams {
 
   @Builder.Default private Set<String> events = new HashSet<>();
 
-  private Boolean skipEventId;
-
   /** Data element filters per data element UID. */
   @Builder.Default private Map<String, List<QueryFilter>> dataElementFilters = new HashMap<>();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapper.java
@@ -147,7 +147,6 @@ class EventOperationParamsMapper {
         .setPageSize(operationParams.getPageSize())
         .setTotalPages(operationParams.isTotalPages())
         .setSkipPaging(operationParams.isSkipPaging())
-        .setSkipEventId(operationParams.getSkipEventId())
         .setIncludeAttributes(false)
         .setIncludeAllDataElements(false)
         .setEvents(operationParams.getEvents())

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventQueryParams.java
@@ -136,8 +136,6 @@ class EventQueryParams {
 
   private Set<String> events = new HashSet<>();
 
-  private Boolean skipEventId;
-
   /**
    * Each attribute will affect the final SQL query. Some attributes are filtered on, while
    * attributes added via {@link #orderBy(TrackedEntityAttribute, SortDirection)} will be ordered
@@ -230,11 +228,6 @@ class EventQueryParams {
    */
   public boolean hasDataElementFilter() {
     return this.hasDataElementFilter;
-  }
-
-  /** Null-safe check for skip event ID parameter. */
-  public boolean isSkipEventId() {
-    return skipEventId != null && skipEventId;
   }
 
   public Program getProgram() {
@@ -530,15 +523,6 @@ class EventQueryParams {
 
   public EventQueryParams setEvents(Set<String> events) {
     this.events = events;
-    return this;
-  }
-
-  public Boolean getSkipEventId() {
-    return skipEventId;
-  }
-
-  public EventQueryParams setSkipEventId(Boolean skipEventId) {
-    this.skipEventId = skipEventId;
     return this;
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -272,11 +272,8 @@ class JdbcEventStore implements EventStore {
               event = eventsByUid.get(eventUid);
             } else {
               event = new Event();
+              event.setUid(eventUid);
               eventsByUid.put(eventUid, event);
-
-              if (!params.isSkipEventId()) {
-                event.setUid(eventUid);
-              }
 
               TrackedEntity te = new TrackedEntity();
               te.setUid(resultSet.getString(COLUMN_TRACKEDENTITY_UID));

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParams.java
@@ -126,9 +126,6 @@ public class TrackedEntityOperationParams {
   /** End date for event for the given program. */
   private Date eventEndDate;
 
-  /** Indicates whether not to include meta data in the response. */
-  private boolean skipMeta;
-
   /** Page number. */
   private Integer page;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapper.java
@@ -143,7 +143,6 @@ class TrackedEntityOperationParamsMapper {
         .setAssignedUserQueryParam(operationParams.getAssignedUserQueryParam())
         .setUser(user)
         .setTrackedEntityUids(operationParams.getTrackedEntityUids())
-        .setSkipMeta(operationParams.isSkipMeta())
         .setPage(operationParams.getPage())
         .setPageSize(operationParams.getPageSize())
         .setTotalPages(operationParams.isTotalPages())

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
@@ -135,9 +135,6 @@ public class TrackedEntityQueryParams {
   /** End date for event for the given program. */
   private Date eventEndDate;
 
-  /** Indicates whether not to include metadata in the response. */
-  private boolean skipMeta;
-
   /** Page number. */
   private Integer page;
 
@@ -664,15 +661,6 @@ public class TrackedEntityQueryParams {
 
   public TrackedEntityQueryParams setEventEndDate(Date eventEndDate) {
     this.eventEndDate = eventEndDate;
-    return this;
-  }
-
-  public boolean isSkipMeta() {
-    return skipMeta;
-  }
-
-  public TrackedEntityQueryParams setSkipMeta(boolean skipMeta) {
-    this.skipMeta = skipMeta;
     return this;
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
@@ -201,7 +201,6 @@ class TrackedEntityOperationParamsMapperTest {
             .eventStatus(EventStatus.COMPLETED)
             .eventStartDate(getDate(2019, 7, 7))
             .eventEndDate(getDate(2020, 7, 7))
-            .skipMeta(true)
             .page(1)
             .pageSize(50)
             .totalPages(false)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
@@ -142,7 +142,6 @@ class EventRequestParamsMapper {
             .pageSize(Objects.requireNonNullElse(requestParams.getPageSize(), DEFAULT_PAGE_SIZE))
             .totalPages(toBooleanDefaultIfNull(requestParams.isTotalPages(), false))
             .skipPaging(toBooleanDefaultIfNull(requestParams.isSkipPaging(), false))
-            .skipEventId(requestParams.getSkipEventId())
             .includeAttributes(false)
             .includeAllDataElements(false)
             .dataElementFilters(dataElementFilters)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/RequestParams.java
@@ -150,8 +150,6 @@ class RequestParams extends PagingAndSortingCriteriaAdapter {
   @OpenApi.Property({UID[].class, CategoryOption.class})
   private Set<UID> attributeCategoryOptions = new HashSet<>();
 
-  private boolean skipMeta;
-
   private boolean includeDeleted;
 
   /**
@@ -165,8 +163,6 @@ class RequestParams extends PagingAndSortingCriteriaAdapter {
 
   @OpenApi.Property({UID[].class, Event.class})
   private Set<UID> events = new HashSet<>();
-
-  private Boolean skipEventId;
 
   /** Comma separated list of data element filters */
   private String filter;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParams.java
@@ -170,9 +170,6 @@ class RequestParams extends PagingAndSortingCriteriaAdapter {
   /** End date for Event for the given Program. */
   private Date eventOccurredBefore;
 
-  /** Indicates whether not to include metadata in the response. */
-  private boolean skipMeta;
-
   /** Indicates whether to include soft-deleted elements */
   private boolean includeDeleted;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
@@ -133,7 +133,6 @@ class TrackedEntityRequestParamsMapper {
             .trackedEntityUids(UID.toValueSet(trackedEntities))
             .attributes(requestParams.getAttribute())
             .filters(requestParams.getFilter())
-            .skipMeta(requestParams.isSkipMeta())
             .page(Objects.requireNonNullElse(requestParams.getPage(), DEFAULT_PAGE))
             .pageSize(Objects.requireNonNullElse(requestParams.getPageSize(), DEFAULT_PAGE_SIZE))
             .totalPages(toBooleanDefaultIfNull(requestParams.isTotalPages(), false))

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/EventsExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/EventsExportController.md
@@ -145,8 +145,6 @@ Get events with given UID(s).
 
 Get events with given UID(s).
 
-### `*.parameter.EventRequestParams.skipEventId`
-
 ### `*.parameter.EventRequestParams.order`
 
 `<propertyName1:sortDirection>[,<propertyName2:sortDirection>...]`

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
@@ -123,8 +123,6 @@ if `assignedUserMode` is either `PROVIDED` or not specified.
 
 ### `*.parameter.TrackedEntityRequestParams.eventOccurredBefore`
 
-### `*.parameter.TrackedEntityRequestParams.skipMeta`
-
 ### `*.parameter.TrackedEntityRequestParams.includeDeleted`
 
 ### `*.parameter.TrackedEntityRequestParams.includeAllAttributes`

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapperTest.java
@@ -105,7 +105,6 @@ class TrackedEntityRequestParamsMapperTest {
     requestParams.setEventStatus(EventStatus.COMPLETED);
     requestParams.setEventOccurredAfter(getDate(2019, 7, 7));
     requestParams.setEventOccurredBefore(getDate(2020, 7, 7));
-    requestParams.setSkipMeta(true);
     requestParams.setPage(1);
     requestParams.setPageSize(50);
     requestParams.setTotalPages(false);


### PR DESCRIPTION
Remove `skipMeta` parameter from `tracker/trackedEntities` and `tracker/events` as it had no implementation.
Remove `skipEventId` parameter from `tracker/events`. If users do not want certain fields to be part of the JSON response they should use the fields query parameter