### PR TITLE
fix: approvedOrgUnitId int -> long [TECH-1653]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataapproval/DataApprovalStatus.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataapproval/DataApprovalStatus.java
@@ -58,7 +58,7 @@ public class DataApprovalStatus {
    * If the selection of data is approved, the ID of the highest organisation unit at which there is
    * approval.
    */
-  private final int approvedOrgUnitId;
+  private final long approvedOrgUnitId;
 
   /**
    * If the selection of data is approved, the approval level (same as above) but if the selection

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/hibernate/HibernateDataApprovalStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/hibernate/HibernateDataApprovalStore.java
@@ -765,7 +765,7 @@ public class HibernateDataApprovalStore extends HibernateGenericStore<DataApprov
       final int level = approved == null ? 0 : Integer.parseInt(approved[0]) - MAX_APPROVAL_LEVEL;
       final boolean accepted =
           approved == null ? false : approved[1].substring(0, 1).equalsIgnoreCase("t");
-      final int approvedOrgUnitId = approved == null ? 0 : Integer.parseInt(approved[2]);
+      final long approvedOrgUnitId = approved == null ? 0 : Long.parseLong(approved[2]);
 
       // null if not approved
       DataApprovalLevel approvedLevel = (level == 0 ? null : levelMap.get(level));


### PR DESCRIPTION
See [TECH-1653](https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/TECH-1653). Some old code in HibernateDataApprovalStore was storing the orgUnitId as int rather than long. This seems to have been overlooked when we were converting all the Hibernate object ids from int to long.

[TECH-1653]: https://dhis2.atlassian.net/browse/TECH-1653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ