### PR TITLE
fix: Harmonize filter field in TrackedEntity exporter [DHIS2-15665]

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/TrackerExportTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/TrackerExportTests.java
@@ -316,8 +316,7 @@ public class TrackerExportTests extends TrackerApiTest {
 
     TrackerApiResponse trackedEntity =
         trackerImportExportActions.getTrackedEntity(
-            "Kj6vYde4LHh",
-            new QueryParamsBuilder().add("fields", "*"));
+            "Kj6vYde4LHh", new QueryParamsBuilder().add("fields", "*"));
 
     TrackerApiResponse trackedEntities =
         trackerImportExportActions.getTrackedEntities(

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/TrackerExportTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/TrackerExportTests.java
@@ -317,13 +317,12 @@ public class TrackerExportTests extends TrackerApiTest {
     TrackerApiResponse trackedEntity =
         trackerImportExportActions.getTrackedEntity(
             "Kj6vYde4LHh",
-            new QueryParamsBuilder().add("fields", "*").add("includeAllAttributes", "true"));
+            new QueryParamsBuilder().add("fields", "*"));
 
     TrackerApiResponse trackedEntities =
         trackerImportExportActions.getTrackedEntities(
             new QueryParamsBuilder()
                 .add("fields", "*")
-                .add("includeAllAttributes", "true")
                 .add("trackedEntity", "Kj6vYde4LHh")
                 .add("orgUnit", "O6uvpzGd5pu"));
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/RequestParams.java
@@ -61,6 +61,16 @@ import org.hisp.dhis.webapi.controller.tracker.view.User;
 class RequestParams extends PagingAndSortingCriteriaAdapter {
   static final String DEFAULT_FIELDS_PARAM = "*,!relationships,!enrollments,!events,!programOwners";
 
+  @Deprecated(forRemoval = true, since = "2.41")
+  // Removed field without previous deprecation.
+  // It is still here in order to be validated and warn the client about the removal
+  private String query;
+
+  @Deprecated(forRemoval = true, since = "2.41")
+  // Removed field without previous deprecation.
+  // It is still here in order to be validated and warn the client about the removal
+  private String attribute;
+
   /** Comma separated list of attribute filters */
   private String filter;
 
@@ -170,6 +180,11 @@ class RequestParams extends PagingAndSortingCriteriaAdapter {
    * potentialDuplicate or not
    */
   private Boolean potentialDuplicate;
+
+  @Deprecated(forRemoval = true, since = "2.41")
+  // Removed field without previous deprecation.
+  // It is still here in order to be validated and warn the client about the removal
+  private String includeAllAttributes;
 
   @OpenApi.Property(value = String[].class)
   private List<FieldPath> fields = FieldFilterParser.parse(DEFAULT_FIELDS_PARAM);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.AssignedUserQueryParam;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
@@ -73,6 +74,8 @@ class TrackedEntityRequestParamsMapper {
 
   public TrackedEntityOperationParams map(
       RequestParams requestParams, User user, List<FieldPath> fields) throws BadRequestException {
+    validateRemovedParameters(requestParams);
+
     Set<UID> assignedUsers =
         validateDeprecatedUidsParameter(
             "assignedUser",
@@ -143,6 +146,19 @@ class TrackedEntityRequestParamsMapper {
     mapOrderParam(builder, requestParams.getOrder());
 
     return builder.build();
+  }
+
+  private void validateRemovedParameters(RequestParams requestParams) throws BadRequestException {
+    if (StringUtils.isNotBlank(requestParams.getQuery())) {
+      throw new BadRequestException("`query` parameter was removed in v41. Use `filter` instead.");
+    }
+    if (StringUtils.isNotBlank(requestParams.getAttribute())) {
+      throw new BadRequestException(
+          "`attribute` parameter was removed in v41. Use `filter` instead.");
+    }
+    if (StringUtils.isNotBlank(requestParams.getIncludeAllAttributes())) {
+      throw new BadRequestException("`includeAllAttributes` parameter was removed in v41.");
+    }
   }
 
   private void mapOrderParam(

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
@@ -28,10 +28,6 @@ NOTE: this query parameter has no effect on a response in CSV!
 
 ## Common for all endpoints
 
-### `*.parameter.TrackedEntityRequestParams.query`
-
-### `*.parameter.TrackedEntityRequestParams.attribute`
-
 ### `*.parameter.TrackedEntityRequestParams.orgUnits`
 
 `<orgUnit1-uid>[,<orgUnit2-uid>...]`
@@ -125,8 +121,6 @@ if `assignedUserMode` is either `PROVIDED` or not specified.
 
 ### `*.parameter.TrackedEntityRequestParams.includeDeleted`
 
-### `*.parameter.TrackedEntityRequestParams.includeAllAttributes`
-
 ### `*.parameter.TrackedEntityRequestParams.potentialDuplicate`
 
 ### `*.parameter.TrackedEntityRequestParams.order`
@@ -162,12 +156,24 @@ for how to use it.
 
 NOTE: this query parameter has no effect on a CSV response!
 
+### `*.parameter.TrackedEntityRequestParams.query`
+
+**REMOVED as of 2.41:** Use parameter `filter`!
+
+### `*.parameter.TrackedEntityRequestParams.attribute`
+
+**REMOVED as of 2.41:** Use parameter `filter`!
+
+### `*.parameter.TrackedEntityRequestParams.includeAllAttributes`
+
+**REMOVED as of 2.41:**!
+
 ### `*.parameter.TrackedEntityRequestParams.filter`
 
 `<filter1>[,<filter2>...]`
 
 Get tracked entities matching given filters on attributes. A filter is a colon separated attribute UID 
-with operator and value pairs. Example: `filter=H9IlTX2X6SL:sw:A` with operator starts with `sw` 
+with optional operator and value pairs. Example: `filter=H9IlTX2X6SL:sw:A` with operator starts with `sw` 
 followed by a value. Special characters like `+` need to be percent-encoded so `%2B` instead of `+`. 
 Characters such as `:` (colon) or `,` (comma), as part of the filter value, need to be escaped by `/` (slash).
 Likewise, `/` needs to be escaped. Multiple operator/value pairs for the same attribute 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapperTest.java
@@ -263,6 +263,27 @@ class TrackedEntityRequestParamsMapperTest {
   }
 
   @Test
+  void shouldFailIfGivenRemovedQueryParameter() {
+    requestParams.setQuery("query");
+
+    assertThrows(BadRequestException.class, () -> mapper.map(requestParams, user));
+  }
+
+  @Test
+  void shouldFailIfGivenRemovedAttributeParameter() {
+    requestParams.setAttribute("IsdLBTOBzMi");
+
+    assertThrows(BadRequestException.class, () -> mapper.map(requestParams, user));
+  }
+
+  @Test
+  void shouldFailIfGivenRemovedIncludeAllAttributesParameter() {
+    requestParams.setIncludeAllAttributes("true");
+
+    assertThrows(BadRequestException.class, () -> mapper.map(requestParams, user));
+  }
+
+  @Test
   void shouldMapOrderParameterInGivenOrderWhenFieldsAreOrderable() throws BadRequestException {
     RequestParams requestParams = new RequestParams();
     requestParams.setOrder(


### PR DESCRIPTION
Return an error if removed parameters `query`, `attribute` or `includeAllAttributes` are used in `GET /tracker/trackedEntities` endpoint and update OpenAPI documentation