### PR TITLE
fix: Refactor tracked endpoints to set default org unit mode [TECH-1588]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -135,6 +135,9 @@ updates:
       - dependency-name: "org.hisp.dhis.rules:*" # Rule engine must be upgraded manually due to circular dependency with ANTLR parser
         versions:
           - ">= 2.0"
+      - dependency-name: "org.hisp.dhis:json-tree" # It needs to be updated only in master
+        versions:
+          - "> 0.5.0"
   # 2.39
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -199,6 +202,9 @@ updates:
       - dependency-name: "org.hisp.dhis.rules:*" # Rule engine must be upgraded manually due to circular dependency with ANTLR parser
         versions:
           - ">= 2.0"
+      - dependency-name: "org.hisp.dhis:json-tree" # It needs to be updated only in master
+        versions:
+          - "> 0.5.0"
     target-branch: "2.39"
     open-pull-requests-limit: 1 # only initially so we do not take away too many CI resources
   # 2.38
@@ -265,5 +271,8 @@ updates:
       - dependency-name: "org.hisp.dhis.rules:*" # Rule engine must be upgraded manually due to circular dependency with ANTLR parser
         versions:
           - ">= 2.0"
+      - dependency-name: "org.hisp.dhis:json-tree" # It needs to be updated only in master
+        versions:
+          - "> 0.5.0"
     target-branch: "2.38"
     open-pull-requests-limit: 1 # only initially so we do not take away too many CI resources

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
@@ -117,8 +117,8 @@ public class TrackedEntityQueryParams {
   /** Tracked entity types to fetch. */
   private List<TrackedEntityType> trackedEntityTypes = Lists.newArrayList();
 
-  /** Selection mode for the specified organisation units, default is DESCENDANTS. */
-  private OrganisationUnitSelectionMode orgUnitMode = OrganisationUnitSelectionMode.DESCENDANTS;
+  /** Selection mode for the specified organisation units */
+  private OrganisationUnitSelectionMode orgUnitMode;
 
   private AssignedUserQueryParam assignedUserQueryParam = AssignedUserQueryParam.ALL;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/EventUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/EventUtils.java
@@ -30,139 +30,14 @@ package org.hisp.dhis.webapi.controller.deprecated.tracker;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.SELECTED;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.function.Function;
-import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
-import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.program.Program;
-import org.hisp.dhis.trackedentity.TrackerAccessManager;
-import org.hisp.dhis.user.User;
 
 @Slf4j
 public class EventUtils {
   private EventUtils() {
     throw new UnsupportedOperationException("Utility class");
-  }
-
-  public static List<OrganisationUnit> validateAccessibleOrgUnits(
-      User user,
-      OrganisationUnit orgUnit,
-      OrganisationUnitSelectionMode orgUnitMode,
-      Program program,
-      Function<String, List<OrganisationUnit>> orgUnitDescendants,
-      TrackerAccessManager trackerAccessManager)
-      throws ForbiddenException {
-    List<OrganisationUnit> accessibleOrgUnits =
-        getUserAccessibleOrgUnits(
-            user, orgUnit, orgUnitMode, program, orgUnitDescendants, trackerAccessManager);
-
-    if (orgUnit != null && accessibleOrgUnits.isEmpty()) {
-      throw new ForbiddenException("User does not have access to orgUnit: " + orgUnit.getUid());
-    }
-
-    return accessibleOrgUnits;
-  }
-
-  /**
-   * Returns a list of all the org units the user has access to
-   *
-   * @param user the user to check the access of
-   * @param orgUnit parent org unit to get descendants/children of
-   * @param orgUnitDescendants function to retrieve org units, in case ou mode is descendants
-   * @param program the program the user wants to access to
-   * @return a list containing the user accessible organisation units
-   */
-  private static List<OrganisationUnit> getUserAccessibleOrgUnits(
-      User user,
-      OrganisationUnit orgUnit,
-      OrganisationUnitSelectionMode orgUnitMode,
-      Program program,
-      Function<String, List<OrganisationUnit>> orgUnitDescendants,
-      TrackerAccessManager trackerAccessManager) {
-
-    switch (orgUnitMode) {
-      case DESCENDANTS:
-        return orgUnit != null
-            ? getAccessibleDescendants(user, program, orgUnitDescendants.apply(orgUnit.getUid()))
-            : Collections.emptyList();
-      case CHILDREN:
-        return orgUnit != null
-            ? getAccessibleDescendants(
-                user,
-                program,
-                Stream.concat(Stream.of(orgUnit), orgUnit.getChildren().stream()).toList())
-            : Collections.emptyList();
-      case CAPTURE:
-        return new ArrayList<>(user.getOrganisationUnits());
-      case ACCESSIBLE:
-        return getAccessibleOrgUnits(user, program);
-      case SELECTED:
-        return getSelectedOrgUnits(user, program, orgUnit, trackerAccessManager);
-      default:
-        return Collections.emptyList();
-    }
-  }
-
-  private static List<OrganisationUnit> getSelectedOrgUnits(
-      User user,
-      Program program,
-      OrganisationUnit orgUnit,
-      TrackerAccessManager trackerAccessManager) {
-    return trackerAccessManager.canAccess(user, program, orgUnit)
-        ? List.of(orgUnit)
-        : Collections.emptyList();
-  }
-
-  private static List<OrganisationUnit> getAccessibleOrgUnits(User user, Program program) {
-    return isProgramAccessRestricted(program)
-        ? new ArrayList<>(user.getOrganisationUnits())
-        : new ArrayList<>(user.getTeiSearchOrganisationUnitsWithFallback());
-  }
-
-  /**
-   * Returns the org units whose path is contained in the user search or capture scope org unit. If
-   * there's a match, it means the user org unit is at the same level or above the supplied org
-   * unit.
-   *
-   * @param user the user to check the access of
-   * @param program the program the user wants to access to
-   * @param orgUnits the org units to check if the user has access to
-   * @return a list with the org units the user has access to
-   */
-  private static List<OrganisationUnit> getAccessibleDescendants(
-      User user, Program program, List<OrganisationUnit> orgUnits) {
-    if (orgUnits.isEmpty()) {
-      return Collections.emptyList();
-    }
-
-    if (isProgramAccessRestricted(program)) {
-      return orgUnits.stream()
-          .filter(
-              availableOrgUnit ->
-                  user.getOrganisationUnits().stream()
-                      .anyMatch(
-                          captureScopeOrgUnit ->
-                              availableOrgUnit.getPath().contains(captureScopeOrgUnit.getPath())))
-          .toList();
-    } else {
-      return orgUnits.stream()
-          .filter(
-              availableOrgUnit ->
-                  user.getTeiSearchOrganisationUnits().stream()
-                      .anyMatch(
-                          searchScopeOrgUnit ->
-                              availableOrgUnit.getPath().contains(searchScopeOrgUnit.getPath())))
-          .toList();
-    }
-  }
-
-  private static boolean isProgramAccessRestricted(Program program) {
-    return program != null && (program.isClosed() || program.isProtected());
   }
 
   /**

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamsValidator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamsValidator.java
@@ -326,6 +326,25 @@ public class RequestParamsValidator {
     }
   }
 
+  public static OrganisationUnitSelectionMode validateOrgUnitModeForTrackedEntities(
+      Set<UID> orgUnits, OrganisationUnitSelectionMode orgUnitMode, Set<UID> trackedEntities)
+      throws BadRequestException {
+
+    validateOrgUnitMode(orgUnitMode, orgUnits);
+    validateOrgUnitOrTrackedEntityIsPresent(orgUnitMode, orgUnits, trackedEntities);
+
+    return orgUnitMode;
+  }
+
+  public static OrganisationUnitSelectionMode validateOrgUnitModeForEnrollmentsAndEvents(
+      Set<UID> orgUnits, OrganisationUnitSelectionMode orgUnitMode) throws BadRequestException {
+
+    validateOrgUnitMode(orgUnitMode, orgUnits);
+    validateOrgUnitIsPresent(orgUnitMode, orgUnits);
+
+    return orgUnitMode;
+  }
+
   /**
    * Validates that no org unit is present if the ou mode is ACCESSIBLE or CAPTURE. If it is, an
    * exception will be thrown. If the org unit mode is not defined, SELECTED will be used by default
@@ -335,13 +354,8 @@ public class RequestParamsValidator {
    * @return a valid org unit mode
    * @throws BadRequestException if a wrong combination of org unit and org unit mode supplied
    */
-  public static OrganisationUnitSelectionMode validateOrgUnitMode(
-      Set<UID> orgUnits,
-      OrganisationUnitSelectionMode orgUnitMode,
-      Set<UID> trackedEntities,
-      boolean validateTrackedEntities)
-      throws BadRequestException {
-
+  private static OrganisationUnitSelectionMode validateOrgUnitMode(
+      OrganisationUnitSelectionMode orgUnitMode, Set<UID> orgUnits) throws BadRequestException {
     if (orgUnitMode == null) {
       return orgUnits.isEmpty() ? ACCESSIBLE : SELECTED;
     }
@@ -351,12 +365,6 @@ public class RequestParamsValidator {
           String.format(
               "orgUnitMode %s cannot be used with orgUnits. Please remove the orgUnit parameter and try again.",
               orgUnitMode));
-    }
-
-    if (validateTrackedEntities) {
-      validateOrgUnitOrTrackedEntityIsPresent(orgUnitMode, orgUnits, trackedEntities);
-    } else {
-      validateOrgUnitIsPresent(orgUnitMode, orgUnits);
     }
 
     return orgUnitMode;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamsValidator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamsValidator.java
@@ -336,63 +336,62 @@ public class RequestParamsValidator {
    * @throws BadRequestException if a wrong combination of org unit and org unit mode supplied
    */
   public static OrganisationUnitSelectionMode validateOrgUnitMode(
-      Set<UID> orgUnits, OrganisationUnitSelectionMode orgUnitMode) throws BadRequestException {
+      Set<UID> orgUnits,
+      OrganisationUnitSelectionMode orgUnitMode,
+      Set<UID> trackedEntities,
+      boolean validateTrackedEntities)
+      throws BadRequestException {
 
     if (orgUnitMode == null) {
       return orgUnits.isEmpty() ? ACCESSIBLE : SELECTED;
     }
 
-    if (!orgUnits.isEmpty()
-        && (orgUnitMode == ACCESSIBLE || orgUnitMode == CAPTURE || orgUnitMode == ALL)) {
+    if (orgUnitModeDoesNotRequireOrgUnit(orgUnitMode) && !orgUnits.isEmpty()) {
       throw new BadRequestException(
           String.format(
               "orgUnitMode %s cannot be used with orgUnits. Please remove the orgUnit parameter and try again.",
               orgUnitMode));
     }
 
-    if ((orgUnitMode == CHILDREN || orgUnitMode == SELECTED || orgUnitMode == DESCENDANTS)
-        && orgUnits.isEmpty()) {
-      throw new BadRequestException(
-          String.format(
-              "At least one org unit is required for orgUnitMode: %s. Please add an orgUnit or use a different orgUnitMode.",
-              orgUnitMode));
+    if (validateTrackedEntities) {
+      validateOrgUnitOrTrackedEntityIsPresent(orgUnitMode, orgUnits, trackedEntities);
+    } else {
+      validateOrgUnitIsPresent(orgUnitMode, orgUnits);
     }
 
     return orgUnitMode;
   }
 
-  /**
-   * Validates that the org unit is not present if the ou mode is ACCESSIBLE or CAPTURE. If it is,
-   * an exception will be thrown. If the org unit mode is not defined, SELECTED will be used by
-   * default if an org unit is present. Otherwise, ACCESSIBLE will be the default.
-   *
-   * @param orgUnit the org unit to validate
-   * @return a valid org unit mode
-   * @throws BadRequestException if a wrong combination of org unit and org unit mode supplied
-   */
-  public static OrganisationUnitSelectionMode validateOrgUnitMode(
-      UID orgUnit, OrganisationUnitSelectionMode orgUnitMode) throws BadRequestException {
-
-    if (orgUnitMode == null) {
-      orgUnitMode = orgUnit != null ? SELECTED : ACCESSIBLE;
-    }
-
-    if ((orgUnitMode == ACCESSIBLE || orgUnitMode == CAPTURE) && orgUnit != null) {
+  private static void validateOrgUnitOrTrackedEntityIsPresent(
+      OrganisationUnitSelectionMode orgUnitMode, Set<UID> orgUnits, Set<UID> trackedEntities)
+      throws BadRequestException {
+    if (orgUnitModeRequiresOrgUnit(orgUnitMode)
+        && orgUnits.isEmpty()
+        && trackedEntities.isEmpty()) {
       throw new BadRequestException(
           String.format(
-              "orgUnitMode %s cannot be used with orgUnits. Please remove the orgUnit parameter and try again.",
+              "At least one org unit or tracked entity is required for orgUnitMode: %s. Please add one of the two or use a different orgUnitMode.",
               orgUnitMode));
     }
+  }
 
-    if ((orgUnitMode == CHILDREN || orgUnitMode == SELECTED || orgUnitMode == DESCENDANTS)
-        && orgUnit == null) {
+  private static void validateOrgUnitIsPresent(
+      OrganisationUnitSelectionMode orgUnitMode, Set<UID> orgUnits) throws BadRequestException {
+    if (orgUnitModeRequiresOrgUnit(orgUnitMode) && orgUnits.isEmpty()) {
       throw new BadRequestException(
           String.format(
-              "orgUnit is required for orgUnitMode: %s. Please add an orgUnit or use a different orgUnitMode.",
+              "At least one org unit is required for orgUnitMode: %s. Please add one org unit or use a different orgUnitMode.",
               orgUnitMode));
     }
+  }
 
-    return orgUnitMode;
+  private static boolean orgUnitModeRequiresOrgUnit(OrganisationUnitSelectionMode orgUnitMode) {
+    return orgUnitMode == CHILDREN || orgUnitMode == SELECTED || orgUnitMode == DESCENDANTS;
+  }
+
+  private static boolean orgUnitModeDoesNotRequireOrgUnit(
+      OrganisationUnitSelectionMode orgUnitMode) {
+    return orgUnitMode == ACCESSIBLE || orgUnitMode == CAPTURE || orgUnitMode == ALL;
   }
 
   public static void validatePaginationParameters(PageRequestParams params)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamsValidator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamsValidator.java
@@ -330,7 +330,7 @@ public class RequestParamsValidator {
       Set<UID> orgUnits, OrganisationUnitSelectionMode orgUnitMode, Set<UID> trackedEntities)
       throws BadRequestException {
 
-    validateOrgUnitMode(orgUnitMode, orgUnits);
+    orgUnitMode = validateOrgUnitMode(orgUnitMode, orgUnits);
     validateOrgUnitOrTrackedEntityIsPresent(orgUnitMode, orgUnits, trackedEntities);
 
     return orgUnitMode;
@@ -339,7 +339,7 @@ public class RequestParamsValidator {
   public static OrganisationUnitSelectionMode validateOrgUnitModeForEnrollmentsAndEvents(
       Set<UID> orgUnits, OrganisationUnitSelectionMode orgUnitMode) throws BadRequestException {
 
-    validateOrgUnitMode(orgUnitMode, orgUnits);
+    orgUnitMode = validateOrgUnitMode(orgUnitMode, orgUnits);
     validateOrgUnitIsPresent(orgUnitMode, orgUnits);
 
     return orgUnitMode;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.enrollment;
 
+import static java.util.Collections.emptySet;
 import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
 import static org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams.DEFAULT_PAGE;
 import static org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams.DEFAULT_PAGE_SIZE;
@@ -69,7 +70,7 @@ class EnrollmentRequestParamsMapper {
         validateDeprecatedParameter(
             "ouMode", requestParams.getOuMode(), "orgUnitMode", requestParams.getOrgUnitMode());
 
-    orgUnitMode = validateOrgUnitMode(orgUnits, orgUnitMode);
+    orgUnitMode = validateOrgUnitMode(orgUnits, orgUnitMode, emptySet(), false);
 
     validateOrderParams(requestParams.getOrder(), ORDERABLE_FIELD_NAMES);
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
@@ -69,7 +69,7 @@ class EnrollmentRequestParamsMapper {
         validateDeprecatedParameter(
             "ouMode", requestParams.getOuMode(), "orgUnitMode", requestParams.getOrgUnitMode());
 
-    validateOrgUnitMode(orgUnits, orgUnitMode);
+    orgUnitMode = validateOrgUnitMode(orgUnits, orgUnitMode);
 
     validateOrderParams(requestParams.getOrder(), ORDERABLE_FIELD_NAMES);
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
@@ -27,14 +27,13 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.enrollment;
 
-import static java.util.Collections.emptySet;
 import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
 import static org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams.DEFAULT_PAGE;
 import static org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams.DEFAULT_PAGE_SIZE;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateDeprecatedParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateDeprecatedUidsParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateOrderParams;
-import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateOrgUnitMode;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateOrgUnitModeForEnrollmentsAndEvents;
 
 import java.util.List;
 import java.util.Objects;
@@ -70,7 +69,7 @@ class EnrollmentRequestParamsMapper {
         validateDeprecatedParameter(
             "ouMode", requestParams.getOuMode(), "orgUnitMode", requestParams.getOrgUnitMode());
 
-    orgUnitMode = validateOrgUnitMode(orgUnits, orgUnitMode, emptySet(), false);
+    orgUnitMode = validateOrgUnitModeForEnrollmentsAndEvents(orgUnits, orgUnitMode);
 
     validateOrderParams(requestParams.getOrder(), ORDERABLE_FIELD_NAMES);
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
@@ -32,7 +32,7 @@ import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValida
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateDeprecatedParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateDeprecatedUidsParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateOrderParams;
-import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateOrgUnitMode;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateOrgUnitModeForEnrollmentsAndEvents;
 
 import java.util.List;
 import java.util.Map;
@@ -65,11 +65,9 @@ class EventRequestParamsMapper {
             "ouMode", requestParams.getOuMode(), "orgUnitMode", requestParams.getOrgUnitMode());
 
     orgUnitMode =
-        validateOrgUnitMode(
+        validateOrgUnitModeForEnrollmentsAndEvents(
             requestParams.getOrgUnit() != null ? Set.of(requestParams.getOrgUnit()) : emptySet(),
-            orgUnitMode,
-            emptySet(),
-            false);
+            orgUnitMode);
 
     UID attributeCategoryCombo =
         validateDeprecatedParameter(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.event;
 
+import static java.util.Collections.emptySet;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.parseFilters;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateDeprecatedParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateDeprecatedUidsParameter;
@@ -63,7 +64,12 @@ class EventRequestParamsMapper {
         validateDeprecatedParameter(
             "ouMode", requestParams.getOuMode(), "orgUnitMode", requestParams.getOrgUnitMode());
 
-    orgUnitMode = validateOrgUnitMode(requestParams.getOrgUnit(), orgUnitMode);
+    orgUnitMode =
+        validateOrgUnitMode(
+            requestParams.getOrgUnit() != null ? Set.of(requestParams.getOrgUnit()) : emptySet(),
+            orgUnitMode,
+            emptySet(),
+            false);
 
     UID attributeCategoryCombo =
         validateDeprecatedParameter(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
@@ -91,7 +91,8 @@ class TrackedEntityRequestParamsMapper {
         validateDeprecatedParameter(
             "ouMode", requestParams.getOuMode(), "orgUnitMode", requestParams.getOrgUnitMode());
 
-    orgUnitMode = validateOrgUnitMode(orgUnitUids, orgUnitMode);
+    orgUnitMode =
+        validateOrgUnitMode(orgUnitUids, orgUnitMode, requestParams.getTrackedEntities(), true);
 
     Set<UID> trackedEntities =
         validateDeprecatedUidsParameter(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
@@ -34,7 +34,7 @@ import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValida
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateDeprecatedParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateDeprecatedUidsParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateOrderParams;
-import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateOrgUnitMode;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateOrgUnitModeForTrackedEntities;
 
 import java.util.List;
 import java.util.Map;
@@ -92,7 +92,8 @@ class TrackedEntityRequestParamsMapper {
             "ouMode", requestParams.getOuMode(), "orgUnitMode", requestParams.getOrgUnitMode());
 
     orgUnitMode =
-        validateOrgUnitMode(orgUnitUids, orgUnitMode, requestParams.getTrackedEntities(), true);
+        validateOrgUnitModeForTrackedEntities(
+            orgUnitUids, orgUnitMode, requestParams.getTrackedEntities());
 
     Set<UID> trackedEntities =
         validateDeprecatedUidsParameter(

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamsValidatorTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamsValidatorTest.java
@@ -304,7 +304,7 @@ class RequestParamsValidatorTest {
     Exception exception =
         assertThrows(
             BadRequestException.class,
-            () -> validateOrgUnitMode(Set.of(UID.of(orgUnit)), orgUnitMode));
+            () -> validateOrgUnitMode(Set.of(UID.of(orgUnit)), orgUnitMode, emptySet(), false));
 
     assertStartsWith(
         String.format("orgUnitMode %s cannot be used with orgUnits.", orgUnitMode),
@@ -317,7 +317,7 @@ class RequestParamsValidatorTest {
       names = {"CAPTURE", "ACCESSIBLE", "ALL"})
   void shouldPassWhenNoOrgUnitSuppliedAndOrgUnitModeDoesNotRequireOrgUnit(
       OrganisationUnitSelectionMode orgUnitMode) {
-    assertDoesNotThrow(() -> validateOrgUnitMode(emptySet(), orgUnitMode));
+    assertDoesNotThrow(() -> validateOrgUnitMode(emptySet(), orgUnitMode, emptySet(), false));
   }
 
   @ParameterizedTest
@@ -326,7 +326,18 @@ class RequestParamsValidatorTest {
       names = {"SELECTED", "DESCENDANTS", "CHILDREN"})
   void shouldPassWhenOrgUnitSuppliedAndOrgUnitModeRequiresOrgUnit(
       OrganisationUnitSelectionMode orgUnitMode) {
-    assertDoesNotThrow(() -> validateOrgUnitMode(Set.of(UID.of(orgUnit)), orgUnitMode));
+    assertDoesNotThrow(
+        () -> validateOrgUnitMode(Set.of(UID.of(orgUnit)), orgUnitMode, emptySet(), false));
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = OrganisationUnitSelectionMode.class,
+      names = {"SELECTED", "DESCENDANTS", "CHILDREN"})
+  void shouldPassWhenTrackedEntitySuppliedAndOrgUnitModeRequiresOrgUnit(
+      OrganisationUnitSelectionMode orgUnitMode) {
+    assertDoesNotThrow(
+        () -> validateOrgUnitMode(emptySet(), orgUnitMode, Set.of(UID.of(TEA_1_UID)), true));
   }
 
   @ParameterizedTest
@@ -336,10 +347,29 @@ class RequestParamsValidatorTest {
   void shouldFailWhenNoOrgUnitSuppliedAndOrgUnitModeRequiresOrgUnit(
       OrganisationUnitSelectionMode orgUnitMode) {
     Exception exception =
-        assertThrows(BadRequestException.class, () -> validateOrgUnitMode(emptySet(), orgUnitMode));
+        assertThrows(
+            BadRequestException.class,
+            () -> validateOrgUnitMode(emptySet(), orgUnitMode, emptySet(), false));
 
     assertStartsWith(
         String.format("At least one org unit is required for orgUnitMode: %s", orgUnitMode),
+        exception.getMessage());
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = OrganisationUnitSelectionMode.class,
+      names = {"SELECTED", "DESCENDANTS", "CHILDREN"})
+  void shouldFailWhenNoOrgUnitNorTrackedEntitySuppliedAndOrgUnitModeRequiresOrgUnit(
+      OrganisationUnitSelectionMode orgUnitMode) {
+    Exception exception =
+        assertThrows(
+            BadRequestException.class,
+            () -> validateOrgUnitMode(emptySet(), orgUnitMode, emptySet(), true));
+
+    assertStartsWith(
+        String.format(
+            "At least one org unit or tracked entity is required for orgUnitMode: %s", orgUnitMode),
         exception.getMessage());
   }
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamsValidatorTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamsValidatorTest.java
@@ -33,7 +33,8 @@ import static org.hisp.dhis.utils.Assertions.assertStartsWith;
 import static org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria.fromOrderString;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.parseFilters;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateOrderParams;
-import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateOrgUnitMode;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateOrgUnitModeForEnrollmentsAndEvents;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateOrgUnitModeForTrackedEntities;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validatePaginationParameters;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -304,7 +305,7 @@ class RequestParamsValidatorTest {
     Exception exception =
         assertThrows(
             BadRequestException.class,
-            () -> validateOrgUnitMode(Set.of(UID.of(orgUnit)), orgUnitMode, emptySet(), false));
+            () -> validateOrgUnitModeForEnrollmentsAndEvents(Set.of(UID.of(orgUnit)), orgUnitMode));
 
     assertStartsWith(
         String.format("orgUnitMode %s cannot be used with orgUnits.", orgUnitMode),
@@ -317,7 +318,7 @@ class RequestParamsValidatorTest {
       names = {"CAPTURE", "ACCESSIBLE", "ALL"})
   void shouldPassWhenNoOrgUnitSuppliedAndOrgUnitModeDoesNotRequireOrgUnit(
       OrganisationUnitSelectionMode orgUnitMode) {
-    assertDoesNotThrow(() -> validateOrgUnitMode(emptySet(), orgUnitMode, emptySet(), false));
+    assertDoesNotThrow(() -> validateOrgUnitModeForEnrollmentsAndEvents(emptySet(), orgUnitMode));
   }
 
   @ParameterizedTest
@@ -327,7 +328,7 @@ class RequestParamsValidatorTest {
   void shouldPassWhenOrgUnitSuppliedAndOrgUnitModeRequiresOrgUnit(
       OrganisationUnitSelectionMode orgUnitMode) {
     assertDoesNotThrow(
-        () -> validateOrgUnitMode(Set.of(UID.of(orgUnit)), orgUnitMode, emptySet(), false));
+        () -> validateOrgUnitModeForEnrollmentsAndEvents(Set.of(UID.of(orgUnit)), orgUnitMode));
   }
 
   @ParameterizedTest
@@ -337,7 +338,9 @@ class RequestParamsValidatorTest {
   void shouldPassWhenTrackedEntitySuppliedAndOrgUnitModeRequiresOrgUnit(
       OrganisationUnitSelectionMode orgUnitMode) {
     assertDoesNotThrow(
-        () -> validateOrgUnitMode(emptySet(), orgUnitMode, Set.of(UID.of(TEA_1_UID)), true));
+        () ->
+            validateOrgUnitModeForTrackedEntities(
+                emptySet(), orgUnitMode, Set.of(UID.of(TEA_1_UID))));
   }
 
   @ParameterizedTest
@@ -349,7 +352,7 @@ class RequestParamsValidatorTest {
     Exception exception =
         assertThrows(
             BadRequestException.class,
-            () -> validateOrgUnitMode(emptySet(), orgUnitMode, emptySet(), false));
+            () -> validateOrgUnitModeForEnrollmentsAndEvents(emptySet(), orgUnitMode));
 
     assertStartsWith(
         String.format("At least one org unit is required for orgUnitMode: %s", orgUnitMode),
@@ -365,7 +368,7 @@ class RequestParamsValidatorTest {
     Exception exception =
         assertThrows(
             BadRequestException.class,
-            () -> validateOrgUnitMode(emptySet(), orgUnitMode, emptySet(), true));
+            () -> validateOrgUnitModeForTrackedEntities(emptySet(), orgUnitMode, emptySet()));
 
     assertStartsWith(
         String.format(

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
@@ -585,6 +585,8 @@ class EventRequestParamsMapperTest {
 
     Exception exception = assertThrows(BadRequestException.class, () -> mapper.map(requestParams));
 
-    assertStartsWith("orgUnit is required for orgUnitMode: " + orgUnitMode, exception.getMessage());
+    assertStartsWith(
+        "At least one org unit is required for orgUnitMode: " + orgUnitMode,
+        exception.getMessage());
   }
 }


### PR DESCRIPTION
In this PR I'm setting the default org unit mode to be used when none is provided in the request.
While I'm at it, I'm also removing some methods from `EventUtils` that were no longer necessary.

Ticket: https://dhis2.atlassian.net/browse/TECH-1588