### PR TITLE
fix: scheduler log on debug for short delays between runs [DHIS2-15826]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobSchedulerLoopService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobSchedulerLoopService.java
@@ -230,8 +230,9 @@ public class DefaultJobSchedulerLoopService implements JobSchedulerLoopService {
             ? new NotifierJobProgress(notifier, job)
             : NoopJobProgress.INSTANCE;
     boolean logInfoOnDebug =
-        job.getLastFinished() != null
-            && Duration.between(job.getLastFinished().toInstant(), Instant.now()).getSeconds()
+        job.getSchedulingType() != SchedulingType.ONCE_ASAP
+            && job.getLastExecuted() != null
+            && Duration.between(job.getLastExecuted().toInstant(), Instant.now()).getSeconds()
                 < systemSettings.getIntSetting(SettingKey.JOBS_LOG_DEBUG_BELOW_SECONDS);
     RecordingJobProgress progress =
         new RecordingJobProgress(messages, job, tracker, true, observer, logInfoOnDebug);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobSchedulerLoopService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobSchedulerLoopService.java
@@ -34,6 +34,8 @@ import static org.hisp.dhis.eventhook.EventUtils.schedulerStart;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -46,6 +48,8 @@ import org.hisp.dhis.eventhook.EventHookPublisher;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.leader.election.LeaderManager;
 import org.hisp.dhis.message.MessageService;
+import org.hisp.dhis.setting.SettingKey;
+import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.user.AuthenticationService;
 import org.slf4j.MDC;
@@ -63,6 +67,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DefaultJobSchedulerLoopService implements JobSchedulerLoopService {
 
+  private final SystemSettingManager systemSettings;
   private final LeaderManager leaderManager;
   private final JobConfigurationStore jobConfigurationStore;
   private final JobConfigurationService jobConfigurationService;
@@ -224,8 +229,12 @@ public class DefaultJobSchedulerLoopService implements JobSchedulerLoopService {
         job.getJobType().isUsingNotifications()
             ? new NotifierJobProgress(notifier, job)
             : NoopJobProgress.INSTANCE;
+    boolean logInfoOnDebug =
+        job.getLastFinished() != null
+            && Duration.between(job.getLastFinished().toInstant(), Instant.now()).getSeconds()
+                < systemSettings.getIntSetting(SettingKey.JOBS_LOG_DEBUG_BELOW_SECONDS);
     RecordingJobProgress progress =
-        new RecordingJobProgress(messages, job, tracker, true, observer);
+        new RecordingJobProgress(messages, job, tracker, true, observer, logInfoOnDebug);
     recordingsById.put(job.getUid(), progress);
     return progress;
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/RecordingJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/RecordingJobProgress.java
@@ -57,6 +57,7 @@ public class RecordingJobProgress implements JobProgress {
   private final JobProgress tracker;
   private final boolean abortOnFailure;
   private final Runnable observer;
+  private final boolean logOnDebug;
 
   private final AtomicBoolean cancellationRequested = new AtomicBoolean();
   private final AtomicBoolean abortAfterFailure = new AtomicBoolean();
@@ -68,7 +69,7 @@ public class RecordingJobProgress implements JobProgress {
   private final boolean usingErrorNotification;
 
   public RecordingJobProgress(JobConfiguration configuration) {
-    this(null, configuration, NoopJobProgress.INSTANCE, true, () -> {});
+    this(null, configuration, NoopJobProgress.INSTANCE, true, () -> {}, false);
   }
 
   public RecordingJobProgress(
@@ -76,12 +77,14 @@ public class RecordingJobProgress implements JobProgress {
       JobConfiguration configuration,
       JobProgress tracker,
       boolean abortOnFailure,
-      Runnable observer) {
+      Runnable observer,
+      boolean logOnDebug) {
     this.messageService = messageService;
     this.configuration = configuration;
     this.tracker = tracker;
     this.abortOnFailure = abortOnFailure;
     this.observer = observer;
+    this.logOnDebug = logOnDebug;
     this.usingErrorNotification =
         messageService != null && configuration.getJobType().isUsingErrorNotification();
   }
@@ -406,7 +409,11 @@ public class RecordingJobProgress implements JobProgress {
   }
 
   private void logInfo(Node source, String action, String message) {
-    if (log.isInfoEnabled()) {
+    if (logOnDebug) {
+      if (log.isDebugEnabled()) {
+        log.debug(formatLogMessage(source, action, message));
+      }
+    } else if (log.isInfoEnabled()) {
       log.info(formatLogMessage(source, action, message));
     }
   }

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
@@ -254,6 +254,12 @@ public enum SettingKey {
   JOBS_MAX_CRON_DELAY_HOURS("jobsMaxCronDelayHours", 4, Integer.class),
 
   /**
+   * A job running with a smaller delay than the given value is logged on debug level instead of
+   * info to not spam the logs.
+   */
+  JOBS_LOG_DEBUG_BELOW_SECONDS("jobsLogDebugBelowSeconds", 180, Integer.class),
+
+  /**
    * Progressive caching factor for the analytics API. To enable, the {@link
    * #ANALYTICS_CACHE_TTL_MODE} must be set to PROGRESSIVE.
    */


### PR DESCRIPTION
### Summary
Adds a new system setting `JOBS_LOG_DEBUG_BELOW_SECONDS` (default is 3 minutes). 
A job running more frequent than the set time in seconds the job logs its normal information on `debug`, otherwise on `info`.
The actual duration to check is computed from the `lastExtecuted` and _now_. Manual runs or run once jobs are never subject to this and will always log on `info`.

### Manual Testing
 Start the server, check the `HEARTBEAT` jobs only is logged on info once.

And/or

* create a new job with a delay less than 3 minutes (the setting)
* check the logs to see it is only logged on info for the first run, then on debug
* do a similar test with a job running every minute based on a CRON expression
* change the setting and see it works as expected, e.g. with a longer time (15min) and a CRON job every 10 minutes
* check a CRON based or a delay based job with a longer time is still logged on info