### PR TITLE
ci:deploy nightly and stable builds on im-play

### DIFF
--- a/jenkinsfiles/canary
+++ b/jenkinsfiles/canary
@@ -41,6 +41,61 @@ pipeline {
                 }
             }
         }
+
+        stage('Update IM Play dev instance') {
+            environment {
+                HTTP = "http --check-status"
+                IM_REPO_URL = "https://github.com/dhis2-sre/im-manager"
+                IM_HOST = "https://api.im.dhis2.org"
+                INSTANCE_URL = "https://play.im.dhis2.org/nightly"
+                IMAGE_REPOSITORY = "core-canary"
+                IMAGE_PULL_POLICY = "Always"
+                FLYWAY_MIGRATE_OUT_OF_ORDER = "true"
+                FLYWAY_REPAIR_BEFORE_MIGRATION = "true"
+                INSTANCE_TTL = "315360000"
+                STARTUP_PROBE_FAILURE_THRESHOLD = "50"
+                LIVENESS_PROBE_TIMEOUT_SECONDS = "3"
+                READINESS_PROBE_TIMEOUT_SECONDS = "3"
+            }
+
+            steps {
+                script {
+                    withCredentials([usernamePassword(credentialsId: 'dhis2-im-bot', passwordVariable: 'PASSWORD', usernameVariable: 'USER_EMAIL')]) {
+                        dir('im-manager') {
+                            gitHelper.sparseCheckout(IM_REPO_URL, "${gitHelper.getLatestTag(IM_REPO_URL)}", '/scripts')
+
+                            echo 'Creating DHIS2 instance on IM...'
+                            def branch = ""
+                            if (env.GIT_BRANCH == 'master') {
+                                env.IMAGE_TAG = "latest"
+                                env.DATABASE_ID = "test-dbs-sierra-leone-dev-sql-gz"
+                            } else {
+                                env.IMAGE_TAG = env.GIT_BRANCH
+                                branch = "-${env.GIT_BRANCH.replaceAll(".", "-")}"
+
+                                dir('scripts/databases') {
+                                    env.DATABASE_ID = sh(
+                                            returnStdout: true,
+                                            script: "./list.sh | jq -r '.[] | select(.name == \"test-dbs\") | .databases[] | select(.name == \"sierra-leone/${env.GIT_BRANCH}.sql.gz\") | .slug'"
+                                    ).trim()
+                                }
+                            }
+
+                            sh '[ -n "$DATABASE_ID" ]'
+                            echo "Database: ${env.DATABASE_ID}"
+
+                            dir('scripts/instances') {
+                                sh "(./findByName.sh play nightly${branch} && ./restart.sh play nightly${branch}) || ./deploy-dhis2.sh play nightly${branch}"
+                                timeout(5) {
+                                    waitFor.statusOk("${env.INSTANCE_URL}${branch}")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         stage ('Build') {
             steps {
                 echo 'Building DHIS2 ...'

--- a/jenkinsfiles/canary
+++ b/jenkinsfiles/canary
@@ -42,7 +42,7 @@ pipeline {
             }
         }
 
-        stage('Update IM Play dev instance') {
+        stage('Update IM Play instance') {
             environment {
                 HTTP = "http --check-status"
                 IM_REPO_URL = "https://github.com/dhis2-sre/im-manager"

--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -233,7 +233,7 @@ pipeline {
                             dir('scripts/instances') {
                                 sh "(./findByName.sh play dev${branch} && ./restart.sh play dev${branch}) || ./deploy-dhis2.sh play dev${branch}"
                                 timeout(5) {
-                                    waitFor.statusOk("${env.INSTANCE_URL}")
+                                    waitFor.statusOk("${env.INSTANCE_URL}${branch}")
                                 }
                             }
                         }

--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -188,7 +188,7 @@ pipeline {
             }
         }
 
-        stage('Update IM Play dev instance') {
+        stage('Update IM Play instance') {
             environment {
                 HTTP = "http --check-status"
                 IM_REPO_URL = "https://github.com/dhis2-sre/im-manager"

--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -141,28 +141,44 @@ pipeline {
 
             steps {
                 script {
+                    if(env.DOCKER_IMAGE_TAG.endsWith("rc")) {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'NOT_BUILT') {
+                            error "Skipping..." // Force an error that we will catch to set the stageResult
+                        }
+                        return
+                    }
+
+                    echo 'Creating DHIS2 instance on IM...'
                     withCredentials([usernamePassword(credentialsId: 'dhis2-im-bot', passwordVariable: 'PASSWORD', usernameVariable: 'USER_EMAIL')]) {
                         dir('im-manager') {
                             gitHelper.sparseCheckout(IM_REPO_URL, "${gitHelper.getLatestTag(IM_REPO_URL)}", '/scripts')
 
-                            echo 'Creating DHIS2 instance on IM...'
-                            env.IMAGE_TAG = env.GIT_BRANCH
-                            def branch = "-${env.GIT_BRANCH.replace(".", "-")}"
+                            def version = env.GIT_BRANCH
+                            if (version.startsWith("patch/")) {
+                                version = version.split("/")[1]
+                                // If version contains more than 2 dots... It's a hotfix
+                                def isHotfix = version.length() - version.replace(".", "").length() > 2
+                                if (isHotfix) {
+                                    int endIndex = version.lastIndexOf(".")
+                                    version = version.substring(0, endIndex)
+                                }
+                            }
 
                             dir('scripts/databases') {
                                 env.DATABASE_ID = sh(
                                         returnStdout: true,
-                                        script: "./list.sh | jq -r '.[] | select(.name == \"test-dbs\") | .databases[] | select(.name == \"sierra-leone/${env.GIT_BRANCH}.sql.gz\") | .slug'"
+                                        script: "./list.sh | jq -r '.[] | select(.name == \"test-dbs\") | .databases[] | select(.name == \"sierra-leone/${version}.sql.gz\") | .slug'"
                                 ).trim()
                             }
 
                             sh '[ -n "$DATABASE_ID" ]'
                             echo "Database: ${env.DATABASE_ID}"
 
+                            def name = "-${version.replace(".", "-")}"
                             dir('scripts/instances') {
-                                sh "(./findByName.sh play stable${branch} && ./restart.sh play stable${branch}) || ./deploy-dhis2.sh play stable${branch}"
+                                sh "(./findByName.sh play stable${name} && ./restart.sh play stable${name}) || ./deploy-dhis2.sh play stable${name}"
                                 timeout(5) {
-                                    waitFor.statusOk("${env.INSTANCE_URL}${branch}")
+                                    waitFor.statusOk("${env.INSTANCE_URL}${name}")
                                 }
                             }
                         }

--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -156,7 +156,7 @@ pipeline {
                             // If version contains more than 2 dots... It's a hotfix
                             def isHotfix = version.length() - version.replace(".", "").length() > 2
                             if (isHotfix) {
-                                int endIndex = version.lastIndexOf(".")
+                                def endIndex = version.lastIndexOf(".")
                                 version = version.substring(0, endIndex)
                             }
 

--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -147,7 +147,7 @@ pipeline {
 
                             echo 'Creating DHIS2 instance on IM...'
                             env.IMAGE_TAG = env.GIT_BRANCH
-                            def branch = "-${env.GIT_BRANCH.replaceAll(".", "-")}"
+                            def branch = "-${env.GIT_BRANCH.replace(".", "-")}"
 
                             dir('scripts/databases') {
                                 env.DATABASE_ID = sh(

--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -123,6 +123,54 @@ pipeline {
             }
         }
 
+        stage('Update IM Play instance') {
+            environment {
+                HTTP = "http --check-status"
+                IM_REPO_URL = "https://github.com/dhis2-sre/im-manager"
+                IM_HOST = "https://api.im.dhis2.org"
+                INSTANCE_URL = "https://play.im.dhis2.org/stable"
+                IMAGE_REPOSITORY = "core"
+                IMAGE_PULL_POLICY = "Always"
+                FLYWAY_MIGRATE_OUT_OF_ORDER = "true"
+                FLYWAY_REPAIR_BEFORE_MIGRATION = "true"
+                INSTANCE_TTL = "315360000"
+                STARTUP_PROBE_FAILURE_THRESHOLD = "50"
+                LIVENESS_PROBE_TIMEOUT_SECONDS = "3"
+                READINESS_PROBE_TIMEOUT_SECONDS = "3"
+            }
+
+            steps {
+                script {
+                    withCredentials([usernamePassword(credentialsId: 'dhis2-im-bot', passwordVariable: 'PASSWORD', usernameVariable: 'USER_EMAIL')]) {
+                        dir('im-manager') {
+                            gitHelper.sparseCheckout(IM_REPO_URL, "${gitHelper.getLatestTag(IM_REPO_URL)}", '/scripts')
+
+                            echo 'Creating DHIS2 instance on IM...'
+                            env.IMAGE_TAG = env.GIT_BRANCH
+                            def branch = "-${env.GIT_BRANCH.replaceAll(".", "-")}"
+
+                            dir('scripts/databases') {
+                                env.DATABASE_ID = sh(
+                                        returnStdout: true,
+                                        script: "./list.sh | jq -r '.[] | select(.name == \"test-dbs\") | .databases[] | select(.name == \"sierra-leone/${env.GIT_BRANCH}.sql.gz\") | .slug'"
+                                ).trim()
+                            }
+
+                            sh '[ -n "$DATABASE_ID" ]'
+                            echo "Database: ${env.DATABASE_ID}"
+
+                            dir('scripts/instances') {
+                                sh "(./findByName.sh play stable${branch} && ./restart.sh play stable${branch}) || ./deploy-dhis2.sh play stable${branch}"
+                                timeout(5) {
+                                    waitFor.statusOk("${env.INSTANCE_URL}${branch}")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         stage ('Sync WAR') {
             steps {
                 echo 'Syncing WAR ...'

--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -156,12 +156,12 @@ pipeline {
                             def version = env.GIT_BRANCH
                             if (version.startsWith("patch/")) {
                                 version = version.split("/")[1]
-                                // If version contains more than 2 dots... It's a hotfix
-                                def isHotfix = version.length() - version.replace(".", "").length() > 2
-                                if (isHotfix) {
-                                    int endIndex = version.lastIndexOf(".")
-                                    version = version.substring(0, endIndex)
-                                }
+                            }
+                            // If version contains more than 2 dots... It's a hotfix
+                            def isHotfix = version.length() - version.replace(".", "").length() > 2
+                            if (isHotfix) {
+                                int endIndex = version.lastIndexOf(".")
+                                version = version.substring(0, endIndex)
                             }
 
                             dir('scripts/databases') {

--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -140,15 +140,11 @@ pipeline {
             }
 
             steps {
+                when {
+                    expression { !env.DOCKER_IMAGE_TAG.endsWith("rc") }
+                }
+                echo 'Creating DHIS2 instance on IM...'
                 script {
-                    if(env.DOCKER_IMAGE_TAG.endsWith("rc")) {
-                        catchError(buildResult: 'SUCCESS', stageResult: 'NOT_BUILT') {
-                            error "Skipping..." // Force an error that we will catch to set the stageResult
-                        }
-                        return
-                    }
-
-                    echo 'Creating DHIS2 instance on IM...'
                     withCredentials([usernamePassword(credentialsId: 'dhis2-im-bot', passwordVariable: 'PASSWORD', usernameVariable: 'USER_EMAIL')]) {
                         dir('im-manager') {
                             gitHelper.sparseCheckout(IM_REPO_URL, "${gitHelper.getLatestTag(IM_REPO_URL)}", '/scripts')


### PR DESCRIPTION
The goal of this PR is to deploy our nightly and stable builds on IM.

In addition to the above, the PR also includes a fix for dev. Previously, the branch wasn't included in the health check. So even if dev-2.40 was being the deploy, dev was the instance being checked.