### PR TITLE
feat: job scheduler - run jobs continuously [DHIS2-16004]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfigurationService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfigurationService.java
@@ -150,14 +150,11 @@ public interface JobConfigurationService {
    * Get all job configurations that should start within the next n seconds.
    *
    * @param dueInNextSeconds number of seconds from now the job should start
-   * @param limitToNext1 true, to only return a single config per {@link JobType}, false to return
-   *     all due jobs
    * @param includeWaiting true to also list jobs that cannot run because another job of the same
    *     type is already running
    * @return only jobs that should start soon within the given number of seconds
    */
-  List<JobConfiguration> getDueJobConfigurations(
-      int dueInNextSeconds, boolean limitToNext1, boolean includeWaiting);
+  List<JobConfiguration> getDueJobConfigurations(int dueInNextSeconds, boolean includeWaiting);
 
   /**
    * Finds stale jobs.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
@@ -183,6 +183,10 @@ public enum JobType {
     this.defaults = defaults;
   }
 
+  /**
+   * @return true, if {@link JobProgress} events should be forwarded to the {@link
+   *     org.eclipse.emf.common.notify.Notifier} API, otherwise false
+   */
   public boolean isUsingNotifications() {
     return this == RESOURCE_TABLE
         || this == SEND_SCHEDULED_MESSAGE
@@ -204,6 +208,10 @@ public enum JobType {
         || this == GEOJSON_IMPORT;
   }
 
+  /**
+   * @return true, when an error notification should be sent by email in case the job execution
+   *     fails, otherwise false
+   */
   public boolean isUsingErrorNotification() {
     return this == ANALYTICS_TABLE
         || this == VALIDATION_RESULTS_NOTIFICATION
@@ -214,6 +222,15 @@ public enum JobType {
         || this == PROGRAM_NOTIFICATIONS
         || this == DATAVALUE_IMPORT
         || this == METADATA_IMPORT;
+  }
+
+  /**
+   * @return true, if jobs of this type should try to run as soon as possible by having job
+   *     scheduler workers execute all known ready jobs of the type, when false only the oldest of
+   *     the ready jobs per type is attempted to start in a single loop cycle
+   */
+  public boolean isUsingContinuousExecution() {
+    return this == METADATA_IMPORT;
   }
 
   public boolean hasJobParameters() {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
@@ -45,7 +45,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -234,7 +233,7 @@ public class DefaultJobConfigurationService implements JobConfigurationService {
   @Override
   @Transactional(readOnly = true)
   public List<JobConfiguration> getDueJobConfigurations(
-      int dueInNextSeconds, boolean limitToNext1, boolean includeWaiting) {
+      int dueInNextSeconds, boolean includeWaiting) {
     Instant now = Instant.now();
     Instant endOfWindow = now.plusSeconds(dueInNextSeconds);
     Duration maxCronDelay =
@@ -243,16 +242,7 @@ public class DefaultJobConfigurationService implements JobConfigurationService {
         jobConfigurationStore
             .getDueJobConfigurations(includeWaiting)
             .filter(c -> c.isDueBetween(now, endOfWindow, maxCronDelay));
-    if (!limitToNext1) return dueJobs.toList();
-    Set<JobType> types = EnumSet.noneOf(JobType.class);
-    return dueJobs
-        .filter(
-            config -> {
-              if (types.contains(config.getJobType())) return false;
-              types.add(config.getJobType());
-              return true;
-            })
-        .toList();
+    return dueJobs.toList();
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobSchedulerLoopService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobSchedulerLoopService.java
@@ -121,6 +121,13 @@ public class DefaultJobSchedulerLoopService implements JobSchedulerLoopService {
     return jobConfigurationStore.getNextInQueue(queue, fromPosition);
   }
 
+  @CheckForNull
+  @Override
+  @Transactional(readOnly = true)
+  public JobConfiguration getJobConfiguration(String jobId) {
+    return jobConfigurationStore.getByUid(jobId);
+  }
+
   @Override
   @Transactional
   public boolean tryRun(@Nonnull String jobId) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobSchedulerLoopService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobSchedulerLoopService.java
@@ -111,7 +111,7 @@ public class DefaultJobSchedulerLoopService implements JobSchedulerLoopService {
   @Override
   @Transactional(readOnly = true)
   public List<JobConfiguration> getDueJobConfigurations(int dueInNextSeconds) {
-    return jobConfigurationService.getDueJobConfigurations(dueInNextSeconds, true, false);
+    return jobConfigurationService.getDueJobConfigurations(dueInNextSeconds, false);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/JobScheduler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/JobScheduler.java
@@ -154,7 +154,7 @@ public class JobScheduler implements Runnable, JobRunner {
       String jobId = jobIds.poll();
       while (jobId != null) {
         JobConfiguration config = service.getJobConfiguration(jobId);
-        if (config != null) {
+        if (config != null && config.getJobStatus() == JobStatus.SCHEDULED) {
           Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
           Instant dueTime = dueTime(now, config);
           runDueJob(config, dueTime);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/JobSchedulerLoopService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/JobSchedulerLoopService.java
@@ -64,6 +64,9 @@ public interface JobSchedulerLoopService {
   List<JobConfiguration> getDueJobConfigurations(int dueInNextSeconds);
 
   @CheckForNull
+  JobConfiguration getJobConfiguration(String jobId);
+
+  @CheckForNull
   JobConfiguration getNextInQueue(String queue, int fromPosition);
 
   /**

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -74,7 +74,7 @@ public class JobConfigurationController extends AbstractCrudController<JobConfig
   public List<JobConfiguration> getDueJobConfigurations(
       @RequestParam int seconds,
       @RequestParam(required = false, defaultValue = "false") boolean includeWaiting) {
-    return jobConfigurationService.getDueJobConfigurations(seconds, false, includeWaiting);
+    return jobConfigurationService.getDueJobConfigurations(seconds, includeWaiting);
   }
 
   @GetMapping("/stale")


### PR DESCRIPTION
### Summary
Adds a feature to the scheduler to allow jobs to execute faster than one per type per loop cycle.

For fast jobs like small imports that only take below 1-2 seconds it is important to run more than one per 20 seconds loop.
Otherwise jobs might be added faster or in higher quantity that the scheduling can execute as it is limited to one per 20 seconds otherwise. This would be 3 per minute, 180 per hour, 4320 per day. For imports this might not be enough and not be fast enough.

### Usage
For future job types to use it their enum constant need to be added to the new https://github.com/dhis2/dhis2-core/pull/15466/files#diff-3ad347fffaf9c8a6f46a781e97b1a5d9770a5fecba98121543414e69428baa48R232 method

### Implementation Notes
To allow importing faster a job type can be hard coded as being _continuous_. For job types of that nature the loop pushes all jobs (IDs) that are potentially ready to a per type queue. If no queue exists a new one is created for the type and a worker spawned that works the queue until all jobs in the queue are processed. The main loop keeps potentially adding to the queue in every loop cycle in the background but the worker will poll and execute the jobs as fast as possible while still ensuring that only one job at a time per type is running. 

The  queue will only remember the job's ID and reload the job configuration when it is time to execute them because the job configuration may have changed in the database since it was added to the queue.

A worker working the queue will always assume the queue was created by the worker so when all entries in the queue are processed the worker clears the queue before it ends so that another worker may be spawned in the future when a new job of the job type is created. 

In the unlikely event that the loop cycle checks if the queue is empty to find out if a worker should be spawned and it is empty because the current worker is just processing the last entry while also a new entry was created since then a second worker is spawned for the same queue. Now two workers will poll from the same queue to empty it and both will try to remove it when done. This is not an issue as they will poll different jobs and the DB still limits execution to 1 job at a time. This means a job might try to run while the other worker's job just got started. It then fails to start and is re-added to the queue in the next loop cycle as a job that is ready to run. 

The goal with this implementation is that while there is in-memory state the design is robust against getting stuck or out-of sync.
In a worst case a job might be delayed and run 1 loop cycle (20 seconds) later than it could have been running but it will eventually be picked up and run if it is ready.

### Manual Testing
* goto import/export app
* export some metadata to a file (chose one object type only to make a small import)
* import the file using a REST tool like POSTman (inspect the request made by the app and replicate it in the tool. the main point to use a tool is so we can create many imports quickly, usually in a tool this can be done by just clicking the send button multiple times)
* wait some 30 seconds
* check the job configurations `lastExecuted` time for the created jobs (`jobType=METADATA_IMPORT`), they should be all started quickly after another and not be about 20 seconds apart, e.g. `/api/jobConfigurations/gist?filter=jobType:eq:METADATA_IMPORT`