### PR TITLE
feat: Add import options for aggregate data exchange [DHIS2-15949]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataexchange/aggregate/TargetRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataexchange/aggregate/TargetRequest.java
@@ -27,8 +27,9 @@
  */
 package org.hisp.dhis.dataexchange.aggregate;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
+import org.hisp.dhis.importexport.ImportStrategy;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -50,4 +51,13 @@ public class TargetRequest implements Serializable {
 
   /** General identifier scheme. */
   @JsonProperty private String idScheme;
+  
+  /** Import strategy. */
+  @JsonProperty private ImportStrategy importStrategy;
+  
+  /** Indicates whether to skip audit records. */
+  @JsonProperty private Boolean skipAudit;
+
+  /** Indicates whether to do a dry run. */
+  @JsonProperty private Boolean dryRun;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataexchange/aggregate/TargetRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataexchange/aggregate/TargetRequest.java
@@ -27,13 +27,13 @@
  */
 package org.hisp.dhis.dataexchange.aggregate;
 
-import java.io.Serializable;
-import org.hisp.dhis.importexport.ImportStrategy;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import org.hisp.dhis.importexport.ImportStrategy;
 
 @Getter
 @Setter
@@ -51,10 +51,10 @@ public class TargetRequest implements Serializable {
 
   /** General identifier scheme. */
   @JsonProperty private String idScheme;
-  
+
   /** Import strategy. */
   @JsonProperty private ImportStrategy importStrategy;
-  
+
   /** Indicates whether to skip audit records. */
   @JsonProperty private Boolean skipAudit;
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dxf2/common/ImportOptions.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dxf2/common/ImportOptions.java
@@ -27,6 +27,15 @@
  */
 package org.hisp.dhis.dxf2.common;
 
+import org.hisp.dhis.common.DxfNamespaces;
+import org.hisp.dhis.common.IdSchemes;
+import org.hisp.dhis.common.MergeMode;
+import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.dxf2.metadata.feedback.ImportReportMode;
+import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.scheduling.JobParameters;
+import org.hisp.dhis.system.notification.NotificationLevel;
+import org.hisp.dhis.user.User;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -38,15 +47,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.Accessors;
-import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.common.IdSchemes;
-import org.hisp.dhis.common.MergeMode;
-import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.dxf2.metadata.feedback.ImportReportMode;
-import org.hisp.dhis.importexport.ImportStrategy;
-import org.hisp.dhis.scheduling.JobParameters;
-import org.hisp.dhis.system.notification.NotificationLevel;
-import org.hisp.dhis.user.User;
 
 /**
  * The idScheme is a general setting which will apply to all objects. The idSchemes can also be
@@ -66,6 +66,12 @@ import org.hisp.dhis.user.User;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ImportOptions implements JobParameters {
 
+  public static final ImportStrategy DEFAULT_IMPORT_STRATEGY = ImportStrategy.CREATE_AND_UPDATE;
+  
+  public static final MergeMode DEFAULT_MERGE_MODE = MergeMode.REPLACE;
+  
+  public static final ImportReportMode DEFAULT_REPORT_MODE = ImportReportMode.FULL;
+  
   @ToString.Exclude private transient User user;
 
   @OpenApi.Ignore
@@ -81,13 +87,13 @@ public class ImportOptions implements JobParameters {
   @JsonProperty(namespace = DxfNamespaces.DXF_2_0)
   private boolean async;
 
-  private ImportStrategy importStrategy = ImportStrategy.CREATE_AND_UPDATE;
+  private ImportStrategy importStrategy = DEFAULT_IMPORT_STRATEGY;
 
   @JsonProperty(namespace = DxfNamespaces.DXF_2_0)
-  private MergeMode mergeMode = MergeMode.REPLACE;
+  private MergeMode mergeMode = DEFAULT_MERGE_MODE;
 
   @JsonProperty(namespace = DxfNamespaces.DXF_2_0)
-  private ImportReportMode reportMode = ImportReportMode.FULL;
+  private ImportReportMode reportMode = DEFAULT_REPORT_MODE;
 
   @JsonProperty(namespace = DxfNamespaces.DXF_2_0)
   private boolean skipExistingCheck;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dxf2/common/ImportOptions.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dxf2/common/ImportOptions.java
@@ -27,15 +27,6 @@
  */
 package org.hisp.dhis.dxf2.common;
 
-import org.hisp.dhis.common.DxfNamespaces;
-import org.hisp.dhis.common.IdSchemes;
-import org.hisp.dhis.common.MergeMode;
-import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.dxf2.metadata.feedback.ImportReportMode;
-import org.hisp.dhis.importexport.ImportStrategy;
-import org.hisp.dhis.scheduling.JobParameters;
-import org.hisp.dhis.system.notification.NotificationLevel;
-import org.hisp.dhis.user.User;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -47,6 +38,15 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.Accessors;
+import org.hisp.dhis.common.DxfNamespaces;
+import org.hisp.dhis.common.IdSchemes;
+import org.hisp.dhis.common.MergeMode;
+import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.dxf2.metadata.feedback.ImportReportMode;
+import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.scheduling.JobParameters;
+import org.hisp.dhis.system.notification.NotificationLevel;
+import org.hisp.dhis.user.User;
 
 /**
  * The idScheme is a general setting which will apply to all objects. The idSchemes can also be
@@ -67,11 +67,11 @@ import lombok.experimental.Accessors;
 public class ImportOptions implements JobParameters {
 
   public static final ImportStrategy DEFAULT_IMPORT_STRATEGY = ImportStrategy.CREATE_AND_UPDATE;
-  
+
   public static final MergeMode DEFAULT_MERGE_MODE = MergeMode.REPLACE;
-  
+
   public static final ImportReportMode DEFAULT_REPORT_MODE = ImportReportMode.FULL;
-  
+
   @ToString.Exclude private transient User user;
 
   @OpenApi.Ignore

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/ObjectUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/ObjectUtils.java
@@ -84,7 +84,7 @@ public class ObjectUtils {
   /**
    * Indicates whether the given object is null.
    *
-   * @param the object.
+   * @param object the object.
    * @return true if not null.
    */
   public static boolean notNull(Object object) {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/ObjectUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/ObjectUtils.java
@@ -82,6 +82,16 @@ public class ObjectUtils {
   }
 
   /**
+   * Indicates whether the given object is null.
+   * 
+   * @param the object.
+   * @return true if not null.
+   */
+  public static boolean notNull(Object object) {
+    return object != null;
+  }
+  
+  /**
    * Indicates whether any of the given conditions are not null and true.
    *
    * @param conditions the conditions.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/ObjectUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/ObjectUtils.java
@@ -83,14 +83,14 @@ public class ObjectUtils {
 
   /**
    * Indicates whether the given object is null.
-   * 
+   *
    * @param the object.
    * @return true if not null.
    */
   public static boolean notNull(Object object) {
     return object != null;
   }
-  
+
   /**
    * Indicates whether any of the given conditions are not null and true.
    *

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/ObjectUtilsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/ObjectUtilsTest.java
@@ -28,11 +28,13 @@
 package org.hisp.dhis.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import com.google.common.collect.Lists;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.importexport.ImportStrategy;
 import org.junit.jupiter.api.Test;
+import com.google.common.collect.Lists;
 
 /**
  * @author Lars Helge Overland
@@ -48,5 +50,11 @@ class ObjectUtilsTest {
     String actual = ObjectUtils.join(elements, ", ", de -> de.getName());
     assertEquals("DataElementA, DataElementB, DataElementC", actual);
     assertEquals(null, ObjectUtils.join(null, ", ", null));
+  }
+  
+  @Test
+  void testNotNull() {
+    assertTrue(ObjectUtils.notNull(ImportStrategy.CREATE_AND_UPDATE));
+    assertFalse(ObjectUtils.notNull(null));
   }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/ObjectUtilsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/ObjectUtilsTest.java
@@ -30,11 +30,12 @@ package org.hisp.dhis.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.collect.Lists;
 import java.util.List;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.junit.jupiter.api.Test;
-import com.google.common.collect.Lists;
 
 /**
  * @author Lars Helge Overland
@@ -51,7 +52,7 @@ class ObjectUtilsTest {
     assertEquals("DataElementA, DataElementB, DataElementC", actual);
     assertEquals(null, ObjectUtils.join(null, ", ", null));
   }
-  
+
   @Test
   void testNotNull() {
     assertTrue(ObjectUtils.notNull(ImportStrategy.CREATE_AND_UPDATE));

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeService.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeService.java
@@ -36,9 +36,12 @@ import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 import static org.hisp.dhis.commons.collection.CollectionUtils.mapToList;
 import static org.hisp.dhis.config.HibernateEncryptionConfig.AES_128_STRING_ENCRYPTOR;
 import static org.hisp.dhis.util.ObjectUtils.notNull;
+
 import java.util.Date;
 import java.util.List;
 import javax.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.AnalyticsAggregationType;
@@ -63,8 +66,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.HttpClientErrorException;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Main service class for aggregate data exchange.

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeService.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeService.java
@@ -35,12 +35,10 @@ import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 import static org.hisp.dhis.commons.collection.CollectionUtils.mapToList;
 import static org.hisp.dhis.config.HibernateEncryptionConfig.AES_128_STRING_ENCRYPTOR;
-
+import static org.hisp.dhis.util.ObjectUtils.notNull;
 import java.util.Date;
 import java.util.List;
 import javax.annotation.Nonnull;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.AnalyticsAggregationType;
@@ -65,6 +63,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.HttpClientErrorException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Main service class for aggregate data exchange.
@@ -250,6 +250,15 @@ public class AggregateDataExchangeService {
     if (isNotBlank(request.getIdScheme())) {
       options.setIdScheme(request.getIdScheme());
     }
+    if (notNull(request.getImportStrategy())) {
+      options.setImportStrategy(request.getImportStrategy());
+    }
+    if (notNull(request.getSkipAudit())) {
+      options.setSkipAudit(request.getSkipAudit());
+    }
+    if (notNull(request.getDryRun())) {
+      options.setDryRun(request.getDryRun());
+    }
 
     return options;
   }
@@ -337,7 +346,6 @@ public class AggregateDataExchangeService {
    */
   IdScheme toIdScheme(String... idSchemes) {
     String idScheme = ObjectUtils.firstNonNull(idSchemes);
-
     return idScheme != null ? IdScheme.from(idScheme) : null;
   }
 

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/client/Dhis2Client.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/client/Dhis2Client.java
@@ -28,12 +28,10 @@
 package org.hisp.dhis.dataexchange.client;
 
 import static java.lang.String.format;
-
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Objects;
-
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdSchemes;
 import org.hisp.dhis.commons.jackson.config.JacksonObjectMapperConfig;
@@ -55,10 +53,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -211,9 +207,13 @@ public class Dhis2Client {
 
     addIfNotDefault(builder, "dataElementIdScheme", idSchemes.getDataElementIdScheme());
     addIfNotDefault(builder, "orgUnitIdScheme", idSchemes.getOrgUnitIdScheme());
-    addIfNotDefault(
-        builder, "categoryOptionComboIdScheme", idSchemes.getCategoryOptionComboIdScheme());
+    addIfNotDefault(builder, "categoryOptionComboIdScheme", 
+        idSchemes.getCategoryOptionComboIdScheme());
     addIfNotDefault(builder, "idScheme", idSchemes.getIdScheme());
+    addIfNotDefault(builder, "importStrategy", 
+        options.getImportStrategy(), ImportOptions.DEFAULT_IMPORT_STRATEGY);
+    addIfNotDefault(builder, "skipAudit", options.isSkipAudit(), false);
+    addIfNotDefault(builder, "dryRun", options.isDryRun(), false);    
 
     return builder.build().toUri();
   }
@@ -231,7 +231,22 @@ public class Dhis2Client {
       builder.queryParam(queryParam, idScheme.name());
     }
   }
-
+  
+  /**
+   * Adds the given value to the URI builder if not equal to the given default value.
+   * 
+   * @param builder the {@link UriComponentsBuilder}.
+   * @param queryParam the query parameter name.
+   * @param value the value.
+   * @param defaultValue the default value.
+   */
+  void addIfNotDefault(UriComponentsBuilder builder, 
+      String queryParam, Object value, Object defaultValue) {
+    if (!Objects.equals(defaultValue, value)) {
+      builder.queryParam(queryParam, value);
+    }
+  }
+  
   /**
    * Returns a {@link ResponseEntity} for the given body and {@link HttpClientErrorException}.
    *

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/client/Dhis2Client.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/client/Dhis2Client.java
@@ -28,10 +28,14 @@
 package org.hisp.dhis.dataexchange.client;
 
 import static java.lang.String.format;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdSchemes;
 import org.hisp.dhis.commons.jackson.config.JacksonObjectMapperConfig;
@@ -53,9 +57,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * API client for DHIS 2.
@@ -207,13 +208,16 @@ public class Dhis2Client {
 
     addIfNotDefault(builder, "dataElementIdScheme", idSchemes.getDataElementIdScheme());
     addIfNotDefault(builder, "orgUnitIdScheme", idSchemes.getOrgUnitIdScheme());
-    addIfNotDefault(builder, "categoryOptionComboIdScheme", 
-        idSchemes.getCategoryOptionComboIdScheme());
+    addIfNotDefault(
+        builder, "categoryOptionComboIdScheme", idSchemes.getCategoryOptionComboIdScheme());
     addIfNotDefault(builder, "idScheme", idSchemes.getIdScheme());
-    addIfNotDefault(builder, "importStrategy", 
-        options.getImportStrategy(), ImportOptions.DEFAULT_IMPORT_STRATEGY);
+    addIfNotDefault(
+        builder,
+        "importStrategy",
+        options.getImportStrategy(),
+        ImportOptions.DEFAULT_IMPORT_STRATEGY);
     addIfNotDefault(builder, "skipAudit", options.isSkipAudit(), false);
-    addIfNotDefault(builder, "dryRun", options.isDryRun(), false);    
+    addIfNotDefault(builder, "dryRun", options.isDryRun(), false);
 
     return builder.build().toUri();
   }
@@ -231,22 +235,22 @@ public class Dhis2Client {
       builder.queryParam(queryParam, idScheme.name());
     }
   }
-  
+
   /**
    * Adds the given value to the URI builder if not equal to the given default value.
-   * 
+   *
    * @param builder the {@link UriComponentsBuilder}.
    * @param queryParam the query parameter name.
    * @param value the value.
    * @param defaultValue the default value.
    */
-  void addIfNotDefault(UriComponentsBuilder builder, 
-      String queryParam, Object value, Object defaultValue) {
+  void addIfNotDefault(
+      UriComponentsBuilder builder, String queryParam, Object value, Object defaultValue) {
     if (!Objects.equals(defaultValue, value)) {
       builder.queryParam(queryParam, value);
     }
   }
-  
+
   /**
    * Returns a {@link ResponseEntity} for the given body and {@link HttpClientErrorException}.
    *

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/client/Dhis2Client.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/client/Dhis2Client.java
@@ -29,13 +29,11 @@ package org.hisp.dhis.dataexchange.client;
 
 import static java.lang.String.format;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.Validate;
+import java.util.Objects;
+
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdSchemes;
 import org.hisp.dhis.commons.jackson.config.JacksonObjectMapperConfig;
@@ -57,6 +55,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * API client for DHIS 2.
@@ -84,8 +87,8 @@ public class Dhis2Client {
     this.authentication = authentication;
     this.restTemplate = new RestTemplate();
     this.objectMapper = JacksonObjectMapperConfig.jsonMapper;
-    Validate.notNull(url);
-    Validate.notNull(authentication);
+    Objects.requireNonNull(url);
+    Objects.requireNonNull(authentication);
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeServiceTest.java
@@ -38,7 +38,6 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.when;
-
 import java.util.Date;
 import java.util.List;
 import org.hisp.dhis.analytics.AggregationType;
@@ -258,7 +257,7 @@ class AggregateDataExchangeServiceTest {
     assertEquals(IdScheme.UID, options.getIdSchemes().getCategoryOptionComboIdScheme());
     assertEquals(IdScheme.UID, options.getIdSchemes().getCategoryOptionIdScheme());
     assertEquals(IdScheme.UID, options.getIdSchemes().getIdScheme());
-    assertNull(options.getImportStrategy());
+    assertEquals(ImportStrategy.CREATE_AND_UPDATE, options.getImportStrategy());
     assertFalse(options.isSkipAudit());
     assertFalse(options.isDryRun());
   }

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeServiceTest.java
@@ -38,6 +38,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.when;
+
 import java.util.Date;
 import java.util.List;
 import org.hisp.dhis.analytics.AggregationType;
@@ -246,9 +247,7 @@ class AggregateDataExchangeServiceTest {
   @Test
   void testToImportOptionsB() {
     TargetRequest request =
-        new TargetRequest()
-            .setDataElementIdScheme("uid")
-            .setOrgUnitIdScheme("code");
+        new TargetRequest().setDataElementIdScheme("uid").setOrgUnitIdScheme("code");
     Target target = new Target().setType(TargetType.EXTERNAL).setApi(new Api()).setRequest(request);
     AggregateDataExchange exchange = new AggregateDataExchange().setTarget(target);
 

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeServiceTest.java
@@ -38,6 +38,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.when;
+
 import java.util.Date;
 import java.util.List;
 import org.hisp.dhis.analytics.AggregationType;

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeServiceTest.java
@@ -38,7 +38,6 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.when;
-
 import java.util.Date;
 import java.util.List;
 import org.hisp.dhis.analytics.AggregationType;
@@ -58,6 +57,7 @@ import org.hisp.dhis.dxf2.datavalueset.DataValueSetService;
 import org.hisp.dhis.dxf2.importsummary.ImportStatus;
 import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
+import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -224,7 +224,10 @@ class AggregateDataExchangeServiceTest {
         new TargetRequest()
             .setDataElementIdScheme("code")
             .setOrgUnitIdScheme("code")
-            .setIdScheme("uid");
+            .setIdScheme("uid")
+            .setImportStrategy(ImportStrategy.CREATE)
+            .setSkipAudit(Boolean.TRUE)
+            .setDryRun(Boolean.TRUE);
     Target target = new Target().setType(TargetType.EXTERNAL).setApi(new Api()).setRequest(request);
     AggregateDataExchange exchange = new AggregateDataExchange().setTarget(target);
 
@@ -235,12 +238,17 @@ class AggregateDataExchangeServiceTest {
     assertEquals(IdScheme.UID, options.getIdSchemes().getCategoryOptionComboIdScheme());
     assertEquals(IdScheme.UID, options.getIdSchemes().getCategoryOptionIdScheme());
     assertEquals(IdScheme.UID, options.getIdSchemes().getIdScheme());
+    assertEquals(ImportStrategy.CREATE, options.getImportStrategy());
+    assertTrue(options.isSkipAudit());
+    assertTrue(options.isDryRun());
   }
 
   @Test
   void testToImportOptionsB() {
     TargetRequest request =
-        new TargetRequest().setDataElementIdScheme("uid").setOrgUnitIdScheme("code");
+        new TargetRequest()
+            .setDataElementIdScheme("uid")
+            .setOrgUnitIdScheme("code");
     Target target = new Target().setType(TargetType.EXTERNAL).setApi(new Api()).setRequest(request);
     AggregateDataExchange exchange = new AggregateDataExchange().setTarget(target);
 
@@ -251,6 +259,9 @@ class AggregateDataExchangeServiceTest {
     assertEquals(IdScheme.UID, options.getIdSchemes().getCategoryOptionComboIdScheme());
     assertEquals(IdScheme.UID, options.getIdSchemes().getCategoryOptionIdScheme());
     assertEquals(IdScheme.UID, options.getIdSchemes().getIdScheme());
+    assertNull(options.getImportStrategy());
+    assertFalse(options.isSkipAudit());
+    assertFalse(options.isDryRun());
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/client/Dhis2ClientTest.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/client/Dhis2ClientTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.dataexchange.client;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.net.URI;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.common.IdScheme;
@@ -67,14 +68,14 @@ class Dhis2ClientTest {
 
     String uriA = client.getDataValueSetUri(optionsA).toString();
     String uriB = client.getDataValueSetUri(optionsB).toString();
-    
+
     String expectedA = base + "/api/dataValueSets?dataElementIdScheme=CODE&orgUnitIdScheme=CODE";
     String expectedB = base + "/api/dataValueSets?orgUnitIdScheme=CODE&idScheme=CODE";
 
     assertEquals(expectedA, uriA);
     assertEquals(expectedB, uriB);
   }
-  
+
   @Test
   void testGetDataValueSetUriB() {
     String base = "https://play.dhis2.org/2.38.0";
@@ -94,7 +95,7 @@ class Dhis2ClientTest {
 
     String uriA = client.getDataValueSetUri(optionsA).toString();
     String uriB = client.getDataValueSetUri(optionsB).toString();
-    
+
     String expectedA = base + "/api/dataValueSets?importStrategy=CREATE&skipAudit=true&dryRun=true";
     String expectedB = base + "/api/dataValueSets";
 
@@ -153,7 +154,7 @@ class Dhis2ClientTest {
     client.addIfNotDefault(builder, "dataElementIdScheme", IdScheme.CODE);
     client.addIfNotDefault(builder, "orgUnitIdScheme", null);
     client.addIfNotDefault(builder, "idScheme", IdScheme.UID);
-    
+
     String expected = "https://server.org?dataElementIdScheme=CODE";
 
     assertEquals(expected, builder.build().toString());
@@ -171,9 +172,10 @@ class Dhis2ClientTest {
     client.addIfNotDefault(builder, "orgUnitIdScheme", IdScheme.UID);
     client.addIfNotDefault(builder, "idScheme", IdScheme.from(new Attribute("fd0zFf0ylhI")));
 
-    String expected = "https://server.org?" + 
-        "dataElementIdScheme=ATTRIBUTE:bFOVPzWwQiC&idScheme=ATTRIBUTE:fd0zFf0ylhI";
-    
+    String expected =
+        "https://server.org?"
+            + "dataElementIdScheme=ATTRIBUTE:bFOVPzWwQiC&idScheme=ATTRIBUTE:fd0zFf0ylhI";
+
     assertEquals(expected, builder.build().toString());
   }
 
@@ -191,7 +193,7 @@ class Dhis2ClientTest {
         ImportStrategy.CREATE_AND_UPDATE);
     client.addIfNotDefault(builder, "skipAudit", true, false);
     client.addIfNotDefault(builder, "dryRun", false, false);
-    
+
     String expected = "https://server.org?skipAudit=true";
 
     assertEquals(expected, builder.build().toString());
@@ -208,7 +210,7 @@ class Dhis2ClientTest {
         builder, "importStrategy", ImportStrategy.CREATE, ImportStrategy.CREATE_AND_UPDATE);
     client.addIfNotDefault(builder, "skipAudit", false, false);
     client.addIfNotDefault(builder, "dryRun", true, false);
-    
+
     String expected = "https://server.org?importStrategy=CREATE&dryRun=true";
 
     assertEquals(expected, builder.build().toString());

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/client/Dhis2ClientTest.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/client/Dhis2ClientTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.dataexchange.client;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.net.URI;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.common.IdScheme;
@@ -144,20 +145,23 @@ class Dhis2ClientTest {
         "https://server.org?dataElementIdScheme=ATTRIBUTE:bFOVPzWwQiC&idScheme=ATTRIBUTE:fd0zFf0ylhI",
         builder.build().toString());
   }
-  
+
   @Test
   void testAddIfNotDefaultA() throws Exception {
     Dhis2Client client =
         Dhis2Client.withBasicAuth("https://play.dhis2.org/2.38.0", "admin", "district");
 
     UriComponentsBuilder builder = UriComponentsBuilder.fromUri(new URI("https://server.org"));
-    
-    client.addIfNotDefault(builder, "importStrategy", ImportStrategy.CREATE_AND_UPDATE, ImportStrategy.CREATE_AND_UPDATE);
+
+    client.addIfNotDefault(
+        builder,
+        "importStrategy",
+        ImportStrategy.CREATE_AND_UPDATE,
+        ImportStrategy.CREATE_AND_UPDATE);
     client.addIfNotDefault(builder, "skipAudit", true, false);
     client.addIfNotDefault(builder, "dryRun", false, false);
-    
-    assertEquals(
-        "https://server.org?skipAudit=true", builder.build().toString());
+
+    assertEquals("https://server.org?skipAudit=true", builder.build().toString());
   }
 
   @Test
@@ -166,11 +170,12 @@ class Dhis2ClientTest {
         Dhis2Client.withBasicAuth("https://play.dhis2.org/2.38.0", "admin", "district");
 
     UriComponentsBuilder builder = UriComponentsBuilder.fromUri(new URI("https://server.org"));
-    
-    client.addIfNotDefault(builder, "importStrategy", ImportStrategy.CREATE, ImportStrategy.CREATE_AND_UPDATE);
+
+    client.addIfNotDefault(
+        builder, "importStrategy", ImportStrategy.CREATE, ImportStrategy.CREATE_AND_UPDATE);
     client.addIfNotDefault(builder, "skipAudit", false, false);
     client.addIfNotDefault(builder, "dryRun", true, false);
-    
+
     assertEquals(
         "https://server.org?importStrategy=CREATE&dryRun=true", builder.build().toString());
   }

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/client/Dhis2ClientTest.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/client/Dhis2ClientTest.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.dataexchange.client;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import java.net.URI;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.common.IdScheme;
@@ -49,10 +48,10 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 class Dhis2ClientTest {
   @Test
-  void testGetDataValueSetUri() {
-    String baseUrl = "https://play.dhis2.org/2.38.0";
+  void testGetDataValueSetUriA() {
+    String base = "https://play.dhis2.org/2.38.0";
 
-    Dhis2Client client = Dhis2Client.withBasicAuth(baseUrl, "admin", "district");
+    Dhis2Client client = Dhis2Client.withBasicAuth(base, "admin", "district");
 
     ImportOptions optionsA =
         new ImportOptions()
@@ -68,10 +67,39 @@ class Dhis2ClientTest {
 
     String uriA = client.getDataValueSetUri(optionsA).toString();
     String uriB = client.getDataValueSetUri(optionsB).toString();
+    
+    String expectedA = base + "/api/dataValueSets?dataElementIdScheme=CODE&orgUnitIdScheme=CODE";
+    String expectedB = base + "/api/dataValueSets?orgUnitIdScheme=CODE&idScheme=CODE";
 
-    assertEquals(
-        baseUrl + "/api/dataValueSets?dataElementIdScheme=CODE&orgUnitIdScheme=CODE", uriA);
-    assertEquals(baseUrl + "/api/dataValueSets?orgUnitIdScheme=CODE&idScheme=CODE", uriB);
+    assertEquals(expectedA, uriA);
+    assertEquals(expectedB, uriB);
+  }
+  
+  @Test
+  void testGetDataValueSetUriB() {
+    String base = "https://play.dhis2.org/2.38.0";
+
+    Dhis2Client client = Dhis2Client.withBasicAuth(base, "admin", "district");
+
+    ImportOptions optionsA =
+        new ImportOptions()
+            .setImportStrategy(ImportStrategy.CREATE)
+            .setSkipAudit(true)
+            .setDryRun(true);
+    ImportOptions optionsB =
+        new ImportOptions()
+            .setImportStrategy(ImportStrategy.CREATE_AND_UPDATE)
+            .setSkipAudit(false)
+            .setDryRun(false);
+
+    String uriA = client.getDataValueSetUri(optionsA).toString();
+    String uriB = client.getDataValueSetUri(optionsB).toString();
+    
+    String expectedA = base + "/api/dataValueSets?importStrategy=CREATE&skipAudit=true&dryRun=true";
+    String expectedB = base + "/api/dataValueSets";
+
+    assertEquals(expectedA, uriA);
+    assertEquals(expectedB, uriB);
   }
 
   @Test
@@ -125,8 +153,10 @@ class Dhis2ClientTest {
     client.addIfNotDefault(builder, "dataElementIdScheme", IdScheme.CODE);
     client.addIfNotDefault(builder, "orgUnitIdScheme", null);
     client.addIfNotDefault(builder, "idScheme", IdScheme.UID);
+    
+    String expected = "https://server.org?dataElementIdScheme=CODE";
 
-    assertEquals("https://server.org?dataElementIdScheme=CODE", builder.build().toString());
+    assertEquals(expected, builder.build().toString());
   }
 
   @Test
@@ -141,9 +171,10 @@ class Dhis2ClientTest {
     client.addIfNotDefault(builder, "orgUnitIdScheme", IdScheme.UID);
     client.addIfNotDefault(builder, "idScheme", IdScheme.from(new Attribute("fd0zFf0ylhI")));
 
-    assertEquals(
-        "https://server.org?dataElementIdScheme=ATTRIBUTE:bFOVPzWwQiC&idScheme=ATTRIBUTE:fd0zFf0ylhI",
-        builder.build().toString());
+    String expected = "https://server.org?" + 
+        "dataElementIdScheme=ATTRIBUTE:bFOVPzWwQiC&idScheme=ATTRIBUTE:fd0zFf0ylhI";
+    
+    assertEquals(expected, builder.build().toString());
   }
 
   @Test
@@ -160,8 +191,10 @@ class Dhis2ClientTest {
         ImportStrategy.CREATE_AND_UPDATE);
     client.addIfNotDefault(builder, "skipAudit", true, false);
     client.addIfNotDefault(builder, "dryRun", false, false);
+    
+    String expected = "https://server.org?skipAudit=true";
 
-    assertEquals("https://server.org?skipAudit=true", builder.build().toString());
+    assertEquals(expected, builder.build().toString());
   }
 
   @Test
@@ -175,9 +208,10 @@ class Dhis2ClientTest {
         builder, "importStrategy", ImportStrategy.CREATE, ImportStrategy.CREATE_AND_UPDATE);
     client.addIfNotDefault(builder, "skipAudit", false, false);
     client.addIfNotDefault(builder, "dryRun", true, false);
+    
+    String expected = "https://server.org?importStrategy=CREATE&dryRun=true";
 
-    assertEquals(
-        "https://server.org?importStrategy=CREATE&dryRun=true", builder.build().toString());
+    assertEquals(expected, builder.build().toString());
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/client/Dhis2ClientTest.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/client/Dhis2ClientTest.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.dataexchange.client;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import java.net.URI;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.common.IdScheme;
@@ -40,6 +39,7 @@ import org.hisp.dhis.dataexchange.client.response.Status;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.importsummary.ImportStatus;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
+import org.hisp.dhis.importexport.ImportStrategy;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -115,7 +115,7 @@ class Dhis2ClientTest {
   }
 
   @Test
-  void testAddIfNotDefaultA() throws Exception {
+  void testAddIfNotDefaultIdSchemeA() throws Exception {
     Dhis2Client client =
         Dhis2Client.withBasicAuth("https://play.dhis2.org/2.38.0", "admin", "district");
 
@@ -129,7 +129,7 @@ class Dhis2ClientTest {
   }
 
   @Test
-  void testAddIfNotDefaultB() throws Exception {
+  void testAddIfNotDefaultIdSchemeB() throws Exception {
     Dhis2Client client =
         Dhis2Client.withBasicAuth("https://play.dhis2.org/2.38.0", "admin", "district");
 
@@ -143,6 +143,36 @@ class Dhis2ClientTest {
     assertEquals(
         "https://server.org?dataElementIdScheme=ATTRIBUTE:bFOVPzWwQiC&idScheme=ATTRIBUTE:fd0zFf0ylhI",
         builder.build().toString());
+  }
+  
+  @Test
+  void testAddIfNotDefaultA() throws Exception {
+    Dhis2Client client =
+        Dhis2Client.withBasicAuth("https://play.dhis2.org/2.38.0", "admin", "district");
+
+    UriComponentsBuilder builder = UriComponentsBuilder.fromUri(new URI("https://server.org"));
+    
+    client.addIfNotDefault(builder, "importStrategy", ImportStrategy.CREATE_AND_UPDATE, ImportStrategy.CREATE_AND_UPDATE);
+    client.addIfNotDefault(builder, "skipAudit", true, false);
+    client.addIfNotDefault(builder, "dryRun", false, false);
+    
+    assertEquals(
+        "https://server.org?skipAudit=true", builder.build().toString());
+  }
+
+  @Test
+  void testAddIfNotDefaultB() throws Exception {
+    Dhis2Client client =
+        Dhis2Client.withBasicAuth("https://play.dhis2.org/2.38.0", "admin", "district");
+
+    UriComponentsBuilder builder = UriComponentsBuilder.fromUri(new URI("https://server.org"));
+    
+    client.addIfNotDefault(builder, "importStrategy", ImportStrategy.CREATE, ImportStrategy.CREATE_AND_UPDATE);
+    client.addIfNotDefault(builder, "skipAudit", false, false);
+    client.addIfNotDefault(builder, "dryRun", true, false);
+    
+    assertEquals(
+        "https://server.org?importStrategy=CREATE&dryRun=true", builder.build().toString());
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
@@ -33,9 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -43,7 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.MapUtils;
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.common.IdentifiableObject;
@@ -53,6 +49,7 @@ import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dashboard.Dashboard;
 import org.hisp.dhis.dataexchange.aggregate.AggregateDataExchange;
 import org.hisp.dhis.dataexchange.aggregate.SourceRequest;
+import org.hisp.dhis.dataexchange.aggregate.Target;
 import org.hisp.dhis.dataexchange.aggregate.TargetType;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.Section;
@@ -83,6 +80,9 @@ import org.hisp.dhis.visualization.Visualization;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -1017,6 +1017,7 @@ class MetadataImportServiceTest extends TransactionalIntegrationTest {
 
     AggregateDataExchange aeA = manager.get(AggregateDataExchange.class, "iFOyIpQciyk");
     assertNotNull(aeA);
+    assertEquals("iFOyIpQciyk", aeA.getUid());
     assertNotNull(aeA.getSource());
     assertNotNull(aeA.getSource().getParams());
     assertNotEmpty(aeA.getSource().getParams().getPeriodTypes());
@@ -1026,12 +1027,14 @@ class MetadataImportServiceTest extends TransactionalIntegrationTest {
     assertNotNull(srA.getName());
     assertNotNull(srA.getVisualization());
     assertNotNull("UID", srA.getOutputDataItemIdScheme());
-    assertNotNull(aeA.getTarget());
-    assertEquals("iFOyIpQciyk", aeA.getUid());
-    assertEquals(TargetType.INTERNAL, aeA.getTarget().getType());
+    Target tA = aeA.getTarget();
+    assertNotNull(tA);
+    assertEquals(TargetType.INTERNAL, tA.getType());
+    assertEquals(ImportStrategy.CREATE_AND_UPDATE, tA.getRequest().getImportStrategy());
 
     AggregateDataExchange aeB = manager.get(AggregateDataExchange.class, "PnWccbwCJLQ");
     assertNotNull(aeB);
+    assertEquals("PnWccbwCJLQ", aeB.getUid());
     assertNotNull(aeB.getSource());
     assertNotNull(aeB.getSource().getParams());
     assertNotEmpty(aeB.getSource().getParams().getPeriodTypes());
@@ -1041,15 +1044,17 @@ class MetadataImportServiceTest extends TransactionalIntegrationTest {
     assertNotNull(srB.getName());
     assertNotNull(srB.getVisualization());
     assertNotNull("UID", srB.getOutputDataItemIdScheme());
-    assertNotNull(aeB.getTarget());
-    assertEquals("PnWccbwCJLQ", aeB.getUid());
-    assertEquals(TargetType.EXTERNAL, aeB.getTarget().getType());
-    assertEquals("https://play.dhis2.org/2.38.1", aeB.getTarget().getApi().getUrl());
-    assertEquals("admin", aeB.getTarget().getApi().getUsername());
-    assertNotNull(aeB.getTarget().getApi().getPassword()); // Encrypted
+    Target tB = aeB.getTarget();
+    assertNotNull(tB);
+    assertEquals(TargetType.EXTERNAL, tB.getType());
+    assertEquals("https://play.dhis2.org/2.38.1", tB.getApi().getUrl());
+    assertEquals("admin", tB.getApi().getUsername());
+    assertNotNull(tB.getApi().getPassword()); // Encrypted
+    assertEquals(ImportStrategy.CREATE_AND_UPDATE, tB.getRequest().getImportStrategy());
 
     AggregateDataExchange aeC = manager.get(AggregateDataExchange.class, "VpQ4qVEseyM");
     assertNotNull(aeC);
+    assertEquals("VpQ4qVEseyM", aeC.getUid());
     assertNotNull(aeC.getSource());
     assertNotNull(aeC.getSource().getParams());
     assertNotEmpty(aeC.getSource().getParams().getPeriodTypes());
@@ -1059,11 +1064,12 @@ class MetadataImportServiceTest extends TransactionalIntegrationTest {
     assertNotNull(srC.getName());
     assertNotNull(srC.getVisualization());
     assertNotNull("UID", srC.getOutputDataItemIdScheme());
-    assertNotNull(aeC.getTarget());
-    assertEquals("VpQ4qVEseyM", aeC.getUid());
-    assertEquals(TargetType.EXTERNAL, aeC.getTarget().getType());
-    assertEquals("https://play.dhis2.org/2.38.1", aeC.getTarget().getApi().getUrl());
-    assertNotNull(aeC.getTarget().getApi().getAccessToken()); // Encrypted
+    Target tC = aeC.getTarget();
+    assertNotNull(tC);
+    assertEquals(TargetType.EXTERNAL, tC.getType());
+    assertEquals("https://play.dhis2.org/2.38.1", tC.getApi().getUrl());
+    assertNotNull(tC.getApi().getAccessToken()); // Encrypted
+    assertEquals(ImportStrategy.CREATE_AND_UPDATE, tC.getRequest().getImportStrategy());
   }
 
   /** Test to make sure createdBy field is immutable. */

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
@@ -33,6 +33,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -40,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.MapUtils;
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.common.IdentifiableObject;
@@ -80,9 +84,6 @@ import org.hisp.dhis.visualization.Visualization;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>

--- a/dhis-2/dhis-test-integration/src/test/resources/dxf2/aggregate_data_exchange.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/dxf2/aggregate_data_exchange.json
@@ -58,10 +58,7 @@
             "outputDataElementIdScheme": "UID",
             "outputOrgUnitIdScheme": "UID",
             "outputDataItemIdScheme": "UID",
-            "outputIdScheme": "UID",
-            "importStrategy": "CREATE_AND_UPDATE",
-            "skipAudit": false,
-            "dryRun": false
+            "outputIdScheme": "UID"
           }
         ]
       },
@@ -71,7 +68,10 @@
           "dataElementIdScheme": null,
           "orgUnitIdScheme": null,
           "categoryOptionComboIdScheme": null,
-          "idScheme": null
+          "idScheme": null,
+          "importStrategy": "CREATE_AND_UPDATE",
+          "skipAudit": false,
+          "dryRun": false
         }
       }
     },
@@ -104,10 +104,7 @@
             "outputDataElementIdScheme": "UID",
             "outputOrgUnitIdScheme": "UID",
             "outputDataItemIdScheme": "UID",
-            "outputIdScheme": "UID",
-            "importStrategy": "CREATE_AND_UPDATE",
-            "skipAudit": false,
-            "dryRun": false
+            "outputIdScheme": "UID"
           }
         ]
       },
@@ -122,7 +119,10 @@
           "dataElementIdScheme": "UID",
           "orgUnitIdScheme": "UID",
           "categoryOptionComboIdScheme": "UID",
-          "idScheme": "UID"
+          "idScheme": "UID",
+          "importStrategy": "CREATE_AND_UPDATE",
+          "skipAudit": false,
+          "dryRun": false
         }
       }
     },
@@ -155,10 +155,7 @@
             "outputDataElementIdScheme": "UID",
             "outputOrgUnitIdScheme": "UID",
             "outputDataItemIdScheme": "UID",
-            "outputIdScheme": "UID",
-            "importStrategy": "CREATE_AND_UPDATE",
-            "skipAudit": false,
-            "dryRun": false
+            "outputIdScheme": "UID"
           }
         ]
       },
@@ -172,7 +169,10 @@
           "dataElementIdScheme": "UID",
           "orgUnitIdScheme": "UID",
           "categoryOptionComboIdScheme": "UID",
-          "idScheme": "UID"
+          "idScheme": "UID",
+          "importStrategy": "CREATE_AND_UPDATE",
+          "skipAudit": false,
+          "dryRun": false
         }
       }
     }

--- a/dhis-2/dhis-test-integration/src/test/resources/dxf2/aggregate_data_exchange.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/dxf2/aggregate_data_exchange.json
@@ -58,7 +58,10 @@
             "outputDataElementIdScheme": "UID",
             "outputOrgUnitIdScheme": "UID",
             "outputDataItemIdScheme": "UID",
-            "outputIdscheme": "UID"
+            "outputIdScheme": "UID",
+            "importStrategy": "CREATE_AND_UPDATE",
+            "skipAudit": false,
+            "dryRun": false
           }
         ]
       },
@@ -101,7 +104,10 @@
             "outputDataElementIdScheme": "UID",
             "outputOrgUnitIdScheme": "UID",
             "outputDataItemIdScheme": "UID",
-            "outputIdscheme": "UID"
+            "outputIdScheme": "UID",
+            "importStrategy": "CREATE_AND_UPDATE",
+            "skipAudit": false,
+            "dryRun": false
           }
         ]
       },
@@ -149,7 +155,10 @@
             "outputDataElementIdScheme": "UID",
             "outputOrgUnitIdScheme": "UID",
             "outputDataItemIdScheme": "UID",
-            "outputIdscheme": "UID"
+            "outputIdScheme": "UID",
+            "importStrategy": "CREATE_AND_UPDATE",
+            "skipAudit": false,
+            "dryRun": false
           }
         ]
       },


### PR DESCRIPTION
Adds support for the following import options for the aggregate data exchange target: `importStrategy`, `skipAudit`, `dryRun`.