### PR TITLE
fix: Export translated values in ER [DHIS2-11509]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
@@ -599,10 +599,10 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
   }
 
   /**
-   * Returns the value of the property referred to by the given IdScheme.
+   * Returns the value of the property referred to by the given {@link IdScheme}.
    *
-   * @param idScheme the IdScheme.
-   * @return the value of the property referred to by the IdScheme.
+   * @param idScheme the {@link IdScheme}.
+   * @return the value of the property referred to by the {@link IdScheme}.
    */
   @Override
   public String getPropertyValue(IdScheme idScheme) {
@@ -623,6 +623,22 @@ public class BaseIdentifiableObject extends BaseLinkableObject implements Identi
     }
 
     return null;
+  }
+
+  /**
+   * Returns the value of the property referred to by the given {@link IdScheme}. If this happens to
+   * refer to NAME, it returns the translatable/display version.
+   *
+   * @param idScheme the {@link IdScheme}.
+   * @return the value of the property referred to by the {@link IdScheme}.
+   */
+  @Override
+  public String getDisplayPropertyValue(IdScheme idScheme) {
+    if (idScheme.is(IdentifiableProperty.NAME)) {
+      return getDisplayName();
+    } else {
+      return getPropertyValue(idScheme);
+    }
   }
 
   /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObject.java
@@ -121,4 +121,7 @@ public interface IdentifiableObject
 
   @JsonIgnore
   String getPropertyValue(IdScheme idScheme);
+
+  @JsonIgnore
+  String getDisplayPropertyValue(IdScheme idScheme);
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/BaseIdentifiableObjectTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/BaseIdentifiableObjectTest.java
@@ -27,10 +27,13 @@
  */
 package org.hisp.dhis.common;
 
+import static org.hisp.dhis.common.IdScheme.CODE;
+import static org.hisp.dhis.common.IdScheme.NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.program.Program;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -52,5 +55,27 @@ class BaseIdentifiableObjectTest {
     assertEquals("CodeA", deA.getPropertyValue(idSchemeCode));
     assertEquals("NameA", deA.getPropertyValue(idSchemeName));
     assertNull(deB.getPropertyValue(idSchemeCode));
+  }
+
+  @Test
+  void testGetDisplayPropertyValueName() {
+    IdScheme idSchemeName = NAME;
+    Program p = new Program("Any program");
+    p.setCode("AnyCode");
+
+    String value = p.getDisplayPropertyValue(idSchemeName);
+
+    assertEquals("Any program", value);
+  }
+
+  @Test
+  void testGetDisplayPropertyValueCode() {
+    IdScheme idSchemeCode = CODE;
+    Program p = new Program("Any program");
+    p.setCode("AnyCode");
+
+    String value = p.getDisplayPropertyValue(idSchemeCode);
+
+    assertEquals("AnyCode", value);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemaIdResponseMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemaIdResponseMapper.java
@@ -42,104 +42,102 @@ import org.springframework.stereotype.Component;
 
 /**
  * This component is responsible for encapsulating the id schema mapping for the response elements
- * based on the given URL id schema params.
+ * based on the given URL ID schemes.
  *
  * @author maikel arabori
  */
 @Component
 public class SchemaIdResponseMapper {
   /**
-   * This method will map the respective element UID's with their respective id schema set. The
-   * 'outputIdScheme' is considered the most general id schema parameter. If set, it will map the
-   * schema id set to all dimension items.
+   * This method will map the respective element UID's with their respective ID scheme set. The
+   * 'outputIdScheme' is considered the most general ID scheme parameter. If set, it will map the
+   * scheme id set to all dimension items.
    *
-   * <p>The other two id schema parameters supported ('outputDataElementIdScheme' and
-   * 'outputOrgUnitIdScheme') will allow fine-grained id schema definitions on top of the general
+   * <p>The other two ID scheme parameters supported ('outputDataElementIdScheme' and
+   * 'outputOrgUnitIdScheme') will allow fine-grained id scheme definitions on top of the general
    * 'outputIdScheme'. If they are set, they will override the 'outputIdScheme' definition.
    *
-   * @param params the params where the id schema options are defined. The current URL params
-   *     supported are: outputIdScheme, outputDataElementIdScheme and outputOrgUnitIdScheme.
-   * @return a Map of <uid, mapping value>
+   * @param params the {@link DataQueryParams} where the identifier scheme options are defined. The
+   *     supported URL parameters are outputIdScheme, outputDataElementIdScheme and
+   *     outputOrgUnitIdScheme.
+   * @return a map of UID and mapping value.
    */
-  public Map<String, String> getSchemeIdResponseMap(final DataQueryParams params) {
-    final Map<String, String> responseMap =
+  public Map<String, String> getSchemeIdResponseMap(DataQueryParams params) {
+    Map<String, String> responseMap =
         getDimensionItemIdSchemeMap(params.getAllDimensionItems(), params.getOutputIdScheme());
 
     if (params.isGeneralOutputIdSchemeSet()) {
-      // Apply a schema to all data element operands using the general
-      // output schema defined.
-      applyGeneralIdSchemaMapping(params, responseMap);
+      // Apply an ID scheme to all data element operands using the general
+      // output ID scheme defined
+      applyIdSchemeMapping(params, responseMap);
     }
 
-    // This section overrides the general schema, so it can be fine-grained.
+    // This section overrides the general ID scheme, so it can be
+    // fine-grained
     if (params.isOutputFormat(DATA_VALUE_SET)) {
       if (params.isOutputDataElementIdSchemeSet()) {
         if (!params.getDataElementOperands().isEmpty()) {
-          // Replace all data elements operands respecting it's
-          // schema definition.
-          applyDataElementOperandsIdSchemaMapping(params, responseMap);
+          // Replace all data elements operands respecting their ID
+          // scheme definition
+          applyDataElementOperandIdSchemeMapping(params, responseMap);
         } else if (!params.getDataElements().isEmpty()) {
-          // Replace all data elements respecting it's schema
-          // definition.
-          applyDataElementsIdSchemaMapping(params, responseMap);
+          // Replace all data elements respecting their ID scheme
+          // definition
+          applyDataElementsIdSchemeMapping(params, responseMap);
         }
       }
     }
 
     // If "outputOrgUnitIdScheme" is set, we replace all org units
-    // values respecting
-    // it's definition.
+    // values respecting it's definition
     if (params.isOutputOrgUnitIdSchemeSet()) {
-      applyOrgUnitIdSchemaMapping(params, responseMap);
+      applyOrgUnitIdSchemeMapping(params, responseMap);
     }
 
     return responseMap;
   }
 
-  private void applyGeneralIdSchemaMapping(
-      final DataQueryParams params, final Map<String, String> map) {
+  private void applyIdSchemeMapping(DataQueryParams params, Map<String, String> map) {
     map.putAll(
         getDataElementOperandIdSchemeMap(
             asTypedList(params.getDataElementOperands()), params.getOutputIdScheme()));
 
-    if (params.getProgramStage() != null) {
+    if (params.hasProgramStage()) {
       map.put(
           params.getProgramStage().getUid(),
-          params.getProgramStage().getPropertyValue(params.getOutputIdScheme()));
+          params.getProgramStage().getDisplayPropertyValue(params.getOutputIdScheme()));
     }
 
-    if (params.getProgram() != null) {
+    if (params.hasProgram()) {
       map.put(
           params.getProgram().getUid(),
-          params.getProgram().getPropertyValue(params.getOutputIdScheme()));
+          params.getProgram().getDisplayPropertyValue(params.getOutputIdScheme()));
     }
 
     if (params instanceof EventQueryParams
         && CollectionUtils.isNotEmpty(((EventQueryParams) params).getItemOptions())) {
-      final Set<Option> options = ((EventQueryParams) params).getItemOptions();
+      Set<Option> options = ((EventQueryParams) params).getItemOptions();
 
-      for (final Option option : options) {
-        map.put(option.getCode(), option.getPropertyValue(params.getOutputIdScheme()));
+      for (Option option : options) {
+        map.put(option.getCode(), option.getDisplayPropertyValue(params.getOutputIdScheme()));
       }
     }
   }
 
-  private void applyDataElementOperandsIdSchemaMapping(
-      final DataQueryParams params, final Map<String, String> map) {
+  private void applyDataElementOperandIdSchemeMapping(
+      DataQueryParams params, Map<String, String> map) {
     map.putAll(
         getDataElementOperandIdSchemeMap(
             asTypedList(params.getDataElementOperands()), params.getOutputDataElementIdScheme()));
   }
 
-  private void applyDataElementsIdSchemaMapping(
-      final DataQueryParams params, final Map<String, String> map) {
+  private void applyDataElementsIdSchemeMapping(DataQueryParams params, Map<String, String> map) {
     map.putAll(
         getDimensionItemIdSchemeMap(
             asTypedList(params.getDataElements()), params.getOutputDataElementIdScheme()));
   }
 
-  private void applyOrgUnitIdSchemaMapping(
-      final DataQueryParams params, final Map<String, String> map) {
+  private void applyOrgUnitIdSchemeMapping(DataQueryParams params, Map<String, String> map) {
     map.putAll(
         getDimensionItemIdSchemeMap(
             asTypedList(params.getOrganisationUnits()), params.getOutputOrgUnitIdScheme()));


### PR DESCRIPTION
**_[Backport from master/2.41]_** (#15142)

Fixes the translation issue in Event Report and Enrollments in the export/download feature.
With this change, the code makes use of the `displayName` which always tries to get the translatable value.