### PR TITLE
fix: Resource table deletion/drop [DHIS2-13773]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/resourcetable/ResourceTable.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/resourcetable/ResourceTable.java
@@ -78,11 +78,11 @@ public abstract class ResourceTable<T> {
   }
 
   public final String getDropTableStatement() {
-    return "drop table " + getTableName() + ";";
+    return "drop table if exists " + getTableName() + " cascade;";
   }
 
   public final String getDropTempTableStatement() {
-    return "drop table " + getTempTableName() + ";";
+    return "drop table if exists " + getTempTableName() + ";";
   }
 
   public final String getRenameTempTableStatement() {


### PR DESCRIPTION
**_[Backport from master/2.41]_**

When deleting resource tables, make sure that `drop` is used, so the export process does not get locked if some other table is making reference to them by any chance.
Clients should not make references to analytics and resource tables unless they really know what they are doing.

** We should also probably drop the respective DB view when the entity View is deleted from Maintenance. This would be a second step to improve how SQL views are handled by the system.