### PR TITLE
fix: Removed a LocaleController test that fails when adding languages

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/LocaleControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/LocaleControllerTest.java
@@ -85,12 +85,6 @@ class LocaleControllerTest extends DhisControllerConvenienceTest {
   }
 
   @Test
-  void testGetUiLocales() {
-    JsonArray response = GET("/locales/ui").content();
-    assertEquals(38, response.size());
-  }
-
-  @Test
   void testGetUiLocalesInUserLanguage() {
     String userEnglishLocale =
         GET("/userSettings/keyUiLocale/?userId=" + ADMIN_USER_UID)


### PR DESCRIPTION
Through transifex PRs, the number of i18n files (languages/locales) may or may not change. Recently, we added a new language, and split one language into two locales. That resulted in 40 locales registered.

This test assumes the number of locales will always be 38, which is wrong, since the number is subject to change at any time.
