### PR TITLE
fix: Remove unnecessary calls to the DB during DataValueSet import [DHIS2-16138]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportValidator.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportValidator.java
@@ -351,9 +351,7 @@ public class DataValueSetImportValidator {
             .getOrgUnitInHierarchyMap()
             .get(
                 valueContext.getOrgUnit().getUid(),
-                () ->
-                    organisationUnitService.isDescendant(
-                        valueContext.getOrgUnit(), context.getCurrentOrgUnits()));
+                () -> valueContext.getOrgUnit().isDescendant(context.getCurrentOrgUnits()));
 
     if (!inUserHierarchy) {
       context.addConflict(

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetImportValidatorTest.java
@@ -110,11 +110,6 @@ class DataValueSetImportValidatorTest {
     approvalService = mock(DataApprovalService.class);
     dataValueService = mock(DataValueService.class);
     organisationUnitService = mock(OrganisationUnitService.class);
-    when(organisationUnitService.isDescendant(any(OrganisationUnit.class), any(Set.class)))
-        .thenReturn(true);
-    when(organisationUnitService.isDescendant(
-            any(OrganisationUnit.class), any(OrganisationUnit.class)))
-        .thenReturn(true);
 
     i18n = mock(I18n.class);
     validator =
@@ -899,6 +894,9 @@ class DataValueSetImportValidatorTest {
     if (ouId != null) {
       OrganisationUnit ou = new OrganisationUnit();
       ou.setUid(ouId);
+      // we set the path here just for the tests. This is usually done by the persistence layer
+      // but there is no interaction with that in these tests.
+      ou.setPath(ou.getPath());
       builder.orgUnit(ou);
     }
     if (coId != null) {


### PR DESCRIPTION
# Summary
During a `DataValueSet` import, calls are made to the DB to get `OrganisationUnit`s. When there are large amounts of `OrganisationUnit`s this can lead to the import taking a long time.
`v38` did not experience these issues.

## Cause
During a large refactor [PR](https://github.com/dhis2/dhis2-core/pull/10600/files#diff-c75338fc725525fa01ea6d9f5a95ecf7c284de7c73b8b3f2dfe57e901d4ae25aL349) the implementation that was working well was changed.
- In `v38` code we check `OrganisationUnit`s that are already in-memory (`ImportContext`).
- Post `v38` we check `OrganisationUnit`s using a service call which in turn calls the DB.

## Fix
Revert back to original implementation, checking the `OrganisationUnit`s in memory.
Needs backporting to:
- 2.39
- 2.40

# Testing
The data below is based on following the steps provided in the Jira issue.
Running locally on a Mac.

| Version | DB | Org Check | Import time |
|---|---|---|---|
| 2.38 | SL | In memory | ~5 seconds |
| 2.39 | SL | In memory | ~5 seconds |
| 2.39 | SL | DB | ~5 minutes |
| 2.40 | SL | In memory | ~5 seconds |
| 2.40 | SL | DB | ~5 minutes |
| dev (master) | SL | In memory | ~5 seconds |
| dev (master) | SL | DB | ~5 minutes |

Also confirmed in the DB logs that the DB query which was being called for `OrganisationUnit` was not called anymore during the import, after the fix.

The test setup in `DataValueSetImportValidatorTest` had to be updated to reflect the change. Instead of using a mock response to always return true no matter what, the test now checks the actual `OrganisationUnit` path, mirroring actual behaviour in the code.

# Notes
During the large refactor PR there was a similar change made to this method:
```
  private boolean isOrgUnitValidForAttrOptionCombo(DataValueContext valueContext) {
    Set<OrganisationUnit> aocOrgUnits = valueContext.getAttrOptionCombo().getOrganisationUnits();
    return aocOrgUnits == null
        || organisationUnitService.isDescendant(valueContext.getOrgUnit(), aocOrgUnits);
  }
```

As the reported issue seems to have been resolved we won't include any changes in this method. We will look into this however to prove if similar changes are required or not (even though it seems like an obvious change).
I did test changing it to use the in-memory & it had no difference with the execution time but that may be due to the data being used.