### PR TITLE
fix: Use org unit path instead of multiple org unit ids [TECH-1586]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -208,14 +208,6 @@ class DefaultEnrollmentService
     } else if (user != null && queryParams.isOrganisationUnitMode(CAPTURE)) {
       queryParams.setOrganisationUnits(user.getOrganisationUnits());
       queryParams.setOrganisationUnitMode(DESCENDANTS);
-    } else if (queryParams.isOrganisationUnitMode(CHILDREN)) {
-      Set<OrganisationUnit> organisationUnits = new HashSet<>(queryParams.getOrganisationUnits());
-
-      for (OrganisationUnit organisationUnit : queryParams.getOrganisationUnits()) {
-        organisationUnits.addAll(organisationUnit.getChildren());
-      }
-
-      queryParams.setOrganisationUnits(organisationUnits);
     }
 
     return getEnrollments(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/HibernateEnrollmentStore.java
@@ -187,23 +187,12 @@ class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enrollment
 
     if (params.hasOrganisationUnits()) {
       if (params.isOrganisationUnitMode(OrganisationUnitSelectionMode.DESCENDANTS)) {
-        String ouClause = "(";
-        SqlHelper orHlp = new SqlHelper(true);
+        hql += hlp.whereAnd() + getDescendantsQuery(params.getOrganisationUnits());
+      } else if (params.isOrganisationUnitMode(OrganisationUnitSelectionMode.CHILDREN)) {
+        hql += hlp.whereAnd() + getChildrenQuery(hlp, params.getOrganisationUnits());
 
-        for (OrganisationUnit organisationUnit : params.getOrganisationUnits()) {
-          ouClause +=
-              orHlp.or() + "en.organisationUnit.path LIKE '" + organisationUnit.getPath() + "%'";
-        }
-
-        ouClause += ")";
-
-        hql += hlp.whereAnd() + ouClause;
       } else {
-        hql +=
-            hlp.whereAnd()
-                + "en.organisationUnit.uid in ("
-                + getQuotedCommaDelimitedString(getUids(params.getOrganisationUnits()))
-                + ")";
+        hql += hlp.whereAnd() + getSelectedQuery(params.getOrganisationUnits());
       }
     }
 
@@ -240,6 +229,48 @@ class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enrollment
     }
 
     return QueryWithOrderBy.builder().query(hql).orderBy(orderBy(params.getOrder())).build();
+  }
+
+  private String getDescendantsQuery(Set<OrganisationUnit> organisationUnits) {
+    StringBuilder ouClause = new StringBuilder();
+    ouClause.append("(");
+
+    SqlHelper orHlp = new SqlHelper(true);
+
+    for (OrganisationUnit organisationUnit : organisationUnits) {
+      ouClause
+          .append(orHlp.or())
+          .append("en.organisationUnit.path LIKE '")
+          .append(organisationUnit.getPath())
+          .append("%'");
+    }
+
+    ouClause.append(")");
+
+    return ouClause.toString();
+  }
+
+  private String getChildrenQuery(SqlHelper hlp, Set<OrganisationUnit> organisationUnits) {
+    StringBuilder orgUnits = new StringBuilder();
+    for (OrganisationUnit organisationUnit : organisationUnits) {
+      orgUnits
+          .append(hlp.or())
+          .append("en.organisationUnit.path LIKE '")
+          .append(organisationUnit.getPath())
+          .append("%'")
+          .append(" AND (en.organisationUnit.hierarchyLevel = ")
+          .append(organisationUnit.getHierarchyLevel())
+          .append(" OR en.organisationUnit.hierarchyLevel = ")
+          .append((organisationUnit.getHierarchyLevel() + 1))
+          .append(")");
+    }
+    return orgUnits.toString();
+  }
+
+  private String getSelectedQuery(Set<OrganisationUnit> organisationUnits) {
+    return "en.organisationUnit.uid in ("
+        + getQuotedCommaDelimitedString(getUids(organisationUnits))
+        + ")";
   }
 
   private static String orderBy(List<Order> orders) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -645,50 +645,67 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     }
 
     if (params.isOrganisationUnitMode(OrganisationUnitSelectionMode.DESCENDANTS)) {
-      SqlHelper orHlp = new SqlHelper(true);
-
-      orgUnits.append("AND (");
-
-      for (OrganisationUnit organisationUnit : params.getOrgUnits()) {
-
-        OrganisationUnit ou = organisationUnitStore.getByUid(organisationUnit.getUid());
-        if (ou != null) {
-          orgUnits.append(orHlp.or()).append("OU.path LIKE '").append(ou.getPath()).append("%'");
-        }
-      }
-
-      orgUnits.append(") ");
+      orgUnits.append(getDescendantsQuery(params));
     } else if (params.isOrganisationUnitMode(OrganisationUnitSelectionMode.CHILDREN)) {
-      SqlHelper orHlp = new SqlHelper(true);
-
-      orgUnits.append("AND (");
-
-      for (OrganisationUnit organisationUnit : params.getOrgUnits()) {
-
-        OrganisationUnit ou = organisationUnitStore.getByUid(organisationUnit.getUid());
-        if (ou != null) {
-          orgUnits
-              .append(orHlp.or())
-              .append("OU.path LIKE '")
-              .append(ou.getPath())
-              .append("%'")
-              .append(" AND (ou.hierarchylevel = ")
-              .append(ou.getHierarchyLevel())
-              .append(" OR ou.hierarchylevel = ")
-              .append((ou.getHierarchyLevel() + 1))
-              .append(")");
-        }
-      }
-
-      orgUnits.append(") ");
-    } else if (!params.isOrganisationUnitMode(OrganisationUnitSelectionMode.ALL)) {
-      orgUnits
-          .append("AND OU.organisationunitid IN (")
-          .append(getCommaDelimitedString(getIdentifiers(params.getOrgUnits())))
-          .append(") ");
+      orgUnits.append(getChildrenQuery(params));
+    } else if (params.isOrganisationUnitMode(OrganisationUnitSelectionMode.SELECTED)) {
+      orgUnits.append(getSelectedQuery(params));
     }
 
     return orgUnits.toString();
+  }
+
+  private String getDescendantsQuery(TrackedEntityQueryParams params) {
+    StringBuilder orgUnits = new StringBuilder();
+    SqlHelper orHlp = new SqlHelper(true);
+
+    orgUnits.append("AND (");
+
+    for (OrganisationUnit organisationUnit : params.getOrgUnits()) {
+
+      OrganisationUnit ou = organisationUnitStore.getByUid(organisationUnit.getUid());
+      if (ou != null) {
+        orgUnits.append(orHlp.or()).append("OU.path LIKE '").append(ou.getPath()).append("%'");
+      }
+    }
+
+    orgUnits.append(") ");
+
+    return orgUnits.toString();
+  }
+
+  private String getChildrenQuery(TrackedEntityQueryParams params) {
+    StringBuilder orgUnits = new StringBuilder();
+    SqlHelper orHlp = new SqlHelper(true);
+
+    orgUnits.append("AND (");
+
+    for (OrganisationUnit organisationUnit : params.getOrgUnits()) {
+
+      OrganisationUnit ou = organisationUnitStore.getByUid(organisationUnit.getUid());
+      if (ou != null) {
+        orgUnits
+            .append(orHlp.or())
+            .append(" OU.path LIKE '")
+            .append(ou.getPath())
+            .append("%'")
+            .append(" AND (ou.hierarchylevel = ")
+            .append(ou.getHierarchyLevel())
+            .append(" OR ou.hierarchylevel = ")
+            .append((ou.getHierarchyLevel() + 1))
+            .append(")");
+      }
+    }
+
+    orgUnits.append(") ");
+
+    return orgUnits.toString();
+  }
+
+  private String getSelectedQuery(TrackedEntityQueryParams params) {
+    return "AND OU.organisationunitid IN ("
+        + getCommaDelimitedString(getIdentifiers(params.getOrgUnits()))
+        + ") ";
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -658,6 +658,29 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
       }
 
       orgUnits.append(") ");
+    } else if (params.isOrganisationUnitMode(OrganisationUnitSelectionMode.CHILDREN)) {
+      SqlHelper orHlp = new SqlHelper(true);
+
+      orgUnits.append("AND (");
+
+      for (OrganisationUnit organisationUnit : params.getOrgUnits()) {
+
+        OrganisationUnit ou = organisationUnitStore.getByUid(organisationUnit.getUid());
+        if (ou != null) {
+          orgUnits
+              .append(orHlp.or())
+              .append("OU.path LIKE '")
+              .append(ou.getPath())
+              .append("%'")
+              .append(" AND (ou.hierarchylevel = ")
+              .append(ou.getHierarchyLevel())
+              .append(" OR ou.hierarchylevel = ")
+              .append((ou.getHierarchyLevel() + 1))
+              .append(")");
+        }
+      }
+
+      orgUnits.append(") ");
     } else if (!params.isOrganisationUnitMode(OrganisationUnitSelectionMode.ALL)) {
       orgUnits
           .append("AND OU.organisationunitid IN (")

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityQueryParams.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.tracker.export.trackedentity;
 
 import static java.lang.Boolean.TRUE;
-import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CHILDREN;
 
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
@@ -170,15 +169,6 @@ public class TrackedEntityQueryParams {
     } else if (user != null && isOrganisationUnitMode(OrganisationUnitSelectionMode.CAPTURE)) {
       setOrgUnits(user.getOrganisationUnits());
       setOrgUnitMode(OrganisationUnitSelectionMode.DESCENDANTS);
-    } else if (isOrganisationUnitMode(CHILDREN)) {
-      Set<OrganisationUnit> organisationUnits = new HashSet<>(getOrgUnits());
-
-      for (OrganisationUnit organisationUnit : getOrgUnits()) {
-        organisationUnits.addAll(organisationUnit.getChildren());
-      }
-
-      setOrgUnits(organisationUnits);
-      setOrgUnitMode(OrganisationUnitSelectionMode.SELECTED);
     }
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -660,7 +660,11 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
 
     List<Enrollment> enrollments = enrollmentService.getEnrollments(operationParams);
     assertContainsOnly(
-        List.of(enrollmentA.getUid(), enrollmentB.getUid(), enrollmentChildA.getUid()),
+        List.of(
+            enrollmentA.getUid(),
+            enrollmentB.getUid(),
+            enrollmentChildA.getUid(),
+            enrollmentGrandchildA.getUid()),
         uids(enrollments));
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -1472,6 +1472,27 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
   }
 
   @Test
+  void
+      shouldReturnAllChildrenOfRequestedOrgUnitsWhenOrgUnitModeChildrenAndMultipleOrgUnitsRequested()
+          throws ForbiddenException, BadRequestException, NotFoundException {
+    TrackedEntityOperationParams operationParams =
+        TrackedEntityOperationParams.builder()
+            .orgUnitMode(CHILDREN)
+            .organisationUnits(Set.of(orgUnitA.getUid(), orgUnitChildA.getUid()))
+            .trackedEntityTypeUid(trackedEntityTypeA.getUid())
+            .user(user)
+            .build();
+
+    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
+    assertContainsOnly(
+        Set.of(
+            trackedEntityA.getUid(),
+            trackedEntityChildA.getUid(),
+            trackedEntityGrandchildA.getUid()),
+        uids(trackedEntities));
+  }
+
+  @Test
   void shouldReturnAllEntitiesWhenSuperuserAndModeAll()
       throws ForbiddenException, BadRequestException, NotFoundException {
     injectSecurityContext(admin);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -1466,7 +1466,14 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
 
     List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(operationParams);
 
-    assertContainsOnly(List.of(trackedEntityA, trackedEntityB, trackedEntityC), trackedEntities);
+    assertContainsOnly(
+        List.of(
+            trackedEntityA,
+            trackedEntityB,
+            trackedEntityC,
+            trackedEntityChildA,
+            trackedEntityGrandchildA),
+        trackedEntities);
   }
 
   @Test


### PR DESCRIPTION
When requested org unit mode is CHILDREN, we are filtering tracked entities and enrollments by uid.
With this PR we'll filter by path, which should have a better performance on the database.

Ticket: https://dhis2.atlassian.net/browse/TECH-1586