### PR TITLE
feat: explicit endpoints to enable/disable a job configuration [DHIS2-16076]

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobSchedulerControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobSchedulerControllerTest.java
@@ -29,8 +29,7 @@ package org.hisp.dhis.webapi.controller;
 
 import static java.lang.String.format;
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 import java.util.Set;
@@ -293,6 +292,34 @@ class JobSchedulerControllerTest extends DhisControllerConvenienceTest {
                 "/scheduler/queues/testQueue",
                 format("{'cronExpression':'0 1 ? * *','sequence':['%s','%s']}", jobIdA, jobIdB))
             .content(HttpStatus.CONFLICT));
+  }
+
+  @Test
+  void testUpdateQueue_EnableDisable() {
+    assertStatus(
+        HttpStatus.CREATED,
+        POST(
+            "/scheduler/queues/testQueue",
+            format(
+                "{'cronExpression':'0 0 1 ? * *','sequence':['%s','%s','%s']}",
+                jobIdA, jobIdB, jobIdC)));
+    assertStatus(HttpStatus.NO_CONTENT, POST("/jobConfigurations/" + jobIdA + "/disable"));
+    JsonObject queue = GET("/scheduler/queues/testQueue").content();
+    assertEquals(
+        List.of(jobIdA, jobIdB, jobIdC),
+        queue.getArray("sequence").asList(JsonString.class).toList(JsonString::string),
+        "queue sequence was changed");
+    JsonArray list = GET("/scheduler").content();
+    assertFalse(list.getObject(0).getBoolean("enabled").booleanValue());
+
+    assertStatus(HttpStatus.NO_CONTENT, POST("/jobConfigurations/" + jobIdA + "/enable"));
+    queue = GET("/scheduler/queues/testQueue").content();
+    assertEquals(
+        List.of(jobIdA, jobIdB, jobIdC),
+        queue.getArray("sequence").asList(JsonString.class).toList(JsonString::string),
+        "queue sequence was changed");
+    list = GET("/scheduler").content();
+    assertTrue(list.getObject(0).getBoolean("enabled").booleanValue());
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -124,6 +124,30 @@ public class JobConfigurationController extends AbstractCrudController<JobConfig
     jobConfigurationService.deleteFinishedJobs(minutes);
   }
 
+  @PostMapping("{uid}/enable")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void enable(@PathVariable("uid") String uid) throws NotFoundException, ConflictException {
+    JobConfiguration obj = jobConfigurationService.getJobConfigurationByUid(uid);
+    if (obj == null) throw new NotFoundException(JobConfiguration.class, uid);
+    checkModifiable(obj, "Job %s is a system job that cannot be modified.");
+    if (!obj.isEnabled()) {
+      obj.setEnabled(true);
+      jobConfigurationService.updateJobConfiguration(obj);
+    }
+  }
+
+  @PostMapping("{uid}/disable")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void disable(@PathVariable("uid") String uid) throws NotFoundException, ConflictException {
+    JobConfiguration obj = jobConfigurationService.getJobConfigurationByUid(uid);
+    if (obj == null) throw new NotFoundException(JobConfiguration.class, uid);
+    checkModifiable(obj, "Job %s is a system job that cannot be modified.");
+    if (obj.isEnabled()) {
+      obj.setEnabled(false);
+      jobConfigurationService.updateJobConfiguration(obj);
+    }
+  }
+
   @Override
   protected void preCreateEntity(JobConfiguration jobConfiguration) throws ConflictException {
     checkModifiable(jobConfiguration, "Job %s must be configurable but was not.");


### PR DESCRIPTION
### Summary
Adds a POST `/api/jobConfigurations/{uid}/enable` and POST `/api/jobConfigurations/{uid}/disable` endpoint to explicitly change the `enabled` state of a `JobConfiguration`.

This is also added as a way to work around the issue that using JSON patch on the `enabled` property has unintended side-effects and cannot be used at the moment. As that fix is likely going to take time this provides a working solution for the app to toggle the state of a job and job queue. 

Long term it is also a good idea to have these state changes modeled as as explicit endpoints as this is the critical user controlled transition of `JobConfiguration`s that might be subject of additional validation or processing in the future anyhow.
So having this as endpoints can't hurt to get a robust API.

### Automatic Testing
Adds a test that confirms that using the new endpoints works with a queue (which is the scenario that would not work using JSON patch)

### Manual Testing
* create a job
* toggle the job enabled status in the app and check the job changes state as expected
* create a job queue
* toggle the job enabled status in the app and check the queue changes state as expected