### PR TITLE
fix: getScheduledNotifications() should take in DataSetNotificationTrigger

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/notifications/DataSetNotificationTemplateService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/notifications/DataSetNotificationTemplateService.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.dataset.notifications;
 
 import java.util.List;
 import org.hisp.dhis.dataset.DataSet;
-import org.hisp.dhis.program.notification.NotificationTrigger;
 
 /** Created by zubair@dhis2.org on 20.07.17. */
 public interface DataSetNotificationTemplateService {
@@ -39,7 +38,7 @@ public interface DataSetNotificationTemplateService {
 
   List<DataSetNotificationTemplate> getCompleteNotifications(DataSet dataSet);
 
-  List<DataSetNotificationTemplate> getScheduledNotifications(NotificationTrigger trigger);
+  List<DataSetNotificationTemplate> getScheduledNotifications(DataSetNotificationTrigger trigger);
 
   List<DataSetNotificationTemplate> getAll();
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/notifications/DataSetNotificationTemplateStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/notifications/DataSetNotificationTemplateStore.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.dataset.notifications;
 import java.util.List;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 import org.hisp.dhis.dataset.DataSet;
-import org.hisp.dhis.program.notification.NotificationTrigger;
 
 /** Created by zubair@dhis2.org on 13.07.17. */
 public interface DataSetNotificationTemplateStore
@@ -38,5 +37,5 @@ public interface DataSetNotificationTemplateStore
   List<DataSetNotificationTemplate> getNotificationsByTriggerType(
       DataSet dataSet, DataSetNotificationTrigger trigger);
 
-  List<DataSetNotificationTemplate> getScheduledNotifications(NotificationTrigger trigger);
+  List<DataSetNotificationTemplate> getScheduledNotifications(DataSetNotificationTrigger trigger);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DefaultDataSetNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DefaultDataSetNotificationService.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.dataset.notifications;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
-import static org.hisp.dhis.program.notification.NotificationTrigger.SCHEDULED_DAYS_DUE_DATE;
 import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM_OUTLIER;
 
 import com.google.common.base.Function;
@@ -149,7 +148,7 @@ public class DefaultDataSetNotificationService implements DataSetNotificationSer
   @Override
   public void sendScheduledDataSetNotificationsForDay(Date day, JobProgress progress) {
     List<DataSetNotificationTemplate> templates =
-        dsntService.getScheduledNotifications(SCHEDULED_DAYS_DUE_DATE);
+        dsntService.getScheduledNotifications(DataSetNotificationTrigger.SCHEDULED_DAYS);
 
     if (templates == null || templates.isEmpty()) {
       log.info("No template found");

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DefaultDataSetNotificationTemplateService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DefaultDataSetNotificationTemplateService.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.dataset.notifications;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.dataset.DataSet;
-import org.hisp.dhis.program.notification.NotificationTrigger;
 import org.springframework.stereotype.Service;
 
 /** Created by zubair@dhis2.org on 20.07.17. */
@@ -57,7 +56,8 @@ public class DefaultDataSetNotificationTemplateService
   }
 
   @Override
-  public List<DataSetNotificationTemplate> getScheduledNotifications(NotificationTrigger trigger) {
+  public List<DataSetNotificationTemplate> getScheduledNotifications(
+      DataSetNotificationTrigger trigger) {
     return store.getScheduledNotifications(trigger);
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/HibernateDataSetNotificationTemplateStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/HibernateDataSetNotificationTemplateStore.java
@@ -32,7 +32,6 @@ import javax.persistence.EntityManager;
 import javax.persistence.criteria.CriteriaBuilder;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
 import org.hisp.dhis.dataset.DataSet;
-import org.hisp.dhis.program.notification.NotificationTrigger;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.user.CurrentUserService;
 import org.springframework.context.ApplicationEventPublisher;
@@ -73,7 +72,8 @@ public class HibernateDataSetNotificationTemplateStore
   }
 
   @Override
-  public List<DataSetNotificationTemplate> getScheduledNotifications(NotificationTrigger trigger) {
+  public List<DataSetNotificationTemplate> getScheduledNotifications(
+      DataSetNotificationTrigger trigger) {
     CriteriaBuilder builder = getCriteriaBuilder();
 
     return getList(

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -2277,16 +2277,19 @@ public abstract class DhisConvenienceTest {
       DataSetNotificationTrigger dataSetNotificationTrigger,
       Integer relativeScheduledDays,
       SendStrategy sendStrategy) {
-    return new DataSetNotificationTemplate(
-        Sets.newHashSet(),
-        Sets.newHashSet(),
-        "Message",
-        notificationRecipient,
-        dataSetNotificationTrigger,
-        "Subject",
-        null,
-        relativeScheduledDays,
-        sendStrategy);
+    DataSetNotificationTemplate dst =
+        new DataSetNotificationTemplate(
+            newHashSet(),
+            newHashSet(),
+            "Message",
+            notificationRecipient,
+            dataSetNotificationTrigger,
+            "Subject",
+            null,
+            relativeScheduledDays,
+            sendStrategy);
+    dst.setName(name);
+    return dst;
   }
 
   public static ValidationNotificationTemplate createValidationNotificationTemplate(String name) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataset/notifications/DataSetNotificationTemplateStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataset/notifications/DataSetNotificationTemplateStoreTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dataset.notifications;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.dataset.DataSetStore;
+import org.hisp.dhis.notification.SendStrategy;
+import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class DataSetNotificationTemplateStoreTest extends SingleSetupIntegrationTestBase {
+
+  @Autowired private DataSetNotificationTemplateStore store;
+  @Autowired private DataSetStore dataSetStore;
+
+  @Test
+  void testGetNotificationsByTriggerTypeAndDataSet() {
+    DataSet dataSet = createDataSet('A');
+    dataSetStore.save(dataSet);
+
+    DataSetNotificationTemplate template =
+        createDataSetNotificationTemplate(
+            "A",
+            DataSetNotificationRecipient.USER_GROUP,
+            DataSetNotificationTrigger.DATA_SET_COMPLETION,
+            1,
+            SendStrategy.SINGLE_NOTIFICATION);
+    template.setDataSets(Set.of(dataSet));
+    store.save(template);
+
+    assertEquals(
+        1,
+        store
+            .getNotificationsByTriggerType(dataSet, DataSetNotificationTrigger.DATA_SET_COMPLETION)
+            .size());
+  }
+
+  @Test
+  void testGetScheduledNotificationsValid() {
+    DataSetNotificationTemplate template =
+        createDataSetNotificationTemplate(
+            "A",
+            DataSetNotificationRecipient.USER_GROUP,
+            DataSetNotificationTrigger.DATA_SET_COMPLETION,
+            1,
+            SendStrategy.SINGLE_NOTIFICATION);
+    store.save(template);
+
+    Assertions.assertEquals(
+        1, store.getScheduledNotifications(DataSetNotificationTrigger.DATA_SET_COMPLETION).size());
+  }
+
+  @Test
+  void testGetScheduledNotificationsNotExist() {
+    DataSetNotificationTemplate template =
+        createDataSetNotificationTemplate(
+            "A",
+            DataSetNotificationRecipient.USER_GROUP,
+            DataSetNotificationTrigger.DATA_SET_COMPLETION,
+            1,
+            SendStrategy.SINGLE_NOTIFICATION);
+    store.save(template);
+
+    Assertions.assertEquals(
+        0, store.getScheduledNotifications(DataSetNotificationTrigger.SCHEDULED_DAYS).size());
+  }
+}


### PR DESCRIPTION
### Issue
- `HibernateDataSetNotificationTemplateStore.getScheduledNotifications` takes in parameter `org.hisp.dhis.program.notification.NotificationTrigger` which is incorrect and cause error 
```
java.lang.IllegalArgumentException: Parameter value [SCHEDULED_DAYS_DUE_DATE] did not match expected type [org.hisp.dhis.dataset.notifications.DataSetNotificationTrigger (n/a)]
```
### Fix
- `HibernateDataSetNotificationTemplateStore.getScheduledNotifications` should take in `org.hisp.dhis.dataset.notifications.DataSetNotificationTrigger`
- Added `DataSetNotificationTemplateStoreTest`
