### PR TITLE
fix: revert acl check on user group update

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroup.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroup.java
@@ -48,15 +48,7 @@ import org.hisp.dhis.schema.transformer.UserPropertyTransformer;
 @JacksonXmlRootElement(localName = "userGroup", namespace = DxfNamespaces.DXF_2_0)
 public class UserGroup extends BaseIdentifiableObject implements MetadataObject {
   public static final String AUTH_USER_ADD = "F_USER_ADD";
-
-  public static final String AUTH_USER_DELETE = "F_USER_DELETE";
-
-  public static final String AUTH_USER_VIEW = "F_USER_VIEW";
-
   public static final String AUTH_USER_ADD_IN_GROUP = "F_USER_ADD_WITHIN_MANAGED_GROUP";
-
-  public static final String AUTH_ADD_MEMBERS_TO_READ_ONLY_USER_GROUPS =
-      "F_USER_GROUPS_READ_ONLY_ADD_MEMBERS";
 
   /** Global unique identifier for UserGroup (to be used for sharing etc) */
   private UUID uuid;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroupService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroupService.java
@@ -46,7 +46,7 @@ public interface UserGroupService {
 
   /**
    * Indicates whether the current user can add or remove members for the user group with the given
-   * UID. To to so the current user must have write access to the group or have read access as well
+   * UID. To do so the current user must have write access to the group or have read access as well
    * as the F_USER_GROUPS_READ_ONLY_ADD_MEMBERS authority.
    *
    * @param uid the user group UID.
@@ -56,13 +56,9 @@ public interface UserGroupService {
 
   boolean canAddOrRemoveMember(String uid, User currentUser);
 
-  void addUserToGroups(User user, @Nonnull Collection<String> uids);
-
   void addUserToGroups(User user, @Nonnull Collection<String> uids, User currentUser);
 
   void removeUserFromGroups(User user, @Nonnull Collection<String> uids);
-
-  void updateUserGroups(User user, @Nonnull Collection<String> uids);
 
   void updateUserGroups(User user, @Nonnull Collection<String> uids, User currentUser);
 
@@ -73,10 +69,6 @@ public interface UserGroupService {
   List<UserGroup> getUserGroupsBetween(int first, int max);
 
   List<UserGroup> getUserGroupsBetweenByName(String name, int first, int max);
-
-  int getUserGroupCount();
-
-  int getUserGroupCountByName(String name);
 
   /** Get UserGroup's display name by given userGroup uid Return null if UserGroup does not exist */
   String getDisplayName(String uid);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
@@ -179,6 +179,7 @@ public class DefaultUserGroupService implements UserGroupService {
 
     for (UserGroup userGroup : new HashSet<>(user.getGroups())) {
       if (!updates.contains(userGroup) && canAddOrRemoveMember(userGroup.getUid(), currentUser)) {
+        before.put(userGroup, userGroup.getMembers().size());
         userGroup.removeUser(user);
       }
     }
@@ -190,11 +191,10 @@ public class DefaultUserGroupService implements UserGroupService {
     }
 
     // Update user group if members have changed
-    updates.forEach(
-        userGroup -> {
-          int after = userGroup.getMembers().size();
-          if (before.get(userGroup) != after) {
-            userGroup.setLastUpdatedBy(user);
+    before.forEach(
+        (userGroup, beforeSize) -> {
+          if (beforeSize != userGroup.getMembers().size()) {
+            userGroup.setLastUpdatedBy(currentUser);
             userGroupStore.updateNoAcl(userGroup);
           }
         });

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
@@ -186,14 +186,13 @@ public class DefaultUserGroupService implements UserGroupService {
     for (UserGroup userGroup : new HashSet<>(user.getGroups())) {
       if (!updates.contains(userGroup) && canAddOrRemoveMember(userGroup.getUid(), currentUser)) {
         userGroup.removeUser(user);
-        userGroupStore.update(userGroup, currentUser);
       }
     }
 
     for (UserGroup userGroup : updates) {
       if (canAddOrRemoveMember(userGroup.getUid(), currentUser)) {
         userGroup.addUser(user);
-        userGroupStore.update(userGroup, currentUser);
+        userGroupStore.updateNoAcl(userGroup);
       }
     }
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -234,7 +234,6 @@ class UserControllerTest extends DhisControllerConvenienceTest {
 
   @Test
   void updateUserHasAccessToUpdateGroups() {
-
     systemSettingManager.saveSystemSetting(SettingKey.CAN_GRANT_OWN_USER_ROLES, Boolean.TRUE);
 
     UserRole roleB = createUserRole("ROLE_B", "F_USER_ADD", "F_USER_GROUPS_READ_ONLY_ADD_MEMBERS");
@@ -249,7 +248,9 @@ class UserControllerTest extends DhisControllerConvenienceTest {
 
     switchContextToUser(user);
 
-    PUT(
+    assertStatus(
+        HttpStatus.OK,
+        PUT(
             "/users/" + user.getUid(),
             " {"
                 + "'name': 'test',"
@@ -267,10 +268,7 @@ class UserControllerTest extends DhisControllerConvenienceTest {
                 + userGroupA.getUid()
                 + "'"
                 + "}]"
-                + "}")
-        .content(HttpStatus.OK)
-        .get("response")
-        .as(JsonImportSummary.class);
+                + "}"));
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -233,6 +233,47 @@ class UserControllerTest extends DhisControllerConvenienceTest {
   }
 
   @Test
+  void updateUserHasAccessToUpdateGroups() {
+
+    systemSettingManager.saveSystemSetting(SettingKey.CAN_GRANT_OWN_USER_ROLES, Boolean.TRUE);
+
+    UserRole roleB = createUserRole("ROLE_B", "F_USER_ADD", "F_USER_GROUPS_READ_ONLY_ADD_MEMBERS");
+    userService.addUserRole(roleB);
+
+    UserGroup userGroupA = createUserGroup('A', emptySet());
+    manager.save(userGroupA);
+
+    User user = createUserWithAuth("someone", "NONE");
+    user.getUserRoles().add(roleB);
+    userService.updateUser(user);
+
+    switchContextToUser(user);
+
+    PUT(
+            "/users/" + user.getUid(),
+            " {"
+                + "'name': 'test',"
+                + "'username':'someone',"
+                + "'userRoles': ["
+                + "{"
+                + "'id':'"
+                + roleB.getUid()
+                + "'"
+                + "}"
+                + "],"
+                + "'userGroups': ["
+                + "{"
+                + "'id':'"
+                + userGroupA.getUid()
+                + "'"
+                + "}]"
+                + "}")
+        .content(HttpStatus.OK)
+        .get("response")
+        .as(JsonImportSummary.class);
+  }
+
+  @Test
   void testUpdateRoles() {
     UserRole userRole = createUserRole("ROLE_B", "ALL");
     userService.addUserRole(userRole);


### PR DESCRIPTION
### Summary
Reverts change to do a full acl check during user group updates. This will not work when an user admin is doing a user update via a PUT operation and the user don't have access to modify user groups. There also exist a special authority allowing a user admin to add and remove group members without having full group modify access.
This is also makes sure the groups only are updated when they actually change, ie. in this instance, the membership count changes.
This PR also do some minor refactoring, mostly just removing some dead code/unused public methods in the user group service and remove a duplicate constant.

## New automatic test
UserControllerTest#updateUserHasAccessToUpdateGroups()


Jira: [DHIS2-15787](https://dhis2.atlassian.net/browse/DHIS2-15787)


[DHIS2-15787]: https://dhis2.atlassian.net/browse/DHIS2-15787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ