### PR TITLE
feat: save file resource content synchronously for jobs [DHIS2-15276]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -336,6 +336,8 @@ public enum ErrorCode {
   /* File resource */
   E6100("Filename not present"),
   E6101("File type not allowed"),
+  E6102("File content could not be stored"),
+  E6103("File resource appears to have no content"),
 
   /* Users */
   E6200("Feedback message recipients user group not defined"),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
-import java.time.Duration;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -90,9 +89,31 @@ public interface FileResourceService {
    */
   List<FileResourceOwner> findOwnersByStorageKey(@CheckForNull String storageKey);
 
-  void saveFileResource(FileResource fileResource, File file);
+  /**
+   * Creates the provided file resource and stores the file content asynchronously.
+   *
+   * @param fileResource the resource to create
+   * @param file the content stored asynchronously
+   */
+  void asyncSaveFileResource(FileResource fileResource, File file);
 
-  String saveFileResource(FileResource fileResource, byte[] bytes);
+  /**
+   * Creates the provided file resource and stores the content asynchronously.
+   *
+   * @param fileResource the resource to create
+   * @param bytes the content stored asynchronously
+   * @return the UID of the created file resource
+   */
+  String asyncSaveFileResource(FileResource fileResource, byte[] bytes);
+
+  /**
+   * Creates the provided file resource and stores the content synchronously.
+   *
+   * @param fileResource the resource to create
+   * @param bytes the content stored asynchronously
+   * @return the UID of the created file resource
+   */
+  String syncSaveFileResource(FileResource fileResource, byte[] bytes) throws ConflictException;
 
   void deleteFileResource(String uid);
 
@@ -100,10 +121,6 @@ public interface FileResourceService {
 
   @Nonnull
   InputStream getFileResourceContent(FileResource fileResource) throws ConflictException;
-
-  @Nonnull
-  InputStream getFileResourceContent(FileResource fileResource, Duration timeout)
-      throws ConflictException;
 
   /** Copy fileResource content to outputStream and Return File content length */
   void copyFileResourceContent(FileResource fileResource, OutputStream outputStream)

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
@@ -129,7 +129,7 @@ public class DefaultJobConfigurationService implements JobConfigurationService {
               FileResourceDomain.JOB_DATA);
       fr.setUid(uid);
       fr.setAssigned(true);
-      fileResourceService.saveFileResource(fr, data);
+      fileResourceService.syncSaveFileResource(fr, data);
     } catch (IOException ex) {
       throw new ConflictException("Failed to create job data file resource: " + ex.getMessage());
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceServiceTest.java
@@ -102,7 +102,7 @@ class FileResourceServiceTest {
 
     File file = new File("");
 
-    subject.saveFileResource(fileResource, file);
+    subject.asyncSaveFileResource(fileResource, file);
 
     verify(fileResourceStore).save(fileResource);
     verify(entityManager).flush();
@@ -122,7 +122,8 @@ class FileResourceServiceTest {
             "very_evil_script.html", "text/html", 1024, "md5", FileResourceDomain.USER_AVATAR);
 
     File file = new File("very_evil_script.html");
-    assertThrows(IllegalQueryException.class, () -> subject.saveFileResource(fileResource, file));
+    assertThrows(
+        IllegalQueryException.class, () -> subject.asyncSaveFileResource(fileResource, file));
   }
 
   @Test
@@ -136,7 +137,8 @@ class FileResourceServiceTest {
             FileResourceDomain.MESSAGE_ATTACHMENT);
 
     File file = new File("suspicious_program.rpm");
-    assertThrows(IllegalQueryException.class, () -> subject.saveFileResource(fileResource, file));
+    assertThrows(
+        IllegalQueryException.class, () -> subject.asyncSaveFileResource(fileResource, file));
   }
 
   @Test
@@ -157,7 +159,7 @@ class FileResourceServiceTest {
 
     fileResource.setUid("imageUid1");
 
-    subject.saveFileResource(fileResource, file);
+    subject.asyncSaveFileResource(fileResource, file);
 
     verify(fileResourceStore).save(fileResource);
     verify(entityManager).flush();
@@ -211,7 +213,7 @@ class FileResourceServiceTest {
 
     fileResource.setUid("imageUid1");
 
-    subject.saveFileResource(fileResource, file);
+    subject.asyncSaveFileResource(fileResource, file);
 
     verify(fileResourceStore).save(fileResource);
     verify(entityManager).flush();

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java
@@ -441,7 +441,7 @@ public class DefaultPushAnalysisService implements PushAnalysisService {
 
     fileResource.setAssigned(true);
 
-    String fileResourceUid = fileResourceService.saveFileResource(fileResource, bytes);
+    String fileResourceUid = fileResourceService.asyncSaveFileResource(fileResource, bytes);
 
     externalFileResource.setFileResource(fileResourceService.getFileResource(fileResourceUid));
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/TrackedEntityServiceTest.java
@@ -162,7 +162,7 @@ class TrackedEntityServiceTest extends TransactionalIntegrationTest {
   protected void setUpTest() throws Exception {
 
     fileResource = createFileResource('F', "fileResource".getBytes());
-    fileResourceService.saveFileResource(fileResource, "fileResource".getBytes());
+    fileResourceService.asyncSaveFileResource(fileResource, "fileResource".getBytes());
 
     userService = _userService;
     user = createAndAddAdminUser(AUTHORITY_ALL);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
@@ -182,12 +182,12 @@ class FileResourceCleanUpJobTest extends IntegrationTestBase {
     content = "filecontentA".getBytes(StandardCharsets.UTF_8);
     FileResource fileResourceA = createFileResource('A', content);
     fileResourceA.setCreated(DateTime.now().minus(Days.ONE).toDate());
-    String uidA = fileResourceService.saveFileResource(fileResourceA, content);
+    String uidA = fileResourceService.asyncSaveFileResource(fileResourceA, content);
 
     content = "filecontentB".getBytes(StandardCharsets.UTF_8);
     FileResource fileResourceB = createFileResource('A', content);
     fileResourceB.setCreated(DateTime.now().minus(Days.ONE).toDate());
-    String uidB = fileResourceService.saveFileResource(fileResourceB, content);
+    String uidB = fileResourceService.asyncSaveFileResource(fileResourceB, content);
 
     User userB = makeUser("B");
     userB.setAvatar(fileResourceB);
@@ -259,7 +259,7 @@ class FileResourceCleanUpJobTest extends IntegrationTestBase {
     organisationUnitService.addOrganisationUnit(orgUnit);
 
     FileResource fileResource = createFileResource(uniqueChar, content);
-    String uid = fileResourceService.saveFileResource(fileResource, content);
+    String uid = fileResourceService.asyncSaveFileResource(fileResource, content);
 
     DataValue dataValue = createDataValue(fileElement, period, orgUnit, uid, null);
     fileResource.setAssigned(true);
@@ -275,7 +275,7 @@ class FileResourceCleanUpJobTest extends IntegrationTestBase {
   private ExternalFileResource createExternal(char uniqueChar, byte[] content) {
     ExternalFileResource externalFileResource = createExternalFileResource(uniqueChar, content);
 
-    fileResourceService.saveFileResource(externalFileResource.getFileResource(), content);
+    fileResourceService.asyncSaveFileResource(externalFileResource.getFileResource(), content);
     externalFileResourceService.saveExternalFileResource(externalFileResource);
 
     FileResource fileResource = externalFileResource.getFileResource();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/icon/IconTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/icon/IconTest.java
@@ -226,7 +226,7 @@ class IconTest extends TrackerTest {
     fileResource.setCreated(new Date());
     fileResource.setAutoFields();
 
-    String fileResourceUid = fileResourceService.saveFileResource(fileResource, content);
+    String fileResourceUid = fileResourceService.asyncSaveFileResource(fileResource, content);
     return fileResourceService.getFileResource(fileResourceUid);
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitServiceTest.java
@@ -1020,7 +1020,7 @@ class OrganisationUnitServiceTest extends SingleSetupIntegrationTestBase {
     fileResource.setAssigned(false);
     fileResource.setCreated(new Date());
     fileResource.setAutoFields();
-    fileResourceService.saveFileResource(fileResource, content);
+    fileResourceService.asyncSaveFileResource(fileResource, content);
     OrganisationUnit orgUnit = createOrganisationUnit('A');
     orgUnit.setImage(fileResource);
     organisationUnitService.addOrganisationUnit(orgUnit);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentityattributevalue/TrackedEntityAttributeValueServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentityattributevalue/TrackedEntityAttributeValueServiceTest.java
@@ -198,10 +198,10 @@ class TrackedEntityAttributeValueServiceTest extends TransactionalIntegrationTes
     content = "filecontentA".getBytes();
     fileResourceA = createFileResource('A', content);
     fileResourceA.setContentType("image/jpg");
-    fileResourceService.saveFileResource(fileResourceA, content);
+    fileResourceService.asyncSaveFileResource(fileResourceA, content);
     content = "filecontentB".getBytes();
     fileResourceB = createFileResource('B', content);
-    fileResourceService.saveFileResource(fileResourceB, content);
+    fileResourceService.asyncSaveFileResource(fileResourceB, content);
     attributeValueA = createTrackedEntityAttributeValue('A', entityInstanceA, attributeA);
     attributeValueB = createTrackedEntityAttributeValue('B', entityInstanceB, attributeB);
     attributeValueA.setValue(fileResourceA.getUid());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityProgramAttributeFileResourceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackedEntityProgramAttributeFileResourceTest.java
@@ -79,7 +79,7 @@ class TrackedEntityProgramAttributeFileResourceTest extends TrackerTest {
             FileResourceDomain.DOCUMENT);
     fileResource.setUid("Jzf6hHNP7jx");
     File file = File.createTempFile("file-resource", "test");
-    fileResourceService.saveFileResource(fileResource, file);
+    fileResourceService.asyncSaveFileResource(fileResource, file);
     assertFalse(fileResource.isAssigned());
     ImportReport importReport =
         trackerImportService.importTracker(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TeTaValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TeTaValidationTest.java
@@ -79,7 +79,7 @@ class TeTaValidationTest extends TrackerTest {
             FileResourceDomain.DOCUMENT);
     fileResource.setUid("Jzf6hHNP7jx");
     File file = File.createTempFile("file-resource", "test");
-    fileResourceService.saveFileResource(fileResource, file);
+    fileResourceService.asyncSaveFileResource(fileResource, file);
     assertFalse(fileResource.isAssigned());
     TrackerObjects trackerObjects =
         fromJson("tracker/validations/te-program_with_tea_fileresource_data.json");
@@ -105,7 +105,7 @@ class TeTaValidationTest extends TrackerTest {
             FileResourceDomain.DOCUMENT);
     fileResource.setUid("Jzf6hHNP7jx");
     File file = File.createTempFile("file-resource", "test");
-    fileResourceService.saveFileResource(fileResource, file);
+    fileResourceService.asyncSaveFileResource(fileResource, file);
     assertFalse(fileResource.isAssigned());
     TrackerObjects trackerObjects =
         fromJson("tracker/validations/te-program_with_tea_fileresource_data.json");

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FileResourceUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FileResourceUtils.java
@@ -210,7 +210,7 @@ public class FileResourceUtils {
       throw new WebMessageException(
           conflict(ErrorCode.E1119, FileResource.class.getSimpleName(), uid));
     }
-    fileResourceService.saveFileResource(fileResource, tmpFile);
+    fileResourceService.asyncSaveFileResource(fileResource, tmpFile);
     return fileResource;
   }
 


### PR DESCRIPTION
### Summary
To ensure the file content of a job that runs immediately is already saved a new method is added to the file resources service which stores the content synchronously via JClouds.

For clarity the existing methods that save the content asynchronously were renamed to reflect this.

New error codes are added for two cases:
* failed to store content synchronously
* content was loaded expecting it exists but it still is null

### Manual Testing
* run many metadata and/or tracker imports (do many POSTs in short order, could be same payload)
* check they all execute in a sequence with no multiple-seconds gaps (see timestamps of the created job configurations)

### Automatic Testing
Existing tests indirectly cover the synchronous content storage as it is now used for metadata and tracker imports.
If all of them pass and the runtime for e2e tests has not increased notably beyond about 15min the behavior is as expected.

The new two error codes cannot be integration tested as this requires a failure of the cloud storage which cannot be simulated (with reasonable effort) except via mocking which at this point adds little value.