### PR TITLE
fix: Always include default cat combo for data set metadata [DHIS2-16129]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
@@ -33,6 +33,8 @@ import static org.hisp.dhis.commons.collection.CollectionUtils.flatMapToSet;
 import static org.hisp.dhis.commons.collection.CollectionUtils.mapToSet;
 import static org.hisp.dhis.commons.collection.ListUtils.distinctUnion;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -42,7 +44,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.SetValuedMap;
 import org.apache.commons.lang3.ObjectUtils;
 import org.hisp.dhis.category.Category;
@@ -71,11 +73,6 @@ import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.stereotype.Service;
-
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import lombok.RequiredArgsConstructor;
 
 /**
  * @author Lars Helge Overland
@@ -159,8 +156,8 @@ public class DefaultDataSetMetadataExportService implements DataSetMetadataExpor
     List<CategoryOption> categoryOptions =
         sortById(getCategoryOptions(dataElementCategories, dataSetCategories, user));
     List<OptionSet> optionSets = sortById(getOptionSets(dataElements));
-    
-    dataSetCategoryCombos.removeAll( dataElementCategoryCombos );
+
+    dataSetCategoryCombos.removeAll(dataElementCategoryCombos);
 
     expressionService.substituteIndicatorExpressions(indicators);
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
@@ -31,10 +31,8 @@ import static org.hisp.dhis.common.IdentifiableObjectUtils.sortById;
 import static org.hisp.dhis.commons.collection.CollectionUtils.addIfNotNull;
 import static org.hisp.dhis.commons.collection.CollectionUtils.flatMapToSet;
 import static org.hisp.dhis.commons.collection.CollectionUtils.mapToSet;
-import static org.hisp.dhis.commons.collection.ListUtils.union;
+import static org.hisp.dhis.commons.collection.ListUtils.distinctUnion;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -44,7 +42,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
+
 import org.apache.commons.collections4.SetValuedMap;
 import org.apache.commons.lang3.ObjectUtils;
 import org.hisp.dhis.category.Category;
@@ -73,6 +71,11 @@ import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import lombok.RequiredArgsConstructor;
 
 /**
  * @author Lars Helge Overland
@@ -138,7 +141,6 @@ public class DefaultDataSetMetadataExportService implements DataSetMetadataExpor
   @Override
   public ObjectNode getDataSetMetadata() {
     User user = currentUserService.getCurrentUser();
-    CategoryCombo defaultCategoryCombo = categoryService.getDefaultCategoryCombo();
     SetValuedMap<String, String> dataSetOrgUnits =
         dataSetService.getDataSetOrganisationUnitsAssociations();
 
@@ -153,12 +155,13 @@ public class DefaultDataSetMetadataExportService implements DataSetMetadataExpor
         sortById(flatMapToSet(dataElementCategoryCombos, CategoryCombo::getCategories));
     List<Category> dataSetCategories =
         sortById(flatMapToSet(dataSetCategoryCombos, CategoryCombo::getCategories));
-    List<Category> categories = union(dataElementCategories, dataSetCategories);
+    List<Category> categories = distinctUnion(dataElementCategories, dataSetCategories);
     List<CategoryOption> categoryOptions =
         sortById(getCategoryOptions(dataElementCategories, dataSetCategories, user));
     List<OptionSet> optionSets = sortById(getOptionSets(dataElements));
+    
+    dataSetCategoryCombos.removeAll( dataElementCategoryCombos );
 
-    dataSetCategoryCombos.remove(defaultCategoryCombo);
     expressionService.substituteIndicatorExpressions(indicators);
 
     ObjectNode rootNode = fieldFilterService.createObjectNode();

--- a/dhis-2/dhis-support/dhis-support-commons/src/test/java/org/hisp/dhis/commons/collection/ListUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/test/java/org/hisp/dhis/commons/collection/ListUtilsTest.java
@@ -1,0 +1,18 @@
+package org.hisp.dhis.commons.collection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ListUtilsTest {
+  @Test
+  void testDistinctUnion() {
+    List<String> listA = List.of("One", "Two", "Three");
+    List<String> listB = List.of("One", "Three", "Four");
+    List<String> listC = List.of("Three", "Five");
+
+    List<String> union = List.of("One", "Two", "Three", "Four", "Five");
+
+    assertEquals(union, ListUtils.distinctUnion(listA, listB, listC));
+  }
+}

--- a/dhis-2/dhis-support/dhis-support-commons/src/test/java/org/hisp/dhis/commons/collection/ListUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/test/java/org/hisp/dhis/commons/collection/ListUtilsTest.java
@@ -1,6 +1,34 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.commons.collection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.List;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
Ensure the default category combo is included for data set metadata in the case where no data elements are associated with it. Ensures no duplication of categories.