### PR TITLE
chore: Rename executiondate to occurreddate in DB [TECH-1615]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/analytics/TimeField.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/analytics/TimeField.java
@@ -40,7 +40,7 @@ import lombok.Getter;
 
 /** Enum that maps database column names to their respective "business" names. */
 public enum TimeField {
-  EVENT_DATE("executiondate"),
+  EVENT_DATE("occurreddate"),
   ENROLLMENT_DATE("enrollmentdate"),
   INCIDENT_DATE("incidentdate"),
   // Not a typo, different naming convention between FE and database

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/AnalyticsPeriodBoundary.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/AnalyticsPeriodBoundary.java
@@ -92,7 +92,7 @@ public class AnalyticsPeriodBoundary extends BaseIdentifiableObject implements E
   public static final Pattern COHORT_HAVING_ATTRIBUTE_PATTERN =
       Pattern.compile(COHORT_HAVING_ATTRIBUTE_REGEX);
 
-  public static final String DB_EVENT_DATE = "executiondate";
+  public static final String DB_EVENT_DATE = "occurreddate";
 
   public static final String DB_ENROLLMENT_DATE = "enrollmentdate";
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/ProgramIndicatorSubqueryBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/ProgramIndicatorSubqueryBuilder.java
@@ -55,7 +55,7 @@ import org.hisp.dhis.relationship.RelationshipType;
  * An example of a generated sub-query is:
  *
  * <pre>
- * avg((date_part('year', age(cast(executiondate as date), cast("iESIqZ0R0R0" as date)))))
+ * avg((date_part('year', age(cast(occurreddate as date), cast("iESIqZ0R0R0" as date)))))
  * FROM analytics_event_uy2gu8kt1jf as subax"
  * </pre>
  *

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/DimensionParam.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/DimensionParam.java
@@ -241,7 +241,7 @@ public class DimensionParam implements UidObject {
     ENROLLMENTDATE(DATETIME, DimensionParamObjectType.PERIOD),
     ENDDATE(DATETIME, DimensionParamObjectType.PERIOD),
     INCIDENTDATE(DATETIME, DimensionParamObjectType.PERIOD),
-    occurreddate(DATETIME, DimensionParamObjectType.PERIOD),
+    EXECUTIONDATE(DATETIME, DimensionParamObjectType.PERIOD),
     LASTUPDATED(DATETIME, DimensionParamObjectType.PERIOD),
     LASTUPDATEDBYDISPLAYNAME(TEXT, DimensionParamObjectType.STATIC),
     CREATED(DATETIME, DimensionParamObjectType.PERIOD),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/DimensionParam.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/DimensionParam.java
@@ -241,7 +241,7 @@ public class DimensionParam implements UidObject {
     ENROLLMENTDATE(DATETIME, DimensionParamObjectType.PERIOD),
     ENDDATE(DATETIME, DimensionParamObjectType.PERIOD),
     INCIDENTDATE(DATETIME, DimensionParamObjectType.PERIOD),
-    EXECUTIONDATE(DATETIME, DimensionParamObjectType.PERIOD),
+    occurreddate(DATETIME, DimensionParamObjectType.PERIOD),
     LASTUPDATED(DATETIME, DimensionParamObjectType.PERIOD),
     LASTUPDATEDBYDISPLAYNAME(TEXT, DimensionParamObjectType.STATIC),
     CREATED(DATETIME, DimensionParamObjectType.PERIOD),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -118,7 +118,7 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
 
   private static final String COL_NAME_EVENT_STATUS = "psistatus";
 
-  private static final String COL_NAME_EVENTDATE = "executiondate";
+  private static final String COL_NAME_EVENTDATE = "occurreddate";
 
   private static final String COL_NAME_ENROLLMENTDATE = "enrollmentdate";
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EnrollmentTimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EnrollmentTimeFieldSqlRenderer.java
@@ -144,11 +144,11 @@ class EnrollmentTimeFieldSqlRenderer extends TimeFieldSqlRenderer {
               + eventTableName
               + ".pi = "
               + ANALYTICS_TBL_ALIAS
-              + ".pi and executiondate is not null ";
+              + ".pi and occurreddate is not null ";
 
       for (AnalyticsPeriodBoundary boundary : boundaries) {
         sql +=
-            " and executiondate "
+            " and occurreddate "
                 + (boundary.getAnalyticsPeriodBoundaryType().isStartBoundary() ? ">=" : "<")
                 + " cast( '"
                 + format.format(boundary.getBoundaryDate(reportingStartDate, reportingEndDate))

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -91,7 +91,7 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
 
   private static final String ANALYTICS_EVENT = "analytics_event_";
 
-  private static final String ORDER_BY_EXECUTION_DATE = "order by executiondate ";
+  private static final String ORDER_BY_EXECUTION_DATE = "order by occurreddate ";
 
   private static final String LIMIT_1 = "limit 1";
 
@@ -553,7 +553,7 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
           && !item.getRepeatableStageParams().simpleStageValueExpected()) {
         return "(select json_agg(t1) from (select "
             + colName
-            + ", incidentdate, scheduleddate, executiondate "
+            + ", incidentdate, scheduleddate, occurreddate "
             + " from "
             + eventTableName
             + " where "
@@ -640,14 +640,14 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
     StringBuilder sb = new StringBuilder();
 
     if (startDate != null) {
-      sb.append(" and executiondate >= ");
+      sb.append(" and occurreddate >= ");
 
       sb.append(
           String.format("%s ", SqlUtils.singleQuote(DateUtils.getMediumDateString(startDate))));
     }
 
     if (endDate != null) {
-      sb.append(" and executiondate <= ");
+      sb.append(" and occurreddate <= ");
 
       sb.append(String.format("%s ", SqlUtils.singleQuote(DateUtils.getMediumDateString(endDate))));
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -319,7 +319,7 @@ public class JdbcEventAnalyticsManager extends AbstractJdbcEventAnalyticsManager
             .add(
                 "psi",
                 "ps",
-                "executiondate",
+                "occurreddate",
                 "storedby",
                 "createdbydisplayname",
                 "lastupdatedbydisplayname",

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -141,7 +141,7 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
           new AnalyticsTableColumn(quote("ao"), CHARACTER_11, NOT_NULL, "ao.uid"),
           new AnalyticsTableColumn(quote("enrollmentdate"), TIMESTAMP, "pi.enrollmentdate"),
           new AnalyticsTableColumn(quote("incidentdate"), TIMESTAMP, "pi.incidentdate"),
-          new AnalyticsTableColumn(quote("executiondate"), TIMESTAMP, "psi.executiondate"),
+          new AnalyticsTableColumn(quote("occurreddate"), TIMESTAMP, "psi.occurreddate"),
           new AnalyticsTableColumn(quote("scheduleddate"), TIMESTAMP, "psi.scheduleddate"),
           new AnalyticsTableColumn(quote("completeddate"), TIMESTAMP, "psi.completeddate"),
 
@@ -262,7 +262,7 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
    *     status
    */
   static String getDateLinkedToStatus() {
-    return "CASE WHEN 'SCHEDULE' = psi.status THEN psi.scheduleddate ELSE psi.executiondate END";
+    return "CASE WHEN 'SCHEDULE' = psi.status THEN psi.scheduleddate ELSE psi.occurreddate END";
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiEventsAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiEventsAnalyticsTableManager.java
@@ -134,7 +134,7 @@ public class JdbcTeiEventsAnalyticsTableManager extends AbstractJdbcTableManager
           new AnalyticsTableColumn(quote("programinstanceuid"), CHARACTER_11, NULL, "pi.uid"),
           new AnalyticsTableColumn(quote("programstageuid"), CHARACTER_11, NULL, "ps.uid"),
           new AnalyticsTableColumn(quote("programstageinstanceuid"), CHARACTER_11, NULL, "psi.uid"),
-          new AnalyticsTableColumn(quote("executiondate"), TIMESTAMP, "psi.executiondate"),
+          new AnalyticsTableColumn(quote("occurreddate"), TIMESTAMP, "psi.occurreddate"),
           new AnalyticsTableColumn(quote("lastupdated"), TIMESTAMP, "psi.lastupdated"),
           new AnalyticsTableColumn(quote("created"), TIMESTAMP, "psi.created"),
           new AnalyticsTableColumn(quote("scheduleddate"), TIMESTAMP, "psi.scheduleddate"),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/context/querybuilder/ContextUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/context/querybuilder/ContextUtils.java
@@ -73,7 +73,7 @@ class ContextUtils {
       SqlParameterManager sqlParameterManager) {
     return "select innermost_evt.*"
         + " from (select *,"
-        + " row_number() over (partition by programinstanceuid order by executiondate desc) as rn"
+        + " row_number() over (partition by programinstanceuid order by occurreddate desc) as rn"
         + " from "
         + ANALYTICS_TEI_EVT
         + trackedEntityType.getUid().toLowerCase()

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/context/querybuilder/ProgramIndicatorQueryBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/context/querybuilder/ProgramIndicatorQueryBuilder.java
@@ -260,7 +260,7 @@ public class ProgramIndicatorQueryBuilder implements SqlQueryBuilder {
         + ", "
         + expression
         + " as value, "
-        + " row_number() over (partition by pi order by executiondate desc) as rn "
+        + " row_number() over (partition by pi order by occurreddate desc) as rn "
         + " from analytics_event_"
         + program.getElement().getUid()
         + " as "

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -214,7 +214,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + programA.getUid()
             + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
             + programStage.getUid()
-            + "' order by executiondate desc limit 1 )";
+            + "' order by occurreddate desc limit 1 )";
 
     if (valueType == ValueType.NUMBER) {
       subSelect = subSelect + " as \"fWIAEtYVEGk\"";
@@ -257,7 +257,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + programUid
             + ".pi = ax.pi and ps = '"
             + repeatableProgramStage.getUid()
-            + "' order by executiondate desc offset 1 limit 1 ) "
+            + "' order by occurreddate desc offset 1 limit 1 ) "
             + "as \""
             + programStageUid
             + "[-1]."
@@ -272,7 +272,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + programUid
             + ".pi = ax.pi and ps = '"
             + programStageUid
-            + "' order by executiondate desc offset 1 limit 1 )) "
+            + "' order by occurreddate desc offset 1 limit 1 )) "
             + "as \""
             + programStageUid
             + "[-1]."
@@ -303,7 +303,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + programA.getUid()
             + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
             + programStage.getUid()
-            + "' order by executiondate desc limit 1 )";
+            + "' order by occurreddate desc limit 1 )";
 
     String expected =
         "ax.\"quarterly\",ax.\"ou\","
@@ -377,7 +377,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + programA.getUid()
             + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
             + programStage.getUid()
-            + "' order by executiondate desc limit 1 )";
+            + "' order by occurreddate desc limit 1 )";
 
     String expected =
         "ax.\"quarterly\",ax.\"ou\","
@@ -404,7 +404,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + programA.getUid()
             + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
             + programStage.getUid()
-            + "' order by executiondate desc limit 1 )";
+            + "' order by occurreddate desc limit 1 )";
 
     String expected = subSelect + " is null";
 
@@ -423,7 +423,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + programA.getUid()
             + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
             + programStage.getUid()
-            + "' order by executiondate desc limit 1 )";
+            + "' order by occurreddate desc limit 1 )";
 
     String expected = subSelect + " is not null";
     testIt(
@@ -441,7 +441,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + programA.getUid()
             + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
             + programStage.getUid()
-            + "' order by executiondate desc limit 1 )";
+            + "' order by occurreddate desc limit 1 )";
 
     String numericValues = String.join(OPTION_SEP, "10", "11", "12");
     String expected =
@@ -467,7 +467,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + programA.getUid()
             + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
             + programStage.getUid()
-            + "' order by executiondate desc limit 1 )";
+            + "' order by occurreddate desc limit 1 )";
 
     String numericValues = String.join(OPTION_SEP, "10", "11", "12");
     String expected = subSelect + " in (" + String.join(",", numericValues.split(OPTION_SEP)) + ")";
@@ -486,7 +486,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + programA.getUid()
             + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
             + programStage.getUid()
-            + "' order by executiondate desc limit 1 )";
+            + "' order by occurreddate desc limit 1 )";
 
     String expected = subSelect + " is null";
     String unexpected = "(" + subSelect + " in (";
@@ -718,7 +718,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
                 + dataElementA.getUid()
                 + "\" is not null and ps = '"
                 + programStage.getUid()
-                + "' order by executiondate desc limit 1 )"));
+                + "' order by occurreddate desc limit 1 )"));
   }
 
   @Test
@@ -744,13 +744,13 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
         is(
             "(select json_agg(t1) from (select \""
                 + dataElementA.getUid()
-                + "\", incidentdate, scheduleddate, executiondate  from analytics_event_"
+                + "\", incidentdate, scheduleddate, occurreddate  from analytics_event_"
                 + programB.getUid()
                 + " where analytics_event_"
                 + programB.getUid()
                 + ".pi = ax.pi and ps = '"
                 + repeatableProgramStage.getUid()
-                + "' and executiondate >= '2022-01-01'  and executiondate <= '2022-01-31' order by executiondate desc LIMIT 100 ) as t1)"));
+                + "' and occurreddate >= '2022-01-01'  and occurreddate <= '2022-01-31' order by occurreddate desc LIMIT 100 ) as t1)"));
   }
 
   @Test
@@ -780,7 +780,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
                 + programB.getUid()
                 + ".pi = ax.pi and ps = '"
                 + repeatableProgramStage.getUid()
-                + "' order by executiondate desc limit 1 )"));
+                + "' order by occurreddate desc limit 1 )"));
   }
 
   @Test
@@ -816,7 +816,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
                 + "and "
                 + colName
                 + " is not null "
-                + "order by executiondate "
+                + "order by occurreddate "
                 + "desc limit 1 )"));
   }
 
@@ -856,7 +856,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
                 + " is not null "
                 + "and ps = '"
                 + item.getProgramStage().getUid()
-                + "' order by executiondate "
+                + "' order by occurreddate "
                 + "desc limit 1 )"));
   }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsManagerTest.java
@@ -115,7 +115,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
   private static final String TABLE_NAME = "analytics_event";
 
   private static final String DEFAULT_COLUMNS_WITH_REGISTRATION =
-      "psi,ps,executiondate,storedby,"
+      "psi,ps,occurreddate,storedby,"
           + "createdbydisplayname"
           + ","
           + "lastupdatedbydisplayname"
@@ -153,7 +153,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "select psi,ps,executiondate,storedby,"
+        "select psi,ps,occurreddate,storedby,"
             + "createdbydisplayname"
             + ","
             + "lastupdatedbydisplayname"
@@ -214,7 +214,7 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
     verify(jdbcTemplate).queryForRowSet(sql.capture());
 
     String expected =
-        "select psi,ps,executiondate,storedby,"
+        "select psi,ps,occurreddate,storedby,"
             + "createdbydisplayname"
             + ","
             + "lastupdatedbydisplayname"
@@ -563,9 +563,9 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
         "from (select \"psi\",ax.\"deabcdefghX\",\"ou\","
             + "\"monthly\",\"jkYhtGth12t\","
             + "row_number() over (partition by ax.\"ou\",ax.\"jkYhtGth12t\" "
-            + "order by ax.\"executiondate\" desc, ax.\"created\" desc) as pe_rank "
+            + "order by ax.\"occurreddate\" desc, ax.\"created\" desc) as pe_rank "
             + "from analytics_event_prabcdefghA as ax "
-            + "where ax.\"executiondate\" >= '2012-01-31' and ax.\"executiondate\" <= '2022-01-31' "
+            + "where ax.\"occurreddate\" >= '2012-01-31' and ax.\"occurreddate\" <= '2022-01-31' "
             + "and ax.\"deabcdefghX\" is not null)";
 
     assertThat(params.isAggregationType(AggregationType.LAST), is(true));
@@ -648,15 +648,15 @@ class EventAnalyticsManagerTest extends EventAnalyticsTest {
         "from (select \"psi\",ax.\""
             + deU.getUid()
             + "\",\"quarterly\",\"ou\","
-            + "row_number() over (partition by ax.\"ou\",ax.\"ao\" order by ax.\"executiondate\" "
+            + "row_number() over (partition by ax.\"ou\",ax.\"ao\" order by ax.\"occurreddate\" "
             + order
             + ", ax.\"created\" "
             + order
             + ") as pe_rank "
             + "from "
             + getTable(programA.getUid())
-            + " as ax where ax.\"executiondate\" >= '1990-03-31' "
-            + "and ax.\"executiondate\" <= '2000-03-31' and ax.\""
+            + " as ax where ax.\"occurreddate\" >= '1990-03-31' "
+            + "and ax.\"occurreddate\" <= '2000-03-31' and ax.\""
             + deU.getUid()
             + "\" is not null)";
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
@@ -86,7 +86,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
     params = new EventQueryParams.Builder(params).withStartEndDatesForPeriods().build();
 
     assertEquals(
-        "((ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-07-01')) ",
+        "((ax.\"occurreddate\" >= '2022-04-01' and ax.\"occurreddate\" < '2022-07-01')) ",
         timeFieldSqlRenderer.renderPeriodTimeFieldSql(params));
   }
 
@@ -103,7 +103,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
     params = new EventQueryParams.Builder(params).withStartEndDatesForPeriods().build();
 
     assertEquals(
-        "((ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-07-01')) ",
+        "((ax.\"occurreddate\" >= '2022-04-01' and ax.\"occurreddate\" < '2022-07-01')) ",
         timeFieldSqlRenderer.renderPeriodTimeFieldSql(params));
   }
 
@@ -172,7 +172,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
     params = new EventQueryParams.Builder(params).withStartEndDatesForPeriods().build();
 
     assertEquals(
-        "((ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-07-01')) ",
+        "((ax.\"occurreddate\" >= '2022-04-01' and ax.\"occurreddate\" < '2022-07-01')) ",
         timeFieldSqlRenderer.renderPeriodTimeFieldSql(params));
   }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
@@ -976,6 +976,6 @@ class JdbcEventAnalyticsTableManagerTest {
   }
 
   private String getDateLinkedToStatus() {
-    return "CASE WHEN 'SCHEDULE' = psi.status THEN psi.scheduleddate ELSE psi.executiondate END";
+    return "CASE WHEN 'SCHEDULE' = psi.status THEN psi.scheduleddate ELSE psi.occurreddate END";
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/PeriodDataProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/PeriodDataProvider.java
@@ -118,7 +118,7 @@ public class PeriodDataProvider {
    */
   private List<Integer> fetchAvailableYears() {
     String dueDateOrExecutionDate =
-        "(case when 'SCHEDULE' = ev.status then ev.scheduleddate else ev.executiondate end)";
+        "(case when 'SCHEDULE' = ev.status then ev.scheduleddate else ev.occurreddate end)";
 
     String sql =
         "( select distinct (extract(year from pe.startdate)) as datayear from period pe )"

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemPsEventdate.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemPsEventdate.java
@@ -66,7 +66,7 @@ public class ProgramItemPsEventdate extends ProgramExpressionItem {
         .getStatementBuilder()
         .getProgramIndicatorEventColumnSql(
             ctx.uid0.getText(),
-            "executiondate",
+            "occurreddate",
             params.getReportingStartDate(),
             params.getReportingEndDate(),
             params.getProgramIndicator());

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/ProgramMinMaxFunction.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/ProgramMinMaxFunction.java
@@ -58,7 +58,7 @@ public abstract class ProgramMinMaxFunction extends ProgramExpressionItem {
 
     if (ctx.uid1 == null) // arg: PS_EVENTDATE:programStageUid
     {
-      columnName = "\"executiondate\"";
+      columnName = "\"occurreddate\"";
     } else // arg: #{programStageUid.dataElementUid}
     {
       String dataElement = ctx.uid1.getText();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEventDate.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEventDate.java
@@ -47,7 +47,7 @@ public class vEventDate extends ProgramDateVariable {
               .getStatementBuilder()
               .getProgramIndicatorEventColumnSql(
                   null,
-                  "executiondate",
+                  "occurreddate",
                   params.getReportingStartDate(),
                   params.getReportingEndDate(),
                   params.getProgramIndicator());
@@ -55,11 +55,11 @@ public class vEventDate extends ProgramDateVariable {
       return maybeAppendEventStatusFilterIntoWhere(sqlStatement);
     }
 
-    return "executiondate";
+    return "occurreddate";
   }
 
   private String maybeAppendEventStatusFilterIntoWhere(String sqlStatement) {
-    int index = sqlStatement.indexOf("order by executiondate");
+    int index = sqlStatement.indexOf("order by occurreddate");
 
     if (index == -1) {
       return sqlStatement;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vScheduledDate.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vScheduledDate.java
@@ -59,7 +59,7 @@ public class vScheduledDate extends ProgramDateVariable {
   }
 
   private String maybeAppendEventStatusFilterIntoWhere(String sqlStatement) {
-    int index = sqlStatement.indexOf("order by executiondate");
+    int index = sqlStatement.indexOf("order by occurreddate");
 
     if (index == -1) {
       return sqlStatement;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
@@ -114,7 +114,7 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
 
   private static final String LIMIT = "LIMIT";
 
-  private static final String EV_EXECUTIONDATE = "EV.executiondate";
+  private static final String EV_EXECUTIONDATE = "EV.occurreddate";
 
   private static final String EV_DUEDATE = "EV.scheduleddate";
 
@@ -359,7 +359,7 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
    * the program_constraint, we also have a subquery to deal with any event-related constraints.
    * These can either be constraints on any static properties, or user assignment. For user
    * assignment, we also join with the userinfo table. For events, we have an index (status,
-   * executiondate) which speeds up the lookup significantly order: Order is used both in the
+   * occurreddate) which speeds up the lookup significantly order: Order is used both in the
    * subquery and the main query. The sort depends on the params (see more info on the related
    * method). We order the subquery to make sure we get correct results before we limit. We order
    * the main query since the aggregation mixes up the order, so to return a consistent order, we

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Enrollment.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Enrollment.hbm.xml
@@ -59,7 +59,7 @@
     <many-to-one name="program" class="org.hisp.dhis.program.Program"
       column="programid" not-null="true" foreign-key="fk_programinstance_programid" lazy="false" />
 
-    <set name="events" order-by="executionDate,scheduleddate" inverse="true">
+    <set name="events" order-by="occurreddate,scheduleddate" inverse="true">
       <key column="enrollmentid"/>
       <one-to-many class="org.hisp.dhis.program.Event"/>
     </set>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Event.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Event.hbm.xml
@@ -46,7 +46,7 @@
 
     <property name="scheduledDate" column="scheduleddate" />
 
-    <property name="occurredDate" column="executiondate" type="timestamp" index="programstageinstance_executiondate" />
+    <property name="occurredDate" column="occurreddate" type="timestamp" index="programstageinstance_executiondate" />
 
     <many-to-one name="organisationUnit" class="org.hisp.dhis.organisationunit.OrganisationUnit" column="organisationunitid"
       foreign-key="fk_programstageinstance_organisationunitid" index="programstageinstance_organisationunitid" />

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
@@ -259,7 +259,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest {
                 + "from analytics_event_Program000A "
                 + "where analytics_event_Program000A.pi = ax.pi "
                 + "and \"DataElmentA\" is not null and \"DataElmentA\" is not null "
-                + "and executiondate < cast( '2021-01-01' as date ) "
+                + "and occurreddate < cast( '2021-01-01' as date ) "
                 + "and ps = 'ProgrmStagA')"));
   }
 
@@ -278,7 +278,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest {
                 + "from analytics_event_Program000A "
                 + "where analytics_event_Program000A.pi = ax.pi "
                 + "and \"DataElmentA\" is not null and \"DataElmentA\" is not null "
-                + "and executiondate >= cast( '2020-01-01' as date ) "
+                + "and occurreddate >= cast( '2020-01-01' as date ) "
                 + "and ps = 'ProgrmStagA')"));
   }
 
@@ -297,7 +297,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest {
                 + "from analytics_event_Program000A "
                 + "where analytics_event_Program000A.pi = ax.pi "
                 + "and \"DataElmentA\" is not null and \"DataElmentA\" is not null "
-                + "and executiondate < cast( '2021-01-01' as date ) and executiondate >= cast( '2020-01-01' as date ) "
+                + "and occurreddate < cast( '2021-01-01' as date ) and occurreddate >= cast( '2020-01-01' as date ) "
                 + "and ps = 'ProgrmStagA')"));
   }
 
@@ -514,10 +514,10 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest {
     assertThat(
         sql,
         is(
-            "(date_part('year',age(cast((select executiondate from analytics_event_Program000A "
-                + "where analytics_event_Program000A.pi = ax.pi and executiondate is not null "
+            "(date_part('year',age(cast((select occurreddate from analytics_event_Program000A "
+                + "where analytics_event_Program000A.pi = ax.pi and occurreddate is not null "
                 + "and ps = 'ProgrmStagA' "
-                + "order by executiondate desc limit 1 ) as date), cast(enrollmentdate as date))))"));
+                + "order by occurreddate desc limit 1 ) as date), cast(enrollmentdate as date))))"));
   }
 
   @Test
@@ -530,11 +530,11 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest {
     assertThat(
         sql,
         is(
-            "(date_part('year',age(cast((select executiondate from analytics_event_Program000A "
-                + "where analytics_event_Program000A.pi = ax.pi and executiondate is not null "
-                + "and executiondate < cast( '2021-01-01' as date ) and executiondate >= cast( '2020-01-01' as date ) "
+            "(date_part('year',age(cast((select occurreddate from analytics_event_Program000A "
+                + "where analytics_event_Program000A.pi = ax.pi and occurreddate is not null "
+                + "and occurreddate < cast( '2021-01-01' as date ) and occurreddate >= cast( '2020-01-01' as date ) "
                 + "and ps = 'ProgrmStagA' "
-                + "order by executiondate desc limit 1 ) as date), cast(enrollmentdate as date)))) < 1"));
+                + "order by occurreddate desc limit 1 ) as date), cast(enrollmentdate as date)))) < 1"));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
@@ -127,7 +127,7 @@ class ProgramSqlGeneratorVariablesTest extends DhisConvenienceTest {
                 + enrollmentIndicator.getProgram().getUid()
                 + " where analytics_event_"
                 + enrollmentIndicator.getProgram().getUid()
-                + ".pi = ax.pi and created is not null order by executiondate desc limit 1 )"));
+                + ".pi = ax.pi and created is not null order by occurreddate desc limit 1 )"));
   }
 
   @Test
@@ -189,13 +189,13 @@ class ProgramSqlGeneratorVariablesTest extends DhisConvenienceTest {
   @Test
   void testExecutionDate() {
     String sql = castString(test("V{execution_date}", new DefaultLiteral(), eventIndicator));
-    assertThat(sql, is("executiondate"));
+    assertThat(sql, is("occurreddate"));
   }
 
   @Test
   void testEventDate() {
     String sql = castString(test("V{event_date}", new DefaultLiteral(), eventIndicator));
-    assertThat(sql, is("executiondate"));
+    assertThat(sql, is("occurreddate"));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/AbstractEventService.java
@@ -800,14 +800,13 @@ public abstract class AbstractEventService
       return;
     }
 
-    Date executionDate = new Date();
+    Date occurreddate = new Date();
 
     if (event.getEventDate() != null) {
-      executionDate = DateUtils.parseDate(event.getEventDate());
+      occurreddate = DateUtils.parseDate(event.getEventDate());
     }
 
-    Date eventDate =
-        executionDate != null ? executionDate : programStageInstance.getScheduledDate();
+    Date eventDate = occurreddate != null ? occurreddate : programStageInstance.getScheduledDate();
 
     validateAttributeOptionComboDate(programStageInstance.getAttributeOptionCombo(), eventDate);
 
@@ -827,7 +826,7 @@ public abstract class AbstractEventService
     }
 
     programStageInstance.setOrganisationUnit(organisationUnit);
-    programStageInstance.setOccurredDate(executionDate);
+    programStageInstance.setOccurredDate(occurreddate);
     eventService.updateEvent(programStageInstance);
   }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/JdbcEventStore.java
@@ -1027,7 +1027,7 @@ public class JdbcEventStore implements EventStore {
             .append(" psi.uid as psi_uid, ")
             .append("ou.uid as ou_uid, p.uid as p_uid, ps.uid as ps_uid, ")
             .append(
-                "psi.eventid as psi_id, psi.status as psi_status, psi.executiondate as psi_executiondate, ")
+                "psi.eventid as psi_id, psi.status as psi_status, psi.occurreddate as psi_executiondate, ")
             .append(
                 "psi.eventdatavalues as psi_eventdatavalues, psi.scheduleddate as psi_duedate, psi.completedby as psi_completedby, psi.storedby as psi_storedby, ")
             .append(
@@ -1240,9 +1240,9 @@ public class JdbcEventStore implements EventStore {
 
       fromBuilder
           .append(hlp.whereAnd())
-          .append(" (psi.executiondate >= ")
+          .append(" (psi.occurreddate >= ")
           .append(":startDate")
-          .append(" or (psi.executiondate is null and psi.scheduleddate >= ")
+          .append(" or (psi.occurreddate is null and psi.scheduleddate >= ")
           .append(":startDate")
           .append(" )) ");
     }
@@ -1252,9 +1252,9 @@ public class JdbcEventStore implements EventStore {
 
       fromBuilder
           .append(hlp.whereAnd())
-          .append(" (psi.executiondate < ")
+          .append(" (psi.occurreddate < ")
           .append(":endDate")
-          .append(" or (psi.executiondate is null and psi.scheduleddate < ")
+          .append(" or (psi.occurreddate is null and psi.scheduleddate < ")
           .append(":endDate")
           .append(" )) ");
     }
@@ -1529,9 +1529,9 @@ public class JdbcEventStore implements EventStore {
 
       sqlBuilder
           .append(hlp.whereAnd())
-          .append(" (psi.executiondate >= ")
+          .append(" (psi.occurreddate >= ")
           .append(":startDate")
-          .append(" or (psi.executiondate is null and psi.scheduleddate >= ")
+          .append(" or (psi.occurreddate is null and psi.scheduleddate >= ")
           .append(":startDate")
           .append(" )) ");
     }
@@ -1541,9 +1541,9 @@ public class JdbcEventStore implements EventStore {
 
       sqlBuilder
           .append(hlp.whereAnd())
-          .append(" (psi.executiondate < ")
+          .append(" (psi.occurreddate < ")
           .append(":endDate ")
-          .append(" or (psi.executiondate is null and psi.scheduleddate < ")
+          .append(" or (psi.occurreddate is null and psi.scheduleddate < ")
           .append(":endDate")
           .append(" )) ");
     }
@@ -1631,7 +1631,7 @@ public class JdbcEventStore implements EventStore {
             .append(hlp.whereAnd())
             .append(PSI_STATUS_EQ)
             .append(":" + PSI_STATUS)
-            .append(" and psi.executiondate is not null ");
+            .append(" and psi.occurreddate is not null ");
       } else if (params.getEventStatus() == EventStatus.OVERDUE) {
         mapSqlParameterSource.addValue(PSI_STATUS, EventStatus.SCHEDULE.name());
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/context/ProgramStageInstanceSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/context/ProgramStageInstanceSupplier.java
@@ -91,7 +91,7 @@ public class ProgramStageInstanceSupplier extends AbstractSupplier<Map<String, E
 
     final String sql =
         "select psi.enrollmentid, psi.programstageid, psi.eventid, "
-            + "psi.uid, psi.status, psi.deleted, psi.eventdatavalues, psi.scheduleddate, psi.executiondate, "
+            + "psi.uid, psi.status, psi.deleted, psi.eventdatavalues, psi.scheduleddate, psi.occurreddate, "
             + "psi.completeddate, psi.attributeoptioncomboid, psi.geometry, "
             + "ou.organisationunitid, ou.uid, ou.code, ou.name, psi.attributeoptioncomboid,  c.uid as coc_uid  "
             + "from event psi join organisationunit ou on psi.organisationunitid = ou.organisationunitid "
@@ -117,7 +117,7 @@ public class ProgramStageInstanceSupplier extends AbstractSupplier<Map<String, E
             psi.setProgramStage(getProgramStage(importOptions, rs.getLong("programstageid")));
             psi.setOrganisationUnit(getOu(rs));
             psi.setScheduledDate(rs.getTimestamp("scheduleddate"));
-            psi.setOccurredDate(rs.getTimestamp("executiondate"));
+            psi.setOccurredDate(rs.getTimestamp("occurreddate"));
             psi.setCompletedDate(rs.getTimestamp("completeddate"));
             psi.setAttributeOptionCombo(getCatOptionCombo(rs));
             try {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/shared/validation/AttributeOptionComboDateCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/shared/validation/AttributeOptionComboDateCheck.java
@@ -51,10 +51,10 @@ public class AttributeOptionComboDateCheck implements Checker {
   public ImportSummary check(ImmutableEvent event, WorkContext ctx) {
     CategoryOptionCombo attributeOptionCombo = ctx.getCategoryOptionComboMap().get(event.getUid());
 
-    Date executionDate = null;
+    Date occurreddate = null;
 
     if (event.getEventDate() != null) {
-      executionDate = DateUtils.parseDate(event.getEventDate());
+      occurreddate = DateUtils.parseDate(event.getEventDate());
     }
 
     Date dueDate = new Date();
@@ -63,7 +63,7 @@ public class AttributeOptionComboDateCheck implements Checker {
       dueDate = DateUtils.parseDate(event.getDueDate());
     }
 
-    Date eventDate = executionDate != null ? executionDate : dueDate;
+    Date eventDate = occurreddate != null ? occurreddate : dueDate;
 
     if (eventDate == null) {
       return error("Event date can not be empty", event.getEvent());

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/trackedentity/store/query/EventQuery.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/trackedentity/store/query/EventQuery.java
@@ -49,7 +49,7 @@ public class EventQuery {
     ID(new TableColumn("psi", "eventid")),
     UID(new TableColumn("psi", "uid")),
     STATUS(new TableColumn("psi", "status")),
-    EXECUTION_DATE(new TableColumn("psi", "executiondate")),
+    EXECUTION_DATE(new TableColumn("psi", "occurreddate")),
     DUE_DATE(new TableColumn("psi", "scheduleddate")),
     STOREDBY(new TableColumn("psi", "storedby")),
     COMPLETEDBY(new TableColumn("psi", "completedby")),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventQuery.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventQuery.java
@@ -39,7 +39,7 @@ public class EventQuery {
     ID(new TableColumn("ev", "eventid")),
     UID(new TableColumn("ev", "uid")),
     STATUS(new TableColumn("ev", "status")),
-    EXECUTION_DATE(new TableColumn("ev", "executiondate")),
+    OCCURRED_DATE(new TableColumn("ev", "occurreddate")),
     SCHEDULED_DATE(new TableColumn("ev", "scheduleddate")),
     STOREDBY(new TableColumn("ev", "storedby")),
     COMPLETEDBY(new TableColumn("ev", "completedby")),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -161,7 +161,7 @@ class JdbcEventStore implements EventStore {
   private static final String COLUMN_ENROLLMENT_DATE = "en_enrollmentdate";
   private static final String COLUMN_ORG_UNIT_UID = "orgunit_uid";
   private static final String COLUMN_TRACKEDENTITY_UID = "te_uid";
-  private static final String COLUMN_EVENT_EXECUTION_DATE = "ev_executiondate";
+  private static final String COLUMN_EVENT_OCCURRED_DATE = "ev_occurreddate";
   private static final String COLUMN_ENROLLMENT_FOLLOWUP = "en_followup";
   private static final String COLUMN_EVENT_STATUS = "ev_status";
   private static final String COLUMN_EVENT_SCHEDULED_DATE = "ev_scheduleddate";
@@ -198,7 +198,7 @@ class JdbcEventStore implements EventStore {
           entry("enrollment.enrollmentDate", COLUMN_ENROLLMENT_DATE),
           entry("organisationUnit.uid", COLUMN_ORG_UNIT_UID),
           entry("enrollment.trackedEntity.uid", COLUMN_TRACKEDENTITY_UID),
-          entry("occurredDate", COLUMN_EVENT_EXECUTION_DATE),
+          entry("occurredDate", COLUMN_EVENT_OCCURRED_DATE),
           entry("enrollment.followUp", COLUMN_ENROLLMENT_FOLLOWUP),
           entry("status", COLUMN_EVENT_STATUS),
           entry("scheduledDate", COLUMN_EVENT_SCHEDULED_DATE),
@@ -327,7 +327,7 @@ class JdbcEventStore implements EventStore {
 
               event.setStoredBy(resultSet.getString(COLUMN_EVENT_STORED_BY));
               event.setScheduledDate(resultSet.getTimestamp(COLUMN_EVENT_SCHEDULED_DATE));
-              event.setOccurredDate(resultSet.getTimestamp(COLUMN_EVENT_EXECUTION_DATE));
+              event.setOccurredDate(resultSet.getTimestamp(COLUMN_EVENT_OCCURRED_DATE));
               event.setCreated(resultSet.getTimestamp(COLUMN_EVENT_CREATED));
               event.setCreatedByUserInfo(
                   EventUtils.jsonToUserInfo(
@@ -733,8 +733,8 @@ class JdbcEventStore implements EventStore {
             .append(COLUMN_EVENT_ID)
             .append(", ev.status as ")
             .append(COLUMN_EVENT_STATUS)
-            .append(", ev.executiondate as ")
-            .append(COLUMN_EVENT_EXECUTION_DATE)
+            .append(", ev.occurreddate as ")
+            .append(COLUMN_EVENT_OCCURRED_DATE)
             .append(", ")
             .append("ev.eventdatavalues as ev_eventdatavalues, ev.scheduleddate as ")
             .append(COLUMN_EVENT_SCHEDULED_DATE)
@@ -985,9 +985,9 @@ class JdbcEventStore implements EventStore {
 
       fromBuilder
           .append(hlp.whereAnd())
-          .append(" (ev.executiondate >= ")
+          .append(" (ev.occurreddate >= ")
           .append(":startDate")
-          .append(" or (ev.executiondate is null and ev.scheduleddate >= ")
+          .append(" or (ev.occurreddate is null and ev.scheduleddate >= ")
           .append(":startDate")
           .append(" )) ");
     }
@@ -998,9 +998,9 @@ class JdbcEventStore implements EventStore {
 
       fromBuilder
           .append(hlp.whereAnd())
-          .append(" (ev.executiondate < ")
+          .append(" (ev.occurreddate < ")
           .append(":endDate")
-          .append(" or (ev.executiondate is null and ev.scheduleddate < ")
+          .append(" or (ev.occurreddate is null and ev.scheduleddate < ")
           .append(":endDate")
           .append(" )) ");
     }
@@ -1372,7 +1372,7 @@ class JdbcEventStore implements EventStore {
             .append(hlp.whereAnd())
             .append(EVENT_STATUS_EQ)
             .append(":" + COLUMN_EVENT_STATUS)
-            .append(" and ev.executiondate is not null ");
+            .append(" and ev.occurreddate is not null ");
       } else if (params.getEventStatus() == EventStatus.OVERDUE) {
         mapSqlParameterSource.addValue(COLUMN_EVENT_STATUS, EventStatus.SCHEDULE.name());
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -96,7 +96,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
 
   private static final String ENROLLMENT_DATE_KEY = "enrollment.enrollmentDate";
 
-  private static final String EV_EXECUTIONDATE = "EV.executiondate";
+  private static final String EV_OCCURREDDATE = "EV.occurreddate";
 
   private static final String EV_SCHEDULEDDATE = "EV.scheduleddate";
 
@@ -278,7 +278,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
    * the program_constraint, we also have a sub-query to deal with any event-related constraints.
    * These can either be constraints on any static properties, or user assignment. For user
    * assignment, we also join with the userinfo table. For events, we have an index (status,
-   * executiondate) which speeds up the lookup significantly order: Order is used both in the
+   * occurreddate) which speeds up the lookup significantly order: Order is used both in the
    * sub-query and the main query. The sort depends on the params (see more info on the related
    * method). We order the sub-query to make sure we get correct results before we limit. We order
    * the main query since the aggregation mixes up the order, so to return a consistent order, we
@@ -796,7 +796,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
 
       if (params.isEventStatus(EventStatus.COMPLETED)) {
         events
-            .append(getQueryDateConditionBetween(whereHlp, EV_EXECUTIONDATE, start, end))
+            .append(getQueryDateConditionBetween(whereHlp, EV_OCCURREDDATE, start, end))
             .append(whereHlp.whereAnd())
             .append(EV_STATUS)
             .append(EQUALS)
@@ -807,7 +807,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
       } else if (params.isEventStatus(EventStatus.VISITED)
           || params.isEventStatus(EventStatus.ACTIVE)) {
         events
-            .append(getQueryDateConditionBetween(whereHlp, EV_EXECUTIONDATE, start, end))
+            .append(getQueryDateConditionBetween(whereHlp, EV_OCCURREDDATE, start, end))
             .append(whereHlp.whereAnd())
             .append(EV_STATUS)
             .append(EQUALS)
@@ -823,7 +823,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
             .append(SPACE)
             .append(IS_NOT_NULL)
             .append(whereHlp.whereAnd())
-            .append(EV_EXECUTIONDATE)
+            .append(EV_OCCURREDDATE)
             .append(SPACE)
             .append(IS_NULL)
             .append(whereHlp.whereAnd())
@@ -836,7 +836,7 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
             .append(SPACE)
             .append(IS_NOT_NULL)
             .append(whereHlp.whereAnd())
-            .append(EV_EXECUTIONDATE)
+            .append(EV_OCCURREDDATE)
             .append(SPACE)
             .append(IS_NULL)
             .append(whereHlp.whereAnd())

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/mapper/EventRowCallbackHandler.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/mapper/EventRowCallbackHandler.java
@@ -68,7 +68,7 @@ public class EventRowCallbackHandler extends AbstractMapper<Event> {
     event.setId(rs.getLong(EventQuery.getColumnName(COLUMNS.ID)));
 
     event.setStatus(EventStatus.valueOf(rs.getString(EventQuery.getColumnName(COLUMNS.STATUS))));
-    event.setOccurredDate(rs.getTimestamp(EventQuery.getColumnName(COLUMNS.EXECUTION_DATE)));
+    event.setOccurredDate(rs.getTimestamp(EventQuery.getColumnName(COLUMNS.OCCURRED_DATE)));
     event.setScheduledDate(rs.getTimestamp(EventQuery.getColumnName(COLUMNS.SCHEDULED_DATE)));
     event.setStoredBy(rs.getString(EventQuery.getColumnName(COLUMNS.STOREDBY)));
     event.setCompletedBy(rs.getString(EventQuery.getColumnName(COLUMNS.COMPLETEDBY)));

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/query/EventQuery.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/query/EventQuery.java
@@ -45,7 +45,7 @@ public class EventQuery {
     ID(new TableColumn("ev", "eventid")),
     UID(new TableColumn("ev", "uid")),
     STATUS(new TableColumn("ev", "status")),
-    EXECUTION_DATE(new TableColumn("ev", "executiondate")),
+    OCCURRED_DATE(new TableColumn("ev", "occurreddate")),
     SCHEDULED_DATE(new TableColumn("ev", "scheduleddate")),
     STOREDBY(new TableColumn("ev", "storedby")),
     COMPLETEDBY(new TableColumn("ev", "completedby")),

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_36__RenameExecutionDateToOccurredDateInEventTable.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_36__RenameExecutionDateToOccurredDateInEventTable.sql
@@ -1,0 +1,11 @@
+-- rename executiondate in event
+
+do $$
+begin
+  if exists(select 1
+    from information_schema.columns
+    where table_schema != 'information_schema' and table_name='event' and column_name='executiondate')
+  then
+alter table event rename column executiondate to occurreddate;
+end if;
+end $$;

--- a/dhis-2/dhis-support/dhis-support-jdbc/src/main/java/org/hisp/dhis/jdbc/statementbuilder/AbstractStatementBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-jdbc/src/main/java/org/hisp/dhis/jdbc/statementbuilder/AbstractStatementBuilder.java
@@ -553,14 +553,14 @@ public abstract class AbstractStatementBuilder implements StatementBuilder {
 
   /**
    * This method is needed to keep the logic/code backward compatible. Previously, we didn't
-   * consider statuses, as we always based on the "executiondate" only (it means ACTIVE and
-   * COMPLETED status).
+   * consider statuses, as we always based on the "occurreddate" only (it means ACTIVE and COMPLETED
+   * status).
    *
    * <p>Now, we also need to support SCHEDULE status for events. For this reason this method
    * compares the status. If the column is "scheduleddate", it means we only want SCHEDULE status,
    * so we return "scheduleddate". In all other cases we assume any other status different from
    * SCHEDULE (which makes it backward compatible). In this case the logic will remain based on
-   * "executiondate".
+   * "occurreddate".
    *
    * @param column
    * @return the backwards compatible column

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventDataQueryServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventDataQueryServiceTest.java
@@ -275,7 +275,7 @@ class EventDataQueryServiceTest extends SingleSetupIntegrationTestBase {
     assertEquals(1, params.getFilterPeriods().size());
     assertEquals(deA, params.getValue());
     assertEquals(1, params.getDesc().size());
-    assertEquals("executiondate", params.getDesc().get(0).getItem().getName());
+    assertEquals("occurreddate", params.getDesc().get(0).getItem().getName());
     assertEquals(AnalyticsAggregationType.AVERAGE, params.getAggregationType());
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceD2FunctionTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceD2FunctionTest.java
@@ -171,8 +171,8 @@ class ProgramIndicatorServiceD2FunctionTest extends SingleSetupIntegrationTestBa
         getSql(
             "d2:condition( 'd2:hasValue(#{ProgrmStagA.DataElmentA})', 1+4, d2:zpvc(#{Program000B.DataElmentB}) )"));
     assertEquals(
-        "case when (((select \"DataElmentA\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentA\" is not null and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by executiondate desc limit 1 ) is not null)) "
-            + "then 1 + 4 else nullif(cast((case when (select \"DataElmentB\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentB\" is not null and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'Program000B' order by executiondate desc limit 1 ) >= 0 then 1 else 0 end) as double precision),0) end",
+        "case when (((select \"DataElmentA\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentA\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) is not null)) "
+            + "then 1 + 4 else nullif(cast((case when (select \"DataElmentB\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentB\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'Program000B' order by occurreddate desc limit 1 ) >= 0 then 1 else 0 end) as double precision),0) end",
         getSqlEnrollment(
             "d2:condition( \"d2:hasValue(#{ProgrmStagA.DataElmentA})\", 1+4, d2:zpvc(#{Program000B.DataElmentB}) )"));
   }
@@ -180,10 +180,10 @@ class ProgramIndicatorServiceD2FunctionTest extends SingleSetupIntegrationTestBa
   @Test
   void testD2Count() {
     assertEquals(
-        "(select count(\"DataElmentA\") from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentA\" is not null and \"DataElmentA\" is not null and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
+        "(select count(\"DataElmentA\") from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentA\" is not null and \"DataElmentA\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
         getSql("d2:count(#{ProgrmStagA.DataElmentA})"));
     assertEquals(
-        "(select count(\"DataElmentA\") from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentA\" is not null and \"DataElmentA\" is not null and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
+        "(select count(\"DataElmentA\") from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentA\" is not null and \"DataElmentA\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
         getSqlEnrollment("d2:count(#{ProgrmStagA.DataElmentA})"));
   }
 
@@ -192,13 +192,13 @@ class ProgramIndicatorServiceD2FunctionTest extends SingleSetupIntegrationTestBa
     assertEquals(
         "(select count(\"DataElmentA\") from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi "
             + "and \"DataElmentA\" is not null and \"DataElmentA\" >= coalesce(case when ax.\"ps\" = 'Program000B' then \"DataElmentB\" else null end::numeric,0) "
-            + "and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
+            + "and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
         getSql(
             "d2:countIfCondition( #{ProgrmStagA.DataElmentA}, ' >= #{Program000B.DataElmentB}')"));
     assertEquals(
         "(select count(\"DataElmentA\") from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentA\" is not null and \"DataElmentA\" >= coalesce("
-            + "(select \"DataElmentB\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentB\" is not null and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'Program000B' order by executiondate desc limit 1 )::numeric,0) "
-            + "and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
+            + "(select \"DataElmentB\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentB\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'Program000B' order by occurreddate desc limit 1 )::numeric,0) "
+            + "and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
         getSqlEnrollment(
             "d2:countIfCondition( #{ProgrmStagA.DataElmentA}, \" >= #{Program000B.DataElmentB}\")"));
   }
@@ -206,21 +206,21 @@ class ProgramIndicatorServiceD2FunctionTest extends SingleSetupIntegrationTestBa
   @Test
   void testD2CountIfValue() {
     assertEquals(
-        "(select count(\"DataElmentA\") from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentA\" is not null and \"DataElmentA\" = 10 and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
+        "(select count(\"DataElmentA\") from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentA\" is not null and \"DataElmentA\" = 10 and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
         getSql("d2:countIfValue(#{ProgrmStagA.DataElmentA}, 10)"));
     assertEquals(
-        "(select count(\"DataElmentA\") from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentA\" is not null and \"DataElmentA\" = 10 and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
+        "(select count(\"DataElmentA\") from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentA\" is not null and \"DataElmentA\" = 10 and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
         getSqlEnrollment("d2:countIfValue(#{ProgrmStagA.DataElmentA}, 10)"));
   }
 
   @Test
   void testD2DaysBetween() {
     assertEquals(
-        "(cast(executiondate as date) - cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentD\" else null end as date))",
+        "(cast(occurreddate as date) - cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentD\" else null end as date))",
         getSql("d2:daysBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)"));
     assertEquals(
-        "(cast((select executiondate from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and executiondate is not null and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by executiondate desc limit 1 ) as date) "
-            + "- cast((select \"DataElmentD\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentD\" is not null and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by executiondate desc limit 1 ) as date))",
+        "(cast((select occurreddate from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and occurreddate is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) as date) "
+            + "- cast((select \"DataElmentD\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentD\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) as date))",
         getSqlEnrollment("d2:daysBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)"));
   }
 
@@ -230,7 +230,7 @@ class ProgramIndicatorServiceD2FunctionTest extends SingleSetupIntegrationTestBa
         "(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentA\" else null end is not null)",
         getSql("d2:hasValue(#{ProgrmStagA.DataElmentA})"));
     assertEquals(
-        "((select \"DataElmentA\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentA\" is not null and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by executiondate desc limit 1 ) is not null)",
+        "((select \"DataElmentA\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentA\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) is not null)",
         getSqlEnrollment("d2:hasValue(#{ProgrmStagA.DataElmentA})"));
   }
 
@@ -238,22 +238,22 @@ class ProgramIndicatorServiceD2FunctionTest extends SingleSetupIntegrationTestBa
   void testD2MaxValue() {
     assertEquals("\"DataElmentA\"", getSql("d2:maxValue(#{ProgrmStagA.DataElmentA})"));
     assertEquals(
-        "(select max(\"DataElmentA\") from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
+        "(select max(\"DataElmentA\") from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
         getSqlEnrollment("d2:maxValue(#{ProgrmStagA.DataElmentA})"));
-    assertEquals("\"executiondate\"", getSql("d2:maxValue(PS_EVENTDATE:ProgrmStagA)"));
+    assertEquals("\"occurreddate\"", getSql("d2:maxValue(PS_EVENTDATE:ProgrmStagA)"));
     assertEquals(
-        "(select max(\"executiondate\") from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
+        "(select max(\"occurreddate\") from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
         getSqlEnrollment("d2:maxValue(PS_EVENTDATE:ProgrmStagA)"));
   }
 
   @Test
   void testD2MinutesBetween() {
     assertEquals(
-        "(extract(epoch from (cast(executiondate as timestamp) - cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentD\" else null end as timestamp))) / 60)",
+        "(extract(epoch from (cast(occurreddate as timestamp) - cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentD\" else null end as timestamp))) / 60)",
         getSql("d2:minutesBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)"));
     assertEquals(
-        "(extract(epoch from (cast((select executiondate from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and executiondate is not null and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by executiondate desc limit 1 ) as timestamp) "
-            + "- cast((select \"DataElmentD\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentD\" is not null and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by executiondate desc limit 1 ) as timestamp))) / 60)",
+        "(extract(epoch from (cast((select occurreddate from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and occurreddate is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) as timestamp) "
+            + "- cast((select \"DataElmentD\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentD\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) as timestamp))) / 60)",
         getSqlEnrollment(
             "d2:minutesBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)"));
   }
@@ -262,39 +262,39 @@ class ProgramIndicatorServiceD2FunctionTest extends SingleSetupIntegrationTestBa
   void testD2MinValue() {
     assertEquals("\"DataElmentA\"", getSql("d2:minValue(#{ProgrmStagA.DataElmentA})"));
     assertEquals(
-        "(select min(\"DataElmentA\") from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
+        "(select min(\"DataElmentA\") from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
         getSqlEnrollment("d2:minValue(#{ProgrmStagA.DataElmentA})"));
-    assertEquals("\"executiondate\"", getSql("d2:minValue(PS_EVENTDATE:ProgrmStagA)"));
+    assertEquals("\"occurreddate\"", getSql("d2:minValue(PS_EVENTDATE:ProgrmStagA)"));
     assertEquals(
-        "(select min(\"executiondate\") from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
+        "(select min(\"occurreddate\") from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA')",
         getSqlEnrollment("d2:minValue(PS_EVENTDATE:ProgrmStagA)"));
   }
 
   @Test
   void testD2MonthsBetween() {
     assertEquals(
-        "((date_part('year',age(cast(executiondate as date), cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentD\" else null end as date)))) * 12 "
-            + "+ date_part('month',age(cast(executiondate as date), cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentD\" else null end as date))))",
+        "((date_part('year',age(cast(occurreddate as date), cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentD\" else null end as date)))) * 12 "
+            + "+ date_part('month',age(cast(occurreddate as date), cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentD\" else null end as date))))",
         getSql("d2:monthsBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)"));
     assertEquals(
-        "((date_part('year',age(cast((select executiondate from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and executiondate is not null and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by executiondate desc limit 1 ) as date), "
-            + "cast((select \"DataElmentD\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentD\" is not null and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by executiondate desc limit 1 ) as date)))) "
-            + "* 12 + date_part('month',age(cast((select executiondate from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and executiondate is not null and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by executiondate desc limit 1 ) as date), "
-            + "cast((select \"DataElmentD\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentD\" is not null and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by executiondate desc limit 1 ) as date))))",
+        "((date_part('year',age(cast((select occurreddate from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and occurreddate is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) as date), "
+            + "cast((select \"DataElmentD\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentD\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) as date)))) "
+            + "* 12 + date_part('month',age(cast((select occurreddate from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and occurreddate is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) as date), "
+            + "cast((select \"DataElmentD\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentD\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) as date))))",
         getSqlEnrollment("d2:monthsBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)"));
   }
 
   @Test
   void testD2Oizp() {
     assertEquals(
-        "((date_part('year',age(cast(executiondate as date), cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentA\" else null end as date)))) * 12 "
-            + "+ date_part('month',age(cast(executiondate as date), cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentA\" else null end as date))))",
+        "((date_part('year',age(cast(occurreddate as date), cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentA\" else null end as date)))) * 12 "
+            + "+ date_part('month',age(cast(occurreddate as date), cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentA\" else null end as date))))",
         getSql("d2:monthsBetween(#{ProgrmStagA.DataElmentA}, PS_EVENTDATE:ProgrmStagA)"));
     assertEquals(
         "coalesce(case when case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentA\" else null end >= 0 then 1 else 0 end, 0)",
         getSql("d2:oizp(#{ProgrmStagA.DataElmentA})"));
     assertEquals(
-        "coalesce(case when (select \"DataElmentA\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentA\" is not null and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by executiondate desc limit 1 ) >= 0 then 1 else 0 end, 0)",
+        "coalesce(case when (select \"DataElmentA\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentA\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) >= 0 then 1 else 0 end, 0)",
         getSqlEnrollment("d2:oizp(#{ProgrmStagA.DataElmentA})"));
   }
 
@@ -317,29 +317,29 @@ class ProgramIndicatorServiceD2FunctionTest extends SingleSetupIntegrationTestBa
   @Test
   void testD2WeeksBetween() {
     assertEquals(
-        "((cast(executiondate as date) - cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentA\" else null end as date))/7)",
+        "((cast(occurreddate as date) - cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentA\" else null end as date))/7)",
         getSql("d2:weeksBetween(#{ProgrmStagA.DataElmentA}, PS_EVENTDATE:ProgrmStagA)"));
     assertEquals(
-        "((cast((select executiondate from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and executiondate is not null and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by executiondate desc limit 1 ) as date) "
-            + "- cast((select \"DataElmentD\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentD\" is not null and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by executiondate desc limit 1 ) as date))/7)",
+        "((cast((select occurreddate from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and occurreddate is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) as date) "
+            + "- cast((select \"DataElmentD\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentD\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) as date))/7)",
         getSqlEnrollment("d2:weeksBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)"));
   }
 
   @Test
   void testD2YearsBetween() {
     assertEquals(
-        "(date_part('year',age(cast(executiondate as date), cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentA\" else null end as date))))",
+        "(date_part('year',age(cast(occurreddate as date), cast(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentA\" else null end as date))))",
         getSql("d2:yearsBetween(#{ProgrmStagA.DataElmentA}, PS_EVENTDATE:ProgrmStagA)"));
     var enrol =
         getSqlEnrollment("d2:yearsBetween(#{ProgrmStagA.DataElmentD}, PS_EVENTDATE:ProgrmStagA)");
     assertEquals(
-        "(date_part('year',age(cast((select executiondate from analytics_event_Program000A "
-            + "where analytics_event_Program000A.pi = ax.pi and executiondate is not null and executiondate < "
-            + "cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' "
-            + "order by executiondate desc limit 1 ) as date), "
+        "(date_part('year',age(cast((select occurreddate from analytics_event_Program000A "
+            + "where analytics_event_Program000A.pi = ax.pi and occurreddate is not null and occurreddate < "
+            + "cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' "
+            + "order by occurreddate desc limit 1 ) as date), "
             + "cast((select \"DataElmentD\" from analytics_event_Program000A "
-            + "where analytics_event_Program000A.pi = ax.pi and \"DataElmentD\" is not null and executiondate < "
-            + "cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by executiondate desc limit 1 ) as date))))",
+            + "where analytics_event_Program000A.pi = ax.pi and \"DataElmentD\" is not null and occurreddate < "
+            + "cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) as date))))",
         enrol);
   }
 
@@ -349,7 +349,7 @@ class ProgramIndicatorServiceD2FunctionTest extends SingleSetupIntegrationTestBa
         "greatest(0,coalesce(case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentA\" else null end::numeric,0) + 5)",
         getSql("d2:zing(#{ProgrmStagA.DataElmentA} + 5)"));
     assertEquals(
-        "greatest(0,coalesce((select \"DataElmentA\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentA\" is not null and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by executiondate desc limit 1 )::numeric,0) + 5)",
+        "greatest(0,coalesce((select \"DataElmentA\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentA\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 )::numeric,0) + 5)",
         getSqlEnrollment("d2:zing(#{ProgrmStagA.DataElmentA} + 5)"));
   }
 
@@ -360,8 +360,8 @@ class ProgramIndicatorServiceD2FunctionTest extends SingleSetupIntegrationTestBa
             + "+ case when case when ax.\"ps\" = 'ProgrmStagA' then \"DataElmentB\" else null end >= 0 then 1 else 0 end) as double precision),0)",
         getSql("d2:zpvc(#{ProgrmStagA.DataElmentA},#{ProgrmStagA.DataElmentB})"));
     assertEquals(
-        "nullif(cast((case when (select \"DataElmentA\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentA\" is not null and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by executiondate desc limit 1 ) >= 0 then 1 else 0 end "
-            + "+ case when (select \"DataElmentB\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentB\" is not null and executiondate < cast( '2020-01-10' as date ) and executiondate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagB' order by executiondate desc limit 1 ) >= 0 then 1 else 0 end) as double precision),0)",
+        "nullif(cast((case when (select \"DataElmentA\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentA\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 ) >= 0 then 1 else 0 end "
+            + "+ case when (select \"DataElmentB\" from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and \"DataElmentB\" is not null and occurreddate < cast( '2020-01-10' as date ) and occurreddate >= cast( '2020-01-09' as date ) and ps = 'ProgrmStagB' order by occurreddate desc limit 1 ) >= 0 then 1 else 0 end) as double precision),0)",
         getSqlEnrollment("d2:zpvc(#{ProgrmStagA.DataElmentA},#{ProgrmStagB.DataElmentB})"));
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceTest.java
@@ -606,12 +606,12 @@ class ProgramIndicatorServiceTest extends TransactionalIntegrationTest {
     Date dateTo = getDate(2019, 12, 31);
     // Generated subquery, since indicatorF is type Enrollment
     String expected =
-        "coalesce((select \"DataElmentA\" from analytics_event_Program000B where analytics_event_Program000B.pi = axx1.pi and \"DataElmentA\" is not null and executiondate < cast( '"
+        "coalesce((select \"DataElmentA\" from analytics_event_Program000B where analytics_event_Program000B.pi = axx1.pi and \"DataElmentA\" is not null and occurreddate < cast( '"
             + "2020-01-11"
-            + "' as date ) and ps = 'ProgrmStagA' order by executiondate desc limit 1 )::numeric,0) - "
-            + "coalesce((select \"DataElmentC\" from analytics_event_Program000B where analytics_event_Program000B.pi = axx1.pi and \"DataElmentC\" is not null and executiondate < cast( '"
+            + "' as date ) and ps = 'ProgrmStagA' order by occurreddate desc limit 1 )::numeric,0) - "
+            + "coalesce((select \"DataElmentC\" from analytics_event_Program000B where analytics_event_Program000B.pi = axx1.pi and \"DataElmentC\" is not null and occurreddate < cast( '"
             + "2020-01-11"
-            + "' as date ) and ps = 'ProgrmStagB' order by executiondate desc limit 1 )::numeric,0)";
+            + "' as date ) and ps = 'ProgrmStagB' order by occurreddate desc limit 1 )::numeric,0)";
     String expression = "#{ProgrmStagA.DataElmentA} - #{ProgrmStagB.DataElmentC}";
     assertEquals(
         expected,

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceVariableTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceVariableTest.java
@@ -125,7 +125,7 @@ class ProgramIndicatorServiceVariableTest extends IntegrationTestBase {
   void testCreationDate() {
     assertEquals("created", getSql("V{creation_date}"));
     assertEquals(
-        "(select created from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and created is not null and executiondate < cast( '2020-02-01' as date ) and executiondate >= cast( '2020-01-01' as date ) order by executiondate desc limit 1 )",
+        "(select created from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and created is not null and occurreddate < cast( '2020-02-01' as date ) and occurreddate >= cast( '2020-01-01' as date ) order by occurreddate desc limit 1 )",
         getSqlEnrollment("V{creation_date}"));
   }
 
@@ -140,7 +140,7 @@ class ProgramIndicatorServiceVariableTest extends IntegrationTestBase {
   void testDueDate() {
     assertEquals("scheduleddate", getSql("V{due_date}"));
     assertEquals(
-        "(select scheduleddate from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and scheduleddate is not null and executiondate < cast( '2020-02-01' as date ) and executiondate >= cast( '2020-01-01' as date ) order by executiondate desc limit 1 )",
+        "(select scheduleddate from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and scheduleddate is not null and occurreddate < cast( '2020-02-01' as date ) and occurreddate >= cast( '2020-01-01' as date ) order by occurreddate desc limit 1 )",
         getSqlEnrollment("V{due_date}"));
   }
 
@@ -166,7 +166,7 @@ class ProgramIndicatorServiceVariableTest extends IntegrationTestBase {
   void testEventStatus() {
     assertEquals("psistatus", getSql("V{event_status}"));
     assertEquals(
-        "(select psistatus from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and psistatus is not null and executiondate < cast( '2020-02-01' as date ) and executiondate >= cast( '2020-01-01' as date ) order by executiondate desc limit 1 )",
+        "(select psistatus from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and psistatus is not null and occurreddate < cast( '2020-02-01' as date ) and occurreddate >= cast( '2020-01-01' as date ) order by occurreddate desc limit 1 )",
         getSqlEnrollment("V{event_status}"));
   }
 
@@ -195,17 +195,17 @@ class ProgramIndicatorServiceVariableTest extends IntegrationTestBase {
 
   @Test
   void testExecutionDate() {
-    assertEquals("executiondate", getSql("V{execution_date}"));
+    assertEquals("occurreddate", getSql("V{execution_date}"));
     assertEquals(
-        "(select executiondate from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and executiondate is not null and executiondate < cast( '2020-02-01' as date ) and executiondate >= cast( '2020-01-01' as date )  and psistatus IN ('COMPLETED', 'ACTIVE') order by executiondate desc limit 1 )",
+        "(select occurreddate from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and occurreddate is not null and occurreddate < cast( '2020-02-01' as date ) and occurreddate >= cast( '2020-01-01' as date )  and psistatus IN ('COMPLETED', 'ACTIVE') order by occurreddate desc limit 1 )",
         getSqlEnrollment("V{execution_date}"));
   }
 
   @Test
   void testEventDate() {
-    assertEquals("executiondate", getSql("V{event_date}"));
+    assertEquals("occurreddate", getSql("V{event_date}"));
     assertEquals(
-        "(select executiondate from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and executiondate is not null and executiondate < cast( '2020-02-01' as date ) and executiondate >= cast( '2020-01-01' as date )  and psistatus IN ('COMPLETED', 'ACTIVE') order by executiondate desc limit 1 )",
+        "(select occurreddate from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and occurreddate is not null and occurreddate < cast( '2020-02-01' as date ) and occurreddate >= cast( '2020-01-01' as date )  and psistatus IN ('COMPLETED', 'ACTIVE') order by occurreddate desc limit 1 )",
         getSqlEnrollment("V{event_date}"));
   }
 
@@ -213,7 +213,7 @@ class ProgramIndicatorServiceVariableTest extends IntegrationTestBase {
   void testScheduledDate() {
     assertEquals("scheduleddate", getSql("V{scheduled_date}"));
     assertEquals(
-        "(select scheduleddate from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and scheduleddate is not null and executiondate < cast( '2020-02-01' as date ) and executiondate >= cast( '2020-01-01' as date )  and psistatus = 'SCHEDULE' order by executiondate desc limit 1 )",
+        "(select scheduleddate from analytics_event_Program000A where analytics_event_Program000A.pi = ax.pi and scheduleddate is not null and occurreddate < cast( '2020-02-01' as date ) and occurreddate >= cast( '2020-01-01' as date )  and psistatus = 'SCHEDULE' order by occurreddate desc limit 1 )",
         getSqlEnrollment("V{scheduled_date}"));
   }
 

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
@@ -585,7 +585,6 @@
       },
       "relationships": [],
       "occurredAt": "2020-01-28T00:00:00.000",
-      "executionDate": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
       "storedBy": "admin",
       "followUp": true,


### PR DESCRIPTION
Following on https://github.com/dhis2/dhis2-core/pull/15642

This PR aims to replace all occurrences of executionDate in the DB and repository layer to occurredDate.
The general rule that we are using is that date fields are suffixed with At in the API and then suffixed with Date in the service and the DB layer.