### PR TITLE
tech: Validate access when ordering by attributes and data element in /tracker [TECH-1610]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapper.java
@@ -31,6 +31,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
@@ -43,6 +44,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
@@ -67,6 +69,8 @@ class TrackedEntityOperationParamsMapper {
 
   @Nonnull private final TrackedEntityAttributeService attributeService;
 
+  @Nonnull private final AclService aclService;
+
   @Transactional(readOnly = true)
   public TrackedEntityQueryParams map(TrackedEntityOperationParams operationParams)
       throws BadRequestException, ForbiddenException {
@@ -84,6 +88,7 @@ class TrackedEntityOperationParamsMapper {
     mapAttributeFilters(params, operationParams.getFilters());
 
     mapOrderParam(params, operationParams.getOrder());
+    validateOrderableAttributes(params.getOrder(), user);
 
     params
         .setProgram(program)
@@ -239,6 +244,21 @@ class TrackedEntityOperationParamsMapper {
             "Cannot order by '"
                 + order.getField()
                 + "'. Tracked entities can be ordered by fields and tracked entity attributes.");
+      }
+    }
+  }
+
+  private void validateOrderableAttributes(List<Order> order, User user) throws ForbiddenException {
+    Set<TrackedEntityAttribute> orderableTeas =
+        order.stream()
+            .filter(o -> o.getField() instanceof TrackedEntityAttribute)
+            .map(o -> (TrackedEntityAttribute) o.getField())
+            .collect(Collectors.toSet());
+
+    for (TrackedEntityAttribute tea : orderableTeas) {
+      if (!aclService.canRead(user, tea)) {
+        throw new ForbiddenException(
+            "User has no access to tracked entity attribute: " + tea.getUid());
       }
     }
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/event/EventOperationParamsMapperTest.java
@@ -358,6 +358,8 @@ class EventOperationParamsMapperTest {
     de1.setUid(DE_1_UID);
     when(dataElementService.getDataElement(DE_1_UID)).thenReturn(de1);
     when(dataElementService.getDataElement(TEA_1_UID)).thenReturn(null);
+    when(aclService.canRead(user, de1)).thenReturn(true);
+    when(aclService.canRead(user, tea1)).thenReturn(true);
 
     EventOperationParams operationParams =
         eventBuilder
@@ -572,6 +574,65 @@ class EventOperationParamsMapperTest {
     EventQueryParams params = mapper.map(operationParams);
     assertNull(params.getOrgUnit());
     assertEquals(ALL, params.getOrgUnitMode());
+  }
+
+  @Test
+  void shouldThrowWhenUserHasNoAccessToDataElementOrder() {
+    User user = new User();
+    UserRole userRole = new UserRole();
+    userRole.setAuthorities(Set.of(F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS.name()));
+    user.setUserRoles(Set.of(userRole));
+
+    when(currentUserService.getCurrentUser()).thenReturn(user);
+    when(organisationUnitService.getOrganisationUnit(orgUnitId)).thenReturn(orgUnit);
+
+    String deUid = CodeGenerator.generateUid();
+    DataElement de = new DataElement();
+    de.setUid(deUid);
+    when(dataElementService.getDataElement(deUid)).thenReturn(de);
+    when(aclService.canRead(user, de)).thenReturn(false);
+
+    EventOperationParams operationParams =
+        eventBuilder
+            .orgUnitMode(ALL)
+            .orgUnitUid(orgUnit.getUid())
+            .orderBy(UID.of(deUid), SortDirection.DESC)
+            .build();
+
+    ForbiddenException exception =
+        assertThrows(ForbiddenException.class, () -> mapper.map(operationParams));
+
+    assertEquals("User has no access to data element: " + deUid, exception.getMessage());
+  }
+
+  @Test
+  void shouldThrowWhenUserHasNoAccessToTrackedEntityAttributeOrder() {
+    User user = new User();
+    UserRole userRole = new UserRole();
+    userRole.setAuthorities(Set.of(F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS.name()));
+    user.setUserRoles(Set.of(userRole));
+
+    when(currentUserService.getCurrentUser()).thenReturn(user);
+    when(organisationUnitService.getOrganisationUnit(orgUnitId)).thenReturn(orgUnit);
+
+    String teaUid = CodeGenerator.generateUid();
+    TrackedEntityAttribute tea = new TrackedEntityAttribute();
+    tea.setUid(teaUid);
+    when(trackedEntityAttributeService.getTrackedEntityAttribute(teaUid)).thenReturn(tea);
+    when(aclService.canRead(user, tea)).thenReturn(false);
+
+    EventOperationParams operationParams =
+        eventBuilder
+            .orgUnitMode(ALL)
+            .orgUnitUid(orgUnit.getUid())
+            .orderBy(UID.of(teaUid), SortDirection.DESC)
+            .build();
+
+    ForbiddenException exception =
+        assertThrows(ForbiddenException.class, () -> mapper.map(operationParams));
+
+    assertEquals(
+        "User has no access to tracked entity attribute: " + teaUid, exception.getMessage());
   }
 
   private User createUserWithAuthority(Authorities authority) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityOperationParamsMapperTest.java
@@ -65,6 +65,7 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStatus;
+import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
@@ -109,6 +110,8 @@ class TrackedEntityOperationParamsMapperTest {
   @Mock private TrackedEntityAttributeService attributeService;
 
   @Mock private TrackedEntityTypeService trackedEntityTypeService;
+
+  @Mock private AclService aclService;
 
   @InjectMocks private TrackedEntityOperationParamsMapper mapper;
 
@@ -497,6 +500,7 @@ class TrackedEntityOperationParamsMapperTest {
     TrackedEntityAttribute tea1 = new TrackedEntityAttribute();
     tea1.setUid(TEA_1_UID);
     when(attributeService.getTrackedEntityAttribute(TEA_1_UID)).thenReturn(tea1);
+    when(aclService.canRead(user, tea1)).thenReturn(true);
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
@@ -552,5 +556,27 @@ class TrackedEntityOperationParamsMapperTest {
     Exception exception =
         assertThrows(BadRequestException.class, () -> mapper.map(operationParams));
     assertStartsWith("Cannot order by 'lastUpdated'", exception.getMessage());
+  }
+
+  @Test
+  void shouldThrowWhenUserHasNoAccessToTrackedEntityAttributeOrder() {
+    TrackedEntityAttribute tea = new TrackedEntityAttribute();
+    tea.setUid(TEA_1_UID);
+    when(attributeService.getTrackedEntityAttribute(TEA_1_UID)).thenReturn(tea);
+
+    when(aclService.canDataRead(user, tea)).thenReturn(false);
+
+    TrackedEntityOperationParams operationParams =
+        TrackedEntityOperationParams.builder()
+            .orgUnitMode(ACCESSIBLE)
+            .user(user)
+            .orderBy(UID.of(TEA_1_UID), SortDirection.ASC)
+            .build();
+
+    ForbiddenException exception =
+        assertThrows(ForbiddenException.class, () -> mapper.map(operationParams));
+
+    assertEquals(
+        "User has no access to tracked entity attribute: " + TEA_1_UID, exception.getMessage());
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
@@ -430,24 +430,6 @@ class OrderAndPaginationExporterTest extends TrackerTest {
   }
 
   @Test
-  void shouldThrowWhenGetTrackedEntityAndUserHasNoAccessToTrackedEntityOrder() {
-    User user = createUserWithAuth("user_no_access_tea");
-    user.setOrganisationUnits(Set.of(orgUnit));
-
-    TrackedEntityOperationParams params =
-        TrackedEntityOperationParams.builder()
-            .organisationUnits(Set.of(orgUnit.getUid()))
-            .orgUnitMode(SELECTED)
-            .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
-            .trackedEntityTypeUid(trackedEntityType.getUid())
-            .user(user)
-            .orderBy(UID.of("toDelete000"), SortDirection.DESC)
-            .build();
-
-    assertThrows(ForbiddenException.class, () -> getTrackedEntities(params));
-  }
-
-  @Test
   void shouldOrderTrackedEntitiesByAttributeWhenFiltered()
       throws ForbiddenException, BadRequestException, NotFoundException {
     TrackedEntityOperationParams params =


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/TECH-1610

Validate access to `de` or `tea` while ordering in `/tracker/events` and `/tracker/trackedentities`.
It uses `canRead` validation of the acl service because `canDataRead` that is also used, for example, in `validateAttributeOptionCombo`  method, does not follow sharing validation because DataElement is not shareable in the schema descriptor. Not sure this is by design. `canDataRead` follows another validation path for `aoc` which includes sharing checks eventually

