### PR TITLE
fix: revert acl check on user group update (#15131)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroup.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroup.java
@@ -48,15 +48,7 @@ import org.hisp.dhis.schema.transformer.UserPropertyTransformer;
 @JacksonXmlRootElement(localName = "userGroup", namespace = DxfNamespaces.DXF_2_0)
 public class UserGroup extends BaseIdentifiableObject implements MetadataObject {
   public static final String AUTH_USER_ADD = "F_USER_ADD";
-
-  public static final String AUTH_USER_DELETE = "F_USER_DELETE";
-
-  public static final String AUTH_USER_VIEW = "F_USER_VIEW";
-
   public static final String AUTH_USER_ADD_IN_GROUP = "F_USER_ADD_WITHIN_MANAGED_GROUP";
-
-  public static final String AUTH_ADD_MEMBERS_TO_READ_ONLY_USER_GROUPS =
-      "F_USER_GROUPS_READ_ONLY_ADD_MEMBERS";
 
   /** Global unique identifier for UserGroup (to be used for sharing etc) */
   private UUID uuid;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroup.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroup.java
@@ -49,6 +49,8 @@ import org.hisp.dhis.schema.transformer.UserPropertyTransformer;
 public class UserGroup extends BaseIdentifiableObject implements MetadataObject {
   public static final String AUTH_USER_ADD = "F_USER_ADD";
   public static final String AUTH_USER_ADD_IN_GROUP = "F_USER_ADD_WITHIN_MANAGED_GROUP";
+  public static final String AUTH_ADD_MEMBERS_TO_READ_ONLY_USER_GROUPS =
+      "F_USER_GROUPS_READ_ONLY_ADD_MEMBERS";
 
   /** Global unique identifier for UserGroup (to be used for sharing etc) */
   private UUID uuid;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroupService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroupService.java
@@ -46,7 +46,7 @@ public interface UserGroupService {
 
   /**
    * Indicates whether the current user can add or remove members for the user group with the given
-   * UID. To to so the current user must have write access to the group or have read access as well
+   * UID. To do so the current user must have write access to the group or have read access as well
    * as the F_USER_GROUPS_READ_ONLY_ADD_MEMBERS authority.
    *
    * @param uid the user group UID.
@@ -56,13 +56,9 @@ public interface UserGroupService {
 
   boolean canAddOrRemoveMember(String uid, User currentUser);
 
-  void addUserToGroups(User user, @Nonnull Collection<String> uids);
-
   void addUserToGroups(User user, @Nonnull Collection<String> uids, User currentUser);
 
   void removeUserFromGroups(User user, @Nonnull Collection<String> uids);
-
-  void updateUserGroups(User user, @Nonnull Collection<String> uids);
 
   void updateUserGroups(User user, @Nonnull Collection<String> uids, User currentUser);
 
@@ -73,10 +69,6 @@ public interface UserGroupService {
   List<UserGroup> getUserGroupsBetween(int first, int max);
 
   List<UserGroup> getUserGroupsBetweenByName(String name, int first, int max);
-
-  int getUserGroupCount();
-
-  int getUserGroupCountByName(String name);
 
   /** Get UserGroup's display name by given userGroup uid Return null if UserGroup does not exist */
   String getDisplayName(String uid);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.user;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.user.UserGroup.AUTH_ADD_MEMBERS_TO_READ_ONLY_USER_GROUPS;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -38,7 +39,6 @@ import javax.annotation.Nonnull;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.cache.HibernateCacheManager;
-import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.security.acl.AclService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -140,7 +140,7 @@ public class DefaultUserGroupService implements UserGroupService {
 
     boolean canUpdate = aclService.canUpdate(currentUser, userGroup);
     boolean canAddMember =
-        currentUser.isAuthorized(Authorities.F_USER_GROUPS_READ_ONLY_ADD_MEMBERS);
+        currentUser.isAuthorized(AUTH_ADD_MEMBERS_TO_READ_ONLY_USER_GROUPS);
 
     return canUpdate || canAddMember;
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
@@ -139,8 +139,7 @@ public class DefaultUserGroupService implements UserGroupService {
     }
 
     boolean canUpdate = aclService.canUpdate(currentUser, userGroup);
-    boolean canAddMember =
-        currentUser.isAuthorized(AUTH_ADD_MEMBERS_TO_READ_ONLY_USER_GROUPS);
+    boolean canAddMember = currentUser.isAuthorized(AUTH_ADD_MEMBERS_TO_READ_ONLY_USER_GROUPS);
 
     return canUpdate || canAddMember;
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
@@ -30,12 +30,15 @@ package org.hisp.dhis.user;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.cache.HibernateCacheManager;
+import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.security.acl.AclService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -137,15 +140,9 @@ public class DefaultUserGroupService implements UserGroupService {
 
     boolean canUpdate = aclService.canUpdate(currentUser, userGroup);
     boolean canAddMember =
-        currentUser.isAuthorized(UserGroup.AUTH_ADD_MEMBERS_TO_READ_ONLY_USER_GROUPS);
+        currentUser.isAuthorized(Authorities.F_USER_GROUPS_READ_ONLY_ADD_MEMBERS);
 
     return canUpdate || canAddMember;
-  }
-
-  @Override
-  @Transactional
-  public void addUserToGroups(User user, Collection<String> uids) {
-    addUserToGroups(user, uids, currentUserService.getCurrentUser());
   }
 
   @Override
@@ -174,28 +171,33 @@ public class DefaultUserGroupService implements UserGroupService {
 
   @Override
   @Transactional
-  public void updateUserGroups(User user, Collection<String> uids) {
-    updateUserGroups(user, uids, currentUserService.getCurrentUser());
-  }
-
-  @Override
-  @Transactional
   public void updateUserGroups(User user, @Nonnull Collection<String> uids, User currentUser) {
     Collection<UserGroup> updates = getUserGroupsByUid(uids);
 
+    Map<UserGroup, Integer> before = new HashMap<>();
+    updates.forEach(userGroup -> before.put(userGroup, userGroup.getMembers().size()));
+
     for (UserGroup userGroup : new HashSet<>(user.getGroups())) {
       if (!updates.contains(userGroup) && canAddOrRemoveMember(userGroup.getUid(), currentUser)) {
+        before.put(userGroup, userGroup.getMembers().size());
         userGroup.removeUser(user);
-        userGroupStore.update(userGroup, currentUser);
       }
     }
 
     for (UserGroup userGroup : updates) {
       if (canAddOrRemoveMember(userGroup.getUid(), currentUser)) {
         userGroup.addUser(user);
-        userGroupStore.update(userGroup, currentUser);
       }
     }
+
+    // Update user group if members have changed
+    before.forEach(
+        (userGroup, beforeSize) -> {
+          if (beforeSize != userGroup.getMembers().size()) {
+            userGroup.setLastUpdatedBy(currentUser);
+            userGroupStore.updateNoAcl(userGroup);
+          }
+        });
   }
 
   private Collection<UserGroup> getUserGroupsByUid(@Nonnull Collection<String> uids) {
@@ -206,18 +208,6 @@ public class DefaultUserGroupService implements UserGroupService {
   @Transactional(readOnly = true)
   public List<UserGroup> getUserGroupByName(String name) {
     return userGroupStore.getAllEqName(name);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public int getUserGroupCount() {
-    return userGroupStore.getCount();
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public int getUserGroupCountByName(String name) {
-    return userGroupStore.getCountLikeName(name);
   }
 
   @Override

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -234,6 +234,45 @@ class UserControllerTest extends DhisControllerConvenienceTest {
   }
 
   @Test
+  void updateUserHasAccessToUpdateGroups() {
+    systemSettingManager.saveSystemSetting(SettingKey.CAN_GRANT_OWN_USER_ROLES, Boolean.TRUE);
+
+    UserRole roleB = createUserRole("ROLE_B", "F_USER_ADD", "F_USER_GROUPS_READ_ONLY_ADD_MEMBERS");
+    userService.addUserRole(roleB);
+
+    UserGroup userGroupA = createUserGroup('A', emptySet());
+    manager.save(userGroupA);
+
+    User user = createUserWithAuth("someone", "NONE");
+    user.getUserRoles().add(roleB);
+    userService.updateUser(user);
+
+    switchContextToUser(user);
+
+    assertStatus(
+        HttpStatus.OK,
+        PUT(
+            "/users/" + user.getUid(),
+            " {"
+                + "'name': 'test',"
+                + "'username':'someone',"
+                + "'userRoles': ["
+                + "{"
+                + "'id':'"
+                + roleB.getUid()
+                + "'"
+                + "}"
+                + "],"
+                + "'userGroups': ["
+                + "{"
+                + "'id':'"
+                + userGroupA.getUid()
+                + "'"
+                + "}]"
+                + "}"));
+  }
+
+  @Test
   void testUpdateRoles() {
     UserRole userRole = createUserRole("ROLE_B", "ALL");
     userService.addUserRole(userRole);


### PR DESCRIPTION
### Summary
Reverts change to do a full acl check during user group updates. This will not work when an user admin is doing a user update via a PUT operation and the user don't have access to modify user groups. There also exist a special authority allowing a user admin to add and remove group members without having full group modify access.
This is also makes sure the groups only are updated when they actually change, ie. in this instance, the membership count changes.
This PR also do some minor refactoring, mostly just removing some dead code/unused public methods in the user group service and remove a duplicate constant.

## New automatic test
UserControllerTest#updateUserHasAccessToUpdateGroups()


Jira: [DHIS2-15787](https://dhis2.atlassian.net/browse/DHIS2-15787)


[DHIS2-15787]: https://dhis2.atlassian.net/browse/DHIS2-15787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ