### PR TITLE
feat: New enum entries for MapService [DHIS2-15979]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/MapService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/MapService.java
@@ -34,5 +34,7 @@ public enum MapService {
   WMS,
   TMS,
   XYZ,
-  VECTOR_STYLE
+  VECTOR_STYLE,
+  GEOJSON_URL,
+  ARCGIS_FEATURE
 }


### PR DESCRIPTION
**_[Backport from master/2.41]_** (#15440)

Support two new vector formats in DHIS2 Maps: 

GEOJSON_URL (GeoJSON URL) 
ARCGIS_FEATURE (ArcGIS Feature Service)
