### PR TITLE
fix: adaption for backport from 41 version [DHIS2-14971]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.analytics.data;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.commons.collections4.CollectionUtils.addIgnoreNull;
 import static org.hisp.dhis.analytics.DataQueryParams.DISPLAY_NAME_ATTRIBUTEOPTIONCOMBO;
 import static org.hisp.dhis.analytics.DataQueryParams.DISPLAY_NAME_CATEGORYOPTIONCOMBO;
 import static org.hisp.dhis.analytics.DataQueryParams.DISPLAY_NAME_DATA_X;
@@ -358,7 +359,8 @@ public class DefaultDataQueryService implements DataQueryService {
         List<String> items = DimensionalObjectUtils.getDimensionItemsFromParam(param);
 
         if (dimension != null && items != null) {
-          list.add(
+          addIgnoreNull(
+              list,
               getDimension(
                   dimension,
                   items,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -150,9 +150,9 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "ax.\"monthly\",ax.\"ou\"  from "
+        "ax.\"quarterly\",ax.\"ou\"  from "
             + getTable(programA.getUid())
-            + " as ax where enrollmentdate >= '2017-01-01' and enrollmentdate < '2018-01-01' and (uidlevel1 = 'ouabcdefghA' ) ";
+            + " as ax where ((enrollmentdate >= '2017-01-01' and enrollmentdate < '2018-01-01')) and (uidlevel1 = 'ouabcdefghA' ) ";
 
     assertTrue(grid.hasLastDataRow());
     assertSql(sql.getValue(), expected);
@@ -172,9 +172,9 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "ax.\"monthly\",ax.\"ou\"  from "
+        "ax.\"quarterly\",ax.\"ou\"  from "
             + getTable(programA.getUid())
-            + " as ax where lastupdated >= '2017-01-01' and lastupdated < '2018-01-01' and (uidlevel1 = 'ouabcdefghA' ) limit 10001";
+            + " as ax where ((lastupdated >= '2017-01-01' and lastupdated < '2018-01-01')) and (uidlevel1 = 'ouabcdefghA' ) limit 10001";
 
     assertSql(sql.getValue(), expected);
   }
@@ -209,7 +209,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
 
     String expected =
         "select pi,tei,enrollmentdate,incidentdate,storedby,createdbydisplayname,lastupdatedbydisplayname,lastupdated,ST_AsGeoJSON(pigeometry),longitude,latitude,"
-            + "ouname,oucode,enrollmentstatus,ax.\"monthly\",ax.\"ou\","
+            + "ouname,oucode,enrollmentstatus,ax.\"quarterly\",ax.\"ou\","
             + "(select \""
             + dataElementUid
             + "\" from analytics_event_"
@@ -242,7 +242,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + ".exists\"  "
             + "from analytics_enrollment_"
             + programUid
-            + " as ax where ax.\"monthly\" in ('2000Q1') and (uidlevel1 = 'ouabcdefghA' ) "
+            + " as ax where ((ax.\"monthly\" in ('2000Q1') ) and (uidlevel1 = 'ouabcdefghA' ) "
             + "and ps = '"
             + programStageUid
             + "' limit 101";
@@ -307,11 +307,11 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + "' order by executiondate desc limit 1 )";
 
     String expected =
-        "ax.\"monthly\",ax.\"ou\","
+        "ax.\"quarterly\",ax.\"ou\","
             + subSelect
             + "  from "
             + getTable(programA.getUid())
-            + " as ax where ax.\"monthly\" in ('2000Q1') and (uidlevel1 = 'ouabcdefghA' ) "
+            + " as ax where (ax.\"monthly\" in ('2000Q1') ) and (uidlevel1 = 'ouabcdefghA' ) "
             + "and ps = '"
             + programStage.getUid()
             + "' and "
@@ -332,9 +332,9 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "ax.\"monthly\",ax.\"ou\"  from "
+        "ax.\"quarterly\",ax.\"ou\"  from "
             + getTable(programA.getUid())
-            + " as ax where ax.\"monthly\" in ('2000Q1') and (uidlevel1 = 'ouabcdefghA' )"
+            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and (uidlevel1 = 'ouabcdefghA' )"
             + " and enrollmentstatus in ('ACTIVE','COMPLETED') limit 10001";
 
     assertSql(sql.getValue(), expected);
@@ -359,12 +359,12 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + "' order by executiondate desc limit 1 )";
 
     String expected =
-        "ax.\"monthly\",ax.\"ou\","
+        "ax.\"quarterly\",ax.\"ou\","
             + subSelect
             + " as \"fWIAEtYVEGk\""
             + "  from "
             + getTable(programA.getUid())
-            + " as ax where ax.\"monthly\" in ('2000Q1') and (uidlevel1 = 'ouabcdefghA' ) "
+            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and (uidlevel1 = 'ouabcdefghA' ) "
             + "and ps = '"
             + programStage.getUid()
             + "' and "
@@ -514,7 +514,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "ax.\"monthly\",ax.\"ou\",(SELECT avg ("
+        "ax.\"quarterly\",ax.\"ou\",(SELECT avg ("
             + piSubquery
             + ") FROM analytics_event_"
             + programA.getUid().toLowerCase()
@@ -532,7 +532,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + "\"  "
             + "from analytics_enrollment_"
             + programA.getUid()
-            + " as ax where enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09' and (uidlevel1 = 'ouabcdefghA' ) limit 101";
+            + " as ax where ((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09')) and (uidlevel1 = 'ouabcdefghA' ) limit 101";
 
     assertSql(sql.getValue(), expected);
   }
@@ -563,7 +563,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "ax.\"monthly\",ax.\"ou\",(SELECT avg ("
+        "ax.\"quarterly\",ax.\"ou\",(SELECT avg ("
             + piSubquery
             + ") FROM analytics_event_"
             + programA.getUid().toLowerCase()
@@ -581,7 +581,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + "\"  "
             + "from analytics_enrollment_"
             + programA.getUid()
-            + " as ax where enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09' and (uidlevel1 = 'ouabcdefghA' ) limit 101";
+            + " as ax where ((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09')) and (uidlevel1 = 'ouabcdefghA' ) limit 101";
 
     assertSql(sql.getValue(), expected);
   }
@@ -638,7 +638,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "ax.\"monthly\",ax.\"ou\",(SELECT avg ("
+        "ax.\"quarterly\",ax.\"ou\",(SELECT avg ("
             + piSubquery
             + ") FROM analytics_event_"
             + programB.getUid().toLowerCase()
@@ -656,7 +656,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + "\"  "
             + "from analytics_enrollment_"
             + programA.getUid()
-            + " as ax where enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09' and (uidlevel1 = 'ouabcdefghA' ) limit 101";
+            + " as ax where ((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09')) and (uidlevel1 = 'ouabcdefghA' ) limit 101";
 
     assertSql(sql.getValue(), expected);
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
@@ -162,7 +162,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
             + ",lastupdated,ST_AsGeoJSON(psigeometry, 6) as geometry,"
             + "longitude,latitude,ouname,oucode,pistatus,psistatus,ax.\"monthly\",ax.\"ou\"  from "
             + getTable(programA.getUid())
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA') limit 101";
+            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') limit 101";
 
     assertThat(sql.getValue(), is(expected));
   }
@@ -222,12 +222,12 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
             + "lastupdatedbydisplayname"
             + ",lastupdated,enrollmentdate,"
             + "incidentdate,tei,pi,ST_AsGeoJSON(psigeometry, 6) as geometry,longitude,latitude,ouname,oucode,pistatus,"
-            + "psistatus,ax.\"monthly\",ax.\"ou\",\""
+            + "psistatus,ax.\"quarterly\",ax.\"ou\",\""
             + dataElement.getUid()
             + "_name"
             + "\"  from "
             + getTable(programA.getUid())
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA')"
+            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA')"
             + " limit 101";
 
     assertThat(sql.getValue(), is(expected));
@@ -245,9 +245,9 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "ax.\"monthly\",ax.\"ou\"  from "
+        "ax.\"quarterly\",ax.\"ou\"  from "
             + getTable(programA.getUid())
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA') ";
+            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') ";
 
     assertSql(expected, sql.getValue());
     assertTrue(grid.hasLastDataRow());
@@ -262,9 +262,9 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "ax.\"monthly\",ax.\"ou\"  from "
+        "ax.\"quarterly\",ax.\"ou\"  from "
             + getTable(programA.getUid())
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
+            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid()
             + "' limit 101";
 
@@ -280,9 +280,9 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "ax.\"monthly\",ax.\"ou\",ax.\"fWIAEtYVEGk\"  from "
+        "ax.\"quarterly\",ax.\"ou\",ax.\"fWIAEtYVEGk\"  from "
             + getTable(programA.getUid())
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
+            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid()
             + "' limit 101";
 
@@ -299,9 +299,9 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "ax.\"monthly\",ax.\"ou\",ax.\"fWIAEtYVEGk\"  from "
+        "ax.\"quarterly\",ax.\"ou\",ax.\"fWIAEtYVEGk\"  from "
             + getTable(programA.getUid())
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
+            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid()
             + "' and ax.\"fWIAEtYVEGk\" > '10' limit 101";
 
@@ -317,9 +317,9 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "ax.\"monthly\",ax.\"ou\"  from "
+        "ax.\"quarterly\",ax.\"ou\"  from "
             + getTable(programA.getUid())
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA')"
+            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA')"
             + " and pistatus in ('ACTIVE','COMPLETED') and psistatus in ('SCHEDULE') limit 101";
 
     assertSql(expected, sql.getValue());
@@ -402,9 +402,9 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "ax.\"monthly\",ax.\"ou\",ax.\"fWIAEtYVEGk\"  from "
+        "ax.\"quarterly\",ax.\"ou\",ax.\"fWIAEtYVEGk\"  from "
             + getTable(programA.getUid())
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
+            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid()
             + "' limit 101";
 
@@ -421,9 +421,9 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "ax.\"monthly\",ax.\"ou\",ax.\"fWIAEtYVEGk\"  from "
+        "ax.\"quarterly\",ax.\"ou\",ax.\"fWIAEtYVEGk\"  from "
             + getTable(programA.getUid())
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
+            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid()
             + "' and ax.\"fWIAEtYVEGk\" > '10' limit 101";
 
@@ -443,18 +443,18 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     assertThat(resultGrid.getRows(), hasSize(1));
     assertThat(resultGrid.getRow(0), hasSize(4));
     assertThat(resultGrid.getRow(0).get(0), is("2000"));
-    assertThat(resultGrid.getRow(0).get(1), is("201701"));
+    assertThat(resultGrid.getRow(0).get(1), is("2017Q1"));
     assertThat(resultGrid.getRow(0).get(2), is("Sierra Leone"));
     assertThat(resultGrid.getRow(0).get(3), is(100));
 
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "select count(ax.\"psi\") as value,ax.\"monthly\",ax.\"ou\",ax.\"fWIAEtYVEGk\" from "
+        "select count(ax.\"psi\") as value,ax.\"quarterly\",ax.\"ou\",ax.\"fWIAEtYVEGk\" from "
             + getTable(programA.getUid())
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
+            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid()
-            + "' group by ax.\"monthly\", ax.\"ou\", ax.\"fWIAEtYVEGk\" limit 200001";
+            + "' group by ax.\"quarterly\", ax.\"ou\", ax.\"fWIAEtYVEGk\" limit 200001";
 
     assertThat(sql.getValue(), is(expected));
   }
@@ -473,18 +473,18 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     assertThat(resultGrid.getRows(), hasSize(1));
     assertThat(resultGrid.getRow(0), hasSize(4));
     assertThat(resultGrid.getRow(0).get(0), is("2000"));
-    assertThat(resultGrid.getRow(0).get(1), is("201701"));
+    assertThat(resultGrid.getRow(0).get(1), is("2017Q1"));
     assertThat(resultGrid.getRow(0).get(2), is("Sierra Leone"));
     assertThat(resultGrid.getRow(0).get(3), is(100));
 
     verify(jdbcTemplate).queryForRowSet(sql.capture());
     String expected =
-        "select count(ax.\"psi\") as value,ax.\"monthly\",ax.\"ou\",ax.\"fWIAEtYVEGk\" from "
+        "select count(ax.\"psi\") as value,ax.\"quarterly\",ax.\"ou\",ax.\"fWIAEtYVEGk\" from "
             + getTable(programA.getUid())
-            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
+            + " as ax where (ax.\"quarterly\" in ('2000Q1') ) and ax.\"uidlevel1\" in ('ouabcdefghA') and ax.\"ps\" = '"
             + programStage.getUid()
             + "' and ax.\"fWIAEtYVEGk\" > '10'"
-            + " group by ax.\"monthly\", ax.\"ou\", ax.\"fWIAEtYVEGk\" limit 200001";
+            + " group by ax.\"quarterly\", ax.\"ou\", ax.\"fWIAEtYVEGk\" limit 200001";
     assertThat(sql.getValue(), is(expected));
   }
 
@@ -613,7 +613,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     String expectedFirstOrLastSubquery =
         "from (select \"psi\",ax.\""
             + deU.getUid()
-            + "\",\"monthly\",\"ou\","
+            + "\",\"quarterly\",\"ou\","
             + "row_number() over (partition by ax.\"ou\",ax.\"ao\" order by ax.\"executiondate\" "
             + order
             + ", ax.\"created\" "
@@ -649,7 +649,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     // Simulate one row only
     when(rowSet.next()).thenReturn(true).thenReturn(false);
 
-    when(rowSet.getString("monthly")).thenReturn("201701");
+    when(rowSet.getString("quarterly")).thenReturn("2017Q1");
     when(rowSet.getString("ou")).thenReturn("Sierra Leone");
     when(rowSet.getInt("value")).thenReturn(100);
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsTest.java
@@ -147,7 +147,7 @@ abstract class EventAnalyticsTest {
     OrganisationUnit ouA = createOrganisationUnit('A');
     ouA.setPath("/" + ouA.getUid());
     EventQueryParams.Builder params = new EventQueryParams.Builder();
-    params.withPeriods(getList(createPeriod("2000Q1")), "monthly");
+    params.withPeriods(getList(createPeriod("2000Q1")), "quarterly");
     params.withOrganisationUnits(getList(ouA));
     params.withTableName(getTableName() + "_" + programA.getUid());
     params.withProgram(programA);
@@ -160,7 +160,7 @@ abstract class EventAnalyticsTest {
     OrganisationUnit ouA = createOrganisationUnit('A');
     ouA.setPath("/" + ouA.getUid());
     EventQueryParams.Builder params = new EventQueryParams.Builder();
-    params.withPeriods(getList(createPeriod("2000Q1")), "monthly");
+    params.withPeriods(getList(createPeriod("2000Q1")), "quarterly");
     params.withOrganisationUnits(getList(ouA));
     params.withTableName(getTableName() + "_" + programA.getUid());
     params.withProgram(programA);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
@@ -36,6 +36,7 @@ import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.common.BaseDimensionalObject;
 import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.jdbc.statementbuilder.PostgreSQLStatementBuilder;
+import org.hisp.dhis.period.DailyPeriodType;
 import org.hisp.dhis.period.MonthlyPeriodType;
 import org.hisp.dhis.period.Period;
 import org.joda.time.DateTime;
@@ -52,11 +53,14 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
 
   private Period peC;
 
+  private Period peD;
+
   @BeforeEach
   void before() {
     peA = new MonthlyPeriodType().createPeriod(new DateTime(2022, 4, 1, 0, 0).toDate());
     peB = new MonthlyPeriodType().createPeriod(new DateTime(2022, 5, 1, 0, 0).toDate());
     peC = new MonthlyPeriodType().createPeriod(new DateTime(2022, 6, 1, 0, 0).toDate());
+    peD = new DailyPeriodType().createPeriod(new DateTime(2023, 1, 1, 0, 0).toDate());
   }
 
   @Test


### PR DESCRIPTION
fix: no e2e tests in 2.39 for analytics [DHIS2-14971]

fix: adaption for backport from 40 version [DHIS2-14971]

fix: adaption for backport from 40 version [DHIS2-14971]

fix: query generation consider multiple periods for single value queries [DHIS2-14971] (#15252)

* fix: query generation consider multiple periods for single value queries [DHIS2-14971]

* fix: sonar warnings [DHIS2-14971]

* fix: formatting [DHIS2-14971]

* fix: fix test [DHIS2-14971]

* fix: e2e test [DHIS2-14971]

* fix: some javadoc [DHIS2-14971]

(cherry picked from commit c63dbd218d14a0fa1c4c674ac51ecd9d8b28fa41)