### PR TITLE
fix: run continuous jobs immediately [DHIS2-15276]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobSchedulerService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobSchedulerService.java
@@ -84,6 +84,12 @@ public class DefaultJobSchedulerService implements JobSchedulerService {
       if (job == null) throw new NotFoundException(JobConfiguration.class, jobId);
       // run "execute now" request directly when scheduling is not active (tests)
       jobRunner.runDueJob(job);
+    } else {
+      JobConfiguration job = jobConfigurationStore.getByUid(jobId);
+      if (job == null) throw new NotFoundException(JobConfiguration.class, jobId);
+      if (job.getJobType().isUsingContinuousExecution()) {
+        jobRunner.runIfDue(job);
+      }
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/JobRunner.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/JobRunner.java
@@ -40,7 +40,27 @@ package org.hisp.dhis.scheduling;
  */
 public interface JobRunner {
 
+  /**
+   * During testing the scheduler might not be active in which case this is false. Otherwise, this
+   * should always be true in a production environment.
+   *
+   * @return true, if the scheduler is running a scheduling loop cycle, otherwise false
+   */
   boolean isScheduling();
 
+  /**
+   * Runs a job if it should now run according to its {@link SchedulingType} and related information
+   * like the CRON expression or the delay time.
+   *
+   * @param config the job to check and potentially run
+   */
+  void runIfDue(JobConfiguration config);
+
+  /**
+   * Manually runs a job. OBS! This bypasses any actual checking if the job is due to run. When this
+   * is called the job will run.
+   *
+   * @param config The job to run.
+   */
   void runDueJob(JobConfiguration config);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/JobScheduler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/JobScheduler.java
@@ -137,20 +137,27 @@ public class JobScheduler implements Runnable, JobRunner {
     }
   }
 
+  @Override
+  public void runIfDue(JobConfiguration job) {
+    runIfDue(Instant.now().truncatedTo(ChronoUnit.SECONDS), job.getJobType(), List.of(job));
+  }
+
   private void runIfDue(Instant now, JobType type, List<JobConfiguration> jobs) {
     if (!type.isUsingContinuousExecution()) {
       runIfDue(now, jobs.get(0));
       return;
     }
-    Queue<String> jobIds =
-        continuousJobsByType.computeIfAbsent(type, key -> new ConcurrentLinkedQueue<>());
-    // add a worker either if no worker is on it (empty new queue) or if there are many jobs
-    boolean spawnWorker = jobIds.isEmpty();
+    Queue<String> jobIds = continuousJobsByType.get(type);
+    boolean spawnWorker = false;
+    if (jobIds == null) {
+      Queue<String> localQueue = new ConcurrentLinkedQueue<>();
+      Queue<String> sharedQueue = continuousJobsByType.putIfAbsent(type, localQueue);
+      spawnWorker = sharedQueue == null; // no previous queue => this thread put the queue
+      jobIds = continuousJobsByType.get(type);
+    }
     // add those IDs to the queue that are not yet in it
-    jobs.stream()
-        .map(JobConfiguration::getUid)
-        .filter(jobId -> !jobIds.contains(jobId))
-        .forEach(jobIds::add);
+    jobs.stream().map(JobConfiguration::getUid).forEach(jobIds::add);
+
     if (spawnWorker) {
       // we want to prevent starting more than one worker per job type
       // but if this does happen it is no issue as both will be pulling


### PR DESCRIPTION
The issue is that during tests when a test e.g. performs an import the actual import is just some milliseconds. But the first import would execute synchronous with the 20sec scheduler loop. So it is done shortly after the loop started to run. The queue would be empty again as the next test is waiting for the previous one to finish which requires finishing the import. So the next test runs again shortly after the loop cycle started, it then adds its import but at that point since the queue was empty the delay of almost 20 seconds has to be "payed" again essentially causing each test that has an import to take 20 seconds which causes overall execution time of the e2e tests go from 15min to 2h. 

To prevent this test issue the continuous jobs are directly added to the queue and also will spawn a worker if no queue was present (and worked) at that time. This should remove the 20 second delay for this type of jobs. The cost is that now there is a concurrent part in the scheduler where both the scheduling loop thread and async web worker threads from `executeNow` will add to the queue and potentially spawn worker.

As the accidental spawning of more than one worker is no issue this does not need to be synchronized the hard way.  