### PR TITLE
fix: Remove parameters from TrackedEntity exporter endpoint [DHIS2-15665]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -345,10 +345,9 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       TrackedEntityQueryParams params,
       boolean skipAccessValidation,
       boolean skipSearchScopeValidation) {
-    if (params.isOrQuery() && !params.hasAttributes() && !params.hasProgram()) {
+    if (params.isOrQuery() && !params.hasProgram()) {
       Collection<TrackedEntityAttribute> attributes =
           trackedEntityAttributeService.getTrackedEntityAttributesDisplayInListNoProgram();
-      params.addAttributes(QueryItem.getQueryItems(attributes));
       params.addFiltersIfNotExist(QueryItem.getQueryItems(attributes));
     }
 
@@ -451,11 +450,6 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       violation = "Query cannot be specified together with filters";
     }
 
-    if (!params.getDuplicateAttributes().isEmpty()) {
-      violation =
-          "Attributes cannot be specified more than once: " + params.getDuplicateAttributes();
-    }
-
     if (!params.getDuplicateFilters().isEmpty()) {
       violation = "Filters cannot be specified more than once: " + params.getDuplicateFilters();
     }
@@ -496,14 +490,14 @@ class DefaultTrackedEntityService implements TrackedEntityService {
 
     if (!params.hasProgram()
         && !params.hasTrackedEntityType()
-        && params.hasAttributesOrFilters()
+        && params.hasFilters()
         && !params.hasAccessibleOrgUnits()) {
       List<String> uniqueAttributeIds =
           trackedEntityAttributeService.getAllSystemWideUniqueTrackedEntityAttributes().stream()
               .map(TrackedEntityAttribute::getUid)
               .toList();
 
-      for (String att : params.getAttributeAndFilterIds()) {
+      for (String att : params.getFilterIds()) {
         if (!uniqueAttributeIds.contains(att)) {
           throw new IllegalQueryException(
               "Either a program or tracked entity type must be specified");
@@ -523,7 +517,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
             "Program and tracked entity cannot be specified simultaneously");
       }
 
-      if (params.hasAttributesOrFilters()) {
+      if (params.hasFilters()) {
         List<String> searchableAttributeIds = new ArrayList<>();
 
         if (params.hasProgram()) {
@@ -543,7 +537,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
 
         List<String> violatingAttributes = new ArrayList<>();
 
-        for (String attributeId : params.getAttributeAndFilterIds()) {
+        for (String attributeId : params.getFilterIds()) {
           if (!searchableAttributeIds.contains(attributeId)) {
             violatingAttributes.add(attributeId);
           }
@@ -616,13 +610,9 @@ class DefaultTrackedEntityService implements TrackedEntityService {
     }
 
     return (!params.hasFilters()
-            && !params.hasAttributes()
             && params.getTrackedEntityType().getMinAttributesRequiredToSearch() > 0)
         || (params.hasFilters()
             && params.getFilters().size()
-                < params.getTrackedEntityType().getMinAttributesRequiredToSearch())
-        || (params.hasAttributes()
-            && params.getAttributes().size()
                 < params.getTrackedEntityType().getMinAttributesRequiredToSearch());
   }
 
@@ -631,14 +621,9 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       return false;
     }
 
-    return (!params.hasFilters()
-            && !params.hasAttributes()
-            && params.getProgram().getMinAttributesRequiredToSearch() > 0)
+    return (!params.hasFilters() && params.getProgram().getMinAttributesRequiredToSearch() > 0)
         || (params.hasFilters()
-            && params.getFilters().size() < params.getProgram().getMinAttributesRequiredToSearch())
-        || (params.hasAttributes()
-            && params.getAttributes().size()
-                < params.getProgram().getMinAttributesRequiredToSearch());
+            && params.getFilters().size() < params.getProgram().getMinAttributesRequiredToSearch());
   }
 
   private void checkIfMaxTeiLimitIsReached(TrackedEntityQueryParams params, int maxTeiLimit) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParams.java
@@ -59,9 +59,6 @@ public class TrackedEntityOperationParams {
   /** Query value, will apply to all relevant attributes. */
   private QueryFilter query;
 
-  /** Attributes to be included in the response. Can be used to filter response. */
-  private String attributes;
-
   /** Filters for the response. */
   private String filters;
 
@@ -143,9 +140,6 @@ public class TrackedEntityOperationParams {
 
   /** Indicates whether to include soft-deleted elements. Default to false */
   @Builder.Default private boolean includeDeleted = false;
-
-  /** Indicates whether to include all te attributes */
-  private boolean includeAllAttributes;
 
   /**
    * Indicates whether the search is internal triggered by the system. The system should trigger

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapper.java
@@ -111,10 +111,6 @@ class TrackedEntityOperationParamsMapper {
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
 
-    List<QueryItem> attributeItems =
-        parseAttributeQueryItems(operationParams.getAttributes(), attributes);
-    params.setAttributes(attributeItems);
-
     List<QueryItem> filters = parseAttributeQueryItems(operationParams.getFilters(), attributes);
     validateDuplicatedAttributeFilters(filters);
     params.setFilters(filters);
@@ -148,7 +144,6 @@ class TrackedEntityOperationParamsMapper {
         .setTotalPages(operationParams.isTotalPages())
         .setSkipPaging(operationParams.isSkipPaging())
         .setIncludeDeleted(operationParams.isIncludeDeleted())
-        .setIncludeAllAttributes(operationParams.isIncludeAllAttributes())
         .setPotentialDuplicate(operationParams.getPotentialDuplicate());
 
     return params;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/DefaultTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/DefaultTrackedEntityStore.java
@@ -159,8 +159,7 @@ public class DefaultTrackedEntityStore extends AbstractStore implements TrackedE
     MapSqlParameterSource paramSource = createIdsParam(ids).addValue("userInfoId", ctx.getUserId());
 
     boolean checkForOwnership =
-        ctx.getQueryParams().isIncludeAllAttributes()
-            || ctx.getParams().isIncludeEnrollments()
+        ctx.getParams().isIncludeEnrollments()
             || ctx.getParams().getTeEnrollmentParams().isIncludeEvents();
 
     String sql;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
@@ -206,7 +206,6 @@ class TrackedEntityOperationParamsMapperTest {
             .totalPages(false)
             .skipPaging(false)
             .includeDeleted(true)
-            .includeAllAttributes(true)
             .build();
 
     final TrackedEntityQueryParams params = mapper.map(operationParams);
@@ -233,7 +232,6 @@ class TrackedEntityOperationParamsMapperTest {
     assertThat(
         params.getAssignedUserQueryParam().getMode(), is(AssignedUserSelectionMode.PROVIDED));
     assertThat(params.isIncludeDeleted(), is(true));
-    assertThat(params.isIncludeAllAttributes(), is(true));
   }
 
   @Test
@@ -400,54 +398,6 @@ class TrackedEntityOperationParamsMapperTest {
     assertThat(
         e.getMessage(),
         anyOf(containsString(TEA_2_UID + ":GT:30"), containsString(TEA_2_UID + ":LT:40")));
-  }
-
-  @Test
-  void testAttributes() throws BadRequestException, ForbiddenException {
-    TrackedEntityOperationParams operationParams =
-        TrackedEntityOperationParams.builder()
-            .orgUnitMode(ACCESSIBLE)
-            .user(user)
-            .attributes(TEA_1_UID + "," + TEA_2_UID)
-            .build();
-
-    TrackedEntityQueryParams params = mapper.map(operationParams);
-
-    List<QueryItem> items = params.getAttributes();
-    assertNotNull(items);
-    // mapping to UIDs as the error message by just relying on QueryItem
-    // equals() is not helpful
-    assertContainsOnly(
-        List.of(TEA_1_UID, TEA_2_UID),
-        items.stream().map(i -> i.getItem().getUid()).collect(Collectors.toList()));
-  }
-
-  @Test
-  void testMappingAttributeWhenAttributeDoesNotExist() {
-    TrackedEntityOperationParams operationParams =
-        TrackedEntityOperationParams.builder()
-            .orgUnitMode(ACCESSIBLE)
-            .user(user)
-            .attributes(TEA_1_UID + "," + "unknown")
-            .build();
-
-    BadRequestException e =
-        assertThrows(BadRequestException.class, () -> mapper.map(operationParams));
-    assertEquals("Attribute does not exist: unknown", e.getMessage());
-  }
-
-  @Test
-  void testMappingFailsOnMissingAttribute() {
-    TrackedEntityOperationParams operationParams =
-        TrackedEntityOperationParams.builder()
-            .orgUnitMode(ACCESSIBLE)
-            .user(user)
-            .attributes(TEA_1_UID + "," + "unknown")
-            .build();
-
-    BadRequestException e =
-        assertThrows(BadRequestException.class, () -> mapper.map(operationParams));
-    assertEquals("Attribute does not exist: unknown", e.getMessage());
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/TrackerExportTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/TrackerExportTests.java
@@ -389,7 +389,7 @@ public class TrackerExportTests extends TrackerApiTest {
         new QueryParamsBuilder()
             .add("orgUnit", "O6uvpzGd5pu")
             .add("program", Constants.TRACKER_PROGRAM_ID)
-            .add("attribute", String.format("kZeSYCgaHTk:%s:%s", operator, searchCriteria));
+            .add("filter", String.format("kZeSYCgaHTk:%s:%s", operator, searchCriteria));
 
     trackerImportExportActions
         .getTrackedEntities(queryParamsBuilder)

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -401,7 +401,6 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
         TrackedEntityOperationParams.builder()
             .organisationUnits(Set.of(orgUnitA.getUid()))
             .trackedEntityTypeUid(trackedEntityTypeA.getUid())
-            .includeAllAttributes(true)
             .build();
 
     trackedEntityTypeA.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
@@ -425,7 +424,6 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .organisationUnits(Set.of(orgUnitA.getUid(), orgUnitB.getUid()))
             .orgUnitMode(DESCENDANTS)
             .trackedEntityTypeUid(trackedEntityTypeA.getUid())
-            .includeAllAttributes(true)
             .user(user)
             .build();
 
@@ -433,27 +431,6 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
         trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
 
     assertContainsOnly(List.of(trackedEntityA, trackedEntityB), trackedEntities);
-  }
-
-  @Test
-  void shouldIncludeAllAttributesOfGivenTrackedEntity()
-      throws ForbiddenException, NotFoundException, BadRequestException {
-    TrackedEntityOperationParams operationParams =
-        TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
-            .orgUnitMode(SELECTED)
-            .includeAllAttributes(true)
-            .trackedEntityUids(Set.of(trackedEntityA.getUid()))
-            .user(user)
-            .build();
-
-    final List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
-
-    assertContainsOnly(List.of(trackedEntityA), trackedEntities);
-    assertContainsOnly(
-        Set.of("A", "B", "C", "E"),
-        attributeNames(trackedEntities.get(0).getTrackedEntityAttributeValues()));
   }
 
   @Test
@@ -467,7 +444,6 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .organisationUnits(Set.of(orgUnitA.getUid()))
             .orgUnitMode(SELECTED)
             .trackedEntityTypeUid(trackedEntityTypeA.getUid())
-            .includeAllAttributes(true)
             .trackedEntityParams(TrackedEntityParams.TRUE)
             .user(user)
             .build();
@@ -498,30 +474,6 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
                 trackedEntities.get(0).getProgramOwners().stream()
                     .map(po -> po.getProgram().getUid())
                     .collect(Collectors.toSet())));
-  }
-
-  @Test
-  void shouldReturnTrackedEntityIncludeAllAttributesInProtectedProgramNoAccess()
-      throws ForbiddenException, NotFoundException, BadRequestException {
-    // this was declared as "remove ownership"; unclear to me how this is removing ownership
-    trackerOwnershipManager.assignOwnership(trackedEntityA, programB, orgUnitB, true, true);
-
-    TrackedEntityOperationParams operationParams =
-        TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnitA.getUid()))
-            .orgUnitMode(SELECTED)
-            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
-            .includeAllAttributes(true)
-            .user(user)
-            .build();
-
-    final List<TrackedEntity> trackedEntities =
-        trackedEntityService.getTrackedEntities(operationParams).getTrackedEntities();
-
-    assertContainsOnly(List.of(trackedEntityA), trackedEntities);
-    assertContainsOnly(
-        Set.of("A", "B", "C"),
-        attributeNames(trackedEntities.get(0).getTrackedEntityAttributeValues()));
   }
 
   @Test
@@ -646,7 +598,6 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .organisationUnits(Set.of(orgUnitA.getUid(), orgUnitB.getUid()))
             .orgUnitMode(DESCENDANTS)
             .trackedEntityTypeUid(trackedEntityTypeA.getUid())
-            .attributes(teaA.getUid())
             .user(user)
             .build();
 
@@ -668,7 +619,6 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .orgUnitMode(DESCENDANTS)
             .trackedEntityTypeUid(trackedEntityTypeA.getUid())
             .filters(teaA.getUid())
-            .attributes(teaA.getUid())
             .user(user)
             .build();
 
@@ -853,7 +803,6 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .orgUnitMode(SELECTED)
             .trackedEntityTypeUid(trackedEntityTypeA.getUid())
             .trackedEntityUids(Set.of(trackedEntityA.getUid()))
-            .includeAllAttributes(true)
             .trackedEntityParams(params)
             .user(user)
             .build();
@@ -886,7 +835,6 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .orgUnitMode(SELECTED)
             .trackedEntityTypeUid(trackedEntityTypeA.getUid())
             .trackedEntityUids(Set.of(trackedEntityA.getUid()))
-            .includeAllAttributes(true)
             .user(user)
             .build();
 
@@ -908,7 +856,6 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .orgUnitMode(SELECTED)
             .trackedEntityTypeUid(trackedEntityTypeA.getUid())
             .trackedEntityUids(Set.of(trackedEntityA.getUid()))
-            .includeAllAttributes(true)
             .trackedEntityParams(params)
             .user(user)
             .build();
@@ -942,7 +889,6 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .organisationUnits(Set.of(orgUnitA.getUid()))
             .orgUnitMode(SELECTED)
             .trackedEntityTypeUid(trackedEntityTypeA.getUid())
-            .includeAllAttributes(true)
             .trackedEntityParams(params)
             .user(user)
             .build();
@@ -971,7 +917,6 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .organisationUnits(Set.of(orgUnitA.getUid()))
             .orgUnitMode(SELECTED)
             .trackedEntityTypeUid(trackedEntityTypeA.getUid())
-            .includeAllAttributes(true)
             .user(user)
             .build();
 
@@ -1006,7 +951,6 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .organisationUnits(Set.of(orgUnitA.getUid()))
             .orgUnitMode(SELECTED)
             .trackedEntityTypeUid(trackedEntityTypeA.getUid())
-            .includeAllAttributes(true)
             .trackedEntityParams(params)
             .user(user)
             .build();
@@ -1054,7 +998,6 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .organisationUnits(Set.of(orgUnitA.getUid()))
             .orgUnitMode(SELECTED)
             .trackedEntityTypeUid(trackedEntityTypeA.getUid())
-            .includeAllAttributes(true)
             .trackedEntityParams(params)
             .user(user)
             .build();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParams.java
@@ -46,7 +46,6 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
-import org.hisp.dhis.webapi.controller.tracker.view.Attribute;
 import org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity;
 import org.hisp.dhis.webapi.controller.tracker.view.User;
 
@@ -64,10 +63,6 @@ class RequestParams extends PagingAndSortingCriteriaAdapter {
 
   /** Query filter for attributes */
   private String query;
-
-  /** Comma separated list of attribute UIDs */
-  @OpenApi.Property({UID[].class, Attribute.class})
-  private String attribute;
 
   /** Comma separated list of attribute filters */
   private String filter;
@@ -172,9 +167,6 @@ class RequestParams extends PagingAndSortingCriteriaAdapter {
 
   /** Indicates whether to include soft-deleted elements */
   private boolean includeDeleted;
-
-  /** Indicates whether to include all TEI attributes */
-  private boolean includeAllAttributes;
 
   /**
    * Potential Duplicate value for TEI. If null, we don't check whether a TEI is a

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
@@ -131,14 +131,12 @@ class TrackedEntityRequestParamsMapper {
                     requestParams.getAssignedUserMode(), user, UID.toValueSet(assignedUsers)))
             .user(user)
             .trackedEntityUids(UID.toValueSet(trackedEntities))
-            .attributes(requestParams.getAttribute())
             .filters(requestParams.getFilter())
             .page(Objects.requireNonNullElse(requestParams.getPage(), DEFAULT_PAGE))
             .pageSize(Objects.requireNonNullElse(requestParams.getPageSize(), DEFAULT_PAGE_SIZE))
             .totalPages(toBooleanDefaultIfNull(requestParams.isTotalPages(), false))
             .skipPaging(toBooleanDefaultIfNull(requestParams.isSkipPaging(), false))
             .includeDeleted(requestParams.isIncludeDeleted())
-            .includeAllAttributes(requestParams.isIncludeAllAttributes())
             .potentialDuplicate(requestParams.getPotentialDuplicate())
             .trackedEntityParams(fieldsParamMapper.map(fields));
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapperTest.java
@@ -110,7 +110,6 @@ class TrackedEntityRequestParamsMapperTest {
     requestParams.setTotalPages(false);
     requestParams.setSkipPaging(false);
     requestParams.setIncludeDeleted(true);
-    requestParams.setIncludeAllAttributes(true);
 
     final TrackedEntityOperationParams params = mapper.map(requestParams, user);
 
@@ -135,7 +134,6 @@ class TrackedEntityRequestParamsMapperTest {
     assertThat(
         params.getAssignedUserQueryParam().getMode(), is(AssignedUserSelectionMode.PROVIDED));
     assertThat(params.isIncludeDeleted(), is(true));
-    assertThat(params.isIncludeAllAttributes(), is(true));
   }
 
   @Test


### PR DESCRIPTION
This is the first PR that removes `attribute` and `includeAllAttributes` parameters in TrackedEntity exporter endpoint.
Next PR will remove `query` parameter