### PR TITLE
fix: Validate search scope in tracked entities requests [TECH-1631]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/OperationsParamsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/OperationsParamsValidator.java
@@ -27,25 +27,14 @@
  */
 package org.hisp.dhis.tracker.export;
 
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
 import static org.hisp.dhis.security.Authorities.F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.feedback.BadRequestException;
-import org.hisp.dhis.feedback.ForbiddenException;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.user.User;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -106,105 +95,5 @@ public class OperationsParamsValidator {
     } else if (user.getOrganisationUnits().isEmpty()) {
       throw new BadRequestException("User needs to be assigned data capture orgunits");
     }
-  }
-
-  /**
-   * Returns a list of all the org units the user has access to
-   *
-   * @param user the user to check the access of
-   * @param orgUnits parent org units to get descendants/children of
-   * @param orgUnitDescendants function to retrieve org units, in case ou mode is descendants
-   * @param program the program the user wants to access to
-   * @return a list containing the user accessible organisation units
-   * @throws ForbiddenException if the user has no access to any of the provided org units
-   */
-  public static Set<OrganisationUnit> validateAccessibleOrgUnits(
-      User user,
-      Set<OrganisationUnit> orgUnits,
-      OrganisationUnitSelectionMode orgUnitMode,
-      Program program,
-      Function<String, List<OrganisationUnit>> orgUnitDescendants,
-      TrackerAccessManager trackerAccessManager)
-      throws ForbiddenException {
-
-    Set<OrganisationUnit> accessibleOrgUnits = new HashSet<>();
-
-    for (OrganisationUnit orgUnit : orgUnits) {
-      Set<OrganisationUnit> accessibleOrgUnitsFound =
-          switch (orgUnitMode) {
-            case DESCENDANTS -> getAccessibleDescendants(
-                user, program, orgUnitDescendants.apply(orgUnit.getUid()));
-            case CHILDREN -> getAccessibleDescendants(
-                user,
-                program,
-                Stream.concat(Stream.of(orgUnit), orgUnit.getChildren().stream()).toList());
-            case SELECTED -> getSelectedOrgUnits(user, program, orgUnit, trackerAccessManager);
-            default -> Collections.emptySet();
-          };
-
-      if (accessibleOrgUnitsFound.isEmpty()) {
-        throw new ForbiddenException("User does not have access to orgUnit: " + orgUnit.getUid());
-      }
-
-      accessibleOrgUnits.addAll(accessibleOrgUnitsFound);
-    }
-
-    if (orgUnitMode == CAPTURE) {
-      return new HashSet<>(user.getOrganisationUnits());
-    } else if (orgUnitMode == ACCESSIBLE) {
-      return getAccessibleOrgUnits(user, program);
-    }
-
-    return accessibleOrgUnits;
-  }
-
-  /**
-   * Returns the org units whose path is contained in the user search or capture scope org unit. If
-   * there's a match, it means the user org unit is at the same level or above the supplied org
-   * unit.
-   *
-   * @param user the user to check the access of
-   * @param program the program the user wants to access to
-   * @param orgUnits the org units to check if the user has access to
-   * @return a list with the org units the user has access to
-   */
-  private static Set<OrganisationUnit> getAccessibleDescendants(
-      User user, Program program, List<OrganisationUnit> orgUnits) {
-    if (orgUnits.isEmpty()) {
-      return Collections.emptySet();
-    }
-
-    Set<OrganisationUnit> userOrgUnits =
-        isProgramAccessRestricted(program)
-            ? user.getOrganisationUnits()
-            : user.getTeiSearchOrganisationUnits();
-
-    return orgUnits.stream()
-        .filter(
-            availableOrgUnit ->
-                userOrgUnits.stream()
-                    .anyMatch(
-                        userOrgUnit -> availableOrgUnit.getPath().contains(userOrgUnit.getPath())))
-        .collect(Collectors.toSet());
-  }
-
-  private static boolean isProgramAccessRestricted(Program program) {
-    return program != null && (program.isClosed() || program.isProtected());
-  }
-
-  private static Set<OrganisationUnit> getAccessibleOrgUnits(User user, Program program) {
-    return isProgramAccessRestricted(program)
-        ? new HashSet<>(user.getOrganisationUnits())
-        : new HashSet<>(user.getTeiSearchOrganisationUnitsWithFallback());
-  }
-
-  private static Set<OrganisationUnit> getSelectedOrgUnits(
-      User user,
-      Program program,
-      OrganisationUnit orgUnit,
-      TrackerAccessManager trackerAccessManager) {
-    return trackerAccessManager.canAccess(user, program, orgUnit)
-        ? Set.of(orgUnit)
-        : Collections.emptySet();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -464,7 +464,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
     if (!params.hasProgram()
         && !params.hasTrackedEntityType()
         && params.hasFilters()
-        && !params.hasAccessibleOrgUnits()) {
+        && !params.hasOrganisationUnits()) {
       List<String> uniqueAttributeIds =
           trackedEntityAttributeService.getAllSystemWideUniqueTrackedEntityAttributes().stream()
               .map(TrackedEntityAttribute::getUid)
@@ -552,10 +552,10 @@ class DefaultTrackedEntityService implements TrackedEntityService {
     Set<OrganisationUnit> searchOrgUnits = new HashSet<>();
 
     if (params.isOrganisationUnitMode(SELECTED)) {
-      searchOrgUnits = params.getAccessibleOrgUnits();
+      searchOrgUnits = params.getOrgUnits();
     } else if (params.isOrganisationUnitMode(CHILDREN)
         || params.isOrganisationUnitMode(DESCENDANTS)) {
-      for (OrganisationUnit orgUnit : params.getAccessibleOrgUnits()) {
+      for (OrganisationUnit orgUnit : params.getOrgUnits()) {
         searchOrgUnits.addAll(orgUnit.getChildren());
       }
     } else if (params.isOrganisationUnitMode(ALL)) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -614,7 +614,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
                 ? "PO.organisationunitid "
                 : "TE.organisationunitid ");
 
-    if (!params.hasAccessibleOrgUnits()) {
+    if (!params.hasOrganisationUnits()) {
       return orgUnits.toString();
     }
 
@@ -623,7 +623,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
 
       orgUnits.append("AND (");
 
-      for (OrganisationUnit organisationUnit : params.getAccessibleOrgUnits()) {
+      for (OrganisationUnit organisationUnit : params.getOrgUnits()) {
 
         OrganisationUnit ou = organisationUnitStore.getByUid(organisationUnit.getUid());
         if (ou != null) {
@@ -635,7 +635,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     } else if (!params.isOrganisationUnitMode(OrganisationUnitSelectionMode.ALL)) {
       orgUnits
           .append("AND OU.organisationunitid IN (")
-          .append(getCommaDelimitedString(getIdentifiers(params.getAccessibleOrgUnits())))
+          .append(getCommaDelimitedString(getIdentifiers(params.getOrgUnits())))
           .append(") ");
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
@@ -77,7 +77,7 @@ public class TrackedEntityQueryParams {
    * Organisation units for which instances in the response were registered at. Is related to the
    * specified OrganisationUnitMode.
    */
-  private Set<OrganisationUnit> accessibleOrgUnits = new HashSet<>();
+  private Set<OrganisationUnit> orgUnits = new HashSet<>();
 
   /** Program for which instances in the response must be enrolled in. */
   private Program program;
@@ -186,19 +186,19 @@ public class TrackedEntityQueryParams {
    */
   public void handleOrganisationUnits() {
     if (user != null && isOrganisationUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE)) {
-      setAccessibleOrgUnits(user.getTeiSearchOrganisationUnitsWithFallback());
+      setOrgUnits(user.getTeiSearchOrganisationUnitsWithFallback());
       setOrgUnitMode(OrganisationUnitSelectionMode.DESCENDANTS);
     } else if (user != null && isOrganisationUnitMode(OrganisationUnitSelectionMode.CAPTURE)) {
-      setAccessibleOrgUnits(user.getOrganisationUnits());
+      setOrgUnits(user.getOrganisationUnits());
       setOrgUnitMode(OrganisationUnitSelectionMode.DESCENDANTS);
     } else if (isOrganisationUnitMode(CHILDREN)) {
-      Set<OrganisationUnit> orgUnits = new HashSet<>(getAccessibleOrgUnits());
+      Set<OrganisationUnit> organisationUnits = new HashSet<>(getOrgUnits());
 
-      for (OrganisationUnit organisationUnit : getAccessibleOrgUnits()) {
-        orgUnits.addAll(organisationUnit.getChildren());
+      for (OrganisationUnit organisationUnit : getOrgUnits()) {
+        organisationUnits.addAll(organisationUnit.getChildren());
       }
 
-      setAccessibleOrgUnits(orgUnits);
+      setOrgUnits(organisationUnits);
       setOrgUnitMode(OrganisationUnitSelectionMode.SELECTED);
     }
   }
@@ -225,8 +225,8 @@ public class TrackedEntityQueryParams {
   }
 
   /** Indicates whether these parameters specify any organisation units. */
-  public boolean hasAccessibleOrgUnits() {
-    return !accessibleOrgUnits.isEmpty();
+  public boolean hasOrganisationUnits() {
+    return orgUnits != null && !orgUnits.isEmpty();
   }
 
   /** Indicates whether these parameters specify a program. */
@@ -377,12 +377,17 @@ public class TrackedEntityQueryParams {
     return filters;
   }
 
-  public Set<OrganisationUnit> getAccessibleOrgUnits() {
-    return accessibleOrgUnits;
+  public Set<OrganisationUnit> getOrgUnits() {
+    return orgUnits;
   }
 
-  public TrackedEntityQueryParams setAccessibleOrgUnits(Set<OrganisationUnit> accessibleOrgUnits) {
-    this.accessibleOrgUnits = accessibleOrgUnits;
+  public TrackedEntityQueryParams addOrgUnits(Set<OrganisationUnit> orgUnits) {
+    this.orgUnits.addAll(orgUnits);
+    return this;
+  }
+
+  public TrackedEntityQueryParams setOrgUnits(Set<OrganisationUnit> accessibleOrgUnits) {
+    this.orgUnits = accessibleOrgUnits;
     return this;
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/OperationsParamsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/OperationsParamsValidatorTest.java
@@ -27,30 +27,16 @@
  */
 package org.hisp.dhis.tracker.export;
 
-import static java.util.Collections.emptySet;
-import static org.hisp.dhis.common.AccessLevel.OPEN;
-import static org.hisp.dhis.common.AccessLevel.PROTECTED;
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ALL;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CHILDREN;
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.DESCENDANTS;
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.SELECTED;
-import static org.hisp.dhis.tracker.export.OperationsParamsValidator.validateAccessibleOrgUnits;
 import static org.hisp.dhis.tracker.export.OperationsParamsValidator.validateOrgUnitMode;
-import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.when;
 
-import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.feedback.BadRequestException;
-import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,17 +44,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class OperationsParamsValidatorTest {
 
-  @Mock OrganisationUnitService organisationUnitService;
-
-  @Mock TrackerAccessManager trackerAccessManager;
-
-  private OrganisationUnit organisationUnit;
   private static final String PARENT_ORG_UNIT_UID = "parent-org-unit";
 
   private final OrganisationUnit captureScopeOrgUnit = createOrgUnit("captureScopeOrgUnit", "uid3");
@@ -77,262 +57,10 @@ class OperationsParamsValidatorTest {
 
   private final Program program = new Program("program");
 
-  private final User user = new User();
-
-  private final List<OrganisationUnit> orgUnitDescendants =
-      List.of(
-          createOrgUnit("orgUnit1", "uid1"),
-          createOrgUnit("orgUnit2", "uid2"),
-          captureScopeOrgUnit,
-          searchScopeOrgUnit);
-
   @BeforeEach
   public void setUp() {
-    organisationUnit = createOrgUnit("orgUnit", PARENT_ORG_UNIT_UID);
+    OrganisationUnit organisationUnit = createOrgUnit("orgUnit", PARENT_ORG_UNIT_UID);
     organisationUnit.setChildren(Set.of(captureScopeOrgUnit, searchScopeOrgUnit));
-  }
-
-  @Test
-  void shouldMapCaptureScopeOrgUnitWhenProgramProtectedAndOuModeDescendants()
-      throws ForbiddenException {
-    when(organisationUnitService.getOrganisationUnitWithChildren(PARENT_ORG_UNIT_UID))
-        .thenReturn(orgUnitDescendants);
-
-    program.setAccessLevel(PROTECTED);
-    user.setOrganisationUnits(Set.of(captureScopeOrgUnit));
-
-    Set<OrganisationUnit> accessibleOrgUnits =
-        validateAccessibleOrgUnits(
-            user,
-            Set.of(organisationUnit),
-            DESCENDANTS,
-            program,
-            organisationUnitService::getOrganisationUnitWithChildren,
-            trackerAccessManager);
-
-    assertContainsOnly(Set.of(captureScopeOrgUnit), accessibleOrgUnits);
-  }
-
-  @Test
-  void shouldMapSearchScopeOrgUnitWhenProgramOpenAndOuModeDescendants() throws ForbiddenException {
-    when(organisationUnitService.getOrganisationUnitWithChildren(PARENT_ORG_UNIT_UID))
-        .thenReturn(orgUnitDescendants);
-
-    program.setAccessLevel(OPEN);
-    user.setTeiSearchOrganisationUnits(Set.of(searchScopeOrgUnit));
-
-    Set<OrganisationUnit> accessibleOrgUnits =
-        validateAccessibleOrgUnits(
-            user,
-            Set.of(organisationUnit),
-            DESCENDANTS,
-            program,
-            organisationUnitService::getOrganisationUnitWithChildren,
-            trackerAccessManager);
-
-    assertContainsOnly(Set.of(searchScopeOrgUnit), accessibleOrgUnits);
-  }
-
-  @Test
-  void shouldFailWhenProgramProtectedAndOuModeDescendantsAndUserHasNoAccessToCaptureScopeOrgUnit() {
-    when(organisationUnitService.getOrganisationUnitWithChildren(PARENT_ORG_UNIT_UID))
-        .thenReturn(orgUnitDescendants);
-
-    program.setAccessLevel(PROTECTED);
-    user.setOrganisationUnits(Set.of(createOrgUnit("made-up-org-unit", "made-up-org-unit-uid")));
-
-    Exception exception =
-        Assertions.assertThrows(
-            ForbiddenException.class,
-            () ->
-                validateAccessibleOrgUnits(
-                    user,
-                    Set.of(organisationUnit),
-                    DESCENDANTS,
-                    program,
-                    organisationUnitService::getOrganisationUnitWithChildren,
-                    trackerAccessManager));
-
-    assertEquals(
-        String.format("User does not have access to orgUnit: %s", PARENT_ORG_UNIT_UID),
-        exception.getMessage());
-  }
-
-  @Test
-  void shouldFailWhenProgramOpenAndOuModeDescendantsAndUserHasNoAccessToSearchScopeOrgUnit() {
-    when(organisationUnitService.getOrganisationUnitWithChildren(PARENT_ORG_UNIT_UID))
-        .thenReturn(orgUnitDescendants);
-
-    program.setAccessLevel(OPEN);
-    user.setTeiSearchOrganisationUnits(
-        Set.of(createOrgUnit("made-up-org-unit", "made-up-org-unit-uid")));
-
-    Exception exception =
-        Assertions.assertThrows(
-            ForbiddenException.class,
-            () ->
-                validateAccessibleOrgUnits(
-                    user,
-                    Set.of(organisationUnit),
-                    DESCENDANTS,
-                    program,
-                    organisationUnitService::getOrganisationUnitWithChildren,
-                    trackerAccessManager));
-
-    assertEquals(
-        String.format("User does not have access to orgUnit: %s", PARENT_ORG_UNIT_UID),
-        exception.getMessage());
-  }
-
-  @Test
-  void shouldMapCaptureScopeOrgUnitWhenProgramProtectedAndOuModeChildren()
-      throws ForbiddenException {
-    program.setAccessLevel(PROTECTED);
-    user.setOrganisationUnits(Set.of(captureScopeOrgUnit));
-
-    Set<OrganisationUnit> accessibleOrgUnits =
-        validateAccessibleOrgUnits(
-            user,
-            Set.of(organisationUnit),
-            CHILDREN,
-            program,
-            organisationUnitService::getOrganisationUnitWithChildren,
-            trackerAccessManager);
-
-    assertContainsOnly(Set.of(captureScopeOrgUnit), accessibleOrgUnits);
-  }
-
-  @Test
-  void shouldMapSearchScopeOrgUnitWhenProgramOpenAndOuModeChildren() throws ForbiddenException {
-    program.setAccessLevel(OPEN);
-    user.setTeiSearchOrganisationUnits(Set.of(searchScopeOrgUnit));
-
-    Set<OrganisationUnit> accessibleOrgUnits =
-        validateAccessibleOrgUnits(
-            user,
-            Set.of(organisationUnit),
-            CHILDREN,
-            program,
-            organisationUnitService::getOrganisationUnitWithChildren,
-            trackerAccessManager);
-
-    assertContainsOnly(Set.of(searchScopeOrgUnit), accessibleOrgUnits);
-  }
-
-  @Test
-  void shouldFailWhenProgramProtectedAndOuModeChildrenAndUserHasNoAccessToCaptureScopeOrgUnit() {
-    program.setAccessLevel(PROTECTED);
-    user.setOrganisationUnits(Set.of(createOrgUnit("made-up-org-unit", "made-up-org-unit-uid")));
-
-    Exception exception =
-        Assertions.assertThrows(
-            ForbiddenException.class,
-            () ->
-                validateAccessibleOrgUnits(
-                    user,
-                    Set.of(organisationUnit),
-                    CHILDREN,
-                    program,
-                    organisationUnitService::getOrganisationUnitWithChildren,
-                    trackerAccessManager));
-
-    assertEquals(
-        String.format("User does not have access to orgUnit: %s", PARENT_ORG_UNIT_UID),
-        exception.getMessage());
-  }
-
-  @Test
-  void shouldFailWhenProgramOpenAndOuModeChildrenAndUserHasNoAccessToSearchScopeOrgUnit() {
-    program.setAccessLevel(OPEN);
-    user.setTeiSearchOrganisationUnits(
-        Set.of(createOrgUnit("made-up-org-unit", "made-up-org-unit-uid")));
-
-    Exception exception =
-        Assertions.assertThrows(
-            ForbiddenException.class,
-            () ->
-                validateAccessibleOrgUnits(
-                    user,
-                    Set.of(organisationUnit),
-                    CHILDREN,
-                    program,
-                    organisationUnitService::getOrganisationUnitWithChildren,
-                    trackerAccessManager));
-
-    assertEquals(
-        String.format("User does not have access to orgUnit: %s", PARENT_ORG_UNIT_UID),
-        exception.getMessage());
-  }
-
-  @Test
-  void shouldMapCaptureScopeOrgUnitWhenOuModeCapture() throws ForbiddenException {
-    program.setAccessLevel(OPEN);
-    user.setOrganisationUnits(Set.of(captureScopeOrgUnit));
-
-    Set<OrganisationUnit> accessibleOrgUnits =
-        validateAccessibleOrgUnits(
-            user,
-            emptySet(),
-            CAPTURE,
-            program,
-            organisationUnitService::getOrganisationUnitWithChildren,
-            trackerAccessManager);
-
-    assertContainsOnly(Set.of(captureScopeOrgUnit), accessibleOrgUnits);
-  }
-
-  @Test
-  void shouldMapSearchScopeOrgUnitWhenOuModeAccessibleAndProgramOpen() throws ForbiddenException {
-    program.setAccessLevel(OPEN);
-    user.setTeiSearchOrganisationUnits(Set.of(searchScopeOrgUnit));
-
-    Set<OrganisationUnit> accessibleOrgUnits =
-        validateAccessibleOrgUnits(
-            user,
-            emptySet(),
-            ACCESSIBLE,
-            program,
-            organisationUnitService::getOrganisationUnitWithChildren,
-            trackerAccessManager);
-
-    assertContainsOnly(Set.of(searchScopeOrgUnit), accessibleOrgUnits);
-  }
-
-  @Test
-  void shouldMapCaptureScopeOrgUnitWhenOuModeAccessibleAndProgramProtected()
-      throws ForbiddenException {
-    program.setAccessLevel(PROTECTED);
-    user.setOrganisationUnits(Set.of(captureScopeOrgUnit));
-
-    Set<OrganisationUnit> accessibleOrgUnits =
-        validateAccessibleOrgUnits(
-            user,
-            emptySet(),
-            ACCESSIBLE,
-            program,
-            organisationUnitService::getOrganisationUnitWithChildren,
-            trackerAccessManager);
-
-    assertContainsOnly(Set.of(captureScopeOrgUnit), accessibleOrgUnits);
-  }
-
-  @Test
-  void shouldMapRequestedOrgUnitWhenOuModeSelected() throws ForbiddenException {
-    program.setAccessLevel(PROTECTED);
-    user.setOrganisationUnits(Set.of(captureScopeOrgUnit));
-
-    when(trackerAccessManager.canAccess(user, program, organisationUnit)).thenReturn(true);
-
-    Set<OrganisationUnit> accessibleOrgUnits =
-        validateAccessibleOrgUnits(
-            user,
-            Set.of(organisationUnit),
-            SELECTED,
-            program,
-            organisationUnitService::getOrganisationUnitWithChildren,
-            trackerAccessManager);
-
-    assertContainsOnly(Set.of(organisationUnit), accessibleOrgUnits);
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
@@ -69,7 +69,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
-import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
@@ -111,8 +110,6 @@ class TrackedEntityOperationParamsMapperTest {
   @Mock private TrackedEntityAttributeService attributeService;
 
   @Mock private TrackedEntityTypeService trackedEntityTypeService;
-
-  @Mock private TrackerAccessManager trackerAccessManager;
 
   @InjectMocks private TrackedEntityOperationParamsMapper mapper;
 
@@ -453,7 +450,7 @@ class TrackedEntityOperationParamsMapperTest {
 
     TrackedEntityQueryParams params = mapper.map(operationParams);
 
-    assertContainsOnly(Set.of(orgUnit1, orgUnit2), params.getAccessibleOrgUnits());
+    assertContainsOnly(Set.of(orgUnit1, orgUnit2), params.getOrgUnits());
   }
 
   @Test
@@ -481,7 +478,8 @@ class TrackedEntityOperationParamsMapperTest {
 
     ForbiddenException e =
         assertThrows(ForbiddenException.class, () -> mapper.map(operationParams));
-    assertEquals("User does not have access to orgUnit: " + ORG_UNIT_1_UID, e.getMessage());
+    assertEquals(
+        "Organisation unit is not part of the search scope: " + ORG_UNIT_1_UID, e.getMessage());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/deprecated/tracker/TrackedEntityCriteriaMapperTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/deprecated/tracker/TrackedEntityCriteriaMapperTest.java
@@ -290,7 +290,7 @@ class TrackedEntityCriteriaMapperTest extends DhisWebSpringTest {
         assertThrows(IllegalQueryException.class, () -> trackedEntityCriteriaMapper.map(criteria));
 
     assertEquals(
-        "User does not have access to organisation unit: " + organisationUnitB.getUid(),
+        "Organisation unit is not part of the search scope: " + organisationUnitB.getUid(),
         e.getMessage());
   }
 
@@ -309,7 +309,7 @@ class TrackedEntityCriteriaMapperTest extends DhisWebSpringTest {
         assertThrows(IllegalQueryException.class, () -> trackedEntityCriteriaMapper.map(criteria));
 
     assertEquals(
-        "User does not have access to organisation unit: " + organisationUnitB.getUid(),
+        "Organisation unit is not part of the search scope: " + organisationUnitB.getUid(),
         e.getMessage());
   }
 


### PR DESCRIPTION
Some changes were made in `/trackedEntities` based on wrong assumptions, this PR will revert these assumptions, which mainly are:

1. Have the service layer only validate the requested org unit is in the search scope, even if the program is restricted.
2. Also in the service layer, remove the logic where we fetch accessible org units. This is not needed anymore, since the filtering of `trackedEntities` will be done in the persistence layer (`DefaultTrackedEntityStore.getOwnedTeisPartitioned`)
3. In the persistence layer, remove the logic where we build the query depending on the list of accessible org units. Here, we need to revert this logic to how it was before, and leave it like that, since it will already filter by search or capture scope depending on the program access level. This is in `HibernateTrackedEntityStore.getFromSubQueryJoinOrgUnitConditions`

Ticket: https://dhis2.atlassian.net/browse/TECH-1631