### PR TITLE
fix: program stage field in event query select duplicate [DHIS2-15899]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -1036,7 +1036,7 @@ public class JdbcEventStore implements EventStore {
             .append("select ")
             .append(getEventSelectIdentifiersByIdScheme(params))
             .append(" psi.uid as psi_uid, ")
-            .append("ou.uid as ou_uid, p.uid as p_uid, ps.uid as ps_uid, ")
+            .append("ou.uid as ou_uid, p.uid as p_uid, ")
             .append(
                 "psi.programstageinstanceid as psi_id, psi.status as psi_status, psi.executiondate as psi_executiondate, ")
             .append(

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/Constants.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/Constants.java
@@ -56,7 +56,7 @@ public class Constants {
       new Program()
           .setUid("f1AyMswryyQ")
           .setTrackedEntityType(Constants.TRACKED_ENTITY_TYPE)
-          .setProgramStages(Arrays.asList("PaOOjwLVW23", "nlXNK4b7LVr"));
+          .setProgramStages(Arrays.asList("PaOOjwLVW23", "nlXNK4b7LVr", "xaOOjwLVW23"));
 
   public static String TRACKER_PROGRAM_ID = "f1AyMswryyQ"; // todo: remove and
   // use

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/importer/TrackerExportTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/importer/TrackerExportTests.java
@@ -474,7 +474,7 @@ public class TrackerExportTests extends TrackerNtiApiTest {
             .extractList("instances.programStage.flatten()");
 
     assertEquals(
-        List.of("nlXNK4b7LVr", "PaOOjwLVW23"),
+        List.of("nlXNK4b7LVr", "xaOOjwLVW23"),
         actualPsList,
         "Program Stage are not in the correct order");
   }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/importer/TrackerExportTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/importer/TrackerExportTests.java
@@ -457,6 +457,29 @@ public class TrackerExportTests extends TrackerNtiApiTest {
   }
 
   @Test
+  public void
+      shouldReturnProgramStageListOrderedByProgramStageAscWhenFieldsAndOrderEqualToProgramStage() {
+    TrackerApiResponse response =
+        trackerActions
+            .postAndGetJobReport(
+                teiWithEnrollmentAndEventsTemplate, new QueryParamsBuilder().add("async=false"))
+            .validateSuccessfulImport();
+
+    List<String> actualPsList =
+        trackerActions
+            .get(
+                "events?order=programStage&fields=programStage&program=f1AyMswryyQ&event=ZwwuwNp6gVd;"
+                    + response.extractImportedEvents().get(0))
+            .validateStatus(200)
+            .extractList("instances.programStage.flatten()");
+
+    assertEquals(
+        List.of("nlXNK4b7LVr", "PaOOjwLVW23"),
+        actualPsList,
+        "Program Stage are not in the correct order");
+  }
+
+  @Test
   void getTeiByPotentialDuplicateParamNull() {
     ApiResponse response = teiActions.get(teiParamsBuilder());
 

--- a/dhis-2/dhis-test-e2e/src/test/resources/setup/tracker_metadata.json
+++ b/dhis-2/dhis-test-e2e/src/test/resources/setup/tracker_metadata.json
@@ -423,6 +423,9 @@
         },
         {
           "id": "PaOOjwLVW23"
+        },
+        {
+          "id": "xaOOjwLVW23"
         }
       ]
     },
@@ -1134,6 +1137,84 @@
           },
           "dataElement": {
             "id": "z3Z4TD3oBCP"
+          },
+          "sharing": {
+            "userGroups": {},
+            "external": false,
+            "users": {}
+          },
+          "favorites": [],
+          "translations": [],
+          "attributeValues": []
+        }
+      ],
+      "translations": [],
+      "attributeValues": [],
+      "programStageSections": []
+    },
+    {
+      "code": "TA_TRACKER_PROGRAM_THIRD_STAGE",
+      "lastUpdated": "2022-01-07T12:50:38.506",
+      "id": "xaOOjwLVW23",
+      "created": "2022-01-07T11:57:37.577",
+      "name": "TA third stage - repeatable",
+      "allowGenerateNextVisit": false,
+      "preGenerateUID": false,
+      "openAfterEnrollment": false,
+      "repeatable": true,
+      "remindCompleted": false,
+      "displayGenerateEventBox": true,
+      "generatedByEnrollmentDate": false,
+      "validationStrategy": "ON_COMPLETE",
+      "autoGenerateEvent": false,
+      "sortOrder": 2,
+      "hideDueDate": false,
+      "blockEntryForm": false,
+      "enableUserAssignment": false,
+      "minDaysFromStart": 3,
+      "program": {
+        "id": "f1AyMswryyQ"
+      },
+      "sharing": {
+        "owner": "M5zQapPyTZI",
+        "userGroups": {
+          "OPVIvvXzNTw": {
+            "access": "rwrw----",
+            "id": "OPVIvvXzNTw"
+          }
+        },
+        "external": false,
+        "public": "rwrw----",
+        "users": {}
+      },
+      "notificationTemplates": [],
+      "programStageDataElements": [
+        {
+          "lastUpdated": "2022-01-07T12:50:38.507",
+          "id": "fACOFO8XvbY",
+          "created": "2022-01-07T12:50:38.507",
+          "displayInReports": false,
+          "skipSynchronization": false,
+          "renderOptionsAsRadio": false,
+          "skipAnalytics": false,
+          "allowFutureDate": false,
+          "compulsory": false,
+          "allowProvidedElsewhere": false,
+          "sortOrder": 1,
+          "favorite": false,
+          "access": {
+            "read": true,
+            "update": true,
+            "externalize": true,
+            "write": true,
+            "delete": true,
+            "manage": true
+          },
+          "programStage": {
+            "id": "xaOOjwLVW23"
+          },
+          "dataElement": {
+            "id": "mB2QHw1tU96"
           },
           "sharing": {
             "userGroups": {},

--- a/dhis-2/dhis-test-e2e/src/test/resources/tracker/importer/teis/teiWithEnrollmentAndEventsNested.json
+++ b/dhis-2/dhis-test-e2e/src/test/resources/tracker/importer/teis/teiWithEnrollmentAndEventsNested.json
@@ -19,7 +19,7 @@
             {
               "scheduledAt": "2019-08-19T13:59:13.688",
               "program": "f1AyMswryyQ",
-              "programStage": "PaOOjwLVW23",
+              "programStage": "xaOOjwLVW23",
               "orgUnit": "O6uvpzGd5pu",
               "enrollmentStatus": "ACTIVE",
               "status": "ACTIVE",

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -107,6 +107,8 @@ class EventExporterTest extends TrackerTest {
 
   private ProgramStage programStage;
 
+  private ProgramStage programStage1;
+
   private Program program;
 
   final Function<EventQueryParams, List<String>> eventsFunction =
@@ -135,6 +137,7 @@ class EventExporterTest extends TrackerTest {
             fromJson("tracker/event_and_enrollment.json", importUser.getUid())));
     orgUnit = get(OrganisationUnit.class, "h4w96yEMlzO");
     programStage = get(ProgramStage.class, "NpsdDv6kKSO");
+    programStage1 = get(ProgramStage.class, "qLZC0lvvxQH");
     program = programStage.getProgram();
     trackedEntityInstance = get(TrackedEntityInstance.class, "dUE514NMOlo");
 
@@ -1449,6 +1452,24 @@ class EventExporterTest extends TrackerTest {
                 String.format(
                     "Expected %s to be in %s", event.getDueDate(), "2019-01-28T12:32:38.100")),
         () -> assertHasTimeStamp(event.getCompletedDate()));
+  }
+
+  @Test
+  void testExportEventsWithProgramStageOrder() {
+
+    EventQueryParams params = new EventQueryParams();
+
+    params.setEvents(Set.of("pTzf9KYMk72", "QRYjLTiJTrA"));
+    params.addOrders(List.of(new OrderParam("programStage", SortDirection.ASC)));
+
+    Events events = eventService.getEvents(params);
+
+    assertNotEmpty(events.getEvents());
+
+    assertEquals(
+        List.of("NpsdDv6kKSO", "qLZC0lvvxQH"),
+        events.getEvents().stream().map(Event::getProgramStage).collect(Collectors.toList()),
+        "Program Stage are not in the correct order");
   }
 
   private void assertNote(User expectedLastUpdatedBy, String expectedNote, Note actual) {


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-15899
Remove the duplicated ps field in the query select statement.
The Integration test is case sensitive differently to the one in e2e due to using a different collation 
Notice that the integration test will fail if we set a default C collation for all tests as agreed see [PR](https://github.com/dhis2/dhis2-core/pull/15388)