### PR TITLE
fix: Make period gen. backward compat. [DHIS2-15573]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/DefaultResourceTableService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/DefaultResourceTableService.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.resourcetable;
 import static java.time.temporal.ChronoUnit.YEARS;
 import static java.util.Comparator.reverseOrder;
 import static java.util.stream.Collectors.toList;
+import static org.hisp.dhis.period.PeriodDataProvider.DataSource.DATABASE;
+import static org.hisp.dhis.period.PeriodDataProvider.DataSource.SYSTEM_DEFINED;
 import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM;
 
 import com.google.common.collect.Lists;
@@ -184,7 +186,9 @@ public class DefaultResourceTableService implements ResourceTableService {
   @Override
   @Transactional
   public void generateDatePeriodTable() {
-    List<Integer> availableYears = periodDataProvider.getAvailableYears();
+    List<Integer> availableYears =
+        periodDataProvider.getAvailableYears(
+            analyticsExportSettings.getMaxPeriodYearsOffset() == null ? SYSTEM_DEFINED : DATABASE);
     checkYearsOffset(availableYears);
 
     resourceTableStore.generateResourceTable(
@@ -203,30 +207,33 @@ public class DefaultResourceTableService implements ResourceTableService {
    * @param yearsToCheck the list of years to be checked.
    */
   private void checkYearsOffset(List<Integer> yearsToCheck) {
-    int maxYearsOffset = analyticsExportSettings.getMaxPeriodYearsOffset();
-    int minRangeAllowed = Year.now().minus(maxYearsOffset, YEARS).getValue();
-    int maxRangeAllowed = Year.now().plus(maxYearsOffset, YEARS).getValue();
+    Integer maxYearsOffset = analyticsExportSettings.getMaxPeriodYearsOffset();
 
-    boolean yearsOutOfRange =
-        yearsToCheck.stream().anyMatch(year -> year < minRangeAllowed || year > maxRangeAllowed);
+    if (maxYearsOffset != null) {
+      int minRangeAllowed = Year.now().minus(maxYearsOffset, YEARS).getValue();
+      int maxRangeAllowed = Year.now().plus(maxYearsOffset, YEARS).getValue();
 
-    if (yearsOutOfRange) {
-      String errorMessage = "Your database contains years out of the allowed offset.";
-      errorMessage +=
-          "\n Range of years allowed (based on your system settings and existing data): "
-              + yearsToCheck.stream()
-                  .filter(year -> year >= minRangeAllowed && year <= maxRangeAllowed)
-                  .toList()
-              + ".";
-      errorMessage +=
-          "\n Years out of range found: "
-              + yearsToCheck.stream()
-                  .filter(year -> year < minRangeAllowed || year > maxRangeAllowed)
-                  .toList()
-              + ".";
+      boolean yearsOutOfRange =
+          yearsToCheck.stream().anyMatch(year -> year < minRangeAllowed || year > maxRangeAllowed);
 
-      log.warn(errorMessage);
-      throw new RuntimeException(errorMessage);
+      if (yearsOutOfRange) {
+        String errorMessage = "Your database contains years out of the allowed offset.";
+        errorMessage +=
+            "\n Range of years allowed (based on your system settings and existing data): "
+                + yearsToCheck.stream()
+                    .filter(year -> year >= minRangeAllowed && year <= maxRangeAllowed)
+                    .toList()
+                + ".";
+        errorMessage +=
+            "\n Years out of range found: "
+                + yearsToCheck.stream()
+                    .filter(year -> year < minRangeAllowed || year > maxRangeAllowed)
+                    .toList()
+                + ".";
+
+        log.warn(errorMessage);
+        throw new RuntimeException(errorMessage);
+      }
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/resourcetable/DefaultResourceTableServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/resourcetable/DefaultResourceTableServiceTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.resourcetable;
 
 import static java.time.temporal.ChronoUnit.YEARS;
+import static org.hisp.dhis.period.PeriodDataProvider.DataSource.DATABASE;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -63,7 +64,7 @@ class DefaultResourceTableServiceTest {
     int defaultOffset = 22;
 
     // When
-    when(periodDataProvider.getAvailableYears()).thenReturn(yearsToCheck);
+    when(periodDataProvider.getAvailableYears(DATABASE)).thenReturn(yearsToCheck);
     when(analyticsExportSettings.getMaxPeriodYearsOffset()).thenReturn(defaultOffset);
 
     // Then
@@ -82,7 +83,7 @@ class DefaultResourceTableServiceTest {
     int zeroOffset = 0;
 
     // When
-    when(periodDataProvider.getAvailableYears()).thenReturn(yearsToCheck);
+    when(periodDataProvider.getAvailableYears(DATABASE)).thenReturn(yearsToCheck);
     when(analyticsExportSettings.getMaxPeriodYearsOffset()).thenReturn(zeroOffset);
 
     // Then
@@ -101,7 +102,7 @@ class DefaultResourceTableServiceTest {
     int zeroOffset = 0;
 
     // When
-    when(periodDataProvider.getAvailableYears()).thenReturn(yearsToCheck);
+    when(periodDataProvider.getAvailableYears(DATABASE)).thenReturn(yearsToCheck);
     when(analyticsExportSettings.getMaxPeriodYearsOffset()).thenReturn(zeroOffset);
     doNothing().when(resourceTableStore).generateResourceTable(any());
 
@@ -120,7 +121,7 @@ class DefaultResourceTableServiceTest {
     int defaultOffset = 2;
 
     // When
-    when(periodDataProvider.getAvailableYears()).thenReturn(yearsToCheck);
+    when(periodDataProvider.getAvailableYears(DATABASE)).thenReturn(yearsToCheck);
     when(analyticsExportSettings.getMaxPeriodYearsOffset()).thenReturn(defaultOffset);
     doNothing().when(resourceTableStore).generateResourceTable(any());
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -43,6 +43,8 @@ import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.getClosingParenthes
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
 import static org.hisp.dhis.analytics.util.AnalyticsUtils.getColumnType;
 import static org.hisp.dhis.analytics.util.DisplayNameUtils.getDisplayName;
+import static org.hisp.dhis.period.PeriodDataProvider.DataSource.DATABASE;
+import static org.hisp.dhis.period.PeriodDataProvider.DataSource.SYSTEM_DEFINED;
 import static org.hisp.dhis.system.util.MathUtils.NUMERIC_LENIENT_REGEXP;
 import static org.hisp.dhis.util.DateUtils.getLongDateString;
 
@@ -242,7 +244,9 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
             "Get tables using earliest: %s, spatial support: %b",
             params.getFromDate(), databaseInfo.isSpatialSupport()));
 
-    List<Integer> availableDataYears = periodDataProvider.getAvailableYears();
+    List<Integer> availableDataYears =
+        periodDataProvider.getAvailableYears(
+            analyticsExportSettings.getMaxPeriodYearsOffset() == null ? SYSTEM_DEFINED : DATABASE);
 
     return params.isLatestUpdate()
         ? getLatestAnalyticsTables(params)
@@ -440,7 +444,9 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
   @Override
   protected void populateTable(
       AnalyticsTableUpdateParams params, AnalyticsTablePartition partition) {
-    List<Integer> availableDataYears = periodDataProvider.getAvailableYears();
+    List<Integer> availableDataYears =
+        periodDataProvider.getAvailableYears(
+            analyticsExportSettings.getMaxPeriodYearsOffset() == null ? SYSTEM_DEFINED : DATABASE);
     Integer firstDataYear = availableDataYears.get(0);
     Integer latestDataYear = availableDataYears.get(availableDataYears.size() - 1);
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiEventsAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiEventsAnalyticsTableManager.java
@@ -49,6 +49,8 @@ import static org.hisp.dhis.analytics.table.PartitionUtils.getEndDate;
 import static org.hisp.dhis.analytics.table.PartitionUtils.getStartDate;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
 import static org.hisp.dhis.commons.util.TextUtils.removeLastComma;
+import static org.hisp.dhis.period.PeriodDataProvider.DataSource.DATABASE;
+import static org.hisp.dhis.period.PeriodDataProvider.DataSource.SYSTEM_DEFINED;
 import static org.hisp.dhis.util.DateUtils.getLongDateString;
 import static org.hisp.dhis.util.DateUtils.getMediumDateString;
 import static org.springframework.util.Assert.notNull;
@@ -229,7 +231,9 @@ public class JdbcTeiEventsAnalyticsTableManager extends AbstractJdbcTableManager
               + "'");
     }
 
-    List<Integer> availableDataYears = periodDataProvider.getAvailableYears();
+    List<Integer> availableDataYears =
+        periodDataProvider.getAvailableYears(
+            analyticsExportSettings.getMaxPeriodYearsOffset() == null ? SYSTEM_DEFINED : DATABASE);
     Integer firstDataYear = availableDataYears.get(0);
     Integer latestDataYear = availableDataYears.get(availableDataYears.size() - 1);
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
@@ -137,8 +137,7 @@ class JdbcEventAnalyticsTableManagerTest {
 
   @Mock private PeriodDataProvider periodDataProvider;
 
-  @Mock
-  private AnalyticsExportSettings analyticsExportSettings;
+  @Mock private AnalyticsExportSettings analyticsExportSettings;
 
   private JdbcEventAnalyticsTableManager subject;
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
@@ -50,6 +50,7 @@ import static org.hisp.dhis.analytics.ColumnDataType.GEOMETRY_POINT;
 import static org.hisp.dhis.analytics.ColumnDataType.INTEGER;
 import static org.hisp.dhis.analytics.ColumnDataType.TEXT;
 import static org.hisp.dhis.analytics.ColumnDataType.TIMESTAMP;
+import static org.hisp.dhis.period.PeriodDataProvider.DataSource.DATABASE;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -136,6 +137,7 @@ class JdbcEventAnalyticsTableManagerTest {
 
   @Mock private PeriodDataProvider periodDataProvider;
 
+  @Mock
   private AnalyticsExportSettings analyticsExportSettings;
 
   private JdbcEventAnalyticsTableManager subject;
@@ -259,9 +261,10 @@ class JdbcEventAnalyticsTableManagerTest {
     addCategoryCombo(program, categoryCombo);
 
     when(idObjectManager.getAllNoAcl(Program.class)).thenReturn(List.of(program));
-    when(periodDataProvider.getAvailableYears()).thenReturn(List.of(2018, 2019, now().getYear()));
+    when(periodDataProvider.getAvailableYears(DATABASE))
+        .thenReturn(List.of(2018, 2019, now().getYear()));
 
-    List<Integer> availableDataYears = periodDataProvider.getAvailableYears();
+    List<Integer> availableDataYears = periodDataProvider.getAvailableYears(DATABASE);
 
     when(jdbcTemplate.queryForList(
             getYearQueryForCurrentYear(program, true, availableDataYears), Integer.class))
@@ -294,9 +297,10 @@ class JdbcEventAnalyticsTableManagerTest {
   void verifyClientSideTimestampsColumns() {
     Program program = createProgram('A');
     when(idObjectManager.getAllNoAcl(Program.class)).thenReturn(List.of(program));
-    when(periodDataProvider.getAvailableYears()).thenReturn(List.of(2018, 2019, now().getYear()));
+    when(periodDataProvider.getAvailableYears(DATABASE))
+        .thenReturn(List.of(2018, 2019, now().getYear()));
 
-    List<Integer> availableDataYears = periodDataProvider.getAvailableYears();
+    List<Integer> availableDataYears = periodDataProvider.getAvailableYears(DATABASE);
 
     when(jdbcTemplate.queryForList(
             getYearQueryForCurrentYear(program, true, availableDataYears), Integer.class))
@@ -330,9 +334,10 @@ class JdbcEventAnalyticsTableManagerTest {
   void verifyAnalyticsEventTableHasDefaultPartition() {
     Program program = createProgram('A');
     when(idObjectManager.getAllNoAcl(Program.class)).thenReturn(List.of(program));
-    when(periodDataProvider.getAvailableYears()).thenReturn(List.of(2021, 2022, 2023, 2024, 2025));
+    when(periodDataProvider.getAvailableYears(DATABASE))
+        .thenReturn(List.of(2021, 2022, 2023, 2024, 2025));
 
-    List<Integer> availableDataYears = periodDataProvider.getAvailableYears();
+    List<Integer> availableDataYears = periodDataProvider.getAvailableYears(DATABASE);
 
     when(jdbcTemplate.queryForList(
             getYearQueryForCurrentYear(program, true, availableDataYears), Integer.class))
@@ -438,9 +443,10 @@ class JdbcEventAnalyticsTableManagerTest {
             .withToday(today)
             .build();
 
-    when(periodDataProvider.getAvailableYears()).thenReturn(List.of(2018, 2019, now().getYear()));
+    when(periodDataProvider.getAvailableYears(DATABASE))
+        .thenReturn(List.of(2018, 2019, now().getYear()));
 
-    List<Integer> availableDataYears = periodDataProvider.getAvailableYears();
+    List<Integer> availableDataYears = periodDataProvider.getAvailableYears(DATABASE);
 
     when(jdbcTemplate.queryForList(
             getYearQueryForCurrentYear(program, true, availableDataYears), Integer.class))
@@ -506,9 +512,10 @@ class JdbcEventAnalyticsTableManagerTest {
             .withToday(today)
             .build();
 
-    when(periodDataProvider.getAvailableYears()).thenReturn(List.of(2018, 2019, now().getYear()));
+    when(periodDataProvider.getAvailableYears(DATABASE))
+        .thenReturn(List.of(2018, 2019, now().getYear()));
 
-    List<Integer> availableDataYears = periodDataProvider.getAvailableYears();
+    List<Integer> availableDataYears = periodDataProvider.getAvailableYears(DATABASE);
 
     when(jdbcTemplate.queryForList(
             getYearQueryForCurrentYear(program, true, availableDataYears), Integer.class))
@@ -562,9 +569,10 @@ class JdbcEventAnalyticsTableManagerTest {
             .withToday(today)
             .build();
 
-    when(periodDataProvider.getAvailableYears()).thenReturn(List.of(2018, 2019, now().getYear()));
+    when(periodDataProvider.getAvailableYears(DATABASE))
+        .thenReturn(List.of(2018, 2019, now().getYear()));
 
-    List<Integer> availableDataYears = periodDataProvider.getAvailableYears();
+    List<Integer> availableDataYears = periodDataProvider.getAvailableYears(DATABASE);
 
     when(jdbcTemplate.queryForList(
             getYearQueryForCurrentYear(programA, true, availableDataYears), Integer.class))
@@ -603,9 +611,10 @@ class JdbcEventAnalyticsTableManagerTest {
     programA.setProgramAttributes(List.of(programTrackedEntityAttribute));
 
     when(idObjectManager.getAllNoAcl(Program.class)).thenReturn(List.of(programA));
-    when(periodDataProvider.getAvailableYears()).thenReturn(List.of(2018, 2019, now().getYear()));
+    when(periodDataProvider.getAvailableYears(DATABASE))
+        .thenReturn(List.of(2018, 2019, now().getYear()));
 
-    List<Integer> availableDataYears = periodDataProvider.getAvailableYears();
+    List<Integer> availableDataYears = periodDataProvider.getAvailableYears(DATABASE);
 
     AnalyticsTableUpdateParams params =
         AnalyticsTableUpdateParams.newBuilder()
@@ -650,9 +659,10 @@ class JdbcEventAnalyticsTableManagerTest {
     programA.setProgramAttributes(List.of(programTrackedEntityAttribute));
 
     when(idObjectManager.getAllNoAcl(Program.class)).thenReturn(List.of(programA));
-    when(periodDataProvider.getAvailableYears()).thenReturn(List.of(2018, 2019, now().getYear()));
+    when(periodDataProvider.getAvailableYears(DATABASE))
+        .thenReturn(List.of(2018, 2019, now().getYear()));
 
-    List<Integer> availableDataYears = periodDataProvider.getAvailableYears();
+    List<Integer> availableDataYears = periodDataProvider.getAvailableYears(DATABASE);
 
     AnalyticsTableUpdateParams params =
         AnalyticsTableUpdateParams.newBuilder()
@@ -688,9 +698,10 @@ class JdbcEventAnalyticsTableManagerTest {
     Program programA = rnd.nextObject(Program.class);
     programA.setId(0);
 
-    when(periodDataProvider.getAvailableYears()).thenReturn(List.of(2018, 2019, now().getYear()));
+    when(periodDataProvider.getAvailableYears(DATABASE))
+        .thenReturn(List.of(2018, 2019, now().getYear()));
 
-    List<Integer> availableDataYears = periodDataProvider.getAvailableYears();
+    List<Integer> availableDataYears = periodDataProvider.getAvailableYears(DATABASE);
     int startYear = availableDataYears.get(0);
     int latestYear = availableDataYears.get(availableDataYears.size() - 1);
 
@@ -751,9 +762,10 @@ class JdbcEventAnalyticsTableManagerTest {
     when(idObjectManager.getAllNoAcl(Program.class)).thenReturn(List.of(programA));
     when(idObjectManager.getDataDimensionsNoAcl(OrganisationUnitGroupSet.class))
         .thenReturn(ouGroupSet);
-    when(periodDataProvider.getAvailableYears()).thenReturn(List.of(2018, 2019, now().getYear()));
+    when(periodDataProvider.getAvailableYears(DATABASE))
+        .thenReturn(List.of(2018, 2019, now().getYear()));
 
-    List<Integer> availableDataYears = periodDataProvider.getAvailableYears();
+    List<Integer> availableDataYears = periodDataProvider.getAvailableYears(DATABASE);
 
     AnalyticsTableUpdateParams params =
         AnalyticsTableUpdateParams.newBuilder().withStartTime(START_TIME).build();
@@ -791,9 +803,10 @@ class JdbcEventAnalyticsTableManagerTest {
 
     when(idObjectManager.getAllNoAcl(Program.class)).thenReturn(List.of(programA));
     when(categoryService.getAttributeCategoryOptionGroupSetsNoAcl()).thenReturn(cogs);
-    when(periodDataProvider.getAvailableYears()).thenReturn(List.of(2018, 2019, now().getYear()));
+    when(periodDataProvider.getAvailableYears(DATABASE))
+        .thenReturn(List.of(2018, 2019, now().getYear()));
 
-    List<Integer> availableDataYears = periodDataProvider.getAvailableYears();
+    List<Integer> availableDataYears = periodDataProvider.getAvailableYears(DATABASE);
 
     when(jdbcTemplate.queryForList(
             getYearQueryForCurrentYear(programA, false, availableDataYears), Integer.class))
@@ -870,9 +883,10 @@ class JdbcEventAnalyticsTableManagerTest {
 
     programA.setProgramAttributes(List.of(programTrackedEntityAttribute));
 
-    when(periodDataProvider.getAvailableYears()).thenReturn(List.of(2018, 2019, now().getYear()));
+    when(periodDataProvider.getAvailableYears(DATABASE))
+        .thenReturn(List.of(2018, 2019, now().getYear()));
 
-    List<Integer> availableDataYears = periodDataProvider.getAvailableYears();
+    List<Integer> availableDataYears = periodDataProvider.getAvailableYears(DATABASE);
     int startYear = availableDataYears.get(0);
     int latestYear = availableDataYears.get(availableDataYears.size() - 1);
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/analytics/AnalyticsExportSettings.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/analytics/AnalyticsExportSettings.java
@@ -69,9 +69,11 @@ public class AnalyticsExportSettings {
    * Returns the years' offset defined for the period generation. See {@link
    * ANALYTICS_MAX_PERIOD_YEARS_OFFSET}.
    *
-   * @return the offset defined in system settings.
+   * @return the offset defined in system settings, or null if nothing is set.
    */
-  public int getMaxPeriodYearsOffset() {
-    return systemSettingManager.getIntSetting(ANALYTICS_MAX_PERIOD_YEARS_OFFSET);
+  public Integer getMaxPeriodYearsOffset() {
+    return systemSettingManager.getIntSetting(ANALYTICS_MAX_PERIOD_YEARS_OFFSET) < 0
+        ? null
+        : systemSettingManager.getIntSetting(ANALYTICS_MAX_PERIOD_YEARS_OFFSET);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/PeriodDataProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/PeriodDataProvider.java
@@ -90,11 +90,11 @@ public class PeriodDataProvider {
   }
 
   /**
-   * Adds some extra years (based on the buffer) to the given list of years.
-   * The extra years are added at the end of the list.
+   * Adds some extra years (based on the buffer) to the given list of years. The extra years are
+   * added at the end of the list.
    *
-   * Let's say that the given list contains [2021, 2024], and the buffer is 3.
-   * This will result in a list like [2021, 2024, 2020, 2025, 2019, 2026, 2018, 2027].
+   * <p>Let's say that the given list contains [2021, 2024], and the buffer is 3. This will result
+   * in a list like [2021, 2024, 2020, 2025, 2019, 2026, 2018, 2027].
    *
    * @param years the list of years to append new years as buffer.
    * @param buffer the buffer representing the amount of years to add.

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/period/PeriodDataProviderTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/period/PeriodDataProviderTest.java
@@ -28,6 +28,11 @@
 package org.hisp.dhis.period;
 
 import static java.time.LocalDate.now;
+import static org.hisp.dhis.period.PeriodDataProvider.BEFORE_AND_AFTER_DATA_YEARS_SUPPORTED;
+import static org.hisp.dhis.period.PeriodDataProvider.DEFAULT_FIRST_YEAR_SUPPORTED;
+import static org.hisp.dhis.period.PeriodDataProvider.DEFAULT_LATEST_YEAR_SUPPORTED;
+import static org.hisp.dhis.period.PeriodDataProvider.DataSource.DATABASE;
+import static org.hisp.dhis.period.PeriodDataProvider.DataSource.SYSTEM_DEFINED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -70,7 +75,7 @@ class PeriodDataProviderTest {
     when(jdbcTemplate.queryForList(anyString(), ArgumentMatchers.<Class<Integer>>any()))
         .thenReturn(storedDataYears);
 
-    List<Integer> dataYears = periodDataProvider.getAvailableYears();
+    List<Integer> dataYears = periodDataProvider.getAvailableYears(DATABASE);
 
     assertEquals(12, dataYears.size());
     assertTrue(dataYears.contains((dataYears.get(storedDataYears.size() - 1) + 5)));
@@ -87,11 +92,33 @@ class PeriodDataProviderTest {
     when(jdbcTemplate.queryForList(anyString(), ArgumentMatchers.<Class<Integer>>any()))
         .thenReturn(storedDataYears);
 
-    List<Integer> dataYears = periodDataProvider.getAvailableYears();
+    List<Integer> dataYears = periodDataProvider.getAvailableYears(DATABASE);
 
     assertEquals(11, dataYears.size());
     assertTrue(dataYears.contains(currentYear + 5));
     assertTrue(dataYears.contains(currentYear - 5));
     assertFalse(dataYears.contains(currentYear - 6));
+  }
+
+  @Test
+  void testGetAvailableYearsFromSystemDefinedSource() {
+    int currentYear = now().getYear();
+
+    List<Integer> years = periodDataProvider.getAvailableYears(SYSTEM_DEFINED);
+
+    assertTrue(containsAllSystemDefined(years));
+    assertTrue(years.contains(currentYear + BEFORE_AND_AFTER_DATA_YEARS_SUPPORTED));
+    assertTrue(years.contains(currentYear - BEFORE_AND_AFTER_DATA_YEARS_SUPPORTED));
+    assertTrue(years.contains(DEFAULT_LATEST_YEAR_SUPPORTED));
+    assertTrue(years.contains(DEFAULT_FIRST_YEAR_SUPPORTED));
+  }
+
+  private boolean containsAllSystemDefined(List<Integer> years) {
+    for (int year = DEFAULT_FIRST_YEAR_SUPPORTED; year <= DEFAULT_LATEST_YEAR_SUPPORTED; year++) {
+      if (!years.contains(year)) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
@@ -273,7 +273,7 @@ public enum SettingKey {
       "keyAnalyticsCacheTtlMode", AnalyticsCacheTtlMode.FIXED, AnalyticsCacheTtlMode.class),
 
   /** The offset of years used during period generation during the analytics export process. */
-  ANALYTICS_MAX_PERIOD_YEARS_OFFSET("keyAnalyticsPeriodYearsOffset", 22, Integer.class),
+  ANALYTICS_MAX_PERIOD_YEARS_OFFSET("keyAnalyticsPeriodYearsOffset", -1, Integer.class),
 
   /**
    * @deprecated use {@link #TRACKED_ENTITY_MAX_LIMIT} instead


### PR DESCRIPTION
Changes to make the recent introduction of dynamic period generation "smoother" for the user.
It makes the dynamic period generation backward compatible.
The dynamic period generation and validations around it will only trigger if the user has asked for it explicitly.

Also, applied some code clean-up and improved a few  Java docs.