### PR TITLE
chore: Rename incidentDate to occurredDate in service layer [TECH-1665]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Enrollment.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Enrollment.java
@@ -67,7 +67,7 @@ public class Enrollment extends SoftDeletableObject {
 
   @AuditAttribute private OrganisationUnit organisationUnit;
 
-  private Date incidentDate;
+  private Date occurredDate;
 
   private Date enrollmentDate;
 
@@ -104,9 +104,9 @@ public class Enrollment extends SoftDeletableObject {
   public Enrollment() {}
 
   public Enrollment(
-      Date enrollmentDate, Date incidentDate, TrackedEntity trackedEntity, Program program) {
+      Date enrollmentDate, Date occurredDate, TrackedEntity trackedEntity, Program program) {
     this.enrollmentDate = enrollmentDate;
-    this.incidentDate = incidentDate;
+    this.occurredDate = occurredDate;
     this.trackedEntity = trackedEntity;
     this.program = program;
   }
@@ -160,7 +160,7 @@ public class Enrollment extends SoftDeletableObject {
     final int prime = 31;
     int result = super.hashCode();
 
-    result = prime * result + ((incidentDate == null) ? 0 : incidentDate.hashCode());
+    result = prime * result + ((occurredDate == null) ? 0 : occurredDate.hashCode());
     result = prime * result + ((enrollmentDate == null) ? 0 : enrollmentDate.hashCode());
     result = prime * result + ((trackedEntity == null) ? 0 : trackedEntity.hashCode());
     result = prime * result + ((program == null) ? 0 : program.hashCode());
@@ -174,7 +174,7 @@ public class Enrollment extends SoftDeletableObject {
   }
 
   private boolean objectEquals(Enrollment other) {
-    return Objects.equals(incidentDate, other.incidentDate)
+    return Objects.equals(occurredDate, other.occurredDate)
         && Objects.equals(enrollmentDate, other.enrollmentDate)
         && Objects.equals(trackedEntity, other.trackedEntity)
         && Objects.equals(program, other.program);
@@ -218,12 +218,12 @@ public class Enrollment extends SoftDeletableObject {
 
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
-  public Date getIncidentDate() {
-    return incidentDate;
+  public Date getOccurredDate() {
+    return occurredDate;
   }
 
-  public void setIncidentDate(Date incidentDate) {
-    this.incidentDate = incidentDate;
+  public void setOccurredDate(Date occurredDate) {
+    this.occurredDate = occurredDate;
   }
 
   @JsonProperty
@@ -405,7 +405,7 @@ public class Enrollment extends SoftDeletableObject {
         + ", organisationUnit="
         + (organisationUnit != null ? organisationUnit.getUid() : "null")
         + ", incidentDate="
-        + incidentDate
+        + occurredDate
         + ", enrollmentDate="
         + enrollmentDate
         + ", entityInstance="
@@ -439,7 +439,7 @@ public class Enrollment extends SoftDeletableObject {
     copy.setEvents(new HashSet<>());
     copy.setFollowup(original.getFollowup());
     copy.setGeometry(original.getGeometry());
-    copy.setIncidentDate(original.getIncidentDate());
+    copy.setOccurredDate(original.getOccurredDate());
     copy.setLastUpdatedAtClient(original.getLastUpdatedAtClient());
     copy.setLastUpdatedByUserInfo(original.getLastUpdatedByUserInfo());
     copy.setMessageConversations(ObjectUtils.copyOf(original.getMessageConversations()));

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/program/EnrollmentTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/program/EnrollmentTest.java
@@ -63,7 +63,7 @@ class EnrollmentTest {
     assertEquals(original.getStatus(), copy.getStatus());
     assertEquals(original.getNotes(), copy.getNotes());
     assertEquals(original.getName(), copy.getName());
-    assertEquals(original.getIncidentDate(), copy.getIncidentDate());
+    assertEquals(original.getOccurredDate(), copy.getOccurredDate());
     assertEquals(original.getEnrollmentDate(), copy.getEnrollmentDate());
     assertEquals(original.getFollowup(), copy.getFollowup());
     assertEquals(original.getGeometry(), copy.getGeometry());
@@ -90,7 +90,7 @@ class EnrollmentTest {
     assertEquals(original.getEnrollmentDate(), copy.getEnrollmentDate());
     assertEquals(original.getFollowup(), copy.getFollowup());
     assertEquals(original.getGeometry(), copy.getGeometry());
-    assertEquals(original.getIncidentDate(), copy.getIncidentDate());
+    assertEquals(original.getOccurredDate(), copy.getOccurredDate());
     assertEquals(original.getName(), copy.getName());
     assertEquals(original.getOrganisationUnit(), copy.getOrganisationUnit());
     assertEquals(original.getStatus(), copy.getStatus());
@@ -121,7 +121,7 @@ class EnrollmentTest {
     e.setEnrollmentDate(new Date());
     e.setEvents(Set.of());
     e.setFollowup(true);
-    e.setIncidentDate(new Date());
+    e.setOccurredDate(new Date());
     e.setMessageConversations(List.of(new MessageConversation()));
     e.setName("Enrollment 1");
     e.setOrganisationUnit(new OrganisationUnit("org1"));
@@ -141,7 +141,7 @@ class EnrollmentTest {
     e.setCompletedDate(null);
     e.setEnrollmentDate(null);
     e.setEvents(null);
-    e.setIncidentDate(null);
+    e.setOccurredDate(null);
     e.setMessageConversations(null);
     e.setOrganisationUnit(null);
     e.setProgram(null);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/notification/ProgramNotificationMessageRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/notification/ProgramNotificationMessageRenderer.java
@@ -56,7 +56,7 @@ public class ProgramNotificationMessageRenderer
                   e -> e.getOrganisationUnit().getDisplayName())
               .put(ProgramTemplateVariable.CURRENT_DATE, e -> formatDate(new Date()))
               .put(ProgramTemplateVariable.ENROLLMENT_DATE, e -> formatDate(e.getEnrollmentDate()))
-              .put(ProgramTemplateVariable.INCIDENT_DATE, e -> formatDate(e.getIncidentDate()))
+              .put(ProgramTemplateVariable.INCIDENT_DATE, e -> formatDate(e.getOccurredDate()))
               .put(
                   ProgramTemplateVariable.DAYS_SINCE_ENROLLMENT_DATE,
                   e -> daysSince(e.getEnrollmentDate()))

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
@@ -357,9 +357,9 @@ public class DefaultEnrollmentService implements EnrollmentService {
     }
 
     if (incidentDate != null) {
-      enrollment.setIncidentDate(incidentDate);
+      enrollment.setOccurredDate(incidentDate);
     } else {
-      enrollment.setIncidentDate(new Date());
+      enrollment.setOccurredDate(new Date());
     }
 
     enrollment.setStatus(programStatus);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEnrollmentStore.java
@@ -449,7 +449,7 @@ public class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enr
     if (trigger == NotificationTrigger.SCHEDULED_DAYS_ENROLLMENT_DATE) {
       return "enrollmentDate";
     } else if (trigger == NotificationTrigger.SCHEDULED_DAYS_INCIDENT_DATE) {
-      return "incidentDate";
+      return "occurredDate";
     }
 
     return null;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CommandSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CommandSMSListener.java
@@ -222,7 +222,7 @@ public abstract class CommandSMSListener extends BaseSMSListener {
     if (enrollments.isEmpty()) {
       Enrollment enrollment = new Enrollment();
       enrollment.setEnrollmentDate(new Date());
-      enrollment.setIncidentDate(new Date());
+      enrollment.setOccurredDate(new Date());
       enrollment.setProgram(smsCommand.getProgram());
       enrollment.setStatus(ProgramStatus.ACTIVE);
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
@@ -184,7 +184,7 @@ public class EnrollmentSMSListener extends CompressionSMSListener {
       enrollment = enrollmentService.getEnrollment(enrollmentid.getUid());
       // Update these dates in case they've changed
       enrollment.setEnrollmentDate(enrollmentDate);
-      enrollment.setIncidentDate(incidentDate);
+      enrollment.setOccurredDate(incidentDate);
     } else {
       enrollment =
           enrollmentService.enrollTrackedEntity(

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
@@ -130,7 +130,7 @@ public class SimpleEventSMSListener extends CompressionSMSListener {
     if (enrollments.isEmpty()) {
       Enrollment enrollment = new Enrollment();
       enrollment.setEnrollmentDate(new Date());
-      enrollment.setIncidentDate(new Date());
+      enrollment.setOccurredDate(new Date());
       enrollment.setProgram(program);
       enrollment.setStatus(ProgramStatus.ACTIVE);
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Enrollment.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Enrollment.hbm.xml
@@ -28,7 +28,7 @@
 
     <property name="lastUpdatedByUserInfo" type="jbUserInfoSnapshot" column="lastupdatedbyuserinfo"/>
 
-    <property name="incidentDate" column="incidentDate"/>
+    <property name="occurredDate" column="incidentDate"/>
 
     <property name="enrollmentDate" column="enrollmentdate" not-null="true"/>
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/TrackerNotificationWebHookServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/TrackerNotificationWebHookServiceTest.java
@@ -139,7 +139,7 @@ class TrackerNotificationWebHookServiceTest extends DhisConvenienceTest {
     enrollment.setProgram(programA);
     enrollment.setOrganisationUnit(organisationUnitA);
     enrollment.setEnrollmentDate(new Date());
-    enrollment.setIncidentDate(new Date());
+    enrollment.setOccurredDate(new Date());
     enrollment.setTrackedEntity(tei);
 
     event = new Event();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/enrollment/AbstractEnrollmentService.java
@@ -318,7 +318,7 @@ public abstract class AbstractEnrollmentService
     enrollment.setProgram(programInstance.getProgram().getUid());
     enrollment.setStatus(EnrollmentStatus.fromProgramStatus(programInstance.getStatus()));
     enrollment.setEnrollmentDate(programInstance.getEnrollmentDate());
-    enrollment.setIncidentDate(programInstance.getIncidentDate());
+    enrollment.setIncidentDate(programInstance.getOccurredDate());
     enrollment.setFollowup(programInstance.getFollowup());
     enrollment.setCompletedDate(programInstance.getCompletedDate());
     enrollment.setCompletedBy(programInstance.getCompletedBy());
@@ -668,7 +668,7 @@ public abstract class AbstractEnrollmentService
       return importSummary;
     }
 
-    if (program.getDisplayIncidentDate() && programInstance.getIncidentDate() == null) {
+    if (program.getDisplayIncidentDate() && programInstance.getOccurredDate() == null) {
       importSummary.setStatus(ImportStatus.ERROR);
       importSummary.setDescription("DisplayIncidentDate is true but IncidentDate is null ");
       importSummary.incrementIgnored();
@@ -676,12 +676,12 @@ public abstract class AbstractEnrollmentService
       return importSummary;
     }
 
-    if (programInstance.getIncidentDate() != null
+    if (programInstance.getOccurredDate() != null
         && !DateUtils.dateIsValid(
-            DateUtils.getMediumDateString(programInstance.getIncidentDate()))) {
+            DateUtils.getMediumDateString(programInstance.getOccurredDate()))) {
       importSummary.setStatus(ImportStatus.ERROR);
       importSummary.setDescription(
-          "Invalid enollment incident date:  " + programInstance.getIncidentDate());
+          "Invalid enollment incident date:  " + programInstance.getOccurredDate());
       importSummary.incrementIgnored();
 
       return importSummary;
@@ -936,7 +936,7 @@ public abstract class AbstractEnrollmentService
     programInstance.setProgram(program);
 
     if (enrollment.getIncidentDate() != null) {
-      programInstance.setIncidentDate(enrollment.getIncidentDate());
+      programInstance.setOccurredDate(enrollment.getIncidentDate());
     }
 
     if (enrollment.getEnrollmentDate() != null) {
@@ -951,7 +951,7 @@ public abstract class AbstractEnrollmentService
 
     programInstance.setFollowup(enrollment.getFollowup());
 
-    if (program.getDisplayIncidentDate() && programInstance.getIncidentDate() == null) {
+    if (program.getDisplayIncidentDate() && programInstance.getOccurredDate() == null) {
       return new ImportSummary(
               ImportStatus.ERROR, "DisplayIncidentDate is true but IncidentDate is null")
           .incrementIgnored();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHook.java
@@ -113,7 +113,7 @@ public class ProgramObjectBundleHook extends AbstractObjectBundleHook<Program> {
     if (getProgramInstancesCount(program) == 0 && program.isWithoutRegistration()) {
       Enrollment pi = new Enrollment();
       pi.setEnrollmentDate(new Date());
-      pi.setIncidentDate(new Date());
+      pi.setOccurredDate(new Date());
       pi.setProgram(program);
       pi.setStatus(ProgramStatus.ACTIVE);
       pi.setStoredBy("system-process");

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHookTest.java
@@ -113,7 +113,7 @@ class ProgramObjectBundleHookTest {
     verify(enrollmentService).addEnrollment(argument.capture());
 
     assertThat(argument.getValue().getEnrollmentDate(), is(notNullValue()));
-    assertThat(argument.getValue().getIncidentDate(), is(notNullValue()));
+    assertThat(argument.getValue().getOccurredDate(), is(notNullValue()));
     assertThat(argument.getValue().getProgram(), is(programA));
     assertThat(argument.getValue().getStatus(), is(ProgramStatus.ACTIVE));
     assertThat(argument.getValue().getStoredBy(), is("system-process"));

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
@@ -406,7 +406,7 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
     }
     return RuleEnrollment.create(
         enrollment.getUid(),
-        enrollment.getIncidentDate(),
+        enrollment.getOccurredDate(),
         enrollment.getEnrollmentDate(),
         RuleEnrollment.Status.valueOf(enrollment.getStatus().toString()),
         orgUnit,

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperServiceTest.java
@@ -465,7 +465,7 @@ class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest {
     enrollment.setStatus(ProgramStatus.ACTIVE);
     enrollment.setAutoFields();
     enrollment.setEnrollmentDate(new Date());
-    enrollment.setIncidentDate(new Date());
+    enrollment.setOccurredDate(new Date());
     enrollment.setTrackedEntity(trackedEntity);
 
     eventA = new Event(enrollment, programStage);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -123,7 +123,7 @@ class DefaultEnrollmentService
     result.setProgram(enrollment.getProgram());
     result.setStatus(enrollment.getStatus());
     result.setEnrollmentDate(enrollment.getEnrollmentDate());
-    result.setIncidentDate(enrollment.getIncidentDate());
+    result.setOccurredDate(enrollment.getOccurredDate());
     result.setFollowup(enrollment.getFollowup());
     result.setCompletedDate(enrollment.getCompletedDate());
     result.setCompletedBy(enrollment.getCompletedBy());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/mapper/EnrollmentRowCallbackHandler.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/mapper/EnrollmentRowCallbackHandler.java
@@ -97,7 +97,7 @@ public class EnrollmentRowCallbackHandler extends AbstractMapper<Enrollment> {
         ProgramStatus.valueOf(rs.getString(EnrollmentQuery.getColumnName(COLUMNS.STATUS))));
     enrollment.setEnrollmentDate(
         rs.getTimestamp(EnrollmentQuery.getColumnName(COLUMNS.ENROLLMENTDATE)));
-    enrollment.setIncidentDate(
+    enrollment.setOccurredDate(
         rs.getTimestamp(EnrollmentQuery.getColumnName(COLUMNS.INCIDENTDATE)));
     enrollment.setCompletedDate(rs.getTimestamp(EnrollmentQuery.getColumnName(COLUMNS.COMPLETED)));
     enrollment.setCompletedBy(rs.getString(EnrollmentQuery.getColumnName(COLUMNS.COMPLETEDBY)));

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/EnrollmentTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/converter/EnrollmentTrackerConverterService.java
@@ -139,10 +139,10 @@ public class EnrollmentTrackerConverterService
     dbEnrollment.setLastUpdatedAtClient(DateUtils.fromInstant(enrollment.getUpdatedAtClient()));
 
     Date enrollmentDate = DateUtils.fromInstant(enrollment.getEnrolledAt());
-    Date incidentDate = DateUtils.fromInstant(enrollment.getOccurredAt());
+    Date occurredDate = DateUtils.fromInstant(enrollment.getOccurredAt());
 
     dbEnrollment.setEnrollmentDate(enrollmentDate);
-    dbEnrollment.setIncidentDate(incidentDate != null ? incidentDate : enrollmentDate);
+    dbEnrollment.setOccurredDate(occurredDate != null ? occurredDate : enrollmentDate);
     dbEnrollment.setOrganisationUnit(organisationUnit);
     dbEnrollment.setProgram(program);
     dbEnrollment.setTrackedEntity(trackedEntity);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/EnrollmentMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/EnrollmentMapper.java
@@ -54,7 +54,7 @@ public interface EnrollmentMapper extends PreheatMapper<Enrollment> {
   @Mapping(target = "trackedEntity")
   @Mapping(target = "organisationUnit")
   @Mapping(target = "created")
-  @Mapping(target = "incidentDate")
+  @Mapping(target = "occurredDate")
   @Mapping(target = "enrollmentDate")
   @Mapping(target = "notes")
   @Mapping(target = "deleted")

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -1631,7 +1631,7 @@ public abstract class DhisConvenienceTest {
     enrollment.setTrackedEntity(te);
     enrollment.setOrganisationUnit(organisationUnit);
     enrollment.setEnrollmentDate(new Date());
-    enrollment.setIncidentDate(new Date());
+    enrollment.setOccurredDate(new Date());
 
     return enrollment;
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
@@ -394,12 +394,12 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
     // Enrollments (Enrollments)
     Enrollment piA = enrollmentService.enrollTrackedEntity(teiA, programA, jan1, jan1, ouE);
     piA.setEnrollmentDate(jan1);
-    piA.setIncidentDate(jan1);
+    piA.setOccurredDate(jan1);
     enrollmentService.addEnrollment(piA);
 
     Enrollment piB = enrollmentService.enrollTrackedEntity(teiA, programB, jan1, jan1, ouE);
     piB.setEnrollmentDate(jan1);
-    piB.setIncidentDate(jan1);
+    piB.setOccurredDate(jan1);
     enrollmentService.addEnrollment(piB);
 
     // Change programA / teiA ownership through time:

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EnrollmentImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EnrollmentImportTest.java
@@ -97,7 +97,7 @@ class EnrollmentImportTest extends TransactionalIntegrationTest {
 
     enrollment = new Enrollment();
     enrollment.setEnrollmentDate(new Date());
-    enrollment.setIncidentDate(new Date());
+    enrollment.setOccurredDate(new Date());
     enrollment.setProgram(program);
     enrollment.setStatus(ProgramStatus.ACTIVE);
     enrollment.setStoredBy("test");

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventImportTest.java
@@ -241,7 +241,7 @@ class EventImportTest extends TransactionalIntegrationTest {
     manager.update(programB);
     enrollment = new Enrollment();
     enrollment.setEnrollmentDate(new Date());
-    enrollment.setIncidentDate(new Date());
+    enrollment.setOccurredDate(new Date());
     enrollment.setProgram(programB);
     enrollment.setStatus(ProgramStatus.ACTIVE);
     enrollment.setStoredBy("test");
@@ -305,7 +305,7 @@ class EventImportTest extends TransactionalIntegrationTest {
   void testAddEventOnProgramWithoutRegistrationAndExistingEnrollment() throws IOException {
     Enrollment dbEnrollment = new Enrollment();
     dbEnrollment.setEnrollmentDate(new Date());
-    dbEnrollment.setIncidentDate(new Date());
+    dbEnrollment.setOccurredDate(new Date());
     dbEnrollment.setProgram(programB);
     dbEnrollment.setStatus(ProgramStatus.ACTIVE);
     dbEnrollment.setStoredBy("test");

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventXmlImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventXmlImportTest.java
@@ -110,7 +110,7 @@ class EventXmlImportTest extends TransactionalIntegrationTest {
     enrollment.setProgram(programA);
     enrollment.setAutoFields();
     enrollment.setEnrollmentDate(new Date());
-    enrollment.setIncidentDate(new Date());
+    enrollment.setOccurredDate(new Date());
     enrollment.setStatus(ProgramStatus.ACTIVE);
     enrollmentService.addEnrollment(enrollment);
     programStageA.getProgramStageDataElements().add(programStageDataElement);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/NoRegistrationSingleEventServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/NoRegistrationSingleEventServiceTest.java
@@ -103,7 +103,7 @@ class NoRegistrationSingleEventServiceTest extends TransactionalIntegrationTest 
     identifiableObjectManager.update(programA);
     Enrollment enrollment = new Enrollment();
     enrollment.setProgram(programA);
-    enrollment.setIncidentDate(new Date());
+    enrollment.setOccurredDate(new Date());
     enrollment.setEnrollmentDate(new Date());
     enrollmentService.addEnrollment(enrollment);
     identifiableObjectManager.update(programA);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/ProgramStageValidationStrategyTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/ProgramStageValidationStrategyTest.java
@@ -204,7 +204,7 @@ class ProgramStageValidationStrategyTest extends TransactionalIntegrationTest {
     manager.update(programA);
     Enrollment enrollment = new Enrollment();
     enrollment.setProgram(programA);
-    enrollment.setIncidentDate(new Date());
+    enrollment.setOccurredDate(new Date());
     enrollment.setEnrollmentDate(new Date());
     enrollment.setTrackedEntity(maleA);
     enrollment.getSharing().addUserAccess(userAccess1);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/security/EventSecurityTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/security/EventSecurityTest.java
@@ -117,7 +117,7 @@ class EventSecurityTest extends TransactionalIntegrationTest {
     manager.update(programA);
     Enrollment enrollment = new Enrollment();
     enrollment.setProgram(programA);
-    enrollment.setIncidentDate(new Date());
+    enrollment.setOccurredDate(new Date());
     enrollment.setEnrollmentDate(new Date());
     enrollmentService.addEnrollment(enrollment);
     manager.update(programA);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
@@ -205,9 +205,9 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
   void testUpdateEnrollment() {
     long idA = enrollmentService.addEnrollment(enrollmentA);
     assertNotNull(enrollmentService.getEnrollment(idA));
-    enrollmentA.setIncidentDate(enrollmentDate);
+    enrollmentA.setOccurredDate(enrollmentDate);
     enrollmentService.updateEnrollment(enrollmentA);
-    assertEquals(enrollmentDate, enrollmentService.getEnrollment(idA).getIncidentDate());
+    assertEquals(enrollmentDate, enrollmentService.getEnrollment(idA).getOccurredDate());
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/relationship/hibernate/RelationshipStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/relationship/hibernate/RelationshipStoreTest.java
@@ -269,7 +269,7 @@ class RelationshipStoreTest extends TransactionalIntegrationTest {
     enrollment.setProgram(programA);
     enrollment.setAutoFields();
     enrollment.setEnrollmentDate(new Date());
-    enrollment.setIncidentDate(new Date());
+    enrollment.setOccurredDate(new Date());
     enrollment.setStatus(ProgramStatus.ACTIVE);
     enrollmentService.addEnrollment(enrollment);
     return enrollment;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -786,7 +786,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
   @Test
   void shouldReturnTrackedEntityIfEnrollmentOccurredAfterPassedDateAndTime()
       throws ForbiddenException, NotFoundException, BadRequestException {
-    Date oneHourBeforeIncidentDate = oneHourBefore(enrollmentA.getIncidentDate());
+    Date oneHourBeforeIncidentDate = oneHourBefore(enrollmentA.getOccurredDate());
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
@@ -805,7 +805,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
   @Test
   void shouldReturnEmptyIfEnrollmentOccurredBeforePassedDateAndTime()
       throws ForbiddenException, NotFoundException, BadRequestException {
-    Date oneHourAfterIncidentDate = oneHourAfter(enrollmentA.getIncidentDate());
+    Date oneHourAfterIncidentDate = oneHourAfter(enrollmentA.getOccurredDate());
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
@@ -824,7 +824,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
   @Test
   void shouldReturnTrackedEntityIfEnrollmentOccurredBeforePassedDateAndTime()
       throws ForbiddenException, NotFoundException, BadRequestException {
-    Date oneHourAfterIncidentDate = oneHourAfter(enrollmentA.getIncidentDate());
+    Date oneHourAfterIncidentDate = oneHourAfter(enrollmentA.getOccurredDate());
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
@@ -843,7 +843,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
   @Test
   void shouldReturnEmptyIfEnrollmentOccurredPassedDateAndTime()
       throws ForbiddenException, NotFoundException, BadRequestException {
-    Date oneHourBeforeIncidentDate = oneHourBefore(enrollmentA.getIncidentDate());
+    Date oneHourBeforeIncidentDate = oneHourBefore(enrollmentA.getOccurredDate());
 
     TrackedEntityOperationParams operationParams =
         TrackedEntityOperationParams.builder()
@@ -1292,7 +1292,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
         () -> checkDate(currentTime, enrollment.getLastUpdated()),
         () -> checkDate(currentTime, enrollment.getLastUpdatedAtClient()),
         () -> checkDate(currentTime, enrollment.getEnrollmentDate()),
-        () -> checkDate(currentTime, enrollment.getIncidentDate()),
+        () -> checkDate(currentTime, enrollment.getOccurredDate()),
         () -> assertNull(enrollment.getStoredBy()));
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/OwnershipTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/OwnershipTest.java
@@ -290,7 +290,7 @@ class OwnershipTest extends TrackerTest {
       Enrollment dbEnrollment, org.hisp.dhis.tracker.imports.domain.Enrollment enrollment) {
     assertEquals(
         DateUtils.fromInstant(enrollment.getEnrolledAt()), dbEnrollment.getEnrollmentDate());
-    assertEquals(DateUtils.fromInstant(enrollment.getOccurredAt()), dbEnrollment.getIncidentDate());
+    assertEquals(DateUtils.fromInstant(enrollment.getOccurredAt()), dbEnrollment.getOccurredDate());
     assertEquals(
         DateUtils.fromInstant(enrollment.getCreatedAtClient()), dbEnrollment.getCreatedAtClient());
     assertEquals(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/TrackedEntityAttributeControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/TrackedEntityAttributeControllerTest.java
@@ -145,7 +145,7 @@ class TrackedEntityAttributeControllerTest extends DhisControllerConvenienceTest
     enrollment = new Enrollment(program, te, orgUnit);
     enrollment.setAutoFields();
     enrollment.setEnrollmentDate(new Date());
-    enrollment.setIncidentDate(new Date());
+    enrollment.setOccurredDate(new Date());
     enrollment.setStatus(ProgramStatus.COMPLETED);
     enrollment.setFollowup(true);
     manager.save(enrollment);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerTest.java
@@ -355,7 +355,7 @@ class EnrollmentsExportControllerTest extends DhisControllerConvenienceTest {
     Enrollment enrollment = new Enrollment(program, te, orgUnit);
     enrollment.setAutoFields();
     enrollment.setEnrollmentDate(new Date());
-    enrollment.setIncidentDate(new Date());
+    enrollment.setOccurredDate(new Date());
     enrollment.setStatus(ProgramStatus.COMPLETED);
     enrollment.setFollowup(true);
     manager.save(enrollment, false);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerTest.java
@@ -406,7 +406,7 @@ class EventsExportControllerTest extends DhisControllerConvenienceTest {
     Enrollment enrollment = new Enrollment(program, te, te.getOrganisationUnit());
     enrollment.setAutoFields();
     enrollment.setEnrollmentDate(new Date());
-    enrollment.setIncidentDate(new Date());
+    enrollment.setOccurredDate(new Date());
     enrollment.setStatus(ProgramStatus.COMPLETED);
     manager.save(enrollment);
     return enrollment;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -697,7 +697,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
     Enrollment enrollment = new Enrollment(program, te, orgUnit);
     enrollment.setAutoFields();
     enrollment.setEnrollmentDate(new Date());
-    enrollment.setIncidentDate(new Date());
+    enrollment.setOccurredDate(new Date());
     enrollment.setStatus(ProgramStatus.COMPLETED);
     manager.save(enrollment, false);
     te.setEnrollments(Set.of(enrollment));

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/trigramsummary/TrigramSummaryControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/trigramsummary/TrigramSummaryControllerTest.java
@@ -188,7 +188,7 @@ class TrigramSummaryControllerTest extends DhisControllerConvenienceTest {
     enrollment = new Enrollment(program, tei, orgUnit);
     enrollment.setAutoFields();
     enrollment.setEnrollmentDate(new Date());
-    enrollment.setIncidentDate(new Date());
+    enrollment.setOccurredDate(new Date());
     enrollment.setStatus(ProgramStatus.COMPLETED);
     enrollment.setFollowup(true);
     manager.save(enrollment);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentMapper.java
@@ -75,7 +75,7 @@ public interface EnrollmentMapper
   @Mapping(target = "program", source = "program.uid")
   @Mapping(target = "orgUnit", source = "organisationUnit.uid")
   @Mapping(target = "enrolledAt", source = "enrollmentDate")
-  @Mapping(target = "occurredAt", source = "incidentDate")
+  @Mapping(target = "occurredAt", source = "occurredDate")
   @Mapping(target = "followUp", source = "followup")
   @Mapping(target = "completedAt", source = "completedDate")
   @Mapping(target = "createdBy", source = "createdByUserInfo")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipItemMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipItemMapper.java
@@ -81,7 +81,7 @@ interface RelationshipItemMapper
   @Mapping(target = "program", source = "program.uid")
   @Mapping(target = "orgUnit", source = "organisationUnit.uid")
   @Mapping(target = "enrolledAt", source = "enrollmentDate")
-  @Mapping(target = "occurredAt", source = "incidentDate")
+  @Mapping(target = "occurredAt", source = "occurredDate")
   @Mapping(target = "followUp", source = "followup")
   @Mapping(target = "completedAt", source = "completedDate")
   @Mapping(target = "createdBy", source = "createdByUserInfo")


### PR DESCRIPTION
`occurredAt` field in `Enrollment` was internally translated to `incidentDate`.
This PR aims to replace all occurrences of `incidentDate` in the service layer to `occurredDate`.
The general rule that we are using is that date fields are suffixed with `At` in the API and then suffixed with `Date` in the service and the DB layer.

**Next PRs**
- Rename `completedAt` in DB layer
- Rename `occurredAt` in DB layer