### PR TITLE
fix: only exclude actual 'run once' jobs from scheduler main list [DHIS2-16074]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
@@ -341,7 +341,10 @@ public class JobConfiguration extends BaseIdentifiableObject implements Secondar
   }
 
   public boolean isRunOnce() {
-    return cronExpression == null && delay == null && queueName == null;
+    return schedulingType == SchedulingType.ONCE_ASAP
+        && cronExpression == null
+        && delay == null
+        && queueName == null;
   }
 
   public boolean isDueBetween(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobSchedulerControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobSchedulerControllerTest.java
@@ -307,6 +307,9 @@ class JobSchedulerControllerTest extends DhisControllerConvenienceTest {
 
     assertStatus(HttpStatus.NO_CONTENT, DELETE("/scheduler/queues/testQueue"));
     assertStatus(HttpStatus.NOT_FOUND, GET("/scheduler/queues/testQueue"));
+    // verify the ex-queue jobs show in the scheduler main list again
+    JsonArray list = GET("/scheduler").content();
+    assertEquals(3, list.size());
   }
 
   @Test


### PR DESCRIPTION
### Summary
The filter applied to the scheduler main list was too unspecific and would also filter out disabled jobs that were removed from a queue and therefore would not have a CRON expression or delay time. 

### Manual Testing
* create some jobs
* create a queue with the new jobs
* delete the queue 
* check the jobs get listed for `/api/scheduler` as disabled