### PR TITLE
fix: TrackedEntity Get Ids : Missing group by enrolledat field [DHIS2-15658]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -1192,7 +1192,12 @@ public class HibernateTrackedEntityInstanceStore
             .append("TET.uid, ")
             .append("TEI.potentialduplicate, ")
             .append("TEI.inactive ")
-            .append(params.isIncludeDeleted() ? ", TEI.deleted " : "");
+            .append(params.isIncludeDeleted() ? ", TEI.deleted " : "")
+            .append(
+                params.getOrders().stream()
+                        .anyMatch(p -> ENROLLED_AT.isPropertyEqualTo(p.getField()))
+                    ? ", TEI. " + ENROLLED_AT.getColumn()
+                    : "");
 
     for (QueryItem queryItem : sortableAttributesAndFilters(params)) {
       groupBy


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-15658

This does not affect the master branch. 
In 2.40 and older versions, when searching TE ids, if we order by `enrolledat` and attributes, we get a SQL exception because `enrolledat` is missing in the group by clause