### PR TITLE
fix: add support for Hikari pool metrics [DHIS2-15419]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-system/pom.xml
@@ -237,6 +237,10 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP</artifactId>
+    </dependency>
 
     <!-- application monitoring -->
 

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/DataSourcePoolMetricsConfig.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/DataSourcePoolMetricsConfig.java
@@ -40,8 +40,8 @@ import javax.sql.DataSource;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.monitoring.metrics.jdbc.C3p0MetadataProvider;
-import org.hisp.dhis.monitoring.metrics.jdbc.DataSourcePoolMetadataProvider;
-import org.hisp.dhis.monitoring.metrics.jdbc.DataSourcePoolMetrics;
+import org.hisp.dhis.monitoring.metrics.jdbc.PoolMetadataProvider;
+import org.hisp.dhis.monitoring.metrics.jdbc.PoolMetrics;
 import org.hisp.dhis.monitoring.metrics.jdbc.HikariMetadataProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -61,10 +61,10 @@ public class DataSourcePoolMetricsConfig {
 
     private final MeterRegistry registry;
 
-    private final Collection<DataSourcePoolMetadataProvider> metadataProviders;
+    private final Collection<PoolMetadataProvider> metadataProviders;
 
     DataSourcePoolMetadataMetricsConfiguration(
-        MeterRegistry registry, Collection<DataSourcePoolMetadataProvider> metadataProviders) {
+        MeterRegistry registry, Collection<PoolMetadataProvider> metadataProviders) {
       this.registry = registry;
       this.metadataProviders = metadataProviders;
     }
@@ -76,7 +76,7 @@ public class DataSourcePoolMetricsConfig {
 
     private void bindDataSourceToRegistry(String beanName, DataSource dataSource) {
       String dataSourceName = getDataSourceName(beanName);
-      new DataSourcePoolMetrics(
+      new PoolMetrics(
               dataSource, this.metadataProviders, dataSourceName, Collections.emptyList())
           .bindTo(this.registry);
     }
@@ -97,7 +97,7 @@ public class DataSourcePoolMetricsConfig {
   }
 
   @Bean
-  public Collection<DataSourcePoolMetadataProvider> dataSourceMetadataProvider() {
+  public Collection<PoolMetadataProvider> dataSourceMetadataProvider() {
     return List.of(
         dataSource -> {
           if (dataSource instanceof ComboPooledDataSource comboPooledDataSource) {

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/DataSourcePoolMetricsConfig.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/DataSourcePoolMetricsConfig.java
@@ -40,9 +40,9 @@ import javax.sql.DataSource;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.monitoring.metrics.jdbc.C3p0MetadataProvider;
+import org.hisp.dhis.monitoring.metrics.jdbc.HikariMetadataProvider;
 import org.hisp.dhis.monitoring.metrics.jdbc.PoolMetadataProvider;
 import org.hisp.dhis.monitoring.metrics.jdbc.PoolMetrics;
-import org.hisp.dhis.monitoring.metrics.jdbc.HikariMetadataProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -76,8 +76,7 @@ public class DataSourcePoolMetricsConfig {
 
     private void bindDataSourceToRegistry(String beanName, DataSource dataSource) {
       String dataSourceName = getDataSourceName(beanName);
-      new PoolMetrics(
-              dataSource, this.metadataProviders, dataSourceName, Collections.emptyList())
+      new PoolMetrics(dataSource, this.metadataProviders, dataSourceName, Collections.emptyList())
           .bindTo(this.registry);
     }
 

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/AbstractPoolMetadata.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/AbstractPoolMetadata.java
@@ -36,8 +36,7 @@ import javax.sql.DataSource;
  * @author Stephane Nicoll
  * @since 2.0.0
  */
-public abstract class AbstractPoolMetadata<T extends DataSource>
-    implements PoolMetadata {
+public abstract class AbstractPoolMetadata<T extends DataSource> implements PoolMetadata {
 
   private final T dataSource;
 

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/C3p0MetadataProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/C3p0MetadataProvider.java
@@ -35,7 +35,7 @@ import lombok.extern.slf4j.Slf4j;
  * @author Luciano Fiandesio
  */
 @Slf4j
-public class C3p0MetadataProvider extends AbstractDataSourcePoolMetadata<ComboPooledDataSource> {
+public class C3p0MetadataProvider extends AbstractPoolMetadata<ComboPooledDataSource> {
   /**
    * Create an instance with the data source to use.
    *

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/CompositePoolMetadataProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/CompositePoolMetadataProvider.java
@@ -34,31 +34,33 @@ import java.util.List;
 import javax.sql.DataSource;
 
 /**
- * A {@link DataSourcePoolMetadataProvider} implementation that returns the first {@link
- * DataSourcePoolMetadata} that is found by one of its delegate.
+ * A {@link PoolMetadataProvider} implementation that returns the first {@link
+ * PoolMetadata} that is found by one of its delegate.
  *
  * @author Stephane Nicoll
- * @since 1.2.0
+ * @since 2.0.0
  */
-public class DataSourcePoolMetadataProviders implements DataSourcePoolMetadataProvider {
-
-  private final List<DataSourcePoolMetadataProvider> providers;
+public class CompositePoolMetadataProvider implements PoolMetadataProvider {
+  private final List<PoolMetadataProvider> providers;
 
   /**
-   * Create a {@link DataSourcePoolMetadataProviders} instance with an initial collection of
+   * Create a {@link CompositePoolMetadataProvider} instance with an initial collection of
    * delegates to use.
    *
    * @param providers the data source pool metadata providers
    */
-  public DataSourcePoolMetadataProviders(
-      Collection<? extends DataSourcePoolMetadataProvider> providers) {
-    this.providers = (providers == null ? Collections.emptyList() : new ArrayList<>(providers));
+  public CompositePoolMetadataProvider(
+      Collection<? extends PoolMetadataProvider> providers) {
+    this.providers =
+        (providers != null)
+            ? Collections.unmodifiableList(new ArrayList<>(providers))
+            : Collections.emptyList();
   }
 
   @Override
-  public DataSourcePoolMetadata getDataSourcePoolMetadata(DataSource dataSource) {
-    for (DataSourcePoolMetadataProvider provider : this.providers) {
-      DataSourcePoolMetadata metadata = provider.getDataSourcePoolMetadata(dataSource);
+  public PoolMetadata getDataSourcePoolMetadata(DataSource dataSource) {
+    for (PoolMetadataProvider provider : this.providers) {
+      PoolMetadata metadata = provider.getDataSourcePoolMetadata(dataSource);
       if (metadata != null) {
         return metadata;
       }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/CompositePoolMetadataProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/CompositePoolMetadataProvider.java
@@ -34,8 +34,8 @@ import java.util.List;
 import javax.sql.DataSource;
 
 /**
- * A {@link PoolMetadataProvider} implementation that returns the first {@link
- * PoolMetadata} that is found by one of its delegate.
+ * A {@link PoolMetadataProvider} implementation that returns the first {@link PoolMetadata} that is
+ * found by one of its delegate.
  *
  * @author Stephane Nicoll
  * @since 2.0.0
@@ -44,13 +44,12 @@ public class CompositePoolMetadataProvider implements PoolMetadataProvider {
   private final List<PoolMetadataProvider> providers;
 
   /**
-   * Create a {@link CompositePoolMetadataProvider} instance with an initial collection of
-   * delegates to use.
+   * Create a {@link CompositePoolMetadataProvider} instance with an initial collection of delegates
+   * to use.
    *
    * @param providers the data source pool metadata providers
    */
-  public CompositePoolMetadataProvider(
-      Collection<? extends PoolMetadataProvider> providers) {
+  public CompositePoolMetadataProvider(Collection<? extends PoolMetadataProvider> providers) {
     this.providers =
         (providers != null)
             ? Collections.unmodifiableList(new ArrayList<>(providers))

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/HikariDataSourcePoolMetadata.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/HikariDataSourcePoolMetadata.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.monitoring.metrics.jdbc;
+
+import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.pool.HikariPool;
+import org.springframework.beans.DirectFieldAccessor;
+
+/**
+ * @author Morten Svanæs
+ */
+public class HikariDataSourcePoolMetadata extends AbstractDataSourcePoolMetadata<HikariDataSource> {
+
+  public HikariDataSourcePoolMetadata(HikariDataSource dataSource) {
+    super(dataSource);
+  }
+
+  @Override
+  public Integer getActive() {
+    try {
+      return getHikariPool().getActiveConnections();
+    } catch (Exception ex) {
+      return null;
+    }
+  }
+
+  @Override
+  public Integer getIdle() {
+    try {
+      return getHikariPool().getIdleConnections();
+    } catch (Exception ex) {
+      return null;
+    }
+  }
+
+  private HikariPool getHikariPool() {
+    return (HikariPool) new DirectFieldAccessor(getDataSource()).getPropertyValue("pool");
+  }
+
+  @Override
+  public Integer getMax() {
+    return getDataSource().getMaximumPoolSize();
+  }
+
+  @Override
+  public Integer getMin() {
+    return getDataSource().getMinimumIdle();
+  }
+
+  @Override
+  public String getValidationQuery() {
+    return getDataSource().getConnectionTestQuery();
+  }
+
+  @Override
+  public Boolean getDefaultAutoCommit() {
+    return getDataSource().isAutoCommit();
+  }
+}

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/HikariMetadataProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/HikariMetadataProvider.java
@@ -32,9 +32,9 @@ import com.zaxxer.hikari.HikariDataSource;
 /**
  * @author Morten Svanæs
  */
-public class HikariMetadataProvider extends AbstractDataSourcePoolMetadata<HikariDataSource> {
+public class HikariMetadataProvider extends AbstractPoolMetadata<HikariDataSource> {
 
-  private HikariDataSourcePoolMetadata hikariDataSourcePoolMetadata;
+  private HikariPoolMetadataAccessor hikariDataSourcePoolMetadata;
 
   /**
    * Create an instance with the data source to use.
@@ -43,7 +43,7 @@ public class HikariMetadataProvider extends AbstractDataSourcePoolMetadata<Hikar
    */
   public HikariMetadataProvider(HikariDataSource dataSource) {
     super(dataSource);
-    this.hikariDataSourcePoolMetadata = new HikariDataSourcePoolMetadata(getDataSource());
+    this.hikariDataSourcePoolMetadata = new HikariPoolMetadataAccessor(getDataSource());
   }
 
   @Override

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/HikariMetadataProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/HikariMetadataProvider.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.monitoring.metrics.jdbc;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+/**
+ * @author Morten Svanæs
+ */
+public class HikariMetadataProvider extends AbstractDataSourcePoolMetadata<HikariDataSource> {
+
+  private HikariDataSourcePoolMetadata hikariDataSourcePoolMetadata;
+
+  /**
+   * Create an instance with the data source to use.
+   *
+   * @param dataSource the data source
+   */
+  public HikariMetadataProvider(HikariDataSource dataSource) {
+    super(dataSource);
+    this.hikariDataSourcePoolMetadata = new HikariDataSourcePoolMetadata(getDataSource());
+  }
+
+  @Override
+  public Integer getActive() {
+    return hikariDataSourcePoolMetadata.getActive();
+  }
+
+  @Override
+  public Integer getMax() {
+    return hikariDataSourcePoolMetadata.getMax();
+  }
+
+  @Override
+  public Integer getMin() {
+    return hikariDataSourcePoolMetadata.getMin();
+  }
+
+  @Override
+  public String getValidationQuery() {
+    return "";
+  }
+
+  @Override
+  public Boolean getDefaultAutoCommit() {
+    return hikariDataSourcePoolMetadata.getDefaultAutoCommit();
+  }
+
+  @Override
+  public Integer getIdle() {
+    return hikariDataSourcePoolMetadata.getIdle();
+  }
+}

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/PoolMetadata.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/PoolMetadata.java
@@ -36,7 +36,7 @@ import javax.sql.DataSource;
  * @author Stephane Nicoll
  * @since 2.0.0
  */
-public interface DataSourcePoolMetadata {
+public interface PoolMetadata {
 
   /**
    * Return the usage of the pool as value between 0 and 1 (or -1 if the pool is not limited).

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/PoolMetadataProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/PoolMetadataProvider.java
@@ -30,43 +30,16 @@ package org.hisp.dhis.monitoring.metrics.jdbc;
 import javax.sql.DataSource;
 
 /**
- * A base {@link DataSourcePoolMetadata} implementation.
- *
- * @param <T> the data source type
- * @author Stephane Nicoll
- * @since 2.0.0
+ * @author Luciano Fiandesio
  */
-public abstract class AbstractDataSourcePoolMetadata<T extends DataSource>
-    implements DataSourcePoolMetadata {
-
-  private final T dataSource;
-
+@FunctionalInterface
+public interface PoolMetadataProvider {
   /**
-   * Create an instance with the data source to use.
+   * Return the {@link PoolMetadata} instance able to manage the specified {@link
+   * DataSource} or {@code null} if the given data source could not be handled.
    *
-   * @param dataSource the data source
+   * @param dataSource the data source.
+   * @return the data source pool metadata.
    */
-  protected AbstractDataSourcePoolMetadata(T dataSource) {
-    this.dataSource = dataSource;
-  }
-
-  @Override
-  public Float getUsage() {
-    Integer maxSize = getMax();
-    Integer currentSize = getActive();
-    if (maxSize == null || currentSize == null) {
-      return null;
-    }
-    if (maxSize < 0) {
-      return -1F;
-    }
-    if (currentSize == 0) {
-      return 0F;
-    }
-    return (float) currentSize / (float) maxSize;
-  }
-
-  protected final T getDataSource() {
-    return this.dataSource;
-  }
+  PoolMetadata getDataSourcePoolMetadata(DataSource dataSource);
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/PoolMetadataProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/PoolMetadataProvider.java
@@ -35,8 +35,8 @@ import javax.sql.DataSource;
 @FunctionalInterface
 public interface PoolMetadataProvider {
   /**
-   * Return the {@link PoolMetadata} instance able to manage the specified {@link
-   * DataSource} or {@code null} if the given data source could not be handled.
+   * Return the {@link PoolMetadata} instance able to manage the specified {@link DataSource} or
+   * {@code null} if the given data source could not be handled.
    *
    * @param dataSource the data source.
    * @return the data source pool metadata.

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/PoolMetadataProviders.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/PoolMetadataProviders.java
@@ -27,19 +27,42 @@
  */
 package org.hisp.dhis.monitoring.metrics.jdbc;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import javax.sql.DataSource;
 
 /**
- * @author Luciano Fiandesio
+ * A {@link PoolMetadataProvider} implementation that returns the first {@link
+ * PoolMetadata} that is found by one of its delegate.
+ *
+ * @author Stephane Nicoll
+ * @since 1.2.0
  */
-@FunctionalInterface
-public interface DataSourcePoolMetadataProvider {
+public class PoolMetadataProviders implements PoolMetadataProvider {
+
+  private final List<PoolMetadataProvider> providers;
+
   /**
-   * Return the {@link DataSourcePoolMetadata} instance able to manage the specified {@link
-   * DataSource} or {@code null} if the given data source could not be handled.
+   * Create a {@link PoolMetadataProviders} instance with an initial collection of
+   * delegates to use.
    *
-   * @param dataSource the data source.
-   * @return the data source pool metadata.
+   * @param providers the data source pool metadata providers
    */
-  DataSourcePoolMetadata getDataSourcePoolMetadata(DataSource dataSource);
+  public PoolMetadataProviders(
+      Collection<? extends PoolMetadataProvider> providers) {
+    this.providers = (providers == null ? Collections.emptyList() : new ArrayList<>(providers));
+  }
+
+  @Override
+  public PoolMetadata getDataSourcePoolMetadata(DataSource dataSource) {
+    for (PoolMetadataProvider provider : this.providers) {
+      PoolMetadata metadata = provider.getDataSourcePoolMetadata(dataSource);
+      if (metadata != null) {
+        return metadata;
+      }
+    }
+    return null;
+  }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/PoolMetadataProviders.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/PoolMetadataProviders.java
@@ -34,8 +34,8 @@ import java.util.List;
 import javax.sql.DataSource;
 
 /**
- * A {@link PoolMetadataProvider} implementation that returns the first {@link
- * PoolMetadata} that is found by one of its delegate.
+ * A {@link PoolMetadataProvider} implementation that returns the first {@link PoolMetadata} that is
+ * found by one of its delegate.
  *
  * @author Stephane Nicoll
  * @since 1.2.0
@@ -45,13 +45,11 @@ public class PoolMetadataProviders implements PoolMetadataProvider {
   private final List<PoolMetadataProvider> providers;
 
   /**
-   * Create a {@link PoolMetadataProviders} instance with an initial collection of
-   * delegates to use.
+   * Create a {@link PoolMetadataProviders} instance with an initial collection of delegates to use.
    *
    * @param providers the data source pool metadata providers
    */
-  public PoolMetadataProviders(
-      Collection<? extends PoolMetadataProvider> providers) {
+  public PoolMetadataProviders(Collection<? extends PoolMetadataProvider> providers) {
     this.providers = (providers == null ? Collections.emptyList() : new ArrayList<>(providers));
   }
 

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/PoolMetrics.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/PoolMetrics.java
@@ -53,11 +53,7 @@ public class PoolMetrics implements MeterBinder {
       Collection<PoolMetadataProvider> metadataProviders,
       String dataSourceName,
       Iterable<Tag> tags) {
-    this(
-        dataSource,
-        new CompositePoolMetadataProvider(metadataProviders),
-        dataSourceName,
-        tags);
+    this(dataSource, new CompositePoolMetadataProvider(metadataProviders), dataSourceName, tags);
   }
 
   public PoolMetrics(
@@ -98,11 +94,9 @@ public class PoolMetrics implements MeterBinder {
     }
   }
 
-  private static class CachingDataSourcePoolMetadataProvider
-      implements PoolMetadataProvider {
+  private static class CachingDataSourcePoolMetadataProvider implements PoolMetadataProvider {
 
-    private static final Map<DataSource, PoolMetadata> cache =
-        new ConcurrentReferenceHashMap<>();
+    private static final Map<DataSource, PoolMetadata> cache = new ConcurrentReferenceHashMap<>();
 
     private final PoolMetadataProvider metadataProvider;
 

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/PoolMetrics.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/monitoring/metrics/jdbc/PoolMetrics.java
@@ -90,7 +90,7 @@ public class PoolMetrics implements MeterBinder {
           "jdbc.connections." + metricName,
           this.tags,
           this.dataSource,
-          (m) -> function.apply(m).doubleValue());
+          m -> function.apply(m).doubleValue());
     }
   }
 
@@ -106,17 +106,12 @@ public class PoolMetrics implements MeterBinder {
 
     <N extends Number> Function<DataSource, N> getValueFunction(
         Function<PoolMetadata, N> function) {
-      return (dataSource) -> function.apply(getDataSourcePoolMetadata(dataSource));
+      return dS -> function.apply(getDataSourcePoolMetadata(dS));
     }
 
     @Override
     public PoolMetadata getDataSourcePoolMetadata(DataSource dataSource) {
-      PoolMetadata metadata = cache.get(dataSource);
-      if (metadata == null) {
-        metadata = this.metadataProvider.getDataSourcePoolMetadata(dataSource);
-        cache.put(dataSource, metadata);
-      }
-      return metadata;
+      return cache.computeIfAbsent(dataSource, this.metadataProvider::getDataSourcePoolMetadata);
     }
   }
 }


### PR DESCRIPTION
# Summary 
* Adds support for collecting metrics from the Hikari DB pool.
* Before this fix, enabling metrics with the property ` monitoring.dbpool.enabled = on`, when also the Hikari pool is enabled with the property `db.pool.type = hikari `, would cause the server failing to start.

#### JIRA:
[DHIS2-15419](https://dhis2.atlassian.net/browse/DHIS2-15419)

[DHIS2-15419]: https://dhis2.atlassian.net/browse/DHIS2-15419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ