### PR TITLE
chore: Update CodeQL steps to follow recommended approach for analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,10 +35,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Initializes the CodeQL tools for scanning.
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
-
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,15 +34,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          # We must fetch at least the immediate parents so that if this is
-          # a pull request then we can checkout the head.
-          fetch-depth: 2
 
-      # If this run was triggered by a pull request event, then checkout
-      # the head of the pull request instead of the merge commit.
-      - run: git checkout HEAD^2
-        if: ${{ github.event_name == 'pull_request' }}
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3


### PR DESCRIPTION
# Summary
Pull Requests are currently failing due to the following error
`[error] File size ([2198461589](tel:2198461589)) is greater than 2 GiB`
during the CodeQL analysis step (post codeql-init step)

While investigating I came across this known recommendation: https://docs.github.com/en/code-security/code-scanning/troubleshooting-code-scanning/unnecessary-step-found 
This warning is present in our CodeQL logs.

This PR will hopefully help with the size of analysis being performed:
- only analysing the merged commit
- not analysing the entire code base every time

This PR should be verified by someone who knows that this is an acceptable change