### PR TITLE
ci: add check for deploy label [skip ci]

### DIFF
--- a/.github/workflows/deploy-instance.yml
+++ b/.github/workflows/deploy-instance.yml
@@ -18,7 +18,7 @@ jobs:
       INSTANCE_NAME: pr-${{ github.event.pull_request.number }}
     steps:
       - name: Wait for API tests
-        uses: lewagon/wait-on-check-action@v1.3.1
+        uses: t3chguy/wait-on-check-action@master
         with:
           ref: ${{ github.head_ref }}
           check-name: 'api-test'

--- a/.github/workflows/deploy-instance.yml
+++ b/.github/workflows/deploy-instance.yml
@@ -14,15 +14,27 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'deploy')
     runs-on: ubuntu-latest
     env:
+      HTTP: https --check-status
+      USER_EMAIL: ${{ secrets.IM_BOT_EMAIL }}
+      PASSWORD: ${{ secrets.IM_BOT_PASSWORD }}
+      IM_HOST: 'https://api.im.dhis2.org'
       INSTANCE_HOST: 'https://dev.im.dhis2.org'
       INSTANCE_NAME: pr-${{ github.event.pull_request.number }}
     steps:
+      - name: Dump context
+        uses: crazy-max/ghaction-dump-context@v2
+
       - name: Wait for API tests
+        # Using this fork of the upstream https://github.com/lewagon/wait-on-check-action,
+        # as it will filter out and check only the latest run of a workflow when checking for the allowed conclusions,
+        # instead of checking all of the re-runs and possibly failing due to skipped or cancelled runs.
+        # See https://github.com/lewagon/wait-on-check-action/issues/85 for more info.
         uses: t3chguy/wait-on-check-action@master
         with:
           ref: ${{ github.head_ref }}
           check-name: 'api-test'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          allowed-conclusions: success
 
       - uses: actions/checkout@v4
         with:
@@ -35,20 +47,19 @@ jobs:
       - name: Deploy DHIS2 instance
         working-directory: scripts/instances
         env:
-          HTTP: https --check-status
-          USER_EMAIL: ${{ secrets.IM_BOT_EMAIL }}
-          PASSWORD: ${{ secrets.IM_BOT_PASSWORD }}
-          IM_HOST: 'https://api.im.dhis2.org'
           IMAGE_REPOSITORY: core-pr
           IMAGE_TAG: ${{ github.event.pull_request.number }}
           IMAGE_PULL_POLICY: Always
-          DATABASE_ID: sl-sierra-leone-dev-sql-gz
+          DATABASE_ID: test-dbs-sierra-leone-dev-sql-gz
         run: ./findByName.sh dev $INSTANCE_NAME && ./restart.sh dev $INSTANCE_NAME || ./deploy-dhis2.sh dev $INSTANCE_NAME
 
       - name: Wait for instance
-        run: timeout 300 bash -c 'while [[ "$(curl -fsSL -o /dev/null -w %{http_code} $INSTANCE_HOST/$INSTANCE_NAME)" != "200" ]]; do sleep 5; done'
+        working-directory: scripts/instances
+        env:
+          EXPECTED_STATUS: Running
+        run: timeout 600 bash -ex -c 'while [[ "$(./status.sh dev $INSTANCE_NAME | jq -r)" != "$EXPECTED_STATUS" ]]; do echo "Instance is not $EXPECTED_STATUS yet ..."; sleep 5; done'
 
-      - name: Generate analytics
+      - name: Start analytics generation
         run: curl -X POST -u "${{ secrets.DHIS2_USERNAME }}:${{ secrets.DHIS2_PASSWORD }}" "$INSTANCE_HOST/$INSTANCE_NAME/api/resourceTables/analytics" -d 'executeTei=true'
 
       - name: Comment instance URL

--- a/.github/workflows/deploy-instance.yml
+++ b/.github/workflows/deploy-instance.yml
@@ -57,7 +57,7 @@ jobs:
         working-directory: scripts/instances
         env:
           EXPECTED_STATUS: Running
-        run: timeout 600 bash -ex -c 'while [[ "$(./status.sh dev $INSTANCE_NAME | jq -r)" != "$EXPECTED_STATUS" ]]; do echo "Instance is not $EXPECTED_STATUS yet ..."; sleep 5; done'
+        run: timeout 600 bash -ex -c 'until [[ "$(./status.sh dev $INSTANCE_NAME | jq -r)" == "$EXPECTED_STATUS" ]]; do echo "Instance is not $EXPECTED_STATUS yet ..."; sleep 5; done'
 
       - name: Start analytics generation
         run: curl -X POST -u "${{ secrets.DHIS2_USERNAME }}:${{ secrets.DHIS2_PASSWORD }}" "$INSTANCE_HOST/$INSTANCE_NAME/api/resourceTables/analytics" -d 'executeTei=true'

--- a/.github/workflows/destroy-instance.yml
+++ b/.github/workflows/destroy-instance.yml
@@ -10,8 +10,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-deploy-label:
+    runs-on: ubuntu-latest
+    outputs:
+      removed: ${{ steps.check.outputs.removed }}
+    steps:
+      - name: Check if "deploy" was removed
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          last_removed_label=$(
+            gh api "repos/$GITHUB_REPOSITORY/issues/${{ github.event.pull_request.number }}/events" \
+            --jq 'map(select(.event == "unlabeled"))[-1].label.name'
+          )
+
+          if [[ "$last_removed_label" == 'deploy' ]]; then
+              echo "removed=true" >> "$GITHUB_OUTPUT"
+          fi
+
   destroy-instance:
-    if: contains(github.event.pull_request.labels.*.name, 'deploy')
+    needs: check-deploy-label
+    if: (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'deploy')) || needs.check-deploy-label.outputs.removed
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/destroy-instance.yml
+++ b/.github/workflows/destroy-instance.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   destroy-instance:
+    if: contains(github.event.pull_request.labels.*.name, 'deploy')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/destroy-instance.yml
+++ b/.github/workflows/destroy-instance.yml
@@ -2,7 +2,7 @@ name: Destroy instance
 
 on:
   pull_request:
-    types: [closed]
+    types: [closed, unlabeled]
 
 # Cancel previous runs of the same workflow and PR number or branch/tag
 concurrency:

--- a/.github/workflows/destroy-instance.yml
+++ b/.github/workflows/destroy-instance.yml
@@ -31,3 +31,9 @@ jobs:
           IM_HOST: 'https://api.im.dhis2.org'
           INSTANCE_NAME: pr-${{ github.event.number }}
         run: ./findByName.sh dev $INSTANCE_NAME && ./destroy.sh dev $INSTANCE_NAME
+
+      - name: Delete instance URL comment
+        uses: actions-cool/maintain-one-comment@v3
+        with:
+          body: "Instance deployed to https://dev.im.dhis2.org/pr-${{ github.event.pull_request.number }}"
+          delete: true


### PR DESCRIPTION
This PR also includes the following improvements/fixes:
* trigger the Destroy workflow when the `deploy` label is removed
* use a fork of the `wait-on-check` action that checks only the latest (current) run of a check, instead of all re-runs
* use IM instance status endpoint for making sure instance is running
* delete instance URL comment when destroying