### PR TITLE
chore: file resource save cleanup

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceContentStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceContentStore.java
@@ -34,6 +34,8 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 /**
  * @author Halvdan Hoem Grelland
@@ -64,7 +66,8 @@ public interface FileResourceContentStore {
    * @param bytes the byte array.
    * @return the key on success or null if saving failed.
    */
-  String saveFileResourceContent(FileResource fileResource, byte[] bytes);
+  @CheckForNull
+  String saveFileResourceContent(@Nonnull FileResource fileResource, @Nonnull byte[] bytes);
 
   /**
    * Save the contents of the File to the file store.
@@ -73,7 +76,8 @@ public interface FileResourceContentStore {
    * @param file the File. Will be consumed upon deletion.
    * @return the key on success or null if saving failed.
    */
-  String saveFileResourceContent(FileResource fileResource, File file);
+  @CheckForNull
+  String saveFileResourceContent(@Nonnull FileResource fileResource, @Nonnull File file);
 
   /**
    * Save the content of image files.
@@ -82,8 +86,9 @@ public interface FileResourceContentStore {
    * @param imageFile will map image dimension to its associated file.
    * @return the key on success or null if saving failed.
    */
+  @CheckForNull
   String saveFileResourceContent(
-      FileResource fileResource, Map<ImageFileDimension, File> imageFile);
+      @Nonnull FileResource fileResource, @Nonnull Map<ImageFileDimension, File> imageFile);
 
   /**
    * Delete the content bytes of a file resource.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/events/BinaryFileSavedEvent.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/events/BinaryFileSavedEvent.java
@@ -27,24 +27,16 @@
  */
 package org.hisp.dhis.fileresource.events;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 /**
  * @Author Zubair Asghar.
  */
+@Getter
+@RequiredArgsConstructor
 public class BinaryFileSavedEvent {
-  private String fileResource;
 
-  private byte[] bytes;
-
-  public BinaryFileSavedEvent(String fileResource, byte[] bytes) {
-    this.fileResource = fileResource;
-    this.bytes = bytes;
-  }
-
-  public String getFileResource() {
-    return fileResource;
-  }
-
-  public byte[] getBytes() {
-    return bytes;
-  }
+  private final String fileResource;
+  private final byte[] bytes;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/events/FileDeletedEvent.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/events/FileDeletedEvent.java
@@ -27,33 +27,18 @@
  */
 package org.hisp.dhis.fileresource.events;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.fileresource.FileResourceDomain;
 
 /**
  * @Author Zubair Asghar.
  */
+@Getter
+@RequiredArgsConstructor
 public class FileDeletedEvent {
-  private String storageKey;
 
-  private String contentType;
-
-  private FileResourceDomain domain;
-
-  public FileDeletedEvent(String storageKey, String contentType, FileResourceDomain domain) {
-    this.storageKey = storageKey;
-    this.contentType = contentType;
-    this.domain = domain;
-  }
-
-  public String getStorageKey() {
-    return storageKey;
-  }
-
-  public String getContentType() {
-    return contentType;
-  }
-
-  public FileResourceDomain getDomain() {
-    return domain;
-  }
+  private final String storageKey;
+  private final String contentType;
+  private final FileResourceDomain domain;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/events/FileSavedEvent.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/events/FileSavedEvent.java
@@ -28,25 +28,16 @@
 package org.hisp.dhis.fileresource.events;
 
 import java.io.File;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 /**
  * @Author Zubair Asghar.
  */
+@Getter
+@RequiredArgsConstructor
 public class FileSavedEvent {
-  private String fileResource;
 
-  private File file;
-
-  public FileSavedEvent(String fileResource, File file) {
-    this.fileResource = fileResource;
-    this.file = file;
-  }
-
-  public String getFileResource() {
-    return fileResource;
-  }
-
-  public File getFile() {
-    return file;
-  }
+  private final String fileResource;
+  private final File file;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/events/ImageFileSavedEvent.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/events/ImageFileSavedEvent.java
@@ -29,26 +29,17 @@ package org.hisp.dhis.fileresource.events;
 
 import java.io.File;
 import java.util.Map;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.fileresource.ImageFileDimension;
 
 /**
  * @Author Zubair Asghar.
  */
+@Getter
+@RequiredArgsConstructor
 public class ImageFileSavedEvent {
-  private String fileResource;
 
-  private Map<ImageFileDimension, File> imageFiles;
-
-  public ImageFileSavedEvent(String fileResource, Map<ImageFileDimension, File> imageFiles) {
-    this.fileResource = fileResource;
-    this.imageFiles = imageFiles;
-  }
-
-  public String getFileResource() {
-    return fileResource;
-  }
-
-  public Map<ImageFileDimension, File> getImageFiles() {
-    return imageFiles;
-  }
+  private final String fileResource;
+  private final Map<ImageFileDimension, File> imageFiles;
 }


### PR DESCRIPTION
Some cleanup around file resource save operations

* use `@Getter` and `@RequiredArgsConstructor` for events
* remove duplication in save methods (`File` vs `byte[]`)