### PR TITLE
chore: reduce job progress log verbosity [DHIS2-15913]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/RecordingJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/RecordingJobProgress.java
@@ -204,7 +204,7 @@ public class RecordingJobProgress implements JobProgress {
     tracker.startingStage(description, workItems);
     Stage stage =
         addStageRecord(getOrAddLastIncompleteProcess(), description, workItems, onFailure);
-    logInfo(stage, "started", description);
+    logInfo(stage, "", description);
   }
 
   @Override
@@ -431,13 +431,9 @@ public class RecordingJobProgress implements JobProgress {
                 + Duration.ofMillis(source.getDuration()).toString().substring(2).toLowerCase()
             : "";
     String msg = message == null ? "" : ": " + message;
+    String type = source instanceof Stage ? "" : source.getClass().getSimpleName() + " ";
     return format(
-        "[%s %s] %s %s%s%s",
-        configuration.getJobType().name(),
-        configuration.getUid(),
-        source.getClass().getSimpleName(),
-        action,
-        duration,
-        msg);
+        "[%s %s] %s%s%s%s",
+        configuration.getJobType().name(), configuration.getUid(), type, action, duration, msg);
   }
 }


### PR DESCRIPTION
Removes the `Stage` type and `started` for stages from the job progress logs.

This is so with normal settings where stages are logged on info and the log level is also configured to info the progress does not repeat the obvious. 