### PR TITLE
fix: wait until file resource content is available

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
@@ -37,12 +37,26 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import org.hisp.dhis.feedback.NotFoundException;
 
 /**
  * @author Halvdan Hoem Grelland
  */
 public interface FileResourceService {
+
+  @CheckForNull
   FileResource getFileResource(String uid);
+
+  /**
+   * Get the {@link FileResource} with the given ID in the {@link FileResourceStorageStatus#STORED}
+   * status
+   *
+   * @param uid the resource to fetch
+   * @return the file resource in status {@link FileResourceStorageStatus#STORED}
+   * @throws NotFoundException when no such file resource exits
+   */
+  @Nonnull
+  FileResource getFileResourceWhenStored(String uid) throws NotFoundException;
 
   /**
    * Lookup a {@link FileResource} by uid and {@link FileResourceDomain}.
@@ -83,6 +97,7 @@ public interface FileResourceService {
 
   void deleteFileResource(FileResource fileResource);
 
+  @CheckForNull
   InputStream getFileResourceContent(FileResource fileResource);
 
   /** Copy fileResource content to outputStream and Return File content length */

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
@@ -37,6 +37,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.NotFoundException;
 
 /**
@@ -48,15 +49,14 @@ public interface FileResourceService {
   FileResource getFileResource(String uid);
 
   /**
-   * Get the {@link FileResource} with the given ID in the {@link FileResourceStorageStatus#STORED}
-   * status
+   * Get the {@link FileResource} with the given ID
    *
    * @param uid the resource to fetch
-   * @return the file resource in status {@link FileResourceStorageStatus#STORED}
+   * @return the file resource
    * @throws NotFoundException when no such file resource exits
    */
   @Nonnull
-  FileResource getFileResourceWhenStored(String uid) throws NotFoundException;
+  FileResource getExistingFileResource(String uid) throws NotFoundException;
 
   /**
    * Lookup a {@link FileResource} by uid and {@link FileResourceDomain}.
@@ -97,8 +97,8 @@ public interface FileResourceService {
 
   void deleteFileResource(FileResource fileResource);
 
-  @CheckForNull
-  InputStream getFileResourceContent(FileResource fileResource);
+  @Nonnull
+  InputStream getFileResourceContent(FileResource fileResource) throws ConflictException;
 
   /** Copy fileResource content to outputStream and Return File content length */
   void copyFileResourceContent(FileResource fileResource, OutputStream outputStream)

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.time.Duration;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -99,6 +100,10 @@ public interface FileResourceService {
 
   @Nonnull
   InputStream getFileResourceContent(FileResource fileResource) throws ConflictException;
+
+  @Nonnull
+  InputStream getFileResourceContent(FileResource fileResource, Duration timeout)
+      throws ConflictException;
 
   /** Copy fileResource content to outputStream and Return File content length */
   void copyFileResourceContent(FileResource fileResource, OutputStream outputStream)

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceStorageStatus.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceStorageStatus.java
@@ -33,6 +33,5 @@ package org.hisp.dhis.fileresource;
 public enum FileResourceStorageStatus {
   NONE, // No content stored
   PENDING, // In transit to store, not available
-  FAILED, // Storing the resource failed
   STORED // Is available from store
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/JCloudsFileResourceContentStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/JCloudsFileResourceContentStore.java
@@ -194,6 +194,7 @@ public class JCloudsFileResourceContentStore implements FileResourceContentStore
     final Blob blob = getBlob(key);
 
     if (blob == null) {
+
       return null;
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/TrackedEntityInstanceController.java
@@ -73,6 +73,7 @@ import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.fileresource.FileResource;
@@ -205,7 +206,7 @@ public class TrackedEntityInstanceController {
       @RequestParam(required = false) Integer height,
       @RequestParam(required = false) ImageFileDimension dimension,
       HttpServletResponse response)
-      throws WebMessageException {
+      throws WebMessageException, ConflictException {
     User user = currentUserService.getCurrentUser();
 
     TrackedEntity trackedEntity = instanceService.getTrackedEntity(teiId);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportJob.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportJob.java
@@ -82,7 +82,7 @@ public class MetadataImportJob implements Job {
     MetadataImportParams params = (MetadataImportParams) config.getJobParameters();
     progress.startingStage("Loading file resource");
     FileResource data =
-        progress.runStage(() -> fileResourceService.getFileResourceWhenStored(config.getUid()));
+        progress.runStage(() -> fileResourceService.getExistingFileResource(config.getUid()));
     progress.startingStage("Loading file content");
     try (InputStream input =
         progress.runStage(() -> fileResourceService.getFileResourceContent(data))) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportJob.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportJob.java
@@ -82,7 +82,7 @@ public class MetadataImportJob implements Job {
     MetadataImportParams params = (MetadataImportParams) config.getJobParameters();
     progress.startingStage("Loading file resource");
     FileResource data =
-        progress.runStage(() -> fileResourceService.getFileResource(config.getUid()));
+        progress.runStage(() -> fileResourceService.getFileResourceWhenStored(config.getUid()));
     progress.startingStage("Loading file content");
     try (InputStream input =
         progress.runStage(() -> fileResourceService.getFileResourceContent(data))) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportJob.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportJob.java
@@ -67,7 +67,7 @@ public class TrackerImportJob implements Job {
     TrackerImportParams params = (TrackerImportParams) config.getJobParameters();
     progress.startingStage("Loading file resource");
     FileResource data =
-        progress.runStage(() -> fileResourceService.getFileResource(config.getUid()));
+        progress.runStage(() -> fileResourceService.getFileResourceWhenStored(config.getUid()));
     progress.startingStage("Loading file content");
     try (InputStream input =
         progress.runStage(() -> fileResourceService.getFileResourceContent(data))) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportJob.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportJob.java
@@ -67,7 +67,7 @@ public class TrackerImportJob implements Job {
     TrackerImportParams params = (TrackerImportParams) config.getJobParameters();
     progress.startingStage("Loading file resource");
     FileResource data =
-        progress.runStage(() -> fileResourceService.getFileResourceWhenStored(config.getUid()));
+        progress.runStage(() -> fileResourceService.getExistingFileResource(config.getUid()));
     progress.startingStage("Loading file content");
     try (InputStream input =
         progress.runStage(() -> fileResourceService.getFileResourceContent(data))) {


### PR DESCRIPTION
`FileResource` content is stored asynchronously which makes it difficult to work with immediately after calling "save". 
Therefore a sleep-waiting was added.