### PR TITLE
chore: Rename endDate to completedDate in service layer [TECH-1665]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Enrollment.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Enrollment.java
@@ -71,7 +71,7 @@ public class Enrollment extends SoftDeletableObject {
 
   private Date enrollmentDate;
 
-  private Date endDate;
+  private Date completedDate;
 
   private UserInfoSnapshot createdByUserInfo;
 
@@ -238,12 +238,12 @@ public class Enrollment extends SoftDeletableObject {
 
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
-  public Date getEndDate() {
-    return endDate;
+  public Date getCompletedDate() {
+    return completedDate;
   }
 
-  public void setEndDate(Date endDate) {
-    this.endDate = endDate;
+  public void setCompletedDate(Date completedDate) {
+    this.completedDate = completedDate;
   }
 
   @JsonProperty
@@ -434,7 +434,7 @@ public class Enrollment extends SoftDeletableObject {
     copy.setCompletedBy(original.getCompletedBy());
     copy.setCreatedAtClient(original.getCreatedAtClient());
     copy.setCreatedByUserInfo(original.getCreatedByUserInfo());
-    copy.setEndDate(original.getEndDate());
+    copy.setCompletedDate(original.getCompletedDate());
     copy.setEnrollmentDate(original.getEnrollmentDate());
     copy.setEvents(new HashSet<>());
     copy.setFollowup(original.getFollowup());

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/program/EnrollmentTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/program/EnrollmentTest.java
@@ -68,7 +68,7 @@ class EnrollmentTest {
     assertEquals(original.getFollowup(), copy.getFollowup());
     assertEquals(original.getGeometry(), copy.getGeometry());
     assertEquals(original.getOrganisationUnit(), copy.getOrganisationUnit());
-    assertEquals(original.getEndDate(), copy.getEndDate());
+    assertEquals(original.getCompletedDate(), copy.getCompletedDate());
     assertEquals(original.getRelationshipItems(), copy.getRelationshipItems());
     assertEquals(original.getCreatedByUserInfo(), copy.getCreatedByUserInfo());
     assertEquals(original.getMessageConversations(), copy.getMessageConversations());
@@ -86,7 +86,7 @@ class EnrollmentTest {
     assertNotEquals(original.getProgram(), copy.getProgram());
 
     assertEquals(original.getCreatedByUserInfo(), copy.getCreatedByUserInfo());
-    assertEquals(original.getEndDate(), copy.getEndDate());
+    assertEquals(original.getCompletedDate(), copy.getCompletedDate());
     assertEquals(original.getEnrollmentDate(), copy.getEnrollmentDate());
     assertEquals(original.getFollowup(), copy.getFollowup());
     assertEquals(original.getGeometry(), copy.getGeometry());
@@ -117,7 +117,7 @@ class EnrollmentTest {
     e.setAutoFields();
     e.setNotes(List.of(new Note("note", "amin")));
     e.setCompletedBy("admin");
-    e.setEndDate(new Date());
+    e.setCompletedDate(new Date());
     e.setEnrollmentDate(new Date());
     e.setEvents(Set.of());
     e.setFollowup(true);
@@ -138,7 +138,7 @@ class EnrollmentTest {
     e.setName(null);
     e.setNotes(null);
     e.setCompletedBy(null);
-    e.setEndDate(null);
+    e.setCompletedDate(null);
     e.setEnrollmentDate(null);
     e.setEvents(null);
     e.setIncidentDate(null);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
@@ -472,7 +472,7 @@ public class DefaultEnrollmentService implements EnrollmentService {
         // Set status as skipped for overdue events, or delete
         // -------------------------------------------------------------
 
-        if (event.getScheduledDate().before(enrollment.getEndDate())) {
+        if (event.getScheduledDate().before(enrollment.getCompletedDate())) {
           event.setStatus(EventStatus.SKIPPED);
           eventStore.update(event);
         } else {
@@ -501,7 +501,7 @@ public class DefaultEnrollmentService implements EnrollmentService {
     // -----------------------------------------------------------------
 
     enrollment.setStatus(ProgramStatus.ACTIVE);
-    enrollment.setEndDate(null);
+    enrollment.setCompletedDate(null);
 
     updateEnrollment(enrollment);
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Enrollment.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Enrollment.hbm.xml
@@ -32,7 +32,7 @@
 
     <property name="enrollmentDate" column="enrollmentdate" not-null="true"/>
 
-    <property name="getCompletedDate" column="enddate"/>
+    <property name="completedDate" column="enddate"/>
 
     <property name="followup" column="followup"/>
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Enrollment.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Enrollment.hbm.xml
@@ -32,7 +32,7 @@
 
     <property name="enrollmentDate" column="enrollmentdate" not-null="true"/>
 
-    <property name="endDate" column="enddate"/>
+    <property name="getCompletedDate" column="enddate"/>
 
     <property name="followup" column="followup"/>
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/enrollment/AbstractEnrollmentService.java
@@ -320,7 +320,7 @@ public abstract class AbstractEnrollmentService
     enrollment.setEnrollmentDate(programInstance.getEnrollmentDate());
     enrollment.setIncidentDate(programInstance.getIncidentDate());
     enrollment.setFollowup(programInstance.getFollowup());
-    enrollment.setCompletedDate(programInstance.getEndDate());
+    enrollment.setCompletedDate(programInstance.getCompletedDate());
     enrollment.setCompletedBy(programInstance.getCompletedBy());
     enrollment.setStoredBy(programInstance.getStoredBy());
     enrollment.setCreatedByUserInfo(programInstance.getCreatedByUserInfo());
@@ -598,7 +598,7 @@ public abstract class AbstractEnrollmentService
       }
 
       programInstance.setCompletedBy(user);
-      programInstance.setEndDate(date);
+      programInstance.setCompletedDate(date);
     }
 
     programInstance.setCreatedByUserInfo(UserInfoSnapshot.from(importOptions.getUser()));
@@ -973,11 +973,11 @@ public abstract class AbstractEnrollmentService
       }
 
       if (EnrollmentStatus.CANCELLED == enrollment.getStatus()) {
-        programInstance.setEndDate(endDate);
+        programInstance.setCompletedDate(endDate);
 
         enrollmentService.cancelEnrollmentStatus(programInstance);
       } else if (EnrollmentStatus.COMPLETED == enrollment.getStatus()) {
-        programInstance.setEndDate(endDate);
+        programInstance.setCompletedDate(endDate);
         programInstance.setCompletedBy(user);
 
         enrollmentService.completeEnrollmentStatus(programInstance);

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/shared/validation/EventBaseCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/shared/validation/EventBaseCheck.java
@@ -115,12 +115,12 @@ public class EventBaseCheck implements Checker {
 
       referenceDate = removeTimeStamp(referenceDate);
 
-      if (referenceDate.after(removeTimeStamp(enrollment.getEndDate()))) {
+      if (referenceDate.after(removeTimeStamp(enrollment.getCompletedDate()))) {
         errors.add(
             "Not possible to add event to a completed enrollment. Event created date ( "
                 + referenceDate
                 + " ) is after enrollment completed date ( "
-                + removeTimeStamp(enrollment.getEndDate())
+                + removeTimeStamp(enrollment.getCompletedDate())
                 + " ).");
       }
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/shared/validation/EventBaseCheckTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/shared/validation/EventBaseCheckTest.java
@@ -129,7 +129,7 @@ class EventBaseCheckTest extends BaseValidationTest {
     Enrollment enrollment = new Enrollment();
     enrollment.setStatus(ProgramStatus.COMPLETED);
     // Set enrollment end date to NOW - one month
-    enrollment.setEndDate(Date.from(ZonedDateTime.now().minusMonths(1).toInstant()));
+    enrollment.setCompletedDate(Date.from(ZonedDateTime.now().minusMonths(1).toInstant()));
     programInstanceMap.put(event.getUid(), enrollment);
     when(workContext.getProgramInstanceMap()).thenReturn(programInstanceMap);
     when(workContext.getImportOptions()).thenReturn(importOptions);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -125,7 +125,7 @@ class DefaultEnrollmentService
     result.setEnrollmentDate(enrollment.getEnrollmentDate());
     result.setIncidentDate(enrollment.getIncidentDate());
     result.setFollowup(enrollment.getFollowup());
-    result.setEndDate(enrollment.getEndDate());
+    result.setCompletedDate(enrollment.getCompletedDate());
     result.setCompletedBy(enrollment.getCompletedBy());
     result.setStoredBy(enrollment.getStoredBy());
     result.setCreatedByUserInfo(enrollment.getCreatedByUserInfo());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/HibernateEnrollmentStore.java
@@ -78,7 +78,7 @@ class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enrollment
    */
   private static final Set<String> ORDERABLE_FIELDS =
       Set.of(
-          "endDate",
+          "completedDate",
           "created",
           "createdAtClient",
           "enrollmentDate",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/mapper/EnrollmentRowCallbackHandler.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/mapper/EnrollmentRowCallbackHandler.java
@@ -99,7 +99,7 @@ public class EnrollmentRowCallbackHandler extends AbstractMapper<Enrollment> {
         rs.getTimestamp(EnrollmentQuery.getColumnName(COLUMNS.ENROLLMENTDATE)));
     enrollment.setIncidentDate(
         rs.getTimestamp(EnrollmentQuery.getColumnName(COLUMNS.INCIDENTDATE)));
-    enrollment.setEndDate(rs.getTimestamp(EnrollmentQuery.getColumnName(COLUMNS.COMPLETED)));
+    enrollment.setCompletedDate(rs.getTimestamp(EnrollmentQuery.getColumnName(COLUMNS.COMPLETED)));
     enrollment.setCompletedBy(rs.getString(EnrollmentQuery.getColumnName(COLUMNS.COMPLETEDBY)));
     enrollment.setStoredBy(rs.getString(EnrollmentQuery.getColumnName(COLUMNS.STOREDBY)));
     enrollment.setDeleted(rs.getBoolean(EnrollmentQuery.getColumnName(COLUMNS.DELETED)));

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/EnrollmentTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/EnrollmentTrackerConverterService.java
@@ -158,10 +158,10 @@ public class EnrollmentTrackerConverterService
 
     if (previousStatus != dbEnrollment.getStatus()) {
       if (dbEnrollment.isCompleted()) {
-        dbEnrollment.setEndDate(now);
+        dbEnrollment.setCompletedDate(now);
         dbEnrollment.setCompletedBy(preheat.getUsername());
       } else if (dbEnrollment.getStatus().equals(ProgramStatus.CANCELLED)) {
-        dbEnrollment.setEndDate(now);
+        dbEnrollment.setCompletedDate(now);
       }
     }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/OwnershipTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/OwnershipTest.java
@@ -175,7 +175,7 @@ class OwnershipTest extends TrackerTest {
         enrollments.stream().filter(e -> e.getUid().equals("TvctPPhpD8u")).findAny().get();
     compareEnrollmentBasicProperties(enrollment, enrollmentParams.getEnrollments().get(0));
     assertNull(enrollment.getCompletedBy());
-    assertNull(enrollment.getEndDate());
+    assertNull(enrollment.getCompletedDate());
 
     org.hisp.dhis.tracker.imports.domain.Enrollment updatedEnrollment =
         enrollmentParams.getEnrollments().get(0);
@@ -194,7 +194,7 @@ class OwnershipTest extends TrackerTest {
     enrollment = enrollments.stream().filter(e -> e.getUid().equals("TvctPPhpD8u")).findAny().get();
     compareEnrollmentBasicProperties(enrollment, updatedEnrollment);
     assertNotNull(enrollment.getCompletedBy());
-    assertNotNull(enrollment.getEndDate());
+    assertNotNull(enrollment.getCompletedDate());
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentMapper.java
@@ -59,7 +59,7 @@ public interface EnrollmentMapper
    */
   Map<String, String> ORDERABLE_FIELDS =
       Map.ofEntries(
-          entry("completedAt", "endDate"),
+          entry("completedAt", "completedDate"),
           entry("createdAt", "created"),
           entry("createdAtClient", "createdAtClient"),
           entry("enrolledAt", "enrollmentDate"),
@@ -77,7 +77,7 @@ public interface EnrollmentMapper
   @Mapping(target = "enrolledAt", source = "enrollmentDate")
   @Mapping(target = "occurredAt", source = "incidentDate")
   @Mapping(target = "followUp", source = "followup")
-  @Mapping(target = "completedAt", source = "endDate")
+  @Mapping(target = "completedAt", source = "completedDate")
   @Mapping(target = "createdBy", source = "createdByUserInfo")
   @Mapping(target = "updatedBy", source = "lastUpdatedByUserInfo")
   @Mapping(target = "relationships", source = "relationshipItems")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipItemMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipItemMapper.java
@@ -83,7 +83,7 @@ interface RelationshipItemMapper
   @Mapping(target = "enrolledAt", source = "enrollmentDate")
   @Mapping(target = "occurredAt", source = "incidentDate")
   @Mapping(target = "followUp", source = "followup")
-  @Mapping(target = "completedAt", source = "endDate")
+  @Mapping(target = "completedAt", source = "completedDate")
   @Mapping(target = "createdBy", source = "createdByUserInfo")
   @Mapping(target = "updatedBy", source = "lastUpdatedByUserInfo")
   @Mapping(target = "attributes", source = "trackedEntity.trackedEntityAttributeValues")


### PR DESCRIPTION
`completedAt` field in `Enrollment` was internally translated to `endDate`.
This PR aims to replace all occurrences of `endDate` in the service layer to `completedDate`.
The general rule that we are using is that date fields are suffixed with `At` in the API and then suffixed with `Date` in the service and the DB layer.

**Next PRs**
- Rename `occurredAt` in service layer
- Rename `completedAt` in DB layer
- Rename `occurredAt` in DB layer