### PR TITLE
chore: Cleanup GET endpoints on CompleteDataSetRegistrationController

### DIFF
--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/CompleteDataSetRegistrationActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/CompleteDataSetRegistrationActions.java
@@ -54,9 +54,20 @@ public class CompleteDataSetRegistrationActions extends RestApiActions {
 
   public ApiResponse getCompleted(String dataSet, String orgUnit, String period) {
     QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder();
-    queryParamsBuilder.add("dataSet", dataSet);
-    queryParamsBuilder.add("orgUnit", orgUnit);
-    queryParamsBuilder.add("period", period);
+    addRequiredParams(queryParamsBuilder, dataSet, orgUnit, period);
     return get(queryParamsBuilder);
+  }
+
+  public ApiResponse getCompletedWithIdScheme(String dataSet, String orgUnit, String period, String idScheme) {
+    QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder();
+    addRequiredParams(queryParamsBuilder, dataSet, orgUnit, period);
+    queryParamsBuilder.add("idScheme", idScheme);
+    return get(queryParamsBuilder);
+  }
+
+  private void addRequiredParams(QueryParamsBuilder builder, String dataSet, String orgUnit, String period) {
+    builder.add("dataSet", dataSet);
+    builder.add("orgUnit", orgUnit);
+    builder.add("period", period);
   }
 }

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/CompleteDataSetRegistrationActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/CompleteDataSetRegistrationActions.java
@@ -46,6 +46,12 @@ public class CompleteDataSetRegistrationActions extends RestApiActions {
     return post("", body, queryParamsBuilder);
   }
 
+  public ApiResponse sendSync(String body) {
+    QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder();
+
+    return post("", body, queryParamsBuilder);
+  }
+
   public ApiResponse getCompleted(String dataSet, String orgUnit, String period) {
     QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder();
     queryParamsBuilder.add("dataSet", dataSet);

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/CompleteDataSetRegistrationActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/CompleteDataSetRegistrationActions.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.actions;
 
+import io.restassured.http.ContentType;
 import org.hisp.dhis.dto.ApiResponse;
 import org.hisp.dhis.helpers.QueryParamsBuilder;
 
@@ -52,20 +53,24 @@ public class CompleteDataSetRegistrationActions extends RestApiActions {
     return post("", body, queryParamsBuilder);
   }
 
-  public ApiResponse getCompleted(String dataSet, String orgUnit, String period) {
+  public ApiResponse getCompletedAsMediaType(
+      String dataSet, String orgUnit, String period, ContentType mediaType) {
     QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder();
     addRequiredParams(queryParamsBuilder, dataSet, orgUnit, period);
-    return get(queryParamsBuilder);
+    String contentType = mediaType != null ? mediaType.toString() : "application/json";
+    return get("", "", contentType, queryParamsBuilder);
   }
 
-  public ApiResponse getCompletedWithIdScheme(String dataSet, String orgUnit, String period, String idScheme) {
+  public ApiResponse getCompletedWithIdScheme(
+      String dataSet, String orgUnit, String period, String idScheme) {
     QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder();
     addRequiredParams(queryParamsBuilder, dataSet, orgUnit, period);
     queryParamsBuilder.add("idScheme", idScheme);
     return get(queryParamsBuilder);
   }
 
-  private void addRequiredParams(QueryParamsBuilder builder, String dataSet, String orgUnit, String period) {
+  private void addRequiredParams(
+      QueryParamsBuilder builder, String dataSet, String orgUnit, String period) {
     builder.add("dataSet", dataSet);
     builder.add("orgUnit", orgUnit);
     builder.add("period", period);

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/RestApiActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/RestApiActions.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.actions;
 
+import static io.restassured.config.XmlConfig.xmlConfig;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.oneOf;
 
@@ -183,7 +184,15 @@ public class RestApiActions {
     addCoverage("GET", resourceId + path);
 
     Response response =
-        this.given().contentType(contentType).accept(accept).when().get(resourceId + path);
+        this.given()
+            .config(
+                RestAssured.config()
+                    .xmlConfig(
+                        xmlConfig().namespaceAware(false)))
+            .contentType(contentType)
+            .accept(accept)
+            .when()
+            .get(resourceId + path);
 
     return new ApiResponse(response);
   }

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/RestApiActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/RestApiActions.java
@@ -185,10 +185,7 @@ public class RestApiActions {
 
     Response response =
         this.given()
-            .config(
-                RestAssured.config()
-                    .xmlConfig(
-                        xmlConfig().namespaceAware(false)))
+            .config(RestAssured.config().xmlConfig(xmlConfig().namespaceAware(false)))
             .contentType(contentType)
             .accept(accept)
             .when()

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/CompleteDataSetRegistrationsTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/CompleteDataSetRegistrationsTest.java
@@ -27,16 +27,18 @@
  */
 package org.hisp.dhis.metadata.metadata_import;
 
-
-import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.restassured.response.ResponseBody;
+import io.restassured.http.ContentType;
 import org.hisp.dhis.ApiTest;
 import org.hisp.dhis.actions.CompleteDataSetRegistrationActions;
 import org.hisp.dhis.actions.LoginActions;
 import org.hisp.dhis.actions.RestApiActions;
 import org.hisp.dhis.actions.SystemActions;
+import org.hisp.dhis.dto.ApiResponse;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -57,195 +59,174 @@ class CompleteDataSetRegistrationsTest extends ApiTest {
     dataSetActions = new RestApiActions("dataSets");
   }
 
-  //  @Test
-  //  void completeDataSetRegistrationsAsync() {
-  //    loginActions.loginAsSuperUser();
-  //
-  //    // create data set
-  //    String dataSet = dataSetWithOrgUnit(1, "O6uvpzGd5pu");
-  //    ApiResponse dataSetResponse = dataSetActions.post(dataSet);
-  //
-  //    assertEquals(201, dataSetResponse.statusCode());
-  //    String dataSetId = dataSetResponse.extractUid();
-  //    assertEquals(11, dataSetId.length());
-  //
-  //    // get complete data sets to show none complete with given criteria
-  //    ApiResponse completedResponse =
-  //        apiActions.getCompletedAsMediaType(dataSetId, "O6uvpzGd5pu", "202301",
-  // ContentType.JSON);
-  //    assertEquals("{}", completedResponse.getAsString());
-  //
-  //    // complete the data set and post async
-  //    String cds = completeDataSet(dataSetId, "202301", "O6uvpzGd5pu");
-  //    ApiResponse completeAsyncResponse = apiActions.sendAsync(cds);
-  //    assertEquals(200, completeAsyncResponse.statusCode());
-  //
-  //    assertTrue(
-  //        completeAsyncResponse
-  //            .getBody()
-  //            .get("message")
-  //            .getAsString()
-  //            .contains("Initiated COMPLETE_DATA_SET_REGISTRATION_IMPORT"));
-  //
-  //    String taskId =
-  //        completeAsyncResponse.getBody().getAsJsonObject("response").get("id").getAsString();
-  //    assertEquals(11, taskId.length());
-  //
-  //    // wait for job to be completed (24 seconds used as the job schedule loop is 20 seconds)
-  //    ApiResponse taskStatus =
-  //        systemActions.waitUntilTaskCompleted("COMPLETE_DATA_SET_REGISTRATION_IMPORT", taskId,
-  // 24);
-  //    assertTrue(taskStatus.getAsString().contains("\"completed\":true"));
-  //
-  //    // get complete data sets which should be 1 now
-  //    ApiResponse completedResponse2 =
-  //        apiActions.getCompletedAsMediaType(dataSetId, "O6uvpzGd5pu", "202301",
-  // ContentType.JSON);
-  //
-  //    // validate async-completed data set
-  //    completedResponse2
-  //        .validate()
-  //        .statusCode(200)
-  //        .body("completeDataSetRegistrations[0].period", equalTo("202301"))
-  //        .body("completeDataSetRegistrations[0].dataSet", equalTo(dataSetId))
-  //        .body("completeDataSetRegistrations[0].organisationUnit", equalTo("O6uvpzGd5pu"))
-  //        .body("completeDataSetRegistrations[0].completed", equalTo(true))
-  //        .body("completeDataSetRegistrations[0].storedBy", equalTo("tasuperadmin"));
-  //  }
-
-  //  @Test
-  //  void completeDataSetRegistrationSyncJson() {
-  //    loginActions.loginAsSuperUser();
-  //
-  //    // create data set
-  //    String dataSet = dataSetWithOrgUnit(2, "g8upMTyEZGZ");
-  //    ApiResponse dataSetResponse = dataSetActions.post(dataSet);
-  //
-  //    assertEquals(201, dataSetResponse.statusCode());
-  //    String dataSetId = dataSetResponse.extractUid();
-  //    assertEquals(11, dataSetId.length());
-  //
-  //    // get complete data sets to confirm none completed with given criteria
-  //    ApiResponse completedResponse =
-  //        apiActions.getCompletedAsMediaType(dataSetId, "g8upMTyEZGZ", "202301",
-  // ContentType.JSON);
-  //    assertEquals("{}", completedResponse.getAsString());
-  //
-  //    // complete the data set and post sync
-  //    String cds = completeDataSet(dataSetId, "202301", "g8upMTyEZGZ");
-  //    ApiResponse completeSyncResponse = apiActions.sendSync(cds);
-  //
-  //    completeSyncResponse
-  //        .validate()
-  //        .statusCode(200)
-  //        .body("message", equalTo("Import was successful."))
-  //        .body("response.status", equalTo("SUCCESS"))
-  //        .body("response.importCount.imported", equalTo(1));
-  //
-  //    // get complete data sets which should be 1 now
-  //    ApiResponse completedResponse2 =
-  //        apiActions.getCompletedAsMediaType(dataSetId, "g8upMTyEZGZ", "202301",
-  // ContentType.JSON);
-  //
-  //    // validate sync-completed data set
-  //    completedResponse2
-  //        .validate()
-  //        .statusCode(200)
-  //        .body("completeDataSetRegistrations[0].period", equalTo("202301"))
-  //        .body("completeDataSetRegistrations[0].dataSet", equalTo(dataSetId))
-  //        .body("completeDataSetRegistrations[0].organisationUnit", equalTo("g8upMTyEZGZ"))
-  //        .body("completeDataSetRegistrations[0].completed", equalTo(true))
-  //        .body("completeDataSetRegistrations[0].storedBy", equalTo("tasuperadmin"));
-  //  }
-
   @Test
-  void completeDataSetRegistrationSyncXml() {
+  void completeDataSetRegistrationsAsync() {
     loginActions.loginAsSuperUser();
 
-    String dataSet = dataSetWithOrgUnit(9, "g8upMTyEZGZ");
-
-    // @formatter:off
-    ResponseBody body = given().body(dataSet)
-                        .when().post("/dataSets").andReturn().body();
-    
-//    post.then().statusCode(201);
-    String uid = body.jsonPath().get("response.uid");
-    assertEquals("uid", uid);
-
-//    .then().statusCode(201).and();
-    //        .body("id", notNullValue())
-    //        .body("name", equalTo("lokesh"))
-    //        .body("email", equalTo("admin@howtodoinjava.com"));
-
     // create data set
-    //    String dataSet = dataSetWithOrgUnit(3, "g8upMTyEZGZ");
-    //    ApiResponse dataSetResponse = dataSetActions.post(dataSet);
-    //    Response post = RestAssured.post("/api/dataSet", dataSet);
+    String dataSet = dataSetWithOrgUnit(1, "O6uvpzGd5pu");
+    ApiResponse dataSetResponse = dataSetActions.post(dataSet);
 
-    //    assertEquals(201, post.getStatusCode());
-    //    String dataSetId = post.body().jsonPath().get("response.uid");
+    assertEquals(201, dataSetResponse.statusCode());
+    String dataSetId = dataSetResponse.extractUid();
+    assertEquals(11, dataSetId.length());
 
-    // complete the data set and post sync
-    //    String cds = completeDataSet(dataSetId, "202301", "g8upMTyEZGZ");
-    //    ApiResponse completeSyncResponse = apiActions.sendSync(cds);
+    // get complete data sets to show none complete with given criteria
+    ApiResponse completedResponse =
+        apiActions.getCompletedAsMediaType(dataSetId, "O6uvpzGd5pu", "202301", ContentType.JSON);
+    assertEquals("{}", completedResponse.getAsString());
 
-    //    completeSyncResponse
-    //        .validate()
-    //        .statusCode(200)
-    //        .body("message", equalTo("Import was successful."))
-    //        .body("response.status", equalTo("SUCCESS"))
-    //        .body("response.importCount.imported", equalTo(1));
+    // complete the data set and post async
+    String cds = completeDataSet(dataSetId, "202301", "O6uvpzGd5pu");
+    ApiResponse completeAsyncResponse = apiActions.sendAsync(cds);
+    assertEquals(200, completeAsyncResponse.statusCode());
 
-    // get complete data sets in xml format
-    //    ApiResponse getXmlResponse =
-    //        apiActions.getCompletedAsMediaType(dataSetId, "g8upMTyEZGZ", "202301",
-    // ContentType.XML);
+    assertTrue(
+        completeAsyncResponse
+            .getBody()
+            .get("message")
+            .getAsString()
+            .contains("Initiated COMPLETE_DATA_SET_REGISTRATION_IMPORT"));
 
-    // validate xml response
-    //    getXmlResponse
-    //        .validate()
-    //        .contentType(ContentType.XML)
-    //        .rootPath("completeDataSetRegistrations.completeDataSetRegistration")
-    //        .body("@period", is("202301"))
-    //        .and()
-    //        .body("@dataSet", is(dataSetId))
-    //        .and()
-    //        .body("@organisationUnit", is("g8upMTyEZGZ"));
+    String taskId =
+        completeAsyncResponse.getBody().getAsJsonObject("response").get("id").getAsString();
+    assertEquals(11, taskId.length());
+
+    // wait for job to be completed (24 seconds used as the job schedule loop is 20 seconds)
+    ApiResponse taskStatus =
+        systemActions.waitUntilTaskCompleted("COMPLETE_DATA_SET_REGISTRATION_IMPORT", taskId, 24);
+    assertTrue(taskStatus.getAsString().contains("\"completed\":true"));
+
+    // get complete data sets which should be 1 now
+    ApiResponse completedResponse2 =
+        apiActions.getCompletedAsMediaType(dataSetId, "O6uvpzGd5pu", "202301", ContentType.JSON);
+
+    // validate async-completed data set
+    completedResponse2
+        .validate()
+        .statusCode(200)
+        .body("completeDataSetRegistrations[0].period", equalTo("202301"))
+        .body("completeDataSetRegistrations[0].dataSet", equalTo(dataSetId))
+        .body("completeDataSetRegistrations[0].organisationUnit", equalTo("O6uvpzGd5pu"))
+        .body("completeDataSetRegistrations[0].completed", equalTo(true))
+        .body("completeDataSetRegistrations[0].storedBy", equalTo("tasuperadmin"));
   }
 
-  //    @Test
-  //    void getCompleteDataSetRegistrationWithIdScheme() {
-  //      loginActions.loginAsSuperUser();
-  //
-  //      // create data set
-  //      String dataSet = dataSetWithOrgUnit(4, "g8upMTyEZGZ");
-  //      ApiResponse dataSetResponse = dataSetActions.post(dataSet);
-  //
-  //      assertEquals(201, dataSetResponse.statusCode());
-  //      String dataSetId = dataSetResponse.extractUid();
-  //
-  //      // complete the data set and post sync
-  //      String cds = completeDataSet(dataSetId, "202301", "g8upMTyEZGZ");
-  //      ApiResponse completeSyncResponse = apiActions.sendSync(cds);
-  //
-  //      completeSyncResponse
-  //          .validate()
-  //          .statusCode(200)
-  //          .body("message", equalTo("Import was successful."))
-  //          .body("response.status", equalTo("SUCCESS"))
-  //          .body("response.importCount.imported", equalTo(1));
-  //
-  //      // get complete data sets with id scheme CODE
-  //      ApiResponse completedResponse2 =
-  //          apiActions.getCompletedWithIdScheme(dataSetId, "g8upMTyEZGZ", "202301", "CODE");
-  //
-  //      // validate sync-completed data set returns CODEs for id scheme
-  //      completedResponse2
-  //          .validate()
-  //          .statusCode(200)
-  //          .body("completeDataSetRegistrations[0].dataSet", equalTo("TEST_CODE 4"))
-  //          .body("completeDataSetRegistrations[0].organisationUnit", equalTo("OU_167609"));
-  //    }
+  @Test
+  void getCompleteDataSetRegistrationSyncJson() {
+    loginActions.loginAsSuperUser();
+
+    // create data set
+    String dataSet = dataSetWithOrgUnit(2, "g8upMTyEZGZ");
+    ApiResponse dataSetResponse = dataSetActions.post(dataSet);
+
+    assertEquals(201, dataSetResponse.statusCode());
+    String dataSetId = dataSetResponse.extractUid();
+    assertEquals(11, dataSetId.length());
+
+    // get complete data sets to confirm none completed with given criteria
+    ApiResponse completedResponse =
+        apiActions.getCompletedAsMediaType(dataSetId, "g8upMTyEZGZ", "202301", ContentType.JSON);
+    assertEquals("{}", completedResponse.getAsString());
+
+    // complete the data set and post sync
+    String cds = completeDataSet(dataSetId, "202301", "g8upMTyEZGZ");
+    ApiResponse completeSyncResponse = apiActions.sendSync(cds);
+
+    completeSyncResponse
+        .validate()
+        .statusCode(200)
+        .body("message", equalTo("Import was successful."))
+        .body("response.status", equalTo("SUCCESS"))
+        .body("response.importCount.imported", equalTo(1));
+
+    // get complete data sets which should be 1 now
+    ApiResponse completedResponse2 =
+        apiActions.getCompletedAsMediaType(dataSetId, "g8upMTyEZGZ", "202301", ContentType.JSON);
+
+    // validate data & media type
+    completedResponse2
+        .validate()
+        .contentType(ContentType.JSON)
+        .statusCode(200)
+        .body("completeDataSetRegistrations[0].period", equalTo("202301"))
+        .body("completeDataSetRegistrations[0].dataSet", equalTo(dataSetId))
+        .body("completeDataSetRegistrations[0].organisationUnit", equalTo("g8upMTyEZGZ"))
+        .body("completeDataSetRegistrations[0].completed", equalTo(true))
+        .body("completeDataSetRegistrations[0].storedBy", equalTo("tasuperadmin"));
+  }
+
+  @Test
+  void getCompleteDataSetRegistrationSyncXml() {
+    loginActions.loginAsSuperUser();
+
+    // create data set
+    String dataSet = dataSetWithOrgUnit(0, "g8upMTyEZGZ");
+    ApiResponse dataSetResponse = dataSetActions.post(dataSet);
+    assertEquals(201, dataSetResponse.statusCode());
+    String dataSetId = dataSetResponse.extractUid();
+    assertEquals(11, dataSetId.length());
+
+    // complete the data set and post
+    String cds = completeDataSet(dataSetId, "202301", "g8upMTyEZGZ");
+    ApiResponse completeSyncResponse = apiActions.sendSync(cds);
+
+    completeSyncResponse
+        .validate()
+        .statusCode(200)
+        .body("message", equalTo("Import was successful."))
+        .body("response.status", equalTo("SUCCESS"))
+        .body("response.importCount.imported", equalTo(1));
+
+    // get complete data sets in xml format
+    ApiResponse getXmlResponse =
+        apiActions.getCompletedAsMediaType(dataSetId, "g8upMTyEZGZ", "202301", ContentType.XML);
+
+    // validate xml response
+    getXmlResponse
+        .validate()
+        .contentType(ContentType.XML)
+        .rootPath("completeDataSetRegistrations.completeDataSetRegistration")
+        .body("@period", is("202301"))
+        .and()
+        .body("@dataSet", is(dataSetId))
+        .and()
+        .body("@organisationUnit", is("g8upMTyEZGZ"));
+  }
+
+  @Test
+  void getCompleteDataSetRegistrationWithIdScheme() {
+    loginActions.loginAsSuperUser();
+
+    // create data set
+    String dataSet = dataSetWithOrgUnit(4, "g8upMTyEZGZ");
+    ApiResponse dataSetResponse = dataSetActions.post(dataSet);
+
+    assertEquals(201, dataSetResponse.statusCode());
+    String dataSetId = dataSetResponse.extractUid();
+
+    // complete the data set and post sync
+    String cds = completeDataSet(dataSetId, "202301", "g8upMTyEZGZ");
+    ApiResponse completeSyncResponse = apiActions.sendSync(cds);
+
+    completeSyncResponse
+        .validate()
+        .statusCode(200)
+        .body("message", equalTo("Import was successful."))
+        .body("response.status", equalTo("SUCCESS"))
+        .body("response.importCount.imported", equalTo(1));
+
+    // get complete data sets with id scheme CODE
+    ApiResponse completedResponse2 =
+        apiActions.getCompletedWithIdScheme(dataSetId, "g8upMTyEZGZ", "202301", "CODE");
+
+    // validate sync-completed data set returns CODEs for id scheme
+    completedResponse2
+        .validate()
+        .statusCode(200)
+        .body("completeDataSetRegistrations[0].dataSet", equalTo("TEST_CODE 4"))
+        .body("completeDataSetRegistrations[0].organisationUnit", equalTo("OU_167609"));
+  }
 
   private String dataSetWithOrgUnit(int uniqueNum, String orgUnit) {
     return """

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/CompleteDataSetRegistrationsTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/CompleteDataSetRegistrationsTest.java
@@ -27,15 +27,16 @@
  */
 package org.hisp.dhis.metadata.metadata_import;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.jupiter.api.Assertions.*;
 
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.restassured.response.ResponseBody;
 import org.hisp.dhis.ApiTest;
 import org.hisp.dhis.actions.CompleteDataSetRegistrationActions;
 import org.hisp.dhis.actions.LoginActions;
 import org.hisp.dhis.actions.RestApiActions;
 import org.hisp.dhis.actions.SystemActions;
-import org.hisp.dhis.dto.ApiResponse;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -56,130 +57,195 @@ class CompleteDataSetRegistrationsTest extends ApiTest {
     dataSetActions = new RestApiActions("dataSets");
   }
 
+  //  @Test
+  //  void completeDataSetRegistrationsAsync() {
+  //    loginActions.loginAsSuperUser();
+  //
+  //    // create data set
+  //    String dataSet = dataSetWithOrgUnit(1, "O6uvpzGd5pu");
+  //    ApiResponse dataSetResponse = dataSetActions.post(dataSet);
+  //
+  //    assertEquals(201, dataSetResponse.statusCode());
+  //    String dataSetId = dataSetResponse.extractUid();
+  //    assertEquals(11, dataSetId.length());
+  //
+  //    // get complete data sets to show none complete with given criteria
+  //    ApiResponse completedResponse =
+  //        apiActions.getCompletedAsMediaType(dataSetId, "O6uvpzGd5pu", "202301",
+  // ContentType.JSON);
+  //    assertEquals("{}", completedResponse.getAsString());
+  //
+  //    // complete the data set and post async
+  //    String cds = completeDataSet(dataSetId, "202301", "O6uvpzGd5pu");
+  //    ApiResponse completeAsyncResponse = apiActions.sendAsync(cds);
+  //    assertEquals(200, completeAsyncResponse.statusCode());
+  //
+  //    assertTrue(
+  //        completeAsyncResponse
+  //            .getBody()
+  //            .get("message")
+  //            .getAsString()
+  //            .contains("Initiated COMPLETE_DATA_SET_REGISTRATION_IMPORT"));
+  //
+  //    String taskId =
+  //        completeAsyncResponse.getBody().getAsJsonObject("response").get("id").getAsString();
+  //    assertEquals(11, taskId.length());
+  //
+  //    // wait for job to be completed (24 seconds used as the job schedule loop is 20 seconds)
+  //    ApiResponse taskStatus =
+  //        systemActions.waitUntilTaskCompleted("COMPLETE_DATA_SET_REGISTRATION_IMPORT", taskId,
+  // 24);
+  //    assertTrue(taskStatus.getAsString().contains("\"completed\":true"));
+  //
+  //    // get complete data sets which should be 1 now
+  //    ApiResponse completedResponse2 =
+  //        apiActions.getCompletedAsMediaType(dataSetId, "O6uvpzGd5pu", "202301",
+  // ContentType.JSON);
+  //
+  //    // validate async-completed data set
+  //    completedResponse2
+  //        .validate()
+  //        .statusCode(200)
+  //        .body("completeDataSetRegistrations[0].period", equalTo("202301"))
+  //        .body("completeDataSetRegistrations[0].dataSet", equalTo(dataSetId))
+  //        .body("completeDataSetRegistrations[0].organisationUnit", equalTo("O6uvpzGd5pu"))
+  //        .body("completeDataSetRegistrations[0].completed", equalTo(true))
+  //        .body("completeDataSetRegistrations[0].storedBy", equalTo("tasuperadmin"));
+  //  }
+
+  //  @Test
+  //  void completeDataSetRegistrationSyncJson() {
+  //    loginActions.loginAsSuperUser();
+  //
+  //    // create data set
+  //    String dataSet = dataSetWithOrgUnit(2, "g8upMTyEZGZ");
+  //    ApiResponse dataSetResponse = dataSetActions.post(dataSet);
+  //
+  //    assertEquals(201, dataSetResponse.statusCode());
+  //    String dataSetId = dataSetResponse.extractUid();
+  //    assertEquals(11, dataSetId.length());
+  //
+  //    // get complete data sets to confirm none completed with given criteria
+  //    ApiResponse completedResponse =
+  //        apiActions.getCompletedAsMediaType(dataSetId, "g8upMTyEZGZ", "202301",
+  // ContentType.JSON);
+  //    assertEquals("{}", completedResponse.getAsString());
+  //
+  //    // complete the data set and post sync
+  //    String cds = completeDataSet(dataSetId, "202301", "g8upMTyEZGZ");
+  //    ApiResponse completeSyncResponse = apiActions.sendSync(cds);
+  //
+  //    completeSyncResponse
+  //        .validate()
+  //        .statusCode(200)
+  //        .body("message", equalTo("Import was successful."))
+  //        .body("response.status", equalTo("SUCCESS"))
+  //        .body("response.importCount.imported", equalTo(1));
+  //
+  //    // get complete data sets which should be 1 now
+  //    ApiResponse completedResponse2 =
+  //        apiActions.getCompletedAsMediaType(dataSetId, "g8upMTyEZGZ", "202301",
+  // ContentType.JSON);
+  //
+  //    // validate sync-completed data set
+  //    completedResponse2
+  //        .validate()
+  //        .statusCode(200)
+  //        .body("completeDataSetRegistrations[0].period", equalTo("202301"))
+  //        .body("completeDataSetRegistrations[0].dataSet", equalTo(dataSetId))
+  //        .body("completeDataSetRegistrations[0].organisationUnit", equalTo("g8upMTyEZGZ"))
+  //        .body("completeDataSetRegistrations[0].completed", equalTo(true))
+  //        .body("completeDataSetRegistrations[0].storedBy", equalTo("tasuperadmin"));
+  //  }
+
   @Test
-  void completeDataSetRegistrationsAsync() {
+  void completeDataSetRegistrationSyncXml() {
     loginActions.loginAsSuperUser();
 
-    // create data set
-    String dataSet = dataSetWithOrgUnit(1, "O6uvpzGd5pu");
-    ApiResponse dataSetResponse = dataSetActions.post(dataSet);
+    String dataSet = dataSetWithOrgUnit(9, "g8upMTyEZGZ");
 
-    assertEquals(201, dataSetResponse.statusCode());
-    String dataSetId = dataSetResponse.extractUid();
-    assertEquals(11, dataSetId.length());
+    // @formatter:off
+    ResponseBody body = given().body(dataSet)
+                        .when().post("/dataSets").andReturn().body();
+    
+//    post.then().statusCode(201);
+    String uid = body.jsonPath().get("response.uid");
+    assertEquals("uid", uid);
 
-    // get complete data sets to show none complete with given criteria
-    ApiResponse completedResponse = apiActions.getCompleted(dataSetId, "O6uvpzGd5pu", "202301");
-    assertEquals("{}", completedResponse.getAsString());
-
-    // complete the data set and post async
-    String cds = completeDataSet(dataSetId, "202301", "O6uvpzGd5pu");
-    ApiResponse completeAsyncResponse = apiActions.sendAsync(cds);
-    assertEquals(200, completeAsyncResponse.statusCode());
-
-    assertTrue(
-        completeAsyncResponse
-            .getBody()
-            .get("message")
-            .getAsString()
-            .contains("Initiated COMPLETE_DATA_SET_REGISTRATION_IMPORT"));
-
-    String taskId =
-        completeAsyncResponse.getBody().getAsJsonObject("response").get("id").getAsString();
-    assertEquals(11, taskId.length());
-
-    // wait for job to be completed (24 seconds used as the job schedule loop is 20 seconds)
-    ApiResponse taskStatus =
-        systemActions.waitUntilTaskCompleted("COMPLETE_DATA_SET_REGISTRATION_IMPORT", taskId, 24);
-    assertTrue(taskStatus.getAsString().contains("\"completed\":true"));
-
-    // get complete data sets which should be 1 now
-    ApiResponse completedResponse2 = apiActions.getCompleted(dataSetId, "O6uvpzGd5pu", "202301");
-
-    // validate async-completed data set
-    completedResponse2
-        .validate()
-        .statusCode(200)
-        .body("completeDataSetRegistrations[0].period", equalTo("202301"))
-        .body("completeDataSetRegistrations[0].dataSet", equalTo(dataSetId))
-        .body("completeDataSetRegistrations[0].organisationUnit", equalTo("O6uvpzGd5pu"))
-        .body("completeDataSetRegistrations[0].completed", equalTo(true))
-        .body("completeDataSetRegistrations[0].storedBy", equalTo("tasuperadmin"));
-  }
-
-  @Test
-  void completeDataSetRegistrationSync() {
-    loginActions.loginAsSuperUser();
+//    .then().statusCode(201).and();
+    //        .body("id", notNullValue())
+    //        .body("name", equalTo("lokesh"))
+    //        .body("email", equalTo("admin@howtodoinjava.com"));
 
     // create data set
-    String dataSet = dataSetWithOrgUnit(2, "g8upMTyEZGZ");
-    ApiResponse dataSetResponse = dataSetActions.post(dataSet);
+    //    String dataSet = dataSetWithOrgUnit(3, "g8upMTyEZGZ");
+    //    ApiResponse dataSetResponse = dataSetActions.post(dataSet);
+    //    Response post = RestAssured.post("/api/dataSet", dataSet);
 
-    assertEquals(201, dataSetResponse.statusCode());
-    String dataSetId = dataSetResponse.extractUid();
-    assertEquals(11, dataSetId.length());
-
-    // get complete data sets to confirm none completed with given criteria
-    ApiResponse completedResponse = apiActions.getCompleted(dataSetId, "g8upMTyEZGZ", "202301");
-    assertEquals("{}", completedResponse.getAsString());
+    //    assertEquals(201, post.getStatusCode());
+    //    String dataSetId = post.body().jsonPath().get("response.uid");
 
     // complete the data set and post sync
-    String cds = completeDataSet(dataSetId, "202301", "g8upMTyEZGZ");
-    ApiResponse completeSyncResponse = apiActions.sendSync(cds);
+    //    String cds = completeDataSet(dataSetId, "202301", "g8upMTyEZGZ");
+    //    ApiResponse completeSyncResponse = apiActions.sendSync(cds);
 
-    completeSyncResponse
-        .validate()
-        .statusCode(200)
-        .body("message", equalTo("Import was successful."))
-        .body("response.status", equalTo("SUCCESS"))
-        .body("response.importCount.imported", equalTo(1));
+    //    completeSyncResponse
+    //        .validate()
+    //        .statusCode(200)
+    //        .body("message", equalTo("Import was successful."))
+    //        .body("response.status", equalTo("SUCCESS"))
+    //        .body("response.importCount.imported", equalTo(1));
 
-    // get complete data sets which should be 1 now
-    ApiResponse completedResponse2 = apiActions.getCompleted(dataSetId, "g8upMTyEZGZ", "202301");
+    // get complete data sets in xml format
+    //    ApiResponse getXmlResponse =
+    //        apiActions.getCompletedAsMediaType(dataSetId, "g8upMTyEZGZ", "202301",
+    // ContentType.XML);
 
-    // validate sync-completed data set
-    completedResponse2
-        .validate()
-        .statusCode(200)
-        .body("completeDataSetRegistrations[0].period", equalTo("202301"))
-        .body("completeDataSetRegistrations[0].dataSet", equalTo(dataSetId))
-        .body("completeDataSetRegistrations[0].organisationUnit", equalTo("g8upMTyEZGZ"))
-        .body("completeDataSetRegistrations[0].completed", equalTo(true))
-        .body("completeDataSetRegistrations[0].storedBy", equalTo("tasuperadmin"));
+    // validate xml response
+    //    getXmlResponse
+    //        .validate()
+    //        .contentType(ContentType.XML)
+    //        .rootPath("completeDataSetRegistrations.completeDataSetRegistration")
+    //        .body("@period", is("202301"))
+    //        .and()
+    //        .body("@dataSet", is(dataSetId))
+    //        .and()
+    //        .body("@organisationUnit", is("g8upMTyEZGZ"));
   }
 
-  @Test
-  void getCompleteDataSetRegistrationWithIdScheme() {
-    loginActions.loginAsSuperUser();
-
-    // create data set
-    String dataSet = dataSetWithOrgUnit(3, "g8upMTyEZGZ");
-    ApiResponse dataSetResponse = dataSetActions.post(dataSet);
-
-    assertEquals(201, dataSetResponse.statusCode());
-    String dataSetId = dataSetResponse.extractUid();
-
-    // complete the data set and post sync
-    String cds = completeDataSet(dataSetId, "202301", "g8upMTyEZGZ");
-    ApiResponse completeSyncResponse = apiActions.sendSync(cds);
-
-    completeSyncResponse
-        .validate()
-        .statusCode(200)
-        .body("message", equalTo("Import was successful."))
-        .body("response.status", equalTo("SUCCESS"))
-        .body("response.importCount.imported", equalTo(1));
-
-    // get complete data sets with id scheme CODE
-    ApiResponse completedResponse2 = apiActions.getCompletedWithIdScheme(dataSetId, "g8upMTyEZGZ", "202301", "CODE");
-
-    // validate sync-completed data set returns CODEs for id scheme
-    completedResponse2
-        .validate()
-        .statusCode(200)
-        .body("completeDataSetRegistrations[0].dataSet", equalTo("TEST_CODE 3"))
-        .body("completeDataSetRegistrations[0].organisationUnit", equalTo("OU_167609"));
-  }
+  //    @Test
+  //    void getCompleteDataSetRegistrationWithIdScheme() {
+  //      loginActions.loginAsSuperUser();
+  //
+  //      // create data set
+  //      String dataSet = dataSetWithOrgUnit(4, "g8upMTyEZGZ");
+  //      ApiResponse dataSetResponse = dataSetActions.post(dataSet);
+  //
+  //      assertEquals(201, dataSetResponse.statusCode());
+  //      String dataSetId = dataSetResponse.extractUid();
+  //
+  //      // complete the data set and post sync
+  //      String cds = completeDataSet(dataSetId, "202301", "g8upMTyEZGZ");
+  //      ApiResponse completeSyncResponse = apiActions.sendSync(cds);
+  //
+  //      completeSyncResponse
+  //          .validate()
+  //          .statusCode(200)
+  //          .body("message", equalTo("Import was successful."))
+  //          .body("response.status", equalTo("SUCCESS"))
+  //          .body("response.importCount.imported", equalTo(1));
+  //
+  //      // get complete data sets with id scheme CODE
+  //      ApiResponse completedResponse2 =
+  //          apiActions.getCompletedWithIdScheme(dataSetId, "g8upMTyEZGZ", "202301", "CODE");
+  //
+  //      // validate sync-completed data set returns CODEs for id scheme
+  //      completedResponse2
+  //          .validate()
+  //          .statusCode(200)
+  //          .body("completeDataSetRegistrations[0].dataSet", equalTo("TEST_CODE 4"))
+  //          .body("completeDataSetRegistrations[0].organisationUnit", equalTo("OU_167609"));
+  //    }
 
   private String dataSetWithOrgUnit(int uniqueNum, String orgUnit) {
     return """

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationControllerTest.java
@@ -219,6 +219,28 @@ class CompleteDataSetRegistrationControllerTest extends DhisControllerConvenienc
   }
 
   @Test
+  void testGetCompleteRegistrationsJsonWithOrgUnitAndPeriodOnly() {
+    // given
+    String ouId = createOrgUnit();
+    addOrgUnitToUserHierarchy(ouId);
+    String period = "202309";
+
+    // when
+    HttpResponse response =
+        GET(
+            "/completeDataSetRegistrations?orgUnit={ou}&period={p}",
+            ouId,
+            period,
+            Accept(APPLICATION_JSON));
+
+    // then
+    assertEquals(HttpStatus.CONFLICT, response.status());
+    assertEquals(
+        "At least one data set must be specified",
+        response.error().getMessage());
+  }
+
+  @Test
   void testGetEmptyCompleteRegistrationsXmlWithDataSetOrgUnitAndPeriod() {
     // given
     String ouId = createOrgUnit();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationControllerTest.java
@@ -98,6 +98,7 @@ class CompleteDataSetRegistrationControllerTest extends DhisControllerConvenienc
 
   @Test
   void testGetCompleteRegistrationsXmlNoQueryParams() {
+    // when
     HttpResponse response = GET("/completeDataSetRegistrations", Accept(APPLICATION_XML));
     assertEquals(HttpStatus.CONFLICT, response.status());
     String content = response.content(APPLICATION_XML.toString());

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationControllerTest.java
@@ -31,10 +31,11 @@ import static org.hisp.dhis.web.WebClient.Accept;
 import static org.hisp.dhis.web.WebClient.Body;
 import static org.hisp.dhis.web.WebClient.ContentType;
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
-import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_JSON;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_XML;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.http.MediaType.APPLICATION_XML;
 
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
@@ -97,19 +98,22 @@ class CompleteDataSetRegistrationControllerTest extends DhisControllerConvenienc
 
   @Test
   void testGetCompleteRegistrationsXmlNoQueryParams() {
-    HttpResponse response = GET("/completeDataSetRegistrations", Accept(CONTENT_TYPE_XML));
-    assertEquals(HttpStatus.BAD_REQUEST, response.status());
-    assertEquals(
-        "Required request parameter 'dataSet' for method parameter type Set is not present",
-        response.error().getMessage());
+    HttpResponse response = GET("/completeDataSetRegistrations", Accept(APPLICATION_XML));
+    assertEquals(HttpStatus.CONFLICT, response.status());
+    String content = response.content(APPLICATION_XML.toString());
+
+    // then
+    assertTrue(
+        content.contains(
+            "At least one organisation unit or organisation unit group must be specified"));
   }
 
   @Test
   void testGetCompleteRegistrationsJsonNoQueryParams() {
-    HttpResponse response = GET("/completeDataSetRegistrations", Accept(CONTENT_TYPE_JSON));
-    assertEquals(HttpStatus.BAD_REQUEST, response.status());
+    HttpResponse response = GET("/completeDataSetRegistrations", Accept(APPLICATION_JSON));
+    assertEquals(HttpStatus.CONFLICT, response.status());
     assertEquals(
-        "Required request parameter 'dataSet' for method parameter type Set is not present",
+        "At least one organisation unit or organisation unit group must be specified",
         response.error().getMessage());
   }
 
@@ -120,7 +124,7 @@ class CompleteDataSetRegistrationControllerTest extends DhisControllerConvenienc
 
     // when
     HttpResponse response =
-        GET("/completeDataSetRegistrations?dataSet={ds}", dsId, Accept(CONTENT_TYPE_JSON));
+        GET("/completeDataSetRegistrations?dataSet={ds}", dsId, Accept(APPLICATION_JSON));
 
     // then
     assertEquals(HttpStatus.CONFLICT, response.status());
@@ -136,9 +140,9 @@ class CompleteDataSetRegistrationControllerTest extends DhisControllerConvenienc
 
     // when
     HttpResponse response =
-        GET("/completeDataSetRegistrations?dataSet={ds}", dsId, Accept(CONTENT_TYPE_XML));
+        GET("/completeDataSetRegistrations?dataSet={ds}", dsId, Accept(APPLICATION_XML));
     assertEquals(HttpStatus.CONFLICT, response.status());
-    String content = response.content(MediaType.APPLICATION_XML.toString());
+    String content = response.content(APPLICATION_XML.toString());
 
     // then
     assertTrue(
@@ -159,7 +163,7 @@ class CompleteDataSetRegistrationControllerTest extends DhisControllerConvenienc
             "/completeDataSetRegistrations?dataSet={ds}&orgUnit={ou}",
             dsId,
             ouId,
-            Accept(CONTENT_TYPE_JSON));
+            Accept(APPLICATION_JSON));
 
     // then
     assertEquals(HttpStatus.CONFLICT, response.status());
@@ -181,11 +185,11 @@ class CompleteDataSetRegistrationControllerTest extends DhisControllerConvenienc
             "/completeDataSetRegistrations?dataSet={ds}&orgUnit={ou}",
             dsId,
             ouId,
-            Accept(CONTENT_TYPE_XML));
+            Accept(APPLICATION_XML));
 
     // then
     assertEquals(HttpStatus.CONFLICT, response.status());
-    String content = response.content(MediaType.APPLICATION_XML.toString());
+    String content = response.content(APPLICATION_XML.toString());
     assertTrue(
         content.contains(
             "At least one period, start/end dates, last updated or last updated duration must be specified"));
@@ -206,7 +210,7 @@ class CompleteDataSetRegistrationControllerTest extends DhisControllerConvenienc
             dsId,
             ouId,
             period,
-            Accept(CONTENT_TYPE_JSON));
+            Accept(APPLICATION_JSON));
 
     // then
     assertEquals(HttpStatus.OK, response.status());
@@ -228,10 +232,10 @@ class CompleteDataSetRegistrationControllerTest extends DhisControllerConvenienc
             dsId,
             ouId,
             period,
-            Accept(CONTENT_TYPE_XML));
+            Accept(APPLICATION_XML));
 
     // then
-    String content = response.content(MediaType.APPLICATION_XML.toString());
+    String content = response.content(APPLICATION_XML.toString());
     assertEquals(
         "<?xml version='1.0' encoding='UTF-8'?><completeDataSetRegistrations xmlns=\"http://dhis2.org/schema/dxf/2.0\"/>",
         content);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationControllerTest.java
@@ -235,9 +235,7 @@ class CompleteDataSetRegistrationControllerTest extends DhisControllerConvenienc
 
     // then
     assertEquals(HttpStatus.CONFLICT, response.status());
-    assertEquals(
-        "At least one data set must be specified",
-        response.error().getMessage());
+    assertEquals("At least one data set must be specified", response.error().getMessage());
   }
 
   @Test

--- a/dhis-2/dhis-web-api/pom.xml
+++ b/dhis-2/dhis-web-api/pom.xml
@@ -396,6 +396,12 @@
       <artifactId>poi</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <version>2.0.1.Final</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/dhis-2/dhis-web-api/pom.xml
+++ b/dhis-2/dhis-web-api/pom.xml
@@ -396,12 +396,6 @@
       <artifactId>poi</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-      <version>2.0.1.Final</version>
-      <scope>compile</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
@@ -61,7 +61,6 @@ import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.dxf2.util.InputUtils;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -125,24 +124,21 @@ public class CompleteDataSetRegistrationController {
   public void getCompleteRegistrations(
       CompleteDataSetRegQueryParams queryParams,
       IdSchemes idSchemes,
-      @RequestHeader("Accept") MediaType mediaType,
+      @RequestHeader(value = "Accept", required = false) MediaType mediaType,
       HttpServletResponse response)
-      throws IOException, BadRequestException {
+      throws IOException {
+
     ExportParams params = getExportParams(queryParams, idSchemes);
 
-    if (APPLICATION_JSON.equals(mediaType) || mediaType.isWildcardType()) {
-      processRequestAsJson(response, params);
-      return;
-    }
     if (APPLICATION_XML.equals(mediaType)) {
       processRequestAsXml(response, params);
       return;
     }
 
-    throw new BadRequestException("Value '" + mediaType + "' not allowed as Media Type");
+    processRequestAsJsonByDefault(response, params);
   }
 
-  private void processRequestAsJson(HttpServletResponse response, ExportParams params)
+  private void processRequestAsJsonByDefault(HttpServletResponse response, ExportParams params)
       throws IOException {
     response.setContentType(CONTENT_TYPE_JSON);
     registrationExchangeService.writeCompleteDataSetRegistrationsJson(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
@@ -123,7 +123,7 @@ public class CompleteDataSetRegistrationController {
       CompleteDataSetRegQueryParams queryParams, IdSchemes idSchemes, HttpServletResponse response)
       throws IOException {
     ExportParams params = getExportParams(queryParams, idSchemes);
-    processRequestAsJsonByDefault(response, params);
+    processRequestAsJson(response, params);
   }
 
   @GetMapping(produces = CONTENT_TYPE_XML)
@@ -134,7 +134,7 @@ public class CompleteDataSetRegistrationController {
     processRequestAsXml(response, params);
   }
 
-  private void processRequestAsJsonByDefault(HttpServletResponse response, ExportParams params)
+  private void processRequestAsJson(HttpServletResponse response, ExportParams params)
       throws IOException {
     response.setContentType(CONTENT_TYPE_JSON);
     registrationExchangeService.writeCompleteDataSetRegistrationsJson(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
@@ -120,9 +120,7 @@ public class CompleteDataSetRegistrationController {
 
   @GetMapping(produces = CONTENT_TYPE_JSON)
   public void getCompleteRegistrationsJson(
-      CompleteDataSetRegQueryParams queryParams,
-      IdSchemes idSchemes,
-      HttpServletResponse response)
+      CompleteDataSetRegQueryParams queryParams, IdSchemes idSchemes, HttpServletResponse response)
       throws IOException {
     ExportParams params = getExportParams(queryParams, idSchemes);
     processRequestAsJsonByDefault(response, params);
@@ -130,9 +128,7 @@ public class CompleteDataSetRegistrationController {
 
   @GetMapping(produces = CONTENT_TYPE_XML)
   public void getCompleteRegistrationsXml(
-      CompleteDataSetRegQueryParams queryParams,
-      IdSchemes idSchemes,
-      HttpServletResponse response)
+      CompleteDataSetRegQueryParams queryParams, IdSchemes idSchemes, HttpServletResponse response)
       throws IOException {
     ExportParams params = getExportParams(queryParams, idSchemes);
     processRequestAsXml(response, params);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
@@ -38,13 +38,11 @@ import static org.springframework.http.MediaType.APPLICATION_XML;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryOptionCombo;
@@ -76,6 +74,7 @@ import org.hisp.dhis.scheduling.JobSchedulerService;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
+import org.hisp.dhis.webapi.webdomain.CompleteDataSetRegQueryParams;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
@@ -124,12 +123,12 @@ public class CompleteDataSetRegistrationController {
 
   @GetMapping(produces = {CONTENT_TYPE_JSON, CONTENT_TYPE_XML})
   public void getCompleteRegistrations(
-      CompleteDataSetRegParams cdsrParams,
+      CompleteDataSetRegQueryParams queryParams,
       IdSchemes idSchemes,
       @RequestHeader("Accept") MediaType mediaType,
       HttpServletResponse response)
       throws IOException, BadRequestException {
-    ExportParams params = getExportParams(cdsrParams, idSchemes);
+    ExportParams params = getExportParams(queryParams, idSchemes);
 
     if (APPLICATION_JSON.equals(mediaType) || mediaType.isWildcardType()) {
       processRequestAsJson(response, params);
@@ -309,32 +308,18 @@ public class CompleteDataSetRegistrationController {
     }
   }
 
-  private ExportParams getExportParams(CompleteDataSetRegParams cdsr, IdSchemes idSchemes) {
+  private ExportParams getExportParams(CompleteDataSetRegQueryParams params, IdSchemes idSchemes) {
     return registrationExchangeService.paramsFromUrl(
-        cdsr.getDataSet(),
-        cdsr.getOrgUnit(),
-        cdsr.getOrgUnitGroup(),
-        cdsr.getPeriod(),
-        cdsr.getStartDate(),
-        cdsr.getEndDate(),
-        cdsr.isChildren(),
-        cdsr.getCreated(),
-        cdsr.getCreatedDuration(),
-        cdsr.getLimit(),
+        params.getDataSet(),
+        params.getOrgUnit(),
+        params.getOrgUnitGroup(),
+        params.getPeriod(),
+        params.getStartDate(),
+        params.getEndDate(),
+        params.isChildren(),
+        params.getCreated(),
+        params.getCreatedDuration(),
+        params.getLimit(),
         idSchemes);
-  }
-
-  @Data
-  private static class CompleteDataSetRegParams {
-    Set<String> dataSet;
-    Set<String> period;
-    Date startDate;
-    Date endDate;
-    boolean children;
-    Set<String> orgUnit;
-    Set<String> orgUnitGroup;
-    Date created;
-    String createdDuration;
-    Integer limit;
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
@@ -75,13 +75,11 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.webdomain.CompleteDataSetRegQueryParams;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.MimeType;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -120,22 +118,24 @@ public class CompleteDataSetRegistrationController {
   // GET
   // -------------------------------------------------------------------------
 
-  @GetMapping(produces = {CONTENT_TYPE_JSON, CONTENT_TYPE_XML})
-  public void getCompleteRegistrations(
+  @GetMapping(produces = CONTENT_TYPE_JSON)
+  public void getCompleteRegistrationsJson(
       CompleteDataSetRegQueryParams queryParams,
       IdSchemes idSchemes,
-      @RequestHeader(value = "Accept", required = false) MediaType mediaType,
       HttpServletResponse response)
       throws IOException {
-
     ExportParams params = getExportParams(queryParams, idSchemes);
-
-    if (APPLICATION_XML.equals(mediaType)) {
-      processRequestAsXml(response, params);
-      return;
-    }
-
     processRequestAsJsonByDefault(response, params);
+  }
+
+  @GetMapping(produces = CONTENT_TYPE_XML)
+  public void getCompleteRegistrationsXml(
+      CompleteDataSetRegQueryParams queryParams,
+      IdSchemes idSchemes,
+      HttpServletResponse response)
+      throws IOException {
+    ExportParams params = getExportParams(queryParams, idSchemes);
+    processRequestAsXml(response, params);
   }
 
   private void processRequestAsJsonByDefault(HttpServletResponse response, ExportParams params)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
@@ -317,7 +317,7 @@ public class CompleteDataSetRegistrationController {
         cdsr.getPeriod(),
         cdsr.getStartDate(),
         cdsr.getEndDate(),
-        cdsr.isIncludeChildren(),
+        cdsr.isChildren(),
         cdsr.getCreated(),
         cdsr.getCreatedDuration(),
         cdsr.getLimit(),
@@ -330,7 +330,7 @@ public class CompleteDataSetRegistrationController {
     Set<String> period;
     Date startDate;
     Date endDate;
-    boolean includeChildren;
+    boolean children;
     Set<String> orgUnit;
     Set<String> orgUnitGroup;
     Date created;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
@@ -122,28 +122,18 @@ public class CompleteDataSetRegistrationController {
   public void getCompleteRegistrationsJson(
       CompleteDataSetRegQueryParams queryParams, IdSchemes idSchemes, HttpServletResponse response)
       throws IOException {
+    response.setContentType(CONTENT_TYPE_JSON);
     ExportParams params = getExportParams(queryParams, idSchemes);
-    processRequestAsJson(response, params);
+    registrationExchangeService.writeCompleteDataSetRegistrationsJson(
+        params, response.getOutputStream());
   }
 
   @GetMapping(produces = CONTENT_TYPE_XML)
   public void getCompleteRegistrationsXml(
       CompleteDataSetRegQueryParams queryParams, IdSchemes idSchemes, HttpServletResponse response)
       throws IOException {
-    ExportParams params = getExportParams(queryParams, idSchemes);
-    processRequestAsXml(response, params);
-  }
-
-  private void processRequestAsJson(HttpServletResponse response, ExportParams params)
-      throws IOException {
-    response.setContentType(CONTENT_TYPE_JSON);
-    registrationExchangeService.writeCompleteDataSetRegistrationsJson(
-        params, response.getOutputStream());
-  }
-
-  private void processRequestAsXml(HttpServletResponse response, ExportParams params)
-      throws IOException {
     response.setContentType(CONTENT_TYPE_XML);
+    ExportParams params = getExportParams(queryParams, idSchemes);
     registrationExchangeService.writeCompleteDataSetRegistrationsXml(
         params, response.getOutputStream());
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2023, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -42,10 +42,8 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.validation.Valid;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
@@ -126,13 +124,12 @@ public class CompleteDataSetRegistrationController {
 
   @GetMapping(produces = {CONTENT_TYPE_JSON, CONTENT_TYPE_XML})
   public void getCompleteRegistrations(
-      @Valid CDSR cdsr,
+      CompleteDataSetRegParams cdsrParams,
+      IdSchemes idSchemes,
       @RequestHeader("Accept") MediaType mediaType,
       HttpServletResponse response)
       throws IOException, BadRequestException {
-    System.out.println(mediaType);
-    System.out.println(cdsr);
-    ExportParams params = getExportParams(cdsr);
+    ExportParams params = getExportParams(cdsrParams, idSchemes);
 
     if (APPLICATION_JSON.equals(mediaType) || mediaType.isWildcardType()) {
       processRequestAsJson(response, params);
@@ -312,7 +309,7 @@ public class CompleteDataSetRegistrationController {
     }
   }
 
-  private ExportParams getExportParams(CDSR cdsr) {
+  private ExportParams getExportParams(CompleteDataSetRegParams cdsr, IdSchemes idSchemes) {
     return registrationExchangeService.paramsFromUrl(
         cdsr.getDataSet(),
         cdsr.getOrgUnit(),
@@ -324,25 +321,12 @@ public class CompleteDataSetRegistrationController {
         cdsr.getCreated(),
         cdsr.getCreatedDuration(),
         cdsr.getLimit(),
-        cdsr.getIdSchemes());
+        idSchemes);
   }
 
-//  public record CDSR(
-//      @Nonnull Set<String> dataSet,
-//      Set<String> period,
-//      Date startDate,
-//      Date endDate,
-//      boolean includeChildren,
-//      Set<String> orgUnit,
-//      Set<String> orgUnitGroup,
-//      Date created,
-//      String createdDuration,
-//      Integer limit,
-//      IdSchemes idSchemes) {}
-
   @Data
-  public static class CDSR {
-    @Nonnull Set<String> dataSet;
+  public static class CompleteDataSetRegParams {
+    Set<String> dataSet;
     Set<String> period;
     Date startDate;
     Date endDate;
@@ -352,6 +336,5 @@ public class CompleteDataSetRegistrationController {
     Date created;
     String createdDuration;
     Integer limit;
-    IdSchemes idSchemes;
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
@@ -325,7 +325,7 @@ public class CompleteDataSetRegistrationController {
   }
 
   @Data
-  public static class CompleteDataSetRegParams {
+  private static class CompleteDataSetRegParams {
     Set<String> dataSet;
     Set<String> period;
     Date startDate;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/CompleteDataSetRegQueryParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/CompleteDataSetRegQueryParams.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.webdomain;
+
+import java.util.Date;
+import java.util.Set;
+import lombok.Data;
+import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.common.UID;
+import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
+import org.hisp.dhis.period.Period;
+
+/**
+ * Class to hold query params for {@link org.hisp.dhis.dataset.CompleteDataSetRegistration}
+ *
+ * @author davidmackessy
+ */
+@Data
+@OpenApi.Shared
+public class CompleteDataSetRegQueryParams {
+
+  @OpenApi.Property({UID[].class, DataSet.class})
+  Set<String> dataSet;
+
+  @OpenApi.Property({Period[].class})
+  Set<String> period;
+
+  @OpenApi.Property Date startDate;
+
+  @OpenApi.Property Date endDate;
+
+  @OpenApi.Property boolean children;
+
+  @OpenApi.Property({UID[].class, OrganisationUnit.class})
+  Set<String> orgUnit;
+
+  @OpenApi.Property({UID[].class, OrganisationUnitGroup.class})
+  Set<String> orgUnitGroup;
+
+  @OpenApi.Property Date created;
+
+  @OpenApi.Property String createdDuration;
+
+  @OpenApi.Property Integer limit;
+}


### PR DESCRIPTION
# Summary
- Clean up `GET` endpoints on `CompleteDataSetRegistrationController` after doing some work recently in this class for a different feature.
- Behaviour has not changed (same validation rules and query params used)

## Changes
- Reduced endpoint params from 13 -> 3
  - 10 params directly related to `CompleteDataSetRegistration` moved to class `CompleteDataSetRegQueryParams` to tidy up and add Open API annotations
  - `HttpServletRequest` param removed as was never used
 - moved `ExportParams` retrieval into a method which both endpoints can use

# Testing
## Automated
- E2E tests
  - `GET` `CompleteDataSetRegistration` in `JSON` format
  - `GET` `CompleteDataSetRegistration` in `XML` format
  - `GET` `CompleteDataSetRegistration` using `IdSchemes` query param `CODE`
- Web API
  - multiple tests with different combinations of query params & formats hitting the validation rules

** updated `GET` `RestApiActions` config to ignore xml namespace as it was adding default namespace tags `tag0` to xml response
