### PR TITLE
feat: Remove sharingRespected property from namespace protection [DHI…

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastore/DatastoreNamespaceProtection.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastore/DatastoreNamespaceProtection.java
@@ -67,8 +67,6 @@ public class DatastoreNamespaceProtection {
 
   private final String namespace;
 
-  private final boolean sharingRespected;
-
   private final ProtectionType reads;
 
   private final ProtectionType writes;
@@ -76,27 +74,18 @@ public class DatastoreNamespaceProtection {
   private final Set<String> authorities;
 
   public DatastoreNamespaceProtection(
-      String namespace, ProtectionType readWrite, boolean sharingRespected, String... authorities) {
-    this(namespace, readWrite, readWrite, sharingRespected, authorities);
+      String namespace, ProtectionType readWrite, String... authorities) {
+    this(namespace, readWrite, readWrite, authorities);
   }
 
   public DatastoreNamespaceProtection(
-      String namespace,
-      ProtectionType reads,
-      ProtectionType writes,
-      boolean sharingRespected,
-      String... authorities) {
-    this(namespace, reads, writes, sharingRespected, new HashSet<>(asList(authorities)));
+      String namespace, ProtectionType reads, ProtectionType writes, String... authorities) {
+    this(namespace, reads, writes, new HashSet<>(asList(authorities)));
   }
 
   public DatastoreNamespaceProtection(
-      String namespace,
-      ProtectionType reads,
-      ProtectionType writes,
-      boolean sharingRespected,
-      Set<String> authorities) {
+      String namespace, ProtectionType reads, ProtectionType writes, Set<String> authorities) {
     this.namespace = namespace;
-    this.sharingRespected = sharingRespected;
     this.reads = reads;
     this.writes = writes;
     this.authorities = authorities;
@@ -110,10 +99,6 @@ public class DatastoreNamespaceProtection {
    * @return true when the {@link org.hisp.dhis.user.sharing.Sharing} of a {@link DatastoreEntry}
    *     should be checked in addition to authority based checks, else false.
    */
-  public boolean isSharingRespected() {
-    return sharingRespected;
-  }
-
   public Set<String> getAuthorities() {
     return authorities;
   }
@@ -129,7 +114,6 @@ public class DatastoreNamespaceProtection {
   @Override
   public String toString() {
     return String.format(
-        "KeyJsonNamespaceProtection{%s r:%s w:%s [%s]%s}",
-        namespace, reads, writes, authorities, (sharingRespected ? "!" : ""));
+        "KeyJsonNamespaceProtection{%s r:%s w:%s [%s]}", namespace, reads, writes, authorities);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/AndroidSettingsApp.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/AndroidSettingsApp.java
@@ -48,6 +48,6 @@ public class AndroidSettingsApp {
   public AndroidSettingsApp(DatastoreService service) {
     service.addProtection(
         new DatastoreNamespaceProtection(
-            NAMESPACE, ProtectionType.NONE, ProtectionType.RESTRICTED, false, AUTHORITY));
+            NAMESPACE, ProtectionType.NONE, ProtectionType.RESTRICTED, AUTHORITY));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -415,8 +415,7 @@ public class DefaultAppManager implements AppManager {
               ? new String[] {WEB_MAINTENANCE_APPMANAGER_AUTHORITY}
               : new String[] {WEB_MAINTENANCE_APPMANAGER_AUTHORITY, app.getSeeAppAuthority()};
       datastoreService.addProtection(
-          new DatastoreNamespaceProtection(
-              namespace, ProtectionType.RESTRICTED, true, authorities));
+          new DatastoreNamespaceProtection(namespace, ProtectionType.RESTRICTED, authorities));
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datastore/DefaultDatastoreService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datastore/DefaultDatastoreService.java
@@ -191,12 +191,10 @@ public class DefaultDatastoreService implements DatastoreService {
     DatastoreNamespaceProtection protection = protectionByNamespace.get(namespace);
     if (userHasNamespaceReadAccess(protection)) {
       T res = read.get();
-      if (res instanceof DatastoreEntry de) {
-        if (!aclService.canRead(currentUserService.getCurrentUser(), de)) {
-          throw new AccessDeniedException(
-              String.format(
-                  "Access denied for key '%s' in namespace '%s'", de.getKey(), namespace));
-        }
+      if (res instanceof DatastoreEntry de
+          && (!aclService.canRead(currentUserService.getCurrentUser(), de))) {
+        throw new AccessDeniedException(
+            String.format("Access denied for key '%s' in namespace '%s'", de.getKey(), namespace));
       }
       return res;
     } else if (protection.getReads() == ProtectionType.RESTRICTED) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datastore/DefaultMetadataDatastoreService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datastore/DefaultMetadataDatastoreService.java
@@ -50,7 +50,6 @@ public class DefaultMetadataDatastoreService implements MetadataDatastoreService
           new DatastoreNamespaceProtection(
               MetadataDatastoreService.METADATA_STORE_NS,
               ProtectionType.HIDDEN,
-              false,
               MetadataDatastoreService.METADATA_SYNC_AUTHORITY));
     }
   }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/orgunitprofile/impl/DefaultOrgUnitProfileService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/orgunitprofile/impl/DefaultOrgUnitProfileService.java
@@ -125,7 +125,6 @@ public class DefaultOrgUnitProfileService implements OrgUnitProfileService {
             ORG_UNIT_PROFILE_NAMESPACE,
             DatastoreNamespaceProtection.ProtectionType.NONE,
             DatastoreNamespaceProtection.ProtectionType.RESTRICTED,
-            false,
             "ALL",
             ORG_UNIT_PROFILE_AUTHORITY));
   }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/datastore/DatastoreKeysTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/datastore/DatastoreKeysTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.datastore;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import org.hisp.dhis.ApiTest;
 import org.hisp.dhis.actions.LoginActions;
 import org.hisp.dhis.actions.RestApiActions;
@@ -365,10 +366,11 @@ class DatastoreKeysTest extends ApiTest {
     assertEquals("[\"arsenal\",\"spurs\"]", entries);
   }
 
-  protected static String newEntry(String team) {
-    return """
-      {"name": "%s","league": "prem"}
-    """.strip().formatted(team);
+  protected static JsonObject newEntry(String team) {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("name", team);
+    jsonObject.addProperty("league", "prem");
+    return jsonObject;
   }
 
   protected static String sharingUserAccess(String userId) {
@@ -381,7 +383,7 @@ class DatastoreKeysTest extends ApiTest {
             "userAccesses": [
                 {
                     "id": "%s",
-                    "access": "r-------"
+                    "access": "rw------"
                 }
             ],
             "userGroupAccesses": []
@@ -403,7 +405,7 @@ class DatastoreKeysTest extends ApiTest {
             "userGroupAccesses": [
                 {
                     "id": "%s",
-                    "access": "r-------"
+                    "access": "rw------"
                 }
             ]
         }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerTest.java
@@ -551,13 +551,11 @@ class DatastoreControllerTest extends DhisControllerConvenienceTest {
 
   private void setUpNamespaceProtection(
       String namespace, ProtectionType readWrite, String... authorities) {
-    service.addProtection(
-        new DatastoreNamespaceProtection(namespace, readWrite, false, authorities));
+    service.addProtection(new DatastoreNamespaceProtection(namespace, readWrite, authorities));
   }
 
   private void setUpNamespaceProtectionWithSharing(
       String namespace, ProtectionType readWrite, String... authorities) {
-    service.addProtection(
-        new DatastoreNamespaceProtection(namespace, readWrite, true, authorities));
+    service.addProtection(new DatastoreNamespaceProtection(namespace, readWrite, authorities));
   }
 }


### PR DESCRIPTION
…S2-16215]

# Summary
Now that sharing is fully implemented in the datastore, the `DatastoreNamespaceProtection` property `sharingProtected` is no longer needed. Sharing can be set in the usual manner. This simplifies access to the datastore.

There are 2 levels of access used in the datastore:
- namespace protection
- standard sharing (read/write ACL)

Only programmatic namespaces used the `sharingProtected` property previously. 
All datastore entries are public (rw------) by default and need explicit updating to restrict sharing access.
Datastore entries are considered metadata.

# Testing
## Automated
Multiple e2e tests added for `update` and `delete` scenarios
There's already many `read` datastore entry e2e tests in place

## Manual
Datastore entries should have the following behaviour:
- superuser can create/read/update/delete
- object owner can create/read/update/delete
- basic user can create/read/update/delete by default
- when default public sharing removed:
  - basic user can create/read/update/delete only when given explicit access (through user or usergroup)