### PR TITLE
fix: use a dedicated DataSource for jdbcTemplates [DHIS2-15597]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/analyze/RequestExecutionPlanStore.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/analyze/RequestExecutionPlanStore.java
@@ -64,7 +64,9 @@ public class RequestExecutionPlanStore implements ExecutionPlanStore {
 
   @Nonnull private final JdbcTemplate jdbcTemplate;
 
-  @Nonnull private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+  @Nonnull
+  @Qualifier("analyticsNamedParameterJdbcTemplate")
+  private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
   @Nonnull private final ScheduledExecutorService executorService;
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/SqlQueryExecutor.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/SqlQueryExecutor.java
@@ -46,7 +46,7 @@ import org.springframework.stereotype.Component;
 public class SqlQueryExecutor implements QueryExecutor<SqlQuery, SqlQueryResult> {
   @Nonnull private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
-  public SqlQueryExecutor(@Qualifier("readOnlyJdbcTemplate") JdbcTemplate jdbcTemplate) {
+  public SqlQueryExecutor(@Qualifier("analyticsReadOnlyJdbcTemplate") JdbcTemplate jdbcTemplate) {
     this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(jdbcTemplate);
   }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/TableInfoReader.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/TableInfoReader.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
@@ -46,6 +47,8 @@ import org.springframework.stereotype.Component;
 @Component
 @AllArgsConstructor
 public class TableInfoReader {
+
+  @Qualifier("analyticsJdbcTemplate")
   private final JdbcTemplate jdbcTemplate;
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManager.java
@@ -152,7 +152,7 @@ public class JdbcAnalyticsManager implements AnalyticsManager {
 
   private final QueryPlanner queryPlanner;
 
-  @Qualifier("readOnlyJdbcTemplate")
+  @Qualifier("analyticsReadOnlyJdbcTemplate")
   private final JdbcTemplate jdbcTemplate;
 
   private final ExecutionPlanStore executionPlanStore;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcRawAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcRawAnalyticsManager.java
@@ -73,7 +73,7 @@ import org.springframework.util.Assert;
 public class JdbcRawAnalyticsManager implements RawAnalyticsManager {
   private static final String DIM_NAME_OU = "ou.path";
 
-  @Qualifier("readOnlyJdbcTemplate")
+  @Qualifier("analyticsReadOnlyJdbcTemplate")
   private final JdbcTemplate jdbcTemplate;
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -232,6 +232,8 @@ public class EventQueryParams extends DataQueryParams {
 
   @Getter protected EndpointAction endpointAction;
 
+  @Getter protected boolean multipleQueries = false;
+
   // -------------------------------------------------------------------------
   // Constructors
   // -------------------------------------------------------------------------
@@ -300,6 +302,7 @@ public class EventQueryParams extends DataQueryParams {
     params.endpointItem = this.endpointItem;
     params.endpointAction = this.endpointAction;
     params.rowContext = this.rowContext;
+    params.multipleQueries = this.multipleQueries;
     return params;
   }
 
@@ -1341,6 +1344,11 @@ public class EventQueryParams extends DataQueryParams {
 
     public Builder withRowContext(boolean rowContext) {
       this.params.rowContext = rowContext;
+      return this;
+    }
+
+    public Builder withMultipleQueries(boolean multipleQueries) {
+      this.params.multipleQueries = multipleQueries;
       return this;
     }
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -156,7 +156,7 @@ public abstract class AbstractJdbcEventAnalyticsManager {
 
   private static final Collector<CharSequence, ?, String> AND_JOINER = joining(AND);
 
-  @Qualifier("readOnlyJdbcTemplate")
+  @Qualifier("analyticsReadOnlyJdbcTemplate")
   protected final JdbcTemplate jdbcTemplate;
 
   protected final ProgramIndicatorService programIndicatorService;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -64,6 +64,7 @@ import static org.hisp.dhis.common.RequestTypeAware.EndpointItem.ENROLLMENT;
 import static org.hisp.dhis.commons.util.TextUtils.getCommaDelimitedString;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.isRelationDoesntExist;
 import static org.hisp.dhis.system.util.MathUtils.getRounded;
+import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -127,6 +128,7 @@ import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.jdbc.BadSqlGrammarException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.rowset.SqlRowSet;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Markus Bekken
@@ -511,6 +513,7 @@ public abstract class AbstractJdbcEventAnalyticsManager {
         .map(RepeatableStageParams::getDimension);
   }
 
+  @Transactional(readOnly = true, propagation = REQUIRES_NEW)
   public Grid getAggregatedEventData(EventQueryParams params, Grid grid, int maxLimit) {
     String aggregateClause = getAggregateClause(params);
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryPlanner.java
@@ -144,8 +144,28 @@ public class DefaultEventQueryPlanner implements EventQueryPlanner {
    */
   private List<EventQueryParams> withTableNameAndPartitions(List<EventQueryParams> queries) {
     List<EventQueryParams> list = new ArrayList<>();
-    queries.forEach(query -> list.add(withTableNameAndPartitions(query)));
+
+    boolean isMultipleQueries = queries.size() > 1;
+
+    queries.forEach(
+        query ->
+            list.add(withMultipleQueries(isMultipleQueries, withTableNameAndPartitions(query))));
+
     return list;
+  }
+
+  /**
+   * Sets the "multipleQueries" flag in EventParams and builds it
+   *
+   * @param isMultipleQueries flag to detect if multiple queries are to be run
+   * @param eventQueryParams the eventQueryParams template
+   * @return an eventQueryParams with proper "multipleQueries" flag set
+   */
+  private EventQueryParams withMultipleQueries(
+      boolean isMultipleQueries, EventQueryParams eventQueryParams) {
+    return new EventQueryParams.Builder(eventQueryParams)
+        .withMultipleQueries(isMultipleQueries)
+        .build();
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -77,6 +77,7 @@ import org.hisp.dhis.program.ProgramIndicatorService;
 import org.hisp.dhis.system.util.SqlUtils;
 import org.hisp.dhis.util.DateUtils;
 import org.locationtech.jts.util.Assert;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.jdbc.BadSqlGrammarException;
 import org.springframework.jdbc.InvalidResultSetAccessException;
@@ -120,7 +121,7 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
           "enrollmentstatus");
 
   public JdbcEnrollmentAnalyticsManager(
-      JdbcTemplate jdbcTemplate,
+      @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       ProgramIndicatorService programIndicatorService,
       ProgramIndicatorSubqueryBuilder programIndicatorSubqueryBuilder,
       EnrollmentTimeFieldSqlRenderer timeFieldSqlRenderer,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -92,6 +92,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.AnalyticsType;
 import org.hisp.dhis.program.ProgramIndicatorService;
 import org.postgresql.util.PSQLException;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.BadSqlGrammarException;
@@ -115,7 +116,7 @@ public class JdbcEventAnalyticsManager extends AbstractJdbcEventAnalyticsManager
   private final EventTimeFieldSqlRenderer timeFieldSqlRenderer;
 
   public JdbcEventAnalyticsManager(
-      JdbcTemplate jdbcTemplate,
+      @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       ProgramIndicatorService programIndicatorService,
       ProgramIndicatorSubqueryBuilder programIndicatorSubqueryBuilder,
       EventTimeFieldSqlRenderer timeFieldSqlRenderer,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/orgunit/data/JdbcOrgUnitAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/orgunit/data/JdbcOrgUnitAnalyticsManager.java
@@ -49,6 +49,7 @@ import org.hisp.dhis.common.QueryRuntimeException;
 import org.hisp.dhis.feedback.ErrorMessage;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroupSet;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.rowset.SqlRowSet;
 import org.springframework.stereotype.Service;
@@ -60,6 +61,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class JdbcOrgUnitAnalyticsManager implements OrgUnitAnalyticsManager {
   private final TableInfoReader tableInfoReader;
+
+  @Qualifier("analyticsJdbcTemplate")
   private final JdbcTemplate jdbcTemplate;
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/partition/JdbcPartitionManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/partition/JdbcPartitionManager.java
@@ -38,6 +38,7 @@ import org.hisp.dhis.analytics.AnalyticsTableType;
 import org.hisp.dhis.analytics.Partitions;
 import org.hisp.dhis.analytics.table.PartitionUtils;
 import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.event.EventListener;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
@@ -51,6 +52,7 @@ import org.springframework.stereotype.Service;
 public class JdbcPartitionManager implements PartitionManager {
   private Map<AnalyticsTableType, Set<String>> analyticsPartitions = new HashMap<>();
 
+  @Qualifier("analyticsJdbcTemplate")
   private final JdbcTemplate jdbcTemplate;
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
@@ -80,6 +80,7 @@ import org.hisp.dhis.system.database.DatabaseInfo;
 import org.hisp.dhis.system.util.MathUtils;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.util.ObjectUtils;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -128,7 +129,7 @@ public class JdbcAnalyticsTableManager extends AbstractJdbcTableManager {
       StatementBuilder statementBuilder,
       PartitionManager partitionManager,
       DatabaseInfo databaseInfo,
-      JdbcTemplate jdbcTemplate,
+      @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       AnalyticsExportSettings analyticsExportSettings,
       PeriodDataProvider periodDataProvider) {
     super(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManager.java
@@ -67,6 +67,7 @@ import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.database.DatabaseInfo;
 import org.hisp.dhis.util.DateUtils;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -87,7 +88,7 @@ public class JdbcCompletenessTableManager extends AbstractJdbcTableManager {
       StatementBuilder statementBuilder,
       PartitionManager partitionManager,
       DatabaseInfo databaseInfo,
-      JdbcTemplate jdbcTemplate,
+      @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       AnalyticsExportSettings analyticsExportSettings,
       PeriodDataProvider periodDataProvider) {
     super(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTargetTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTargetTableManager.java
@@ -62,6 +62,7 @@ import org.hisp.dhis.period.PeriodDataProvider;
 import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.database.DatabaseInfo;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -91,7 +92,7 @@ public class JdbcCompletenessTargetTableManager extends AbstractJdbcTableManager
       StatementBuilder statementBuilder,
       PartitionManager partitionManager,
       DatabaseInfo databaseInfo,
-      JdbcTemplate jdbcTemplate,
+      @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       AnalyticsExportSettings analyticsExportSettings,
       PeriodDataProvider periodDataProvider) {
     super(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
@@ -63,6 +63,7 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.database.DatabaseInfo;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -83,7 +84,7 @@ public class JdbcEnrollmentAnalyticsTableManager extends AbstractEventJdbcTableM
       StatementBuilder statementBuilder,
       PartitionManager partitionManager,
       DatabaseInfo databaseInfo,
-      JdbcTemplate jdbcTemplate,
+      @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       AnalyticsExportSettings analyticsExportSettings,
       PeriodDataProvider periodDataProvider) {
     super(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -83,6 +83,7 @@ import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.database.DatabaseInfo;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.util.DateUtils;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -111,7 +112,7 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
       StatementBuilder statementBuilder,
       PartitionManager partitionManager,
       DatabaseInfo databaseInfo,
-      JdbcTemplate jdbcTemplate,
+      @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       AnalyticsExportSettings analyticsExportSettings,
       PeriodDataProvider periodDataProvider) {
     super(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOrgUnitTargetTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOrgUnitTargetTableManager.java
@@ -57,6 +57,7 @@ import org.hisp.dhis.period.PeriodDataProvider;
 import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.database.DatabaseInfo;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -77,7 +78,7 @@ public class JdbcOrgUnitTargetTableManager extends AbstractJdbcTableManager {
       StatementBuilder statementBuilder,
       PartitionManager partitionManager,
       DatabaseInfo databaseInfo,
-      JdbcTemplate jdbcTemplate,
+      @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       AnalyticsExportSettings analyticsExportSettings,
       PeriodDataProvider periodDataProvider) {
     super(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManager.java
@@ -66,6 +66,7 @@ import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.database.DatabaseInfo;
 import org.hisp.quick.JdbcConfiguration;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -97,7 +98,7 @@ public class JdbcOwnershipAnalyticsTableManager extends AbstractEventJdbcTableMa
       StatementBuilder statementBuilder,
       PartitionManager partitionManager,
       DatabaseInfo databaseInfo,
-      JdbcTemplate jdbcTemplate,
+      @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       JdbcConfiguration jdbcConfiguration,
       AnalyticsExportSettings analyticsExportSettings,
       PeriodDataProvider periodDataProvider) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiAnalyticsTableManager.java
@@ -82,6 +82,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -107,7 +108,7 @@ public class JdbcTeiAnalyticsTableManager extends AbstractJdbcTableManager {
       StatementBuilder statementBuilder,
       PartitionManager partitionManager,
       DatabaseInfo databaseInfo,
-      JdbcTemplate jdbcTemplate,
+      @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       TrackedEntityTypeService trackedEntityTypeService,
       TrackedEntityAttributeService trackedEntityAttributeService,
       AnalyticsExportSettings settings,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiEnrollmentsAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiEnrollmentsAnalyticsTableManager.java
@@ -70,6 +70,7 @@ import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.database.DatabaseInfo;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -89,7 +90,7 @@ public class JdbcTeiEnrollmentsAnalyticsTableManager extends AbstractJdbcTableMa
       StatementBuilder statementBuilder,
       PartitionManager partitionManager,
       DatabaseInfo databaseInfo,
-      JdbcTemplate jdbcTemplate,
+      @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       TrackedEntityTypeService trackedEntityTypeService,
       AnalyticsExportSettings settings,
       PeriodDataProvider periodDataProvider) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiEventsAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiEventsAnalyticsTableManager.java
@@ -79,6 +79,7 @@ import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.database.DatabaseInfo;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -100,7 +101,7 @@ public class JdbcTeiEventsAnalyticsTableManager extends AbstractJdbcTableManager
       StatementBuilder statementBuilder,
       PartitionManager partitionManager,
       DatabaseInfo databaseInfo,
-      JdbcTemplate jdbcTemplate,
+      @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       TrackedEntityTypeService trackedEntityTypeService,
       AnalyticsExportSettings settings,
       PeriodDataProvider periodDataProvider) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcValidationResultTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcValidationResultTableManager.java
@@ -65,6 +65,7 @@ import org.hisp.dhis.resourcetable.ResourceTableService;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.database.DatabaseInfo;
 import org.hisp.dhis.util.DateUtils;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
@@ -91,7 +92,7 @@ public class JdbcValidationResultTableManager extends AbstractJdbcTableManager {
       StatementBuilder statementBuilder,
       PartitionManager partitionManager,
       DatabaseInfo databaseInfo,
-      JdbcTemplate jdbcTemplate,
+      @Qualifier("analyticsJdbcTemplate") JdbcTemplate jdbcTemplate,
       AnalyticsExportSettings analyticsExportSettings,
       PeriodDataProvider periodDataProvider) {
     super(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
@@ -114,7 +114,13 @@ public class AnalyticsUtils {
       Pattern.compile(DataQueryParams.PREFIX_ORG_UNIT_LEVEL + "(\\d+)");
 
   public static final String ERR_MSG_TABLE_NOT_EXISTING =
-      "Query failed, likely because the requested analytics table does not exist";
+      "Query failed, likely because the requested analytics table does not exist: ";
+
+  public static final String ERR_MSG_SQL_SYNTAX_ERROR =
+      "An error occurred during the execution of an analytics query: ";
+
+  public static final String ERR_MSG_SILENT_FALLBACK =
+      "An exception occurred - silently fallback since it's multiple analytics query: ";
 
   /**
    * Returns an SQL statement for retrieving raw data values for an aggregate query.

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/webmessage/WebMessageUtils.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/webmessage/WebMessageUtils.java
@@ -268,11 +268,20 @@ public final class WebMessageUtils {
   }
 
   public static ErrorCode getErrorCode(SQLException ex) {
-    String sqlState = Optional.of(ex).map(SQLException::getSQLState).orElse("");
-
-    if (StringUtils.isNotBlank(sqlState) && (sqlState.equals("42P01"))) {
+    if (isRelationDoesntExist(ex)) {
       return ErrorCode.E7144;
     }
     return ErrorCode.E7145;
+  }
+
+  /**
+   * Utility method to detect if the {@link SQLException} refers to a missing relation in the
+   * database
+   *
+   * @param ex a {@link SQLException} to analyze
+   * @return true if the error is a missing relation error, false otherwise
+   */
+  public static boolean isRelationDoesntExist(SQLException ex) {
+    return Optional.of(ex).map(SQLException::getSQLState).filter("42P01"::equals).isPresent();
   }
 }

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -82,14 +82,27 @@ public enum ConfigurationKey {
   /** JDBC driver class. */
   CONNECTION_DRIVER_CLASS("connection.driver_class", "org.postgresql.Driver", false),
 
+  /** Analytics JDBC driver class. */
+  ANALYTICS_CONNECTION_DRIVER_CLASS(
+      "analytics.connection.driver_class", "org.postgresql.Driver", false),
+
   /** Database connection URL. */
   CONNECTION_URL("connection.url", "", false),
+
+  /** Analytics Database connection URL. */
+  ANALYTICS_CONNECTION_URL("analytics.connection.url", "", false),
 
   /** Database username. */
   CONNECTION_USERNAME("connection.username", "", false),
 
+  /** Analytics Database username. */
+  ANALYTICS_CONNECTION_USERNAME("analytics.connection.username", "", false),
+
   /** Database password (sensitive). */
   CONNECTION_PASSWORD("connection.password", "", true),
+
+  /** Analytics Database password (sensitive). */
+  ANALYTICS_CONNECTION_PASSWORD("analytics.connection.password", "", true),
 
   /** Sets 'hibernate.cache.use_second_level_cache'. (default: true) */
   USE_SECOND_LEVEL_CACHE("hibernate.cache.use_second_level_cache", "true", false),
@@ -107,8 +120,16 @@ public enum ConfigurationKey {
   /** Max size of connection pool (default: 80). */
   CONNECTION_POOL_MAX_SIZE("connection.pool.max_size", "80", false),
 
+  /** Analytics Max size of connection pool (default: 80). */
+  ANALYTICS_CONNECTION_POOL_MAX_SIZE("analytics.connection.pool.max_size", "80", false),
+
   /** Minimum number of Connections a pool will maintain at any given time (default: 5). */
   CONNECTION_POOL_MIN_SIZE("connection.pool.min_size", "5", false),
+
+  /**
+   * Analytics Minimum number of Connections a pool will maintain at any given time (default: 5).
+   */
+  ANALYTICS_CONNECTION_POOL_MIN_SIZE("analytics.connection.pool.min_size", "5", false),
 
   /**
    * Number of Connections a pool will try to acquire upon startup. Should be between minPoolSize
@@ -117,10 +138,22 @@ public enum ConfigurationKey {
   CONNECTION_POOL_INITIAL_SIZE("connection.pool.initial_size", "5", false),
 
   /**
+   * Number of Connections a pool will try to acquire upon startup. Should be between minPoolSize
+   * and maxPoolSize. (default: 5).
+   */
+  ANALYTICS_CONNECTION_POOL_INITIAL_SIZE("analytics.connection.pool.initial_size", "5", false),
+
+  /**
    * Determines how many connections at a time will try to acquire when the pool is exhausted.
    * (default: 5).
    */
   CONNECTION_POOL_ACQUIRE_INCR("connection.pool.acquire_incr", "5", false),
+
+  /**
+   * Determines how many connections at a time will try to acquire when the pool is exhausted.
+   * (default: 5).
+   */
+  ANALYTICS_CONNECTION_POOL_ACQUIRE_INCR("analytics.connection.pool.acquire_incr", "5", false),
 
   /**
    * Seconds a Connection can remain pooled but unused before being discarded. Zero means idle
@@ -129,10 +162,23 @@ public enum ConfigurationKey {
   CONNECTION_POOL_MAX_IDLE_TIME("connection.pool.max_idle_time", "7200", false),
 
   /**
+   * Seconds a Connection can remain pooled but unused before being discarded. Zero means idle
+   * connections never expire (default: 7200).
+   */
+  ANALYTICS_CONNECTION_POOL_MAX_IDLE_TIME("analytics.connection.pool.max_idle_time", "7200", false),
+
+  /**
    * Number of seconds that Connections in excess of minPoolSize should be permitted to remain idle
    * in the pool before being culled (default: 0).
    */
   CONNECTION_POOL_MAX_IDLE_TIME_EXCESS_CON("connection.pool.max_idle_time_excess_con", "0", false),
+
+  /**
+   * Number of seconds that Connections in excess of minPoolSize should be permitted to remain idle
+   * in the pool before being culled (default: 0).
+   */
+  ANALYTICS_CONNECTION_POOL_MAX_IDLE_TIME_EXCESS_CON(
+      "analytics.connection.pool.max_idle_time_excess_con", "0", false),
 
   /**
    * If this is a number greater than 0, dhis2 will test all idle, pooled but unchecked-out
@@ -141,10 +187,24 @@ public enum ConfigurationKey {
   CONNECTION_POOL_IDLE_CON_TEST_PERIOD("connection.pool.idle.con.test.period", "0", false),
 
   /**
+   * If this is a number greater than 0, dhis2 will test all idle, pooled but unchecked-out
+   * connections, every this number of seconds (default: 0).
+   */
+  ANALYTICS_CONNECTION_POOL_IDLE_CON_TEST_PERIOD(
+      "analytics.connection.pool.idle.con.test.period", "0", false),
+
+  /**
    * If true, an operation will be performed at every connection checkout to verify that the
    * connection is valid (default: false).
    */
   CONNECTION_POOL_TEST_ON_CHECKOUT("connection.pool.test.on.checkout", Constants.OFF, false),
+
+  /**
+   * If true, an operation will be performed at every connection checkout to verify that the
+   * connection is valid (default: false).
+   */
+  ANALYTICS_CONNECTION_POOL_TEST_ON_CHECKOUT(
+      "analytics.connection.pool.test.on.checkout", Constants.OFF, false),
 
   /**
    * If true, an operation will be performed asynchronously at every connection checkin to verify
@@ -153,10 +213,24 @@ public enum ConfigurationKey {
   CONNECTION_POOL_TEST_ON_CHECKIN("connection.pool.test.on.checkin", Constants.ON, false),
 
   /**
+   * If true, an operation will be performed asynchronously at every connection checkin to verify
+   * that the connection is valid (default: true).
+   */
+  ANALYTICS_CONNECTION_POOL_TEST_ON_CHECKIN(
+      "analytics.connection.pool.test.on.checkin", Constants.ON, false),
+
+  /**
    * Hikari DB pool feature. Connection pool timeout: Set the maximum number of milliseconds that a
    * client will wait for a connection from the pool. (default: 30s)
    */
   CONNECTION_POOL_TIMEOUT("connection.pool.timeout", String.valueOf(SECONDS.toMillis(30)), false),
+
+  /**
+   * Analytics Hikari DB pool feature. Connection pool timeout: Set the maximum number of
+   * milliseconds that a client will wait for a connection from the pool. (default: 30s)
+   */
+  ANALYTICS_CONNECTION_POOL_TIMEOUT(
+      "analytics.connection.pool.timeout", String.valueOf(SECONDS.toMillis(30)), false),
 
   /**
    * Sets the maximum number of milliseconds that the Hikari pool will wait for a connection to be
@@ -165,8 +239,21 @@ public enum ConfigurationKey {
   CONNECTION_POOL_VALIDATION_TIMEOUT(
       "connection.pool.validation_timeout", String.valueOf(SECONDS.toMillis(5)), false),
 
+  /**
+   * Sets the maximum number of milliseconds that the Analytics Hikari pool will wait for a
+   * connection to be validated as alive. (default: 5ms)
+   */
+  ANALYTICS_CONNECTION_POOL_VALIDATION_TIMEOUT(
+      "analytics.connection.pool.validation_timeout", String.valueOf(SECONDS.toMillis(5)), false),
+
   /** Configure the number of helper threads used by C3P0 pool for jdbc operations (default: 3). */
   CONNECTION_POOL_NUM_THREADS("connection.pool.num.helper.threads", "3", false),
+
+  /**
+   * Configure the number of helper threads used by Analytics C3P0 pool for jdbc operations
+   * (default: 3).
+   */
+  ANALYTICS_CONNECTION_POOL_NUM_THREADS("analytics.connection.pool.num.helper.threads", "3", false),
 
   /**
    * Defines the query that will be executed for all connection tests. Ideally this config is not
@@ -174,6 +261,9 @@ public enum ConfigurationKey {
    * simply for evaluation, do not use it unless there is a reason to.
    */
   CONNECTION_POOL_TEST_QUERY("connection.pool.preferred.test.query"),
+
+  /** Defines the query that will be executed for all Analytics connection tests. */
+  ANALYTICS_CONNECTION_POOL_TEST_QUERY("analytics.connection.pool.preferred.test.query"),
 
   /** LDAP server URL. (default: ldaps://0:1) */
   LDAP_URL("ldap.url", "ldaps://0:1", false),

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/AnalyticsDataSourceConfig.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/AnalyticsDataSourceConfig.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.config;
+
+import static org.hisp.dhis.config.DataSourceConfig.getActualDataSource;
+import static org.hisp.dhis.config.DataSourceConfig.getDataSource;
+
+import com.google.common.base.MoreObjects;
+import javax.sql.DataSource;
+import org.hisp.dhis.datasource.DefaultReadOnlyDataSourceManager;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.hibernate.HibernateConfigurationProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+@Configuration
+public class AnalyticsDataSourceConfig {
+
+  @Bean("analyticsDataSource")
+  @DependsOn("analyticsActualDataSource")
+  public DataSource jdbcDataSource(
+      DhisConfigurationProvider dhisConfig,
+      @Qualifier("analyticsActualDataSource") DataSource actualDataSource) {
+    return getDataSource(dhisConfig, actualDataSource);
+  }
+
+  @Bean("analyticsActualDataSource")
+  public DataSource jdbcActualDataSource(
+      DhisConfigurationProvider dhisConfig,
+      HibernateConfigurationProvider hibernateConfigurationProvider) {
+    return getActualDataSource(dhisConfig, hibernateConfigurationProvider);
+  }
+
+  @Bean("analyticsNamedParameterJdbcTemplate")
+  @DependsOn("analyticsDataSource")
+  public NamedParameterJdbcTemplate namedParameterJdbcTemplate(
+      @Qualifier("analyticsDataSource") DataSource dataSource) {
+    return new NamedParameterJdbcTemplate(dataSource);
+  }
+
+  @Bean("executionPlanJdbcTemplate")
+  @DependsOn("analyticsDataSource")
+  public JdbcTemplate executionPlanJdbcTemplate(
+      @Qualifier("analyticsDataSource") DataSource dataSource) {
+    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+    jdbcTemplate.setFetchSize(1000);
+    jdbcTemplate.setQueryTimeout(10);
+    return jdbcTemplate;
+  }
+
+  @Bean("analyticsReadOnlyJdbcTemplate")
+  @DependsOn("analyticsDataSource")
+  public JdbcTemplate readOnlyJdbcTemplate(
+      DhisConfigurationProvider dhisConfig,
+      @Qualifier("analyticsDataSource") DataSource dataSource) {
+    DefaultReadOnlyDataSourceManager manager = new DefaultReadOnlyDataSourceManager(dhisConfig);
+
+    JdbcTemplate jdbcTemplate =
+        new JdbcTemplate(MoreObjects.firstNonNull(manager.getReadOnlyDataSource(), dataSource));
+    jdbcTemplate.setFetchSize(1000);
+
+    return jdbcTemplate;
+  }
+
+  @Bean("analyticsJdbcTemplate")
+  @DependsOn("analyticsDataSource")
+  public JdbcTemplate jdbcTemplate(@Qualifier("analyticsDataSource") DataSource dataSource) {
+    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+    jdbcTemplate.setFetchSize(1000);
+    return jdbcTemplate;
+  }
+}

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/datasource/DatabasePoolUtils.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/datasource/DatabasePoolUtils.java
@@ -27,7 +27,45 @@
  */
 package org.hisp.dhis.datasource;
 
-import com.google.common.base.MoreObjects;
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static java.lang.Integer.parseInt;
+import static java.lang.Long.parseLong;
+import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_CONNECTION_DRIVER_CLASS;
+import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_CONNECTION_PASSWORD;
+import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_CONNECTION_POOL_ACQUIRE_INCR;
+import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_CONNECTION_POOL_IDLE_CON_TEST_PERIOD;
+import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_CONNECTION_POOL_INITIAL_SIZE;
+import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_CONNECTION_POOL_MAX_IDLE_TIME;
+import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_CONNECTION_POOL_MAX_IDLE_TIME_EXCESS_CON;
+import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_CONNECTION_POOL_MAX_SIZE;
+import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_CONNECTION_POOL_MIN_SIZE;
+import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_CONNECTION_POOL_NUM_THREADS;
+import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_CONNECTION_POOL_TEST_ON_CHECKIN;
+import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_CONNECTION_POOL_TEST_ON_CHECKOUT;
+import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_CONNECTION_POOL_TEST_QUERY;
+import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_CONNECTION_POOL_TIMEOUT;
+import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_CONNECTION_POOL_VALIDATION_TIMEOUT;
+import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_CONNECTION_URL;
+import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_CONNECTION_USERNAME;
+import static org.hisp.dhis.external.conf.ConfigurationKey.CONNECTION_DRIVER_CLASS;
+import static org.hisp.dhis.external.conf.ConfigurationKey.CONNECTION_PASSWORD;
+import static org.hisp.dhis.external.conf.ConfigurationKey.CONNECTION_POOL_ACQUIRE_INCR;
+import static org.hisp.dhis.external.conf.ConfigurationKey.CONNECTION_POOL_IDLE_CON_TEST_PERIOD;
+import static org.hisp.dhis.external.conf.ConfigurationKey.CONNECTION_POOL_INITIAL_SIZE;
+import static org.hisp.dhis.external.conf.ConfigurationKey.CONNECTION_POOL_MAX_IDLE_TIME;
+import static org.hisp.dhis.external.conf.ConfigurationKey.CONNECTION_POOL_MAX_IDLE_TIME_EXCESS_CON;
+import static org.hisp.dhis.external.conf.ConfigurationKey.CONNECTION_POOL_MAX_SIZE;
+import static org.hisp.dhis.external.conf.ConfigurationKey.CONNECTION_POOL_MIN_SIZE;
+import static org.hisp.dhis.external.conf.ConfigurationKey.CONNECTION_POOL_NUM_THREADS;
+import static org.hisp.dhis.external.conf.ConfigurationKey.CONNECTION_POOL_TEST_ON_CHECKIN;
+import static org.hisp.dhis.external.conf.ConfigurationKey.CONNECTION_POOL_TEST_ON_CHECKOUT;
+import static org.hisp.dhis.external.conf.ConfigurationKey.CONNECTION_POOL_TEST_QUERY;
+import static org.hisp.dhis.external.conf.ConfigurationKey.CONNECTION_POOL_TIMEOUT;
+import static org.hisp.dhis.external.conf.ConfigurationKey.CONNECTION_POOL_VALIDATION_TIMEOUT;
+import static org.hisp.dhis.external.conf.ConfigurationKey.CONNECTION_URL;
+import static org.hisp.dhis.external.conf.ConfigurationKey.CONNECTION_USERNAME;
+
+import com.google.common.collect.ImmutableMap;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -35,10 +73,14 @@ import java.beans.PropertyVetoException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import javax.sql.DataSource;
 import lombok.Builder;
 import lombok.Data;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.external.conf.ConfigurationKey;
@@ -50,6 +92,48 @@ import org.hisp.dhis.hibernate.HibernateConfigurationProvider;
  */
 @Slf4j
 public class DatabasePoolUtils {
+
+  /**
+   * This enums maps each database config key into a corresponding analytics config key. This is
+   * used to allow the analytics database to be configured separately from the main database.
+   */
+  @RequiredArgsConstructor
+  public enum ConfigKeyMapper {
+    ANALYTICS(
+        ImmutableMap.<ConfigurationKey, ConfigurationKey>builder()
+            /* common keys for all connection pools */
+            .put(CONNECTION_URL, ANALYTICS_CONNECTION_URL)
+            .put(CONNECTION_USERNAME, ANALYTICS_CONNECTION_USERNAME)
+            .put(CONNECTION_PASSWORD, ANALYTICS_CONNECTION_PASSWORD)
+            .put(CONNECTION_DRIVER_CLASS, ANALYTICS_CONNECTION_DRIVER_CLASS)
+            .put(CONNECTION_POOL_MAX_SIZE, ANALYTICS_CONNECTION_POOL_MAX_SIZE)
+            .put(CONNECTION_POOL_TEST_QUERY, ANALYTICS_CONNECTION_POOL_TEST_QUERY)
+            /* hikari-specific */
+            .put(CONNECTION_POOL_TIMEOUT, ANALYTICS_CONNECTION_POOL_TIMEOUT)
+            .put(CONNECTION_POOL_VALIDATION_TIMEOUT, ANALYTICS_CONNECTION_POOL_VALIDATION_TIMEOUT)
+            /* C3P0-specific */
+            .put(CONNECTION_POOL_ACQUIRE_INCR, ANALYTICS_CONNECTION_POOL_ACQUIRE_INCR)
+            .put(CONNECTION_POOL_MAX_IDLE_TIME, ANALYTICS_CONNECTION_POOL_MAX_IDLE_TIME)
+            .put(CONNECTION_POOL_MIN_SIZE, ANALYTICS_CONNECTION_POOL_MIN_SIZE)
+            .put(CONNECTION_POOL_INITIAL_SIZE, ANALYTICS_CONNECTION_POOL_INITIAL_SIZE)
+            .put(CONNECTION_POOL_TEST_ON_CHECKIN, ANALYTICS_CONNECTION_POOL_TEST_ON_CHECKIN)
+            .put(CONNECTION_POOL_TEST_ON_CHECKOUT, ANALYTICS_CONNECTION_POOL_TEST_ON_CHECKOUT)
+            .put(
+                CONNECTION_POOL_MAX_IDLE_TIME_EXCESS_CON,
+                ANALYTICS_CONNECTION_POOL_MAX_IDLE_TIME_EXCESS_CON)
+            .put(
+                CONNECTION_POOL_IDLE_CON_TEST_PERIOD,
+                ANALYTICS_CONNECTION_POOL_IDLE_CON_TEST_PERIOD)
+            .put(CONNECTION_POOL_NUM_THREADS, ANALYTICS_CONNECTION_POOL_NUM_THREADS)
+            .build()),
+    POSTGRESQL(Collections.emptyMap());
+
+    private final Map<ConfigurationKey, ConfigurationKey> keyMap;
+
+    public ConfigurationKey getConfigKey(ConfigurationKey key) {
+      return keyMap.getOrDefault(key, key);
+    }
+  }
 
   public enum dbPoolTypes {
     C3P0,
@@ -76,6 +160,12 @@ public class DatabasePoolUtils {
     private String acquireIncrement;
 
     private String maxIdleTime;
+
+    private ConfigKeyMapper mapper;
+
+    public ConfigKeyMapper getMapper() {
+      return Optional.ofNullable(mapper).orElse(ConfigKeyMapper.POSTGRESQL);
+    }
   }
 
   public static DataSource createDbPool(PoolConfig config)
@@ -99,30 +189,39 @@ public class DatabasePoolUtils {
     throw new IllegalArgumentException(msg);
   }
 
-  public static DataSource createHikariDbPool(PoolConfig config) throws SQLException {
+  private static DataSource createHikariDbPool(PoolConfig config) throws SQLException {
+    ConfigKeyMapper mapper = config.getMapper();
+
     DhisConfigurationProvider dhisConfig = config.getDhisConfig();
 
-    final String driverClassName = dhisConfig.getProperty(ConfigurationKey.CONNECTION_DRIVER_CLASS);
+    final String driverClassName =
+        dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_DRIVER_CLASS));
+
     final String jdbcUrl =
-        MoreObjects.firstNonNull(
-            config.getJdbcUrl(), dhisConfig.getProperty(ConfigurationKey.CONNECTION_URL));
+        firstNonNull(
+            config.getJdbcUrl(), dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_URL)));
+
     final String username =
-        MoreObjects.firstNonNull(
-            config.getUsername(), dhisConfig.getProperty(ConfigurationKey.CONNECTION_USERNAME));
+        firstNonNull(
+            config.getUsername(), dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_USERNAME)));
+
     final String password =
-        MoreObjects.firstNonNull(
-            config.getPassword(), dhisConfig.getProperty(ConfigurationKey.CONNECTION_PASSWORD));
+        firstNonNull(
+            config.getPassword(), dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_PASSWORD)));
+
     final long connectionTimeout =
-        Long.parseLong(dhisConfig.getProperty(ConfigurationKey.CONNECTION_POOL_TIMEOUT));
+        parseLong(dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_POOL_TIMEOUT)));
     final long validationTimeout =
-        Long.parseLong(dhisConfig.getProperty(ConfigurationKey.CONNECTION_POOL_VALIDATION_TIMEOUT));
+        parseLong(dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_POOL_VALIDATION_TIMEOUT)));
+
     final int maxPoolSize =
         Integer.parseInt(
-            MoreObjects.firstNonNull(
+            firstNonNull(
                 config.getMaxPoolSize(),
-                dhisConfig.getProperty(ConfigurationKey.CONNECTION_POOL_MAX_SIZE)));
+                dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_POOL_MAX_SIZE))));
+
     final String connectionTestQuery =
-        dhisConfig.getProperty(ConfigurationKey.CONNECTION_POOL_TEST_QUERY);
+        dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_POOL_TEST_QUERY));
 
     HikariConfig hc = new HikariConfig();
     hc.setPoolName("HikariDataSource_" + CodeGenerator.generateCode(10));
@@ -145,53 +244,56 @@ public class DatabasePoolUtils {
     return ds;
   }
 
-  public static DataSource createC3p0DbPool(PoolConfig config)
+  private static DataSource createC3p0DbPool(PoolConfig config)
       throws PropertyVetoException, SQLException {
+    ConfigKeyMapper mapper = config.getMapper();
+
     DhisConfigurationProvider dhisConfig = config.getDhisConfig();
 
-    final String driverClassName = dhisConfig.getProperty(ConfigurationKey.CONNECTION_DRIVER_CLASS);
+    final String driverClassName =
+        dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_DRIVER_CLASS));
     final String jdbcUrl =
-        MoreObjects.firstNonNull(
-            config.getJdbcUrl(), dhisConfig.getProperty(ConfigurationKey.CONNECTION_URL));
+        firstNonNull(
+            config.getJdbcUrl(), dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_URL)));
     final String username =
-        MoreObjects.firstNonNull(
-            config.getUsername(), dhisConfig.getProperty(ConfigurationKey.CONNECTION_USERNAME));
+        firstNonNull(
+            config.getUsername(), dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_USERNAME)));
     final String password =
-        MoreObjects.firstNonNull(
-            config.getPassword(), dhisConfig.getProperty(ConfigurationKey.CONNECTION_PASSWORD));
+        firstNonNull(
+            config.getPassword(), dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_PASSWORD)));
     final int maxPoolSize =
-        Integer.parseInt(
-            MoreObjects.firstNonNull(
+        parseInt(
+            firstNonNull(
                 config.getMaxPoolSize(),
-                dhisConfig.getProperty(ConfigurationKey.CONNECTION_POOL_MAX_SIZE)));
+                dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_POOL_MAX_SIZE))));
     final int acquireIncrement =
-        Integer.parseInt(
-            MoreObjects.firstNonNull(
+        parseInt(
+            firstNonNull(
                 config.getAcquireIncrement(),
-                dhisConfig.getProperty(ConfigurationKey.CONNECTION_POOL_ACQUIRE_INCR)));
+                dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_POOL_ACQUIRE_INCR))));
     final int maxIdleTime =
-        Integer.parseInt(
-            MoreObjects.firstNonNull(
+        parseInt(
+            firstNonNull(
                 config.maxIdleTime,
-                dhisConfig.getProperty(ConfigurationKey.CONNECTION_POOL_MAX_IDLE_TIME)));
+                dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_POOL_MAX_IDLE_TIME))));
 
     final int minPoolSize =
-        Integer.parseInt(dhisConfig.getProperty(ConfigurationKey.CONNECTION_POOL_MIN_SIZE));
+        parseInt(dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_POOL_MIN_SIZE)));
     final int initialSize =
-        Integer.parseInt(dhisConfig.getProperty(ConfigurationKey.CONNECTION_POOL_INITIAL_SIZE));
-    boolean testOnCheckIn = dhisConfig.isEnabled(ConfigurationKey.CONNECTION_POOL_TEST_ON_CHECKIN);
+        parseInt(dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_POOL_INITIAL_SIZE)));
+    boolean testOnCheckIn =
+        dhisConfig.isEnabled(mapper.getConfigKey(CONNECTION_POOL_TEST_ON_CHECKIN));
     boolean testOnCheckOut =
-        dhisConfig.isEnabled(ConfigurationKey.CONNECTION_POOL_TEST_ON_CHECKOUT);
+        dhisConfig.isEnabled(mapper.getConfigKey(CONNECTION_POOL_TEST_ON_CHECKOUT));
     final int maxIdleTimeExcessConnections =
-        Integer.parseInt(
-            dhisConfig.getProperty(ConfigurationKey.CONNECTION_POOL_MAX_IDLE_TIME_EXCESS_CON));
+        parseInt(
+            dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_POOL_MAX_IDLE_TIME_EXCESS_CON)));
     final int idleConnectionTestPeriod =
-        Integer.parseInt(
-            dhisConfig.getProperty(ConfigurationKey.CONNECTION_POOL_IDLE_CON_TEST_PERIOD));
+        parseInt(dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_POOL_IDLE_CON_TEST_PERIOD)));
     final String preferredTestQuery =
-        dhisConfig.getProperty(ConfigurationKey.CONNECTION_POOL_TEST_QUERY);
+        dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_POOL_TEST_QUERY));
     final int numHelperThreads =
-        Integer.parseInt(dhisConfig.getProperty(ConfigurationKey.CONNECTION_POOL_NUM_THREADS));
+        parseInt(dhisConfig.getProperty(mapper.getConfigKey(CONNECTION_POOL_NUM_THREADS)));
 
     ComboPooledDataSource dataSource = new ComboPooledDataSource();
     dataSource.setDriverClass(driverClassName);

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/aggregate/AnalyticsQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/aggregate/AnalyticsQueryTest.java
@@ -199,4 +199,21 @@ public class AnalyticsQueryTest extends AnalyticsApiTest {
             "202210",
             "Cholera is an infection of the small intestine caused by the bacterium Vibrio cholerae.\n\nThe main symptoms are watery diarrhea and vomiting. This may result in dehydration and in severe cases grayish-bluish skin.[1] Transmission occurs primarily by drinking water or eating food that has been contaminated by the feces (waste product) of an infected person, including one with no apparent symptoms.\n\nThe severity of the diarrhea and vomiting can lead to rapid dehydration and electrolyte imbalance, and death in some cases. The primary treatment is oral rehydration therapy, typically with oral rehydration solution, to replace water and electrolytes. If this is not tolerated or does not provide improvement fast enough, intravenous fluids can also be used. Antibacterial drugs are beneficial in those with severe disease to shorten its duration and severity."));
   }
+
+  @Test
+  public void testQueryFailsGracefullyIfMultipleQueries() {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add(
+                "dimension=cX5k9anHEHd:apsOixVZlf1;jRbMi0aBjYn,dx:luLGbE2WKGP;nq5ohBSWj6E,pe:LAST_12_MONTHS")
+            .add("filter=ou:USER_ORGUNIT")
+            .add("displayProperty=SHORTNAME");
+
+    // When
+    ApiResponse response = analyticsActions.get(params);
+
+    // Then
+    response.validate().statusCode(200);
+  }
 }

--- a/dhis-2/dhis-test-web-api/pom.xml
+++ b/dhis-2/dhis-test-web-api/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-service-core</artifactId>
-      <scope>compile</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hisp.dhis</groupId>
@@ -334,6 +334,11 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/WebTestConfiguration.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/WebTestConfiguration.java
@@ -35,6 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.association.jdbc.JdbcOrgUnitAssociationStoreConfiguration;
 import org.hisp.dhis.commons.jackson.config.JacksonObjectMapperConfig;
 import org.hisp.dhis.commons.util.DebugUtils;
+import org.hisp.dhis.config.AnalyticsDataSourceConfig;
 import org.hisp.dhis.config.DataSourceConfig;
 import org.hisp.dhis.config.HibernateConfig;
 import org.hisp.dhis.config.HibernateEncryptionConfig;
@@ -54,6 +55,7 @@ import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.security.SystemAuthoritiesProvider;
 import org.hisp.dhis.webapi.mvc.ContentNegotiationConfig;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.ComponentScan.Filter;
@@ -63,6 +65,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.ImportResource;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.annotation.Order;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
 import org.springframework.security.authentication.event.AuthenticationFailureBadCredentialsEvent;
@@ -93,6 +96,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Import({
   HibernateConfig.class,
   DataSourceConfig.class,
+  AnalyticsDataSourceConfig.class,
   JdbcConfig.class,
   FlywayConfig.class,
   HibernateEncryptionConfig.class,
@@ -125,7 +129,14 @@ public class WebTestConfiguration {
 
   @Autowired private DhisConfigurationProvider dhisConfigurationProvider;
 
-  @Bean("dataSource")
+  @Bean(name = {"namedParameterJdbcTemplate", "analyticsNamedParameterJdbcTemplate"})
+  @Primary
+  public NamedParameterJdbcTemplate namedParameterJdbcTemplate(
+      @Qualifier("dataSource") DataSource dataSource) {
+    return new NamedParameterJdbcTemplate(dataSource);
+  }
+
+  @Bean(name = {"dataSource", "analyticsDataSource"})
   @Primary
   public DataSource actualDataSource(
       HibernateConfigurationProvider hibernateConfigurationProvider) {


### PR DESCRIPTION
When we mix Hibernate and Spring JdbcTemplate code in the same flow, we end up having the same connection/transaction used for both.
While I can't see any advantage of doing so (since we can always propagate an exception in jdbcTemplate to have the hibernate session rollback), we have indeed issues when we want to gracefully handle jdbcTemplate exception without a rollback.
This is impossible in the current scenario due to the fact that springs detects any exception thrown during the flow, even if they are gracefully caught, and marks the transaction as rollback.
To avoid this side effect, we need to separate the data source used by spring and the one used by hibernate (just analytics).
In this PR we create an analyticsJdbcTemplate dedicated datasource, and we also add a flag to detect if multiple analytics queries are running.