### PR TITLE
fix: Close database connection after test statement.

### DIFF
--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/datasource/DatabasePoolUtils.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/datasource/DatabasePoolUtils.java
@@ -342,10 +342,12 @@ public class DatabasePoolUtils {
   }
 
   public static void testConnection(DataSource dataSource) throws SQLException {
-    Connection conn = dataSource.getConnection();
 
-    try (Statement stmt = conn.createStatement()) {
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
       stmt.executeQuery("select 'connection_test' as connection_test;");
+    } catch ( SQLException e ) {
+      log.error( e.getMessage() );
     }
   }
 }

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/datasource/DatabasePoolUtils.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/datasource/DatabasePoolUtils.java
@@ -346,8 +346,8 @@ public class DatabasePoolUtils {
     try (Connection conn = dataSource.getConnection();
         Statement stmt = conn.createStatement()) {
       stmt.executeQuery("select 'connection_test' as connection_test;");
-    } catch ( SQLException e ) {
-      log.error( e.getMessage() );
+    } catch (SQLException e) {
+      log.error(e.getMessage());
     }
   }
 }


### PR DESCRIPTION
Use the try-resource pattern to automatically close the database connection during startup. 