### PR TITLE
chore: Use enrollmentUids as any other parameter [TECH-1645]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -40,8 +40,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
-import org.hisp.dhis.common.Pager;
-import org.hisp.dhis.common.SlimPager;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
@@ -195,15 +193,6 @@ class DefaultEnrollmentService
   @Override
   public List<Enrollment> getEnrollments(EnrollmentOperationParams params)
       throws ForbiddenException, BadRequestException, NotFoundException {
-    if (!params.getEnrollmentUids().isEmpty()) {
-      List<org.hisp.dhis.program.Enrollment> enrollments = new ArrayList<>();
-      for (String uid : params.getEnrollmentUids()) {
-        enrollments.add(
-            getEnrollment(uid, params.getEnrollmentParams(), params.isIncludeDeleted()));
-      }
-      return enrollments;
-    }
-
     EnrollmentQueryParams queryParams = paramsMapper.map(params);
 
     decideAccess(queryParams);
@@ -235,25 +224,6 @@ class DefaultEnrollmentService
   public Page<Enrollment> getEnrollments(EnrollmentOperationParams params, PageParams pageParams)
       throws ForbiddenException, BadRequestException, NotFoundException {
     EnrollmentQueryParams queryParams = paramsMapper.map(params);
-
-    if (!params.getEnrollmentUids().isEmpty()) {
-      List<org.hisp.dhis.program.Enrollment> enrollments = new ArrayList<>();
-      for (String uid : params.getEnrollmentUids()) {
-        enrollments.add(
-            getEnrollment(uid, params.getEnrollmentParams(), params.isIncludeDeleted()));
-      }
-
-      Pager pager;
-
-      if (pageParams.isPageTotal()) {
-        int count = enrollmentStore.countEnrollments(queryParams);
-        pager = new Pager(pageParams.getPage(), count, pageParams.getPageSize());
-      } else {
-        pager = new SlimPager(pageParams.getPage(), pageParams.getPageSize(), true);
-      }
-
-      return Page.of(enrollments, pager);
-    }
 
     decideAccess(queryParams);
     validate(queryParams);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapper.java
@@ -88,6 +88,7 @@ class EnrollmentOperationParamsMapper {
     params.setIncludeDeleted(operationParams.isIncludeDeleted());
     params.setUser(user);
     params.setOrder(operationParams.getOrder());
+    params.setEnrollmentUids(operationParams.getEnrollmentUids());
 
     return params;
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentQueryParams.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.tracker.export.enrollment;
 
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -49,6 +51,9 @@ import org.hisp.dhis.webapi.controller.event.mapper.SortDirection;
 @Data
 @Accessors(chain = true)
 class EnrollmentQueryParams {
+
+  /** Set of enrollment uids to explicitly select. */
+  private Set<String> enrollmentUids = new HashSet<>();
 
   /** Last updated for enrollment. */
   private Date lastUpdated;
@@ -170,6 +175,10 @@ class EnrollmentQueryParams {
   /** Indicates whether this params specifies a tracked entity instance. */
   public boolean hasTrackedEntity() {
     return this.trackedEntity != null;
+  }
+
+  public boolean hasEnrollmentUids() {
+    return isNotEmpty(this.enrollmentUids);
   }
 
   /** Indicates whether this params is of the given organisation unit mode. */

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/HibernateEnrollmentStore.java
@@ -154,6 +154,14 @@ class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enrollment
     String hql = "from Enrollment en";
     SqlHelper hlp = new SqlHelper(true);
 
+    if (params.hasEnrollmentUids()) {
+      hql +=
+          hlp.whereAnd()
+              + "en.uid in ("
+              + getQuotedCommaDelimitedString(params.getEnrollmentUids())
+              + ")";
+    }
+
     if (params.hasLastUpdatedDuration()) {
       hql +=
           hlp.whereAnd()

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -400,6 +400,25 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
   }
 
   @Test
+  void shouldGetEnrollmentWhenEnrollmentsAndOtherParamsAreSpecified()
+      throws ForbiddenException, BadRequestException, NotFoundException {
+    programA.getSharing().setPublicAccess(AccessStringHelper.FULL);
+
+    manager.updateNoAcl(programA);
+
+    EnrollmentOperationParams params =
+        EnrollmentOperationParams.builder()
+            .programUid(programA.getUid())
+            .enrollmentUids(Set.of(enrollmentA.getUid()))
+            .build();
+
+    List<Enrollment> enrollments = enrollmentService.getEnrollments(params);
+
+    assertNotNull(enrollments);
+    assertContainsOnly(List.of(enrollmentA.getUid()), uids(enrollments));
+  }
+
+  @Test
   void shouldGetEnrollmentsByTrackedEntityWhenUserHasAccessToTrackedEntityType()
       throws ForbiddenException, BadRequestException, NotFoundException {
     programA.getSharing().setPublicAccess(AccessStringHelper.DATA_READ);


### PR DESCRIPTION
`enrollmentUids` were used as an alternative way to retrieve enrollments, instead of checking all the other parameters.
This was inconsistent with all the other entities.
Now we are using the `enrollmentUids` as an extra parameter to be used as a filter in the underlying query.
This is simplify the code and removing some duplicated logic