### PR TITLE
fix: subExpression bool aggregation [DHIS2-15936]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/analytics/AggregationType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/analytics/AggregationType.java
@@ -63,6 +63,10 @@ public enum AggregationType {
   private static final Set<AggregationType> FIRST_TYPES =
       Set.of(FIRST, FIRST_AVERAGE_ORG_UNIT, FIRST_FIRST_ORG_UNIT);
 
+  /** Types that allow non-numeric output such as String or boolean (and possibly also numeric output) */
+  private static final Set<AggregationType> ALLOWS_NONNUMERIC_TYPES =
+      Set.of(LAST, FIRST, MIN, MAX, NONE, CUSTOM, DEFAULT);
+
   private final String value;
 
   private boolean aggregatable;
@@ -90,6 +94,10 @@ public enum AggregationType {
 
   public boolean isFirst() {
     return FIRST_TYPES.contains(this);
+  }
+
+  public boolean allowsNonnumeric()  {
+    return ALLOWS_NONNUMERIC_TYPES.contains(this);
   }
 
   public static AggregationType fromValue(String value) {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/analytics/AggregationType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/analytics/AggregationType.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.analytics;
 
-import java.util.Set;
+import java.util.EnumSet;
 
 /**
  * Enum which represents the aggregation type.
@@ -57,15 +57,18 @@ public enum AggregationType {
   CUSTOM("custom", false),
   DEFAULT("default", false);
 
-  private static final Set<AggregationType> LAST_TYPES =
-      Set.of(LAST, LAST_AVERAGE_ORG_UNIT, LAST_LAST_ORG_UNIT);
+  private static final EnumSet<AggregationType> LAST_TYPES =
+      EnumSet.of(LAST, LAST_AVERAGE_ORG_UNIT, LAST_LAST_ORG_UNIT);
 
-  private static final Set<AggregationType> FIRST_TYPES =
-      Set.of(FIRST, FIRST_AVERAGE_ORG_UNIT, FIRST_FIRST_ORG_UNIT);
+  private static final EnumSet<AggregationType> FIRST_TYPES =
+      EnumSet.of(FIRST, FIRST_AVERAGE_ORG_UNIT, FIRST_FIRST_ORG_UNIT);
 
-  /** Types that allow non-numeric output such as String or boolean (and possibly also numeric output) */
-  private static final Set<AggregationType> ALLOWS_NONNUMERIC_TYPES =
-      Set.of(LAST, FIRST, MIN, MAX, NONE, CUSTOM, DEFAULT);
+  /**
+   * Types that allow non-numeric output such as String or boolean (and possibly also numeric
+   * output)
+   */
+  private static final EnumSet<AggregationType> ALLOWS_NONNUMERIC_TYPES =
+      EnumSet.of(LAST, FIRST, MIN, MAX, NONE, CUSTOM, DEFAULT);
 
   private final String value;
 
@@ -96,7 +99,7 @@ public enum AggregationType {
     return FIRST_TYPES.contains(this);
   }
 
-  public boolean allowsNonnumeric()  {
+  public boolean allowsNonnumeric() {
     return ALLOWS_NONNUMERIC_TYPES.contains(this);
   }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGenerator.java
@@ -259,7 +259,10 @@ public class JdbcSubexpressionQueryGenerator {
 
     String value = quote(dataElement.getValueColumn());
 
-    String cast = (dataElement.getValueType().isBoolean()) ? "::int::bool" : "";
+    String cast =
+        (dataElement.getValueType().isBoolean() && dataElement.getAggregationType().allowsNonnumeric())
+            ? "::int::bool"
+            : "";
 
     String column = getItemColumnName(deUid, cocUid, aocUid, dataElement.getQueryMods());
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcSubexpressionQueryGenerator.java
@@ -260,7 +260,8 @@ public class JdbcSubexpressionQueryGenerator {
     String value = quote(dataElement.getValueColumn());
 
     String cast =
-        (dataElement.getValueType().isBoolean() && dataElement.getAggregationType().allowsNonnumeric())
+        (dataElement.getValueType().isBoolean()
+                && dataElement.getAggregationType().allowsNonnumeric())
             ? "::int::bool"
             : "";
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
@@ -306,7 +306,7 @@ class AnalyticsServiceTest extends SingleSetupIntegrationTestBase {
     deC = createDataElement('C');
     deD = createDataElement('D');
     deE = createDataElement('E', INTEGER, SUM);
-    deF = createDataElement('F', BOOLEAN, COUNT);
+    deF = createDataElement('F', BOOLEAN, MAX);
     deG = createDataElement('G', TEXT, MAX);
     deH = createDataElement('H', DATE, MAX);
 
@@ -1115,6 +1115,21 @@ class AnalyticsServiceTest extends SingleSetupIntegrationTestBase {
 
     assertDataValues(
         Map.of("indicatorAA-ouabcdefghA-201701", 3.0),
+        DataQueryParams.newBuilder()
+            .withOrganisationUnit(ouA)
+            .withIndicators(List.of(inA))
+            .withAggregationType(AnalyticsAggregationType.SUM)
+            .withPeriods(List.of(peJan, peFeb))
+            .withOutputFormat(OutputFormat.ANALYTICS)
+            .build());
+  }
+
+  @Test
+  void testIndicatorSubexpressionBooleanSum() {
+    withIndicator(inA, "subExpression( if( #{" + deF.getUid() + "}.aggregationType(SUM) > 0, 5, 6 ) )");
+
+    assertDataValues(
+        Map.of("indicatorAA-ouabcdefghA-201701", 5.0),
         DataQueryParams.newBuilder()
             .withOrganisationUnit(ouA)
             .withIndicators(List.of(inA))

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.analytics.data;
 
 import static java.util.Collections.emptyList;
-import static org.hisp.dhis.analytics.AggregationType.COUNT;
 import static org.hisp.dhis.analytics.AggregationType.MAX;
 import static org.hisp.dhis.analytics.AggregationType.SUM;
 import static org.hisp.dhis.common.ValueType.BOOLEAN;
@@ -1126,7 +1125,8 @@ class AnalyticsServiceTest extends SingleSetupIntegrationTestBase {
 
   @Test
   void testIndicatorSubexpressionBooleanSum() {
-    withIndicator(inA, "subExpression( if( #{" + deF.getUid() + "}.aggregationType(SUM) > 0, 5, 6 ) )");
+    withIndicator(
+        inA, "subExpression( if( #{" + deF.getUid() + "}.aggregationType(SUM) > 0, 5, 6 ) )");
 
     assertDataValues(
         Map.of("indicatorAA-ouabcdefghA-201701", 5.0),


### PR DESCRIPTION
See [DHIS2-15936](https://dhis2.atlassian.net/browse/DHIS2-15936).

Note that this fix still casts boolean aggregations as a boolean when it makes sense for the result to also be a boolean (e.g. MIN, MAX).

This fix has been tested on the SL Demo DB with the test procedure described in the ticket, and produced the "fixed" screen shot in the ticket.

[DHIS2-15936]: https://dhis2.atlassian.net/browse/DHIS2-15936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ