### PR TITLE
ci: fix analytics api workflow [skip ci]

### DIFF
--- a/.github/workflows/run-api-analytics-tests.yml
+++ b/.github/workflows/run-api-analytics-tests.yml
@@ -88,7 +88,7 @@ jobs:
       contains(needs.*.result, 'failure') &&
       github.ref == 'refs/heads/master'
 
-    needs: [ api-test ]
+    needs: [ api-analytics-test ]
     steps:
       - uses: rtCamp/action-slack-notify@v2
         env:


### PR DESCRIPTION
As part of [this PR](https://github.com/dhis2/dhis2-core/pull/15433) I changed the job name of the Run analytics API tests workflow from `api-test` to `api-analytics-test`, in order to avoid name duplication and referncing the job in other workflows.