### PR TITLE
feat: invalidate user session when user's role memberships changes

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -84,7 +84,6 @@ import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.util.ObjectUtils;
 import org.jboss.aerogear.security.otp.api.Base32;
 import org.springframework.context.annotation.Lazy;
-import org.springframework.security.core.session.SessionInformation;
 import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -798,9 +797,7 @@ public class DefaultUserService implements UserService {
 
   @Override
   public void expireActiveSessions(User user) {
-    List<SessionInformation> sessions = sessionRegistry.getAllSessions(user, false);
-
-    sessions.forEach(SessionInformation::expireNow);
+    currentUserService.invalidateUserSessions(user.getUid());
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -84,7 +84,6 @@ import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.util.ObjectUtils;
 import org.jboss.aerogear.security.otp.api.Base32;
 import org.springframework.context.annotation.Lazy;
-import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -107,8 +107,6 @@ public class DefaultUserService implements UserService {
 
   private final PasswordManager passwordManager;
 
-  private final SessionRegistry sessionRegistry;
-
   private final SecurityService securityService;
 
   private final Cache<String> userDisplayNameCache;
@@ -125,7 +123,6 @@ public class DefaultUserService implements UserService {
       SystemSettingManager systemSettingManager,
       CacheProvider cacheProvider,
       @Lazy PasswordManager passwordManager,
-      @Lazy SessionRegistry sessionRegistry,
       @Lazy SecurityService securityService,
       AclService aclService,
       @Lazy OrganisationUnitService organisationUnitService) {
@@ -134,7 +131,6 @@ public class DefaultUserService implements UserService {
     checkNotNull(userRoleStore);
     checkNotNull(systemSettingManager);
     checkNotNull(passwordManager);
-    checkNotNull(sessionRegistry);
     checkNotNull(securityService);
     checkNotNull(aclService);
     checkNotNull(organisationUnitService);
@@ -145,7 +141,6 @@ public class DefaultUserService implements UserService {
     this.currentUserService = currentUserService;
     this.systemSettingManager = systemSettingManager;
     this.passwordManager = passwordManager;
-    this.sessionRegistry = sessionRegistry;
     this.securityService = securityService;
     this.userDisplayNameCache = cacheProvider.createUserDisplayNameCache();
     this.aclService = aclService;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
 import static org.hisp.dhis.user.User.populateUserCredentialsDtoFields;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -51,14 +50,11 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.preheat.PreheatIdentifier;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.system.util.ValidationUtils;
-import org.hisp.dhis.user.CurrentUserDetailsImpl;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserRole;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.user.UserSettingService;
-import org.springframework.security.core.session.SessionInformation;
-import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.stereotype.Component;
 
 /**
@@ -208,7 +204,6 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook<User> {
       currentUserService.invalidateUserSessions(persistedUser.getUid());
     }
   }
-
 
   private Boolean userRolesUpdated(User preUpdateUser, User persistedUser) {
     Set<String> before =

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
@@ -64,6 +64,8 @@ import org.springframework.stereotype.Component;
 @AllArgsConstructor
 public class UserObjectBundleHook extends AbstractObjectBundleHook<User> {
   public static final String USERNAME = "username";
+  public static final String INVALIDATE_SESSIONS_KEY = "shouldInvalidateUserSessions";
+  public static final String PRE_UPDATE_USER_KEY = "preUpdateUser";
 
   private final UserService userService;
 
@@ -140,7 +142,6 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook<User> {
 
     if (currentUser != null) {
       user.getCogsDimensionConstraints().addAll(currentUser.getCogsDimensionConstraints());
-
       user.getCatDimensionConstraints().addAll(currentUser.getCatDimensionConstraints());
     }
   }
@@ -166,8 +167,8 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook<User> {
   public void preUpdate(User user, User persisted, ObjectBundle bundle) {
     if (user == null) return;
 
-    bundle.putExtras(user, "preUpdateUser", user);
-    bundle.putExtras(persisted, "shouldInvalidateUser", userRolesUpdated(user, persisted));
+    bundle.putExtras(user, PRE_UPDATE_USER_KEY, user);
+    bundle.putExtras(persisted, INVALIDATE_SESSIONS_KEY, userRolesUpdated(user, persisted));
 
     if (persisted.getAvatar() != null
         && (user.getAvatar() == null
@@ -184,27 +185,6 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook<User> {
     }
   }
 
-  @Override
-  public void postUpdate(User persistedUser, ObjectBundle bundle) {
-    final User preUpdateUser = (User) bundle.getExtras(persistedUser, "preUpdateUser");
-    final Boolean shouldInvalidateUser =
-        (Boolean) bundle.getExtras(persistedUser, "shouldInvalidateUser");
-
-    if (!StringUtils.isEmpty(preUpdateUser.getPassword())) {
-      userService.encodeAndSetPassword(persistedUser, preUpdateUser.getPassword());
-      sessionFactory.getCurrentSession().update(persistedUser);
-    }
-
-    bundle.removeExtras(persistedUser, "preUpdateUser");
-    bundle.removeExtras(persistedUser, "shouldInvalidateUser");
-
-    userSettingService.saveUserSettings(persistedUser.getSettings(), persistedUser);
-
-    if (Boolean.TRUE.equals(shouldInvalidateUser)) {
-      currentUserService.invalidateUserSessions(persistedUser.getUid());
-    }
-  }
-
   private Boolean userRolesUpdated(User preUpdateUser, User persistedUser) {
     Set<String> before =
         preUpdateUser.getUserRoles().stream().map(UserRole::getUid).collect(Collectors.toSet());
@@ -212,6 +192,27 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook<User> {
         persistedUser.getUserRoles().stream().map(UserRole::getUid).collect(Collectors.toSet());
 
     return !Objects.equals(before, after);
+  }
+
+  @Override
+  public void postUpdate(User persistedUser, ObjectBundle bundle) {
+    final User preUpdateUser = (User) bundle.getExtras(persistedUser, PRE_UPDATE_USER_KEY);
+    final Boolean invalidateSessions =
+        (Boolean) bundle.getExtras(persistedUser, INVALIDATE_SESSIONS_KEY);
+
+    if (!StringUtils.isEmpty(preUpdateUser.getPassword())) {
+      userService.encodeAndSetPassword(persistedUser, preUpdateUser.getPassword());
+      sessionFactory.getCurrentSession().update(persistedUser);
+    }
+
+    userSettingService.saveUserSettings(persistedUser.getSettings(), persistedUser);
+
+    if (Boolean.TRUE.equals(invalidateSessions)) {
+      currentUserService.invalidateUserSessions(persistedUser.getUid());
+    }
+
+    bundle.removeExtras(persistedUser, PRE_UPDATE_USER_KEY);
+    bundle.removeExtras(persistedUser, INVALIDATE_SESSIONS_KEY);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserRoleBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserRoleBundleHook.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
+
+import static org.hisp.dhis.user.User.populateUserCredentialsDtoFields;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.adapter.BaseIdentifiableObject_;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.external.conf.ConfigurationKey;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.fileresource.FileResource;
+import org.hisp.dhis.fileresource.FileResourceService;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.preheat.PreheatIdentifier;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.system.util.ValidationUtils;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserRole;
+import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.UserSettingService;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Morten Svanæs <msvanaes@dhi2.org>
+ */
+@Component
+@AllArgsConstructor
+@Slf4j
+public class UserRoleBundleHook extends AbstractObjectBundleHook<UserRole> {
+
+  private final UserService userService;
+
+  private final FileResourceService fileResourceService;
+
+  private final CurrentUserService currentUserService;
+
+  private final AclService aclService;
+
+  private final UserSettingService userSettingService;
+
+  private final DhisConfigurationProvider dhisConfig;
+
+  @Override
+  public void validate(UserRole user, ObjectBundle bundle, Consumer<ErrorReport> addReports) {
+
+    String s = "s";
+    log.info("s = {}", s);
+//
+//    if (bundle.getImportMode().isCreate() && !ValidationUtils.isValidUid(user.getUid())) {
+//      addReports.accept(
+//          new ErrorReport(User.class, ErrorCode.E4014, user.getUid(), "uid")
+//              .setErrorProperty("uid"));
+//    }
+//
+//    if (bundle.getImportMode().isCreate()
+//        && !ValidationUtils.usernameIsValid(user.getUsername(), user.isInvitation())) {
+//      addReports.accept(
+//          new ErrorReport(User.class, ErrorCode.E4049, USERNAME, user.getUsername())
+//              .setErrorProperty(USERNAME));
+//    }
+//
+//    boolean usernameExists = userService.getUserByUsername(user.getUsername()) != null;
+//    if ((bundle.getImportMode().isCreate() && usernameExists)) {
+//      addReports.accept(
+//          new ErrorReport(User.class, ErrorCode.E4054, USERNAME, user.getUsername())
+//              .setErrorProperty(USERNAME));
+//    }
+//
+//    User existingUser = userService.getUser(user.getUid());
+//    if (bundle.getImportMode().isUpdate()
+//        && existingUser != null
+//        && user.getUsername() != null
+//        && !user.getUsername().equals(existingUser.getUsername())) {
+//      addReports.accept(
+//          new ErrorReport(User.class, ErrorCode.E4056, USERNAME, user.getUsername())
+//              .setErrorProperty(USERNAME));
+//    }
+//
+//    boolean openIdMappingExists = userService.getUserByOpenId(user.getOpenId()) != null;
+//    if ((dhisConfig.isDisabled(ConfigurationKey.LINKED_ACCOUNTS_ENABLED) && openIdMappingExists)) {
+//      addReports.accept(
+//          new ErrorReport(User.class, ErrorCode.E4054, "OIDC mapping value", user.getOpenId())
+//              .setErrorProperty(USERNAME));
+//    }
+//
+//    if (user.getUserRoles() == null || user.getUserRoles().isEmpty()) {
+//      addReports.accept(
+//          new ErrorReport(User.class, ErrorCode.E4055, USERNAME, user.getUsername())
+//              .setErrorProperty(USERNAME));
+//    }
+//
+//    if (user.getWhatsApp() != null && !ValidationUtils.validateWhatsApp(user.getWhatsApp())) {
+//      addReports.accept(
+//          new ErrorReport(User.class, ErrorCode.E4027, user.getWhatsApp(), "whatsApp")
+//              .setErrorProperty("whatsApp"));
+//    }
+  }
+
+  @Override
+  public void preCreate(UserRole user, ObjectBundle bundle) {
+    log.info("preCreate");
+//    if (user == null) return;
+//
+//    User currentUser = currentUserService.getCurrentUser();
+//
+//    if (currentUser != null) {
+//      user.getCogsDimensionConstraints().addAll(currentUser.getCogsDimensionConstraints());
+//
+//      user.getCatDimensionConstraints().addAll(currentUser.getCatDimensionConstraints());
+//    }
+  }
+
+  @Override
+  public void postCreate(UserRole user, ObjectBundle bundle) {
+    log.info("postCreate");
+//    if (!StringUtils.isEmpty(user.getPassword())) {
+//      userService.encodeAndSetPassword(user, user.getPassword());
+//    }
+//
+//    if (user.getAvatar() != null) {
+//      FileResource fileResource = fileResourceService.getFileResource(user.getAvatar().getUid());
+//      fileResource.setAssigned(true);
+//      fileResourceService.updateFileResource(fileResource);
+//    }
+//
+//    preheatService.connectReferences(user, bundle.getPreheat(), bundle.getPreheatIdentifier());
+//    sessionFactory.getCurrentSession().update(user);
+//    userSettingService.saveUserSettings(user.getSettings(), user);
+  }
+
+  @Override
+  public void preUpdate(UserRole user, UserRole persisted, ObjectBundle bundle) {
+    log.info("preUpdate");
+//    if (user == null) return;
+//
+//    bundle.putExtras(user, "preUpdateUser", user);
+//
+//    if (persisted.getAvatar() != null
+//        && (user.getAvatar() == null
+//            || !persisted.getAvatar().getUid().equals(user.getAvatar().getUid()))) {
+//      FileResource fileResource =
+//          fileResourceService.getFileResource(persisted.getAvatar().getUid());
+//      fileResourceService.updateFileResource(fileResource);
+//
+//      if (user.getAvatar() != null) {
+//        fileResource = fileResourceService.getFileResource(user.getAvatar().getUid());
+//        fileResource.setAssigned(true);
+//        fileResourceService.updateFileResource(fileResource);
+//      }
+//    }
+  }
+
+  @Override
+  public void postUpdate(UserRole persistedUser, ObjectBundle bundle) {
+    log.info("postUpdate");
+//    final User preUpdateUser = (User) bundle.getExtras(persistedUser, "preUpdateUser");
+//
+//    if (!StringUtils.isEmpty(preUpdateUser.getPassword())) {
+//      userService.encodeAndSetPassword(persistedUser, preUpdateUser.getPassword());
+//      sessionFactory.getCurrentSession().update(persistedUser);
+//    }
+//
+//    bundle.removeExtras(persistedUser, "preUpdateUser");
+//    userSettingService.saveUserSettings(persistedUser.getSettings(), persistedUser);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void postCommit(ObjectBundle bundle) {
+    log.info("postCommit");
+//
+//    Iterable<User> objects = bundle.getObjects(User.class);
+//
+//    Map<String, Map<String, Object>> userReferences = bundle.getObjectReferences(User.class);
+//
+//    if (userReferences == null || userReferences.isEmpty()) {
+//      return;
+//    }
+//
+//    for (User identifiableObject : objects) {
+//      User user = identifiableObject;
+//
+//      user = bundle.getPreheat().get(bundle.getPreheatIdentifier(), user);
+//
+//      Map<String, Object> userReferenceMap = userReferences.get(identifiableObject.getUid());
+//
+//      if (user == null || userReferenceMap == null || userReferenceMap.isEmpty()) {
+//        continue;
+//      }
+//
+//      Set<UserRole> userRoles = (Set<UserRole>) userReferenceMap.get("userRoles");
+//      user.setUserRoles(Objects.requireNonNullElseGet(userRoles, HashSet::new));
+//
+//      Set<OrganisationUnit> organisationUnits =
+//          (Set<OrganisationUnit>) userReferenceMap.get("organisationUnits");
+//      user.setOrganisationUnits(organisationUnits);
+//
+//      Set<OrganisationUnit> dataViewOrganisationUnits =
+//          (Set<OrganisationUnit>) userReferenceMap.get("dataViewOrganisationUnits");
+//      user.setDataViewOrganisationUnits(dataViewOrganisationUnits);
+//
+//      Set<OrganisationUnit> teiSearchOrganisationUnits =
+//          (Set<OrganisationUnit>) userReferenceMap.get("teiSearchOrganisationUnits");
+//      user.setTeiSearchOrganisationUnits(teiSearchOrganisationUnits);
+//
+//      user.setCreatedBy((User) userReferenceMap.get(BaseIdentifiableObject_.CREATED_BY));
+//
+//      if (user.getCreatedBy() == null) {
+//        user.setCreatedBy(bundle.getUser());
+//      }
+//
+//      user.setLastUpdatedBy(bundle.getUser());
+//
+//      preheatService.connectReferences(user, bundle.getPreheat(), bundle.getPreheatIdentifier());
+//
+//      handleNoAccessRoles(user, bundle, userRoles);
+//
+//      sessionFactory.getCurrentSession().update(user);
+//    }
+  }
+
+  /**
+   * If currentUser doesn't have read access to a UserRole, and it is included in the payload, then
+   * that UserRole should not be removed from updating User.
+   *
+   * @param user the updating User.
+   * @param bundle the ObjectBundle.
+   */
+  private void handleNoAccessRoles(User user, ObjectBundle bundle, Set<UserRole> userRoles) {
+    Set<UserRole> roles = user.getUserRoles();
+    Set<String> currentRoles =
+        roles.stream().map(IdentifiableObject::getUid).collect(Collectors.toSet());
+
+    if (userRoles != null) {
+      userRoles.stream()
+          .filter(role -> !currentRoles.contains(role.getUid()))
+          .forEach(
+              role -> {
+                UserRole persistedRole = bundle.getPreheat().get(PreheatIdentifier.UID, role);
+
+                if (persistedRole == null) {
+                  persistedRole = manager.getNoAcl(UserRole.class, role.getUid());
+                }
+
+                if (!aclService.canRead(bundle.getUser(), persistedRole)) {
+                  roles.add(persistedRole);
+                }
+              });
+    }
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserRoleBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserRoleBundleHook.java
@@ -55,7 +55,7 @@ public class UserRoleBundleHook extends AbstractObjectBundleHook<UserRole> {
     bundle.putExtras(update, INVALIDATE_SESSION_KEY, userRolesUpdated(update, existing));
   }
 
-  private Object userRolesUpdated(UserRole update, UserRole existing) {
+  private Boolean userRolesUpdated(UserRole update, UserRole existing) {
     Set<String> newAuthorities = update.getAuthorities();
     Set<String> existingAuthorities = existing.getAuthorities();
     return !Objects.equals(newAuthorities, existingAuthorities);

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserRoleBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserRoleBundleHook.java
@@ -27,30 +27,18 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
 
-import static org.hisp.dhis.user.User.populateUserCredentialsDtoFields;
-
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.common.adapter.BaseIdentifiableObject_;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
-import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
-import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
-import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.fileresource.FileResourceService;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.preheat.PreheatIdentifier;
 import org.hisp.dhis.security.acl.AclService;
-import org.hisp.dhis.system.util.ValidationUtils;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserRole;
@@ -83,178 +71,182 @@ public class UserRoleBundleHook extends AbstractObjectBundleHook<UserRole> {
 
     String s = "s";
     log.info("s = {}", s);
-//
-//    if (bundle.getImportMode().isCreate() && !ValidationUtils.isValidUid(user.getUid())) {
-//      addReports.accept(
-//          new ErrorReport(User.class, ErrorCode.E4014, user.getUid(), "uid")
-//              .setErrorProperty("uid"));
-//    }
-//
-//    if (bundle.getImportMode().isCreate()
-//        && !ValidationUtils.usernameIsValid(user.getUsername(), user.isInvitation())) {
-//      addReports.accept(
-//          new ErrorReport(User.class, ErrorCode.E4049, USERNAME, user.getUsername())
-//              .setErrorProperty(USERNAME));
-//    }
-//
-//    boolean usernameExists = userService.getUserByUsername(user.getUsername()) != null;
-//    if ((bundle.getImportMode().isCreate() && usernameExists)) {
-//      addReports.accept(
-//          new ErrorReport(User.class, ErrorCode.E4054, USERNAME, user.getUsername())
-//              .setErrorProperty(USERNAME));
-//    }
-//
-//    User existingUser = userService.getUser(user.getUid());
-//    if (bundle.getImportMode().isUpdate()
-//        && existingUser != null
-//        && user.getUsername() != null
-//        && !user.getUsername().equals(existingUser.getUsername())) {
-//      addReports.accept(
-//          new ErrorReport(User.class, ErrorCode.E4056, USERNAME, user.getUsername())
-//              .setErrorProperty(USERNAME));
-//    }
-//
-//    boolean openIdMappingExists = userService.getUserByOpenId(user.getOpenId()) != null;
-//    if ((dhisConfig.isDisabled(ConfigurationKey.LINKED_ACCOUNTS_ENABLED) && openIdMappingExists)) {
-//      addReports.accept(
-//          new ErrorReport(User.class, ErrorCode.E4054, "OIDC mapping value", user.getOpenId())
-//              .setErrorProperty(USERNAME));
-//    }
-//
-//    if (user.getUserRoles() == null || user.getUserRoles().isEmpty()) {
-//      addReports.accept(
-//          new ErrorReport(User.class, ErrorCode.E4055, USERNAME, user.getUsername())
-//              .setErrorProperty(USERNAME));
-//    }
-//
-//    if (user.getWhatsApp() != null && !ValidationUtils.validateWhatsApp(user.getWhatsApp())) {
-//      addReports.accept(
-//          new ErrorReport(User.class, ErrorCode.E4027, user.getWhatsApp(), "whatsApp")
-//              .setErrorProperty("whatsApp"));
-//    }
+    //
+    //    if (bundle.getImportMode().isCreate() && !ValidationUtils.isValidUid(user.getUid())) {
+    //      addReports.accept(
+    //          new ErrorReport(User.class, ErrorCode.E4014, user.getUid(), "uid")
+    //              .setErrorProperty("uid"));
+    //    }
+    //
+    //    if (bundle.getImportMode().isCreate()
+    //        && !ValidationUtils.usernameIsValid(user.getUsername(), user.isInvitation())) {
+    //      addReports.accept(
+    //          new ErrorReport(User.class, ErrorCode.E4049, USERNAME, user.getUsername())
+    //              .setErrorProperty(USERNAME));
+    //    }
+    //
+    //    boolean usernameExists = userService.getUserByUsername(user.getUsername()) != null;
+    //    if ((bundle.getImportMode().isCreate() && usernameExists)) {
+    //      addReports.accept(
+    //          new ErrorReport(User.class, ErrorCode.E4054, USERNAME, user.getUsername())
+    //              .setErrorProperty(USERNAME));
+    //    }
+    //
+    //    User existingUser = userService.getUser(user.getUid());
+    //    if (bundle.getImportMode().isUpdate()
+    //        && existingUser != null
+    //        && user.getUsername() != null
+    //        && !user.getUsername().equals(existingUser.getUsername())) {
+    //      addReports.accept(
+    //          new ErrorReport(User.class, ErrorCode.E4056, USERNAME, user.getUsername())
+    //              .setErrorProperty(USERNAME));
+    //    }
+    //
+    //    boolean openIdMappingExists = userService.getUserByOpenId(user.getOpenId()) != null;
+    //    if ((dhisConfig.isDisabled(ConfigurationKey.LINKED_ACCOUNTS_ENABLED) &&
+    // openIdMappingExists)) {
+    //      addReports.accept(
+    //          new ErrorReport(User.class, ErrorCode.E4054, "OIDC mapping value", user.getOpenId())
+    //              .setErrorProperty(USERNAME));
+    //    }
+    //
+    //    if (user.getUserRoles() == null || user.getUserRoles().isEmpty()) {
+    //      addReports.accept(
+    //          new ErrorReport(User.class, ErrorCode.E4055, USERNAME, user.getUsername())
+    //              .setErrorProperty(USERNAME));
+    //    }
+    //
+    //    if (user.getWhatsApp() != null && !ValidationUtils.validateWhatsApp(user.getWhatsApp())) {
+    //      addReports.accept(
+    //          new ErrorReport(User.class, ErrorCode.E4027, user.getWhatsApp(), "whatsApp")
+    //              .setErrorProperty("whatsApp"));
+    //    }
   }
 
   @Override
   public void preCreate(UserRole user, ObjectBundle bundle) {
     log.info("preCreate");
-//    if (user == null) return;
-//
-//    User currentUser = currentUserService.getCurrentUser();
-//
-//    if (currentUser != null) {
-//      user.getCogsDimensionConstraints().addAll(currentUser.getCogsDimensionConstraints());
-//
-//      user.getCatDimensionConstraints().addAll(currentUser.getCatDimensionConstraints());
-//    }
+    //    if (user == null) return;
+    //
+    //    User currentUser = currentUserService.getCurrentUser();
+    //
+    //    if (currentUser != null) {
+    //      user.getCogsDimensionConstraints().addAll(currentUser.getCogsDimensionConstraints());
+    //
+    //      user.getCatDimensionConstraints().addAll(currentUser.getCatDimensionConstraints());
+    //    }
   }
 
   @Override
   public void postCreate(UserRole user, ObjectBundle bundle) {
     log.info("postCreate");
-//    if (!StringUtils.isEmpty(user.getPassword())) {
-//      userService.encodeAndSetPassword(user, user.getPassword());
-//    }
-//
-//    if (user.getAvatar() != null) {
-//      FileResource fileResource = fileResourceService.getFileResource(user.getAvatar().getUid());
-//      fileResource.setAssigned(true);
-//      fileResourceService.updateFileResource(fileResource);
-//    }
-//
-//    preheatService.connectReferences(user, bundle.getPreheat(), bundle.getPreheatIdentifier());
-//    sessionFactory.getCurrentSession().update(user);
-//    userSettingService.saveUserSettings(user.getSettings(), user);
+    //    if (!StringUtils.isEmpty(user.getPassword())) {
+    //      userService.encodeAndSetPassword(user, user.getPassword());
+    //    }
+    //
+    //    if (user.getAvatar() != null) {
+    //      FileResource fileResource =
+    // fileResourceService.getFileResource(user.getAvatar().getUid());
+    //      fileResource.setAssigned(true);
+    //      fileResourceService.updateFileResource(fileResource);
+    //    }
+    //
+    //    preheatService.connectReferences(user, bundle.getPreheat(),
+    // bundle.getPreheatIdentifier());
+    //    sessionFactory.getCurrentSession().update(user);
+    //    userSettingService.saveUserSettings(user.getSettings(), user);
   }
 
   @Override
   public void preUpdate(UserRole user, UserRole persisted, ObjectBundle bundle) {
     log.info("preUpdate");
-//    if (user == null) return;
-//
-//    bundle.putExtras(user, "preUpdateUser", user);
-//
-//    if (persisted.getAvatar() != null
-//        && (user.getAvatar() == null
-//            || !persisted.getAvatar().getUid().equals(user.getAvatar().getUid()))) {
-//      FileResource fileResource =
-//          fileResourceService.getFileResource(persisted.getAvatar().getUid());
-//      fileResourceService.updateFileResource(fileResource);
-//
-//      if (user.getAvatar() != null) {
-//        fileResource = fileResourceService.getFileResource(user.getAvatar().getUid());
-//        fileResource.setAssigned(true);
-//        fileResourceService.updateFileResource(fileResource);
-//      }
-//    }
+    //    if (user == null) return;
+    //
+    //    bundle.putExtras(user, "preUpdateUser", user);
+    //
+    //    if (persisted.getAvatar() != null
+    //        && (user.getAvatar() == null
+    //            || !persisted.getAvatar().getUid().equals(user.getAvatar().getUid()))) {
+    //      FileResource fileResource =
+    //          fileResourceService.getFileResource(persisted.getAvatar().getUid());
+    //      fileResourceService.updateFileResource(fileResource);
+    //
+    //      if (user.getAvatar() != null) {
+    //        fileResource = fileResourceService.getFileResource(user.getAvatar().getUid());
+    //        fileResource.setAssigned(true);
+    //        fileResourceService.updateFileResource(fileResource);
+    //      }
+    //    }
   }
 
   @Override
   public void postUpdate(UserRole persistedUser, ObjectBundle bundle) {
     log.info("postUpdate");
-//    final User preUpdateUser = (User) bundle.getExtras(persistedUser, "preUpdateUser");
-//
-//    if (!StringUtils.isEmpty(preUpdateUser.getPassword())) {
-//      userService.encodeAndSetPassword(persistedUser, preUpdateUser.getPassword());
-//      sessionFactory.getCurrentSession().update(persistedUser);
-//    }
-//
-//    bundle.removeExtras(persistedUser, "preUpdateUser");
-//    userSettingService.saveUserSettings(persistedUser.getSettings(), persistedUser);
+    //    final User preUpdateUser = (User) bundle.getExtras(persistedUser, "preUpdateUser");
+    //
+    //    if (!StringUtils.isEmpty(preUpdateUser.getPassword())) {
+    //      userService.encodeAndSetPassword(persistedUser, preUpdateUser.getPassword());
+    //      sessionFactory.getCurrentSession().update(persistedUser);
+    //    }
+    //
+    //    bundle.removeExtras(persistedUser, "preUpdateUser");
+    //    userSettingService.saveUserSettings(persistedUser.getSettings(), persistedUser);
   }
 
   @Override
   @SuppressWarnings("unchecked")
   public void postCommit(ObjectBundle bundle) {
     log.info("postCommit");
-//
-//    Iterable<User> objects = bundle.getObjects(User.class);
-//
-//    Map<String, Map<String, Object>> userReferences = bundle.getObjectReferences(User.class);
-//
-//    if (userReferences == null || userReferences.isEmpty()) {
-//      return;
-//    }
-//
-//    for (User identifiableObject : objects) {
-//      User user = identifiableObject;
-//
-//      user = bundle.getPreheat().get(bundle.getPreheatIdentifier(), user);
-//
-//      Map<String, Object> userReferenceMap = userReferences.get(identifiableObject.getUid());
-//
-//      if (user == null || userReferenceMap == null || userReferenceMap.isEmpty()) {
-//        continue;
-//      }
-//
-//      Set<UserRole> userRoles = (Set<UserRole>) userReferenceMap.get("userRoles");
-//      user.setUserRoles(Objects.requireNonNullElseGet(userRoles, HashSet::new));
-//
-//      Set<OrganisationUnit> organisationUnits =
-//          (Set<OrganisationUnit>) userReferenceMap.get("organisationUnits");
-//      user.setOrganisationUnits(organisationUnits);
-//
-//      Set<OrganisationUnit> dataViewOrganisationUnits =
-//          (Set<OrganisationUnit>) userReferenceMap.get("dataViewOrganisationUnits");
-//      user.setDataViewOrganisationUnits(dataViewOrganisationUnits);
-//
-//      Set<OrganisationUnit> teiSearchOrganisationUnits =
-//          (Set<OrganisationUnit>) userReferenceMap.get("teiSearchOrganisationUnits");
-//      user.setTeiSearchOrganisationUnits(teiSearchOrganisationUnits);
-//
-//      user.setCreatedBy((User) userReferenceMap.get(BaseIdentifiableObject_.CREATED_BY));
-//
-//      if (user.getCreatedBy() == null) {
-//        user.setCreatedBy(bundle.getUser());
-//      }
-//
-//      user.setLastUpdatedBy(bundle.getUser());
-//
-//      preheatService.connectReferences(user, bundle.getPreheat(), bundle.getPreheatIdentifier());
-//
-//      handleNoAccessRoles(user, bundle, userRoles);
-//
-//      sessionFactory.getCurrentSession().update(user);
-//    }
+    //
+    //    Iterable<User> objects = bundle.getObjects(User.class);
+    //
+    //    Map<String, Map<String, Object>> userReferences = bundle.getObjectReferences(User.class);
+    //
+    //    if (userReferences == null || userReferences.isEmpty()) {
+    //      return;
+    //    }
+    //
+    //    for (User identifiableObject : objects) {
+    //      User user = identifiableObject;
+    //
+    //      user = bundle.getPreheat().get(bundle.getPreheatIdentifier(), user);
+    //
+    //      Map<String, Object> userReferenceMap = userReferences.get(identifiableObject.getUid());
+    //
+    //      if (user == null || userReferenceMap == null || userReferenceMap.isEmpty()) {
+    //        continue;
+    //      }
+    //
+    //      Set<UserRole> userRoles = (Set<UserRole>) userReferenceMap.get("userRoles");
+    //      user.setUserRoles(Objects.requireNonNullElseGet(userRoles, HashSet::new));
+    //
+    //      Set<OrganisationUnit> organisationUnits =
+    //          (Set<OrganisationUnit>) userReferenceMap.get("organisationUnits");
+    //      user.setOrganisationUnits(organisationUnits);
+    //
+    //      Set<OrganisationUnit> dataViewOrganisationUnits =
+    //          (Set<OrganisationUnit>) userReferenceMap.get("dataViewOrganisationUnits");
+    //      user.setDataViewOrganisationUnits(dataViewOrganisationUnits);
+    //
+    //      Set<OrganisationUnit> teiSearchOrganisationUnits =
+    //          (Set<OrganisationUnit>) userReferenceMap.get("teiSearchOrganisationUnits");
+    //      user.setTeiSearchOrganisationUnits(teiSearchOrganisationUnits);
+    //
+    //      user.setCreatedBy((User) userReferenceMap.get(BaseIdentifiableObject_.CREATED_BY));
+    //
+    //      if (user.getCreatedBy() == null) {
+    //        user.setCreatedBy(bundle.getUser());
+    //      }
+    //
+    //      user.setLastUpdatedBy(bundle.getUser());
+    //
+    //      preheatService.connectReferences(user, bundle.getPreheat(),
+    // bundle.getPreheatIdentifier());
+    //
+    //      handleNoAccessRoles(user, bundle, userRoles);
+    //
+    //      sessionFactory.getCurrentSession().update(user);
+    //    }
   }
 
   /**

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/config/IntegrationTestConfig.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/config/IntegrationTestConfig.java
@@ -33,6 +33,8 @@ import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.session.SessionRegistry;
+import org.springframework.security.core.session.SessionRegistryImpl;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.ldap.authentication.LdapAuthenticator;
@@ -74,6 +76,11 @@ public class IntegrationTestConfig {
             .withEnv("LC_COLLATE", "C");
 
     POSTGRES_CONTAINER.start();
+  }
+
+  @Bean
+  public static SessionRegistry sessionRegistry() {
+    return new SessionRegistryImpl();
   }
 
   @Bean

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/TestableCacheInvalidationConfiguration.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/TestableCacheInvalidationConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
+import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.security.core.session.SessionRegistryImpl;
 
 /**
@@ -51,7 +52,7 @@ import org.springframework.security.core.session.SessionRegistryImpl;
 @Conditional(value = CacheInvalidationEnabledCondition.class)
 public class TestableCacheInvalidationConfiguration {
   @Bean
-  public static SessionRegistryImpl sessionRegistry() {
+  public static SessionRegistry sessionRegistry() {
     return new SessionRegistryImpl();
   }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/WebTestConfiguration.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/WebTestConfiguration.java
@@ -69,7 +69,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
 import org.springframework.security.authentication.event.AuthenticationFailureBadCredentialsEvent;
-import org.springframework.security.core.session.SessionRegistryImpl;
+import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.ldap.authentication.LdapAuthenticator;
 import org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator;
@@ -123,7 +123,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Order(10)
 public class WebTestConfiguration {
   @Bean
-  public static SessionRegistryImpl sessionRegistry() {
+  public static SessionRegistry sessionRegistry() {
     return new org.springframework.security.core.session.SessionRegistryImpl();
   }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -152,8 +152,11 @@ class UserControllerTest extends DhisControllerConvenienceTest {
 
     UserRole roleB = createUserRole("ROLE_B", "ALL");
     userService.addUserRole(roleB);
-    superUser.getUserRoles().add(roleB);
-    userService.updateUser(superUser);
+
+    PATCH(
+            "/users/" + superUser.getUid(),
+            "[{'op':'add','path':'/userRoles','value':[{'id':'" + roleB.getUid() + "'}]}]")
+        .content(HttpStatus.OK);
 
     String roleBID = userService.getUserRoleByName("ROLE_B").getUid();
 


### PR DESCRIPTION
# Summary 
* The user will now be logged out of any current sessions when their role memberships are changed by an admin via the user admin UI or via an API call. Or if any of the assigned roles changes authorities, similarly. Without this feature, the user's new role assignments or role changes will not be effective in the ongoing sessions.

# Automatic test
* UserControllerTest#updateRolesShouldInvalidateUserSessions()

# Manual test
### Test role assignment will log out the users
1. Create two users, one admin and one non-admin.
2. As the admin user, create a superuser role that ass the “ALL” authority.
3. As the admin user, assign the superuser role to the non-admin user.
4. Log in as the non-admin user and try to edit a user in the user admin, this should work.
5. As admin (in another browser), remove the superuser role from the non-admin user.
6. As the non-admin user, try to go to any other page, you should now observe that you will be logged out and redirected to the login page.

### Test role changes will log out the users
1. Create two users, one admin and one non-admin.
2. As the admin user, create a superuser role that ass the “ALL” authority.
3. As the admin user, assign the superuser role to the non-admin user.
4. Log in as the non-admin user and try to edit a user in the user admin, this should work.
5. As admin (in another browser), remove the superuser “ALL” authority from the superuser role.
7. As the non-admin user, try to go to any other page, you should now observe that you will be logged out and 

### Jira:
[DHIS2-10334](https://dhis2.atlassian.net/browse/DHIS2-10334)

[DHIS2-10334]: https://dhis2.atlassian.net/browse/DHIS2-10334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ