### PR TITLE
feat: Add output data item ID scheme to analytics [DHIS2-15935]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/AggregateAnalyticsQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/AggregateAnalyticsQueryCriteria.java
@@ -138,16 +138,22 @@ public class AggregateAnalyticsQueryCriteria {
   private IdScheme outputIdScheme;
 
   /**
-   * Identifier scheme to use for metadata items the query response. Specific to org units. See
+   * Identifier scheme to use for metadata items the query response. Specific to data items. See
    * {@link IdScheme} for valid values.
    */
-  private IdScheme outputOrgUnitIdScheme;
+  private IdScheme outputDataItemIdScheme;
 
   /**
    * Identifier scheme to use for metadata items the query response. Specific to data elements. See
    * {@link IdScheme} for valid values.
    */
   private IdScheme outputDataElementIdScheme;
+
+  /**
+   * Identifier scheme to use for metadata items the query response. Specific to org units. See
+   * {@link IdScheme} for valid values.
+   */
+  private IdScheme outputOrgUnitIdScheme;
 
   /**
    * Identifier scheme to use for metadata items in the query request, can be an identifier, code or

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DataQueryRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DataQueryRequest.java
@@ -83,6 +83,8 @@ public class DataQueryRequest {
 
   protected IdScheme outputIdScheme;
 
+  protected IdScheme outputDataItemIdScheme;
+
   protected IdScheme outputDataElementIdScheme;
 
   protected IdScheme outputOrgUnitIdScheme;
@@ -232,6 +234,11 @@ public class DataQueryRequest {
       return this;
     }
 
+    public DataQueryRequestBuilder outputDataItemIdScheme(IdScheme outputDataItemIdScheme) {
+      this.request.outputDataItemIdScheme = outputDataItemIdScheme;
+      return this;
+    }
+
     public DataQueryRequestBuilder outputDataElementIdScheme(IdScheme outputDataElementIdScheme) {
       this.request.outputDataElementIdScheme = outputDataElementIdScheme;
       return this;
@@ -300,8 +307,9 @@ public class DataQueryRequest {
       this.request.order = criteria.getOrder();
       this.request.orgUnitField = criteria.getOrgUnitField();
       this.request.outputIdScheme = criteria.getOutputIdScheme();
-      this.request.outputOrgUnitIdScheme = criteria.getOutputOrgUnitIdScheme();
+      this.request.outputDataItemIdScheme = criteria.getOutputDataItemIdScheme();
       this.request.outputDataElementIdScheme = criteria.getOutputDataElementIdScheme();
+      this.request.outputOrgUnitIdScheme = criteria.getOutputOrgUnitIdScheme();
       this.request.preAggregationMeasureCriteria = criteria.getPreAggregationMeasureCriteria();
       this.request.relativePeriodDate = criteria.getRelativePeriodDate();
       this.request.showHierarchy = criteria.isShowHierarchy();

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataexchange/aggregate/SourceRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataexchange/aggregate/SourceRequest.java
@@ -72,6 +72,9 @@ public class SourceRequest implements Serializable {
   /** Output org unit identifier scheme. */
   @JsonProperty private String outputOrgUnitIdScheme;
 
+  /** Output data item identifier scheme. */
+  @JsonProperty private String outputDataItemIdScheme;
+
   /** Output identifier scheme. */
   @JsonProperty private String outputIdScheme;
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -49,11 +49,6 @@ import static org.hisp.dhis.common.DimensionalObject.QUERY_MODS_ID_SEPARATOR;
 import static org.hisp.dhis.common.DimensionalObject.VALUE_COLUMN_NAME;
 import static org.hisp.dhis.common.DimensionalObjectUtils.asList;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getList;
-
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -118,6 +113,10 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.util.ObjectUtils;
 import org.springframework.util.Assert;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 /**
  * Class representing query parameters for retrieving aggregated data from the analytics service.
@@ -1215,8 +1214,9 @@ public class DataQueryParams {
   }
 
   /** Indicates whether a non-default identifier scheme is specified. */
-  public boolean hasCustomIdSchemaSet() {
+  public boolean hasCustomIdSchemeSet() {
     return isGeneralOutputIdSchemeSet()
+        || isOutputDataItemIdSchemeSet()
         || isOutputDataElementIdSchemeSet()
         || isOutputOrgUnitIdSchemeSet();
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -1,29 +1,24 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
- * All rights reserved.
+ * Copyright (c) 2004-2022, University of Oslo All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * Redistributions of source code must retain the above copyright notice, this
- * list of conditions and the following disclaimer.
+ * Redistribution and use in source and binary forms, with or without modification, are permitted
+ * provided that the following conditions are met: Redistributions of source code must retain the
+ * above copyright notice, this list of conditions and the following disclaimer.
  *
- * Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- * Neither the name of the HISP project nor the names of its contributors may
- * be used to endorse or promote products derived from this software without
- * specific prior written permission.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ * and the following disclaimer in the documentation and/or other materials provided with the
+ * distribution. Neither the name of the HISP project nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific prior written
+ * permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.hisp.dhis.analytics;
 
@@ -49,11 +44,6 @@ import static org.hisp.dhis.common.DimensionalObject.QUERY_MODS_ID_SEPARATOR;
 import static org.hisp.dhis.common.DimensionalObject.VALUE_COLUMN_NAME;
 import static org.hisp.dhis.common.DimensionalObjectUtils.asList;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getList;
-
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -118,17 +108,18 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.util.ObjectUtils;
 import org.springframework.util.Assert;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 /**
  * Class representing query parameters for retrieving aggregated data from the analytics service.
  * Example instantiation:
  *
  * <pre>
- * DataQueryParams params = DataQueryParams.newBuilder()
- *     .withDataElements( deA, deB )
- *     .withOrganisationUnits( ouA, ouB )
- *     .withFilterPeriods( peA, peB )
- *     .build();
+ * DataQueryParams params = DataQueryParams.newBuilder().withDataElements(deA, deB)
+ *     .withOrganisationUnits(ouA, ouB).withFilterPeriods(peA, peB).build();
  * </pre>
  *
  * @author Lars Helge Overland
@@ -201,23 +192,14 @@ public class DataQueryParams {
   public static final int NUMERATOR_DENOMINATOR_PROPERTIES_COUNT = 5;
 
   public static final Set<Class<? extends BaseDimensionalObject>> DYNAMIC_DIM_CLASSES =
-      Set.of(
-          OrganisationUnitGroupSet.class,
-          DataElementGroupSet.class,
-          CategoryOptionGroupSet.class,
-          Category.class);
+      Set.of(OrganisationUnitGroupSet.class, DataElementGroupSet.class,
+          CategoryOptionGroupSet.class, Category.class);
 
   private static final Set<String> DIMENSION_PERMUTATION_IGNORE_DIMS =
       Set.of(DATA_X_DIM_ID, CATEGORYOPTIONCOMBO_DIM_ID);
 
-  public static final Set<DimensionType> COMPLETENESS_DIMENSION_TYPES =
-      Set.of(
-          DATA_X,
-          PERIOD,
-          ORGANISATION_UNIT,
-          ORGANISATION_UNIT_GROUP_SET,
-          CATEGORY_OPTION_GROUP_SET,
-          CATEGORY);
+  public static final Set<DimensionType> COMPLETENESS_DIMENSION_TYPES = Set.of(DATA_X, PERIOD,
+      ORGANISATION_UNIT, ORGANISATION_UNIT_GROUP_SET, CATEGORY_OPTION_GROUP_SET, CATEGORY);
 
   /** The dimensions. */
   protected List<DimensionalObject> dimensions = new ArrayList<>();
@@ -298,26 +280,23 @@ public class DataQueryParams {
   protected DisplayProperty displayProperty;
 
   /**
-   * The general id scheme, which drives the values in the query response.
-   *
-   * <p>For implementation details @see
-   * org.hisp.dhis.analytics.data.handling.MetadataHandler#applyIdScheme(DataQueryParams, Grid)
+   * The general identifier scheme, which drives the values in the query response.
    */
   protected IdScheme outputIdScheme;
 
   /**
-   * The id schema specific for data elements.
-   *
-   * <p>For implementation details @see
-   * org.hisp.dhis.analytics.data.handling.MetadataHandler#applyIdScheme(DataQueryParams, Grid)
+   * The identifier scheme specific for data items, including indicators, data elements, data sets
+   * and program indicators
+   */
+  protected IdScheme outputDataItemIdScheme;
+
+  /**
+   * The identifier scheme specific for data elements.
    */
   protected IdScheme outputDataElementIdScheme;
 
   /**
-   * The id schema specific for org units.
-   *
-   * <p>For implementation details @see
-   * org.hisp.dhis.analytics.data.handling.MetadataHandler#applyIdScheme(DataQueryParams, Grid)
+   * The identifier scheme specific for org units.
    */
   protected IdScheme outputOrgUnitIdScheme;
 
@@ -484,7 +463,8 @@ public class DataQueryParams {
   /**
    * Copies all properties of this query onto the given query.
    *
-   * <p>The
+   * <p>
+   * The
    *
    * <pre>
    * processingHints
@@ -515,6 +495,7 @@ public class DataQueryParams {
     params.includeMetadataDetails = this.includeMetadataDetails;
     params.displayProperty = this.displayProperty;
     params.outputIdScheme = this.outputIdScheme;
+    params.outputDataItemIdScheme = this.outputDataItemIdScheme;
     params.outputDataElementIdScheme = this.outputDataElementIdScheme;
     params.outputOrgUnitIdScheme = this.outputOrgUnitIdScheme;
     params.outputFormat = this.outputFormat;
@@ -570,62 +551,42 @@ public class DataQueryParams {
   protected QueryKey getQueryKey() {
     QueryKey key = new QueryKey();
 
-    dimensions.forEach(
-        e ->
-            key.add(
-                "dimension",
-                "[" + e.getKey() + "]" + getDimensionalItemKeywords(e.getDimensionItemKeywords())));
-    filters.forEach(
-        e ->
-            key.add(
-                "filter",
-                "[" + e.getKey() + "]" + getDimensionalItemKeywords(e.getDimensionItemKeywords())));
+    dimensions.forEach(e -> key.add("dimension",
+        "[" + e.getKey() + "]" + getDimensionalItemKeywords(e.getDimensionItemKeywords())));
+    filters.forEach(e -> key.add("filter",
+        "[" + e.getKey() + "]" + getDimensionalItemKeywords(e.getDimensionItemKeywords())));
 
     measureCriteria.forEach((k, v) -> key.add("measureCriteria", (String.valueOf(k) + v)));
-    preAggregateMeasureCriteria.forEach(
-        (k, v) -> key.add("preAggregateMeasureCriteria", (String.valueOf(k) + v)));
+    preAggregateMeasureCriteria
+        .forEach((k, v) -> key.add("preAggregateMeasureCriteria", (String.valueOf(k) + v)));
 
-    return key.add("aggregationType", aggregationType)
-        .add("skipMeta", skipMeta)
-        .add("skipData", skipData)
-        .add("skipHeaders", skipHeaders)
-        .add("skipRounding", skipRounding)
-        .add("completedOnly", completedOnly)
-        .add("hierarchyMeta", hierarchyMeta)
-        .add("ignoreLimit", ignoreLimit)
-        .add("hideEmptyRows", hideEmptyRows)
-        .add("hideEmptyColumns", hideEmptyColumns)
-        .add("showHierarchy", showHierarchy)
+    return key.add("aggregationType", aggregationType).add("skipMeta", skipMeta)
+        .add("skipData", skipData).add("skipHeaders", skipHeaders).add("skipRounding", skipRounding)
+        .add("completedOnly", completedOnly).add("hierarchyMeta", hierarchyMeta)
+        .add("ignoreLimit", ignoreLimit).add("hideEmptyRows", hideEmptyRows)
+        .add("hideEmptyColumns", hideEmptyColumns).add("showHierarchy", showHierarchy)
         .add("includeNumDen", includeNumDen)
         .add("includePeriodStartEndDates", includePeriodStartEndDates)
         .add("includeMetadataDetails", includeMetadataDetails)
-        .add("displayProperty", displayProperty)
-        .add("outputIdScheme", outputIdScheme)
+        .add("displayProperty", displayProperty).add("outputIdScheme", outputIdScheme)
+        .add("outputDataItemIdScheme", outputDataItemIdScheme)
         .add("outputDataElementIdScheme", outputDataElementIdScheme)
-        .add("outputOrgUnitIdScheme", outputOrgUnitIdScheme)
-        .add("outputFormat", outputFormat)
-        .add("duplicatesOnly", duplicatesOnly)
-        .add("approvalLevel", approvalLevel)
-        .add("startDate", startDate)
-        .add("endDate", endDate)
-        .add("order", order)
-        .add("timeField", timeField)
-        .add("orgUnitField", orgUnitField)
+        .add("outputOrgUnitIdScheme", outputOrgUnitIdScheme).add("outputFormat", outputFormat)
+        .add("duplicatesOnly", duplicatesOnly).add("approvalLevel", approvalLevel)
+        .add("startDate", startDate).add("endDate", endDate).add("order", order)
+        .add("timeField", timeField).add("orgUnitField", orgUnitField)
         .add("expressiondimensionitems", getExpressionDimensionItemsExpressions())
-        .addIgnoreNull("apiVersion", apiVersion)
-        .addIgnoreNull("locale", locale);
+        .addIgnoreNull("apiVersion", apiVersion).addIgnoreNull("locale", locale);
   }
 
   private String getExpressionDimensionItemsExpressions() {
     return this.getExpressionDimensionItems().stream()
-        .map(edi -> ((ExpressionDimensionItem) edi).getExpression())
-        .collect(Collectors.joining());
+        .map(edi -> ((ExpressionDimensionItem) edi).getExpression()).collect(Collectors.joining());
   }
 
   private String getDimensionalItemKeywords(DimensionItemKeywords keywords) {
     if (keywords != null) {
-      return keywords.getKeywords().stream()
-          .map(DimensionItemKeywords.Keyword::getKey)
+      return keywords.getKeywords().stream().map(DimensionItemKeywords.Keyword::getKey)
           .collect(Collectors.joining(":"));
     }
 
@@ -684,9 +645,7 @@ public class DataQueryParams {
 
   /** Returns the latest period based on the period end date. */
   public Period getLatestPeriod() {
-    return getAllPeriods().stream()
-        .map(Period.class::cast)
-        .min(DescendingPeriodComparator.INSTANCE)
+    return getAllPeriods().stream().map(Period.class::cast).min(DescendingPeriodComparator.INSTANCE)
         .orElse(null);
   }
 
@@ -725,10 +684,8 @@ public class DataQueryParams {
     for (DimensionalItemObject object : getAllPeriods()) {
       Period period = (Period) object;
 
-      earliestStartDate =
-          period.getStartDate().before(earliestStartDate)
-              ? period.getStartDate()
-              : earliestStartDate;
+      earliestStartDate = period.getStartDate().before(earliestStartDate) ? period.getStartDate()
+          : earliestStartDate;
     }
 
     return earliestStartDate;
@@ -795,14 +752,9 @@ public class DataQueryParams {
   /** Returns the list of organisation unit levels as dimensions. */
   public List<DimensionalObject> getOrgUnitLevelsAsDimensions() {
     return orgUnitLevels.stream()
-        .map(
-            l ->
-                new BaseDimensionalObject(
-                    PREFIX_ORG_UNIT_LEVEL + l.getLevel(),
-                    DimensionType.ORGANISATION_UNIT_LEVEL,
-                    PREFIX_ORG_UNIT_LEVEL + l.getLevel(),
-                    l.getName(),
-                    List.of()))
+        .map(l -> new BaseDimensionalObject(PREFIX_ORG_UNIT_LEVEL + l.getLevel(),
+            DimensionType.ORGANISATION_UNIT_LEVEL, PREFIX_ORG_UNIT_LEVEL + l.getLevel(),
+            l.getName(), List.of()))
         .collect(Collectors.toList());
   }
 
@@ -835,8 +787,9 @@ public class DataQueryParams {
    * Indicates whether this query requires aggregation of data. No aggregation takes place if
    * aggregation type is none, first or last, or if data type is text.
    *
-   * <p>Note that the check for {@link DataType#TEXT} is for backwards compatibility only and text
-   * type data elements should have an appropriate aggregation type.
+   * <p>
+   * Note that the check for {@link DataType#TEXT} is for backwards compatibility only and text type
+   * data elements should have an appropriate aggregation type.
    */
   public boolean isAggregation() {
     return !(isAnyAggregationType(AggregationType.NONE, AggregationType.FIRST, AggregationType.LAST)
@@ -868,10 +821,8 @@ public class DataQueryParams {
 
     if (dataPeriodType != null) {
       for (DimensionalItemObject aggregatePeriod : getDimensionOrFilterItems(PERIOD_DIM_ID)) {
-        Period dataPeriod =
-            dataPeriodType.createPeriod(
-                ((Period) aggregatePeriod).getStartDate(),
-                ((Period) aggregatePeriod).getDateField());
+        Period dataPeriod = dataPeriodType.createPeriod(((Period) aggregatePeriod).getStartDate(),
+            ((Period) aggregatePeriod).getDateField());
 
         map.putValue(dataPeriod, aggregatePeriod);
 
@@ -881,10 +832,8 @@ public class DataQueryParams {
           // corresponding to the second part of the financial year so
           // that the query will count both years.
 
-          Period endYear =
-              dataPeriodType.createPeriod(
-                  ((Period) aggregatePeriod).getEndDate(),
-                  ((Period) aggregatePeriod).getDateField());
+          Period endYear = dataPeriodType.createPeriod(((Period) aggregatePeriod).getEndDate(),
+              ((Period) aggregatePeriod).getDateField());
           map.putValue(endYear, aggregatePeriod);
         }
       }
@@ -972,13 +921,13 @@ public class DataQueryParams {
    * Retrieves the options for the given dimension and dimension type. Returns an empty list if the
    * filtering options do not match any dimension.
    */
-  public List<DimensionalItemObject> getFilterOptions(
-      String filter, DataDimensionItemType dataDimensionItemType) {
+  public List<DimensionalItemObject> getFilterOptions(String filter,
+      DataDimensionItemType dataDimensionItemType) {
     int index = filters.indexOf(new BaseDimensionalObject(filter));
 
     return index != -1
-        ? AnalyticsUtils.getByDataDimensionItemType(
-            dataDimensionItemType, filters.get(index).getItems())
+        ? AnalyticsUtils.getByDataDimensionItemType(dataDimensionItemType,
+            filters.get(index).getItems())
         : new ArrayList<>();
   }
 
@@ -1012,16 +961,14 @@ public class DataQueryParams {
 
   /** Returns a list of dimensions and filters of the given dimension type. */
   public List<DimensionalObject> getDimensionsAndFilters(DimensionType dimensionType) {
-    return getDimensionsAndFilters().stream()
-        .filter(d -> dimensionType == d.getDimensionType())
+    return getDimensionsAndFilters().stream().filter(d -> dimensionType == d.getDimensionType())
         .collect(Collectors.toList());
   }
 
   /** Returns a list of dimensions and filters of the given set of dimension types. */
   public List<DimensionalObject> getDimensionsAndFilters(Set<DimensionType> dimensionTypes) {
     return getDimensionsAndFilters().stream()
-        .filter(d -> dimensionTypes.contains(d.getDimensionType()))
-        .collect(Collectors.toList());
+        .filter(d -> dimensionTypes.contains(d.getDimensionType())).collect(Collectors.toList());
   }
 
   /** Returns all dimensions except any period dimension. */
@@ -1063,10 +1010,10 @@ public class DataQueryParams {
   }
 
   /**
-   * unlike {@link DataQueryParams#getDimensionOrFilterItems(String)}, which returns the {@link
-   * DimensionalItemObject} found in the first matching dimensions or filters, this method returns
-   * all {@link DimensionalItemObject} for all matching dimensions or filters. Dimensions have
-   * precedence over filters.
+   * unlike {@link DataQueryParams#getDimensionOrFilterItems(String)}, which returns the
+   * {@link DimensionalItemObject} found in the first matching dimensions or filters, this method
+   * returns all {@link DimensionalItemObject} for all matching dimensions or filters. Dimensions
+   * have precedence over filters.
    *
    * @param key
    * @return all {@link DimensionalItemObject} for all matching dimensions or filters.
@@ -1085,32 +1032,26 @@ public class DataQueryParams {
       Collection<DimensionalObject> dimensionalObjects, String key) {
     return dimensionalObjects.stream()
         .filter(dimensionalObject -> StringUtils.equals(dimensionalObject.getDimension(), key))
-        .map(DimensionalObject::getItems)
-        .flatMap(Collection::stream)
-        .toList();
+        .map(DimensionalObject::getItems).flatMap(Collection::stream).toList();
   }
 
   /** Returns all dimension items part of dimensions of the given dimension type. */
   public List<DimensionalItemObject> getDimensionalItemObjects(DimensionType dimensionType) {
-    return getDimensionsAndFilters(dimensionType).stream()
-        .map(DimensionalObject::getItems)
-        .flatMap(Collection::stream)
-        .collect(Collectors.toList());
+    return getDimensionsAndFilters(dimensionType).stream().map(DimensionalObject::getItems)
+        .flatMap(Collection::stream).collect(Collectors.toList());
   }
 
   /**
-   * Retrieves the dimension items for the given dimension. If the given dimension is {@link
-   * DimensionalObject#CATEGORYOPTIONCOMBO_DIM_ID}, the category option combinations associated with
-   * all data elements in this query through their category combinations are retrieved.
+   * Retrieves the dimension items for the given dimension. If the given dimension is
+   * {@link DimensionalObject#CATEGORYOPTIONCOMBO_DIM_ID}, the category option combinations
+   * associated with all data elements in this query through their category combinations are
+   * retrieved.
    */
   private List<DimensionalItemObject> getDimensionItemObjects(String dimension) {
     if (CATEGORYOPTIONCOMBO_DIM_ID.equals(dimension)) {
-      return getDataElements().stream()
-          .map(de -> ((DataElement) de).getCategoryCombos())
-          .flatMap(Collection::stream)
-          .distinct() // Get unique category combinations
-          .map(CategoryCombo::getSortedOptionCombos)
-          .flatMap(Collection::stream)
+      return getDataElements().stream().map(de -> ((DataElement) de).getCategoryCombos())
+          .flatMap(Collection::stream).distinct() // Get unique category combinations
+          .map(CategoryCombo::getSortedOptionCombos).flatMap(Collection::stream)
           .collect(Collectors.toList());
     } else {
       return getDimensionOptions(dimension);
@@ -1118,10 +1059,10 @@ public class DataQueryParams {
   }
 
   /**
-   * Retrieves the options for the given dimension identifier. If the {@link
-   * DimensionalObject#CATEGORYOPTIONCOMBO_DIM_ID} dimension is specified, all category option
-   * combinations for the first data element is returned. Returns an empty list if the dimension is
-   * not present.
+   * Retrieves the options for the given dimension identifier. If the
+   * {@link DimensionalObject#CATEGORYOPTIONCOMBO_DIM_ID} dimension is specified, all category
+   * option combinations for the first data element is returned. Returns an empty list if the
+   * dimension is not present.
    */
   public List<DimensionalItemObject> getDimensionItemsExplodeCoc(String dimension) {
     return getDimensionItemObjects(dimension);
@@ -1205,25 +1146,28 @@ public class DataQueryParams {
     return getStartEndDatesAsPeriod().getDaysInPeriod();
   }
 
-  /** Indicates whether this query defines a master identifier scheme different from UID. */
+  /** Indicates whether this query defines an identifier scheme different from UID. */
   public boolean isGeneralOutputIdSchemeSet() {
     return outputIdScheme != null && !IdScheme.UID.equals(outputIdScheme);
   }
+  
+  public boolean isOutputDataItemIdSchemeSet() {
+    return outputDataItemIdScheme != null && !IdScheme.UID.equals(outputDataItemIdScheme);
+  }
 
-  /** Indicates whether this query defines a master identifier scheme different from UID. */
+  /** Indicates whether this query defines an identifier scheme different from UID. */
   public boolean isOutputDataElementIdSchemeSet() {
     return outputDataElementIdScheme != null && !IdScheme.UID.equals(outputDataElementIdScheme);
   }
 
-  /** Indicates whether this query defines a master identifier scheme different from UID. */
+  /** Indicates whether this query defines an identifier scheme different from UID. */
   public boolean isOutputOrgUnitIdSchemeSet() {
     return outputOrgUnitIdScheme != null && !IdScheme.UID.equals(outputOrgUnitIdScheme);
   }
 
   /** Indicates whether a non-default identifier scheme is specified. */
   public boolean hasCustomIdSchemaSet() {
-    return isGeneralOutputIdSchemeSet()
-        || isOutputDataElementIdSchemeSet()
+    return isGeneralOutputIdSchemeSet() || isOutputDataElementIdSchemeSet()
         || isOutputOrgUnitIdSchemeSet();
   }
 
@@ -1287,10 +1231,8 @@ public class DataQueryParams {
     }
 
     for (int i = datesRange.size() - 1; i > 0; i--) {
-      boolean diffAboveOneDay =
-          DateUtils.daysBetween(
-                  datesRange.get(i - 1).getEndDate(), datesRange.get(i).getStartDate())
-              > 1;
+      boolean diffAboveOneDay = DateUtils.daysBetween(datesRange.get(i - 1).getEndDate(),
+          datesRange.get(i).getStartDate()) > 1;
 
       if (diffAboveOneDay) {
         return false;
@@ -1323,8 +1265,8 @@ public class DataQueryParams {
   }
 
   /**
-   * Indicates whether a non-default time field is specified (default is {@link
-   * TimeField#EVENT_DATE}.
+   * Indicates whether a non-default time field is specified (default is
+   * {@link TimeField#EVENT_DATE}.
    */
   public boolean hasTimeField() {
     return timeField != null && !DEFAULT_TIME_FIELDS.contains(timeField);
@@ -1339,9 +1281,9 @@ public class DataQueryParams {
   }
 
   /**
-   * Returns the time field as field (column) value using {@link
-   * DataQueryParams#getTimeFieldAsField()}. Returns the default {@link TimeField#EVENT_DATE} if not
-   * specified.
+   * Returns the time field as field (column) value using
+   * {@link DataQueryParams#getTimeFieldAsField()}. Returns the default {@link TimeField#EVENT_DATE}
+   * if not specified.
    */
   public String getTimeFieldAsFieldFallback() {
     return ObjectUtils.firstNonNull(getTimeFieldAsField(), TimeField.EVENT_DATE.getField());
@@ -1418,9 +1360,8 @@ public class DataQueryParams {
   public boolean hasProgramIndicatorDimension() {
     DimensionalObject dimension = getDimensionOrFilter(DATA_X_DIM_ID);
 
-    List<DimensionalItemObject> items =
-        AnalyticsUtils.getByDataDimensionItemType(
-            DataDimensionItemType.PROGRAM_INDICATOR, dimension.getItems());
+    List<DimensionalItemObject> items = AnalyticsUtils
+        .getByDataDimensionItemType(DataDimensionItemType.PROGRAM_INDICATOR, dimension.getItems());
 
     return isNotEmpty(items);
   }
@@ -1447,31 +1388,29 @@ public class DataQueryParams {
   public List<DataElement> getSkipTotalDataElements() {
     List<DataElement> dataElements = DimensionalObjectUtils.asTypedList(getAllDataElements());
 
-    return dataElements.stream()
-        .filter(de -> de.getCategoryCombo().isSkipTotal())
-        .filter(de -> !isAllCategoriesDimensionOrFilterWithItems(de))
-        .collect(Collectors.toList());
+    return dataElements.stream().filter(de -> de.getCategoryCombo().isSkipTotal())
+        .filter(de -> !isAllCategoriesDimensionOrFilterWithItems(de)).collect(Collectors.toList());
   }
 
   /**
-   * Returns true if an aggregation type is defined, and this is type is a "last" {@link
-   * AggregationType}".
+   * Returns true if an aggregation type is defined, and this is type is a "last"
+   * {@link AggregationType}".
    */
   public boolean isLastPeriodAggregationType() {
     return hasAggregationType() && getAggregationType().isLastPeriodAggregationType();
   }
 
   /**
-   * Returns true if an aggregation type is defined, and this is type is "first" {@link
-   * AggregationType}.
+   * Returns true if an aggregation type is defined, and this is type is "first"
+   * {@link AggregationType}.
    */
   public boolean isFirstPeriodAggregationType() {
     return hasAggregationType() && getAggregationType().isFirstPeriodAggregationType();
   }
 
   /**
-   * Returns true if an aggregation type is defined, and this is type is a "first" or "last" {@link
-   * AggregationType}.
+   * Returns true if an aggregation type is defined, and this is type is a "first" or "last"
+   * {@link AggregationType}.
    */
   public boolean isFirstOrLastPeriodAggregationType() {
     return hasAggregationType() && getAggregationType().isFirstOrLastPeriodAggregationType();
@@ -1502,16 +1441,13 @@ public class DataQueryParams {
    * Sets the given options for the given dimension. If the dimension exists, replaces the dimension
    * items with the given items. If not, creates a new dimension with the given items.
    */
-  protected DataQueryParams setDimensionOptions(
-      String dimension,
-      DimensionType type,
-      String dimensionName,
-      List<DimensionalItemObject> options) {
+  protected DataQueryParams setDimensionOptions(String dimension, DimensionType type,
+      String dimensionName, List<DimensionalItemObject> options) {
     int index = dimensions.indexOf(new BaseDimensionalObject(dimension));
 
     if (index != -1) {
-      dimensions.set(
-          index, new BaseDimensionalObject(dimension, type, dimensionName, null, options));
+      dimensions.set(index,
+          new BaseDimensionalObject(dimension, type, dimensionName, null, options));
     } else {
       dimensions.add(new BaseDimensionalObject(dimension, type, dimensionName, null, options));
     }
@@ -1550,17 +1486,12 @@ public class DataQueryParams {
 
     if (!getPeriods().isEmpty()) // Period is dimension
     {
-      setDimensionOptions(
-          PERIOD_DIM_ID,
-          DimensionType.PERIOD,
+      setDimensionOptions(PERIOD_DIM_ID, DimensionType.PERIOD,
           dataPeriodType.getName().toLowerCase(),
           new ArrayList<>(dataPeriodAggregationPeriodMap.keySet()));
     } else // Period is filter
     {
-      setFilterOptions(
-          PERIOD_DIM_ID,
-          DimensionType.PERIOD,
-          dataPeriodType.getName().toLowerCase(),
+      setFilterOptions(PERIOD_DIM_ID, DimensionType.PERIOD, dataPeriodType.getName().toLowerCase(),
           new ArrayList<>(dataPeriodAggregationPeriodMap.keySet()));
     }
   }
@@ -1598,8 +1529,8 @@ public class DataQueryParams {
   }
 
   /** Sets the items for the given dimension, if the dimension exists. */
-  private DataQueryParams setDimensionOptions(
-      String dimension, List<DimensionalItemObject> options) {
+  private DataQueryParams setDimensionOptions(String dimension,
+      List<DimensionalItemObject> options) {
     BaseDimensionalObject dim = (BaseDimensionalObject) getDimension(dimension);
 
     if (dim != null) {
@@ -1610,10 +1541,7 @@ public class DataQueryParams {
   }
 
   /** Sets the options for the given filter. */
-  private DataQueryParams setFilterOptions(
-      String filter,
-      DimensionType type,
-      String dimensionName,
+  private DataQueryParams setFilterOptions(String filter, DimensionType type, String dimensionName,
       List<DimensionalItemObject> options) {
     int index = filters.indexOf(new BaseDimensionalObject(filter));
 
@@ -1684,10 +1612,8 @@ public class DataQueryParams {
   private DataQueryParams retainDataDimensionReportingRates(ReportingRateMetric metric) {
     DimensionalObject dimension = getDimensionOrFilter(DATA_X_DIM_ID);
 
-    List<ReportingRate> items =
-        DimensionalObjectUtils.asTypedList(
-            AnalyticsUtils.getByDataDimensionItemType(
-                DataDimensionItemType.REPORTING_RATE, dimension.getItems()));
+    List<ReportingRate> items = DimensionalObjectUtils.asTypedList(AnalyticsUtils
+        .getByDataDimensionItemType(DataDimensionItemType.REPORTING_RATE, dimension.getItems()));
 
     items = items.stream().filter(r -> metric == r.getMetric()).collect(Collectors.toList());
 
@@ -1724,8 +1650,8 @@ public class DataQueryParams {
    * @param itemType the data dimension type, or all types if null.
    * @param options the data dimension options.
    */
-  private void setDataDimensionOptions(
-      @Nullable DataDimensionItemType itemType, List<? extends DimensionalItemObject> options) {
+  private void setDataDimensionOptions(@Nullable DataDimensionItemType itemType,
+      List<? extends DimensionalItemObject> options) {
     List<DimensionalItemObject> existing = getDimensionOptions(DATA_X_DIM_ID);
 
     if (itemType != null) {
@@ -1735,9 +1661,8 @@ public class DataQueryParams {
     DimensionalObject dimension = getDimension(DATA_X_DIM_ID);
 
     if (dimension == null) {
-      dimension =
-          new BaseDimensionalObject(
-              DATA_X_DIM_ID, DimensionType.DATA_X, null, DISPLAY_NAME_DATA_X, options);
+      dimension = new BaseDimensionalObject(DATA_X_DIM_ID, DimensionType.DATA_X, null,
+          DISPLAY_NAME_DATA_X, options);
       addDimension(dimension);
     } else {
       dimension.getItems().removeAll(existing);
@@ -1751,7 +1676,7 @@ public class DataQueryParams {
    *
    * @param dataElement the {@link DataElement}.
    * @return true if all categories of the category combo of the given data element are specified as
-   *     dimensions or filters with items.
+   *         dimensions or filters with items.
    */
   private boolean isAllCategoriesDimensionOrFilterWithItems(DataElement dataElement) {
     for (Category category : dataElement.getCategoryCombo().getCategories()) {
@@ -1908,14 +1833,9 @@ public class DataQueryParams {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("Dimensions", dimensions)
-        .add("Filters", filters)
-        .add("Aggregation type", aggregationType)
-        .add("Measure criteria", measureCriteria)
-        .add("Output format", outputFormat)
-        .add("API version", apiVersion)
-        .add("Locale", locale)
+    return MoreObjects.toStringHelper(this).add("Dimensions", dimensions).add("Filters", filters)
+        .add("Aggregation type", aggregationType).add("Measure criteria", measureCriteria)
+        .add("Output format", outputFormat).add("API version", apiVersion).add("Locale", locale)
         .toString();
   }
 
@@ -2002,6 +1922,10 @@ public class DataQueryParams {
   public IdScheme getOutputIdScheme() {
     return outputIdScheme;
   }
+  
+  public IdScheme getOutputDataItemIdScheme() {
+    return outputDataItemIdScheme;
+  }
 
   public IdScheme getOutputDataElementIdScheme() {
     return outputDataElementIdScheme;
@@ -2061,6 +1985,10 @@ public class DataQueryParams {
 
   public void setOutputIdScheme(IdScheme outputIdScheme) {
     this.outputIdScheme = outputIdScheme;
+  }
+  
+  public void setOutputDataItemIdScheme(IdScheme outputDataItemIdScheme) {
+    this.outputDataItemIdScheme = outputDataItemIdScheme;
   }
 
   public void setOutputDataElementIdScheme(IdScheme outputDataElementIdScheme) {
@@ -2178,22 +2106,20 @@ public class DataQueryParams {
 
   /** Returns all data sets part of a dimension or filter. */
   public Set<DimensionalItemObject> getAllDataSets() {
-    return getAllReportingRates().stream()
-        .map(ReportingRate.class::cast)
-        .map(ReportingRate::getDataSet)
-        .collect(Collectors.toSet());
+    return getAllReportingRates().stream().map(ReportingRate.class::cast)
+        .map(ReportingRate::getDataSet).collect(Collectors.toSet());
   }
 
   /** Returns all program attributes part of a dimension or filter. */
   public List<DimensionalItemObject> getAllProgramAttributes() {
-    return ImmutableList.copyOf(
-        ListUtils.union(getProgramAttributes(), getFilterProgramAttributes()));
+    return ImmutableList
+        .copyOf(ListUtils.union(getProgramAttributes(), getFilterProgramAttributes()));
   }
 
   /** Returns all program data elements part of a dimension or filter. */
   public List<DimensionalItemObject> getAllProgramDataElements() {
-    return ImmutableList.copyOf(
-        ListUtils.union(getProgramDataElements(), getFilterProgramDataElements()));
+    return ImmutableList
+        .copyOf(ListUtils.union(getProgramDataElements(), getFilterProgramDataElements()));
   }
 
   /** Returns all program attributes part of a dimension or filter. */
@@ -2203,30 +2129,26 @@ public class DataQueryParams {
 
   /** Returns all validation results part of a dimension or filter. */
   public List<DimensionalItemObject> getAllValidationResults() {
-    return ImmutableList.copyOf(
-        ListUtils.union(getValidationResults(), getFilterValidationResults()));
+    return ImmutableList
+        .copyOf(ListUtils.union(getValidationResults(), getFilterValidationResults()));
   }
 
   /** Returns all periods part of a dimension or filter. */
   public List<DimensionalItemObject> getAllPeriods() {
     return Stream.concat(dimensions.stream(), filters.stream())
-        .filter(d -> PERIOD == d.getDimensionType())
-        .flatMap(d -> d.getItems().stream())
-        .toList();
+        .filter(d -> PERIOD == d.getDimensionType()).flatMap(d -> d.getItems().stream()).toList();
   }
 
   /** Returns all organisation units part of a dimension or filter. */
   public List<DimensionalItemObject> getAllOrganisationUnits() {
-    return ImmutableList.copyOf(
-        ListUtils.union(getOrganisationUnits(), getFilterOrganisationUnits()));
+    return ImmutableList
+        .copyOf(ListUtils.union(getOrganisationUnits(), getFilterOrganisationUnits()));
   }
 
   /** Returns all typed organisation part of a dimension or filter. */
   public List<OrganisationUnit> getAllTypedOrganisationUnits() {
-    return ImmutableList.copyOf(
-        getAllOrganisationUnits().stream()
-            .map(OrganisationUnit.class::cast)
-            .collect(Collectors.toList()));
+    return ImmutableList.copyOf(getAllOrganisationUnits().stream().map(OrganisationUnit.class::cast)
+        .collect(Collectors.toList()));
   }
 
   /** Returns all data element group sets specified as dimensions or filters. */
@@ -2245,10 +2167,8 @@ public class DataQueryParams {
 
   /** Returns all category options parts of categories specified as dimensions or filters. */
   public Set<DimensionalItemObject> getCategoryOptions() {
-    return getDimensionsAndFilters(DimensionType.CATEGORY).stream()
-        .map(DimensionalObject::getItems)
-        .flatMap(Collection::stream)
-        .collect(Collectors.toSet());
+    return getDimensionsAndFilters(DimensionType.CATEGORY).stream().map(DimensionalObject::getItems)
+        .flatMap(Collection::stream).collect(Collectors.toSet());
   }
 
   /**
@@ -2258,15 +2178,11 @@ public class DataQueryParams {
   public Set<IdentifiableObject> getProgramsInAttributesAndDataElements() {
     Set<IdentifiableObject> programs = new HashSet<>();
 
-    getAllProgramAttributes().stream()
-        .map(ProgramTrackedEntityAttributeDimensionItem.class::cast)
-        .filter(a -> a.getProgram() != null)
-        .forEach(a -> programs.add(a.getProgram()));
+    getAllProgramAttributes().stream().map(ProgramTrackedEntityAttributeDimensionItem.class::cast)
+        .filter(a -> a.getProgram() != null).forEach(a -> programs.add(a.getProgram()));
 
-    getAllProgramDataElements().stream()
-        .map(ProgramDataElementDimensionItem.class::cast)
-        .filter(d -> d.getProgram() != null)
-        .forEach(d -> programs.add(d.getProgram()));
+    getAllProgramDataElements().stream().map(ProgramDataElementDimensionItem.class::cast)
+        .filter(d -> d.getProgram() != null).forEach(d -> programs.add(d.getProgram()));
 
     return programs;
   }
@@ -2277,44 +2193,38 @@ public class DataQueryParams {
 
   /** Returns all indicators part of the data dimension. */
   public List<DimensionalItemObject> getIndicators() {
-    return ImmutableList.copyOf(
-        AnalyticsUtils.getByDataDimensionItemType(
-            DataDimensionItemType.INDICATOR, getDimensionOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
+        DataDimensionItemType.INDICATOR, getDimensionOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all data elements part of the data dimension. */
   public List<DimensionalItemObject> getDataElements() {
-    return ImmutableList.copyOf(
-        AnalyticsUtils.getByDataDimensionItemType(
-            DataDimensionItemType.DATA_ELEMENT, getDimensionOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
+        DataDimensionItemType.DATA_ELEMENT, getDimensionOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all data element operands part of the data dimension. */
   public List<DimensionalItemObject> getDataElementOperands() {
-    return ImmutableList.copyOf(
-        AnalyticsUtils.getByDataDimensionItemType(
-            DataDimensionItemType.DATA_ELEMENT_OPERAND, getDimensionOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
+        DataDimensionItemType.DATA_ELEMENT_OPERAND, getDimensionOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all reporting rates part of the data dimension. */
   public List<DimensionalItemObject> getReportingRates() {
-    return ImmutableList.copyOf(
-        AnalyticsUtils.getByDataDimensionItemType(
-            DataDimensionItemType.REPORTING_RATE, getDimensionOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
+        DataDimensionItemType.REPORTING_RATE, getDimensionOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all program indicators part of the data dimension. */
   public List<DimensionalItemObject> getProgramIndicators() {
-    return ImmutableList.copyOf(
-        AnalyticsUtils.getByDataDimensionItemType(
-            DataDimensionItemType.PROGRAM_INDICATOR, getDimensionOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
+        DataDimensionItemType.PROGRAM_INDICATOR, getDimensionOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all program data elements part of the data dimension. */
   public List<DimensionalItemObject> getProgramDataElements() {
-    return ImmutableList.copyOf(
-        AnalyticsUtils.getByDataDimensionItemType(
-            DataDimensionItemType.PROGRAM_DATA_ELEMENT, getDimensionOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
+        DataDimensionItemType.PROGRAM_DATA_ELEMENT, getDimensionOptions(DATA_X_DIM_ID)));
   }
 
   /**
@@ -2325,40 +2235,31 @@ public class DataQueryParams {
     final Set<DimensionalItemObject> dataElements = new HashSet<>();
 
     dataElements.addAll(getDataElements());
-    dataElements.addAll(
-        getDataElementOperands().stream()
-            .map(DataElementOperand.class::cast)
-            .map(DataElementOperand::getDataElement)
-            .collect(Collectors.toList()));
-    dataElements.addAll(
-        getProgramDataElements().stream()
-            .map(ProgramDataElementDimensionItem.class::cast)
-            .map(ProgramDataElementDimensionItem::getDataElement)
-            .collect(Collectors.toList()));
+    dataElements.addAll(getDataElementOperands().stream().map(DataElementOperand.class::cast)
+        .map(DataElementOperand::getDataElement).collect(Collectors.toList()));
+    dataElements
+        .addAll(getProgramDataElements().stream().map(ProgramDataElementDimensionItem.class::cast)
+            .map(ProgramDataElementDimensionItem::getDataElement).collect(Collectors.toList()));
 
     return ImmutableList.copyOf(dataElements);
   }
 
   /** Returns all indicators part of the data dimension. */
   public List<DimensionalItemObject> getProgramAttributes() {
-    return ImmutableList.copyOf(
-        AnalyticsUtils.getByDataDimensionItemType(
-            DataDimensionItemType.PROGRAM_ATTRIBUTE, getDimensionOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
+        DataDimensionItemType.PROGRAM_ATTRIBUTE, getDimensionOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all expression dimension items part of the data dimension. */
   public List<DimensionalItemObject> getExpressionDimensionItems() {
-    return ImmutableList.copyOf(
-        AnalyticsUtils.getByDataDimensionItemType(
-            DataDimensionItemType.EXPRESSION_DIMENSION_ITEM, getDimensionOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
+        DataDimensionItemType.EXPRESSION_DIMENSION_ITEM, getDimensionOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all subexpression dimension items part of the data dimension. */
   public List<DimensionalItemObject> getSubexpressions() {
-    return ImmutableList.copyOf(
-        AnalyticsUtils.getByDataDimensionItemType(
-            DataDimensionItemType.SUBEXPRESSION_DIMENSION_ITEM,
-            getDimensionOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
+        DataDimensionItemType.SUBEXPRESSION_DIMENSION_ITEM, getDimensionOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns the first (or only) subexpression dimension item. */
@@ -2414,9 +2315,8 @@ public class DataQueryParams {
 
   /** Returns all program data elements part of the data dimension. */
   public List<DimensionalItemObject> getValidationResults() {
-    return ImmutableList.copyOf(
-        AnalyticsUtils.getByDataDimensionItemType(
-            DataDimensionItemType.VALIDATION_RULE, getDimensionOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
+        DataDimensionItemType.VALIDATION_RULE, getDimensionOptions(DATA_X_DIM_ID)));
   }
 
   // -------------------------------------------------------------------------
@@ -2425,58 +2325,50 @@ public class DataQueryParams {
 
   /** Returns all indicators part of the data filter. */
   public List<DimensionalItemObject> getFilterIndicators() {
-    return ImmutableList.copyOf(
-        AnalyticsUtils.getByDataDimensionItemType(
-            DataDimensionItemType.INDICATOR, getFilterOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
+        DataDimensionItemType.INDICATOR, getFilterOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all program indicators part of the data filter. */
   public List<DimensionalItemObject> getFilterProgramIndicators() {
-    return ImmutableList.copyOf(
-        AnalyticsUtils.getByDataDimensionItemType(
-            DataDimensionItemType.PROGRAM_INDICATOR, getFilterOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
+        DataDimensionItemType.PROGRAM_INDICATOR, getFilterOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all data elements part of the data filter. */
   public List<DimensionalItemObject> getFilterDataElements() {
-    return ImmutableList.copyOf(
-        AnalyticsUtils.getByDataDimensionItemType(
-            DataDimensionItemType.DATA_ELEMENT, getFilterOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
+        DataDimensionItemType.DATA_ELEMENT, getFilterOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all reporting rates part of the data filter. */
   public List<DimensionalItemObject> getFilterReportingRates() {
-    return ImmutableList.copyOf(
-        AnalyticsUtils.getByDataDimensionItemType(
-            DataDimensionItemType.REPORTING_RATE, getFilterOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
+        DataDimensionItemType.REPORTING_RATE, getFilterOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all program data elements part of the data filter. */
   public List<DimensionalItemObject> getFilterProgramDataElements() {
-    return ImmutableList.copyOf(
-        AnalyticsUtils.getByDataDimensionItemType(
-            DataDimensionItemType.PROGRAM_DATA_ELEMENT, getFilterOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
+        DataDimensionItemType.PROGRAM_DATA_ELEMENT, getFilterOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all program attributes part of the data filter. */
   public List<DimensionalItemObject> getFilterProgramAttributes() {
-    return ImmutableList.copyOf(
-        AnalyticsUtils.getByDataDimensionItemType(
-            DataDimensionItemType.PROGRAM_ATTRIBUTE, getFilterOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
+        DataDimensionItemType.PROGRAM_ATTRIBUTE, getFilterOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all expression dimension items part of the data filter. */
   public List<DimensionalItemObject> getFilterExpressionDimensionItems() {
-    return ImmutableList.copyOf(
-        AnalyticsUtils.getByDataDimensionItemType(
-            DataDimensionItemType.EXPRESSION_DIMENSION_ITEM, getFilterOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
+        DataDimensionItemType.EXPRESSION_DIMENSION_ITEM, getFilterOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all validation results part of the validation result filter. */
   public List<DimensionalItemObject> getFilterValidationResults() {
-    return ImmutableList.copyOf(
-        AnalyticsUtils.getByDataDimensionItemType(
-            DataDimensionItemType.VALIDATION_RULE, getFilterOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
+        DataDimensionItemType.VALIDATION_RULE, getFilterOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all periods part of the period filter. */
@@ -2557,11 +2449,8 @@ public class DataQueryParams {
       return this;
     }
 
-    public Builder addOrSetDimensionOptions(
-        String dimension,
-        DimensionType type,
-        String dimensionName,
-        List<DimensionalItemObject> options) {
+    public Builder addOrSetDimensionOptions(String dimension, DimensionType type,
+        String dimensionName, List<DimensionalItemObject> options) {
       this.params.setDimensionOptions(dimension, type, dimensionName, options);
       return this;
     }
@@ -2609,48 +2498,39 @@ public class DataQueryParams {
 
     public Builder withProgramDataElements(
         List<? extends DimensionalItemObject> programDataElements) {
-      this.params.setDataDimensionOptions(
-          DataDimensionItemType.PROGRAM_DATA_ELEMENT, programDataElements);
+      this.params.setDataDimensionOptions(DataDimensionItemType.PROGRAM_DATA_ELEMENT,
+          programDataElements);
       return this;
     }
 
     public Builder withProgramAttributes(List<? extends DimensionalItemObject> programAttributes) {
-      this.params.setDataDimensionOptions(
-          DataDimensionItemType.PROGRAM_ATTRIBUTE, programAttributes);
+      this.params.setDataDimensionOptions(DataDimensionItemType.PROGRAM_ATTRIBUTE,
+          programAttributes);
       return this;
     }
 
     public Builder withCategoryOptionCombos(
         List<? extends DimensionalItemObject> categoryOptionCombos) {
-      this.params.setDimensionOptions(
-          CATEGORYOPTIONCOMBO_DIM_ID,
-          DimensionType.CATEGORY_OPTION_COMBO,
-          null,
-          asList(categoryOptionCombos));
+      this.params.setDimensionOptions(CATEGORYOPTIONCOMBO_DIM_ID,
+          DimensionType.CATEGORY_OPTION_COMBO, null, asList(categoryOptionCombos));
       return this;
     }
 
     public Builder withAttributeOptionCombos(
         List<? extends DimensionalItemObject> attributeOptionCombos) {
-      this.params.setDimensionOptions(
-          ATTRIBUTEOPTIONCOMBO_DIM_ID,
-          DimensionType.ATTRIBUTE_OPTION_COMBO,
-          null,
-          asList(attributeOptionCombos));
+      this.params.setDimensionOptions(ATTRIBUTEOPTIONCOMBO_DIM_ID,
+          DimensionType.ATTRIBUTE_OPTION_COMBO, null, asList(attributeOptionCombos));
       return this;
     }
 
     public Builder withCategory(Category category) {
-      this.params.setDimensionOptions(
-          category.getUid(), DimensionType.CATEGORY, null, new ArrayList<>(category.getItems()));
+      this.params.setDimensionOptions(category.getUid(), DimensionType.CATEGORY, null,
+          new ArrayList<>(category.getItems()));
       return this;
     }
 
     public Builder withDataElementGroupSet(DataElementGroupSet groupSet) {
-      this.params.setDimensionOptions(
-          groupSet.getUid(),
-          DimensionType.DATA_ELEMENT_GROUP_SET,
-          null,
+      this.params.setDimensionOptions(groupSet.getUid(), DimensionType.DATA_ELEMENT_GROUP_SET, null,
           new ArrayList<>(groupSet.getItems()));
       return this;
     }
@@ -2661,14 +2541,14 @@ public class DataQueryParams {
     }
 
     public Builder withPeriods(String periodName, List<? extends DimensionalItemObject> periods) {
-      this.params.setDimensionOptions(
-          PERIOD_DIM_ID, DimensionType.PERIOD, periodName, asList(periods));
+      this.params.setDimensionOptions(PERIOD_DIM_ID, DimensionType.PERIOD, periodName,
+          asList(periods));
       return this;
     }
 
     public Builder withPeriods(List<? extends DimensionalItemObject> periods, String periodType) {
-      this.params.setDimensionOptions(
-          PERIOD_DIM_ID, DimensionType.PERIOD, periodType.toLowerCase(), asList(periods));
+      this.params.setDimensionOptions(PERIOD_DIM_ID, DimensionType.PERIOD, periodType.toLowerCase(),
+          asList(periods));
       this.params.periodType = periodType;
       return this;
     }
@@ -2679,8 +2559,8 @@ public class DataQueryParams {
     }
 
     public Builder withOrganisationUnits(List<? extends DimensionalItemObject> organisationUnits) {
-      this.params.setDimensionOptions(
-          ORGUNIT_DIM_ID, DimensionType.ORGANISATION_UNIT, null, asList(organisationUnits));
+      this.params.setDimensionOptions(ORGUNIT_DIM_ID, DimensionType.ORGANISATION_UNIT, null,
+          asList(organisationUnits));
       return this;
     }
 
@@ -2732,8 +2612,8 @@ public class DataQueryParams {
 
     public Builder withFilterOrganisationUnits(
         List<? extends DimensionalItemObject> organisationUnits) {
-      this.params.setFilterOptions(
-          ORGUNIT_DIM_ID, DimensionType.ORGANISATION_UNIT, null, asList(organisationUnits));
+      this.params.setFilterOptions(ORGUNIT_DIM_ID, DimensionType.ORGANISATION_UNIT, null,
+          asList(organisationUnits));
       return this;
     }
 
@@ -2830,6 +2710,11 @@ public class DataQueryParams {
 
     public Builder withOutputIdScheme(IdScheme outputIdScheme) {
       this.params.outputIdScheme = outputIdScheme;
+      return this;
+    }
+    
+    public Builder withOutputDataItemIdScheme(IdScheme outputDataItemIdScheme) {
+      this.params.outputDataItemIdScheme = outputDataItemIdScheme;
       return this;
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -49,6 +49,11 @@ import static org.hisp.dhis.common.DimensionalObject.QUERY_MODS_ID_SEPARATOR;
 import static org.hisp.dhis.common.DimensionalObject.VALUE_COLUMN_NAME;
 import static org.hisp.dhis.common.DimensionalObjectUtils.asList;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getList;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -113,10 +118,6 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.util.ObjectUtils;
 import org.springframework.util.Assert;
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 /**
  * Class representing query parameters for retrieving aggregated data from the analytics service.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -285,8 +285,8 @@ public class DataQueryParams {
   protected IdScheme outputIdScheme;
 
   /**
-   * The identifier scheme specific for data items, including indicators, data elements, data sets
-   * and program indicators
+   * The identifier scheme specific for data items, including indicators, data elements and program 
+   * indicators
    */
   protected IdScheme outputDataItemIdScheme;
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -1,24 +1,29 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo All rights reserved.
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification, are permitted
- * provided that the following conditions are met: Redistributions of source code must retain the
- * above copyright notice, this list of conditions and the following disclaimer.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
  *
- * Redistributions in binary form must reproduce the above copyright notice, this list of conditions
- * and the following disclaimer in the documentation and/or other materials provided with the
- * distribution. Neither the name of the HISP project nor the names of its contributors may be used
- * to endorse or promote products derived from this software without specific prior written
- * permission.
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
- * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
- * WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.hisp.dhis.analytics;
 
@@ -44,6 +49,11 @@ import static org.hisp.dhis.common.DimensionalObject.QUERY_MODS_ID_SEPARATOR;
 import static org.hisp.dhis.common.DimensionalObject.VALUE_COLUMN_NAME;
 import static org.hisp.dhis.common.DimensionalObjectUtils.asList;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getList;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -108,10 +118,6 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.util.ObjectUtils;
 import org.springframework.util.Assert;
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 /**
  * Class representing query parameters for retrieving aggregated data from the analytics service.
@@ -192,14 +198,23 @@ public class DataQueryParams {
   public static final int NUMERATOR_DENOMINATOR_PROPERTIES_COUNT = 5;
 
   public static final Set<Class<? extends BaseDimensionalObject>> DYNAMIC_DIM_CLASSES =
-      Set.of(OrganisationUnitGroupSet.class, DataElementGroupSet.class,
-          CategoryOptionGroupSet.class, Category.class);
+      Set.of(
+          OrganisationUnitGroupSet.class,
+          DataElementGroupSet.class,
+          CategoryOptionGroupSet.class,
+          Category.class);
 
   private static final Set<String> DIMENSION_PERMUTATION_IGNORE_DIMS =
       Set.of(DATA_X_DIM_ID, CATEGORYOPTIONCOMBO_DIM_ID);
 
-  public static final Set<DimensionType> COMPLETENESS_DIMENSION_TYPES = Set.of(DATA_X, PERIOD,
-      ORGANISATION_UNIT, ORGANISATION_UNIT_GROUP_SET, CATEGORY_OPTION_GROUP_SET, CATEGORY);
+  public static final Set<DimensionType> COMPLETENESS_DIMENSION_TYPES =
+      Set.of(
+          DATA_X,
+          PERIOD,
+          ORGANISATION_UNIT,
+          ORGANISATION_UNIT_GROUP_SET,
+          CATEGORY_OPTION_GROUP_SET,
+          CATEGORY);
 
   /** The dimensions. */
   protected List<DimensionalObject> dimensions = new ArrayList<>();
@@ -279,25 +294,19 @@ public class DataQueryParams {
   /** Indicates which property to display for meta-data. */
   protected DisplayProperty displayProperty;
 
-  /**
-   * The general identifier scheme, which drives the values in the query response.
-   */
+  /** The general identifier scheme, which drives the values in the query response. */
   protected IdScheme outputIdScheme;
 
   /**
-   * The identifier scheme specific for data items, including indicators, data elements and program 
+   * The identifier scheme specific for data items, including indicators, data elements and program
    * indicators
    */
   protected IdScheme outputDataItemIdScheme;
 
-  /**
-   * The identifier scheme specific for data elements.
-   */
+  /** The identifier scheme specific for data elements. */
   protected IdScheme outputDataElementIdScheme;
 
-  /**
-   * The identifier scheme specific for org units.
-   */
+  /** The identifier scheme specific for org units. */
   protected IdScheme outputOrgUnitIdScheme;
 
   /** The output format, default is OutputFormat.ANALYTICS. */
@@ -463,8 +472,7 @@ public class DataQueryParams {
   /**
    * Copies all properties of this query onto the given query.
    *
-   * <p>
-   * The
+   * <p>The
    *
    * <pre>
    * processingHints
@@ -551,42 +559,63 @@ public class DataQueryParams {
   protected QueryKey getQueryKey() {
     QueryKey key = new QueryKey();
 
-    dimensions.forEach(e -> key.add("dimension",
-        "[" + e.getKey() + "]" + getDimensionalItemKeywords(e.getDimensionItemKeywords())));
-    filters.forEach(e -> key.add("filter",
-        "[" + e.getKey() + "]" + getDimensionalItemKeywords(e.getDimensionItemKeywords())));
+    dimensions.forEach(
+        e ->
+            key.add(
+                "dimension",
+                "[" + e.getKey() + "]" + getDimensionalItemKeywords(e.getDimensionItemKeywords())));
+    filters.forEach(
+        e ->
+            key.add(
+                "filter",
+                "[" + e.getKey() + "]" + getDimensionalItemKeywords(e.getDimensionItemKeywords())));
 
     measureCriteria.forEach((k, v) -> key.add("measureCriteria", (String.valueOf(k) + v)));
-    preAggregateMeasureCriteria
-        .forEach((k, v) -> key.add("preAggregateMeasureCriteria", (String.valueOf(k) + v)));
+    preAggregateMeasureCriteria.forEach(
+        (k, v) -> key.add("preAggregateMeasureCriteria", (String.valueOf(k) + v)));
 
-    return key.add("aggregationType", aggregationType).add("skipMeta", skipMeta)
-        .add("skipData", skipData).add("skipHeaders", skipHeaders).add("skipRounding", skipRounding)
-        .add("completedOnly", completedOnly).add("hierarchyMeta", hierarchyMeta)
-        .add("ignoreLimit", ignoreLimit).add("hideEmptyRows", hideEmptyRows)
-        .add("hideEmptyColumns", hideEmptyColumns).add("showHierarchy", showHierarchy)
+    return key.add("aggregationType", aggregationType)
+        .add("skipMeta", skipMeta)
+        .add("skipData", skipData)
+        .add("skipHeaders", skipHeaders)
+        .add("skipRounding", skipRounding)
+        .add("completedOnly", completedOnly)
+        .add("hierarchyMeta", hierarchyMeta)
+        .add("ignoreLimit", ignoreLimit)
+        .add("hideEmptyRows", hideEmptyRows)
+        .add("hideEmptyColumns", hideEmptyColumns)
+        .add("showHierarchy", showHierarchy)
         .add("includeNumDen", includeNumDen)
         .add("includePeriodStartEndDates", includePeriodStartEndDates)
         .add("includeMetadataDetails", includeMetadataDetails)
-        .add("displayProperty", displayProperty).add("outputIdScheme", outputIdScheme)
+        .add("displayProperty", displayProperty)
+        .add("outputIdScheme", outputIdScheme)
         .add("outputDataItemIdScheme", outputDataItemIdScheme)
         .add("outputDataElementIdScheme", outputDataElementIdScheme)
-        .add("outputOrgUnitIdScheme", outputOrgUnitIdScheme).add("outputFormat", outputFormat)
-        .add("duplicatesOnly", duplicatesOnly).add("approvalLevel", approvalLevel)
-        .add("startDate", startDate).add("endDate", endDate).add("order", order)
-        .add("timeField", timeField).add("orgUnitField", orgUnitField)
+        .add("outputOrgUnitIdScheme", outputOrgUnitIdScheme)
+        .add("outputFormat", outputFormat)
+        .add("duplicatesOnly", duplicatesOnly)
+        .add("approvalLevel", approvalLevel)
+        .add("startDate", startDate)
+        .add("endDate", endDate)
+        .add("order", order)
+        .add("timeField", timeField)
+        .add("orgUnitField", orgUnitField)
         .add("expressiondimensionitems", getExpressionDimensionItemsExpressions())
-        .addIgnoreNull("apiVersion", apiVersion).addIgnoreNull("locale", locale);
+        .addIgnoreNull("apiVersion", apiVersion)
+        .addIgnoreNull("locale", locale);
   }
 
   private String getExpressionDimensionItemsExpressions() {
     return this.getExpressionDimensionItems().stream()
-        .map(edi -> ((ExpressionDimensionItem) edi).getExpression()).collect(Collectors.joining());
+        .map(edi -> ((ExpressionDimensionItem) edi).getExpression())
+        .collect(Collectors.joining());
   }
 
   private String getDimensionalItemKeywords(DimensionItemKeywords keywords) {
     if (keywords != null) {
-      return keywords.getKeywords().stream().map(DimensionItemKeywords.Keyword::getKey)
+      return keywords.getKeywords().stream()
+          .map(DimensionItemKeywords.Keyword::getKey)
           .collect(Collectors.joining(":"));
     }
 
@@ -645,7 +674,9 @@ public class DataQueryParams {
 
   /** Returns the latest period based on the period end date. */
   public Period getLatestPeriod() {
-    return getAllPeriods().stream().map(Period.class::cast).min(DescendingPeriodComparator.INSTANCE)
+    return getAllPeriods().stream()
+        .map(Period.class::cast)
+        .min(DescendingPeriodComparator.INSTANCE)
         .orElse(null);
   }
 
@@ -684,8 +715,10 @@ public class DataQueryParams {
     for (DimensionalItemObject object : getAllPeriods()) {
       Period period = (Period) object;
 
-      earliestStartDate = period.getStartDate().before(earliestStartDate) ? period.getStartDate()
-          : earliestStartDate;
+      earliestStartDate =
+          period.getStartDate().before(earliestStartDate)
+              ? period.getStartDate()
+              : earliestStartDate;
     }
 
     return earliestStartDate;
@@ -752,9 +785,14 @@ public class DataQueryParams {
   /** Returns the list of organisation unit levels as dimensions. */
   public List<DimensionalObject> getOrgUnitLevelsAsDimensions() {
     return orgUnitLevels.stream()
-        .map(l -> new BaseDimensionalObject(PREFIX_ORG_UNIT_LEVEL + l.getLevel(),
-            DimensionType.ORGANISATION_UNIT_LEVEL, PREFIX_ORG_UNIT_LEVEL + l.getLevel(),
-            l.getName(), List.of()))
+        .map(
+            l ->
+                new BaseDimensionalObject(
+                    PREFIX_ORG_UNIT_LEVEL + l.getLevel(),
+                    DimensionType.ORGANISATION_UNIT_LEVEL,
+                    PREFIX_ORG_UNIT_LEVEL + l.getLevel(),
+                    l.getName(),
+                    List.of()))
         .collect(Collectors.toList());
   }
 
@@ -787,9 +825,8 @@ public class DataQueryParams {
    * Indicates whether this query requires aggregation of data. No aggregation takes place if
    * aggregation type is none, first or last, or if data type is text.
    *
-   * <p>
-   * Note that the check for {@link DataType#TEXT} is for backwards compatibility only and text type
-   * data elements should have an appropriate aggregation type.
+   * <p>Note that the check for {@link DataType#TEXT} is for backwards compatibility only and text
+   * type data elements should have an appropriate aggregation type.
    */
   public boolean isAggregation() {
     return !(isAnyAggregationType(AggregationType.NONE, AggregationType.FIRST, AggregationType.LAST)
@@ -821,8 +858,10 @@ public class DataQueryParams {
 
     if (dataPeriodType != null) {
       for (DimensionalItemObject aggregatePeriod : getDimensionOrFilterItems(PERIOD_DIM_ID)) {
-        Period dataPeriod = dataPeriodType.createPeriod(((Period) aggregatePeriod).getStartDate(),
-            ((Period) aggregatePeriod).getDateField());
+        Period dataPeriod =
+            dataPeriodType.createPeriod(
+                ((Period) aggregatePeriod).getStartDate(),
+                ((Period) aggregatePeriod).getDateField());
 
         map.putValue(dataPeriod, aggregatePeriod);
 
@@ -832,8 +871,10 @@ public class DataQueryParams {
           // corresponding to the second part of the financial year so
           // that the query will count both years.
 
-          Period endYear = dataPeriodType.createPeriod(((Period) aggregatePeriod).getEndDate(),
-              ((Period) aggregatePeriod).getDateField());
+          Period endYear =
+              dataPeriodType.createPeriod(
+                  ((Period) aggregatePeriod).getEndDate(),
+                  ((Period) aggregatePeriod).getDateField());
           map.putValue(endYear, aggregatePeriod);
         }
       }
@@ -921,13 +962,13 @@ public class DataQueryParams {
    * Retrieves the options for the given dimension and dimension type. Returns an empty list if the
    * filtering options do not match any dimension.
    */
-  public List<DimensionalItemObject> getFilterOptions(String filter,
-      DataDimensionItemType dataDimensionItemType) {
+  public List<DimensionalItemObject> getFilterOptions(
+      String filter, DataDimensionItemType dataDimensionItemType) {
     int index = filters.indexOf(new BaseDimensionalObject(filter));
 
     return index != -1
-        ? AnalyticsUtils.getByDataDimensionItemType(dataDimensionItemType,
-            filters.get(index).getItems())
+        ? AnalyticsUtils.getByDataDimensionItemType(
+            dataDimensionItemType, filters.get(index).getItems())
         : new ArrayList<>();
   }
 
@@ -961,14 +1002,16 @@ public class DataQueryParams {
 
   /** Returns a list of dimensions and filters of the given dimension type. */
   public List<DimensionalObject> getDimensionsAndFilters(DimensionType dimensionType) {
-    return getDimensionsAndFilters().stream().filter(d -> dimensionType == d.getDimensionType())
+    return getDimensionsAndFilters().stream()
+        .filter(d -> dimensionType == d.getDimensionType())
         .collect(Collectors.toList());
   }
 
   /** Returns a list of dimensions and filters of the given set of dimension types. */
   public List<DimensionalObject> getDimensionsAndFilters(Set<DimensionType> dimensionTypes) {
     return getDimensionsAndFilters().stream()
-        .filter(d -> dimensionTypes.contains(d.getDimensionType())).collect(Collectors.toList());
+        .filter(d -> dimensionTypes.contains(d.getDimensionType()))
+        .collect(Collectors.toList());
   }
 
   /** Returns all dimensions except any period dimension. */
@@ -1010,10 +1053,10 @@ public class DataQueryParams {
   }
 
   /**
-   * unlike {@link DataQueryParams#getDimensionOrFilterItems(String)}, which returns the
-   * {@link DimensionalItemObject} found in the first matching dimensions or filters, this method
-   * returns all {@link DimensionalItemObject} for all matching dimensions or filters. Dimensions
-   * have precedence over filters.
+   * unlike {@link DataQueryParams#getDimensionOrFilterItems(String)}, which returns the {@link
+   * DimensionalItemObject} found in the first matching dimensions or filters, this method returns
+   * all {@link DimensionalItemObject} for all matching dimensions or filters. Dimensions have
+   * precedence over filters.
    *
    * @param key
    * @return all {@link DimensionalItemObject} for all matching dimensions or filters.
@@ -1032,26 +1075,32 @@ public class DataQueryParams {
       Collection<DimensionalObject> dimensionalObjects, String key) {
     return dimensionalObjects.stream()
         .filter(dimensionalObject -> StringUtils.equals(dimensionalObject.getDimension(), key))
-        .map(DimensionalObject::getItems).flatMap(Collection::stream).toList();
+        .map(DimensionalObject::getItems)
+        .flatMap(Collection::stream)
+        .toList();
   }
 
   /** Returns all dimension items part of dimensions of the given dimension type. */
   public List<DimensionalItemObject> getDimensionalItemObjects(DimensionType dimensionType) {
-    return getDimensionsAndFilters(dimensionType).stream().map(DimensionalObject::getItems)
-        .flatMap(Collection::stream).collect(Collectors.toList());
+    return getDimensionsAndFilters(dimensionType).stream()
+        .map(DimensionalObject::getItems)
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
   }
 
   /**
-   * Retrieves the dimension items for the given dimension. If the given dimension is
-   * {@link DimensionalObject#CATEGORYOPTIONCOMBO_DIM_ID}, the category option combinations
-   * associated with all data elements in this query through their category combinations are
-   * retrieved.
+   * Retrieves the dimension items for the given dimension. If the given dimension is {@link
+   * DimensionalObject#CATEGORYOPTIONCOMBO_DIM_ID}, the category option combinations associated with
+   * all data elements in this query through their category combinations are retrieved.
    */
   private List<DimensionalItemObject> getDimensionItemObjects(String dimension) {
     if (CATEGORYOPTIONCOMBO_DIM_ID.equals(dimension)) {
-      return getDataElements().stream().map(de -> ((DataElement) de).getCategoryCombos())
-          .flatMap(Collection::stream).distinct() // Get unique category combinations
-          .map(CategoryCombo::getSortedOptionCombos).flatMap(Collection::stream)
+      return getDataElements().stream()
+          .map(de -> ((DataElement) de).getCategoryCombos())
+          .flatMap(Collection::stream)
+          .distinct() // Get unique category combinations
+          .map(CategoryCombo::getSortedOptionCombos)
+          .flatMap(Collection::stream)
           .collect(Collectors.toList());
     } else {
       return getDimensionOptions(dimension);
@@ -1059,10 +1108,10 @@ public class DataQueryParams {
   }
 
   /**
-   * Retrieves the options for the given dimension identifier. If the
-   * {@link DimensionalObject#CATEGORYOPTIONCOMBO_DIM_ID} dimension is specified, all category
-   * option combinations for the first data element is returned. Returns an empty list if the
-   * dimension is not present.
+   * Retrieves the options for the given dimension identifier. If the {@link
+   * DimensionalObject#CATEGORYOPTIONCOMBO_DIM_ID} dimension is specified, all category option
+   * combinations for the first data element is returned. Returns an empty list if the dimension is
+   * not present.
    */
   public List<DimensionalItemObject> getDimensionItemsExplodeCoc(String dimension) {
     return getDimensionItemObjects(dimension);
@@ -1150,7 +1199,7 @@ public class DataQueryParams {
   public boolean isGeneralOutputIdSchemeSet() {
     return outputIdScheme != null && !IdScheme.UID.equals(outputIdScheme);
   }
-  
+
   public boolean isOutputDataItemIdSchemeSet() {
     return outputDataItemIdScheme != null && !IdScheme.UID.equals(outputDataItemIdScheme);
   }
@@ -1167,7 +1216,8 @@ public class DataQueryParams {
 
   /** Indicates whether a non-default identifier scheme is specified. */
   public boolean hasCustomIdSchemaSet() {
-    return isGeneralOutputIdSchemeSet() || isOutputDataElementIdSchemeSet()
+    return isGeneralOutputIdSchemeSet()
+        || isOutputDataElementIdSchemeSet()
         || isOutputOrgUnitIdSchemeSet();
   }
 
@@ -1231,8 +1281,10 @@ public class DataQueryParams {
     }
 
     for (int i = datesRange.size() - 1; i > 0; i--) {
-      boolean diffAboveOneDay = DateUtils.daysBetween(datesRange.get(i - 1).getEndDate(),
-          datesRange.get(i).getStartDate()) > 1;
+      boolean diffAboveOneDay =
+          DateUtils.daysBetween(
+                  datesRange.get(i - 1).getEndDate(), datesRange.get(i).getStartDate())
+              > 1;
 
       if (diffAboveOneDay) {
         return false;
@@ -1265,8 +1317,8 @@ public class DataQueryParams {
   }
 
   /**
-   * Indicates whether a non-default time field is specified (default is
-   * {@link TimeField#EVENT_DATE}.
+   * Indicates whether a non-default time field is specified (default is {@link
+   * TimeField#EVENT_DATE}.
    */
   public boolean hasTimeField() {
     return timeField != null && !DEFAULT_TIME_FIELDS.contains(timeField);
@@ -1281,9 +1333,9 @@ public class DataQueryParams {
   }
 
   /**
-   * Returns the time field as field (column) value using
-   * {@link DataQueryParams#getTimeFieldAsField()}. Returns the default {@link TimeField#EVENT_DATE}
-   * if not specified.
+   * Returns the time field as field (column) value using {@link
+   * DataQueryParams#getTimeFieldAsField()}. Returns the default {@link TimeField#EVENT_DATE} if not
+   * specified.
    */
   public String getTimeFieldAsFieldFallback() {
     return ObjectUtils.firstNonNull(getTimeFieldAsField(), TimeField.EVENT_DATE.getField());
@@ -1360,8 +1412,9 @@ public class DataQueryParams {
   public boolean hasProgramIndicatorDimension() {
     DimensionalObject dimension = getDimensionOrFilter(DATA_X_DIM_ID);
 
-    List<DimensionalItemObject> items = AnalyticsUtils
-        .getByDataDimensionItemType(DataDimensionItemType.PROGRAM_INDICATOR, dimension.getItems());
+    List<DimensionalItemObject> items =
+        AnalyticsUtils.getByDataDimensionItemType(
+            DataDimensionItemType.PROGRAM_INDICATOR, dimension.getItems());
 
     return isNotEmpty(items);
   }
@@ -1388,29 +1441,31 @@ public class DataQueryParams {
   public List<DataElement> getSkipTotalDataElements() {
     List<DataElement> dataElements = DimensionalObjectUtils.asTypedList(getAllDataElements());
 
-    return dataElements.stream().filter(de -> de.getCategoryCombo().isSkipTotal())
-        .filter(de -> !isAllCategoriesDimensionOrFilterWithItems(de)).collect(Collectors.toList());
+    return dataElements.stream()
+        .filter(de -> de.getCategoryCombo().isSkipTotal())
+        .filter(de -> !isAllCategoriesDimensionOrFilterWithItems(de))
+        .collect(Collectors.toList());
   }
 
   /**
-   * Returns true if an aggregation type is defined, and this is type is a "last"
-   * {@link AggregationType}".
+   * Returns true if an aggregation type is defined, and this is type is a "last" {@link
+   * AggregationType}".
    */
   public boolean isLastPeriodAggregationType() {
     return hasAggregationType() && getAggregationType().isLastPeriodAggregationType();
   }
 
   /**
-   * Returns true if an aggregation type is defined, and this is type is "first"
-   * {@link AggregationType}.
+   * Returns true if an aggregation type is defined, and this is type is "first" {@link
+   * AggregationType}.
    */
   public boolean isFirstPeriodAggregationType() {
     return hasAggregationType() && getAggregationType().isFirstPeriodAggregationType();
   }
 
   /**
-   * Returns true if an aggregation type is defined, and this is type is a "first" or "last"
-   * {@link AggregationType}.
+   * Returns true if an aggregation type is defined, and this is type is a "first" or "last" {@link
+   * AggregationType}.
    */
   public boolean isFirstOrLastPeriodAggregationType() {
     return hasAggregationType() && getAggregationType().isFirstOrLastPeriodAggregationType();
@@ -1441,13 +1496,16 @@ public class DataQueryParams {
    * Sets the given options for the given dimension. If the dimension exists, replaces the dimension
    * items with the given items. If not, creates a new dimension with the given items.
    */
-  protected DataQueryParams setDimensionOptions(String dimension, DimensionType type,
-      String dimensionName, List<DimensionalItemObject> options) {
+  protected DataQueryParams setDimensionOptions(
+      String dimension,
+      DimensionType type,
+      String dimensionName,
+      List<DimensionalItemObject> options) {
     int index = dimensions.indexOf(new BaseDimensionalObject(dimension));
 
     if (index != -1) {
-      dimensions.set(index,
-          new BaseDimensionalObject(dimension, type, dimensionName, null, options));
+      dimensions.set(
+          index, new BaseDimensionalObject(dimension, type, dimensionName, null, options));
     } else {
       dimensions.add(new BaseDimensionalObject(dimension, type, dimensionName, null, options));
     }
@@ -1486,12 +1544,17 @@ public class DataQueryParams {
 
     if (!getPeriods().isEmpty()) // Period is dimension
     {
-      setDimensionOptions(PERIOD_DIM_ID, DimensionType.PERIOD,
+      setDimensionOptions(
+          PERIOD_DIM_ID,
+          DimensionType.PERIOD,
           dataPeriodType.getName().toLowerCase(),
           new ArrayList<>(dataPeriodAggregationPeriodMap.keySet()));
     } else // Period is filter
     {
-      setFilterOptions(PERIOD_DIM_ID, DimensionType.PERIOD, dataPeriodType.getName().toLowerCase(),
+      setFilterOptions(
+          PERIOD_DIM_ID,
+          DimensionType.PERIOD,
+          dataPeriodType.getName().toLowerCase(),
           new ArrayList<>(dataPeriodAggregationPeriodMap.keySet()));
     }
   }
@@ -1529,8 +1592,8 @@ public class DataQueryParams {
   }
 
   /** Sets the items for the given dimension, if the dimension exists. */
-  private DataQueryParams setDimensionOptions(String dimension,
-      List<DimensionalItemObject> options) {
+  private DataQueryParams setDimensionOptions(
+      String dimension, List<DimensionalItemObject> options) {
     BaseDimensionalObject dim = (BaseDimensionalObject) getDimension(dimension);
 
     if (dim != null) {
@@ -1541,7 +1604,10 @@ public class DataQueryParams {
   }
 
   /** Sets the options for the given filter. */
-  private DataQueryParams setFilterOptions(String filter, DimensionType type, String dimensionName,
+  private DataQueryParams setFilterOptions(
+      String filter,
+      DimensionType type,
+      String dimensionName,
       List<DimensionalItemObject> options) {
     int index = filters.indexOf(new BaseDimensionalObject(filter));
 
@@ -1612,8 +1678,10 @@ public class DataQueryParams {
   private DataQueryParams retainDataDimensionReportingRates(ReportingRateMetric metric) {
     DimensionalObject dimension = getDimensionOrFilter(DATA_X_DIM_ID);
 
-    List<ReportingRate> items = DimensionalObjectUtils.asTypedList(AnalyticsUtils
-        .getByDataDimensionItemType(DataDimensionItemType.REPORTING_RATE, dimension.getItems()));
+    List<ReportingRate> items =
+        DimensionalObjectUtils.asTypedList(
+            AnalyticsUtils.getByDataDimensionItemType(
+                DataDimensionItemType.REPORTING_RATE, dimension.getItems()));
 
     items = items.stream().filter(r -> metric == r.getMetric()).collect(Collectors.toList());
 
@@ -1650,8 +1718,8 @@ public class DataQueryParams {
    * @param itemType the data dimension type, or all types if null.
    * @param options the data dimension options.
    */
-  private void setDataDimensionOptions(@Nullable DataDimensionItemType itemType,
-      List<? extends DimensionalItemObject> options) {
+  private void setDataDimensionOptions(
+      @Nullable DataDimensionItemType itemType, List<? extends DimensionalItemObject> options) {
     List<DimensionalItemObject> existing = getDimensionOptions(DATA_X_DIM_ID);
 
     if (itemType != null) {
@@ -1661,8 +1729,9 @@ public class DataQueryParams {
     DimensionalObject dimension = getDimension(DATA_X_DIM_ID);
 
     if (dimension == null) {
-      dimension = new BaseDimensionalObject(DATA_X_DIM_ID, DimensionType.DATA_X, null,
-          DISPLAY_NAME_DATA_X, options);
+      dimension =
+          new BaseDimensionalObject(
+              DATA_X_DIM_ID, DimensionType.DATA_X, null, DISPLAY_NAME_DATA_X, options);
       addDimension(dimension);
     } else {
       dimension.getItems().removeAll(existing);
@@ -1676,7 +1745,7 @@ public class DataQueryParams {
    *
    * @param dataElement the {@link DataElement}.
    * @return true if all categories of the category combo of the given data element are specified as
-   *         dimensions or filters with items.
+   *     dimensions or filters with items.
    */
   private boolean isAllCategoriesDimensionOrFilterWithItems(DataElement dataElement) {
     for (Category category : dataElement.getCategoryCombo().getCategories()) {
@@ -1833,9 +1902,14 @@ public class DataQueryParams {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("Dimensions", dimensions).add("Filters", filters)
-        .add("Aggregation type", aggregationType).add("Measure criteria", measureCriteria)
-        .add("Output format", outputFormat).add("API version", apiVersion).add("Locale", locale)
+    return MoreObjects.toStringHelper(this)
+        .add("Dimensions", dimensions)
+        .add("Filters", filters)
+        .add("Aggregation type", aggregationType)
+        .add("Measure criteria", measureCriteria)
+        .add("Output format", outputFormat)
+        .add("API version", apiVersion)
+        .add("Locale", locale)
         .toString();
   }
 
@@ -1922,7 +1996,7 @@ public class DataQueryParams {
   public IdScheme getOutputIdScheme() {
     return outputIdScheme;
   }
-  
+
   public IdScheme getOutputDataItemIdScheme() {
     return outputDataItemIdScheme;
   }
@@ -1986,7 +2060,7 @@ public class DataQueryParams {
   public void setOutputIdScheme(IdScheme outputIdScheme) {
     this.outputIdScheme = outputIdScheme;
   }
-  
+
   public void setOutputDataItemIdScheme(IdScheme outputDataItemIdScheme) {
     this.outputDataItemIdScheme = outputDataItemIdScheme;
   }
@@ -2106,20 +2180,22 @@ public class DataQueryParams {
 
   /** Returns all data sets part of a dimension or filter. */
   public Set<DimensionalItemObject> getAllDataSets() {
-    return getAllReportingRates().stream().map(ReportingRate.class::cast)
-        .map(ReportingRate::getDataSet).collect(Collectors.toSet());
+    return getAllReportingRates().stream()
+        .map(ReportingRate.class::cast)
+        .map(ReportingRate::getDataSet)
+        .collect(Collectors.toSet());
   }
 
   /** Returns all program attributes part of a dimension or filter. */
   public List<DimensionalItemObject> getAllProgramAttributes() {
-    return ImmutableList
-        .copyOf(ListUtils.union(getProgramAttributes(), getFilterProgramAttributes()));
+    return ImmutableList.copyOf(
+        ListUtils.union(getProgramAttributes(), getFilterProgramAttributes()));
   }
 
   /** Returns all program data elements part of a dimension or filter. */
   public List<DimensionalItemObject> getAllProgramDataElements() {
-    return ImmutableList
-        .copyOf(ListUtils.union(getProgramDataElements(), getFilterProgramDataElements()));
+    return ImmutableList.copyOf(
+        ListUtils.union(getProgramDataElements(), getFilterProgramDataElements()));
   }
 
   /** Returns all program attributes part of a dimension or filter. */
@@ -2129,26 +2205,30 @@ public class DataQueryParams {
 
   /** Returns all validation results part of a dimension or filter. */
   public List<DimensionalItemObject> getAllValidationResults() {
-    return ImmutableList
-        .copyOf(ListUtils.union(getValidationResults(), getFilterValidationResults()));
+    return ImmutableList.copyOf(
+        ListUtils.union(getValidationResults(), getFilterValidationResults()));
   }
 
   /** Returns all periods part of a dimension or filter. */
   public List<DimensionalItemObject> getAllPeriods() {
     return Stream.concat(dimensions.stream(), filters.stream())
-        .filter(d -> PERIOD == d.getDimensionType()).flatMap(d -> d.getItems().stream()).toList();
+        .filter(d -> PERIOD == d.getDimensionType())
+        .flatMap(d -> d.getItems().stream())
+        .toList();
   }
 
   /** Returns all organisation units part of a dimension or filter. */
   public List<DimensionalItemObject> getAllOrganisationUnits() {
-    return ImmutableList
-        .copyOf(ListUtils.union(getOrganisationUnits(), getFilterOrganisationUnits()));
+    return ImmutableList.copyOf(
+        ListUtils.union(getOrganisationUnits(), getFilterOrganisationUnits()));
   }
 
   /** Returns all typed organisation part of a dimension or filter. */
   public List<OrganisationUnit> getAllTypedOrganisationUnits() {
-    return ImmutableList.copyOf(getAllOrganisationUnits().stream().map(OrganisationUnit.class::cast)
-        .collect(Collectors.toList()));
+    return ImmutableList.copyOf(
+        getAllOrganisationUnits().stream()
+            .map(OrganisationUnit.class::cast)
+            .collect(Collectors.toList()));
   }
 
   /** Returns all data element group sets specified as dimensions or filters. */
@@ -2167,8 +2247,10 @@ public class DataQueryParams {
 
   /** Returns all category options parts of categories specified as dimensions or filters. */
   public Set<DimensionalItemObject> getCategoryOptions() {
-    return getDimensionsAndFilters(DimensionType.CATEGORY).stream().map(DimensionalObject::getItems)
-        .flatMap(Collection::stream).collect(Collectors.toSet());
+    return getDimensionsAndFilters(DimensionType.CATEGORY).stream()
+        .map(DimensionalObject::getItems)
+        .flatMap(Collection::stream)
+        .collect(Collectors.toSet());
   }
 
   /**
@@ -2178,11 +2260,15 @@ public class DataQueryParams {
   public Set<IdentifiableObject> getProgramsInAttributesAndDataElements() {
     Set<IdentifiableObject> programs = new HashSet<>();
 
-    getAllProgramAttributes().stream().map(ProgramTrackedEntityAttributeDimensionItem.class::cast)
-        .filter(a -> a.getProgram() != null).forEach(a -> programs.add(a.getProgram()));
+    getAllProgramAttributes().stream()
+        .map(ProgramTrackedEntityAttributeDimensionItem.class::cast)
+        .filter(a -> a.getProgram() != null)
+        .forEach(a -> programs.add(a.getProgram()));
 
-    getAllProgramDataElements().stream().map(ProgramDataElementDimensionItem.class::cast)
-        .filter(d -> d.getProgram() != null).forEach(d -> programs.add(d.getProgram()));
+    getAllProgramDataElements().stream()
+        .map(ProgramDataElementDimensionItem.class::cast)
+        .filter(d -> d.getProgram() != null)
+        .forEach(d -> programs.add(d.getProgram()));
 
     return programs;
   }
@@ -2193,38 +2279,44 @@ public class DataQueryParams {
 
   /** Returns all indicators part of the data dimension. */
   public List<DimensionalItemObject> getIndicators() {
-    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
-        DataDimensionItemType.INDICATOR, getDimensionOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(
+        AnalyticsUtils.getByDataDimensionItemType(
+            DataDimensionItemType.INDICATOR, getDimensionOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all data elements part of the data dimension. */
   public List<DimensionalItemObject> getDataElements() {
-    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
-        DataDimensionItemType.DATA_ELEMENT, getDimensionOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(
+        AnalyticsUtils.getByDataDimensionItemType(
+            DataDimensionItemType.DATA_ELEMENT, getDimensionOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all data element operands part of the data dimension. */
   public List<DimensionalItemObject> getDataElementOperands() {
-    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
-        DataDimensionItemType.DATA_ELEMENT_OPERAND, getDimensionOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(
+        AnalyticsUtils.getByDataDimensionItemType(
+            DataDimensionItemType.DATA_ELEMENT_OPERAND, getDimensionOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all reporting rates part of the data dimension. */
   public List<DimensionalItemObject> getReportingRates() {
-    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
-        DataDimensionItemType.REPORTING_RATE, getDimensionOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(
+        AnalyticsUtils.getByDataDimensionItemType(
+            DataDimensionItemType.REPORTING_RATE, getDimensionOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all program indicators part of the data dimension. */
   public List<DimensionalItemObject> getProgramIndicators() {
-    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
-        DataDimensionItemType.PROGRAM_INDICATOR, getDimensionOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(
+        AnalyticsUtils.getByDataDimensionItemType(
+            DataDimensionItemType.PROGRAM_INDICATOR, getDimensionOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all program data elements part of the data dimension. */
   public List<DimensionalItemObject> getProgramDataElements() {
-    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
-        DataDimensionItemType.PROGRAM_DATA_ELEMENT, getDimensionOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(
+        AnalyticsUtils.getByDataDimensionItemType(
+            DataDimensionItemType.PROGRAM_DATA_ELEMENT, getDimensionOptions(DATA_X_DIM_ID)));
   }
 
   /**
@@ -2235,31 +2327,40 @@ public class DataQueryParams {
     final Set<DimensionalItemObject> dataElements = new HashSet<>();
 
     dataElements.addAll(getDataElements());
-    dataElements.addAll(getDataElementOperands().stream().map(DataElementOperand.class::cast)
-        .map(DataElementOperand::getDataElement).collect(Collectors.toList()));
-    dataElements
-        .addAll(getProgramDataElements().stream().map(ProgramDataElementDimensionItem.class::cast)
-            .map(ProgramDataElementDimensionItem::getDataElement).collect(Collectors.toList()));
+    dataElements.addAll(
+        getDataElementOperands().stream()
+            .map(DataElementOperand.class::cast)
+            .map(DataElementOperand::getDataElement)
+            .collect(Collectors.toList()));
+    dataElements.addAll(
+        getProgramDataElements().stream()
+            .map(ProgramDataElementDimensionItem.class::cast)
+            .map(ProgramDataElementDimensionItem::getDataElement)
+            .collect(Collectors.toList()));
 
     return ImmutableList.copyOf(dataElements);
   }
 
   /** Returns all indicators part of the data dimension. */
   public List<DimensionalItemObject> getProgramAttributes() {
-    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
-        DataDimensionItemType.PROGRAM_ATTRIBUTE, getDimensionOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(
+        AnalyticsUtils.getByDataDimensionItemType(
+            DataDimensionItemType.PROGRAM_ATTRIBUTE, getDimensionOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all expression dimension items part of the data dimension. */
   public List<DimensionalItemObject> getExpressionDimensionItems() {
-    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
-        DataDimensionItemType.EXPRESSION_DIMENSION_ITEM, getDimensionOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(
+        AnalyticsUtils.getByDataDimensionItemType(
+            DataDimensionItemType.EXPRESSION_DIMENSION_ITEM, getDimensionOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all subexpression dimension items part of the data dimension. */
   public List<DimensionalItemObject> getSubexpressions() {
-    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
-        DataDimensionItemType.SUBEXPRESSION_DIMENSION_ITEM, getDimensionOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(
+        AnalyticsUtils.getByDataDimensionItemType(
+            DataDimensionItemType.SUBEXPRESSION_DIMENSION_ITEM,
+            getDimensionOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns the first (or only) subexpression dimension item. */
@@ -2315,8 +2416,9 @@ public class DataQueryParams {
 
   /** Returns all program data elements part of the data dimension. */
   public List<DimensionalItemObject> getValidationResults() {
-    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
-        DataDimensionItemType.VALIDATION_RULE, getDimensionOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(
+        AnalyticsUtils.getByDataDimensionItemType(
+            DataDimensionItemType.VALIDATION_RULE, getDimensionOptions(DATA_X_DIM_ID)));
   }
 
   // -------------------------------------------------------------------------
@@ -2325,50 +2427,58 @@ public class DataQueryParams {
 
   /** Returns all indicators part of the data filter. */
   public List<DimensionalItemObject> getFilterIndicators() {
-    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
-        DataDimensionItemType.INDICATOR, getFilterOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(
+        AnalyticsUtils.getByDataDimensionItemType(
+            DataDimensionItemType.INDICATOR, getFilterOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all program indicators part of the data filter. */
   public List<DimensionalItemObject> getFilterProgramIndicators() {
-    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
-        DataDimensionItemType.PROGRAM_INDICATOR, getFilterOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(
+        AnalyticsUtils.getByDataDimensionItemType(
+            DataDimensionItemType.PROGRAM_INDICATOR, getFilterOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all data elements part of the data filter. */
   public List<DimensionalItemObject> getFilterDataElements() {
-    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
-        DataDimensionItemType.DATA_ELEMENT, getFilterOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(
+        AnalyticsUtils.getByDataDimensionItemType(
+            DataDimensionItemType.DATA_ELEMENT, getFilterOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all reporting rates part of the data filter. */
   public List<DimensionalItemObject> getFilterReportingRates() {
-    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
-        DataDimensionItemType.REPORTING_RATE, getFilterOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(
+        AnalyticsUtils.getByDataDimensionItemType(
+            DataDimensionItemType.REPORTING_RATE, getFilterOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all program data elements part of the data filter. */
   public List<DimensionalItemObject> getFilterProgramDataElements() {
-    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
-        DataDimensionItemType.PROGRAM_DATA_ELEMENT, getFilterOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(
+        AnalyticsUtils.getByDataDimensionItemType(
+            DataDimensionItemType.PROGRAM_DATA_ELEMENT, getFilterOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all program attributes part of the data filter. */
   public List<DimensionalItemObject> getFilterProgramAttributes() {
-    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
-        DataDimensionItemType.PROGRAM_ATTRIBUTE, getFilterOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(
+        AnalyticsUtils.getByDataDimensionItemType(
+            DataDimensionItemType.PROGRAM_ATTRIBUTE, getFilterOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all expression dimension items part of the data filter. */
   public List<DimensionalItemObject> getFilterExpressionDimensionItems() {
-    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
-        DataDimensionItemType.EXPRESSION_DIMENSION_ITEM, getFilterOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(
+        AnalyticsUtils.getByDataDimensionItemType(
+            DataDimensionItemType.EXPRESSION_DIMENSION_ITEM, getFilterOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all validation results part of the validation result filter. */
   public List<DimensionalItemObject> getFilterValidationResults() {
-    return ImmutableList.copyOf(AnalyticsUtils.getByDataDimensionItemType(
-        DataDimensionItemType.VALIDATION_RULE, getFilterOptions(DATA_X_DIM_ID)));
+    return ImmutableList.copyOf(
+        AnalyticsUtils.getByDataDimensionItemType(
+            DataDimensionItemType.VALIDATION_RULE, getFilterOptions(DATA_X_DIM_ID)));
   }
 
   /** Returns all periods part of the period filter. */
@@ -2449,8 +2559,11 @@ public class DataQueryParams {
       return this;
     }
 
-    public Builder addOrSetDimensionOptions(String dimension, DimensionType type,
-        String dimensionName, List<DimensionalItemObject> options) {
+    public Builder addOrSetDimensionOptions(
+        String dimension,
+        DimensionType type,
+        String dimensionName,
+        List<DimensionalItemObject> options) {
       this.params.setDimensionOptions(dimension, type, dimensionName, options);
       return this;
     }
@@ -2498,39 +2611,48 @@ public class DataQueryParams {
 
     public Builder withProgramDataElements(
         List<? extends DimensionalItemObject> programDataElements) {
-      this.params.setDataDimensionOptions(DataDimensionItemType.PROGRAM_DATA_ELEMENT,
-          programDataElements);
+      this.params.setDataDimensionOptions(
+          DataDimensionItemType.PROGRAM_DATA_ELEMENT, programDataElements);
       return this;
     }
 
     public Builder withProgramAttributes(List<? extends DimensionalItemObject> programAttributes) {
-      this.params.setDataDimensionOptions(DataDimensionItemType.PROGRAM_ATTRIBUTE,
-          programAttributes);
+      this.params.setDataDimensionOptions(
+          DataDimensionItemType.PROGRAM_ATTRIBUTE, programAttributes);
       return this;
     }
 
     public Builder withCategoryOptionCombos(
         List<? extends DimensionalItemObject> categoryOptionCombos) {
-      this.params.setDimensionOptions(CATEGORYOPTIONCOMBO_DIM_ID,
-          DimensionType.CATEGORY_OPTION_COMBO, null, asList(categoryOptionCombos));
+      this.params.setDimensionOptions(
+          CATEGORYOPTIONCOMBO_DIM_ID,
+          DimensionType.CATEGORY_OPTION_COMBO,
+          null,
+          asList(categoryOptionCombos));
       return this;
     }
 
     public Builder withAttributeOptionCombos(
         List<? extends DimensionalItemObject> attributeOptionCombos) {
-      this.params.setDimensionOptions(ATTRIBUTEOPTIONCOMBO_DIM_ID,
-          DimensionType.ATTRIBUTE_OPTION_COMBO, null, asList(attributeOptionCombos));
+      this.params.setDimensionOptions(
+          ATTRIBUTEOPTIONCOMBO_DIM_ID,
+          DimensionType.ATTRIBUTE_OPTION_COMBO,
+          null,
+          asList(attributeOptionCombos));
       return this;
     }
 
     public Builder withCategory(Category category) {
-      this.params.setDimensionOptions(category.getUid(), DimensionType.CATEGORY, null,
-          new ArrayList<>(category.getItems()));
+      this.params.setDimensionOptions(
+          category.getUid(), DimensionType.CATEGORY, null, new ArrayList<>(category.getItems()));
       return this;
     }
 
     public Builder withDataElementGroupSet(DataElementGroupSet groupSet) {
-      this.params.setDimensionOptions(groupSet.getUid(), DimensionType.DATA_ELEMENT_GROUP_SET, null,
+      this.params.setDimensionOptions(
+          groupSet.getUid(),
+          DimensionType.DATA_ELEMENT_GROUP_SET,
+          null,
           new ArrayList<>(groupSet.getItems()));
       return this;
     }
@@ -2541,14 +2663,14 @@ public class DataQueryParams {
     }
 
     public Builder withPeriods(String periodName, List<? extends DimensionalItemObject> periods) {
-      this.params.setDimensionOptions(PERIOD_DIM_ID, DimensionType.PERIOD, periodName,
-          asList(periods));
+      this.params.setDimensionOptions(
+          PERIOD_DIM_ID, DimensionType.PERIOD, periodName, asList(periods));
       return this;
     }
 
     public Builder withPeriods(List<? extends DimensionalItemObject> periods, String periodType) {
-      this.params.setDimensionOptions(PERIOD_DIM_ID, DimensionType.PERIOD, periodType.toLowerCase(),
-          asList(periods));
+      this.params.setDimensionOptions(
+          PERIOD_DIM_ID, DimensionType.PERIOD, periodType.toLowerCase(), asList(periods));
       this.params.periodType = periodType;
       return this;
     }
@@ -2559,8 +2681,8 @@ public class DataQueryParams {
     }
 
     public Builder withOrganisationUnits(List<? extends DimensionalItemObject> organisationUnits) {
-      this.params.setDimensionOptions(ORGUNIT_DIM_ID, DimensionType.ORGANISATION_UNIT, null,
-          asList(organisationUnits));
+      this.params.setDimensionOptions(
+          ORGUNIT_DIM_ID, DimensionType.ORGANISATION_UNIT, null, asList(organisationUnits));
       return this;
     }
 
@@ -2612,8 +2734,8 @@ public class DataQueryParams {
 
     public Builder withFilterOrganisationUnits(
         List<? extends DimensionalItemObject> organisationUnits) {
-      this.params.setFilterOptions(ORGUNIT_DIM_ID, DimensionType.ORGANISATION_UNIT, null,
-          asList(organisationUnits));
+      this.params.setFilterOptions(
+          ORGUNIT_DIM_ID, DimensionType.ORGANISATION_UNIT, null, asList(organisationUnits));
       return this;
     }
 
@@ -2712,7 +2834,7 @@ public class DataQueryParams {
       this.params.outputIdScheme = outputIdScheme;
       return this;
     }
-    
+
     public Builder withOutputDataItemIdScheme(IdScheme outputDataItemIdScheme) {
       this.params.outputDataItemIdScheme = outputDataItemIdScheme;
       return this;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/CommonParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/CommonParams.java
@@ -31,6 +31,7 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
 import static org.hisp.dhis.common.IdScheme.UID;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.DESCENDANTS;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -38,6 +39,9 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifier;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionParam;
 import org.hisp.dhis.common.DimensionalItemObject;
@@ -46,12 +50,9 @@ import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
 
 /**
- * This is a reusable and shared representation of queryable items to be used by the service and 
+ * This is a reusable and shared representation of queryable items to be used by the service and
  * store layers.
  *
  * <p>It encapsulates the most common objects that are very likely to be used by the majority of

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/CommonParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/CommonParams.java
@@ -31,7 +31,6 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
 import static org.hisp.dhis.common.IdScheme.UID;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.DESCENDANTS;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -39,9 +38,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifier;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionParam;
 import org.hisp.dhis.common.DimensionalItemObject;
@@ -50,10 +46,13 @@ import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
- * This is a reusable and shared representation of queryable items to be used by the service/dao
- * layers.
+ * This is a reusable and shared representation of queryable items to be used by the service and 
+ * store layers.
  *
  * <p>It encapsulates the most common objects that are very likely to be used by the majority of
  * analytics queries.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
@@ -160,6 +160,7 @@ public class DefaultDataQueryService implements DataQueryService {
         .withIncludeMetadataDetails(request.isIncludeMetadataDetails())
         .withDisplayProperty(request.getDisplayProperty())
         .withOutputIdScheme(request.getOutputIdScheme())
+        .withOutputDataItemIdScheme(request.getOutputDataItemIdScheme())
         .withOutputDataElementIdScheme(request.getOutputDataElementIdScheme())
         .withOutputOrgUnitIdScheme(request.getOutputOrgUnitIdScheme())
         .withDuplicatesOnly(request.isDuplicatesOnly())

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/MetadataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/MetadataHandler.java
@@ -172,7 +172,7 @@ public class MetadataHandler {
    */
   void applyIdScheme(DataQueryParams params, Grid grid) {
     if (!params.isSkipMeta()) {
-      if (params.hasCustomIdSchemaSet()) {
+      if (params.hasCustomIdSchemeSet()) {
         grid.substituteMetaData(schemeIdResponseMapper.getSchemeIdResponseMap(params));
       }
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapper.java
@@ -32,7 +32,6 @@ import static org.hisp.dhis.analytics.OutputFormat.DATA_VALUE_SET;
 import static org.hisp.dhis.common.DimensionalObjectUtils.asTypedList;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getDataElementOperandIdSchemeMap;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getDimensionItemIdSchemeMap;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -87,13 +86,13 @@ public class SchemeIdResponseMapper {
       applyDataElementOperandIdSchemeMapping(params, map);
     }
 
-    System.out.println("IS DATA ITEM SET: " + params.isOutputDataElementIdSchemeSet());
+    System.out.println("IS DATA ITEM SETB: " + params.isOutputDataItemIdSchemeSet());
     // Apply data item output ID scheme
     if (params.isOutputDataItemIdSchemeSet()) {
       applyIdSchemeMapping(params.getDataElements(), map, params.getOutputDataItemIdScheme());
       applyIdSchemeMapping(params.getIndicators(), map, params.getOutputDataItemIdScheme());
       applyIdSchemeMapping(params.getProgramIndicators(), map, params.getOutputDataItemIdScheme());
-      System.out.println("SET DATA ITEM ID SCHEME: " + params.getOutputDataItemIdScheme());
+      System.out.println("SET DATA ITEM ID SCHEMEB: " + params.getOutputDataItemIdScheme());
     }
 
     // Apply data element output ID scheme
@@ -158,7 +157,7 @@ public class SchemeIdResponseMapper {
    * @param grid the {@link Grid}.
    */
   public void applyCustomIdScheme(EventQueryParams params, Grid grid) {
-    if (!params.isSkipMeta() && params.hasCustomIdSchemaSet()) {
+    if (!params.isSkipMeta() && params.hasCustomIdSchemeSet()) {
       grid.substituteMetaData(getSchemeIdResponseMap(params));
     }
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapper.java
@@ -70,35 +70,45 @@ public class SchemeIdResponseMapper {
    * @return a map of UID and mapping value.
    */
   public Map<String, String> getSchemeIdResponseMap(DataQueryParams params) {
-    Map<String, String> responseMap =
+    Map<String, String> map =
         getDimensionItemIdSchemeMap(params.getAllDimensionItems(), params.getOutputIdScheme());
 
+    // Apply general output ID scheme
     if (params.isGeneralOutputIdSchemeSet()) {
-      // Apply the general output ID scheme
-      applyIdSchemeMapping(params, responseMap);
+      applyIdSchemeMapping(params, map);
     }
 
     // Handle output format {@link OutputFormat#DATA_VALUE_SET}
     if (params.isOutputFormat(DATA_VALUE_SET) && params.isOutputDataElementIdSchemeSet()) {
       // Apply data element operand output ID scheme
       if (!params.getDataElementOperands().isEmpty()) {
-        applyDataElementOperandIdSchemeMapping(params, responseMap);
+        applyDataElementOperandIdSchemeMapping(params, map);
       }
     }
 
-    // Apply data element output ID scheme
-    if (params.isOutputDataElementIdSchemeSet() && !params.getDataElements().isEmpty()) {
+    // Apply data item output ID scheme
+    if (params.isOutputDataItemIdSchemeSet()) {
       applyIdSchemeMapping(
-          params.getDataElements(), responseMap, params.getOutputDataElementIdScheme());
+          params.getDataElements(), map, params.getOutputDataItemIdScheme());
+      applyIdSchemeMapping(
+          params.getIndicators(), map, params.getOutputDataItemIdScheme());
+      applyIdSchemeMapping(
+          params.getProgramIndicators(), map, params.getOutputDataItemIdScheme());
+    }
+    
+    // Apply data element output ID scheme
+    if (params.isOutputDataElementIdSchemeSet()) {
+      applyIdSchemeMapping(
+          params.getDataElements(), map, params.getOutputDataElementIdScheme());
     }
 
     // Apply organisation unit output ID scheme
-    if (params.isOutputOrgUnitIdSchemeSet() && !params.getOrganisationUnits().isEmpty()) {
+    if (params.isOutputOrgUnitIdSchemeSet()) {
       applyIdSchemeMapping(
-          params.getOrganisationUnits(), responseMap, params.getOutputOrgUnitIdScheme());
+          params.getOrganisationUnits(), map, params.getOutputOrgUnitIdScheme());
     }
 
-    return responseMap;
+    return map;
   }
 
   /**
@@ -116,31 +126,31 @@ public class SchemeIdResponseMapper {
    * @return a map of UID and mapping value.
    */
   public Map<String, String> getSchemeIdResponseMap(CommonParams params) {
-    Map<String, String> responseMap =
+    Map<String, String> map =
         getDimensionItemIdSchemeMap(
             params.delegate().getAllDimensionalItemObjects(), params.getOutputIdScheme());
 
+    // Apply general output ID scheme
     if (params.isGeneralOutputIdSchemeSet()) {
-      // Apply an ID scheme to all data element operands using the general output ID scheme defined.
-      applyIdSchemeMapping(params, responseMap);
+      applyIdSchemeMapping(params, map);
     }
 
     List<DimensionalItemObject> dataElements = params.delegate().getAllDataElements();
 
     if (isNotEmpty(dataElements)) {
-      // Replace all data elements respecting their ID scheme definition.
+      // Apply data element output ID scheme
       applyIdSchemeMapping(
-          dataElements, responseMap, params.getOutputDataElementIdScheme());
+          dataElements, map, params.getOutputDataElementIdScheme());
     }
 
     List<DimensionalItemObject> orgUnits = params.delegate().getOrgUnitDimensionOrFilterItems();
 
-    // If "outputOrgUnitIdScheme" is set, we replace all org units values respecting its definition.
+    // Apply organisation unit output ID scheme
     if (params.isOutputOrgUnitIdSchemeSet() && isNotEmpty(orgUnits)) {
-      applyIdSchemeMapping(orgUnits, responseMap, params.getOutputOrgUnitIdScheme());
+      applyIdSchemeMapping(orgUnits, map, params.getOutputOrgUnitIdScheme());
     }
 
-    return responseMap;
+    return map;
   }
 
   /**
@@ -276,6 +286,8 @@ public class SchemeIdResponseMapper {
       List<DimensionalItemObject> dimensionalItemObjects,
       Map<String, String> map,
       IdScheme outputIdScheme) {
-    map.putAll(getDimensionItemIdSchemeMap(asTypedList(dimensionalItemObjects), outputIdScheme));
+    if (!dimensionalItemObjects.isEmpty()) {
+      map.putAll(getDimensionItemIdSchemeMap(asTypedList(dimensionalItemObjects), outputIdScheme));
+    }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapper.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.analytics.OutputFormat.DATA_VALUE_SET;
 import static org.hisp.dhis.common.DimensionalObjectUtils.asTypedList;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getDataElementOperandIdSchemeMap;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getDimensionItemIdSchemeMap;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapper.java
@@ -80,8 +80,8 @@ public class SchemeIdResponseMapper {
 
     // Handle output format {@link OutputFormat#DATA_VALUE_SET}
     if (params.isOutputFormat(DATA_VALUE_SET) && params.isOutputDataElementIdSchemeSet()) {
+      // Apply data element operand output ID scheme
       if (!params.getDataElementOperands().isEmpty()) {
-        // Apply data element operand output ID scheme
         applyDataElementOperandIdSchemeMapping(params, responseMap);
       }
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapper.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.analytics.OutputFormat.DATA_VALUE_SET;
 import static org.hisp.dhis.common.DimensionalObjectUtils.asTypedList;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getDataElementOperandIdSchemeMap;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getDimensionItemIdSchemeMap;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -88,24 +89,19 @@ public class SchemeIdResponseMapper {
 
     // Apply data item output ID scheme
     if (params.isOutputDataItemIdSchemeSet()) {
-      applyIdSchemeMapping(
-          params.getDataElements(), map, params.getOutputDataItemIdScheme());
-      applyIdSchemeMapping(
-          params.getIndicators(), map, params.getOutputDataItemIdScheme());
-      applyIdSchemeMapping(
-          params.getProgramIndicators(), map, params.getOutputDataItemIdScheme());
+      applyIdSchemeMapping(params.getDataElements(), map, params.getOutputDataItemIdScheme());
+      applyIdSchemeMapping(params.getIndicators(), map, params.getOutputDataItemIdScheme());
+      applyIdSchemeMapping(params.getProgramIndicators(), map, params.getOutputDataItemIdScheme());
     }
-    
+
     // Apply data element output ID scheme
     if (params.isOutputDataElementIdSchemeSet()) {
-      applyIdSchemeMapping(
-          params.getDataElements(), map, params.getOutputDataElementIdScheme());
+      applyIdSchemeMapping(params.getDataElements(), map, params.getOutputDataElementIdScheme());
     }
 
     // Apply organisation unit output ID scheme
     if (params.isOutputOrgUnitIdSchemeSet()) {
-      applyIdSchemeMapping(
-          params.getOrganisationUnits(), map, params.getOutputOrgUnitIdScheme());
+      applyIdSchemeMapping(params.getOrganisationUnits(), map, params.getOutputOrgUnitIdScheme());
     }
 
     return map;
@@ -139,8 +135,7 @@ public class SchemeIdResponseMapper {
 
     if (isNotEmpty(dataElements)) {
       // Apply data element output ID scheme
-      applyIdSchemeMapping(
-          dataElements, map, params.getOutputDataElementIdScheme());
+      applyIdSchemeMapping(dataElements, map, params.getOutputDataElementIdScheme());
     }
 
     List<DimensionalItemObject> orgUnits = params.delegate().getOrgUnitDimensionOrFilterItems();
@@ -277,7 +272,7 @@ public class SchemeIdResponseMapper {
 
   /**
    * Adds the entries to the given map.
-   * 
+   *
    * @param dimensionalItemObjects the list of {@link DimensionalItemObject}.
    * @param map the map.
    * @param outputIdScheme the output {@link IdScheme}.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapper.java
@@ -87,13 +87,11 @@ public class SchemeIdResponseMapper {
       applyDataElementOperandIdSchemeMapping(params, map);
     }
 
-    System.out.println("IS DATA ITEM SETB: " + params.isOutputDataItemIdSchemeSet());
     // Apply data item output ID scheme
     if (params.isOutputDataItemIdSchemeSet()) {
       applyIdSchemeMapping(params.getDataElements(), map, params.getOutputDataItemIdScheme());
       applyIdSchemeMapping(params.getIndicators(), map, params.getOutputDataItemIdScheme());
       applyIdSchemeMapping(params.getProgramIndicators(), map, params.getOutputDataItemIdScheme());
-      System.out.println("SET DATA ITEM ID SCHEMEB: " + params.getOutputDataItemIdScheme());
     }
 
     // Apply data element output ID scheme

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapper.java
@@ -88,13 +88,13 @@ public class SchemeIdResponseMapper {
 
     // Apply data element output ID scheme
     if (params.isOutputDataElementIdSchemeSet() && !params.getDataElements().isEmpty()) {
-      applyDataElementIdSchemeMapping(
+      applyIdSchemeMapping(
           params.getDataElements(), responseMap, params.getOutputDataElementIdScheme());
     }
 
     // Apply organisation unit output ID scheme
     if (params.isOutputOrgUnitIdSchemeSet() && !params.getOrganisationUnits().isEmpty()) {
-      applyOrgUnitIdSchemeMapping(
+      applyIdSchemeMapping(
           params.getOrganisationUnits(), responseMap, params.getOutputOrgUnitIdScheme());
     }
 
@@ -129,7 +129,7 @@ public class SchemeIdResponseMapper {
 
     if (isNotEmpty(dataElements)) {
       // Replace all data elements respecting their ID scheme definition.
-      applyDataElementIdSchemeMapping(
+      applyIdSchemeMapping(
           dataElements, responseMap, params.getOutputDataElementIdScheme());
     }
 
@@ -137,7 +137,7 @@ public class SchemeIdResponseMapper {
 
     // If "outputOrgUnitIdScheme" is set, we replace all org units values respecting its definition.
     if (params.isOutputOrgUnitIdSchemeSet() && isNotEmpty(orgUnits)) {
-      applyOrgUnitIdSchemeMapping(orgUnits, responseMap, params.getOutputOrgUnitIdScheme());
+      applyIdSchemeMapping(orgUnits, responseMap, params.getOutputOrgUnitIdScheme());
     }
 
     return responseMap;
@@ -265,17 +265,10 @@ public class SchemeIdResponseMapper {
             asTypedList(params.getDataElementOperands()), params.getOutputDataElementIdScheme()));
   }
 
-  private void applyDataElementIdSchemeMapping(
-      List<DimensionalItemObject> dataElements,
+  private void applyIdSchemeMapping(
+      List<DimensionalItemObject> dimensionalItemObjects,
       Map<String, String> map,
-      IdScheme outputDataElementIdScheme) {
-    map.putAll(getDimensionItemIdSchemeMap(asTypedList(dataElements), outputDataElementIdScheme));
-  }
-
-  private void applyOrgUnitIdSchemeMapping(
-      List<DimensionalItemObject> orgUnits,
-      Map<String, String> map,
-      IdScheme outputOrgUnitIdScheme) {
-    map.putAll(getDimensionItemIdSchemeMap(asTypedList(orgUnits), outputOrgUnitIdScheme));
+      IdScheme outputIdScheme) {
+    map.putAll(getDimensionItemIdSchemeMap(asTypedList(dimensionalItemObjects), outputIdScheme));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapper.java
@@ -80,11 +80,11 @@ public class SchemeIdResponseMapper {
     }
 
     // Handle output format {@link OutputFormat#DATA_VALUE_SET}
-    if (params.isOutputFormat(DATA_VALUE_SET) && params.isOutputDataElementIdSchemeSet()) {
-      // Apply data element operand output ID scheme
-      if (!params.getDataElementOperands().isEmpty()) {
-        applyDataElementOperandIdSchemeMapping(params, map);
-      }
+    // Apply data element operand output ID scheme
+    if (params.isOutputFormat(DATA_VALUE_SET)
+        && params.isOutputDataElementIdSchemeSet()
+        && !params.getDataElementOperands().isEmpty()) {
+      applyDataElementOperandIdSchemeMapping(params, map);
     }
 
     // Apply data item output ID scheme

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapper.java
@@ -265,6 +265,13 @@ public class SchemeIdResponseMapper {
             asTypedList(params.getDataElementOperands()), params.getOutputDataElementIdScheme()));
   }
 
+  /**
+   * Adds the entries to the given map.
+   * 
+   * @param dimensionalItemObjects the list of {@link DimensionalItemObject}.
+   * @param map the map.
+   * @param outputIdScheme the output {@link IdScheme}.
+   */
   private void applyIdSchemeMapping(
       List<DimensionalItemObject> dimensionalItemObjects,
       Map<String, String> map,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapper.java
@@ -87,11 +87,13 @@ public class SchemeIdResponseMapper {
       applyDataElementOperandIdSchemeMapping(params, map);
     }
 
+    System.out.println("IS DATA ITEM SET: " + params.isOutputDataElementIdSchemeSet());
     // Apply data item output ID scheme
     if (params.isOutputDataItemIdSchemeSet()) {
       applyIdSchemeMapping(params.getDataElements(), map, params.getOutputDataItemIdScheme());
       applyIdSchemeMapping(params.getIndicators(), map, params.getOutputDataItemIdScheme());
       applyIdSchemeMapping(params.getProgramIndicators(), map, params.getOutputDataItemIdScheme());
+      System.out.println("SET DATA ITEM ID SCHEME: " + params.getOutputDataItemIdScheme());
     }
 
     // Apply data element output ID scheme

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceDimensionItemKeywordTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceDimensionItemKeywordTest.java
@@ -54,6 +54,7 @@ import org.hisp.dhis.common.DataQueryRequest;
 import org.hisp.dhis.common.DimensionItemKeywords;
 import org.hisp.dhis.common.DimensionService;
 import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.UserOrgUnitType;
@@ -454,6 +455,22 @@ class DataQueryServiceDimensionItemKeywordTest {
     assertThat(aggregation.getMetadataItem().getUid(), is(dataElementGroup.getUid()));
     assertThat(aggregation.getMetadataItem().getCode(), is(dataElementGroup.getCode()));
     assertThat(aggregation.getMetadataItem().getName(), is(dataElementGroup.getName()));
+  }
+
+  @Test
+  void convertAnalyticsRequestWithOutputIdScheme() {
+    DataQueryRequest request =
+        DataQueryRequest.newBuilder()
+            .outputDataItemIdScheme(IdScheme.CODE)
+            .outputOrgUnitIdScheme(IdScheme.NAME)
+            .outputIdScheme(IdScheme.UID)
+            .build();
+
+    DataQueryParams params = target.getFromRequest(request);
+
+    assertThat(params.getOutputDataItemIdScheme(), is(IdScheme.CODE));
+    assertThat(params.getOutputOrgUnitIdScheme(), is(IdScheme.NAME));
+    assertThat(params.getOutputIdScheme(), is(IdScheme.NAME));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceDimensionItemKeywordTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceDimensionItemKeywordTest.java
@@ -37,6 +37,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Ordering;
+import com.google.common.collect.Sets;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -76,9 +80,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Ordering;
-import com.google.common.collect.Sets;
 
 /**
  * @author Luciano Fiandesio

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceDimensionItemKeywordTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceDimensionItemKeywordTest.java
@@ -37,10 +37,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Ordering;
-import com.google.common.collect.Sets;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -80,6 +76,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Ordering;
+import com.google.common.collect.Sets;
 
 /**
  * @author Luciano Fiandesio
@@ -470,7 +469,7 @@ class DataQueryServiceDimensionItemKeywordTest {
 
     assertThat(params.getOutputDataItemIdScheme(), is(IdScheme.CODE));
     assertThat(params.getOutputOrgUnitIdScheme(), is(IdScheme.NAME));
-    assertThat(params.getOutputIdScheme(), is(IdScheme.NAME));
+    assertThat(params.getOutputIdScheme(), is(IdScheme.UID));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapperTest.java
@@ -36,6 +36,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hisp.dhis.DhisConvenienceTest.createProgram;
 import static org.hisp.dhis.analytics.DataQueryParams.newBuilder;
+import static org.hisp.dhis.analytics.OutputFormat.ANALYTICS;
 import static org.hisp.dhis.analytics.OutputFormat.DATA_VALUE_SET;
 import static org.hisp.dhis.analytics.common.params.dimension.DimensionParamType.DIMENSIONS;
 import static org.hisp.dhis.analytics.common.params.dimension.ElementWithOffset.emptyElementWithOffset;
@@ -54,7 +55,6 @@ import static org.hisp.dhis.common.ValueType.TEXT;
 import static org.hisp.dhis.period.PeriodType.getPeriodFromIsoString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -539,6 +539,30 @@ class SchemeIdResponseMapperTest {
     assertThat(
         responseMap.get(categoryOptionComboC.getUid()),
         is(equalTo(categoryOptionComboC.getCode())));
+  }
+
+  @Test
+  void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeOverridesOutputOrgUnitIdScheme() {
+    List<DataElement> dataElementsStub = stubDataElements();
+    OrganisationUnit orUnitStub = stubOrgUnit();
+    Period periodStub = stubPeriod();
+    DataQueryParams theDataQueryParams =
+        stubDataElementQueryParams(dataElementsStub, orUnitStub, periodStub, ANALYTICS);
+    theDataQueryParams.setOutputIdScheme(NAME);
+    theDataQueryParams.setOutputDataElementIdScheme(CODE);
+
+    Map<String, String> responseMap =
+        schemeIdResponseMapper.getSchemeIdResponseMap(theDataQueryParams);
+
+    String orgUnitUid = orUnitStub.getUid();
+    String periodIsoDate = periodStub.getIsoDate();
+    DataElement dataElementA = dataElementsStub.get(0);
+    DataElement dataElementB = dataElementsStub.get(1);
+
+    assertThat(responseMap.get(orgUnitUid), is(equalTo(orUnitStub.getName())));
+    assertThat(responseMap.get(periodIsoDate), is(equalTo(periodStub.getName())));
+    assertThat(responseMap.get(dataElementA.getUid()), is(equalTo(dataElementA.getCode())));
+    assertThat(responseMap.get(dataElementB.getUid()), is(equalTo(dataElementB.getCode())));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapperTest.java
@@ -55,6 +55,7 @@ import static org.hisp.dhis.common.ValueType.TEXT;
 import static org.hisp.dhis.period.PeriodType.getPeriodFromIsoString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapperTest.java
@@ -220,7 +220,7 @@ class SchemeIdResponseMapperTest {
   }
 
   @Test
-  void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeIsSetToNameForDataValueSet() {
+  void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeIsSetToName() {
     List<DataElement> dataElementsStub = stubDataElements();
     OrganisationUnit orUnitStub = stubOrgUnit();
     Period periodStub = stubPeriod();
@@ -243,7 +243,7 @@ class SchemeIdResponseMapperTest {
   }
 
   @Test
-  void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeIsSetToCodeForDataValueSet() {
+  void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeIsSetToCode() {
     List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
     OrganisationUnit orUnitStub = stubOrgUnit();
     Period periodStub = stubPeriod();
@@ -274,7 +274,7 @@ class SchemeIdResponseMapperTest {
   }
 
   @Test
-  void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeIsSetToUuidForDataValueSet() {
+  void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeIsSetToUuid() {
     List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
     OrganisationUnit orUnitStub = stubOrgUnit();
     Period periodStub = stubPeriod();
@@ -301,7 +301,7 @@ class SchemeIdResponseMapperTest {
   }
 
   @Test
-  void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeIsSetToUidForDataValueSet() {
+  void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeIsSetToUid() {
     List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
     OrganisationUnit orUnitStub = stubOrgUnit();
     Period periodStub = stubPeriod();
@@ -328,7 +328,7 @@ class SchemeIdResponseMapperTest {
   }
 
   @Test
-  void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeIsSetToNameForDataValueSet() {
+  void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeIsSetToName() {
     List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
     OrganisationUnit orUnitStub = stubOrgUnit();
     Period periodStub = stubPeriod();
@@ -355,7 +355,7 @@ class SchemeIdResponseMapperTest {
   }
 
   @Test
-  void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeIsSetToCodeForDataValueSet() {
+  void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeIsSetToCode() {
     List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
     OrganisationUnit orUnitStub = stubOrgUnit();
     Period periodStub = stubPeriod();
@@ -382,7 +382,7 @@ class SchemeIdResponseMapperTest {
   }
 
   @Test
-  void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeIsSetToUuidForDataValueSet() {
+  void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeIsSetToUuid() {
     List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
     OrganisationUnit orUnitStub = stubOrgUnit();
     Period periodStub = stubPeriod();
@@ -409,7 +409,7 @@ class SchemeIdResponseMapperTest {
   }
 
   @Test
-  void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeIsSetToUidForDataValueSet() {
+  void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeIsSetToUid() {
     List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
     OrganisationUnit orUnitStub = stubOrgUnit();
     Period periodStub = stubPeriod();
@@ -436,8 +436,7 @@ class SchemeIdResponseMapperTest {
   }
 
   @Test
-  void
-      testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeOverridesOutputOrgUnitIdSchemeForDataValueSet() {
+  void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeOverridesOutputIdScheme() {
     List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
     OrganisationUnit orUnitStub = stubOrgUnit();
     Period periodStub = stubPeriod();
@@ -471,8 +470,7 @@ class SchemeIdResponseMapperTest {
   }
 
   @Test
-  void
-      testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeOverridesOutputOrgUnitIdSchemeForDataValueSet() {
+  void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeOverridesOutputOrgUnitIdScheme() {
     List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
     OrganisationUnit orUnitStub = stubOrgUnit();
     Period periodStub = stubPeriod();
@@ -507,8 +505,7 @@ class SchemeIdResponseMapperTest {
   }
 
   @Test
-  void
-      testGetSchemeIdResponseMapWhenOutputDataElementAndOrgUnitIdSchemeOverrideOutputOrgUnitIdSchemeForDataValueSet() {
+  void testGetSchemeIdResponseMapWhenOutputDataElementOrgUnitIdSchemeOverrideOutputIdScheme() {
     List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
     OrganisationUnit orUnitStub = stubOrgUnit();
     Period periodStub = stubPeriod();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapperTest.java
@@ -636,7 +636,7 @@ class SchemeIdResponseMapperTest {
   }
 
   @Test
-  void testApplyOptionAndLegendSetMappingWhenHasOptionSetAndSchemeNAME() {
+  void testApplyOptionAndLegendSetMappingWhenHasOptionSetAndSchemeName() {
     // Given
     Option option = new Option("name", "code");
     option.setUid("uid");
@@ -661,7 +661,7 @@ class SchemeIdResponseMapperTest {
   }
 
   @Test
-  void testApplyOptionAndLegendSetMappingWhenHasOptionSetAndSchemeCODE() {
+  void testApplyOptionAndLegendSetMappingWhenHasOptionSetAndSchemeCode() {
     // Given
     Option option = new Option("name", "code");
     option.setUid("uid");
@@ -686,7 +686,7 @@ class SchemeIdResponseMapperTest {
   }
 
   @Test
-  void testApplyOptionAndLegendSetMappingWhenHasOptionSetAndSchemeUID() {
+  void testApplyOptionAndLegendSetMappingWhenHasOptionSetAndSchemeUid() {
     // Given
     Option option = new Option("name", "code");
     option.setUid("uid");
@@ -711,7 +711,7 @@ class SchemeIdResponseMapperTest {
   }
 
   @Test
-  void testApplyOptionAndLegendSetMappingWhenHasLegendSetAndSchemeNAME() {
+  void testApplyOptionAndLegendSetMappingWhenHasLegendSetAndSchemeName() {
     // Given
     Legend legend = new Legend();
     legend.setUid("uid");
@@ -738,7 +738,7 @@ class SchemeIdResponseMapperTest {
   }
 
   @Test
-  void testApplyOptionAndLegendSetMappingWhenHasLegendSetAndSchemeCODE() {
+  void testApplyOptionAndLegendSetMappingWhenHasLegendSetAndSchemeCode() {
     // Given
     Legend legend = new Legend();
     legend.setUid("uid");
@@ -765,7 +765,7 @@ class SchemeIdResponseMapperTest {
   }
 
   @Test
-  void testApplyOptionAndLegendSetMappingWhenHasLegendSetAndSchemeUID() {
+  void testApplyOptionAndLegendSetMappingWhenHasLegendSetAndSchemeUid() {
     // Given
     Legend legend = new Legend();
     legend.setUid("uid");

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapperTest.java
@@ -55,6 +55,7 @@ import static org.hisp.dhis.common.ValueType.TEXT;
 import static org.hisp.dhis.period.PeriodType.getPeriodFromIsoString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -591,7 +592,8 @@ class SchemeIdResponseMapperTest {
     assertThat(responseMap.get(periodIsoDate), is(equalTo(periodStub.getName())));
     assertThat(responseMap.get(dataElementA.getUid()), is(equalTo(dataElementA.getCode())));
     assertThat(responseMap.get(indicatorA.getUid()), is(equalTo(indicatorA.getCode())));
-    assertThat(responseMap.get(programIndicatorA.getUid()), is(equalTo(programIndicatorA.getCode())));
+    assertThat(
+        responseMap.get(programIndicatorA.getUid()), is(equalTo(programIndicatorA.getCode())));
   }
 
   @Test
@@ -926,23 +928,23 @@ class SchemeIdResponseMapperTest {
 
     return newArrayList(dataElementA, dataElementB);
   }
-  
+
   private List<DimensionalItemObject> stubDataItems() {
     DataElement dataElementA = new DataElement();
     dataElementA.setUid("fM8kR4FOTR6");
     dataElementA.setName("DataElementNameA");
     dataElementA.setCode("DataElementCodeA");
-    
+
     Indicator indicatorA = new Indicator();
     indicatorA.setUid("SN78k0lNyvd");
     indicatorA.setName("IndicatorNameA");
     indicatorA.setCode("IndicatorCodeA");
-    
+
     ProgramIndicator programIndicatorA = new ProgramIndicator();
     programIndicatorA.setUid("fCGiVvsXbkY");
     programIndicatorA.setName("ProgramIndicatorNameA");
     programIndicatorA.setCode("ProgramIndicatorCodeA");
-    
+
     return newArrayList(dataElementA, indicatorA, programIndicatorA);
   }
 

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeService.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeService.java
@@ -265,10 +265,13 @@ public class AggregateDataExchangeService {
     String queryOutputIdScheme = params.getOutputIdScheme();
 
     IdScheme inputIdScheme = toIdSchemeOrDefault(request.getInputIdScheme());
+
     IdScheme outputDataElementIdScheme =
         toIdScheme(queryOutputIdScheme, request.getOutputDataElementIdScheme());
     IdScheme outputOrgUnitIdScheme =
         toIdScheme(queryOutputIdScheme, request.getOutputOrgUnitIdScheme());
+    IdScheme outputDataItemIdScheme =
+        toIdScheme(queryOutputIdScheme, request.getOutputDataItemIdScheme());
     IdScheme outputIdScheme = toIdScheme(queryOutputIdScheme, request.getOutputIdScheme());
 
     List<DimensionalObject> filters =
@@ -282,6 +285,7 @@ public class AggregateDataExchangeService {
         .withAggregationType(toAnalyticsAggregationType(request.getAggregationType()))
         .withOutputDataElementIdScheme(outputDataElementIdScheme)
         .withOutputOrgUnitIdScheme(outputOrgUnitIdScheme)
+        .withOutputDataItemIdScheme(outputDataItemIdScheme)
         .withOutputIdScheme(outputIdScheme)
         .build();
   }

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeServiceTest.java
@@ -191,6 +191,7 @@ class AggregateDataExchangeServiceTest {
             .setAggregationType(AggregationType.COUNT)
             .setOutputDataElementIdScheme(IdScheme.UID.name())
             .setOutputOrgUnitIdScheme(IdScheme.CODE.name())
+            .setOutputDataItemIdScheme(IdScheme.NAME.name())
             .setOutputIdScheme(IdScheme.CODE.name());
 
     DataQueryParams query = service.toDataQueryParams(sourceRequest, new SourceDataQueryParams());
@@ -203,6 +204,7 @@ class AggregateDataExchangeServiceTest {
         query.getAggregationType());
     assertEquals(IdScheme.UID, query.getOutputDataElementIdScheme());
     assertEquals(IdScheme.CODE, query.getOutputOrgUnitIdScheme());
+    assertEquals(IdScheme.NAME, query.getOutputDataItemIdScheme());
     assertEquals(IdScheme.CODE, query.getOutputIdScheme());
 
     SourceDataQueryParams params =
@@ -212,6 +214,7 @@ class AggregateDataExchangeServiceTest {
 
     assertEquals(IdScheme.CODE, query.getOutputDataElementIdScheme());
     assertEquals(IdScheme.CODE, query.getOutputOrgUnitIdScheme());
+    assertEquals(IdScheme.CODE, query.getOutputDataItemIdScheme());
     assertEquals(IdScheme.CODE, query.getOutputIdScheme());
   }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJob.java
@@ -28,11 +28,8 @@
 package org.hisp.dhis.dxf2.metadata.jobs;
 
 import static java.lang.String.format;
-
 import java.util.Date;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.dxf2.metadata.MetadataImportParams;
 import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncParams;
 import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncPostProcessor;
@@ -41,7 +38,6 @@ import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncService;
 import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncSummary;
 import org.hisp.dhis.dxf2.metadata.sync.exception.DhisVersionMismatchException;
 import org.hisp.dhis.dxf2.metadata.sync.exception.MetadataSyncServiceException;
-import org.hisp.dhis.dxf2.synch.SynchronizationManager;
 import org.hisp.dhis.metadata.version.MetadataVersion;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
@@ -52,6 +48,8 @@ import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Component;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * This is the runnable that takes care of the Metadata Synchronization. Leverages Spring
@@ -92,8 +90,6 @@ public class MetadataSyncJob implements Job {
   private final SystemSettingManager systemSettingManager;
 
   private final RetryTemplate retryTemplate;
-
-  private final SynchronizationManager synchronizationManager;
 
   private final MetadataSyncPreProcessor metadataSyncPreProcessor;
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJob.java
@@ -28,8 +28,11 @@
 package org.hisp.dhis.dxf2.metadata.jobs;
 
 import static java.lang.String.format;
+
 import java.util.Date;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.dxf2.metadata.MetadataImportParams;
 import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncParams;
 import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncPostProcessor;
@@ -48,8 +51,6 @@ import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Component;
-import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * This is the runnable that takes care of the Metadata Synchronization. Leverages Spring

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobParametersTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobParametersTest.java
@@ -28,15 +28,14 @@
 package org.hisp.dhis.dxf2.metadata.jobs;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import java.util.ArrayList;
 import java.util.List;
 import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
@@ -47,7 +46,6 @@ import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncService;
 import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncSummary;
 import org.hisp.dhis.dxf2.metadata.sync.exception.DhisVersionMismatchException;
 import org.hisp.dhis.dxf2.metadata.sync.exception.MetadataSyncServiceException;
-import org.hisp.dhis.dxf2.synch.SynchronizationManager;
 import org.hisp.dhis.metadata.version.MetadataVersion;
 import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.NoopJobProgress;
@@ -77,8 +75,6 @@ class MetadataSyncJobParametersTest {
 
   @Mock private MetadataSyncPostProcessor metadataSyncPostProcessor;
 
-  @Mock private SynchronizationManager synchronizationManager;
-
   @Mock private MetadataSyncService metadataSyncService;
 
   private MetadataSyncJob metadataSyncJob;
@@ -104,7 +100,6 @@ class MetadataSyncJobParametersTest {
         new MetadataSyncJob(
             systemSettingManager,
             retryTemplate,
-            synchronizationManager,
             metadataSyncPreProcessor,
             metadataSyncPostProcessor,
             metadataSyncService,

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobParametersTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobParametersTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import java.util.ArrayList;
 import java.util.List;
 import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
@@ -1025,6 +1025,7 @@ class MetadataImportServiceTest extends TransactionalIntegrationTest {
     assertNotNull(srA);
     assertNotNull(srA.getName());
     assertNotNull(srA.getVisualization());
+    assertNotNull("UID", srA.getOutputDataItemIdScheme());
     assertNotNull(aeA.getTarget());
     assertEquals("iFOyIpQciyk", aeA.getUid());
     assertEquals(TargetType.INTERNAL, aeA.getTarget().getType());
@@ -1039,6 +1040,7 @@ class MetadataImportServiceTest extends TransactionalIntegrationTest {
     assertNotNull(srB);
     assertNotNull(srB.getName());
     assertNotNull(srB.getVisualization());
+    assertNotNull("UID", srB.getOutputDataItemIdScheme());
     assertNotNull(aeB.getTarget());
     assertEquals("PnWccbwCJLQ", aeB.getUid());
     assertEquals(TargetType.EXTERNAL, aeB.getTarget().getType());
@@ -1056,6 +1058,7 @@ class MetadataImportServiceTest extends TransactionalIntegrationTest {
     assertNotNull(srC);
     assertNotNull(srC.getName());
     assertNotNull(srC.getVisualization());
+    assertNotNull("UID", srC.getOutputDataItemIdScheme());
     assertNotNull(aeC.getTarget());
     assertEquals("VpQ4qVEseyM", aeC.getUid());
     assertEquals(TargetType.EXTERNAL, aeC.getTarget().getType());

--- a/dhis-2/dhis-test-integration/src/test/resources/dxf2/aggregate_data_exchange.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/dxf2/aggregate_data_exchange.json
@@ -54,10 +54,11 @@
             "ou": [
               "ImspTQPwCqd"
             ],
-            "inputIdScheme": null,
-            "outputDataElementIdScheme": null,
-            "outputOrgUnitIdScheme": null,
-            "outputIdscheme": null
+            "inputIdScheme": "UID",
+            "outputDataElementIdScheme": "UID",
+            "outputOrgUnitIdScheme": "UID",
+            "outputDataItemIdScheme": "UID",
+            "outputIdscheme": "UID"
           }
         ]
       },
@@ -99,6 +100,7 @@
             "inputIdScheme": "UID",
             "outputDataElementIdScheme": "UID",
             "outputOrgUnitIdScheme": "UID",
+            "outputDataItemIdScheme": "UID",
             "outputIdscheme": "UID"
           }
         ]
@@ -146,6 +148,7 @@
             "inputIdScheme": "UID",
             "outputDataElementIdScheme": "UID",
             "outputOrgUnitIdScheme": "UID",
+            "outputDataItemIdScheme": "UID",
             "outputIdscheme": "UID"
           }
         ]


### PR DESCRIPTION
Adds "output data item ID scheme" to the analytics API. The query parameter is `outputDataItemIdScheme`, and applies to data elements, indicators and program indicators.

Adds "output data item ID scheme" to source request of the aggregate data exchange service. The ID scheme is passed through to the analytics service.

The purpose of the "output data item ID scheme" is to allow for defining a common ID scheme for the "dx" or "data item" dimension in analytics. As a user, you may select various data elements, indicators and program indicators in the same request, and you would like to apply a common ID scheme across all items.

This PR also fixes a minor bug where the `output data element ID scheme" only was applied to the analytics data value set output format.