### PR TITLE
fix: Ignore order in category options test [DHIS2-16094] [2.40]

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -44,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.IOException;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -620,8 +621,9 @@ class EventExporterTest extends TrackerTest {
                                 "category options and combo of event " + e.getUid(),
                                 () -> assertEquals("cr89ebDZrac", e.getAttributeOptionCombo()),
                                 () ->
-                                    assertEquals(
-                                        "xwZ2u3WyQR0;M58XdOfhiJ7", e.getAttributeCategoryOptions()),
+                                    assertContainsOnly(
+                                        Set.of("xwZ2u3WyQR0", "M58XdOfhiJ7"),
+                                        Arrays.asList(e.getAttributeCategoryOptions().split(";"))),
                                 () ->
                                     assertEquals(
                                         2,


### PR DESCRIPTION
Fix flay test `shouldReturnEventsGivenCategoryOptionCombo`, no need to check the orders of the parameters.

Ticket: https://dhis2.atlassian.net/browse/DHIS2-16094