### PR TITLE
chore:Replace organisation units with no groups integrity check with SQL

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
@@ -444,10 +444,6 @@ public class DefaultDataIntegrityService implements DataIntegrityService {
     return toSimpleIssueList(organisationUnitService.getOrphanedOrganisationUnits().stream());
   }
 
-  List<DataIntegrityIssue> getOrganisationUnitsWithoutGroups() {
-    return toSimpleIssueList(organisationUnitService.getOrganisationUnitsWithoutGroups().stream());
-  }
-
   List<DataIntegrityIssue> getOrganisationUnitsViolatingExclusiveGroupSets() {
     return toIssueList(
         organisationUnitService.getOrganisationUnitsViolatingExclusiveGroupSets().stream(),
@@ -610,10 +606,6 @@ public class DefaultDataIntegrityService implements DataIntegrityService {
         OrganisationUnit.class,
         this::getOrphanedOrganisationUnits);
     registerNonDatabaseIntegrityCheck(
-        DataIntegrityCheckType.ORG_UNITS_WITHOUT_GROUPS,
-        OrganisationUnit.class,
-        this::getOrganisationUnitsWithoutGroups);
-    registerNonDatabaseIntegrityCheck(
         DataIntegrityCheckType.ORG_UNITS_VIOLATING_EXCLUSIVE_GROUP_SETS,
         OrganisationUnit.class,
         this::getOrganisationUnitsViolatingExclusiveGroupSets);
@@ -621,7 +613,6 @@ public class DefaultDataIntegrityService implements DataIntegrityService {
         DataIntegrityCheckType.ORG_UNIT_GROUPS_WITHOUT_GROUP_SETS,
         OrganisationUnitGroup.class,
         this::getOrganisationUnitGroupsWithoutGroupSets);
-
     registerNonDatabaseIntegrityCheck(
         DataIntegrityCheckType.VALIDATION_RULES_WITHOUT_GROUPS,
         ValidationRule.class,

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
@@ -27,6 +27,7 @@ checks:
   - orgunits/orgunits_invalid_geometry.yaml
   - orgunits/orgunits_no_geometry.yaml
   - orgunits/orgunits_same_name_and_parent.yaml
+  - orgunits/orgunits_no_groups.yaml
   - option_sets/option_sets_empty.yaml
   - option_sets/unused_option_sets.yaml
   - option_sets/option_sets_wrong_sort_order.yaml

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/orgunits/orgunits_no_groups.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/orgunits/orgunits_no_groups.yaml
@@ -1,0 +1,54 @@
+# Copyright (c) 2004-2022, University of Oslo
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# Neither the name of the HISP project nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+---
+name: orgunits_no_groups
+description: Organisation units with no groups.
+section: Organisation units
+section_order: 13
+summary_sql: >-
+  WITH orgunits_no_groups as (
+  SELECT uid,name from organisationunit
+  where organisationunitid NOT IN (
+  SELECT organisationunitid from orgunitgroupmembers))
+  SELECT 
+  COUNT(*)as value,
+  100.0 * COUNT(*) / NULLIF( (SELECT COUNT(*) FROM organisationunit), 0) as percent
+  FROM orgunits_no_groups;
+details_sql: >-
+  SELECT uid,name from organisationunit
+  where organisationunitid NOT IN (
+  SELECT organisationunitid from orgunitgroupmembers)
+  ORDER BY name;
+details_id_type: organisationUnits
+severity: WARNING
+introduction: |
+  All organisation units should usually belong to at least one organisation unit group.
+  When organisation units do not belong to any groups, they become more difficult to identify
+  in analysis apps like the data visualizer.
+recommendation: |
+  Create useful organisation unit groups to help users filter certain classes of organisation
+  units. These groups may or may not be used in organisation unit group sets

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
@@ -429,13 +429,6 @@ class DataIntegrityServiceTest {
   }
 
   @Test
-  void testGetOrganisationUnitsWithoutGroups() {
-    subject.getOrganisationUnitsWithoutGroups();
-    verify(organisationUnitService).getOrganisationUnitsWithoutGroups();
-    verifyNoMoreInteractions(organisationUnitService);
-  }
-
-  @Test
   void testGetProgramRulesWithNoExpression() {
     programRuleB.setCondition(null);
     when(programRuleService.getProgramRulesWithNoCondition()).thenReturn(List.of(programRuleB));

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
@@ -56,7 +56,7 @@ class DataIntegrityYamlReaderTest {
 
     List<DataIntegrityCheck> checks = new ArrayList<>();
     readYaml(checks, "data-integrity-checks.yaml", "data-integrity-checks", CLASS_PATH);
-    assertEquals(63, checks.size());
+    assertEquals(64, checks.size());
 
     // Names should be unique
     List<String> allNames = checks.stream().map(DataIntegrityCheck::getName).toList();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityOrganisationUnitsNoGroupsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityOrganisationUnitsNoGroupsControllerTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.dataintegrity;
+
+import static org.hisp.dhis.web.WebClientUtils.assertStatus;
+
+import org.hisp.dhis.web.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Checks for organisation units with no groups. {@see
+ * dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/orgunits/orgunits_no_groups.yaml}
+ *
+ * @author Jason P. Pickering
+ */
+public class DataIntegrityOrganisationUnitsNoGroupsControllerTest
+    extends AbstractDataIntegrityIntegrationTest {
+  private String orgunitA;
+
+  private String orgunitB;
+
+  private String testOrgUnitGroupA;
+
+  private static final String check = "orgunits_no_groups";
+
+  private static final String detailsIdType = "organisationUnits";
+
+  @Test
+  void testOrgunitsNoGroups() {
+
+    orgunitA =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/organisationUnits",
+                "{ 'name': 'Fish District', 'shortName': 'Fish District', 'openingDate' : '2022-01-01'}"));
+
+    orgunitB =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/organisationUnits",
+                "{ 'name': 'Pizza District', 'shortName': 'Pizza District', 'openingDate' : '2022-01-01'}"));
+
+    // Create an orgunit group
+    testOrgUnitGroupA =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/organisationUnitGroups",
+                "{'name': 'Type A', 'shortName': 'Type A', 'organisationUnits' : [{'id' : '"
+                    + orgunitA
+                    + "'}]}"));
+    assertHasDataIntegrityIssues(
+        detailsIdType, check, 50, orgunitB, "Pizza District", "Type", true);
+  }
+
+  @Test
+  void testOrgunitsInGroups() {
+
+    orgunitA =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/organisationUnits",
+                "{ 'name': 'Fish District', 'shortName': 'Fish District', 'openingDate' : '2022-01-01'}"));
+
+    orgunitB =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/organisationUnits",
+                "{ 'name': 'Pizza District', 'shortName': 'Pizza District', 'openingDate' : '2022-01-01'}"));
+
+    // Create an orgunit group
+    testOrgUnitGroupA =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/organisationUnitGroups",
+                "{'name': 'Type A', 'shortName': 'Type A', 'organisationUnits' : [{'id' : '"
+                    + orgunitA
+                    + "'}, {'id' : '"
+                    + orgunitB
+                    + "'}]}"));
+    assertHasNoDataIntegrityIssues(detailsIdType, check, true);
+  }
+
+  @Test
+  void testOrgUnitsNoGroupsDivideByZero() {
+    assertHasNoDataIntegrityIssues(detailsIdType, check, false);
+  }
+}


### PR DESCRIPTION
Replaces the integrity check relating to organisation units with no groups with an SQL based equivalent. 