### PR TITLE
fix: Use LocationManager interface as dep so Int tests run locally

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
@@ -86,7 +86,7 @@ import org.hisp.dhis.dataset.DataSetService;
 import org.hisp.dhis.expression.Expression;
 import org.hisp.dhis.expression.ExpressionService;
 import org.hisp.dhis.expression.ExpressionValidationOutcome;
-import org.hisp.dhis.external.location.DefaultLocationManager;
+import org.hisp.dhis.external.location.LocationManager;
 import org.hisp.dhis.external.location.LocationManagerException;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.i18n.I18nManager;
@@ -129,7 +129,7 @@ public class DefaultDataIntegrityService implements DataIntegrityService {
 
   private final I18nManager i18nManager;
 
-  private final DefaultLocationManager locationManager;
+  private final LocationManager locationManager;
 
   private final ProgramRuleService programRuleService;
 


### PR DESCRIPTION
# Issue
- Integration tests fail to run locally due to error
`DefaultDataIntegrityService.class]: Unsatisfied dependency expressed through constructor parameter 1; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'org.hisp.dhis.external.location.DefaultLocationManager' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {}`

# Fix
- use the `LocationManager` interface as the dependency in the service
- tested locally and Int tests now run
- App comes up locally & Data Integrity checks still load