### PR TITLE
fix: remove renamed job from DB [DHIS2-15276]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_34__job_configuration_rename.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_34__job_configuration_rename.sql
@@ -1,0 +1,3 @@
+-- delete existing rows with the enum as it got renamed
+-- a new row will be inserted automatically at startup
+delete from jobconfiguration where jobtype = 'HEARTBEAT';


### PR DESCRIPTION
In #15575 the heartbeat job got renamed but I forgot to remove existing row from DB so they would not cause errors on load when trying to map their job type value to `JobType` enum. 