### PR TITLE
fix: tracker/events not returning event relationships [DHIS2-16117] [ 2.40 ]

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/TrackerNtiApiTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/TrackerNtiApiTest.java
@@ -194,6 +194,17 @@ public class TrackerNtiApiTest extends TrackerApiTest {
     return trackerActions.postAndGetJobReport(payload).validateSuccessfulImport();
   }
 
+  protected TrackerApiResponse importRelationshipEventToTei(String event, String tei) {
+    JsonObject payload =
+        new RelationshipDataBuilder()
+            .setFromEntity("event", event)
+            .setToTrackedEntity(tei)
+            .setRelationshipType("gdc6uOvgoji")
+            .array();
+
+    return trackerActions.postAndGetJobReport(payload).validateSuccessfulImport();
+  }
+
   @AfterEach
   public void afterEachNTI() {
     loginActions.loginAsSuperUser();

--- a/dhis-2/dhis-test-e2e/src/test/resources/setup/tracker_metadata.json
+++ b/dhis-2/dhis-test-e2e/src/test/resources/setup/tracker_metadata.json
@@ -3259,6 +3259,41 @@
           }
         }
       }
+    },
+    {
+      "lastUpdated": "2020-11-20T09:06:23.348",
+      "id": "gdc6uOvgoji",
+      "created": "2020-11-20T09:06:23.348",
+      "name": "Person to Event",
+      "code": "Person to Event",
+      "bidirectional": false,
+      "displayName": "Person to Event",
+      "fromToName": "Person to Event",
+      "displayFromToName": "Person to Event",
+      "favorite": false,
+      "toConstraint": {
+        "relationshipEntity": "TRACKED_ENTITY_INSTANCE",
+        "trackedEntityType": {
+          "id": "Q9GufDoplCL",
+          "code": "TA_PERSON_TET"
+        }
+      },
+      "fromConstraint": {
+        "relationshipEntity": "PROGRAM_STAGE_INSTANCE",
+        "programStage": {
+          "id": "PaOOjwLVW23"
+        }
+      },
+      "sharing": {
+        "public": "rw------",
+        "external": false,
+        "userGroups": {
+          "OPVIvvXzNTw": {
+            "id": "OPVIvvXzNTw",
+            "access": "rwrw----"
+          }
+        }
+      }
     }
   ]
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
@@ -104,6 +104,10 @@ public class TrackerEventsExportController {
       throws BadRequestException, ForbiddenException {
     EventQueryParams eventQueryParams = requestToSearchParams.map(eventCriteria);
 
+    EventParams eventParams = eventsMapper.map(fields);
+
+    eventQueryParams.setIncludeRelationships(eventParams.isIncludeRelationships());
+
     if (areAllEnrollmentsInvalid(eventCriteria, eventQueryParams)) {
       return new PagingWrapper<ObjectNode>().withInstances(Collections.emptyList());
     }


### PR DESCRIPTION
see https://github.com/dhis2/dhis2-core/pull/15626

Before master,  the params are not mapped in different layers.  Also, the mapper is still shared with the old tracker.
Therefore, we only set the inclusion of the relationship in the controller