### PR TITLE
feat(dataelement): add reference to programstageelements

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElement.java
@@ -72,6 +72,7 @@ import org.hisp.dhis.period.YearlyPeriodType;
 import org.hisp.dhis.schema.PropertyType;
 import org.hisp.dhis.schema.annotation.Property;
 import org.hisp.dhis.schema.annotation.PropertyRange;
+import org.hisp.dhis.program.ProgramStageDataElement;
 
 /**
  * @author Kristian Nordal
@@ -106,6 +107,9 @@ public class DataElement extends BaseDimensionalItemObject
 
   /** The data sets which this data element is a member of. */
   private Set<DataSetElement> dataSetElements = new HashSet<>();
+
+/** The program stages which this data element is a member of. */
+  private Set<ProgramStageDataElement> programStageDataElements = new HashSet<>();
 
   /** The lower organisation unit levels for aggregation. */
   private List<Integer> aggregationLevels = new ArrayList<>();
@@ -564,6 +568,17 @@ public class DataElement extends BaseDimensionalItemObject
 
   public void setDataSetElements(Set<DataSetElement> dataSetElements) {
     this.dataSetElements = dataSetElements;
+  }
+
+  @JsonProperty
+  @JacksonXmlElementWrapper(localName = "programStageDataElements", namespace = DxfNamespaces.DXF_2_0)
+  @JacksonXmlProperty(localName = "programStageDataElements", namespace = DxfNamespaces.DXF_2_0)
+  public Set<ProgramStageDataElement> getProgramStageDataElements() {
+    return programStageDataElements;
+  }
+
+  public void setProgramStageDataElements(Set<ProgramStageDataElement> programStageDataElements) {
+    this.programStageDataElements = programStageDataElements;
   }
 
   @JsonProperty

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStage.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStage.java
@@ -154,6 +154,7 @@ public class ProgramStage extends BaseNameableObject implements MetadataObject {
   public boolean addDataElement(DataElement dataElement, Integer sortOrder) {
     ProgramStageDataElement element =
         new ProgramStageDataElement(this, dataElement, false, sortOrder);
+    dataElement.getProgramStageDataElements().add(element);
     element.setAutoFields();
 
     return this.programStageDataElements.add(element);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElement.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataelement/hibernate/DataElement.hbm.xml
@@ -65,6 +65,12 @@
       <one-to-many class="org.hisp.dhis.dataset.DataSetElement" />
     </set>
 
+    <set name="programStageDataElements" table="programstagedataelement" inverse="true">
+      <cache usage="read-write" />
+      <key column="dataelementid" foreign-key="fk_programstagedataelement_dataelementid" not-null="true" />
+      <one-to-many class="org.hisp.dhis.program.ProgramStageDataElement" />
+    </set>
+
     <list name="aggregationLevels" table="dataelementaggregationlevels">
       <cache usage="read-write" />
       <key column="dataelementid" foreign-key="fk_dataelementaggregationlevels_dataelementid" />


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-16062

Adds the reverse reference from `dataElement`->`programStageDataElements`. As far as I understand this is basically the same as the reverse reference to `dataSetElements`. 

This is mostly useful to allow us to filter `dataElements` by `programStage` and `program`. Eg.

```
/api/dataElements?fields=name,id&filter=programStageDataElements.programStage.program.id:eq:IpHINAT79UW
```