### PR TITLE
fix: Remove org unit in user scope from flaky test [DHIS2-16130]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentOperationParamsMapperTest.java
@@ -177,7 +177,7 @@ class EnrollmentOperationParamsMapperTest {
   void shouldThrowExceptionWhenOrgUnitNotFound() {
     EnrollmentOperationParams operationParams =
         EnrollmentOperationParams.builder()
-            .orgUnitUids(Set.of("JW6BrFd0HLu", ORG_UNIT_2_UID))
+            .orgUnitUids(Set.of("JW6BrFd0HLu"))
             .orgUnitMode(SELECTED)
             .programUid(PROGRAM_UID)
             .build();


### PR DESCRIPTION
Removes the org unit passed in the test which is part of the user scope, to make test consistently pass with the expected result.
Ticket: https://dhis2.atlassian.net/browse/DHIS2-16130