### PR TITLE
fix: Non data dimension org. unit, analytics 500 error [DHIS2-14923]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryRuntimeException.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryRuntimeException.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.common;
 
 import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorMessage;
 
 public class QueryRuntimeException extends RuntimeException {
   private ErrorCode errorCode;
@@ -53,5 +54,33 @@ public class QueryRuntimeException extends RuntimeException {
    */
   public ErrorCode getErrorCode() {
     return errorCode;
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param message the exception message.
+   */
+  public QueryRuntimeException(String message) {
+    super(message);
+  }
+
+  /**
+   * Constructor. Sets the message and error code based on the error message.
+   *
+   * @param errorMessage the {@link ErrorMessage}.
+   */
+  public QueryRuntimeException(ErrorMessage errorMessage) {
+    super(errorMessage);
+  }
+
+  /**
+   * Constructor. Sets the message based on the error code and arguments.
+   *
+   * @param errorCode the {@link ErrorCode}.
+   * @param args the message format arguments.
+   */
+  public QueryRuntimeException(ErrorCode errorCode, Object... args) {
+    super(errorCode, args);
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryRuntimeException.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryRuntimeException.java
@@ -48,6 +48,16 @@ public class QueryRuntimeException extends RuntimeException {
   }
 
   /**
+   * Constructor. Sets the message and error code based on the error message.
+   *
+   * @param errorMessage the {@link ErrorMessage}.
+   */
+  public QueryRuntimeException(ErrorMessage errorMessage) {
+    super(errorMessage.getMessage());
+    this.errorCode = errorMessage.getErrorCode();
+  }
+
+  /**
    * Returns the {@link ErrorCode} of the exception.
    *
    * @return the {@link ErrorCode} of the exception.
@@ -63,24 +73,5 @@ public class QueryRuntimeException extends RuntimeException {
    */
   public QueryRuntimeException(String message) {
     super(message);
-  }
-
-  /**
-   * Constructor. Sets the message and error code based on the error message.
-   *
-   * @param errorMessage the {@link ErrorMessage}.
-   */
-  public QueryRuntimeException(ErrorMessage errorMessage) {
-    super(errorMessage);
-  }
-
-  /**
-   * Constructor. Sets the message based on the error code and arguments.
-   *
-   * @param errorCode the {@link ErrorCode}.
-   * @param args the message format arguments.
-   */
-  public QueryRuntimeException(ErrorCode errorCode, Object... args) {
-    super(errorCode, args);
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -364,6 +364,8 @@ public enum ErrorCode {
   /* Org unit analytics */
   E7300("At least one organisation unit must be specified"),
   E7301("At least one organisation unit group set must be specified"),
+  E7302(
+      "Invalid organisation unit sets specified: `{0}`. Please verify it and also ensure that the analytics job was run"),
 
   /* Debug analytics */
   E7400("Debug query must contain at least one data element, one period and one organisation unit"),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/TableInfoReader.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/TableInfoReader.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.common;
+
+import static java.util.stream.Collectors.toUnmodifiableSet;
+import static org.springframework.util.Assert.hasText;
+
+import java.util.Set;
+import javax.annotation.Nonnull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Component responsible for querying meta information related to DB tables, as well as providing
+ * helper methods on top of the meta information.
+ *
+ * @author maikel arabori
+ */
+@Component
+@AllArgsConstructor
+public class TableInfoReader {
+  private final JdbcTemplate jdbcTemplate;
+
+  /**
+   * Returns the metadata information for the given table.
+   *
+   * @param tableName the name of the table where the information should be retrieved.
+   * @return the populated {@link TableInfo} object.
+   * @throws IllegalArgumentException if the argument 'tableName' is null or blank.
+   */
+  public TableInfo getInfo(@Nonnull String tableName) {
+    hasText(tableName, "Param 'tableName' cannot be null/blank");
+
+    String sql =
+        "select column_name"
+            + " from information_schema.columns"
+            + " where table_schema = 'public'"
+            + " and table_name = ?";
+
+    Set<String> tableColumns =
+        jdbcTemplate.queryForList(sql, String.class, tableName).stream()
+            .collect(toUnmodifiableSet());
+
+    return new TableInfo(tableName, tableColumns);
+  }
+
+  /**
+   * Checks whether the given table contains all set of columns provided.
+   *
+   * @param table the table where the columns will be checked against.
+   * @param columnsToCheck the columns to check (if they exist or not in the given table).
+   * @return the set of missing columns, if any, or empty.
+   * @throws IllegalArgumentException if the argument is null or blank.
+   */
+  public Set<String> checkColumnsPresence(@Nonnull String table, Set<String> columnsToCheck) {
+    hasText(table, "Param 'table' cannot be null/blank");
+
+    Set<String> columnsInTable = getInfo(table).getColumns();
+    return columnsToCheck.stream()
+        .filter(c -> !columnsInTable.contains(c))
+        .collect(toUnmodifiableSet());
+  }
+
+  /**
+   * Object representing the information related to the meta information of the respective table.
+   */
+  @Data
+  @AllArgsConstructor
+  public static class TableInfo {
+    private String name;
+    private Set<String> columns;
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/orgunit/data/JdbcOrgUnitAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/orgunit/data/JdbcOrgUnitAnalyticsManager.java
@@ -27,106 +27,149 @@
  */
 package org.hisp.dhis.analytics.orgunit.data;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Collectors.toUnmodifiableSet;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.hisp.dhis.common.DimensionalObject.DIMENSION_SEP;
 import static org.hisp.dhis.commons.util.TextUtils.getCommaDelimitedString;
 import static org.hisp.dhis.commons.util.TextUtils.getQuotedCommaDelimitedString;
+import static org.hisp.dhis.feedback.ErrorCode.E7302;
 import static org.hisp.dhis.system.util.SqlUtils.quote;
 
-import com.google.common.collect.Lists;
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.analytics.common.TableInfoReader;
 import org.hisp.dhis.analytics.orgunit.OrgUnitAnalyticsManager;
 import org.hisp.dhis.analytics.orgunit.OrgUnitQueryParams;
+import org.hisp.dhis.common.QueryRuntimeException;
+import org.hisp.dhis.feedback.ErrorMessage;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroupSet;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.rowset.SqlRowSet;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 /**
  * @author Lars Helge Overland
  */
-@Component("org.hisp.dhis.analytics.orgunit.OrgUnitAnalyticsManager")
+@Service("org.hisp.dhis.analytics.orgunit.OrgUnitAnalyticsManager")
+@RequiredArgsConstructor
 public class JdbcOrgUnitAnalyticsManager implements OrgUnitAnalyticsManager {
+  private final TableInfoReader tableInfoReader;
   private final JdbcTemplate jdbcTemplate;
-
-  public JdbcOrgUnitAnalyticsManager(JdbcTemplate jdbcTemplate) {
-    checkNotNull(jdbcTemplate);
-
-    this.jdbcTemplate = jdbcTemplate;
-  }
 
   @Override
   public Map<String, Integer> getOrgUnitData(OrgUnitQueryParams params) {
+    checkForMissingOrgUnitGroupSetColumns(params);
+
     Map<String, Integer> dataMap = new HashMap<>();
 
-    List<String> columns = getMetadataColumns(params);
+    Set<String> columns = getMetadataColumns(params);
 
-    String sql = getQuerySql(params);
-
-    SqlRowSet rowSet = jdbcTemplate.queryForRowSet(sql);
+    SqlRowSet rowSet = jdbcTemplate.queryForRowSet(getQuerySql(params));
 
     while (rowSet.next()) {
-      StringBuilder key = new StringBuilder();
-
-      for (String column : columns) {
-        key.append(rowSet.getString(column)).append(DIMENSION_SEP);
-      }
-
-      key.deleteCharAt(key.length() - 1);
-
+      String key = columns.stream().map(rowSet::getString).collect(joining(DIMENSION_SEP));
       int value = rowSet.getInt("count");
 
-      dataMap.put(key.toString(), value);
+      dataMap.put(key, value);
     }
 
     return dataMap;
   }
 
-  private List<String> getMetadataColumns(OrgUnitQueryParams params) {
-    List<String> columns = Lists.newArrayList("orgunit");
-    params.getOrgUnitGroupSets().forEach(ougs -> columns.add(ougs.getUid()));
+  /**
+   * Checks if there is an org. unit dimension column, specified in the given params, not present in
+   * the respective DB table ("_organisationunitgroupsetstructure"). If a dimension column (which in
+   * this case represents an org. unit group set) is found to be missing in the table, it will not
+   * be possible to query for the missing org. unit group set. In such cases, the request cannot be
+   * processed.
+   *
+   * @param params the query params {@link OrgUnitQueryParams}.
+   * @throws QueryRuntimeException if there are missing columns.
+   */
+  private void checkForMissingOrgUnitGroupSetColumns(OrgUnitQueryParams params) {
+    Set<String> missingColumns =
+        tableInfoReader.checkColumnsPresence(
+            "_organisationunitgroupsetstructure", getOrgUnitGroupSetUids(params));
+
+    boolean hasMissingColumns = isNotEmpty(missingColumns);
+
+    if (hasMissingColumns) {
+      throw new QueryRuntimeException(new ErrorMessage(E7302, missingColumns));
+    }
+  }
+
+  /**
+   * Returns dimension columns for the given query params.
+   *
+   * @param params the {@link OrgUnitQueryParams}.
+   * @return a set of columns.
+   */
+  private Set<String> getOrgUnitGroupSetUids(OrgUnitQueryParams params) {
+    return params.getOrgUnitGroupSets().stream()
+        .map(OrganisationUnitGroupSet::getUid)
+        .collect(toUnmodifiableSet());
+  }
+
+  /**
+   * Returns metadata column names for the given query. Note that the "orgunit" column is always
+   * returned.
+   *
+   * @param params the {@link OrgUnitQueryParams}.
+   * @return a set of column names.
+   */
+  private Set<String> getMetadataColumns(OrgUnitQueryParams params) {
+    Set<String> columns = new HashSet<>(getOrgUnitGroupSetUids(params));
+    columns.add("orgunit");
+
     return columns;
   }
 
+  /**
+   * Returns a SQL query based on the given query.
+   *
+   * @param params the {@link OrgUnitQueryParams}.
+   * @return a SQL query.
+   */
   private String getQuerySql(OrgUnitQueryParams params) {
     String levelCol = String.format("ous.uidlevel%d", params.getOrgUnitLevel());
 
-    List<String> orgUnits =
-        params.getOrgUnits().stream().map(OrganisationUnit::getUid).collect(Collectors.toList());
+    Set<String> orgUnits =
+        params.getOrgUnits().stream().map(OrganisationUnit::getUid).collect(toSet());
 
-    List<String> quotedGroupSets =
+    Set<String> quotedGroupSets =
         params.getOrgUnitGroupSets().stream()
             .map(OrganisationUnitGroupSet::getUid)
             .map(uid -> quote("ougs", uid))
-            .collect(Collectors.toList());
+            .collect(toSet());
 
-    String sql =
-        "select "
-            + levelCol
-            + " as orgunit, "
-            + getCommaDelimitedString(quotedGroupSets)
-            + ", count(ougs.organisationunitid) as count "
-            + "from "
-            + quote("_orgunitstructure")
-            + " ous "
-            + "inner join "
-            + quote("_organisationunitgroupsetstructure")
-            + " ougs on ous.organisationunitid = ougs.organisationunitid "
-            + "where "
-            + levelCol
-            + " in ("
-            + getQuotedCommaDelimitedString(orgUnits)
-            + ") "
-            + "group by "
-            + levelCol
-            + ", "
-            + getCommaDelimitedString(quotedGroupSets)
-            + ";";
-
-    return sql;
+    return "select "
+        + levelCol
+        + " as orgunit, "
+        + getCommaDelimitedString(quotedGroupSets)
+        + ", "
+        + "count(ougs.organisationunitid) as count "
+        + "from "
+        + quote("_orgunitstructure")
+        + " ous "
+        + "inner join "
+        + quote("_organisationunitgroupsetstructure")
+        + " "
+        + "ougs on ous.organisationunitid = ougs.organisationunitid "
+        + "where "
+        + levelCol
+        + " in ("
+        + getQuotedCommaDelimitedString(orgUnits)
+        + ") "
+        + "group by "
+        + levelCol
+        + ", "
+        + getCommaDelimitedString(quotedGroupSets)
+        + ";";
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/TableInfoReaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/TableInfoReaderTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.common;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Unit tests for {@link TableInfoReader}.
+ *
+ * @author maikel arabori
+ */
+@ExtendWith(MockitoExtension.class)
+class TableInfoReaderTest {
+
+  public static final String QUERY_TABLE_COLUMN_NAMES =
+      "select column_name"
+          + " from information_schema.columns"
+          + " where table_schema = 'public'"
+          + " and table_name = ?";
+  @Mock private JdbcTemplate jdbcTemplate;
+
+  private TableInfoReader tableInfoReader;
+
+  @BeforeEach
+  public void beforeAll() {
+    tableInfoReader = new TableInfoReader(jdbcTemplate);
+  }
+
+  @Test
+  void testCheckColumnsPresenceWhenAllColumnsArePresent() {
+    // Given
+    String tableName = "tableName";
+    List<String> columns = List.of("col1", "col2");
+
+    // When
+    when(jdbcTemplate.queryForList(QUERY_TABLE_COLUMN_NAMES, String.class, tableName))
+        .thenReturn(columns);
+    Set<String> absentColumns =
+        tableInfoReader.checkColumnsPresence(tableName, new HashSet<>(columns));
+
+    // Then
+    assertTrue(absentColumns.isEmpty());
+  }
+
+  @Test
+  void testCheckColumnsPresenceWhenOneColumnsIsMissing() {
+    // Given
+    String tableName = "tableName";
+    List<String> columns = List.of("col1", "col2");
+    Set<String> hasMissing = Set.of("col1", "col3");
+    String sql =
+        "select column_name"
+            + " from information_schema.columns"
+            + " where table_schema = 'public'"
+            + " and table_name = ?";
+
+    // When
+    when(jdbcTemplate.queryForList(sql, String.class, tableName)).thenReturn(columns);
+    Set<String> absentColumns = tableInfoReader.checkColumnsPresence(tableName, hasMissing);
+
+    // Then
+    assertTrue(absentColumns.contains("col3"));
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/orgunit/data/JdbcOrgUnitAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/orgunit/data/JdbcOrgUnitAnalyticsManagerTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.orgunit.data;
+
+import static org.hisp.dhis.DhisConvenienceTest.createOrganisationUnitGroupSet;
+import static org.hisp.dhis.feedback.ErrorCode.E7302;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.hisp.dhis.analytics.common.TableInfoReader;
+import org.hisp.dhis.analytics.orgunit.OrgUnitQueryParams;
+import org.hisp.dhis.common.QueryRuntimeException;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroupSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.rowset.SqlRowSet;
+
+/**
+ * Unit tests for {@link JdbcOrgUnitAnalyticsManager}.
+ *
+ * @author maikel arabori
+ */
+@ExtendWith(MockitoExtension.class)
+class JdbcOrgUnitAnalyticsManagerTest {
+
+  @Mock private JdbcTemplate jdbcTemplate;
+
+  @Mock private SqlRowSet sqlRowSet;
+
+  @Mock private TableInfoReader tableInfoReader;
+
+  private JdbcOrgUnitAnalyticsManager jdbcOrgUnitAnalyticsManager;
+
+  @BeforeEach
+  public void beforeAll() {
+    jdbcOrgUnitAnalyticsManager = new JdbcOrgUnitAnalyticsManager(tableInfoReader, jdbcTemplate);
+  }
+
+  @Test
+  void testGetOrgUnitDataWithSuccess() {
+    // Given
+    OrganisationUnitGroupSet organisationUnitGroupSet1 = createOrganisationUnitGroupSet('A');
+    organisationUnitGroupSet1.setUid("abc123");
+
+    OrganisationUnitGroupSet organisationUnitGroupSet2 = createOrganisationUnitGroupSet('B');
+    organisationUnitGroupSet2.setUid("abc456");
+
+    List<OrganisationUnitGroupSet> organisationUnitGroupSets =
+        List.of(organisationUnitGroupSet1, organisationUnitGroupSet2);
+
+    OrgUnitQueryParams params =
+        new OrgUnitQueryParams.Builder().withOrgUnitGroupSets(organisationUnitGroupSets).build();
+
+    mockSqlRowSet();
+
+    // When
+    when(tableInfoReader.checkColumnsPresence(
+            "_organisationunitgroupsetstructure", Set.of("abc123", "abc456")))
+        .thenReturn(Set.of());
+    when(jdbcTemplate.queryForRowSet(anyString())).thenReturn(sqlRowSet);
+    Map<String, Integer> data = jdbcOrgUnitAnalyticsManager.getOrgUnitData(params);
+
+    // Then
+    // Based on the mocked sqlRowSet.
+    assertEquals(1, data.get("OrgUnit-Abc123-Abc456"));
+  }
+
+  @Test
+  void testGetOrgUnitDataWithInvalidOrgUnitSetDimension() {
+    // Given
+    String invalidOrgUnitSetDim = "xyz123";
+
+    OrganisationUnitGroupSet organisationUnitGroupSet1 = createOrganisationUnitGroupSet('A');
+    organisationUnitGroupSet1.setUid("abc123");
+
+    OrganisationUnitGroupSet organisationUnitGroupSet2 = createOrganisationUnitGroupSet('B');
+    organisationUnitGroupSet2.setUid("abc456");
+
+    List<OrganisationUnitGroupSet> organisationUnitGroupSets =
+        List.of(organisationUnitGroupSet1, organisationUnitGroupSet2);
+
+    OrgUnitQueryParams params =
+        new OrgUnitQueryParams.Builder().withOrgUnitGroupSets(organisationUnitGroupSets).build();
+
+    // When
+    when(tableInfoReader.checkColumnsPresence(
+            "_organisationunitgroupsetstructure", Set.of("abc123", "abc456")))
+        .thenReturn(Set.of(invalidOrgUnitSetDim));
+
+    // Then
+    assertThrows(
+        QueryRuntimeException.class,
+        () -> jdbcOrgUnitAnalyticsManager.getOrgUnitData(params),
+        E7302.getMessage());
+  }
+
+  private void mockSqlRowSet() {
+    // Simulate 2 results.
+    when(sqlRowSet.next()).thenReturn(true).thenReturn(true).thenReturn(false);
+
+    when(sqlRowSet.getString("orgunit")).thenReturn("OrgUnit");
+    when(sqlRowSet.getString("abc123")).thenReturn("Abc123");
+    when(sqlRowSet.getString("abc456")).thenReturn("Abc456");
+    when(sqlRowSet.getInt("count")).thenReturn(1);
+  }
+}


### PR DESCRIPTION
**_[Backport from master/2.41]_** (#15085)

The respective endpoint is returning `500 internal server` error for calls to the org. unit analytics API (`api/orgUnitAnalytics`) when the query references an org. unit group set that is not set to be a data dimension.

It happens that when the org. unit group set is not defined as `data dimension`, it is not exported as analytics data, and hence cannot be queried. The column for this org. unit group set will not exist in the analytics table, and any query referencing this column will fail. In this case, with `500 error`.

This fix will return a friendly user message if users try to query an org. unit group set that is not defined as a data dimension.

Also, I applied some small code improvements.

**NOTE**: It's also recommended to exclude org. unit sets not that are not defined as data dimensions. This should be done by the client app, probably filtering out the ones that are not data dimensions. ie:
```
http://localhost:8080/dhis/api/organisationUnitGroupSets?paging=false&fields=id,displayName,organisationUnitGroups[id,displayName]&filter=dataDimension:eq:true
```
