### PR TITLE
Revert "chore(deps): bump org.junit:junit-bom from 5.9.3 to 5.10.0 in /dhis-2"

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -211,7 +211,7 @@
     <slf4j.version>1.7.36</slf4j.version>
 
     <!-- Test -->
-    <junit.version>5.10.0</junit.version>
+    <junit.version>5.9.3</junit.version>
     <mockito.version>5.2.0</mockito.version>
     <powermock.version>2.0.9</powermock.version>
     <hamcrest.version>2.2</hamcrest.version>


### PR DESCRIPTION
Reverts dhis2/dhis2-core#14698

There might be a bug in GitHub action 🤔 or maybe we have not set it up correctly in older branches.

Since this is a minor update we get one approval. Auto-merge is enabled. Auto-merge should only merge if all checks pass. In this case the h2 tests actually failed.