### PR TITLE
fix: Add OptionSet/Options into metadata [DHIS2-15775]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -32,6 +32,7 @@ import static java.util.Optional.empty;
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.joinWith;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.DIMENSIONS;
@@ -82,6 +83,7 @@ import org.hisp.dhis.common.RepeatableStageParams;
 import org.hisp.dhis.common.SlimPager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.option.Option;
+import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.user.User;
@@ -537,6 +539,29 @@ public abstract class AbstractAnalyticsService {
                     option.getDisplayProperty(params.getDisplayProperty()),
                     includeDetails ? option.getUid() : null,
                     option.getCode())));
+
+    addOptionsSetIntoMap(metadataItemMap, itemOptions);
+  }
+
+  /**
+   * Adds the {@link OptionSet} objects associated with each {@link Option} in the list of given
+   * "itemOptions". Internal rules ensure that only options in the give "itemOptions" will be
+   * present in its respective {@link OptionSet}.
+   *
+   * @param metadataItemMap the metadata item map.
+   * @param itemOptions the set of {@link Option} where to extract each {@link OptionSet}.
+   */
+  private void addOptionsSetIntoMap(
+      Map<String, MetadataItem> metadataItemMap, Set<Option> itemOptions) {
+    // Group all options set available.
+    Set<OptionSet> optionSets = itemOptions.stream().map(Option::getOptionSet).collect(toSet());
+
+    // Add option set into the metadata.
+    optionSets.forEach(
+        optionSet ->
+            metadataItemMap.put(
+                optionSet.getUid(),
+                new MetadataItem(optionSet.getDisplayName(), optionSet, itemOptions)));
   }
 
   /**


### PR DESCRIPTION
**_[Backport from 2.41/master]_** (#15067)

Historically, `OptionSets` allow the creation of `Option` codes that are not unique across the system.
`Option` codes are unique only within their respective `OptionSet`.

This might become problematic when users define the same `Option` code in different `OptionSets`. Some parts of the application that rely purely on the `Option` code cannot know which `OptionSet` it belongs to. This is a problem in the `Metadata` object, currently used in analytics requests.

So, instead of returning only the `Option`, we will also return the `OptionSet`. This will allow consumers to find out the `OptionSet` a `Option` belongs to, if needed.

The new object returned will look like this:
```
{
  "metaData": {
    "items": {
      "optionset1id": {
        "uid": "option set id 1",
        "name": "option set name 1",
        "options": [
          {
            "uid": "optionid1",
            "code": "PASSIVE"
          },
          {
            "uid": "optionid2",
            "code": "REACTIVE"
          }
        ]
      },
      "optionset2id": {
        "uid": "option set id 2",
        "name": "option set name 2",
        "options": [
          {
            "uid": "optionid3",
            "code": "PASSIVE"
          }
        ]
      },
...
}
```

Example of request:
```
http://localhost:8080/dhis/api/41/analytics/events/query/IpHINAT79UW?dimension=ou:USER_ORGUNIT,A03MvHHogjR.ebaJjqltK5N:IN:1;2&headers=ouname,A03MvHHogjR.ebaJjqltK5N&totalPages=false&displayProperty=NAME&outputType=EVENT&pageSize=10&page=1&includeMetadataDetails=true&stage=A03MvHHogjR&filter=pe:LAST_12_MONTHS&relativePeriodDate=2022-10-01
```