### PR TITLE
chore: move handling of total count and pagination to store TECH-1638

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -27,13 +27,11 @@
  */
 package org.hisp.dhis.tracker.export.event;
 
-import static java.util.Collections.emptyMap;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
@@ -173,7 +171,7 @@ class DefaultEventService implements EventService {
     EventQueryParams queryParams = paramsMapper.map(operationParams);
     queryParams.setSkipPaging(true);
 
-    return eventStore.getEvents(queryParams, emptyMap());
+    return eventStore.getEvents(queryParams);
   }
 
   @Override
@@ -185,7 +183,7 @@ class DefaultEventService implements EventService {
     queryParams.setTotalPages(pageParams.isPageTotal());
     queryParams.setSkipPaging(false);
 
-    List<Event> events = new ArrayList<>(eventStore.getEvents(queryParams, emptyMap()));
+    List<Event> events = new ArrayList<>(eventStore.getEvents(queryParams));
 
     Pager pager;
     if (pageParams.isPageTotal()) {
@@ -205,8 +203,7 @@ class DefaultEventService implements EventService {
 
   /**
    * This method will apply the logic related to the parameter 'totalPages=false'. This works in
-   * conjunction with the method: {@link EventStore#getEvents(EventQueryParams,
-   * Map<String,Set<String>>)}
+   * conjunction with the method: {@link EventStore#getEvents(EventQueryParams) <String,Set<String>>)}
    *
    * <p>This is needed because we need to query (pageSize + 1) at DB level. The resulting query will
    * allow us to evaluate if we are in the last page or not. And this is what his method does,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventQueryParams.java
@@ -57,11 +57,6 @@ import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
  * @author Lars Helge Overland
  */
 class EventQueryParams {
-
-  public static final int DEFAULT_PAGE = 1;
-
-  public static final int DEFAULT_PAGE_SIZE = 50;
-
   private Program program;
 
   private ProgramStage programStage;
@@ -106,14 +101,6 @@ class EventQueryParams {
   private CategoryOptionCombo categoryOptionCombo;
 
   private IdSchemes idSchemes = new IdSchemes();
-
-  private Integer page;
-
-  private Integer pageSize;
-
-  private boolean totalPages;
-
-  private boolean skipPaging;
 
   private boolean includeRelationships;
 
@@ -166,38 +153,7 @@ class EventQueryParams {
 
   @Getter private AssignedUserQueryParam assignedUserQueryParam = AssignedUserQueryParam.ALL;
 
-  // -------------------------------------------------------------------------
-  // Constructors
-  // -------------------------------------------------------------------------
-
   public EventQueryParams() {}
-
-  // -------------------------------------------------------------------------
-  // Logic
-  // -------------------------------------------------------------------------
-
-  public boolean isPaging() {
-    return page != null || pageSize != null;
-  }
-
-  public int getPageWithDefault() {
-    return page != null && page > 0 ? page : DEFAULT_PAGE;
-  }
-
-  public int getPageSizeWithDefault() {
-    return pageSize != null && pageSize >= 0 ? pageSize : DEFAULT_PAGE_SIZE;
-  }
-
-  public int getOffset() {
-    return (getPageWithDefault() - 1) * getPageSizeWithDefault();
-  }
-
-  /** Sets paging properties to default values. */
-  public void setDefaultPaging() {
-    this.page = DEFAULT_PAGE;
-    this.pageSize = DEFAULT_PAGE_SIZE;
-    this.skipPaging = false;
-  }
 
   public boolean hasProgram() {
     return program != null;
@@ -427,42 +383,6 @@ class EventQueryParams {
 
   public EventQueryParams setIdSchemes(IdSchemes idSchemes) {
     this.idSchemes = idSchemes;
-    return this;
-  }
-
-  public Integer getPage() {
-    return page;
-  }
-
-  public EventQueryParams setPage(Integer page) {
-    this.page = page;
-    return this;
-  }
-
-  public Integer getPageSize() {
-    return pageSize;
-  }
-
-  public EventQueryParams setPageSize(Integer pageSize) {
-    this.pageSize = pageSize;
-    return this;
-  }
-
-  public boolean isTotalPages() {
-    return totalPages;
-  }
-
-  public EventQueryParams setTotalPages(boolean totalPages) {
-    this.totalPages = totalPages;
-    return this;
-  }
-
-  public boolean isSkipPaging() {
-    return skipPaging;
-  }
-
-  public EventQueryParams setSkipPaging(boolean skipPaging) {
-    this.skipPaging = skipPaging;
     return this;
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventStore.java
@@ -49,6 +49,4 @@ public interface EventStore {
    * occur before calling {@link #getEvents(EventQueryParams)}.
    */
   Set<String> getOrderableFields();
-
-  int getEventCount(EventQueryParams params);
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventStore.java
@@ -30,17 +30,23 @@ package org.hisp.dhis.tracker.export.event;
 import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.tracker.export.Page;
+import org.hisp.dhis.tracker.export.PageParams;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 public interface EventStore {
+  /** Get all events matching given params. */
   List<Event> getEvents(EventQueryParams params);
 
+  /** Get a page of events matching given params. */
+  Page<Event> getEvents(EventQueryParams params, PageParams pageParams);
+
   /**
-   * Fields the {@link #getEvents(EventQueryParams)} can order events by. Ordering by fields
-   * other than these is considered a programmer error. Validation of user provided field names
-   * should occur before calling {@link #getEvents(EventQueryParams)}.
+   * Fields the {@link #getEvents(EventQueryParams)} can order events by. Ordering by fields other
+   * than these is considered a programmer error. Validation of user provided field names should
+   * occur before calling {@link #getEvents(EventQueryParams)}.
    */
   Set<String> getOrderableFields();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventStore.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.tracker.export.event;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import org.hisp.dhis.program.Event;
 
@@ -36,12 +35,12 @@ import org.hisp.dhis.program.Event;
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 public interface EventStore {
-  List<Event> getEvents(EventQueryParams params, Map<String, Set<String>> psdesWithSkipSyncTrue);
+  List<Event> getEvents(EventQueryParams params);
 
   /**
-   * Fields the {@link #getEvents(EventSearchParams, Map)} can order events by. Ordering by fields
+   * Fields the {@link #getEvents(EventQueryParams)} can order events by. Ordering by fields
    * other than these is considered a programmer error. Validation of user provided field names
-   * should occur before calling {@link #getEvents(EventSearchParams, Map)}.
+   * should occur before calling {@link #getEvents(EventQueryParams)}.
    */
   Set<String> getOrderableFields();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -553,8 +553,7 @@ class JdbcEventStore implements EventStore {
     return sqlBuilder.toString();
   }
 
-  @Override
-  public int getEventCount(EventQueryParams params) {
+  private int getEventCount(EventQueryParams params) {
     User user = currentUserService.getCurrentUser();
     setAccessiblePrograms(user, params);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -57,7 +57,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Supplier;
+import java.util.function.IntSupplier;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -239,7 +239,7 @@ class JdbcEventStore implements EventStore {
   @Override
   public Page<Event> getEvents(EventQueryParams queryParams, PageParams pageParams) {
     List<Event> events = getEvents(queryParams, Optional.of(pageParams));
-    Supplier<Integer> eventCount = () -> getEventCount(queryParams);
+    IntSupplier eventCount = () -> getEventCount(queryParams);
     return getPage(pageParams, events, eventCount);
   }
 
@@ -442,10 +442,10 @@ class JdbcEventStore implements EventStore {
    * @param eventCount a supplier of the number of events in the final Page
    * @return a full Pager in case the page totals are fetched and a SlimPager otherwise
    */
-  private Page<Event> getPage(
-      PageParams pageParams, List<Event> events, Supplier<Integer> eventCount) {
+  private Page<Event> getPage(PageParams pageParams, List<Event> events, IntSupplier eventCount) {
     if (pageParams.isPageTotal()) {
-      Pager pager = new Pager(pageParams.getPage(), eventCount.get(), pageParams.getPageSize());
+      Pager pager =
+          new Pager(pageParams.getPage(), eventCount.getAsInt(), pageParams.getPageSize());
       return Page.of(events, pager);
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -207,10 +207,6 @@ class JdbcEventStore implements EventStore {
           entry("assignedUser", COLUMN_EVENT_ASSIGNED_USER_USERNAME),
           entry("assignedUser.displayName", COLUMN_EVENT_ASSIGNED_USER_DISPLAY_NAME));
 
-  // -------------------------------------------------------------------------
-  // Dependencies
-  // -------------------------------------------------------------------------
-
   // Cannot use DefaultRenderService mapper. Does not work properly -
   // DHIS2-6102
   private static final ObjectReader eventDataValueJsonReader =
@@ -229,13 +225,8 @@ class JdbcEventStore implements EventStore {
 
   private final RelationshipStore relationshipStore;
 
-  // -------------------------------------------------------------------------
-  // EventStore implementation
-  // -------------------------------------------------------------------------
-
   @Override
-  public List<Event> getEvents(
-      EventQueryParams params, Map<String, Set<String>> psdesWithSkipSyncTrue) {
+  public List<Event> getEvents( EventQueryParams params) {
     User user = currentUserService.getCurrentUser();
 
     setAccessiblePrograms(user, params);


### PR DESCRIPTION
Having the logic of fetching `pageSize + 1` events in the store and the removal of the extra event in the service is error prone. This is now done transparently in the store.

Total count is expensive and should thus be discouraged. Do not expose this as part of the service as its not needed right now.

As our store are concerned with generating SQL we should try to adopt the appropriate language for that domain. Our methods are often named `getYYYQuery` while they do not actually generate a SQL query. For example `getOrderQuery(params)` actually generates https://www.postgresql.org/docs/current/queries-limit.html limit and offset clauses.

Remove any pagination related fields and methods from `EventQueryParams` as these are fully represented by the `PageParams`.

Opt for not mutating the `List<Event>` when removing the `pageSize + 1` event in ` getPage`.
