### PR TITLE
fix: Skip tmp tables check for closed programs [TECH-1671]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerOwnershipManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerOwnershipManager.java
@@ -246,12 +246,12 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager {
     OrganisationUnit ou =
         getOwner(entityInstance.getId(), program, entityInstance::getOrganisationUnit);
 
-    if (program.isOpen() || program.isAudited()) {
-      return organisationUnitService.isInUserSearchHierarchyCached(user, ou);
-    } else {
-      return organisationUnitService.isInUserHierarchyCached(user, ou)
+    return switch (program.getAccessLevel()) {
+      case OPEN, AUDITED -> organisationUnitService.isInUserSearchHierarchyCached(user, ou);
+      case PROTECTED -> organisationUnitService.isInUserHierarchyCached(user, ou)
           || hasTemporaryAccess(entityInstance, program, user);
-    }
+      case CLOSED -> organisationUnitService.isInUserHierarchyCached(user, ou);
+    };
   }
 
   @Override
@@ -262,12 +262,13 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager {
       return true;
     }
 
-    if (program.isOpen() || program.isAudited()) {
-      return organisationUnitService.isInUserSearchHierarchyCached(user, owningOrgUnit);
-    } else {
-      return organisationUnitService.isInUserHierarchyCached(user, owningOrgUnit)
+    return switch (program.getAccessLevel()) {
+      case OPEN, AUDITED -> organisationUnitService.isInUserSearchHierarchyCached(
+          user, owningOrgUnit);
+      case PROTECTED -> organisationUnitService.isInUserHierarchyCached(user, owningOrgUnit)
           || hasTemporaryAccessWithUid(entityInstance, program, user);
-    }
+      case CLOSED -> organisationUnitService.isInUserHierarchyCached(user, owningOrgUnit);
+    };
   }
 
   @Override

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackerOwnershipManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackerOwnershipManagerTest.java
@@ -66,6 +66,8 @@ class TrackerOwnershipManagerTest extends IntegrationTestBase {
 
   private Program programA;
 
+  private Program programB;
+
   private User userA;
 
   private User userB;
@@ -87,6 +89,9 @@ class TrackerOwnershipManagerTest extends IntegrationTestBase {
     programA = createProgram('A');
     programA.setAccessLevel(AccessLevel.PROTECTED);
     programService.addProgram(programA);
+    programB = createProgram('B');
+    programB.setAccessLevel(AccessLevel.CLOSED);
+    programService.addProgram(programB);
 
     userA = createUserWithAuth("userA");
     userA.addOrganisationUnit(organisationUnitA);
@@ -128,5 +133,49 @@ class TrackerOwnershipManagerTest extends IntegrationTestBase {
         entityInstanceA1, programA, organisationUnitB, false, true);
     assertFalse(trackerOwnershipAccessManager.hasAccess(userA, entityInstanceA1, programA));
     assertTrue(trackerOwnershipAccessManager.hasAccess(userB, entityInstanceA1, programA));
+  }
+
+  @Test
+  void shouldHaveAccessWhenProgramProtectedAndUserInCaptureScope() {
+    assertTrue(trackerOwnershipAccessManager.hasAccess(userA, entityInstanceA1, programA));
+    assertTrue(
+        trackerOwnershipAccessManager.hasAccess(
+            userA, entityInstanceA1.getUid(), entityInstanceA1.getOrganisationUnit(), programA));
+  }
+
+  @Test
+  void shouldHaveAccessWhenProgramProtectedAndHasTemporaryAccess() {
+    trackerOwnershipAccessManager.grantTemporaryOwnership(
+        entityInstanceA1, programA, userB, "test protected program");
+    assertTrue(trackerOwnershipAccessManager.hasAccess(userB, entityInstanceA1, programA));
+    assertTrue(
+        trackerOwnershipAccessManager.hasAccess(
+            userB, entityInstanceA1.getUid(), entityInstanceA1.getOrganisationUnit(), programA));
+  }
+
+  @Test
+  void shouldNotHaveAccessWhenProgramProtectedAndUserNotInCaptureScopeNorHasTemporaryAccess() {
+    assertFalse(trackerOwnershipAccessManager.hasAccess(userB, entityInstanceA1, programA));
+    assertFalse(
+        trackerOwnershipAccessManager.hasAccess(
+            userB, entityInstanceA1.getUid(), entityInstanceA1.getOrganisationUnit(), programA));
+  }
+
+  @Test
+  void shouldHaveAccessWhenProgramClosedAndUserInCaptureScope() {
+    assertTrue(trackerOwnershipAccessManager.hasAccess(userB, entityInstanceB1, programB));
+    assertTrue(
+        trackerOwnershipAccessManager.hasAccess(
+            userB, entityInstanceB1.getUid(), entityInstanceB1.getOrganisationUnit(), programB));
+  }
+
+  @Test
+  void shouldNotHaveAccessWhenProgramClosedAndUserHasTemporaryAccess() {
+    trackerOwnershipAccessManager.grantTemporaryOwnership(
+        entityInstanceA1, programB, userB, "test closed program");
+    assertFalse(trackerOwnershipAccessManager.hasAccess(userB, entityInstanceA1, programB));
+    assertFalse(
+        trackerOwnershipAccessManager.hasAccess(
+            userB, entityInstanceA1.getUid(), entityInstanceA1.getOrganisationUnit(), programB));
   }
 }


### PR DESCRIPTION
We don't need to check the temporary access tables when the program requested is closed.

Ticket: https://dhis2.atlassian.net/browse/TECH-1671