### PR TITLE
fix: Harmonize filter field in TrackedEntity exporter [DHIS2-15665]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -37,7 +37,6 @@ import static org.hisp.dhis.common.Pager.DEFAULT_PAGE_SIZE;
 import static org.hisp.dhis.common.SlimPager.FIRST_PAGE;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -341,12 +340,6 @@ class DefaultTrackedEntityService implements TrackedEntityService {
   }
 
   public List<Long> getTrackedEntityIds(TrackedEntityQueryParams params) {
-    if (!params.hasProgram()) {
-      Collection<TrackedEntityAttribute> attributes =
-          trackedEntityAttributeService.getTrackedEntityAttributesDisplayInListNoProgram();
-      attributes.forEach(params::filterBy);
-    }
-
     decideAccess(params);
     validate(params);
     validateSearchScope(params);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -558,7 +558,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
   private String getFromSubQueryJoinOrderByAttributes(TrackedEntityQueryParams params) {
     StringBuilder joinOrderAttributes = new StringBuilder();
 
-    for (TrackedEntityAttribute orderAttribute : params.getAttributeInOrderButNotInFilter()) {
+    for (TrackedEntityAttribute orderAttribute : params.getLeftJoinAttributes()) {
 
       joinOrderAttributes
           .append(" LEFT JOIN trackedentityattributevalue AS ")
@@ -956,11 +956,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
       return "ORDER BY " + StringUtils.join(orderFields, ',') + SPACE;
     }
 
-    if (params.getFilters().entrySet().stream().noneMatch(qi -> qi.getKey().isUnique())) {
-      return "ORDER BY " + DEFAULT_ORDER + " ";
-    }
-
-    return "";
+    return "ORDER BY " + DEFAULT_ORDER + " ";
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -41,7 +41,6 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -362,16 +361,12 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
             .append(" FROM trackedentity " + MAIN_QUERY_ALIAS + " ")
 
             // INNER JOIN on constraints
-            // filter={uid1} => Map.of(tea, List.of(null))
-            // filter={uid1}:eq:2 => Map.of(tea, List.of(new QueryFilter(EQ,"in")))
-            // order={uid1}:desc&filter={uid1} => Map.of(tea, List.of(new QueryFilter(EQ,"in")))
             .append(joinAttributeValue(params))
             .append(getFromSubQueryJoinProgramOwnerConditions(params))
             .append(getFromSubQueryJoinOrgUnitConditions(params))
             .append(getFromSubQueryJoinEnrollmentConditions(params))
 
             // LEFT JOIN attributes we need to sort on.
-            // order={uid1}:desc => Map.of(tea,List.of())
             .append(getFromSubQueryJoinOrderByAttributes(params))
 
             // WHERE
@@ -387,23 +382,6 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     }
 
     return fromSubQuery.append(") TE ").toString();
-  }
-
-  /**
-   * Get a map of attributes and filters that contains sortable attributes also defined as filters.
-   * A null filter means that the filter on an attribute is actually present but no value was
-   * provided.
-   */
-  private Map<TrackedEntityAttribute, List<QueryFilter>> sortableAttributesAndFilters(
-      TrackedEntityQueryParams params) {
-    List<String> ordersIdentifier =
-        params.getOrder().stream()
-            .filter(o -> o.getField() instanceof TrackedEntityAttribute)
-            .map(o -> ((TrackedEntityAttribute) o.getField()).getUid())
-            .toList();
-    return params.getFilters().entrySet().stream()
-        .filter(attribute -> ordersIdentifier.contains(attribute.getKey().getUid()))
-        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
   /**
@@ -443,13 +421,10 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
           columns.add(ENROLLMENT_ALIAS + ".enrollmentdate as " + ENROLLMENT_DATE_ALIAS);
         }
       } else if (order.getField() instanceof TrackedEntityAttribute tea) {
-        if (sortableAttributesAndFilters(params).keySet().stream()
-            .anyMatch(att -> att.getUid().equals(tea.getUid()))) {
-          columns.add(
-              statementBuilder.columnQuote(tea.getUid())
-                  + ".value AS "
-                  + statementBuilder.columnQuote(tea.getUid()));
-        }
+        columns.add(
+            statementBuilder.columnQuote(tea.getUid())
+                + ".value AS "
+                + statementBuilder.columnQuote(tea.getUid()));
       } else {
         throw new IllegalArgumentException(
             String.format(
@@ -539,10 +514,8 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
   private String joinAttributeValue(TrackedEntityQueryParams params) {
     StringBuilder attributes = new StringBuilder();
 
-    List<Map.Entry<TrackedEntityAttribute, List<QueryFilter>>> filterItems =
-        params.getFilters().entrySet().stream().filter(f -> !f.getValue().isEmpty()).toList();
-
-    for (Map.Entry<TrackedEntityAttribute, List<QueryFilter>> filters : filterItems) {
+    for (Map.Entry<TrackedEntityAttribute, List<QueryFilter>> filters :
+        params.getFilters().entrySet()) {
       String col = statementBuilder.columnQuote(filters.getKey().getUid());
       String teaId = col + ".trackedentityattributeid";
       String teav = "lower(" + col + ".value)";
@@ -559,7 +532,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
           .append(ted)
           .append(" = TE.trackedentityid ");
 
-      for (QueryFilter filter : filters.getValue().stream().filter(Objects::nonNull).toList()) {
+      for (QueryFilter filter : filters.getValue()) {
         String encodedFilter = statementBuilder.encode(filter.getFilter(), false);
         attributes
             .append("AND ")
@@ -585,22 +558,18 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
   private String getFromSubQueryJoinOrderByAttributes(TrackedEntityQueryParams params) {
     StringBuilder joinOrderAttributes = new StringBuilder();
 
-    for (Map.Entry<TrackedEntityAttribute, List<QueryFilter>> orderAttribute :
-        sortableAttributesAndFilters(params).entrySet()) {
-      if (!orderAttribute.getValue().isEmpty()) { // We already joined this if it is a filter.
-        continue;
-      }
+    for (TrackedEntityAttribute orderAttribute : params.getAttributeInOrderButNotInFilter()) {
 
       joinOrderAttributes
           .append(" LEFT JOIN trackedentityattributevalue AS ")
-          .append(statementBuilder.columnQuote(orderAttribute.getKey().getUid()))
+          .append(statementBuilder.columnQuote(orderAttribute.getUid()))
           .append(" ON ")
-          .append(statementBuilder.columnQuote(orderAttribute.getKey().getUid()))
+          .append(statementBuilder.columnQuote(orderAttribute.getUid()))
           .append(".trackedentityid = TE.trackedentityid ")
           .append("AND ")
-          .append(statementBuilder.columnQuote(orderAttribute.getKey().getUid()))
+          .append(statementBuilder.columnQuote(orderAttribute.getUid()))
           .append(".trackedentityattributeid = ")
-          .append(orderAttribute.getKey().getId())
+          .append(orderAttribute.getId())
           .append(SPACE);
     }
 
@@ -917,21 +886,21 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
    *     from.
    */
   private String getQueryRelatedTables(TrackedEntityQueryParams params) {
-    Set<TrackedEntityAttribute> filters = params.getFilters().keySet();
     StringBuilder relatedTables = new StringBuilder();
 
     relatedTables.append(
         "LEFT JOIN trackedentitytype TET ON TET.trackedentitytypeid = TE.trackedentitytypeid ");
 
-    if (!filters.isEmpty()) {
-      String filterString =
-          getCommaDelimitedString(filters.stream().map(IdentifiableObject::getId).toList());
+    if (!params.getAttributes().isEmpty()) {
+      String attributeIds =
+          getCommaDelimitedString(
+              params.getAttributes().stream().map(IdentifiableObject::getId).toList());
 
       relatedTables
           .append("LEFT JOIN trackedentityattributevalue TEAV ")
           .append("ON TEAV.trackedentityid = TE.trackedentityid ")
           .append("AND TEAV.trackedentityattributeid IN (")
-          .append(filterString)
+          .append(attributeIds)
           .append(") ");
 
       relatedTables
@@ -987,8 +956,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
       return "ORDER BY " + StringUtils.join(orderFields, ',') + SPACE;
     }
 
-    if (params.getFilters().entrySet().stream()
-        .noneMatch(qi -> !qi.getValue().isEmpty() && qi.getKey().isUnique())) {
+    if (params.getFilters().entrySet().stream().noneMatch(qi -> qi.getKey().isUnique())) {
       return "ORDER BY " + DEFAULT_ORDER + " ";
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
@@ -363,11 +363,13 @@ public class TrackedEntityQueryParams {
     return (getPageWithDefault() - 1) * getPageSizeWithDefault();
   }
 
+  /** Returns attributes that are either ordered by or present in any filter. */
   public Set<TrackedEntityAttribute> getAttributes() {
     return SetUtils.union(filters.keySet(), getOrderAttributes());
   }
 
-  public Set<TrackedEntityAttribute> getAttributeInOrderButNotInFilter() {
+  /** Returns attributes that are only ordered by and not present in any filter. */
+  public Set<TrackedEntityAttribute> getLeftJoinAttributes() {
     return SetUtils.difference(getOrderAttributes(), filters.keySet());
   }
 
@@ -626,11 +628,7 @@ public class TrackedEntityQueryParams {
 
   /**
    * Filter out any tracked entity that have no value for the given tracked entity attribute {@code
-   * tea}. A filter without an operator is represented as a list with one null value to
-   * differentiate it from a filter created by an order clause that is represented by an empty list.
-   * A filter without an operator will overwrite a filter created by the order clause. A filter
-   * without an operator will not have any effect if another filter on the same attribute is already
-   * present.
+   * tea}.
    */
   public TrackedEntityQueryParams filterBy(TrackedEntityAttribute tea) {
     this.filters.putIfAbsent(tea, new ArrayList<>());


### PR DESCRIPTION
The goal of this PR is to simplify the management of filters and orders in `TrackedEntityQueryParams` and make it transparent for the consumer how to use the API.

Instead of having the store deal with the complexity of filters, we are exposing 3 different ways to get orders and filters information:
- `getAttributes()`: Returns attributes that are either ordered by or present in any filter.
- `getLeftJoinAttributes()`: Returns attributes that are only ordered by and not present in any filter.
- `getFilters()`: Returns all the filters specified by the client.

The first 2 methods are hiding the complexity around the interactions between filters and orders. In particular the fact that an attribute that is present in an order will be translated to a `LEFT JOIN` in the store, only and only if it is not present in any filter.