### PR TITLE
feature: Migrate GeoJSON import job to use new Job setup [DHIS2-15939]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
@@ -55,6 +55,7 @@ import org.hisp.dhis.scheduling.parameters.DataIntegrityJobParameters;
 import org.hisp.dhis.scheduling.parameters.DataSynchronizationJobParameters;
 import org.hisp.dhis.scheduling.parameters.DisableInactiveUsersJobParameters;
 import org.hisp.dhis.scheduling.parameters.EventProgramsDataSynchronizationJobParameters;
+import org.hisp.dhis.scheduling.parameters.GeoJsonImportJobParams;
 import org.hisp.dhis.scheduling.parameters.LockExceptionCleanupJobParameters;
 import org.hisp.dhis.scheduling.parameters.MetadataSyncJobParameters;
 import org.hisp.dhis.scheduling.parameters.MonitoringJobParameters;
@@ -290,7 +291,8 @@ public class JobConfiguration extends BaseIdentifiableObject implements Secondar
         @JsonSubTypes.Type(value = TestJobParameters.class, name = "TEST"),
         @JsonSubTypes.Type(
             value = ImportOptions.class,
-            name = "COMPLETE_DATA_SET_REGISTRATION_IMPORT")
+            name = "COMPLETE_DATA_SET_REGISTRATION_IMPORT"),
+        @JsonSubTypes.Type(value = GeoJsonImportJobParams.class, name = "GEO_JSON_IMPORT")
       })
   public JobParameters getJobParameters() {
     return jobParameters;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.scheduling.parameters.DataIntegrityJobParameters;
 import org.hisp.dhis.scheduling.parameters.DataSynchronizationJobParameters;
 import org.hisp.dhis.scheduling.parameters.DisableInactiveUsersJobParameters;
 import org.hisp.dhis.scheduling.parameters.EventProgramsDataSynchronizationJobParameters;
+import org.hisp.dhis.scheduling.parameters.GeoJsonImportJobParams;
 import org.hisp.dhis.scheduling.parameters.LockExceptionCleanupJobParameters;
 import org.hisp.dhis.scheduling.parameters.MetadataSyncJobParameters;
 import org.hisp.dhis.scheduling.parameters.MockJobParameters;
@@ -102,7 +103,7 @@ public enum JobType {
   DATAVALUE_IMPORT_INTERNAL(),
   METADATA_IMPORT(),
   DATAVALUE_IMPORT(ImportOptions.class),
-  GEOJSON_IMPORT(),
+  GEOJSON_IMPORT(GeoJsonImportJobParams.class),
   EVENT_IMPORT(),
   ENROLLMENT_IMPORT(),
   TEI_IMPORT(),
@@ -199,7 +200,8 @@ public enum JobType {
         || this == PREDICTOR
         || this == DATAVALUE_IMPORT
         || this == COMPLETE_DATA_SET_REGISTRATION_IMPORT
-        || this == METADATA_IMPORT;
+        || this == METADATA_IMPORT
+        || this == GEOJSON_IMPORT;
   }
 
   public boolean isUsingErrorNotification() {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/GeoJsonImportJobParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/GeoJsonImportJobParams.java
@@ -25,19 +25,20 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.dxf2.geojson;
+package org.hisp.dhis.scheduling.parameters;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.hisp.dhis.common.IdentifiableProperty;
+import org.hisp.dhis.scheduling.JobParameters;
 import org.hisp.dhis.user.User;
 
 @Builder(toBuilder = true)
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class GeoJsonImportParams {
+public class GeoJsonImportJobParams implements JobParameters {
   /**
    * If true the import is validated and processed without actually modifying any organisation unit
    * or storing GeoJSON data.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/GeoJsonImportJobParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/GeoJsonImportJobParams.java
@@ -33,12 +33,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hisp.dhis.common.IdentifiableProperty;
 import org.hisp.dhis.scheduling.JobParameters;
 import org.hisp.dhis.user.User;
 
 @Builder(toBuilder = true)
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class GeoJsonImportJobParams implements JobParameters {
@@ -58,5 +60,5 @@ public class GeoJsonImportJobParams implements JobParameters {
    */
   @JsonProperty private String attributeId;
 
-  @JsonProperty private User user;
+  private User user;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/GeoJsonImportJobParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/GeoJsonImportJobParams.java
@@ -27,33 +27,36 @@
  */
 package org.hisp.dhis.scheduling.parameters;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hisp.dhis.common.IdentifiableProperty;
 import org.hisp.dhis.scheduling.JobParameters;
 import org.hisp.dhis.user.User;
 
 @Builder(toBuilder = true)
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class GeoJsonImportJobParams implements JobParameters {
   /**
    * If true the import is validated and processed without actually modifying any organisation unit
    * or storing GeoJSON data.
    */
-  private final boolean dryRun;
+  @JsonProperty private boolean dryRun;
 
-  private final String orgUnitIdProperty;
+  @JsonProperty private String orgUnitIdProperty;
 
-  private final IdentifiableProperty idType;
+  @JsonProperty private IdentifiableProperty idType;
 
   /**
    * Optional UID that refers to an {@link org.hisp.dhis.attribute.Attribute} for which the geometry
    * is stored.
    */
-  private final String attributeId;
+  @JsonProperty private String attributeId;
 
-  private final User user;
+  @JsonProperty private User user;
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
@@ -40,6 +40,7 @@ import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -111,6 +112,7 @@ public class DefaultJobConfigurationService implements JobConfigurationService {
       throws ConflictException {
     try {
       byte[] data = IOUtils.toByteArray(content);
+      String s = new String(data, StandardCharsets.UTF_8);
       FileResource fr =
           new FileResource(
               "job_input_data_for_" + uid,

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
@@ -40,7 +40,6 @@ import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -112,7 +111,6 @@ public class DefaultJobConfigurationService implements JobConfigurationService {
       throws ConflictException {
     try {
       byte[] data = IOUtils.toByteArray(content);
-      String s = new String(data, StandardCharsets.UTF_8);
       FileResource fr =
           new FileResource(
               "job_input_data_for_" + uid,

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/DefaultGeoJsonService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/DefaultGeoJsonService.java
@@ -59,6 +59,7 @@ import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonValue;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitStore;
+import org.hisp.dhis.scheduling.parameters.GeoJsonImportJobParams;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.system.util.GeoUtils;
 import org.locationtech.jts.geom.Geometry;
@@ -110,7 +111,7 @@ public class DefaultGeoJsonService implements GeoJsonService {
   @Override
   @Transactional
   public GeoJsonImportReport importGeoData(
-      GeoJsonImportParams params, InputStream geoJsonFeatureCollection) {
+      GeoJsonImportJobParams params, InputStream geoJsonFeatureCollection) {
     GeoJsonImportReport report = new GeoJsonImportReport();
     Attribute attribute = validateAttribute(params.getAttributeId(), report);
     if (report.getConflictCount() > 0) {
@@ -183,7 +184,7 @@ public class DefaultGeoJsonService implements GeoJsonService {
   }
 
   private Function<OrganisationUnit, String> getGeoJsonFeatureToOrgUnitIdentifier(
-      GeoJsonImportParams params) {
+      GeoJsonImportJobParams params) {
     switch (params.getIdType()) {
       case CODE:
         return OrganisationUnit::getCode;
@@ -195,7 +196,7 @@ public class DefaultGeoJsonService implements GeoJsonService {
   }
 
   private List<OrganisationUnit> fetchOrganisationUnits(
-      GeoJsonImportParams params, @Nonnull Set<String> ouIdentifiers) {
+      GeoJsonImportJobParams params, @Nonnull Set<String> ouIdentifiers) {
     switch (params.getIdType()) {
       case CODE:
         return organisationUnitStore.getByCode(ouIdentifiers, params.getUser());
@@ -230,7 +231,7 @@ public class DefaultGeoJsonService implements GeoJsonService {
   }
 
   private boolean validateGeometry(
-      GeoJsonImportParams params,
+      GeoJsonImportJobParams params,
       OrganisationUnit target,
       JsonObject geometry,
       GeoJsonImportReport report,
@@ -298,7 +299,7 @@ public class DefaultGeoJsonService implements GeoJsonService {
   }
 
   private void updateGeometry(
-      GeoJsonImportParams params,
+      GeoJsonImportJobParams params,
       Attribute attribute,
       OrganisationUnit target,
       JsonObject geometry,
@@ -373,7 +374,7 @@ public class DefaultGeoJsonService implements GeoJsonService {
   }
 
   private void executeUpdate(
-      GeoJsonImportParams params, GeoJsonImportReport report, GeometryUpdate update) {
+      GeoJsonImportJobParams params, GeoJsonImportReport report, GeometryUpdate update) {
     try {
       if (update.needsUpdate() && !params.isDryRun()) {
         organisationUnitStore.update(update.target());

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/GeoJsonService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/GeoJsonService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.dxf2.geojson;
 
 import java.io.InputStream;
+import org.hisp.dhis.scheduling.parameters.GeoJsonImportJobParams;
 
 /**
  * Service for handling import/export of GeoJSON.
@@ -42,7 +43,7 @@ public interface GeoJsonService {
    * @param geoJsonData expected to be a GeoJSON feature-collection root object
    * @return a report with statistics and conflicts
    */
-  GeoJsonImportReport importGeoData(GeoJsonImportParams params, InputStream geoJsonData);
+  GeoJsonImportReport importGeoData(GeoJsonImportJobParams params, InputStream geoJsonData);
 
   /**
    * Clears all GeoJSON data from all organisation units for the given attribute. If the attribute

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/job/GeoJsonImportJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/job/GeoJsonImportJob.java
@@ -1,0 +1,50 @@
+package org.hisp.dhis.dxf2.geojson.job;
+
+import java.io.IOException;
+import java.io.InputStream;
+import lombok.AllArgsConstructor;
+import org.hisp.dhis.dxf2.geojson.GeoJsonImportReport;
+import org.hisp.dhis.dxf2.geojson.GeoJsonService;
+import org.hisp.dhis.fileresource.FileResource;
+import org.hisp.dhis.fileresource.FileResourceService;
+import org.hisp.dhis.scheduling.Job;
+import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
+import org.hisp.dhis.scheduling.JobType;
+import org.hisp.dhis.scheduling.parameters.GeoJsonImportJobParams;
+import org.hisp.dhis.system.notification.Notifier;
+import org.springframework.stereotype.Component;
+
+@AllArgsConstructor
+@Component
+public class GeoJsonImportJob implements Job {
+
+  private final GeoJsonService geoJsonService;
+  private final FileResourceService fileResourceService;
+  private final Notifier notifier;
+
+  @Override
+  public JobType getJobType() {
+    return JobType.GEOJSON_IMPORT;
+  }
+
+  @Override
+  public void execute(JobConfiguration jobConfig, JobProgress progress) {
+    progress.startingProcess("GeoJSON import started");
+    GeoJsonImportJobParams jobParams = (GeoJsonImportJobParams) jobConfig.getJobParameters();
+
+    progress.startingStage("Loading file resource");
+    FileResource data =
+        progress.runStage(() -> fileResourceService.getFileResource(jobConfig.getUid()));
+    progress.startingStage("Loading file content");
+
+    try (InputStream input =
+        progress.runStage(() -> fileResourceService.getFileResourceContent(data))) {
+      GeoJsonImportReport report = geoJsonService.importGeoData(jobParams, input);
+      progress.completedProcess("GeoJSON import complete");
+      notifier.addJobSummary(jobConfig, report, GeoJsonImportReport.class);
+    } catch (IOException e) {
+      progress.failedProcess(e);
+    }
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/job/GeoJsonImportJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/job/GeoJsonImportJob.java
@@ -67,8 +67,10 @@ public class GeoJsonImportJob implements Job {
 
     try (InputStream input =
         progress.runStage(() -> fileResourceService.getFileResourceContent(data))) {
+      progress.startingStage("Importing GeoJSON started");
       GeoJsonImportReport report = geoJsonService.importGeoData(jobParams, input);
-      progress.completedProcess("GeoJSON import complete");
+      progress.completedStage("Importing GeoJSON completed");
+      progress.completedProcess("GeoJSON import completed");
       notifier.addJobSummary(jobConfig, report, GeoJsonImportReport.class);
     } catch (IOException e) {
       progress.failedProcess(e);

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/job/GeoJsonImportJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/job/GeoJsonImportJob.java
@@ -1,3 +1,30 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.dxf2.geojson.job;
 
 import java.io.IOException;

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/GeoJsonImportTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/GeoJsonImportTest.java
@@ -68,7 +68,6 @@ class GeoJsonImportTest extends ApiTest {
 
     // post geo json async
     ApiResponse postGeoJsonAsyncResponse = restApiActions.post("/geometry?async=true", geoJson);
-    assertEquals("200", postGeoJsonAsyncResponse.getAsString());
     assertEquals(200, postGeoJsonAsyncResponse.statusCode());
 
     assertTrue(
@@ -76,7 +75,7 @@ class GeoJsonImportTest extends ApiTest {
             .getBody()
             .get("message")
             .getAsString()
-            .contains("Initiated GeoJSON import"));
+            .contains("Initiated GEOJSON_IMPORT"));
 
     String taskId =
         postGeoJsonAsyncResponse.getBody().getAsJsonObject("response").get("id").getAsString();

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/GeoJsonImportTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/GeoJsonImportTest.java
@@ -68,6 +68,7 @@ class GeoJsonImportTest extends ApiTest {
 
     // post geo json async
     ApiResponse postGeoJsonAsyncResponse = restApiActions.post("/geometry?async=true", geoJson);
+    assertEquals("200", postGeoJsonAsyncResponse.getAsString());
     assertEquals(200, postGeoJsonAsyncResponse.statusCode());
 
     assertTrue(
@@ -98,24 +99,29 @@ class GeoJsonImportTest extends ApiTest {
 
   private String geoJson() {
     return """
-        {
-            "type": "Feature",
-            "id": "ImspTQPwCqd",
-            "geometry": {
-                "type": "Point",
-                "coordinates": [-12.56262192106476,7.376283621891673]
-            },
-            "properties": {
-                "Shape_Leng": 20.8503761122,
-                "Shape_Area": 5.96427565724,
-                "shapeName": "Republic of Sierra Leone",
-                "Level": "ADM0",
-                "shapeISO": "SLE",
-                "shapeID": "SLE-ADM0-89611731B79725766",
-                "shapeGroup": "SLE",
-                "shapeType": "ADM0",
-                "code": "OU_525"
+        { 
+          "type": "FeatureCollection",
+          "features":[
+            {
+              "type": "Feature",
+              "id": "ImspTQPwCqd",
+              "geometry": {
+                  "type": "Point",
+                  "coordinates": [-12.56262192106476,7.376283621891673]
+              },
+              "properties": {
+                  "Shape_Leng": 20.8503761122,
+                  "Shape_Area": 5.96427565724,
+                  "shapeName": "Republic of Sierra Leone",
+                  "Level": "ADM0",
+                  "shapeISO": "SLE",
+                  "shapeID": "SLE-ADM0-89611731B79725766",
+                  "shapeGroup": "SLE",
+                  "shapeType": "ADM0",
+                  "code": "OU_525"
+              }
             }
+          ]
         }
         """;
   }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/GeoJsonImportTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/GeoJsonImportTest.java
@@ -37,7 +37,7 @@ import org.hisp.dhis.actions.LoginActions;
 import org.hisp.dhis.actions.RestApiActions;
 import org.hisp.dhis.actions.SystemActions;
 import org.hisp.dhis.dto.ApiResponse;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -48,15 +48,14 @@ class GeoJsonImportTest extends ApiTest {
   private SystemActions systemActions;
   private RestApiActions restApiActions;
 
-  @BeforeAll
+  private String geoJson;
+
+  @BeforeEach
   public void before() {
     loginActions = new LoginActions();
     systemActions = new SystemActions();
     restApiActions = new RestApiActions("organisationUnits");
-  }
 
-  @Test
-  void geoJsonImportAsync() {
     loginActions.loginAsSuperUser();
 
     // make sure org unit has no geo json data
@@ -64,8 +63,11 @@ class GeoJsonImportTest extends ApiTest {
     assertEquals(200, deleteOrgUnitResponse.statusCode());
 
     // create geo json
-    String geoJson = geoJson();
+    geoJson = geoJson();
+  }
 
+  @Test
+  void geoJsonImportAsync() {
     // get org unit geometry to show currently empty
     ApiResponse getOrgUnitResponse = restApiActions.get("/ImspTQPwCqd");
     assertNull(getOrgUnitResponse.getBody().get("geometry"));
@@ -102,25 +104,16 @@ class GeoJsonImportTest extends ApiTest {
 
   @Test
   void geoJsonImportSync() {
-    loginActions.loginAsSuperUser();
-
-    // make sure org unit has no geo json data
-    ApiResponse deleteOrgUnitResponse = restApiActions.delete("/ImspTQPwCqd/geometry");
-    assertEquals(200, deleteOrgUnitResponse.statusCode());
-
-    // create geo json
-    String geoJson = geoJson();
-
     // get org unit geometry to show currently empty
     ApiResponse getOrgUnitResponse = restApiActions.get("/ImspTQPwCqd");
     assertNull(getOrgUnitResponse.getBody().get("geometry"));
 
-    // post geo json async
-    ApiResponse postGeoJsonAsyncResponse = restApiActions.post("/geometry", geoJson);
-    assertEquals(200, postGeoJsonAsyncResponse.statusCode());
+    // post geo json sync
+    ApiResponse postGeoJsonSyncResponse = restApiActions.post("/geometry", geoJson);
+    assertEquals(200, postGeoJsonSyncResponse.statusCode());
 
     assertTrue(
-        postGeoJsonAsyncResponse
+        postGeoJsonSyncResponse
             .getBody()
             .get("message")
             .getAsString()
@@ -129,7 +122,7 @@ class GeoJsonImportTest extends ApiTest {
     // get org unit again which should now contain geometry property
     ApiResponse getUpdatedOrgUnit = restApiActions.get("/ImspTQPwCqd");
 
-    // validate async-completed geo json import
+    // validate sync-completed geo json import
     getUpdatedOrgUnit
         .validate()
         .statusCode(200)

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/GeoJsonImportTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/GeoJsonImportTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.metadata.metadata_import;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hisp.dhis.ApiTest;
+import org.hisp.dhis.actions.LoginActions;
+import org.hisp.dhis.actions.RestApiActions;
+import org.hisp.dhis.actions.SystemActions;
+import org.hisp.dhis.dto.ApiResponse;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author david mackessy
+ */
+class GeoJsonImportTest extends ApiTest {
+  private LoginActions loginActions;
+  private SystemActions systemActions;
+  private RestApiActions restApiActions;
+
+  @BeforeAll
+  public void before() {
+    loginActions = new LoginActions();
+    systemActions = new SystemActions();
+    restApiActions = new RestApiActions("organisationUnits");
+  }
+
+  @Test
+  void completeDataSetRegistrationsAsync() {
+    loginActions.loginAsSuperUser();
+
+    // create geo json
+    String geoJson2 = geoJson2();
+
+    // get org unit geometry to show currently empty
+    ApiResponse completedResponse = restApiActions.get("/ImspTQPwCqd");
+    assertNull(completedResponse.getBody().get("geometry"));
+
+    // post geo json async
+    ApiResponse completeAsyncResponse = restApiActions.post("/geometry?async=true", geoJson2);
+    assertEquals(200, completeAsyncResponse.statusCode());
+
+    assertTrue(
+        completeAsyncResponse
+            .getBody()
+            .get("message")
+            .getAsString()
+            .contains("Initiated GeoJSON import"));
+
+    String taskId =
+        completeAsyncResponse.getBody().getAsJsonObject("response").get("id").getAsString();
+    assertEquals(11, taskId.length());
+
+    // wait for job to be completed (24 seconds used as the job schedule loop is 20 seconds)
+    ApiResponse taskStatus = systemActions.waitUntilTaskCompleted("GEOJSON_IMPORT", taskId, 24);
+    assertTrue(taskStatus.getAsString().contains("\"completed\":true"));
+
+    // get complete data sets which should be 1 now
+    ApiResponse completedResponse3 = restApiActions.get("/ImspTQPwCqd");
+
+    // validate async-completed geo json import
+    completedResponse3
+        .validate()
+        .statusCode(200)
+        .body("geometry.type", equalTo("Point"))
+        .body("geometry.coordinates.size()", equalTo(2));
+  }
+
+  private String geoJson2() {
+    return """
+        {
+            "type": "Feature",
+            "id": "ImspTQPwCqd",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [-12.56262192106476,7.376283621891673]
+            },
+            "properties": {
+                "Shape_Leng": 20.8503761122,
+                "Shape_Area": 5.96427565724,
+                "shapeName": "Republic of Sierra Leone",
+                "Level": "ADM0",
+                "shapeISO": "SLE",
+                "shapeID": "SLE-ADM0-89611731B79725766",
+                "shapeGroup": "SLE",
+                "shapeType": "ADM0",
+                "code": "OU_525"
+            }
+        }
+        """;
+  }
+}

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/GeoJsonImportTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/metadata/metadata_import/GeoJsonImportTest.java
@@ -139,7 +139,7 @@ class GeoJsonImportTest extends ApiTest {
 
   private String geoJson() {
     return """
-        { 
+        {
           "type": "FeatureCollection",
           "features":[
             {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/GeoJsonImportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/GeoJsonImportController.java
@@ -109,16 +109,17 @@ public class GeoJsonImportController {
   private WebMessage runImport(
       boolean async, GeoJsonImportJobParams params, HttpServletRequest request)
       throws ConflictException, NotFoundException, IOException {
+    User currentUser = currentUserService.getCurrentUser();
     if (async) {
       JobConfiguration jobConfig = new JobConfiguration(JobType.GEOJSON_IMPORT);
       jobConfig.setJobParameters(params);
-      jobConfig.setExecutedBy(currentUserService.getCurrentUser().getUid());
+      jobConfig.setExecutedBy(currentUser.getUid());
       jobSchedulerService.executeNow(
           jobConfigurationService.create(jobConfig, APPLICATION_JSON, request.getInputStream()));
 
       return jobConfigurationReport(jobConfig);
     }
-
+    params.setUser(currentUser);
     return toWebMessage(geoJsonService.importGeoData(params, request.getInputStream()));
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/GeoJsonImportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/GeoJsonImportController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2023, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,37 +28,33 @@
 package org.hisp.dhis.webapi.controller;
 
 import static java.lang.String.format;
-import static org.apache.commons.io.IOUtils.toBufferedInputStream;
 import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.hisp.dhis.common.IdentifiableProperty.UID;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.jobConfigurationReport;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
-import lombok.AllArgsConstructor;
-import org.hibernate.SessionFactory;
+import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.IdentifiableProperty;
 import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.dbms.DbmsUtils;
-import org.hisp.dhis.dxf2.geojson.GeoJsonImportParams;
 import org.hisp.dhis.dxf2.geojson.GeoJsonImportReport;
 import org.hisp.dhis.dxf2.geojson.GeoJsonService;
 import org.hisp.dhis.dxf2.importsummary.ImportStatus;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
+import org.hisp.dhis.feedback.ConflictException;
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.feedback.Status;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobConfigurationService;
+import org.hisp.dhis.scheduling.JobSchedulerService;
 import org.hisp.dhis.scheduling.JobType;
-import org.hisp.dhis.security.SecurityContextRunnable;
-import org.hisp.dhis.system.notification.NotificationLevel;
-import org.hisp.dhis.system.notification.Notifier;
+import org.hisp.dhis.scheduling.parameters.GeoJsonImportJobParams;
 import org.hisp.dhis.user.CurrentUser;
+import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserService;
-import org.springframework.core.task.TaskExecutor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -74,21 +70,19 @@ import org.springframework.web.bind.annotation.RestController;
 @OpenApi.Tags("data")
 @RequestMapping("/organisationUnits")
 @RestController
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class GeoJsonImportController {
   private final GeoJsonService geoJsonService;
 
-  private final Notifier notifier;
+  private final JobSchedulerService jobSchedulerService;
 
-  private final TaskExecutor taskExecutor;
+  private final JobConfigurationService jobConfigurationService;
 
-  private final SessionFactory sessionFactory;
-
-  private final UserService userService;
+  private final CurrentUserService currentUserService;
 
   @PostMapping(
       value = "/geometry",
-      consumes = {"application/geo+json", "application/json"})
+      consumes = {"application/json"})
   public WebMessage postImport(
       @RequestParam(defaultValue = "true") boolean geoJsonId,
       @RequestParam(required = false) String geoJsonProperty,
@@ -96,11 +90,10 @@ public class GeoJsonImportController {
       @RequestParam(required = false) String attributeId,
       @RequestParam(required = false) boolean dryRun,
       @RequestParam(required = false, defaultValue = "false") boolean async,
-      HttpServletRequest request,
-      @CurrentUser User currentUser)
-      throws IOException {
-    GeoJsonImportParams params =
-        GeoJsonImportParams.builder()
+      HttpServletRequest request)
+      throws IOException, ConflictException, NotFoundException {
+    GeoJsonImportJobParams params =
+        GeoJsonImportJobParams.builder()
             .attributeId(attributeId)
             .dryRun(dryRun)
             .idType(
@@ -108,22 +101,25 @@ public class GeoJsonImportController {
                     ? UID
                     : IdentifiableProperty.valueOf(orgUnitProperty.toUpperCase()))
             .orgUnitIdProperty(geoJsonId ? "id" : "properties." + geoJsonProperty)
-            .user(currentUser)
             .build();
 
-    return runImport(async, params, request.getInputStream());
+    return runImport(async, params, request);
   }
 
-  private WebMessage runImport(boolean async, GeoJsonImportParams params, ServletInputStream data)
-      throws IOException {
+  private WebMessage runImport(
+      boolean async, GeoJsonImportJobParams params, HttpServletRequest request)
+      throws ConflictException, NotFoundException, IOException {
     if (async) {
-      JobConfiguration config =
-          new JobConfiguration("GeoJSON import", JobType.GEOJSON_IMPORT, params.getUser().getUid());
-      taskExecutor.execute(new GeoJsonAsyncImporter(params, config, toBufferedInputStream(data)));
-      return jobConfigurationReport(config);
+      JobConfiguration jobConfig = new JobConfiguration(JobType.GEOJSON_IMPORT);
+      jobConfig.setJobParameters(params);
+      jobConfig.setExecutedBy(currentUserService.getCurrentUser().getUid());
+      jobSchedulerService.executeNow(
+          jobConfigurationService.create(jobConfig, APPLICATION_JSON, request.getInputStream()));
+
+      return jobConfigurationReport(jobConfig);
     }
 
-    return toWebMessage(geoJsonService.importGeoData(params, data));
+    return toWebMessage(geoJsonService.importGeoData(params, request.getInputStream()));
   }
 
   @PreAuthorize("hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')")
@@ -141,8 +137,8 @@ public class GeoJsonImportController {
       @RequestParam(required = false) boolean dryRun,
       @RequestBody String geometry,
       @CurrentUser User currentUser) {
-    GeoJsonImportParams params =
-        GeoJsonImportParams.builder()
+    GeoJsonImportJobParams params =
+        GeoJsonImportJobParams.builder()
             .user(currentUser)
             .attributeId(attributeId)
             .dryRun(dryRun)
@@ -178,52 +174,5 @@ public class GeoJsonImportController {
       status = Status.WARNING;
     }
     return ok(msg).setStatus(status).setResponse(report);
-  }
-
-  @AllArgsConstructor
-  private class GeoJsonAsyncImporter extends SecurityContextRunnable {
-
-    private final GeoJsonImportParams params;
-
-    private final JobConfiguration config;
-
-    private final InputStream data;
-
-    @Override
-    public void before() {
-      DbmsUtils.bindSessionToThread(sessionFactory);
-    }
-
-    @Override
-    public void after() {
-      DbmsUtils.unbindSessionFromThread(sessionFactory);
-    }
-
-    @Override
-    public void call() {
-      notifier.clear(config);
-      notifier.notify(config, NotificationLevel.INFO, "GeoJSON import stared", false);
-      GeoJsonImportReport report = geoJsonService.importGeoData(reattachedParams(), data);
-      notifier.notify(
-          config,
-          NotificationLevel.INFO,
-          "GeoJSON import complete. " + report.getImportCount(),
-          true);
-      notifier.addJobSummary(config, report, GeoJsonImportReport.class);
-    }
-
-    @Override
-    public void handleError(Throwable ex) {
-      notifier.notify(
-          config, NotificationLevel.ERROR, "GeoJSON import failed: " + ex.getMessage(), true);
-    }
-
-    /**
-     * This is a work-around for the time being because the user otherwise is not attached to the
-     * session. What we should be using here instead is the CurrentUserDetails
-     */
-    private GeoJsonImportParams reattachedParams() {
-      return params.toBuilder().user(userService.getUser(params.getUser().getUid())).build();
-    }
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/GeoJsonImportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/GeoJsonImportController.java
@@ -82,7 +82,7 @@ public class GeoJsonImportController {
 
   @PostMapping(
       value = "/geometry",
-      consumes = {"application/json"})
+      consumes = {"application/geo+json", "application/json"})
   public WebMessage postImport(
       @RequestParam(defaultValue = "true") boolean geoJsonId,
       @RequestParam(required = false) String geoJsonProperty,


### PR DESCRIPTION
# Summary
Migrate the custom `GeoJsonAsyncImporter` task execution to use the new Job setup, bringing it in line with 
how all other jobs are run.

## Changes
- add new JSON Subtype `GEO_JSON_IMPORT` to `JobConfiguration`
- refactored `GeoJsonImportParams ` to `GeoJsonImportJobParams` and implement `JobParameters`
- new `GeoJsonImportJob`

# Testing
## Automated
- added 2 E2E tests
  - async import of GeoJSON
  - sync import of GeoJSON

## Manual