### PR TITLE
chore: Rename incidentdate to occurreddate in DB [TECH-1665]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
@@ -107,7 +107,7 @@ public class JdbcEnrollmentAnalyticsTableManager extends AbstractEventJdbcTableM
       List.of(
           new AnalyticsTableColumn(quote("pi"), CHARACTER_11, NOT_NULL, "pi.uid"),
           new AnalyticsTableColumn(quote("enrollmentdate"), TIMESTAMP, "pi.enrollmentdate"),
-          new AnalyticsTableColumn(quote("incidentdate"), TIMESTAMP, "pi.incidentdate"),
+          new AnalyticsTableColumn(quote("incidentdate"), TIMESTAMP, "pi.occurreddate"),
           new AnalyticsTableColumn(
               quote("completeddate"),
               TIMESTAMP,
@@ -228,7 +228,7 @@ public class JdbcEnrollmentAnalyticsTableManager extends AbstractEventJdbcTableM
             + "and pi.lastupdated <= '"
             + getLongDateString(params.getStartTime())
             + "' "
-            + "and pi.incidentdate is not null "
+            + "and pi.occurreddate is not null "
             + "and pi.deleted is false ";
 
     populateTableInternal(partition, getDimensionColumns(program), fromClause);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -140,7 +140,7 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
           new AnalyticsTableColumn(quote("ps"), CHARACTER_11, NOT_NULL, "ps.uid"),
           new AnalyticsTableColumn(quote("ao"), CHARACTER_11, NOT_NULL, "ao.uid"),
           new AnalyticsTableColumn(quote("enrollmentdate"), TIMESTAMP, "pi.enrollmentdate"),
-          new AnalyticsTableColumn(quote("incidentdate"), TIMESTAMP, "pi.incidentdate"),
+          new AnalyticsTableColumn(quote("incidentdate"), TIMESTAMP, "pi.occurreddate"),
           new AnalyticsTableColumn(quote("occurreddate"), TIMESTAMP, "psi.occurreddate"),
           new AnalyticsTableColumn(quote("scheduleddate"), TIMESTAMP, "psi.scheduleddate"),
           new AnalyticsTableColumn(quote("completeddate"), TIMESTAMP, "psi.completeddate"),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiEnrollmentsAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiEnrollmentsAnalyticsTableManager.java
@@ -121,7 +121,7 @@ public class JdbcTeiEnrollmentsAnalyticsTableManager extends AbstractJdbcTableMa
           new AnalyticsTableColumn(quote("programinstanceuid"), CHARACTER_11, NULL, "pi.uid"),
           new AnalyticsTableColumn(quote("enrollmentdate"), TIMESTAMP, "pi.enrollmentdate"),
           new AnalyticsTableColumn(quote("enddate"), TIMESTAMP, "pi.completeddate"),
-          new AnalyticsTableColumn(quote("incidentdate"), TIMESTAMP, "pi.incidentdate"),
+          new AnalyticsTableColumn(quote("incidentdate"), TIMESTAMP, "pi.occurreddate"),
           new AnalyticsTableColumn(quote("enrollmentstatus"), VARCHAR_50, "pi.status"),
           new AnalyticsTableColumn(quote("pigeometry"), GEOMETRY, "pi.geometry")
               .withIndexType(GIST),
@@ -256,7 +256,7 @@ public class JdbcTeiEnrollmentsAnalyticsTableManager extends AbstractJdbcTableMa
                 + " and psi.status in ("
                 + join(",", EXPORTABLE_EVENT_STATUSES)
                 + "))")
-        .append(" and pi.incidentdate is not null ")
+        .append(" and pi.occurreddate is not null ")
         .append(" and pi.deleted is false");
 
     invokeTimeAndLog(sql.toString(), partition.getTempTableName());

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
@@ -336,7 +336,7 @@ public class DefaultEnrollmentService implements EnrollmentService {
       Program program,
       ProgramStatus programStatus,
       Date enrollmentDate,
-      Date incidentDate,
+      Date occurredDate,
       OrganisationUnit organisationUnit,
       String uid) {
     if (program.getTrackedEntityType() != null
@@ -356,8 +356,8 @@ public class DefaultEnrollmentService implements EnrollmentService {
       enrollment.setEnrollmentDate(new Date());
     }
 
-    if (incidentDate != null) {
-      enrollment.setOccurredDate(incidentDate);
+    if (occurredDate != null) {
+      enrollment.setOccurredDate(occurredDate);
     } else {
       enrollment.setOccurredDate(new Date());
     }
@@ -373,13 +373,13 @@ public class DefaultEnrollmentService implements EnrollmentService {
       TrackedEntity trackedEntity,
       Program program,
       Date enrollmentDate,
-      Date incidentDate,
+      Date occurredDate,
       OrganisationUnit organisationUnit) {
     return enrollTrackedEntity(
         trackedEntity,
         program,
         enrollmentDate,
-        incidentDate,
+        occurredDate,
         organisationUnit,
         CodeGenerator.generateUid());
   }
@@ -390,7 +390,7 @@ public class DefaultEnrollmentService implements EnrollmentService {
       TrackedEntity trackedEntity,
       Program program,
       Date enrollmentDate,
-      Date incidentDate,
+      Date occurredDate,
       OrganisationUnit organisationUnit,
       String uid) {
     // ---------------------------------------------------------------------
@@ -403,7 +403,7 @@ public class DefaultEnrollmentService implements EnrollmentService {
             program,
             ProgramStatus.ACTIVE,
             enrollmentDate,
-            incidentDate,
+            occurredDate,
             organisationUnit,
             uid);
     addEnrollment(enrollment);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventService.java
@@ -160,7 +160,7 @@ public class DefaultEventService implements EventService {
       Enrollment enrollment,
       ProgramStage programStage,
       Date enrollmentDate,
-      Date incidentDate,
+      Date occurredDate,
       OrganisationUnit organisationUnit) {
     Event event = null;
     Date currentDate = new Date();
@@ -169,7 +169,7 @@ public class DefaultEventService implements EventService {
     if (programStage.getGeneratedByEnrollmentDate()) {
       dateCreatedEvent = enrollmentDate;
     } else {
-      dateCreatedEvent = incidentDate;
+      dateCreatedEvent = occurredDate;
     }
 
     Date dueDate = DateUtils.addDays(dateCreatedEvent, programStage.getMinDaysFromStart());

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vIncidentDate.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vIncidentDate.java
@@ -37,6 +37,6 @@ import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 public class vIncidentDate extends ProgramDateVariable {
   @Override
   public Object getSql(CommonExpressionVisitor visitor) {
-    return "incidentdate";
+    return "occurreddate";
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
@@ -953,14 +953,14 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
 
     if (params.hasProgramIncidentStartDate()) {
       program
-          .append("AND EN.incidentdate >= '")
+          .append("AND EN.occurreddate >= '")
           .append(getLongDateString(params.getProgramIncidentStartDate()))
           .append("' ");
     }
 
     if (params.hasProgramIncidentEndDate()) {
       program
-          .append("AND EN.incidentdate <= '")
+          .append("AND EN.occurreddate <= '")
           .append(getLongDateString(params.getProgramIncidentEndDate()))
           .append("' ");
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Enrollment.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Enrollment.hbm.xml
@@ -28,7 +28,7 @@
 
     <property name="lastUpdatedByUserInfo" type="jbUserInfoSnapshot" column="lastupdatedbyuserinfo"/>
 
-    <property name="occurredDate" column="incidentDate"/>
+    <property name="occurredDate" column="occurreddate"/>
 
     <property name="enrollmentDate" column="enrollmentdate" not-null="true"/>
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
@@ -201,7 +201,7 @@ class ProgramSqlGeneratorVariablesTest extends DhisConvenienceTest {
   @Test
   void testIncidentDate() {
     String sql = castString(test("V{incident_date}", new DefaultLiteral(), eventIndicator));
-    assertThat(sql, is("incidentdate"));
+    assertThat(sql, is("occurreddate"));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/JdbcEventStore.java
@@ -1052,7 +1052,7 @@ public class JdbcEventStore implements EventStore {
 
     return selectBuilder
         .append(
-            "pi.uid as pi_uid, pi.status as pi_status, pi.followup as pi_followup, pi.enrollmentdate as pi_enrollmentdate, pi.incidentdate as pi_incidentdate, ")
+            "pi.uid as pi_uid, pi.status as pi_status, pi.followup as pi_followup, pi.enrollmentdate as pi_enrollmentdate, pi.occurreddate as pi_incidentdate, ")
         .append("p.type as p_type, ps.uid as ps_uid, ou.name as ou_name, ")
         .append(
             "tei.trackedentityid as tei_id, tei.uid as tei_uid, teiou.uid as tei_ou, teiou.name as tei_ou_name, tei.created as tei_created, tei.inactive as tei_inactive ")
@@ -1171,13 +1171,13 @@ public class JdbcEventStore implements EventStore {
           "enrollmentOccurredBefore", params.getEnrollmentOccurredBefore(), Types.TIMESTAMP);
       fromBuilder
           .append(hlp.whereAnd())
-          .append(" (pi.incidentdate <= :enrollmentOccurredBefore ) ");
+          .append(" (pi.occurreddate <= :enrollmentOccurredBefore ) ");
     }
 
     if (params.getEnrollmentOccurredAfter() != null) {
       mapSqlParameterSource.addValue(
           "enrollmentOccurredAfter", params.getEnrollmentOccurredAfter(), Types.TIMESTAMP);
-      fromBuilder.append(hlp.whereAnd()).append(" (pi.incidentdate >= :enrollmentOccurredAfter ) ");
+      fromBuilder.append(hlp.whereAnd()).append(" (pi.occurreddate >= :enrollmentOccurredAfter ) ");
     }
 
     if (params.getDueDateStart() != null) {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/trackedentity/store/query/EnrollmentQuery.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/trackedentity/store/query/EnrollmentQuery.java
@@ -77,7 +77,7 @@ public class EnrollmentQuery {
           .put(COLUMNS.LAST_UPDATED_BY, new TableColumn("pi", "lastupdatedbyuserinfo"))
           .put(COLUMNS.STATUS, new TableColumn("pi", "status"))
           .put(COLUMNS.ENROLLMENTDATE, new TableColumn("pi", "enrollmentdate"))
-          .put(COLUMNS.INCIDENTDATE, new TableColumn("pi", "incidentdate"))
+          .put(COLUMNS.INCIDENTDATE, new TableColumn("pi", "occurreddate"))
           .put(COLUMNS.FOLLOWUP, new TableColumn("pi", "followup"))
           .put(COLUMNS.COMPLETED, new TableColumn("pi", "completeddate"))
           .put(COLUMNS.COMPLETEDBY, new TableColumn("pi", "completedby"))

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -791,7 +791,7 @@ class JdbcEventStore implements EventStore {
                 + COLUMN_ENROLLMENT_FOLLOWUP
                 + ", en.enrollmentdate as "
                 + COLUMN_ENROLLMENT_DATE
-                + ", en.incidentdate as en_incidentdate, ")
+                + ", en.occurreddate as en_occurreddate, ")
         .append("p.type as p_type, ")
         .append("te.trackedentityid as te_id, te.uid as ")
         .append(COLUMN_TRACKEDENTITY_UID)
@@ -914,13 +914,13 @@ class JdbcEventStore implements EventStore {
           "enrollmentOccurredBefore", params.getEnrollmentOccurredBefore(), Types.TIMESTAMP);
       fromBuilder
           .append(hlp.whereAnd())
-          .append(" (en.incidentdate <= :enrollmentOccurredBefore ) ");
+          .append(" (en.occurreddate <= :enrollmentOccurredBefore ) ");
     }
 
     if (params.getEnrollmentOccurredAfter() != null) {
       mapSqlParameterSource.addValue(
           "enrollmentOccurredAfter", params.getEnrollmentOccurredAfter(), Types.TIMESTAMP);
-      fromBuilder.append(hlp.whereAnd()).append(" (en.incidentdate >= :enrollmentOccurredAfter ) ");
+      fromBuilder.append(hlp.whereAnd()).append(" (en.occurreddate >= :enrollmentOccurredAfter ) ");
     }
 
     if (params.getScheduleAtStartDate() != null) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -786,14 +786,14 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
 
     if (params.hasProgramIncidentStartDate()) {
       program
-          .append("AND EN.incidentdate >= '")
+          .append("AND EN.occurreddate >= '")
           .append(getLongDateString(params.getProgramIncidentStartDate()))
           .append("' ");
     }
 
     if (params.hasProgramIncidentEndDate()) {
       program
-          .append("AND EN.incidentdate <= '")
+          .append("AND EN.occurreddate <= '")
           .append(getLongDateString(params.getProgramIncidentEndDate()))
           .append("' ");
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/mapper/EnrollmentRowCallbackHandler.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/mapper/EnrollmentRowCallbackHandler.java
@@ -98,7 +98,7 @@ public class EnrollmentRowCallbackHandler extends AbstractMapper<Enrollment> {
     enrollment.setEnrollmentDate(
         rs.getTimestamp(EnrollmentQuery.getColumnName(COLUMNS.ENROLLMENTDATE)));
     enrollment.setOccurredDate(
-        rs.getTimestamp(EnrollmentQuery.getColumnName(COLUMNS.INCIDENTDATE)));
+        rs.getTimestamp(EnrollmentQuery.getColumnName(COLUMNS.OCCURREDDATE)));
     enrollment.setCompletedDate(rs.getTimestamp(EnrollmentQuery.getColumnName(COLUMNS.COMPLETED)));
     enrollment.setCompletedBy(rs.getString(EnrollmentQuery.getColumnName(COLUMNS.COMPLETEDBY)));
     enrollment.setStoredBy(rs.getString(EnrollmentQuery.getColumnName(COLUMNS.STOREDBY)));

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/query/EnrollmentQuery.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/query/EnrollmentQuery.java
@@ -47,7 +47,7 @@ public class EnrollmentQuery {
     STATUS,
     GEOMETRY,
     ENROLLMENTDATE,
-    INCIDENTDATE,
+    OCCURREDDATE,
     FOLLOWUP,
     COMPLETED,
     COMPLETEDBY,
@@ -74,7 +74,7 @@ public class EnrollmentQuery {
           .put(COLUMNS.LAST_UPDATED_BY, new TableColumn("en", "lastupdatedbyuserinfo"))
           .put(COLUMNS.STATUS, new TableColumn("en", "status"))
           .put(COLUMNS.ENROLLMENTDATE, new TableColumn("en", "enrollmentdate"))
-          .put(COLUMNS.INCIDENTDATE, new TableColumn("en", "incidentdate"))
+          .put(COLUMNS.OCCURREDDATE, new TableColumn("en", "occurreddate"))
           .put(COLUMNS.FOLLOWUP, new TableColumn("en", "followup"))
           .put(COLUMNS.COMPLETED, new TableColumn("en", "completeddate"))
           .put(COLUMNS.COMPLETEDBY, new TableColumn("en", "completedby"))

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_38__RenameIncidentDateToOccurredDateInEnrollmentTable.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_38__RenameIncidentDateToOccurredDateInEnrollmentTable.sql
@@ -1,0 +1,11 @@
+-- rename enddate in enrollment
+
+do $$
+begin
+  if exists(select 1
+    from information_schema.columns
+    where table_schema != 'information_schema' and table_name='enrollment' and column_name='incidentdate')
+  then
+alter table enrollment rename column incidentdate to occurreddate;
+end if;
+end $$;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceTest.java
@@ -487,7 +487,7 @@ class ProgramIndicatorServiceTest extends TransactionalIntegrationTest {
 
   @Test
   void testGetAnalyticsSQl2() {
-    String expected = "((cast(incidentdate as date) - cast(enrollmentdate as date))) / 7.0";
+    String expected = "((cast(occurreddate as date) - cast(enrollmentdate as date))) / 7.0";
     assertEquals(
         expected,
         programIndicatorService.getAnalyticsSql(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceVariableTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceVariableTest.java
@@ -219,8 +219,8 @@ class ProgramIndicatorServiceVariableTest extends IntegrationTestBase {
 
   @Test
   void testIncidentDate() {
-    assertEquals("incidentdate", getSql("V{incident_date}"));
-    assertEquals("incidentdate", getSqlEnrollment("V{incident_date}"));
+    assertEquals("occurreddate", getSql("V{incident_date}"));
+    assertEquals("occurreddate", getSqlEnrollment("V{incident_date}"));
   }
 
   @Test


### PR DESCRIPTION
Following on https://github.com/dhis2/dhis2-core/pull/15687

This PR aims to replace all occurrences of incidentDate in the DB and repository layer to occurredDate.
The general rule that we are using is that date fields are suffixed with At in the API and then suffixed with Date in the service and the DB layer.