### PR TITLE
fix: Allow search capture scope without org unit [TECH-1635]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramInstanceService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.program;
 
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ALL;
+import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CHILDREN;
 
 import java.util.Date;
@@ -256,7 +257,9 @@ public class DefaultProgramInstanceService implements ProgramInstanceService {
     User user = params.getUser();
 
     if (!params.hasOrganisationUnits()
-        && !(params.isOrganisationUnitMode(ALL) || params.isOrganisationUnitMode(ACCESSIBLE))) {
+        && !(params.isOrganisationUnitMode(ALL)
+            || params.isOrganisationUnitMode(ACCESSIBLE)
+            || params.isOrganisationUnitMode(CAPTURE))) {
       violation = "At least one organisation unit must be specified";
     }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramInstanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramInstanceServiceTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.program;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Sets;
@@ -37,14 +38,18 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
+import org.hisp.dhis.user.User;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -255,6 +260,47 @@ class ProgramInstanceServiceTest extends TransactionalIntegrationTest {
                 .setOrganisationUnitMode(OrganisationUnitSelectionMode.SELECTED));
     assertEquals(1, programInstances.size());
     assertTrue(programInstances.contains(programInstanceA));
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = OrganisationUnitSelectionMode.class,
+      names = {"ACCESSIBLE", "CAPTURE"})
+  void shouldFindEnrollmentsWhenOrgUnitModeDoesNotRequireOrgUnit(
+      OrganisationUnitSelectionMode orgUnitMode) {
+    User user = new User();
+    user.setOrganisationUnits(Set.of(organisationUnitA));
+    programInstanceService.addProgramInstance(programInstanceA);
+    programInstanceService.addProgramInstance(programInstanceC);
+    programInstanceService.addProgramInstance(programInstanceD);
+
+    List<ProgramInstance> programInstances =
+        programInstanceService.getProgramInstances(
+            new ProgramInstanceQueryParams().setOrganisationUnitMode(orgUnitMode).setUser(user));
+    assertEquals(3, programInstances.size());
+    assertTrue(programInstances.contains(programInstanceA));
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = OrganisationUnitSelectionMode.class,
+      names = {"CHILDREN", "DESCENDANTS", "SELECTED"})
+  void shouldFailWhenOrgUnitModeRequiresOrgUnit(OrganisationUnitSelectionMode orgUnitMode) {
+    User user = new User();
+    user.setOrganisationUnits(Set.of(organisationUnitA));
+    programInstanceService.addProgramInstance(programInstanceA);
+    programInstanceService.addProgramInstance(programInstanceC);
+    programInstanceService.addProgramInstance(programInstanceD);
+
+    ProgramInstanceQueryParams queryParams =
+        new ProgramInstanceQueryParams().setOrganisationUnitMode(orgUnitMode).setUser(user);
+
+    IllegalQueryException exception =
+        assertThrows(
+            IllegalQueryException.class,
+            () -> programInstanceService.getProgramInstances(queryParams));
+
+    assertEquals("At least one organisation unit must be specified", exception.getMessage());
   }
 
   @Test


### PR DESCRIPTION
Capture mode should be used without specifying an org unit in the request.