### PR TITLE
chore: remove dump context step from deploy workflow [skip ci]

### DIFF
--- a/.github/workflows/deploy-instance.yml
+++ b/.github/workflows/deploy-instance.yml
@@ -21,9 +21,6 @@ jobs:
       INSTANCE_HOST: 'https://dev.im.dhis2.org'
       INSTANCE_NAME: pr-${{ github.event.pull_request.number }}
     steps:
-      - name: Dump context
-        uses: crazy-max/ghaction-dump-context@v2
-
       - name: Wait for API tests
         # Using this fork of the upstream https://github.com/lewagon/wait-on-check-action,
         # as it will filter out and check only the latest run of a workflow when checking for the allowed conclusions,


### PR DESCRIPTION
Removing a step that was used while working on the workflow and wasn't removed before merging by mistake.