### PR TITLE
fix: Investigate simultaneous updates of data values is not updating at all [ DHIS2-16080 ]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/AbstractEventService.java
@@ -55,6 +55,7 @@ import static org.hisp.dhis.dxf2.deprecated.tracker.event.EventSearchParams.PAGE
 import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
 import static org.hisp.dhis.util.DateUtils.getMediumDateString;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -758,6 +759,39 @@ public abstract class AbstractEventService
 
     return eventManager.updateEvent(
         event, workContextLoader.load(localImportOptions, Collections.singletonList(event)));
+  }
+
+  /**
+   * @param event
+   * @return
+   * @throws JsonProcessingException
+   */
+  @Transactional
+  @Override
+  public ImportSummary updateEventDataValues(
+      org.hisp.dhis.dxf2.deprecated.tracker.event.Event event) throws JsonProcessingException {
+
+    Set<EventDataValue> eventDataValues =
+        workContextLoader
+            .load(
+                ImportOptions.getDefaultImportOptions(),
+                Collections.singletonList(
+                    event)) // load the event data values merging existing and new values
+            .getEventDataValueMap()
+            .get(event.getEvent())
+            .stream()
+            .filter(
+                edv ->
+                    event.getDataValues().stream()
+                        .anyMatch(
+                            input ->
+                                input
+                                    .getDataElement()
+                                    .equals(edv.getDataElement()))) // filter only for the required
+            // data elements
+            .collect(Collectors.toSet());
+
+    return eventManager.updateEventDataValues(event, eventDataValues);
   }
 
   @Transactional

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/AbstractEventService.java
@@ -771,15 +771,14 @@ public abstract class AbstractEventService
   public ImportSummary updateEventDataValues(
       org.hisp.dhis.dxf2.deprecated.tracker.event.Event event) throws JsonProcessingException {
 
+    WorkContext context =
+        workContextLoader.load(
+            ImportOptions.getDefaultImportOptions(),
+            Collections.singletonList(
+                event)); // load the event data values merging existing and new values
+
     Set<EventDataValue> eventDataValues =
-        workContextLoader
-            .load(
-                ImportOptions.getDefaultImportOptions(),
-                Collections.singletonList(
-                    event)) // load the event data values merging existing and new values
-            .getEventDataValueMap()
-            .get(event.getEvent())
-            .stream()
+        context.getEventDataValueMap().get(event.getEvent()).stream()
             .filter(
                 edv ->
                     event.getDataValues().stream()
@@ -791,7 +790,7 @@ public abstract class AbstractEventService
             // data elements
             .collect(Collectors.toSet());
 
-    return eventManager.updateEventDataValues(event, eventDataValues);
+    return eventManager.updateEventDataValues(event, eventDataValues, context);
   }
 
   @Transactional

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/EventService.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.dxf2.deprecated.tracker.event;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Date;
@@ -186,4 +187,8 @@ public interface EventService {
   ImportSummaries deleteEvents(List<String> uids, boolean clearSession);
 
   void validate(EventSearchParams params, User user);
+
+  ImportSummary updateEventDataValues(
+      org.hisp.dhis.dxf2.deprecated.tracker.event.Event updatedEvent)
+      throws JsonProcessingException;
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/DefaultEventPersistenceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/DefaultEventPersistenceService.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.dxf2.deprecated.tracker.event.persistence;
 
-import static java.lang.String.format;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -131,17 +130,18 @@ public class DefaultEventPersistenceService implements EventPersistenceService {
     de.setDataElement(null); // de uid is used as a key in the json, so we don't need it here
 
     String query =
-        format(
-            "UPDATE event SET "
-                + "eventdatavalues= (CASE"
-                + "        WHEN eventdatavalues->:de IS NOT NULL"
-                + "        THEN jsonb_set(eventdatavalues, '{%1$s}', (eventdatavalues->:de) || '%2$s')"
-                + "        WHEN eventdatavalues->:de IS NULL"
-                + "        THEN jsonb_insert(eventdatavalues, '{%1$s}', '%2$s')"
-                + "    END) ,"
-                + " lastupdated = current_timestamp "
-                + "WHERE  uid = :event",
-            uid, mapper.writeValueAsString(de));
+        """
+                UPDATE event SET
+                eventdatavalues= (CASE
+                        WHEN eventdatavalues->:de IS NOT NULL
+                          THEN jsonb_set(eventdatavalues, '{%1$s}', (eventdatavalues->:de) || '%2$s')
+                        WHEN eventdatavalues->:de IS NULL
+                          THEN jsonb_insert(eventdatavalues, '{%1$s}', '%2$s')
+                 END) ,
+                lastupdated = current_timestamp
+                WHERE  uid = :event
+             """
+            .formatted(uid, mapper.writeValueAsString(de));
 
     entityManager
         .createNativeQuery(query)

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/DefaultEventPersistenceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/DefaultEventPersistenceService.java
@@ -123,7 +123,7 @@ public class DefaultEventPersistenceService implements EventPersistenceService {
 
   @Override
   @Transactional
-  public void updateDataElements(
+  public void updateEventDataValues(
       EventDataValue de, org.hisp.dhis.dxf2.deprecated.tracker.event.Event event)
       throws JsonProcessingException {
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/DefaultEventPersistenceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/DefaultEventPersistenceService.java
@@ -44,7 +44,6 @@ import org.hisp.dhis.dxf2.deprecated.tracker.importer.mapper.ProgramStageInstanc
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.UserInfoSnapshot;
-import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -125,7 +124,9 @@ public class DefaultEventPersistenceService implements EventPersistenceService {
   @Override
   @Transactional
   public void updateEventDataValues(
-      EventDataValue de, org.hisp.dhis.dxf2.deprecated.tracker.event.Event event, User user)
+      EventDataValue de,
+      org.hisp.dhis.dxf2.deprecated.tracker.event.Event event,
+      WorkContext workContext)
       throws JsonProcessingException {
 
     String uid = de.getDataElement();
@@ -151,8 +152,16 @@ public class DefaultEventPersistenceService implements EventPersistenceService {
         .setParameter("event", event.getEvent())
         .setParameter("de", uid)
         .setParameter(
-            "lastupdatedbyuserinfo", mapper.writeValueAsString(UserInfoSnapshot.from(user)))
+            "lastupdatedbyuserinfo",
+            mapper.writeValueAsString(
+                UserInfoSnapshot.from(workContext.getImportOptions().getUser())))
         .executeUpdate();
+  }
+
+  @Override
+  public void updateTrackedEntityInstances(
+      WorkContext context, List<org.hisp.dhis.dxf2.deprecated.tracker.event.Event> events) {
+    updateTeis(context, events);
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/EventPersistenceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/EventPersistenceService.java
@@ -67,5 +67,5 @@ public interface EventPersistenceService {
    */
   void delete(WorkContext context, List<Event> events);
 
-  void updateDataElements(EventDataValue de, Event event) throws JsonProcessingException;
+  void updateEventDataValues(EventDataValue de, Event event) throws JsonProcessingException;
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/EventPersistenceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/EventPersistenceService.java
@@ -32,7 +32,6 @@ import java.util.List;
 import org.hisp.dhis.dxf2.deprecated.tracker.event.Event;
 import org.hisp.dhis.dxf2.deprecated.tracker.importer.context.WorkContext;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
-import org.hisp.dhis.user.User;
 
 /**
  * Wrapper service for Event-related operations. This service acts as a transactional wrapper for
@@ -68,6 +67,8 @@ public interface EventPersistenceService {
    */
   void delete(WorkContext context, List<Event> events);
 
-  void updateEventDataValues(EventDataValue de, Event event, User user)
+  void updateEventDataValues(EventDataValue de, Event event, WorkContext workContext)
       throws JsonProcessingException;
+
+  void updateTrackedEntityInstances(final WorkContext context, final List<Event> events);
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/EventPersistenceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/EventPersistenceService.java
@@ -27,9 +27,11 @@
  */
 package org.hisp.dhis.dxf2.deprecated.tracker.event.persistence;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
 import org.hisp.dhis.dxf2.deprecated.tracker.event.Event;
 import org.hisp.dhis.dxf2.deprecated.tracker.importer.context.WorkContext;
+import org.hisp.dhis.eventdatavalue.EventDataValue;
 
 /**
  * Wrapper service for Event-related operations. This service acts as a transactional wrapper for
@@ -64,4 +66,6 @@ public interface EventPersistenceService {
    * @param events a List of {@see Event}
    */
   void delete(WorkContext context, List<Event> events);
+
+  void updateDataElements(EventDataValue de, Event event) throws JsonProcessingException;
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/EventPersistenceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/EventPersistenceService.java
@@ -32,6 +32,7 @@ import java.util.List;
 import org.hisp.dhis.dxf2.deprecated.tracker.event.Event;
 import org.hisp.dhis.dxf2.deprecated.tracker.importer.context.WorkContext;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
+import org.hisp.dhis.user.User;
 
 /**
  * Wrapper service for Event-related operations. This service acts as a transactional wrapper for
@@ -67,5 +68,6 @@ public interface EventPersistenceService {
    */
   void delete(WorkContext context, List<Event> events);
 
-  void updateEventDataValues(EventDataValue de, Event event) throws JsonProcessingException;
+  void updateEventDataValues(EventDataValue de, Event event, User user)
+      throws JsonProcessingException;
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/EventManager.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/EventManager.java
@@ -39,6 +39,7 @@ import static org.hisp.dhis.importexport.ImportStrategy.CREATE;
 import static org.hisp.dhis.importexport.ImportStrategy.DELETE;
 import static org.hisp.dhis.importexport.ImportStrategy.UPDATE;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -99,6 +100,19 @@ public class EventManager {
   @Nonnull private final CurrentUserService currentUserService;
 
   private static final String IMPORT_ERROR_STRING = "Invalid or conflicting data";
+
+  public ImportSummary updateEventDataValues(
+      org.hisp.dhis.dxf2.deprecated.tracker.event.Event event, Set<EventDataValue> eventDataValues)
+      throws JsonProcessingException {
+    final ImportSummaries importSummaries = new ImportSummaries();
+
+    for (EventDataValue de : eventDataValues) {
+      eventPersistenceService.updateDataElements(de, event);
+    }
+    incrementSummaryTotals(List.of(event), importSummaries, UPDATE);
+
+    return importSummaries.getImportSummaries().get(0);
+  }
 
   public ImportSummary addEvent(
       final org.hisp.dhis.dxf2.deprecated.tracker.event.Event event,

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/EventManager.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/EventManager.java
@@ -107,7 +107,7 @@ public class EventManager {
     final ImportSummaries importSummaries = new ImportSummaries();
 
     for (EventDataValue de : eventDataValues) {
-      eventPersistenceService.updateDataElements(de, event);
+      eventPersistenceService.updateEventDataValues(de, event);
     }
     incrementSummaryTotals(List.of(event), importSummaries, UPDATE);
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/EventManager.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/EventManager.java
@@ -111,9 +111,10 @@ public class EventManager {
     executorsByPhase.get(EventProcessorPhase.UPDATE_PRE).execute(context, List.of(event));
 
     for (EventDataValue de : eventDataValues) {
-      eventPersistenceService.updateEventDataValues(
-          de, event, context.getImportOptions().getUser());
+      eventPersistenceService.updateEventDataValues(de, event, context);
     }
+
+    eventPersistenceService.updateTrackedEntityInstances(context, List.of(event));
 
     incrementSummaryTotals(List.of(event), importSummaries, UPDATE);
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/EventManager.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/EventManager.java
@@ -102,13 +102,19 @@ public class EventManager {
   private static final String IMPORT_ERROR_STRING = "Invalid or conflicting data";
 
   public ImportSummary updateEventDataValues(
-      org.hisp.dhis.dxf2.deprecated.tracker.event.Event event, Set<EventDataValue> eventDataValues)
+      org.hisp.dhis.dxf2.deprecated.tracker.event.Event event,
+      Set<EventDataValue> eventDataValues,
+      WorkContext context)
       throws JsonProcessingException {
     final ImportSummaries importSummaries = new ImportSummaries();
 
+    executorsByPhase.get(EventProcessorPhase.UPDATE_PRE).execute(context, List.of(event));
+
     for (EventDataValue de : eventDataValues) {
-      eventPersistenceService.updateEventDataValues(de, event);
+      eventPersistenceService.updateEventDataValues(
+          de, event, context.getImportOptions().getUser());
     }
+
     incrementSummaryTotals(List.of(event), importSummaries, UPDATE);
 
     return importSummaries.getImportSummaries().get(0);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventImportTest.java
@@ -321,16 +321,6 @@ class EventImportTest extends TransactionalIntegrationTest {
     assertNotNull(eventDataValueB.getLastUpdated());
   }
 
-  private org.hisp.dhis.dxf2.deprecated.tracker.event.Event createEventJson(
-      String program, String programStage, String orgUnit, String person) {
-    org.hisp.dhis.dxf2.deprecated.tracker.event.Event event = createEvent(null);
-    event.setProgram(program);
-    event.setProgramStage(programStage);
-    event.setOrgUnit(orgUnit);
-    event.setTrackedEntityInstance(person);
-    return event;
-  }
-
   @Test
   void testAddEventOnProgramWithoutRegistration() throws IOException {
     InputStream is =

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventImportTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.dxf2.deprecated.tracker;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hisp.dhis.user.UserRole.AUTHORITY_ALL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -160,8 +161,6 @@ class EventImportTest extends TransactionalIntegrationTest {
   @Override
   protected void setUpTest() throws Exception {
     userService = _userService;
-    superUser = preCreateInjectAdminUser();
-    injectSecurityContext(superUser);
 
     organisationUnitA = createOrganisationUnit('A');
     organisationUnitB = createOrganisationUnit('B');
@@ -250,7 +249,8 @@ class EventImportTest extends TransactionalIntegrationTest {
     enrollment.setUid(CodeGenerator.generateUid());
     manager.save(enrollment);
     event = createEvent("eventUid001");
-    createUserAndInjectSecurityContext(true);
+    superUser = createAndAddAdminUser(AUTHORITY_ALL);
+    injectSecurityContext(superUser);
   }
 
   @Test
@@ -305,6 +305,8 @@ class EventImportTest extends TransactionalIntegrationTest {
     assertNotNull(eventDataValueA);
     assertEquals(eventDataValueA.getValue(), dataValueA.getValue());
     assertEquals(eventDataValueA.getStoredBy(), superUser.getName());
+    assertNotNull(eventDataValueA.getCreatedByUserInfo());
+    assertNotNull(eventDataValueA.getLastUpdatedByUserInfo());
     assertNotNull(eventDataValueA.getCreated());
     assertNotNull(eventDataValueA.getLastUpdated());
 
@@ -317,6 +319,8 @@ class EventImportTest extends TransactionalIntegrationTest {
     assertNotNull(eventDataValueB);
     assertEquals(eventDataValueB.getValue(), dataValueB.getValue());
     assertEquals(eventDataValueB.getStoredBy(), superUser.getName());
+    assertNotNull(eventDataValueB.getCreatedByUserInfo());
+    assertNotNull(eventDataValueB.getLastUpdatedByUserInfo());
     assertNotNull(eventDataValueB.getCreated());
     assertNotNull(eventDataValueB.getLastUpdated());
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventImportTest.java
@@ -31,6 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hisp.dhis.user.UserRole.AUTHORITY_ALL;
+import static org.hisp.dhis.util.DateUtils.getIso8601NoTz;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -260,7 +261,7 @@ class EventImportTest extends TransactionalIntegrationTest {
             programB.getUid(),
             programStageB.getUid(),
             organisationUnitB.getUid(),
-            null,
+            trackedEntityInstanceMaleA.getTrackedEntityInstance(),
             dataElementB,
             "10");
     String uid = eventService.addEventsJson(is, null).getImportSummaries().get(0).getReference();
@@ -285,6 +286,8 @@ class EventImportTest extends TransactionalIntegrationTest {
     dataValueB.setStoredBy(superUser.getName());
 
     event.setDataValues(Set.of(dataValueA, dataValueB));
+
+    Date now = new Date();
 
     eventService.updateEventDataValues(event);
 
@@ -323,6 +326,11 @@ class EventImportTest extends TransactionalIntegrationTest {
     assertNotNull(eventDataValueB.getLastUpdatedByUserInfo());
     assertNotNull(eventDataValueB.getCreated());
     assertNotNull(eventDataValueB.getLastUpdated());
+
+    TrackedEntityInstance trackedEntityInstance =
+        trackedEntityInstanceService.getTrackedEntityInstance(
+            trackedEntityInstanceMaleA.getTrackedEntityInstance());
+    assertTrue(trackedEntityInstance.getLastUpdated().compareTo(getIso8601NoTz(now)) > 0);
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/EventController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/EventController.java
@@ -1154,7 +1154,7 @@ public class EventController {
     Event updatedEvent = renderService.fromJson(inputStream, Event.class);
     updatedEvent.setEvent(uid);
 
-    return updateEvent(updatedEvent, true, null);
+    return importSummary(eventService.updateEventDataValues(updatedEvent));
   }
 
   @PutMapping(value = "/{uid}/eventDate", consumes = APPLICATION_JSON_VALUE)


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-16080

In the old tracker, we have the `/events` endpoint:
` @PutMapping(value = "/{uid}/{dataElementUid}"` 
which is supposed to update the event data values although it goes through the generic event update.
The front end sends multiple requests in a very quick sequence to this endpoint.

There are 2 points about this issue:
- With the `WorkContextLoader`, info about the existing `eventdatavalues` field is preloaded. Therefore, if we have a concurrent update we might preload data element values that are no longer valid and have been updated in the meanwhile
- Apparently, using the spring JdbcTemplate `batchUpdate`, the concurrency and waiting for the same row update is not in place because it has a default isolation level.

### Solution - Relying on `@Transactional`
One possible solution is to process one data element value at a time and save it to the `eventdatavalues` JSON.
This is done using the Postgres function `jsonb_set` or `jsonb_insert` which updates or inserts at specific positions inside the JSON.
`@Transactional `should handle the concurrency for us if we use hibernate queries. Therefore, multiple concurrent requests for the same row are queued and handled by the JPA at the database level.

### Alternative solution
An alternative approach to this issue is to use locking. There are 2 possible locking we can use:

- Optimistic locking: hibernate recommends we use the `@Version` field so we can catch if the row we are updating is the current version or not. This can have a big impact on the current state of the `event` table
- Pessimistic locking. This will eventually result in using the `SELECT .. FOR UPDATE` syntax which can slow down performances and create deadlocks. Note this should correspond to the isolation level of `SERIALIZABLE`