### PR TITLE
Revert "chore(deps): bump codecov/codecov-action from 3 to 4 (#15158)"

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,7 +25,7 @@ jobs:
         run: mvn clean install --threads 2C --batch-mode --no-transfer-progress --update-snapshots -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty
         timeout-minutes: 30
       - name: Report coverage to codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           directory: ./dhis-2
           flags: unit
@@ -80,7 +80,7 @@ jobs:
           if-no-files-found: error # check our logging configuration if that happens
           retention-days: 3
       - name: Report coverage to codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           directory: ./dhis-2
           flags: integration
@@ -131,7 +131,7 @@ jobs:
           if-no-files-found: error # check our logging configuration if that happens
           retention-days: 3
       - name: Report coverage to codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           directory: ./dhis-2
           flags: integration-h2


### PR DESCRIPTION
This reverts commit 6e38072d1db86b3dd0ff94967c394a27e67e476d.

Build fails on master with

> Unable to resolve action `codecov/codecov-action@v4`, unable to find version `v4`