### PR TITLE
feat: Add system setting for parallel jobs in analytics export [DHIS2-15880]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
@@ -111,7 +111,7 @@ public class DefaultAnalyticsTableGenerator implements AnalyticsTableGenerator {
 
     progress.startingStage("Invalidate analytics caches", SKIP_STAGE);
     progress.runStage(analyticsCache::invalidateAll);
-    progress.completedProcess("Analytics tables updated");
+    progress.completedProcess("Analytics tables updated: " + clock.time());
   }
 
   private void updateLastSuccessfulSystemSettings(AnalyticsTableUpdateParams params, Clock clock) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
@@ -314,7 +314,7 @@ public class DefaultAnalyticsTableService implements AnalyticsTableService {
     Integer parallelJobs =
         systemSettingManager.getIntegerSetting(SettingKey.PARALLEL_JOBS_IN_ANALYTICS_TABLE_EXPORT);
     Integer databaseCpus = systemSettingManager.getIntegerSetting(SettingKey.DATABASE_SERVER_CPUS);
-    Integer serverCpus = SystemUtils.getCpuCores();
+    int serverCpus = SystemUtils.getCpuCores();
 
     if (parallelJobs != null && parallelJobs > 0) {
       return parallelJobs;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
@@ -78,7 +78,7 @@ public class DefaultAnalyticsTableService implements AnalyticsTableService {
 
   @Override
   public void update(AnalyticsTableUpdateParams params, JobProgress progress) {
-    int processNo = getProcessNo();
+    int parallelJobs = getParallelJobs();
 
     int tableUpdates = 0;
 
@@ -91,8 +91,8 @@ public class DefaultAnalyticsTableService implements AnalyticsTableService {
             .startClock()
             .logTime(
                 String.format(
-                    "Starting update of type: %s, table name: '%s', processes: %d",
-                    tableType, tableType.getTableName(), processNo));
+                    "Starting update of type: %s, table name: '%s', parallel jobs: %d",
+                    tableType, tableType.getTableName(), parallelJobs));
 
     progress.startingStage("Validating Analytics Table " + tableType);
     String validState = tableManager.validState();
@@ -207,7 +207,7 @@ public class DefaultAnalyticsTableService implements AnalyticsTableService {
       AnalyticsTableUpdateParams params,
       List<AnalyticsTablePartition> partitions,
       JobProgress progress) {
-    int parallelism = Math.min(getProcessNo(), partitions.size());
+    int parallelism = Math.min(getParallelJobs(), partitions.size());
     log.info("Populate table task number: " + parallelism);
 
     progress.runStageInParallel(
@@ -241,7 +241,7 @@ public class DefaultAnalyticsTableService implements AnalyticsTableService {
         progress.startingStage(
             "Applying aggregation level " + level + " " + tableType, partitions.size());
         progress.runStageInParallel(
-            getProcessNo(),
+            getParallelJobs(),
             partitions,
             AnalyticsTablePartition::getTableName,
             partition -> tableManager.applyAggregationLevels(partition, dataElements, level));
@@ -256,7 +256,7 @@ public class DefaultAnalyticsTableService implements AnalyticsTableService {
   /** Vacuums the given analytics tables. */
   private void vacuumTables(List<AnalyticsTablePartition> partitions, JobProgress progress) {
     progress.runStageInParallel(
-        getProcessNo(),
+        getParallelJobs(),
         partitions,
         AnalyticsTablePartition::getTableName,
         tableManager::vacuumTables);
@@ -267,7 +267,7 @@ public class DefaultAnalyticsTableService implements AnalyticsTableService {
     AnalyticsTableType type = getAnalyticsTableType();
 
     progress.runStageInParallel(
-        getProcessNo(),
+        getParallelJobs(),
         indexes,
         index -> getIndexName(index, type).replace("\"", ""),
         tableManager::createIndex);
@@ -299,15 +299,35 @@ public class DefaultAnalyticsTableService implements AnalyticsTableService {
   }
 
   /**
-   * Gets the number of available cores. Uses explicit number from system setting if available.
-   * Detects number of cores from current server runtime if not. Subtracts one to the number of
-   * cores if greater than two to allow one core for general system operations.
+   * Returns the number of parallel jobs to use for processing analytics tables. The order of
+   * determination is:
+   *
+   * <ul>
+   *   <li>The system setting for parallel jobs in analytics table export, if set.
+   *   <li>The system setting for number of available processors of the database server, if set.
+   *   <li>The number of available processors of the application server, minus 1 if > 2.
+   * </ul>
+   *
+   * @return the number of parallel jobs to use for processing analytics tables.
    */
-  private int getProcessNo() {
-    Integer cores = systemSettingManager.getIntegerSetting(SettingKey.DATABASE_SERVER_CPUS);
+  int getParallelJobs() {
+    Integer parallelJobs =
+        systemSettingManager.getIntegerSetting(SettingKey.PARALLEL_JOBS_IN_ANALYTICS_TABLE_EXPORT);
+    Integer databaseCpus = systemSettingManager.getIntegerSetting(SettingKey.DATABASE_SERVER_CPUS);
+    Integer serverCpus = SystemUtils.getCpuCores();
 
-    cores = (cores == null || cores == 0) ? SystemUtils.getCpuCores() : cores;
+    if (parallelJobs != null && parallelJobs > 0) {
+      return parallelJobs;
+    }
 
-    return cores > 2 ? (cores - 1) : cores;
+    if (databaseCpus != null && databaseCpus > 0) {
+      return databaseCpus;
+    }
+
+    if (serverCpus > 2) {
+      return serverCpus - 1;
+    }
+
+    return serverCpus;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/AnalyticsTableServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/AnalyticsTableServiceTest.java
@@ -42,7 +42,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Lars Helge Overland
  */
 @ExtendWith(MockitoExtension.class)
-public class AnalyticsTableServiceTest {
+class AnalyticsTableServiceTest {
 
   @Mock private SystemSettingManager systemSettingManager;
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/AnalyticsTableServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/AnalyticsTableServiceTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.table;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import org.hisp.dhis.setting.SettingKey;
+import org.hisp.dhis.setting.SystemSettingManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Lars Helge Overland
+ */
+@ExtendWith(MockitoExtension.class)
+public class AnalyticsTableServiceTest {
+
+  @Mock private SystemSettingManager systemSettingManager;
+
+  @InjectMocks private DefaultAnalyticsTableService tableService;
+
+  @Test
+  void testGetParallelJobsA() {
+    when(systemSettingManager.getIntegerSetting(SettingKey.PARALLEL_JOBS_IN_ANALYTICS_TABLE_EXPORT))
+        .thenReturn(1);
+    when(systemSettingManager.getIntegerSetting(SettingKey.DATABASE_SERVER_CPUS)).thenReturn(8);
+
+    assertEquals(1, tableService.getParallelJobs());
+  }
+
+  @Test
+  void testGetParallelJobsB() {
+    when(systemSettingManager.getIntegerSetting(SettingKey.PARALLEL_JOBS_IN_ANALYTICS_TABLE_EXPORT))
+        .thenReturn(null);
+    when(systemSettingManager.getIntegerSetting(SettingKey.DATABASE_SERVER_CPUS)).thenReturn(8);
+
+    assertEquals(8, tableService.getParallelJobs());
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
@@ -121,7 +121,8 @@ public enum SettingKey {
       "keyRespectMetaDataStartEndDatesInAnalyticsTableExport", Boolean.FALSE, Boolean.class),
   SKIP_DATA_TYPE_VALIDATION_IN_ANALYTICS_TABLE_EXPORT(
       "keySkipDataTypeValidationInAnalyticsTableExport", Boolean.FALSE, Boolean.class),
-  PARALLEL_JOBS_IN_ANALYTICS_TABLE_EXPORT( "keyParallelJobsInAnalyticsTableExport", -1, Integer.class ),
+  PARALLEL_JOBS_IN_ANALYTICS_TABLE_EXPORT(
+      "keyParallelJobsInAnalyticsTableExport", -1, Integer.class),
   CUSTOM_LOGIN_PAGE_LOGO("keyCustomLoginPageLogo", Boolean.FALSE, Boolean.class),
   CUSTOM_TOP_MENU_LOGO("keyCustomTopMenuLogo", Boolean.FALSE, Boolean.class),
   DATABASE_SERVER_CPUS("keyDatabaseServerCpus", 0, Integer.class),

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
@@ -121,6 +121,7 @@ public enum SettingKey {
       "keyRespectMetaDataStartEndDatesInAnalyticsTableExport", Boolean.FALSE, Boolean.class),
   SKIP_DATA_TYPE_VALIDATION_IN_ANALYTICS_TABLE_EXPORT(
       "keySkipDataTypeValidationInAnalyticsTableExport", Boolean.FALSE, Boolean.class),
+  PARALLEL_JOBS_IN_ANALYTICS_TABLE_EXPORT( "keyParallelJobsInAnalyticsTableExport", -1, Integer.class ),
   CUSTOM_LOGIN_PAGE_LOGO("keyCustomLoginPageLogo", Boolean.FALSE, Boolean.class),
   CUSTOM_TOP_MENU_LOGO("keyCustomTopMenuLogo", Boolean.FALSE, Boolean.class),
   DATABASE_SERVER_CPUS("keyDatabaseServerCpus", 0, Integer.class),


### PR DESCRIPTION
This PR adds a system setting for explicitly setting the number of parallel threads/jobs to use for the analytics table export. The number of jobs is currently inferred from the available processors on the application server. This is useful when you want to experiment with the number of parallel jobs to measure performance.