### PR TITLE
fix: Skip stage in export instead of aborting [DHIS2-15573]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/DefaultResourceTableService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/DefaultResourceTableService.java
@@ -218,11 +218,13 @@ public class DefaultResourceTableService implements ResourceTableService {
                   .collect(toList())
               + ".";
       errorMessage +=
-          "\n Years are out of range found: "
+          "\n Years out of range found: "
               + yearsToCheck.stream()
                   .filter(year -> year < minRangeAllowed || year > maxRangeAllowed)
                   .collect(toList())
               + ".";
+
+      log.warn(errorMessage);
       throw new RuntimeException(errorMessage);
     }
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
@@ -178,7 +178,7 @@ public class DefaultAnalyticsTableGenerator implements AnalyticsTableGenerator {
     generators.put(
         "generating CategoryOptionCombo table",
         resourceTableService::generateCategoryOptionComboTable);
-    progress.startingStage("Generating resource tables", generators.size());
+    progress.startingStage("Generating resource tables", generators.size(), SKIP_STAGE);
     progress.runStage(generators);
 
     resourceTableService.createAllSqlViews(progress);


### PR DESCRIPTION
**_[Backport from master/2.41]_** (#15247)

This change will prevent the analytics process from aborting if some invalid year is found during the date/period resource table generation. Instead, it will warn the user, log a **_warning message_** (like the one below), and continue the process.

**_Your database contains years out of the allowed offset. Range of years allowed (based on your system settings and existing data): [2022, 2023, 2024]. Years out of range found: [2003, 2004, 2005, 2006, 2007, 2008, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2025, 2026, 2027, 2028, 2029]._**

It relates to the original changes in #15039
