### PR TITLE
feat: Add sorting into EventVisualization [DHIS2-14956]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualization.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualization.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.eventvisualization;
 
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.ArrayUtils.contains;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.join;
 import static org.hisp.dhis.common.AnalyticsType.EVENT;
 import static org.hisp.dhis.common.DimensionalObjectUtils.TITLE_ITEM_SEP;
@@ -131,6 +134,9 @@ public class EventVisualization extends BaseAnalyticalObject
   // -------------------------------------------------------------------------
 
   private List<String> filterDimensions = new ArrayList<>();
+
+  /** Stores the sorting state in the current object. */
+  private List<Sorting> sorting = new ArrayList<>();
 
   // -------------------------------------------------------------------------
   // Transient properties
@@ -584,6 +590,19 @@ public class EventVisualization extends BaseAnalyticalObject
     this.filterDimensions = filterDimensions;
   }
 
+  @JsonProperty("sorting")
+  @JacksonXmlElementWrapper(localName = "sorting", namespace = DXF_2_0)
+  @JacksonXmlProperty(localName = "sortingItem", namespace = DXF_2_0)
+  public List<Sorting> getSorting() {
+    return sorting;
+  }
+
+  public void setSorting(List<Sorting> sorting) {
+    if (sorting != null) {
+      this.sorting = sorting.stream().distinct().collect(toList());
+    }
+  }
+
   // -------------------------------------------------------------------------
   // AnalyticalObject
   // -------------------------------------------------------------------------
@@ -630,6 +649,21 @@ public class EventVisualization extends BaseAnalyticalObject
     setDimensionItemsForFilters(object, dataItemGrid, true);
 
     return object != null ? object.getItems() : null;
+  }
+
+  /** Validates the state of the current list of {@link Sorting} objects (if one is defined). */
+  public void validateSortingState() {
+    List<String> columns = getColumnDimensions();
+    List<Sorting> sortingList = getSorting().stream().collect(toList());
+
+    sortingList.forEach(
+        s -> {
+          if (isBlank(s.getDimension()) || s.getDirection() == null) {
+            throw new IllegalArgumentException("Sorting is not valid");
+          } else if (columns.stream().noneMatch(c -> contains(s.getDimension().split("\\."), c))) {
+            throw new IllegalStateException(s.getDimension());
+          }
+        });
   }
 
   public AnalyticsType getAnalyticsType() {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/Sorting.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/Sorting.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.eventvisualization;
+
+import static org.hisp.dhis.common.DxfNamespaces.DXF_2_0;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import java.io.Serializable;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.hisp.dhis.analytics.SortOrder;
+
+/** This class is responsible for the encapsulation of objects and attributes related to sorting. */
+@Data
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@NoArgsConstructor
+public class Sorting implements Serializable {
+  /** A dimension can have the format "uid", "uid.uid1", "uid.uid1.uid2" or "uid[-2].uid1". */
+  @EqualsAndHashCode.Include
+  @JsonProperty(required = true)
+  @JacksonXmlProperty(namespace = DXF_2_0)
+  private String dimension;
+
+  @JsonProperty(required = true)
+  @JacksonXmlProperty(namespace = DXF_2_0)
+  private SortOrder direction;
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -361,6 +361,9 @@ public enum ErrorCode {
   E7230("Header param `{0}` does not exist"),
   E7231("Legacy `{0}` can be updated only through event visualizations"),
   E7234("Query filter: `{0}` not valid for query item value type: `{1}`"),
+  E7237("Sorting must have a valid dimension and a direction"),
+  E7238("Sorting dimension ‘{0}’ is not a column"),
+
   /* Org unit analytics */
   E7300("At least one organisation unit must be specified"),
   E7301("At least one organisation unit group set must be specified"),

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventvisualization.hibernate/EventVisualization.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventvisualization.hibernate/EventVisualization.hbm.xml
@@ -286,6 +286,8 @@
 
         <property name="simpleDimensions" type="jblSimpleEventDimensions"/>
 
+        <property name="sorting" type="jblSorting"/>
+
         <property name="eventRepetitions" type="jblEventRepetition"/>
 
         <!-- Dynamic attribute values -->

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_51__Add_sorting_to_eventvisualization.sql.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_51__Add_sorting_to_eventvisualization.sql.sql
@@ -1,0 +1,4 @@
+-- https://dhis2.atlassian.net/browse/DHIS2-14956
+-- Adds a new column "sorting" into EventVisualization table.
+
+alter table eventvisualization add column if not exists "sorting" jsonb default '[]'::jsonb;

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/org/hisp/dhis/usertype/UserTypes.hbm.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/org/hisp/dhis/usertype/UserTypes.hbm.xml
@@ -61,6 +61,10 @@
     <param name="clazz">org.hisp.dhis.eventvisualization.EventRepetition</param>
   </typedef>
 
+  <typedef class="org.hisp.dhis.hibernate.jsonb.type.JsonListBinaryType" name="jblSorting">
+    <param name="clazz">org.hisp.dhis.eventvisualization.Sorting</param>
+  </typedef>
+
   <typedef class="org.hisp.dhis.hibernate.jsonb.type.JsonBinaryType" name="jblDashboardLayout">
     <param name="clazz">org.hisp.dhis.dashboard.design.Layout</param>
   </typedef>

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/EventVisualizationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/EventVisualizationControllerTest.java
@@ -28,13 +28,12 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.CREATED;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -269,22 +268,230 @@ class EventVisualizationControllerTest extends DhisControllerConvenienceTest {
   }
 
   @Test
-  void testPost() {
+  void testPostSortingObject() {
     // Given
+    String dimension = "pe";
+    String sorting = "'sorting': [{'dimension': '" + dimension + "', 'direction':'ASC'}]";
     String body =
-        "{'name': 'Test post', 'type': 'LINE_LIST', 'program': {'id': '"
+        "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
             + mockProgram.getUid()
-            + "'}, 'skipRounding': true}";
+            + "'}, 'columns': [{'dimension': '"
+            + dimension
+            + "'}],"
+            + sorting
+            + "}";
 
     // When
     String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
 
     // Then
-    JsonObject response = GET("/eventVisualizations/" + uid).content();
+    String getParams = "?fields=:all,columns[:all,items,sorting]";
+    JsonObject response = GET("/eventVisualizations/" + uid + getParams).content();
 
-    assertThat(response.get("name").node().value(), is(equalTo("Test post")));
-    assertThat(response.get("type").node().value(), is(equalTo("LINE_LIST")));
-    assertThat(response.get("program").node().get("id").value(), is(equalTo(mockProgram.getUid())));
-    assertThat(response.get("skipRounding").node().value(), is(equalTo(true)));
+    assertThat(response.get("sorting").toString(), containsString("pe"));
+    assertThat(response.get("sorting").toString(), containsString("ASC"));
+  }
+
+  @Test
+  void testPostSortingObjectWithPrefixedColumn() {
+    // Given
+    String programStageUid = mockProgramStage.getUid();
+    String dimensionUid = mockProgramIndicator.getUid();
+    String sorting =
+        "'sorting': [{'dimension': '"
+            + programStageUid
+            + "."
+            + dimensionUid
+            + "', 'direction':'ASC'}]";
+    String body =
+        "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
+            + mockProgram.getUid()
+            + "'}, 'columns': [{'dimension': '"
+            + dimensionUid
+            + "',"
+            + "'programStage': {'id':'"
+            + programStageUid
+            + "'}"
+            + "}],"
+            + sorting
+            + "}";
+
+    // When
+    String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
+
+    // Then
+    String getParams = "?fields=:all,columns[:all,items,sorting]";
+    JsonObject response = GET("/eventVisualizations/" + uid + getParams).content();
+
+    assertThat(
+        response.get("sorting").toString(), containsString(programStageUid + "." + dimensionUid));
+    assertThat(response.get("sorting").toString(), containsString("ASC"));
+  }
+
+  @Test
+  void testPostSortingObjectWithPrefixedColumnWithIndex() {
+    // Given
+    String programStageUid = mockProgramStage.getUid() + "[-2]";
+    String dimensionUid = mockProgramIndicator.getUid();
+    String sorting =
+        "'sorting': [{'dimension': '"
+            + programStageUid
+            + "."
+            + dimensionUid
+            + "', 'direction':'ASC'}]";
+    String body =
+        "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
+            + mockProgram.getUid()
+            + "'}, 'columns': [{'dimension': '"
+            + dimensionUid
+            + "',"
+            + "'programStage': {'id':'"
+            + programStageUid
+            + "'}"
+            + "}],"
+            + sorting
+            + "}";
+
+    // When
+    String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
+
+    // Then
+    String getParams = "?fields=:all,columns[:all,items,sorting]";
+    JsonObject response = GET("/eventVisualizations/" + uid + getParams).content();
+
+    assertThat(
+        response.get("sorting").toString(), containsString(programStageUid + "." + dimensionUid));
+    assertThat(response.get("sorting").toString(), containsString("ASC"));
+  }
+
+  @Test
+  void testPostMultipleSortingObject() {
+    // Given
+    String dimension1 = "pe";
+    String dimension2 = "ou";
+    String sorting =
+        "'sorting': [{'dimension': '"
+            + dimension1
+            + "', 'direction':'ASC'},"
+            + "{'dimension': '"
+            + dimension2
+            + "', 'direction':'DESC'}]";
+    String body =
+        "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
+            + mockProgram.getUid()
+            + "'}, 'columns': [{'dimension': '"
+            + dimension1
+            + "'}, {'dimension': '"
+            + dimension2
+            + "'}],"
+            + sorting
+            + "}";
+
+    // When
+    String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
+
+    // Then
+    String getParams = "?fields=:all,columns[:all,items,sorting]";
+    JsonObject response = GET("/eventVisualizations/" + uid + getParams).content();
+
+    assertThat(response.get("sorting").toString(), containsString("pe"));
+    assertThat(response.get("sorting").toString(), containsString("ASC"));
+    assertThat(response.get("sorting").toString(), containsString("ou"));
+    assertThat(response.get("sorting").toString(), containsString("DESC"));
+  }
+
+  @Test
+  void testPostSortingObjectWithDuplication() {
+    // Given
+    String dimension = "pe";
+    String sorting =
+        "'sorting': [{'dimension': '"
+            + dimension
+            + "', 'direction':'ASC'},"
+            + "{'dimension': '"
+            + dimension
+            + "', 'direction':'DESC'}]";
+    String body =
+        "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
+            + mockProgram.getUid()
+            + "'}, 'columns': [{'dimension': '"
+            + dimension
+            + "'}],"
+            + sorting
+            + "}";
+
+    // When
+    String uid = assertStatus(CREATED, POST("/eventVisualizations/", body));
+
+    // Then
+    String getParams = "?fields=:all,columns[:all,items,sorting]";
+    JsonObject response = GET("/eventVisualizations/" + uid + getParams).content();
+
+    assertThat(response.get("sorting").toString(), containsString("pe"));
+    assertThat(response.get("sorting").toString(), containsString("ASC"));
+    assertThat(response.get("sorting").toString(), not(containsString("DESC")));
+  }
+
+  @Test
+  void testPostInvalidSortingObject() {
+    // Given
+    String invalidDimension = "invalidOne";
+    String sorting = "'sorting': [{'dimension': '" + invalidDimension + "', 'direction':'ASC'}]";
+    String body =
+        "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
+            + mockProgram.getUid()
+            + "'}, 'columns': [{'dimension': 'pe'}],"
+            + sorting
+            + "}";
+
+    // When
+    HttpResponse response = POST("/eventVisualizations/", body);
+
+    // Then
+    assertEquals(
+        "Sorting dimension ‘" + invalidDimension + "’ is not a column",
+        response.error(CONFLICT).getMessage());
+  }
+
+  @Test
+  void testPostBlankSortingObject() {
+    // Given
+    String blankDimension = " ";
+    String sorting = "'sorting': [{'dimension': '" + blankDimension + "', 'direction':'ASC'}]";
+    String body =
+        "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
+            + mockProgram.getUid()
+            + "'}, 'columns': [{'dimension': 'pe'}],"
+            + sorting
+            + "}";
+
+    // When
+    HttpResponse response = POST("/eventVisualizations/", body);
+
+    // Then
+    assertEquals(
+        "Sorting must have a valid dimension and a direction",
+        response.error(CONFLICT).getMessage());
+  }
+
+  @Test
+  void testPostNullSortingObject() {
+    // Given
+    String blankDimension = " ";
+    String sorting = "'sorting': [{'dimension': '" + blankDimension + "', 'direction':'ASC'}]";
+    String body =
+        "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
+            + mockProgram.getUid()
+            + "'}, 'columns': [{'dimension': 'pe'}],"
+            + sorting
+            + "}";
+
+    // When
+    HttpResponse response = POST("/eventVisualizations/", body);
+
+    // Then
+    assertEquals(
+        "Sorting must have a valid dimension and a direction",
+        response.error(CONFLICT).getMessage());
   }
 }


### PR DESCRIPTION
**_[Backport from  master/2.41]_** #14195 #14520

Adding a Sorting object into EventVisualization.
The sorting direction has to be consistent with the dimensions (columns) defined in the EventVisualization object.
Only dimension columns can be sorted.

In the Line Listing app, this will allow users to save the sorting direction they want for a particular EventVisualization.