### PR TITLE
feat: support token filter with translated value [DHIS2-15757]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/TokenOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/TokenOperator.java
@@ -27,20 +27,14 @@
  */
 package org.hisp.dhis.query.operators;
 
-import static org.hisp.dhis.user.UserSettingKey.DB_LOCALE;
-import static org.hisp.dhis.user.UserSettingKey.UI_LOCALE;
-
-import java.util.Locale;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
-import org.apache.commons.lang3.ObjectUtils;
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Restrictions;
 import org.hisp.dhis.hibernate.jsonb.type.JsonbFunctions;
 import org.hisp.dhis.query.Typed;
 import org.hisp.dhis.query.planner.QueryPath;
-import org.hisp.dhis.user.CurrentUserUtil;
 
 /**
  * @author Henning Håkonsen
@@ -76,10 +70,8 @@ public class TokenOperator<T extends Comparable<? super T>> extends Operator<T> 
                 root.get(queryPath.getPath()),
                 builder.literal(TokenUtils.createRegex(value).toString())),
             true);
-    Locale currentLocale =
-        ObjectUtils.defaultIfNull(
-            CurrentUserUtil.getUserSetting(DB_LOCALE), CurrentUserUtil.getUserSetting(UI_LOCALE));
-    if (currentLocale == null
+
+    if (queryPath.getLocale() == null
         || !queryPath.getProperty().isTranslatable()
         || queryPath.getProperty().getTranslationKey() == null) {
       return defaultSearch;
@@ -90,7 +82,7 @@ public class TokenOperator<T extends Comparable<? super T>> extends Operator<T> 
             Boolean.class,
             root.get("translations"),
             builder.literal("{" + queryPath.getProperty().getTranslationKey() + "}"),
-            builder.literal(currentLocale.getLanguage()),
+            builder.literal(queryPath.getLocale().getLanguage()),
             builder.literal(TokenUtils.createRegex(value).toString())),
         true);
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/QueryPath.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/QueryPath.java
@@ -30,15 +30,16 @@ package org.hisp.dhis.query.planner;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import java.util.Arrays;
-import lombok.AllArgsConstructor;
+import java.util.Locale;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.schema.Property;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class QueryPath {
   private final Property property;
 
@@ -47,6 +48,12 @@ public class QueryPath {
   private final String[] alias;
 
   private static final Joiner PATH_JOINER = Joiner.on(".");
+
+  /**
+   * If this locale is not null then the query must use the translations jsonb column instead of
+   * default properties.
+   */
+  private Locale locale;
 
   public QueryPath(Property property, boolean persisted) {
     this(property, persisted, new String[0]);
@@ -68,6 +75,14 @@ public class QueryPath {
 
   public boolean haveAlias(int n) {
     return alias != null && alias.length > n;
+  }
+
+  public void setLocale(Locale locale) {
+    this.locale = locale;
+  }
+
+  public Locale getLocale() {
+    return locale;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/DefaultQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/DefaultQueryServiceTest.java
@@ -42,6 +42,7 @@ import org.hisp.dhis.query.planner.DefaultQueryPlanner;
 import org.hisp.dhis.query.planner.QueryPlanner;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.schema.descriptors.OrganisationUnitSchemaDescriptor;
+import org.hisp.dhis.setting.SystemSettingManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -65,9 +66,11 @@ class DefaultQueryServiceTest {
 
   @Mock private SchemaService schemaService;
 
+  @Mock private SystemSettingManager systemSettingManager;
+
   @BeforeEach
   public void setUp() {
-    QueryPlanner queryPlanner = new DefaultQueryPlanner(schemaService);
+    QueryPlanner queryPlanner = new DefaultQueryPlanner(schemaService, systemSettingManager);
     subject =
         new DefaultQueryService(
             queryParser, queryPlanner, criteriaQueryEngine, inMemoryQueryEngine);

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/planner/DefaultQueryPlannerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/planner/DefaultQueryPlannerTest.java
@@ -44,6 +44,7 @@ import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.schema.descriptors.DataElementSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.OrganisationUnitSchemaDescriptor;
+import org.hisp.dhis.setting.SystemSettingManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -60,9 +61,11 @@ class DefaultQueryPlannerTest {
 
   @Mock private SchemaService schemaService;
 
+  @Mock private SystemSettingManager systemSettingManager;
+
   @BeforeEach
   public void setUp() {
-    this.subject = new DefaultQueryPlanner(schemaService);
+    this.subject = new DefaultQueryPlanner(schemaService, systemSettingManager);
   }
 
   @Test

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_39__Create_jsonb_function_search_translations_token.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_39__Create_jsonb_function_search_translations_token.sql
@@ -1,0 +1,19 @@
+/**
+  Find translated value that matches given token and given locale.
+    @param $1 the translations column name
+    @param $2 the properties to search for (array of strings such as '{NAME,SHORT_NAME}')
+    @param $3 the locale language to search for
+    @param $4 the token to search (example : '(?=.*année)')
+ */
+CREATE OR replace FUNCTION jsonb_search_translated_token(jsonb, text, text, text)
+RETURNS bool
+AS $$
+SELECT exists(
+    SELECT 1
+    FROM  jsonb_array_elements($1) trans
+    WHERE trans->>'property' = ANY ($2::text[])
+         AND trans->>'locale' = $3
+         AND trans->>'value' ~* $4
+);
+$$
+LANGUAGE SQL IMMUTABLE PARALLEL SAFE;

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/jsonb/type/JsonbFunctions.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/jsonb/type/JsonbFunctions.java
@@ -79,4 +79,6 @@ public class JsonbFunctions {
    * to search $2 Regular expression for matching
    */
   public static final String REGEXP_SEARCH = "regexp_search";
+
+  public static final String SEARCH_TRANSLATION_TOKEN = "jsonb_search_translated_token";
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractDatastoreControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractDatastoreControllerTest.java
@@ -29,23 +29,12 @@ package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.utils.JavaToJson.toJson;
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import org.hisp.dhis.jsontree.JsonArray;
-import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserSettingKey;
-import org.hisp.dhis.user.UserSettingService;
 import org.hisp.dhis.utils.JavaToJson;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
-import org.hisp.dhis.webapi.DhisControllerIntegrationTest;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Base class for testing the {@link DatastoreController} providing helpers to set up entries in the
@@ -78,53 +67,5 @@ abstract class AbstractDatastoreControllerTest extends DhisControllerConvenience
             "eats",
             eats == null ? List.of() : eats.stream().map(food -> Map.of("name", food)));
     postEntry("pets", key, toJson(obj));
-  }
-
-  static class CrudControllerIntegrationTest extends DhisControllerIntegrationTest {
-
-    @Autowired private UserSettingService userSettingService;
-
-    @Test
-    void testSearchByToken() {
-      String id =
-          assertStatus(
-              HttpStatus.CREATED,
-              POST(
-                  "/dataSets/",
-                  "{'name':'My data set', 'shortName': 'MDS', 'periodType':'Monthly'}"));
-
-      PUT(
-              "/dataSets/" + id + "/translations",
-              "{'translations': [{'locale':'fr', 'property':'NAME', 'value':'fr dataSet'}]}")
-          .content(HttpStatus.NO_CONTENT);
-
-      JsonArray translations =
-          GET("/dataSets/{id}/translations", id).content().getArray("translations");
-      assertEquals(1, translations.size());
-
-      assertTrue(
-          GET("/dataSets?filter=identifiable:token:fr", id)
-              .content()
-              .getArray("dataSets")
-              .isEmpty());
-      User userA = createAndAddUser("userA", null, "ALL");
-      userSettingService.saveUserSetting(UserSettingKey.DB_LOCALE, Locale.FRENCH, userA);
-      injectSecurityContext(userA);
-      assertTrue(
-          GET("/dataSets?filter=identifiable:token:bb", id)
-              .content()
-              .getArray("dataSets")
-              .isEmpty());
-      assertFalse(
-          GET("/dataSets?filter=identifiable:token:fr", id)
-              .content()
-              .getArray("dataSets")
-              .isEmpty());
-      assertFalse(
-          GET("/dataSets?filter=identifiable:token:dataSet", id)
-              .content()
-              .getArray("dataSets")
-              .isEmpty());
-    }
   }
 }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandControllerTest.java
@@ -72,6 +72,7 @@ import org.hisp.dhis.random.BeanRandomizer;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.mvc.messageconverter.JsonMessageConverter;
@@ -109,6 +110,8 @@ class DataElementOperandControllerTest {
 
   @Mock private CategoryService dataElementCategoryService;
 
+  @Mock private SystemSettingManager systemSettingManager;
+
   private QueryService queryService;
 
   @Mock private CurrentUserService currentUserService;
@@ -124,7 +127,7 @@ class DataElementOperandControllerTest {
     QueryService _queryService =
         new DefaultQueryService(
             new DefaultJpaQueryParser(schemaService),
-            new DefaultQueryPlanner(schemaService),
+            new DefaultQueryPlanner(schemaService, systemSettingManager),
             mock(JpaCriteriaQueryEngine.class),
             new InMemoryQueryEngine<>(schemaService, mock(AclService.class), currentUserService));
     // Use "spy" on queryService, because we want a partial mock: we only


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-15757

#### Summary
- Current api filter `identifiable:token:aaa` search for records using those fields : uid, code, name, shortName. However the filter does not support search by translated value with user selected locale.
#### Solution
- Add a jsonb function `jsonb_search_translated_token` which looks up the token in `translations` jsonb column instead of the default column.
- The logic of choosing `translations` or default columns for querying  depends on UserSetting DB_LOCALE and SystemSetting DB_LOCALE. We only query `translations` column if user locale is different from system locale.
#### Test
- Added  tests in `CrudControllerIntegrationTest`