### PR TITLE
fix: Investigate simultaneous updates of data values is not updating at all [ DHIS2-16080 ]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/AbstractEventService.java
@@ -762,6 +762,13 @@ public abstract class AbstractEventService
 
   @Transactional
   @Override
+  public ImportSummary updateDataElements(
+      org.hisp.dhis.dxf2.deprecated.tracker.event.Event event) {
+    return eventManager.updateDataElements(event);
+  }
+
+  @Transactional
+  @Override
   public void updateEventForNote(org.hisp.dhis.dxf2.deprecated.tracker.event.Event event) {
     org.hisp.dhis.program.Event programStageInstance = eventService.getEvent(event.getEvent());
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/DataValue.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/DataValue.java
@@ -197,9 +197,6 @@ public class DataValue {
   }
 
   public String toString1() {
-    return "'{\""
-        + "value\" : "
-        + value
-        + "}'";
+    return "'{\"" + "value\" : " + value + "}'";
   }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/DataValue.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/DataValue.java
@@ -195,4 +195,11 @@ public class DataValue {
         + '\''
         + '}';
   }
+
+  public String toString1() {
+    return "'{\""
+        + "value\" : "
+        + value
+        + "}'";
+  }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/EventService.java
@@ -186,4 +186,6 @@ public interface EventService {
   ImportSummaries deleteEvents(List<String> uids, boolean clearSession);
 
   void validate(EventSearchParams params, User user);
+
+  ImportSummary updateDataElements(org.hisp.dhis.dxf2.deprecated.tracker.event.Event updatedEvent);
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/EventService.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.dxf2.deprecated.tracker.event;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Date;
@@ -187,5 +188,7 @@ public interface EventService {
 
   void validate(EventSearchParams params, User user);
 
-  ImportSummary updateDataElements(org.hisp.dhis.dxf2.deprecated.tracker.event.Event updatedEvent);
+  ImportSummary updateEventDataValues(
+      org.hisp.dhis.dxf2.deprecated.tracker.event.Event updatedEvent)
+      throws JsonProcessingException;
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/DefaultEventPersistenceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/DefaultEventPersistenceService.java
@@ -27,19 +27,22 @@
  */
 package org.hisp.dhis.dxf2.deprecated.tracker.event.persistence;
 
+import static java.lang.String.format;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.persistence.EntityManager;
-
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.dxf2.deprecated.tracker.event.EventCommentStore;
 import org.hisp.dhis.dxf2.deprecated.tracker.event.EventStore;
 import org.hisp.dhis.dxf2.deprecated.tracker.importer.context.WorkContext;
 import org.hisp.dhis.dxf2.deprecated.tracker.importer.mapper.ProgramStageInstanceMapper;
+import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.program.Event;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -55,6 +58,8 @@ public class DefaultEventPersistenceService implements EventPersistenceService {
   @Nonnull private final EventCommentStore jdbcEventCommentStore;
 
   @Nonnull private final EntityManager entityManager;
+
+  @Nonnull private final ObjectMapper mapper;
 
   @Override
   @Transactional
@@ -117,9 +122,33 @@ public class DefaultEventPersistenceService implements EventPersistenceService {
   }
 
   @Override
-  public void updateDataElements(String query) {
+  @Transactional
+  public void updateDataElements(
+      EventDataValue de, org.hisp.dhis.dxf2.deprecated.tracker.event.Event event)
+      throws JsonProcessingException {
 
-    entityManager.createNativeQuery(query).executeUpdate();
+    String uid = de.getDataElement();
+    de.setDataElement(
+        null); // de uid is used as a key in the json, so we don't need it here when updating
+
+    String query =
+        format(
+            "UPDATE event SET "
+                + "eventdatavalues= (CASE"
+                + "        WHEN eventdatavalues->:de IS NOT NULL"
+                + "        THEN jsonb_set(eventdatavalues, '{%1$s}', (eventdatavalues->:de) || '%2$s')"
+                + "        WHEN eventdatavalues->:de IS NULL"
+                + "        THEN jsonb_insert(eventdatavalues, '{%1$s}', '%2$s')"
+                + "    END) ,"
+                + " lastupdated = current_timestamp "
+                + "WHERE  uid = :event",
+            uid, mapper.writeValueAsString(de));
+
+    entityManager
+        .createNativeQuery(query)
+        .setParameter("event", event.getEvent())
+        .setParameter("de", uid)
+        .executeUpdate();
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/DefaultEventPersistenceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/DefaultEventPersistenceService.java
@@ -33,6 +33,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.persistence.EntityManager;
+
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.dxf2.deprecated.tracker.event.EventCommentStore;
 import org.hisp.dhis.dxf2.deprecated.tracker.event.EventStore;
@@ -51,6 +53,8 @@ public class DefaultEventPersistenceService implements EventPersistenceService {
   @Nonnull private final EventStore jdbcEventStore;
 
   @Nonnull private final EventCommentStore jdbcEventCommentStore;
+
+  @Nonnull private final EntityManager entityManager;
 
   @Override
   @Transactional
@@ -110,6 +114,12 @@ public class DefaultEventPersistenceService implements EventPersistenceService {
     if (isNotEmpty(events)) {
       jdbcEventStore.delete(events);
     }
+  }
+
+  @Override
+  public void updateDataElements(String query) {
+
+    entityManager.createNativeQuery(query).executeUpdate();
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/EventPersistenceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/EventPersistenceService.java
@@ -64,4 +64,6 @@ public interface EventPersistenceService {
    * @param events a List of {@see Event}
    */
   void delete(WorkContext context, List<Event> events);
+
+  void updateDataElements(String s);
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/EventPersistenceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/EventPersistenceService.java
@@ -27,9 +27,11 @@
  */
 package org.hisp.dhis.dxf2.deprecated.tracker.event.persistence;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
 import org.hisp.dhis.dxf2.deprecated.tracker.event.Event;
 import org.hisp.dhis.dxf2.deprecated.tracker.importer.context.WorkContext;
+import org.hisp.dhis.eventdatavalue.EventDataValue;
 
 /**
  * Wrapper service for Event-related operations. This service acts as a transactional wrapper for
@@ -65,5 +67,5 @@ public interface EventPersistenceService {
    */
   void delete(WorkContext context, List<Event> events);
 
-  void updateDataElements(String s);
+  void updateDataElements(EventDataValue de, Event event) throws JsonProcessingException;
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/EventManager.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/EventManager.java
@@ -100,6 +100,27 @@ public class EventManager {
 
   private static final String IMPORT_ERROR_STRING = "Invalid or conflicting data";
 
+  public ImportSummary updateDataElements(
+      org.hisp.dhis.dxf2.deprecated.tracker.event.Event events) {
+    for (DataValue de : events.getDataValues()) {
+
+      String s =
+          String.format(
+              "UPDATE event SET "
+                  + "eventdatavalues= (CASE"
+                  + "        WHEN eventdatavalues->'%1$s' IS NOT NULL"
+                  + "        THEN jsonb_set(eventdatavalues, '{%1$s}', %2$s)"
+                  + "        WHEN eventdatavalues->'%1$s' IS NULL"
+                  + "        THEN jsonb_insert(eventdatavalues, '{%1$s}', %2$s)"
+                  + "    END)"
+                  + "WHERE  uid = '%1$s'",
+              de.getDataElement(), de.toString1());
+
+      eventPersistenceService.updateDataElements(s);
+    }
+    return null;
+  }
+
   public ImportSummary addEvent(
       final org.hisp.dhis.dxf2.deprecated.tracker.event.Event event,
       final WorkContext workContext) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventImportTest.java
@@ -253,6 +253,31 @@ class EventImportTest extends TransactionalIntegrationTest {
   }
 
   @Test
+  void testUpdateDataElements() {
+    org.hisp.dhis.dxf2.deprecated.tracker.event.Event event =
+        createEventJson(
+            programB.getUid(), programStageB.getUid(), organisationUnitB.getUid(), null);
+
+    DataValue dataValue = new DataValue();
+    dataValue.setValue("10");
+    dataValue.setDataElement(dataElementA.getUid());
+    event.setDataValues(Set.of(dataValue));
+    event.setStatus(EventStatus.COMPLETED);
+
+    eventService.updateDataElements(event);
+  }
+
+  private org.hisp.dhis.dxf2.deprecated.tracker.event.Event createEventJson(
+      String program, String programStage, String orgUnit, String person) {
+    org.hisp.dhis.dxf2.deprecated.tracker.event.Event event = createEvent(null);
+    event.setProgram(program);
+    event.setProgramStage(programStage);
+    event.setOrgUnit(orgUnit);
+    event.setTrackedEntityInstance(person);
+    return event;
+  }
+
+  @Test
   void testAddEventOnProgramWithoutRegistration() throws IOException {
     InputStream is =
         createEventJsonInputStream(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventImportTest.java
@@ -69,6 +69,7 @@ import org.hisp.dhis.dxf2.importsummary.ImportStatus;
 import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.event.EventStatus;
+import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.organisationunit.FeatureType;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -253,18 +254,71 @@ class EventImportTest extends TransactionalIntegrationTest {
   }
 
   @Test
-  void testUpdateDataElements() {
-    org.hisp.dhis.dxf2.deprecated.tracker.event.Event event =
-        createEventJson(
-            programB.getUid(), programStageB.getUid(), organisationUnitB.getUid(), null);
+  void shouldUpdateEventDataValues_whenAddingDataValuesToEvent() throws IOException {
+    InputStream is =
+        createEventJsonInputStream(
+            programB.getUid(),
+            programStageB.getUid(),
+            organisationUnitB.getUid(),
+            null,
+            dataElementB,
+            "10");
+    String uid = eventService.addEventsJson(is, null).getImportSummaries().get(0).getReference();
 
-    DataValue dataValue = new DataValue();
-    dataValue.setValue("10");
-    dataValue.setDataElement(dataElementA.getUid());
-    event.setDataValues(Set.of(dataValue));
-    event.setStatus(EventStatus.COMPLETED);
+    org.hisp.dhis.dxf2.deprecated.tracker.event.Event event = createEvent(uid);
 
-    eventService.updateDataElements(event);
+    Event ev = programStageInstanceService.getEvent(uid);
+
+    assertNotNull(ev);
+    assertEquals(1, ev.getEventDataValues().size());
+
+    // add a new data value and update an existing one
+
+    DataValue dataValueA = new DataValue();
+    dataValueA.setValue("20");
+    dataValueA.setDataElement(dataElementA.getUid());
+    dataValueA.setStoredBy(superUser.getName());
+
+    DataValue dataValueB = new DataValue();
+    dataValueB.setValue("20");
+    dataValueB.setDataElement(dataElementB.getUid());
+    dataValueB.setStoredBy(superUser.getName());
+
+    event.setDataValues(Set.of(dataValueA, dataValueB));
+
+    eventService.updateEventDataValues(event);
+
+    manager.clear();
+
+    ev = programStageInstanceService.getEvent(event.getUid());
+
+    assertNotNull(ev);
+    assertNotNull(ev.getEventDataValues());
+    assertEquals(2, ev.getEventDataValues().size());
+
+    EventDataValue eventDataValueA =
+        ev.getEventDataValues().stream()
+            .filter(edv -> edv.getDataElement().equals(dataValueA.getDataElement()))
+            .findFirst()
+            .orElse(null);
+
+    assertNotNull(eventDataValueA);
+    assertEquals(eventDataValueA.getValue(), dataValueA.getValue());
+    assertEquals(eventDataValueA.getStoredBy(), superUser.getName());
+    assertNotNull(eventDataValueA.getCreated());
+    assertNotNull(eventDataValueA.getLastUpdated());
+
+    EventDataValue eventDataValueB =
+        ev.getEventDataValues().stream()
+            .filter(edv -> edv.getDataElement().equals(dataValueB.getDataElement()))
+            .findFirst()
+            .orElse(null);
+
+    assertNotNull(eventDataValueB);
+    assertEquals(eventDataValueB.getValue(), dataValueB.getValue());
+    assertEquals(eventDataValueB.getStoredBy(), superUser.getName());
+    assertNotNull(eventDataValueB.getCreated());
+    assertNotNull(eventDataValueB.getLastUpdated());
   }
 
   private org.hisp.dhis.dxf2.deprecated.tracker.event.Event createEventJson(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/EventController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/EventController.java
@@ -1154,7 +1154,15 @@ public class EventController {
     Event updatedEvent = renderService.fromJson(inputStream, Event.class);
     updatedEvent.setEvent(uid);
 
-    return updateEvent(updatedEvent, true, null);
+    return updateEvent1(updatedEvent);
+  }
+
+
+  private WebMessage updateEvent1(
+    Event updatedEvent) {
+    ImportSummary importSummary =
+      eventService.updateDataElements(updatedEvent);
+    return importSummary(importSummary);
   }
 
   @PutMapping(value = "/{uid}/eventDate", consumes = APPLICATION_JSON_VALUE)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/EventController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/EventController.java
@@ -1154,15 +1154,7 @@ public class EventController {
     Event updatedEvent = renderService.fromJson(inputStream, Event.class);
     updatedEvent.setEvent(uid);
 
-    return updateEvent1(updatedEvent);
-  }
-
-
-  private WebMessage updateEvent1(
-    Event updatedEvent) {
-    ImportSummary importSummary =
-      eventService.updateDataElements(updatedEvent);
-    return importSummary(importSummary);
+    return importSummary(eventService.updateEventDataValues(updatedEvent));
   }
 
   @PutMapping(value = "/{uid}/eventDate", consumes = APPLICATION_JSON_VALUE)


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-16080

In the old tracker, we have the `/events` endpoint:
` @PutMapping(value = "/{uid}/{dataElementUid}"`
which is supposed to update the event data values although it goes through the generic event update.

There are 2 points about this issue:
1-  With the `WorkContextLoader`, info about the existing `eventdatavalues` field is preloaded. Therefore, if we have a concurrent update we might preload data element values that are no longer valid
2- Apparently, using the spring JdbcTemplate `batchUpdate` the concurrency and wait for the same row update is not working.

### Solution - Relying on `@Transactional` 
One possible solution to this issue is to process one data element value at a time inside the JSON. 
This is done using the Postgres function `jsonb_update` or `jsonb_insert`.
`@Transactional` should handle the concurrency for us if we use hibernate queries.

### Alternative solution
An alternative approach to this issue is to use locking. There are 2 possible locking we can use:
- Optimistic locking: hibernate recommends we use the `@Version` field so we can catch if the row we are updating is the current version or not. This can have a big impact on the current state of the `event` table
- Pessimistic locking. This will eventually result in using the `SELECT .. FOR UPDATE` syntax which can slow down performances and create deadlocks
