### PR TITLE
fix: attributeValue validator should ignore empty string

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/attribute/DefaultAttributeValidator.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/attribute/DefaultAttributeValidator.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.attribute.AttributeValue;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
@@ -91,6 +92,9 @@ public class DefaultAttributeValidator implements AttributeValidator {
    */
   @Override
   public void validate(ValueType valueType, String value, Consumer<ErrorReport> addError) {
+    if (StringUtils.isEmpty(value)) {
+      return;
+    }
     mapValidators.getOrDefault(valueType, str -> List.of()).apply(value).forEach(addError::accept);
 
     mapEntityCheck

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/attribute/MetadataAttributeCheckTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/attribute/MetadataAttributeCheckTest.java
@@ -578,4 +578,22 @@ class MetadataAttributeCheckTest {
     assertFalse(CollectionUtils.isEmpty(objectReportList));
     assertEquals(ErrorCode.E6021, objectReportList.get(0).getErrorReports().get(0).getErrorCode());
   }
+
+  @Test
+  void testEmptyValue() {
+    attribute.setValueType(ValueType.EMAIL);
+    organisationUnit.getAttributeValues().add(new AttributeValue(attribute, ""));
+    List<ObjectReport> objectReportList = new ArrayList<>();
+
+    metadataAttributeCheck.check(
+        objectBundle,
+        OrganisationUnit.class,
+        Lists.newArrayList(organisationUnit),
+        Collections.emptyList(),
+        ImportStrategy.CREATE_AND_UPDATE,
+        validationContext,
+        objectReport -> objectReportList.add(objectReport));
+
+    assertTrue(CollectionUtils.isEmpty(objectReportList));
+  }
 }


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-15860
### Summary
- Currently metadata attribute values are validated by `MandatoryAttributesCheck` even when they are an empty string.
- `AttributeValidator` should ignore empty string. We already have `MandatoryAttributesCheck` to validate mandatory attributes.
- If user post an empty string for an attribute value which is not mandatory then the existing value will be deleted. 
### Test
- Add a new Attribute type Email, assign it to User.
- Create or update a User, leave the email attribute blank.
- Expected: create or update User successfully. If updating then existing attribute value is deleted. 