### PR TITLE
fix: Add OptionSet/Options into metadata [DHIS2-15775]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/MetadataItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/MetadataItem.java
@@ -27,12 +27,18 @@
  */
 package org.hisp.dhis.common;
 
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.appendIfMissing;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 import org.hisp.dhis.analytics.AggregationType;
@@ -43,6 +49,8 @@ import org.hisp.dhis.expressiondimensionitem.ExpressionDimensionItem;
 import org.hisp.dhis.hibernate.HibernateProxyUtils;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorType;
+import org.hisp.dhis.option.Option;
+import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramDataElementDimensionItem;
@@ -90,6 +98,8 @@ public class MetadataItem implements Serializable {
 
   @JsonProperty private ObjectStyle style;
 
+  @JsonProperty private List<Map<String, String>> options;
+
   private transient String serverBaseUrl;
 
   // -------------------------------------------------------------------------
@@ -135,6 +145,15 @@ public class MetadataItem implements Serializable {
     this.description = program.getDescription();
   }
 
+  public MetadataItem(String name, OptionSet optionSet, Set<Option> withOptions) {
+    if (optionSet != null) {
+      this.name = name;
+      this.uid = optionSet.getUid();
+
+      addOptions(optionSet, withOptions);
+    }
+  }
+
   public MetadataItem(String name, ProgramStage programStage) {
     this.name = name;
 
@@ -150,6 +169,31 @@ public class MetadataItem implements Serializable {
   // -------------------------------------------------------------------------
   // Logic
   // -------------------------------------------------------------------------
+
+  /**
+   * Adds the options, from the given option set, that matches the "withOptions" collection. The
+   * options that match will become part of this metadata item object.
+   *
+   * @param optionSet the base {@link OptionSet}.
+   * @param withOptions the set of {@link Option} to be included.
+   */
+  private void addOptions(OptionSet optionSet, Set<Option> withOptions) {
+    List<Option> allOptions = optionSet.getOptions();
+    if (isNotEmpty(withOptions) && isNotEmpty(allOptions)) {
+      this.options = new ArrayList<>();
+
+      withOptions.forEach(
+          option -> {
+            if (option != null && allOptions.contains(option)) {
+              Map<String, String> attrs = new HashMap<>();
+              attrs.put("uid", option.getUid());
+              attrs.put("code", option.getCode());
+
+              this.options.add(attrs);
+            }
+          });
+    }
+  }
 
   private void setDataItem(DimensionalItemObject dimensionalItemObject) {
     if (dimensionalItemObject == null) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -32,6 +32,7 @@ import static java.util.Optional.empty;
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.joinWith;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.DIMENSIONS;
@@ -84,6 +85,7 @@ import org.hisp.dhis.common.RepeatableStageParams;
 import org.hisp.dhis.common.SlimPager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.option.Option;
+import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.user.User;
@@ -578,6 +580,29 @@ public abstract class AbstractAnalyticsService {
                     option.getDisplayProperty(params.getDisplayProperty()),
                     includeDetails ? option.getUid() : null,
                     option.getCode())));
+
+    addOptionsSetIntoMap(metadataItemMap, itemOptions);
+  }
+
+  /**
+   * Adds the {@link OptionSet} objects associated with each {@link Option} in the list of given
+   * "itemOptions". Internal rules ensure that only options in the give "itemOptions" will be
+   * present in its respective {@link OptionSet}.
+   *
+   * @param metadataItemMap the metadata item map.
+   * @param itemOptions the set of {@link Option} where to extract each {@link OptionSet}.
+   */
+  private void addOptionsSetIntoMap(
+      Map<String, MetadataItem> metadataItemMap, Set<Option> itemOptions) {
+    // Group all options set available.
+    Set<OptionSet> optionSets = itemOptions.stream().map(Option::getOptionSet).collect(toSet());
+
+    // Add option set into the metadata.
+    optionSets.forEach(
+        optionSet ->
+            metadataItemMap.put(
+                optionSet.getUid(),
+                new MetadataItem(optionSet.getDisplayName(), optionSet, itemOptions)));
   }
 
   /**

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventQueryTest.java
@@ -35,12 +35,16 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hisp.dhis.analytics.ValidationHelper.validateHeader;
 import static org.hisp.dhis.analytics.ValidationHelper.validateRow;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 import java.util.List;
+import java.util.Map;
 import org.hisp.dhis.AnalyticsApiTest;
 import org.hisp.dhis.actions.analytics.AnalyticsEventActions;
 import org.hisp.dhis.dto.ApiResponse;
 import org.hisp.dhis.helpers.QueryParamsBuilder;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -390,5 +394,166 @@ public class EventQueryTest extends AnalyticsApiTest {
         false,
         true,
         "hiQ3QFheQ3O");
+  }
+
+  @Test
+  public void queryMetadataInfoForOptionSetAndOptionsWhenNoData() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
+            .add("asc=lastupdated")
+            .add("headers=ouname,A03MvHHogjR.ebaJjqltK5N")
+            .add("lastUpdated=LAST_5_YEARS")
+            .add("stage=A03MvHHogjR")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("outputType=EVENT")
+            .add("pageSize=0")
+            .add("page=1")
+            .add("dimension=ou:USER_ORGUNIT,A03MvHHogjR.ebaJjqltK5N:IN:1;2")
+            .add("relativePeriodDate=2022-10-01");
+
+    // When
+    ApiResponse response = analyticsEventActions.query().get("IpHINAT79UW", JSON, JSON, params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(2)))
+        .body("rows", hasSize(equalTo(0)))
+        .body("height", equalTo(0))
+        .body("width", equalTo(0))
+        .body("headerWidth", equalTo(2));
+
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":0,\"isLastPage\":false},\"items\":{\"kzgQRhOCadd\":{\"uid\":\"kzgQRhOCadd\",\"name\":\"MNCH Polio doses (0-3)\",\"options\":[{\"code\":\"2\",\"uid\":\"Xr0M5yEhtpT\"},{\"code\":\"1\",\"uid\":\"lFFqylGiWLk\"}]},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"NUMBER\",\"totalAggregationType\":\"SUM\"},\"ebaJjqltK5N\":{\"uid\":\"ebaJjqltK5N\",\"code\":\"DE_2006104\",\"name\":\"MCH OPV dose\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"TEXT\",\"aggregationType\":\"AVERAGE\",\"totalAggregationType\":\"SUM\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"Xr0M5yEhtpT\":{\"uid\":\"Xr0M5yEhtpT\",\"code\":\"2\",\"name\":\"Dose 2\"},\"A03MvHHogjR.ebaJjqltK5N\":{\"uid\":\"ebaJjqltK5N\",\"code\":\"DE_2006104\",\"name\":\"MCH OPV dose\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"TEXT\",\"aggregationType\":\"AVERAGE\",\"totalAggregationType\":\"SUM\"},\"LAST_5_YEARS\":{\"name\":\"Last 5 years\"},\"lFFqylGiWLk\":{\"uid\":\"lFFqylGiWLk\",\"code\":\"1\",\"name\":\"Dose 1\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"],\"A03MvHHogjR.ebaJjqltK5N\":[\"lFFqylGiWLk\",\"Xr0M5yEhtpT\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // Assert headers.
+    validateHeader(
+        response, 0, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, true);
+    validateHeader(
+        response,
+        1,
+        "A03MvHHogjR.ebaJjqltK5N",
+        "MCH OPV dose",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+
+    // Assert rows.
+  }
+
+  @Test
+  public void queryMetadataInfoForOptionSetAndOptionsWhenOneRows() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
+            .add("asc=lastupdated")
+            .add("headers=ouname,A03MvHHogjR.ebaJjqltK5N")
+            .add("lastUpdated=LAST_5_YEARS")
+            .add("stage=A03MvHHogjR")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("outputType=EVENT")
+            .add("pageSize=1")
+            .add("page=1")
+            .add("dimension=ou:USER_ORGUNIT,A03MvHHogjR.ebaJjqltK5N:IN:1;2")
+            .add("relativePeriodDate=2022-10-01");
+
+    // When
+    ApiResponse response = analyticsEventActions.query().get("IpHINAT79UW", JSON, JSON, params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(2)))
+        .body("rows", hasSize(equalTo(1)))
+        .body("height", equalTo(1))
+        .body("width", equalTo(2))
+        .body("headerWidth", equalTo(2));
+
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":1,\"isLastPage\":false},\"items\":{\"kzgQRhOCadd\":{\"uid\":\"kzgQRhOCadd\",\"name\":\"MNCH Polio doses (0-3)\",\"options\":[{\"code\":\"1\",\"uid\":\"lFFqylGiWLk\"}]},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"NUMBER\",\"totalAggregationType\":\"SUM\"},\"ebaJjqltK5N\":{\"uid\":\"ebaJjqltK5N\",\"code\":\"DE_2006104\",\"name\":\"MCH OPV dose\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"TEXT\",\"aggregationType\":\"AVERAGE\",\"totalAggregationType\":\"SUM\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"A03MvHHogjR.ebaJjqltK5N\":{\"uid\":\"ebaJjqltK5N\",\"code\":\"DE_2006104\",\"name\":\"MCH OPV dose\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"TEXT\",\"aggregationType\":\"AVERAGE\",\"totalAggregationType\":\"SUM\"},\"LAST_5_YEARS\":{\"name\":\"Last 5 years\"},\"lFFqylGiWLk\":{\"uid\":\"lFFqylGiWLk\",\"code\":\"1\",\"name\":\"Dose 1\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"],\"A03MvHHogjR.ebaJjqltK5N\":[\"lFFqylGiWLk\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // Assert headers.
+    validateHeader(
+        response, 0, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, true);
+    validateHeader(
+        response,
+        1,
+        "A03MvHHogjR.ebaJjqltK5N",
+        "MCH OPV dose",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+
+    // Assert rows.
+    validateRow(response, 0, List.of("Ngelehun CHC", "1"));
+  }
+
+  @Test
+  public void queryMetadataInfoForOptionSetAndOptionsWhenTenRows() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
+            .add("asc=lastupdated")
+            .add("headers=ouname,A03MvHHogjR.ebaJjqltK5N")
+            .add("lastUpdated=LAST_5_YEARS")
+            .add("stage=A03MvHHogjR")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("outputType=EVENT")
+            .add("pageSize=1")
+            .add("page=10")
+            .add("dimension=ou:USER_ORGUNIT,A03MvHHogjR.ebaJjqltK5N:IN:1;2")
+            .add("relativePeriodDate=2022-10-01");
+
+    // When
+    ApiResponse response = analyticsEventActions.query().get("IpHINAT79UW", JSON, JSON, params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(2)))
+        .body("rows", hasSize(equalTo(1)))
+        .body("height", equalTo(1))
+        .body("width", equalTo(2))
+        .body("headerWidth", equalTo(2));
+
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":10,\"pageSize\":1,\"isLastPage\":false},\"items\":{\"kzgQRhOCadd\":{\"uid\":\"kzgQRhOCadd\",\"name\":\"MNCH Polio doses (0-3)\",\"options\":[{\"code\":\"1\",\"uid\":\"lFFqylGiWLk\"}]},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"NUMBER\",\"totalAggregationType\":\"SUM\"},\"ebaJjqltK5N\":{\"uid\":\"ebaJjqltK5N\",\"code\":\"DE_2006104\",\"name\":\"MCH OPV dose\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"TEXT\",\"aggregationType\":\"AVERAGE\",\"totalAggregationType\":\"SUM\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"A03MvHHogjR.ebaJjqltK5N\":{\"uid\":\"ebaJjqltK5N\",\"code\":\"DE_2006104\",\"name\":\"MCH OPV dose\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"TEXT\",\"aggregationType\":\"AVERAGE\",\"totalAggregationType\":\"SUM\"},\"LAST_5_YEARS\":{\"name\":\"Last 5 years\"},\"lFFqylGiWLk\":{\"uid\":\"lFFqylGiWLk\",\"code\":\"1\",\"name\":\"Dose 1\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"],\"A03MvHHogjR.ebaJjqltK5N\":[\"lFFqylGiWLk\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // Assert headers.
+    validateHeader(
+        response, 0, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, true);
+    validateHeader(
+        response,
+        1,
+        "A03MvHHogjR.ebaJjqltK5N",
+        "MCH OPV dose",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+
+    // Assert rows.
+    validateRow(response, 0, List.of("Ngelehun CHC", "1"));
   }
 }


### PR DESCRIPTION
**_[Backport from 2.41/master]_** (#15067)

Historically, `OptionSets` allow the creation of `Option` codes that are not unique across the system.
`Option` codes are unique only within their respective `OptionSet`.

This might become problematic when users define the same `Option` code in different `OptionSets`. Some parts of the application that rely purely on the `Option` code cannot know which `OptionSet` it belongs to. This is a problem in the `Metadata` object, currently used in analytics requests.

So, instead of returning only the `Option`, we will also return the `OptionSet`. This will allow consumers to find out the `OptionSet` a `Option` belongs to, if needed.

The new object returned will look like this:
```
{
  "metaData": {
    "items": {
      "optionset1id": {
        "uid": "option set id 1",
        "name": "option set name 1",
        "options": [
          {
            "uid": "optionid1",
            "code": "PASSIVE"
          },
          {
            "uid": "optionid2",
            "code": "REACTIVE"
          }
        ]
      },
      "optionset2id": {
        "uid": "option set id 2",
        "name": "option set name 2",
        "options": [
          {
            "uid": "optionid3",
            "code": "PASSIVE"
          }
        ]
      },
...
}
```

Example of request:
```
http://localhost:8080/dhis/api/41/analytics/events/query/IpHINAT79UW?dimension=ou:USER_ORGUNIT,A03MvHHogjR.ebaJjqltK5N:IN:1;2&headers=ouname,A03MvHHogjR.ebaJjqltK5N&totalPages=false&displayProperty=NAME&outputType=EVENT&pageSize=10&page=1&includeMetadataDetails=true&stage=A03MvHHogjR&filter=pe:LAST_12_MONTHS&relativePeriodDate=2022-10-01
```