### PR TITLE
chore: remove pageSize+1 logic as we never expose SlimPager TECH-1638

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
@@ -656,15 +656,15 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "first page",
-        () -> assertSlimPager(1, 1, false, firstPage.getPager()),
-        () -> assertEquals(List.of("D9PbzJY8bJM"), eventUids(firstPage)));
+        () -> assertPager(1, 1, firstPage),
+        () -> assertEquals(List.of("D9PbzJY8bJM"), uids(firstPage)));
 
     Page<Event> secondPage = eventService.getEvents(operationParams, new PageParams(2, 1, false));
 
     assertAll(
-        "second (last) page",
-        () -> assertSlimPager(2, 1, true, secondPage.getPager()),
-        () -> assertEquals(List.of("pTzf9KYMk72"), eventUids(secondPage)));
+        "second page is the last page",
+        () -> assertPager(2, 1, secondPage),
+        () -> assertEquals(List.of("pTzf9KYMk72"), uids(secondPage)));
 
     assertIsEmpty(getEvents(operationParams, new PageParams(3, 3, false)));
   }
@@ -677,9 +677,12 @@ class OrderAndPaginationExporterTest extends TrackerTest {
             .programStageUid(programStage.getUid())
             .build();
 
-    List<String> events = getEvents(params, new PageParams(1, 2, true));
+    Page<Event> page = eventService.getEvents(params, new PageParams(1, 2, true));
 
-    assertContainsOnly(List.of("D9PbzJY8bJM", "pTzf9KYMk72"), events);
+    assertAll(
+        "page with total counts",
+        () -> assertPager(1, 2, 2, page),
+        () -> assertEquals(List.of("D9PbzJY8bJM", "pTzf9KYMk72"), uids(page)));
   }
 
   @Test
@@ -699,19 +702,15 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "first page",
-        () -> assertSlimPager(1, 3, false, firstPage.getPager()),
-        () ->
-            assertEquals(
-                List.of("ck7DzdxqLqA", "OTmjvJDn0Fu", "kWjSezkXHVp"), eventUids(firstPage)));
+        () -> assertPager(1, 3, firstPage),
+        () -> assertEquals(List.of("ck7DzdxqLqA", "OTmjvJDn0Fu", "kWjSezkXHVp"), uids(firstPage)));
 
     Page<Event> secondPage = eventService.getEvents(operationParams, new PageParams(2, 3, false));
 
     assertAll(
-        "second (last) page",
-        () -> assertSlimPager(2, 3, true, secondPage.getPager()),
-        () ->
-            assertEquals(
-                List.of("lumVtWwwy0O", "QRYjLTiJTrA", "cadc5eGj0j7"), eventUids(secondPage)));
+        "second page is the last page",
+        () -> assertPager(2, 3, secondPage),
+        () -> assertEquals(List.of("lumVtWwwy0O", "QRYjLTiJTrA", "cadc5eGj0j7"), uids(secondPage)));
 
     assertIsEmpty(getEvents(operationParams, new PageParams(3, 3, false)));
   }
@@ -732,9 +731,9 @@ class OrderAndPaginationExporterTest extends TrackerTest {
     Page<Event> events = eventService.getEvents(params, new PageParams(1, 2, true));
 
     assertAll(
-        "first page",
-        () -> assertPager(1, 2, 6, events.getPager()),
-        () -> assertEquals(List.of("ck7DzdxqLqA", "OTmjvJDn0Fu"), eventUids(events)));
+        "page with total counts",
+        () -> assertPager(1, 2, 6, events),
+        () -> assertEquals(List.of("ck7DzdxqLqA", "OTmjvJDn0Fu"), uids(events)));
   }
 
   @Test
@@ -870,15 +869,15 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "first page",
-        () -> assertSlimPager(1, 1, false, firstPage.getPager()),
-        () -> assertEquals(List.of("D9PbzJY8bJM"), eventUids(firstPage)));
+        () -> assertPager(1, 1, firstPage),
+        () -> assertEquals(List.of("D9PbzJY8bJM"), uids(firstPage)));
 
     Page<Event> secondPage = eventService.getEvents(operationParams, new PageParams(2, 1, false));
 
     assertAll(
         "second (last) page",
-        () -> assertSlimPager(2, 1, true, secondPage.getPager()),
-        () -> assertEquals(List.of("pTzf9KYMk72"), eventUids(secondPage)));
+        () -> assertPager(2, 1, secondPage),
+        () -> assertEquals(List.of("pTzf9KYMk72"), uids(secondPage)));
 
     assertIsEmpty(getEvents(operationParams, new PageParams(3, 3, false)));
   }
@@ -1290,6 +1289,21 @@ class OrderAndPaginationExporterTest extends TrackerTest {
                 isLast ? "should be the last page" : "should NOT be the last page"));
   }
 
+  private static <T> void assertPager(int pageNumber, int pageSize, Page<T> page) {
+    Pager pager = page.getPager();
+    assertNotNull(pager, "pagintated results should have a pager");
+    assertAll(
+        "pagination details",
+        () -> assertEquals(pageNumber, pager.getPage(), "number of current page"),
+        () -> assertEquals(pageSize, pager.getPageSize(), "page size"));
+  }
+
+  private static <T> void assertPager(int pageNumber, int pageSize, int totalCount, Page<T> page) {
+    Pager pager = page.getPager();
+    assertNotNull(pager, "pagintated results should have a pager");
+    assertPager(pageNumber, pageSize, totalCount, pager);
+  }
+
   private static void assertPager(int pageNumber, int pageSize, int totalCount, Pager pager) {
     assertAll(
         "pagination details",
@@ -1323,7 +1337,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
     return uids(relationshipService.getRelationships(params).getRelationships());
   }
 
-  private static List<String> eventUids(Page<Event> events) {
+  private static <T extends BaseIdentifiableObject> List<String> uids(Page<T> events) {
     return uids(events.getItems());
   }
 


### PR DESCRIPTION
this logic was added by mistake to events and enrollments and then propagated to the other entities when we refactored pagination. The `isLastPage` from `SlimPager` was never returned from new tracker endpoints.

`curl -s -u admin:district https://play.dhis2.org/dev/api/tracker/events\?\&page\=2\&pageSize\=4\&totalPages\=true\&order\=programStage:asc\&fields\=event | jq`

```json
{
  "page": 2,
  "total": 373603,
  "pageCount": 93401,
  "pageSize": 4,
  "instances": [
    {
      "event": "RGWzjuz7eTt"
    },
    {
      "event": "Yzx5VJzvQmJ"
    },
    {
      "event": "dOeZnvyjdsW"
    },
    {
      "event": "uh0sdUZhnWZ"
    }
  ]
}
```

`curl -s -u admin:district https://play.dhis2.org/dev/api/tracker/events\?\&page\=2\&pageSize\=4\&totalPages\=false\&order\=programStage:asc\&fields\=event | jq`

```json
{
  "page": 2,
  "pageSize": 4,
  "instances": [
    {
      "event": "Yzx5VJzvQmJ"
    },
    {
      "event": "dOeZnvyjdsW"
    },
    {
      "event": "uh0sdUZhnWZ"
    },
    {
      "event": "nfYuLdN48gD"
    }
  ]
}
```

The commons [Pager](https://github.com/dhis2/dhis2-core/blob/1afc9c8e2e00517f620e23f90d404a88071f21d6/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Pager.java#L43) was likely built with metadata endpoints in mind. In metadata endpoints totals are always returned. This does not match the tracker endpoints. So right now since we are using the common `Pager` we pass total `0` when we do not fetch totals. When returning the pagination fields in JSON we rely on [PagingWrapper](https://github.com/dhis2/dhis2-core/blob/1afc9c8e2e00517f620e23f90d404a88071f21d6/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingWrapper.java#L79) which uses `Integer`. Important is that we set it to null in case the user did not want the total counts. Otherwise we would return `0`.
