### PR TITLE
fix: Export translated values in ER [DHIS2-11509]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
@@ -600,10 +600,10 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
   }
 
   /**
-   * Returns the value of the property referred to by the given IdScheme.
+   * Returns the value of the property referred to by the given {@link IdScheme}.
    *
-   * @param idScheme the IdScheme.
-   * @return the value of the property referred to by the IdScheme.
+   * @param idScheme the {@link IdScheme}.
+   * @return the value of the property referred to by the {@link IdScheme}.
    */
   @Override
   public String getPropertyValue(IdScheme idScheme) {
@@ -624,6 +624,22 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
     }
 
     return null;
+  }
+
+  /**
+   * Returns the value of the property referred to by the given {@link IdScheme}. If this happens to
+   * refer to NAME, it returns the translatable/display version.
+   *
+   * @param idScheme the {@link IdScheme}.
+   * @return the value of the property referred to by the {@link IdScheme}.
+   */
+  @Override
+  public String getDisplayPropertyValue(IdScheme idScheme) {
+    if (idScheme.is(IdentifiableProperty.NAME)) {
+      return getDisplayName();
+    } else {
+      return getPropertyValue(idScheme);
+    }
   }
 
   /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObject.java
@@ -121,4 +121,7 @@ public interface IdentifiableObject
 
   @JsonIgnore
   String getPropertyValue(IdScheme idScheme);
+
+  @JsonIgnore
+  String getDisplayPropertyValue(IdScheme idScheme);
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/BaseIdentifiableObjectTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/BaseIdentifiableObjectTest.java
@@ -27,10 +27,13 @@
  */
 package org.hisp.dhis.common;
 
+import static org.hisp.dhis.common.IdScheme.CODE;
+import static org.hisp.dhis.common.IdScheme.NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.program.Program;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -52,5 +55,27 @@ class BaseIdentifiableObjectTest {
     assertEquals("CodeA", deA.getPropertyValue(idSchemeCode));
     assertEquals("NameA", deA.getPropertyValue(idSchemeName));
     assertNull(deB.getPropertyValue(idSchemeCode));
+  }
+
+  @Test
+  void testGetDisplayPropertyValueName() {
+    IdScheme idSchemeName = NAME;
+    Program p = new Program("Any program");
+    p.setCode("AnyCode");
+
+    String value = p.getDisplayPropertyValue(idSchemeName);
+
+    assertEquals("Any program", value);
+  }
+
+  @Test
+  void testGetDisplayPropertyValueCode() {
+    IdScheme idSchemeCode = CODE;
+    Program p = new Program("Any program");
+    p.setCode("AnyCode");
+
+    String value = p.getDisplayPropertyValue(idSchemeCode);
+
+    assertEquals("AnyCode", value);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemaIdResponseMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemaIdResponseMapper.java
@@ -63,7 +63,7 @@ public class SchemaIdResponseMapper {
    * @return a map of UID and mapping value.
    */
   public Map<String, String> getSchemeIdResponseMap(DataQueryParams params) {
-    final Map<String, String> responseMap =
+    Map<String, String> responseMap =
         getDimensionItemIdSchemeMap(params.getAllDimensionItems(), params.getOutputIdScheme());
 
     if (params.isGeneralOutputIdSchemeSet()) {
@@ -105,21 +105,21 @@ public class SchemaIdResponseMapper {
     if (params.hasProgramStage()) {
       map.put(
           params.getProgramStage().getUid(),
-          params.getProgramStage().getPropertyValue(params.getOutputIdScheme()));
+          params.getProgramStage().getDisplayPropertyValue(params.getOutputIdScheme()));
     }
 
     if (params.hasProgram()) {
       map.put(
           params.getProgram().getUid(),
-          params.getProgram().getPropertyValue(params.getOutputIdScheme()));
+          params.getProgram().getDisplayPropertyValue(params.getOutputIdScheme()));
     }
 
     if (params instanceof EventQueryParams
         && CollectionUtils.isNotEmpty(((EventQueryParams) params).getItemOptions())) {
       Set<Option> options = ((EventQueryParams) params).getItemOptions();
 
-      for (final Option option : options) {
-        map.put(option.getCode(), option.getPropertyValue(params.getOutputIdScheme()));
+      for (Option option : options) {
+        map.put(option.getCode(), option.getDisplayPropertyValue(params.getOutputIdScheme()));
       }
     }
   }


### PR DESCRIPTION
**_[Backport from master/2.41]_** (#15142)

Fixes the translation issue in Event Report and Enrollments in the export/download feature.
With this change, the code makes use of the `displayName` which always tries to get the translatable value.