### PR TITLE
fix: Export translated values in ER [DHIS2-11509]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
@@ -513,10 +513,10 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
   }
 
   /**
-   * Returns the value of the property referred to by the given IdScheme.
+   * Returns the value of the property referred to by the given {@link IdScheme}.
    *
-   * @param idScheme the IdScheme.
-   * @return the value of the property referred to by the IdScheme.
+   * @param idScheme the {@link IdScheme}.
+   * @return the value of the property referred to by the {@link IdScheme}.
    */
   @Override
   public String getPropertyValue(IdScheme idScheme) {
@@ -537,6 +537,22 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
     }
 
     return null;
+  }
+
+  /**
+   * Returns the value of the property referred to by the given {@link IdScheme}. If this happens to
+   * refer to NAME, it returns the translatable/display version.
+   *
+   * @param idScheme the {@link IdScheme}.
+   * @return the value of the property referred to by the {@link IdScheme}.
+   */
+  @Override
+  public String getDisplayPropertyValue(IdScheme idScheme) {
+    if (idScheme.is(IdentifiableProperty.NAME)) {
+      return getDisplayName();
+    } else {
+      return getPropertyValue(idScheme);
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObject.java
@@ -105,6 +105,9 @@ public interface IdentifiableObject
   @JsonIgnore
   String getPropertyValue(IdScheme idScheme);
 
+  @JsonIgnore
+  String getDisplayPropertyValue(IdScheme idScheme);
+
   default boolean hasSharing() {
     return getSharing() != null;
   }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/BaseIdentifiableObjectTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/BaseIdentifiableObjectTest.java
@@ -28,6 +28,8 @@
 package org.hisp.dhis.common;
 
 import static org.hisp.dhis.common.BaseIdentifiableObject.copySet;
+import static org.hisp.dhis.common.IdScheme.CODE;
+import static org.hisp.dhis.common.IdScheme.NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -86,5 +88,27 @@ class BaseIdentifiableObjectTest {
     Set<ProgramSection> copiedSections = copySet(program, null, ProgramSection.copyOf);
 
     assertTrue(copiedSections.isEmpty());
+  }
+
+  @Test
+  void testGetDisplayPropertyValueName() {
+    IdScheme idSchemeName = NAME;
+    Program p = new Program("Any program");
+    p.setCode("AnyCode");
+
+    String value = p.getDisplayPropertyValue(idSchemeName);
+
+    assertEquals("Any program", value);
+  }
+
+  @Test
+  void testGetDisplayPropertyValueCode() {
+    IdScheme idSchemeCode = CODE;
+    Program p = new Program("Any program");
+    p.setCode("AnyCode");
+
+    String value = p.getDisplayPropertyValue(idSchemeCode);
+
+    assertEquals("AnyCode", value);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapper.java
@@ -209,13 +209,13 @@ public class SchemeIdResponseMapper {
   private void applyIdSchemeMapping(CommonParams params, Map<String, String> map) {
     if (isNotEmpty(params.getPrograms())) {
       for (Program program : params.getPrograms()) {
-        map.put(program.getUid(), program.getPropertyValue(params.getOutputIdScheme()));
+        map.put(program.getUid(), program.getDisplayPropertyValue(params.getOutputIdScheme()));
       }
     }
 
     if (isNotEmpty(params.delegate().getProgramStages())) {
       for (ProgramStage stage : params.delegate().getProgramStages()) {
-        map.put(stage.getUid(), stage.getPropertyValue(params.getOutputIdScheme()));
+        map.put(stage.getUid(), stage.getDisplayPropertyValue(params.getOutputIdScheme()));
       }
     }
 
@@ -223,7 +223,7 @@ public class SchemeIdResponseMapper {
       Set<Option> options = params.delegate().getItemsOptions();
 
       for (Option option : options) {
-        map.put(option.getCode(), option.getPropertyValue(params.getOutputIdScheme()));
+        map.put(option.getCode(), option.getDisplayPropertyValue(params.getOutputIdScheme()));
       }
     }
   }
@@ -244,13 +244,13 @@ public class SchemeIdResponseMapper {
     if (params.hasProgramStage()) {
       map.put(
           params.getProgramStage().getUid(),
-          params.getProgramStage().getPropertyValue(params.getOutputIdScheme()));
+          params.getProgramStage().getDisplayPropertyValue(params.getOutputIdScheme()));
     }
 
     if (params.hasProgram()) {
       map.put(
           params.getProgram().getUid(),
-          params.getProgram().getPropertyValue(params.getOutputIdScheme()));
+          params.getProgram().getDisplayPropertyValue(params.getOutputIdScheme()));
     }
 
     if (params instanceof EventQueryParams
@@ -258,7 +258,7 @@ public class SchemeIdResponseMapper {
       Set<Option> options = ((EventQueryParams) params).getItemOptions();
 
       for (Option option : options) {
-        map.put(option.getCode(), option.getPropertyValue(params.getOutputIdScheme()));
+        map.put(option.getCode(), option.getDisplayPropertyValue(params.getOutputIdScheme()));
       }
     }
   }


### PR DESCRIPTION
Fixes the translation issue in Event Report and Enrollments in the export/download feature.
With this change, the code makes use of the `displayName` which always tries to get the translatable value.