### PR TITLE
ci: add workflows to deploy/destroy IM instance on PR

### DIFF
--- a/.github/workflows/deploy-instance.yml
+++ b/.github/workflows/deploy-instance.yml
@@ -1,0 +1,53 @@
+name: Deploy instance
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled, synchronize]
+
+# Cancel previous runs of the same workflow and PR number or branch/tag
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-instance:
+    if: contains(github.event.pull_request.labels.*.name, 'deploy')
+    runs-on: ubuntu-latest
+    env:
+      INSTANCE_NAME: pr-${{ github.event.pull_request.number }}
+    steps:
+      - name: Wait for API tests
+        uses: lewagon/wait-on-check-action@v1.3.1
+        with:
+          ref: ${{ github.head_ref }}
+          check-name: 'api-test'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/checkout@v4
+        with:
+          repository: dhis2-sre/im-manager
+          sparse-checkout: scripts/instances
+
+      - name: Install HTTPie
+        run: python -m pip install httpie
+
+      - name: Deploy DHIS2 instance
+        working-directory: scripts/instances
+        env:
+          HTTP: https --check-status
+          USER_EMAIL: ${{ secrets.IM_BOT_EMAIL }}
+          PASSWORD: ${{ secrets.IM_BOT_PASSWORD }}
+          IM_HOST: 'https://api.im.dhis2.org'
+          IMAGE_REPOSITORY: core-pr
+          IMAGE_TAG: ${{ github.event.pull_request.number }}
+          IMAGE_PULL_POLICY: Always
+          DATABASE_ID: sl-sierra-leone-dev-sql-gz
+        run: ./findByName.sh dev $INSTANCE_NAME && ./restart.sh dev $INSTANCE_NAME || ./deploy-dhis2.sh dev $INSTANCE_NAME
+
+      - name: Wait for instance
+        run: timeout 300 bash -c 'while [[ "$(curl -fsSL -o /dev/null -w %{http_code} https://dev.im.dhis2.org/$INSTANCE_NAME)" != "200" ]]; do sleep 5; done'
+
+      - name: Comment instance URL
+        uses: actions-cool/maintain-one-comment@v3
+        with:
+          body: "Instance deployed to https://dev.im.dhis2.org/pr-${{ github.event.pull_request.number }}"

--- a/.github/workflows/deploy-instance.yml
+++ b/.github/workflows/deploy-instance.yml
@@ -14,6 +14,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'deploy')
     runs-on: ubuntu-latest
     env:
+      INSTANCE_HOST: 'https://dev.im.dhis2.org'
       INSTANCE_NAME: pr-${{ github.event.pull_request.number }}
     steps:
       - name: Wait for API tests
@@ -45,7 +46,10 @@ jobs:
         run: ./findByName.sh dev $INSTANCE_NAME && ./restart.sh dev $INSTANCE_NAME || ./deploy-dhis2.sh dev $INSTANCE_NAME
 
       - name: Wait for instance
-        run: timeout 300 bash -c 'while [[ "$(curl -fsSL -o /dev/null -w %{http_code} https://dev.im.dhis2.org/$INSTANCE_NAME)" != "200" ]]; do sleep 5; done'
+        run: timeout 300 bash -c 'while [[ "$(curl -fsSL -o /dev/null -w %{http_code} $INSTANCE_HOST/$INSTANCE_NAME)" != "200" ]]; do sleep 5; done'
+
+      - name: Generate analytics
+        run: curl -X POST -u 'admin:district' "$INSTANCE_HOST/$INSTANCE_NAME/api/resourceTables/analytics"
 
       - name: Comment instance URL
         uses: actions-cool/maintain-one-comment@v3

--- a/.github/workflows/deploy-instance.yml
+++ b/.github/workflows/deploy-instance.yml
@@ -49,7 +49,7 @@ jobs:
         run: timeout 300 bash -c 'while [[ "$(curl -fsSL -o /dev/null -w %{http_code} $INSTANCE_HOST/$INSTANCE_NAME)" != "200" ]]; do sleep 5; done'
 
       - name: Generate analytics
-        run: curl -X POST -u 'admin:district' "$INSTANCE_HOST/$INSTANCE_NAME/api/resourceTables/analytics"
+        run: curl -X POST -u "${{ secrets.DHIS2_USERNAME }}:${{ secrets.DHIS2_PASSWORD }}" "$INSTANCE_HOST/$INSTANCE_NAME/api/resourceTables/analytics" -d 'executeTei=true'
 
       - name: Comment instance URL
         uses: actions-cool/maintain-one-comment@v3

--- a/.github/workflows/destroy-instance.yml
+++ b/.github/workflows/destroy-instance.yml
@@ -1,0 +1,32 @@
+name: Destroy instance
+
+on:
+  pull_request:
+    types: [closed]
+
+# Cancel previous runs of the same workflow and PR number or branch/tag
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  destroy-instance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: dhis2-sre/im-manager
+          sparse-checkout: scripts/instances
+
+      - name: Install HTTPie
+        run: python -m pip install httpie
+
+      - name: Destroy DHIS2 instance
+        working-directory: scripts/instances
+        env:
+          HTTP: https --check-status
+          USER_EMAIL: ${{ secrets.IM_BOT_EMAIL }}
+          PASSWORD: ${{ secrets.IM_BOT_PASSWORD }}
+          IM_HOST: 'https://api.im.dhis2.org'
+          INSTANCE_NAME: pr-${{ github.event.number }}
+        run: ./findByName.sh dev $INSTANCE_NAME && ./destroy.sh dev $INSTANCE_NAME

--- a/.github/workflows/run-api-analytics-tests.yml
+++ b/.github/workflows/run-api-analytics-tests.yml
@@ -12,7 +12,7 @@ concurrency:
   group: ${{ github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  api-test:
+  api-analytics-test:
     env:
       CORE_IMAGE_NAME: "dhis2/core-dev:local"
       PR_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
This PR enables deploying (and destroying) a DHIS2 instance (with the [Instance Manager](https://github.com/dhis2-sre/im-manager)) via the `deploy` label.

The Deploy workflow will: 
* wait for the "Run api tests" workflow, as this is where we build the PR docker images and it probably doesn't make sense to create an instance before/without the API tests passing
* deploy an instance via the IM, using the image built for the current PR
* wait for the instance to be ready
* trigger analytics generation
* add a comment in the PR with the URL of the instance

The Destroy workflow will clean up the deployed instance when closing/merging the PR.

