### PR TITLE
feat: Add createdAtClient to relationships [DHIS2-15666]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/Relationship.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/Relationship.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.io.Serializable;
+import java.util.Date;
 import org.hisp.dhis.audit.AuditAttribute;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.Auditable;
@@ -50,6 +51,8 @@ import org.hisp.dhis.common.SoftDeletableObject;
 public class Relationship extends SoftDeletableObject implements Serializable {
   /** Determines if a de-serialized file is compatible with this class. */
   private static final long serialVersionUID = 3818815755138507997L;
+
+  private Date createdAtClient;
 
   @AuditAttribute private RelationshipType relationshipType;
 
@@ -84,6 +87,15 @@ public class Relationship extends SoftDeletableObject implements Serializable {
   // -------------------------------------------------------------------------
   // Getters and setters
   // -------------------------------------------------------------------------
+
+  @JsonProperty
+  public Date getCreatedAtClient() {
+    return createdAtClient;
+  }
+
+  public void setCreatedAtClient(Date createdAtClient) {
+    this.createdAtClient = createdAtClient;
+  }
 
   /**
    * @return the relationshipType

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/relationship/hibernate/Relationship.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/relationship/hibernate/Relationship.hbm.xml
@@ -43,5 +43,6 @@
 
         <property name="deleted" column="deleted"/>
 
+        <property name="createdAtClient" type="timestamp" />
     </class>
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -188,6 +188,7 @@ public class DefaultRelationshipService implements RelationshipService {
     result.setRelationshipType(relationship.getRelationshipType());
     result.setFrom(withNestedEntity(relationship.getFrom()));
     result.setTo(withNestedEntity(relationship.getTo()));
+    result.setCreatedAtClient(relationship.getCreatedAtClient());
     return result;
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
@@ -65,7 +65,7 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
    * Relationships can be ordered by given fields which correspond to fields on {@link
    * org.hisp.dhis.relationship.Relationship}.
    */
-  private static final Set<String> ORDERABLE_FIELDS = Set.of("created");
+  private static final Set<String> ORDERABLE_FIELDS = Set.of("created", "createdAtClient");
 
   private static final String TRACKED_ENTITY = "trackedEntity";
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/AbstractStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/AbstractStore.java
@@ -51,7 +51,7 @@ abstract class AbstractStore {
           + "where ri.%s in (:ids)";
   private static final String GET_RELATIONSHIP_BY_RELATIONSHIP_ID =
       "select "
-          + "r.uid as rel_uid, r.created, r.lastupdated, rst.name as reltype_name, rst.uid as reltype_uid, rst.bidirectional as reltype_bi, "
+          + "r.uid as rel_uid, r.created, r.createdatclient, r.lastupdated, rst.name as reltype_name, rst.uid as reltype_uid, rst.bidirectional as reltype_bi, "
           + "coalesce((select 'te|' || te.uid from trackedentity te "
           + "join relationshipitem ri on te.trackedentityid = ri.trackedentityid "
           + "where ri.relationshipitemid = r.to_relationshipitemid) , (select 'en|' || en.uid "

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/mapper/RelationshipRowCallbackHandler.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/mapper/RelationshipRowCallbackHandler.java
@@ -82,6 +82,7 @@ public class RelationshipRowCallbackHandler extends AbstractMapper<RelationshipI
     relationship.setRelationshipType(type);
     relationship.setCreated(rs.getTimestamp("created"));
     relationship.setLastUpdated(rs.getTimestamp("lastupdated"));
+    relationship.setCreatedAtClient(rs.getTimestamp("createdatclient"));
 
     RelationshipItem from = createItem(rs.getString("from_uid"));
     from.setRelationship(relationship);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/RelationshipTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/RelationshipTrackerConverterService.java
@@ -120,16 +120,17 @@ public class RelationshipTrackerConverterService
     org.hisp.dhis.relationship.RelationshipItem toItem =
         new org.hisp.dhis.relationship.RelationshipItem();
 
+    Date now = new Date();
     if (toRelationship == null) {
-      Date now = new Date();
 
       toRelationship = new org.hisp.dhis.relationship.Relationship();
       toRelationship.setUid(fromRelationship.getRelationship());
       toRelationship.setCreated(now);
-      toRelationship.setLastUpdated(now);
     }
+    toRelationship.setLastUpdated(now);
 
     toRelationship.setRelationshipType(relationshipType);
+    toRelationship.setCreatedAtClient(DateUtils.fromInstant(fromRelationship.getCreatedAtClient()));
 
     if (fromRelationship.getRelationship() != null) {
       toRelationship.setUid(fromRelationship.getRelationship());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Relationship.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/Relationship.java
@@ -51,6 +51,8 @@ public class Relationship implements TrackerDto {
 
   @JsonProperty private Instant createdAt;
 
+  @JsonProperty private Instant createdAtClient;
+
   @JsonProperty private Instant updatedAt;
 
   @JsonProperty private boolean bidirectional;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/RelationshipMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/RelationshipMapper.java
@@ -52,6 +52,7 @@ public interface RelationshipMapper extends PreheatMapper<Relationship> {
   @Mapping(target = "createdBy")
   @Mapping(target = "lastUpdated")
   @Mapping(target = "lastUpdatedBy")
+  @Mapping(target = "createdAtClient")
   @Mapping(target = "deleted")
   Relationship map(Relationship relationship);
 

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_29__Add_createdatclient_to_relationship.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_29__Add_createdatclient_to_relationship.sql
@@ -1,3 +1,1 @@
 alter table relationship add column if not exists "createdatclient" timestamp;
-
-update relationship set createdatclient = created where createdatclient IS NULL;

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_29__Add_createdatclient_to_relationship.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_29__Add_createdatclient_to_relationship.sql
@@ -1,0 +1,3 @@
+alter table relationship add column if not exists "createdatclient" timestamp;
+
+update relationship set createdatclient = created where createdatclient IS NULL;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAssertions.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAssertions.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.program.Event;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.tracker.TrackerType;
+import org.hisp.dhis.util.DateUtils;
 
 public class JsonAssertions {
 
@@ -67,6 +68,10 @@ public class JsonAssertions {
   public static void assertRelationship(Relationship expected, JsonRelationship actual) {
     assertFalse(actual.isEmpty(), "relationship should not be empty");
     assertEquals(expected.getUid(), actual.getRelationship(), "relationship UID");
+    assertEquals(
+        DateUtils.getIso8601NoTz(expected.getCreatedAtClient()),
+        actual.getCreatedAtClient(),
+        "createdAtClient date");
     assertEquals(
         expected.getRelationshipType().getUid(),
         actual.getRelationshipType(),

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonRelationship.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonRelationship.java
@@ -43,6 +43,10 @@ public interface JsonRelationship extends JsonObject {
     return getString("relationshipType").string();
   }
 
+  default String getCreatedAtClient() {
+    return getString("createdAtClient").string();
+  }
+
   default JsonRelationshipItem getFrom() {
     return get("from").as(JsonRelationshipItem.class);
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -171,7 +171,8 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
             .content(HttpStatus.OK)
             .as(JsonRelationship.class);
 
-    assertHasOnlyMembers(relationship, "relationship", "relationshipType", "from", "to");
+    assertHasOnlyMembers(
+        relationship, "relationship", "relationshipType", "createdAtClient", "from", "to");
     assertRelationship(r, relationship);
     assertHasOnlyUid(from.getUid(), "event", relationship.getObject("from"));
     assertHasOnlyUid(to.getUid(), "trackedEntity", relationship.getObject("to"));
@@ -245,9 +246,26 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
             .getList("instances", JsonRelationship.class);
 
     JsonObject relationship = assertFirstRelationship(r, relationships);
-    assertHasOnlyMembers(relationship, "relationship", "relationshipType", "from", "to");
+    assertHasOnlyMembers(
+        relationship, "relationship", "relationshipType", "createdAtClient", "from", "to");
     assertHasOnlyUid(from.getUid(), "event", relationship.getObject("from"));
     assertHasOnlyUid(to.getUid(), "trackedEntity", relationship.getObject("to"));
+  }
+
+  @Test
+  void getRelationshipsByEventWithAllFields() {
+    TrackedEntity to = trackedEntity();
+    Event from = event(enrollment(to));
+    Relationship r = relationship(from, to);
+
+    JsonList<JsonRelationship> relationships =
+        GET("/tracker/relationships?event={uid}&fields=*", from.getUid())
+            .content(HttpStatus.OK)
+            .getList("instances", JsonRelationship.class);
+
+    JsonRelationship relationship = assertFirstRelationship(r, relationships);
+    assertEventWithinRelationshipItem(from, relationship.getFrom());
+    assertTrackedEntityWithinRelationshipItem(to, relationship.getTo());
   }
 
   @Test
@@ -782,6 +800,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
 
     r.setAutoFields();
     r.getSharing().setOwner(owner);
+    r.setCreatedAtClient(new Date());
     manager.save(r, false);
     return r;
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipMapper.java
@@ -46,13 +46,15 @@ public interface RelationshipMapper
    * Relationships can be ordered by given fields which correspond to fields on {@link
    * org.hisp.dhis.relationship.Relationship}.
    */
-  Map<String, String> ORDERABLE_FIELDS = Map.ofEntries(entry("createdAt", "created"));
+  Map<String, String> ORDERABLE_FIELDS =
+      Map.ofEntries(entry("createdAt", "created"), entry("createdAtClient", "createdAtClient"));
 
   @Mapping(target = "relationship", source = "uid")
   @Mapping(target = "relationshipType", source = "relationshipType.uid")
   @Mapping(target = "relationshipName", source = "relationshipType.name")
   @Mapping(target = "bidirectional", source = "relationshipType.bidirectional")
   @Mapping(target = "createdAt", source = "created")
+  @Mapping(target = "createdAtClient", source = "createdAtClient")
   @Mapping(target = "updatedAt", source = "lastUpdated")
   @Override
   Relationship from(org.hisp.dhis.relationship.Relationship relationship);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RequestParams.java
@@ -46,7 +46,7 @@ import org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity;
 class RequestParams extends PagingAndSortingCriteriaAdapter {
 
   static final String DEFAULT_FIELDS_PARAM =
-      "relationship,relationshipType,from[trackedEntity[trackedEntity],enrollment[enrollment],event[event]],to[trackedEntity[trackedEntity],enrollment[enrollment],event[event]]";
+      "relationship,relationshipType,createdAtClient,from[trackedEntity[trackedEntity],enrollment[enrollment],event[event]],to[trackedEntity[trackedEntity],enrollment[enrollment],event[event]]";
 
   /**
    * @deprecated use {@link #trackedEntity} instead

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Relationship.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Relationship.java
@@ -59,6 +59,8 @@ public class Relationship {
 
   @JsonProperty private Instant createdAt;
 
+  @JsonProperty private Instant createdAtClient;
+
   @JsonProperty private Instant updatedAt;
 
   @JsonProperty private boolean bidirectional;

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/RelationshipsExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/RelationshipsExportController.md
@@ -52,6 +52,7 @@ Get relationships in given order. Relationships can be ordered by the following 
 properties
 
 * `createdAt`
+* `createdAtClient`
 
 Valid `sortDirection`s are `asc` and `desc`. `sortDirection` is case-insensitive. `sortDirection`
 defaults to `asc` for properties without explicit `sortDirection` as in `order=createdAt`.


### PR DESCRIPTION
Adding `createdAtClient` field to relationship entity in tracker (not adding it in deprecated tracker) and adding the possibility to order by this field.
`createdAtClient` was also added to the list of default fields to be returned when exporting a relationship.

**Changes required to support new field**
- Flyway script to add the column in the relationship table
- Add the field in Hibernate mapping for relationship
- Update the relationship object in all the layers and the relative mappers
- Update aggregate importer getting relationships inside a TE
- Update all the tests that were importing/exporting relationships
- Added tests for the ordering by the new field