### PR TITLE
feat: datastore partial and rolling updates [DHIS2-16224]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastore/DatastoreService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastore/DatastoreService.java
@@ -31,6 +31,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.datastore.DatastoreNamespaceProtection.ProtectionType;
 import org.hisp.dhis.feedback.BadRequestException;
@@ -137,13 +139,28 @@ public interface DatastoreService {
   void addEntry(DatastoreEntry entry) throws ConflictException, BadRequestException;
 
   /**
-   * Updates an entry.
+   * Updates the entry value (path is undefined or empty) or updates the existing value the the
+   * provided path with the provided value.
    *
-   * @param entry the updated KeyJsonValue.
-   * @throws IllegalArgumentException when the entry value is not valid JSON
-   * @throws AccessDeniedException when user lacks authority for namespace or entry
+   * <p>If a roll size is provided and the exiting value (at path) is an array the array is not
+   * replaced with the value but the value is appended to the array. The head of the array is
+   * dropped if the size of the array is equal or larger than the roll size.
+   *
+   * @param ns namespace to update
+   * @param key key to update
+   * @param value the new JSON value, null to remove the entry or clear the property at the provided
+   *     path
+   * @param path to update, null or empty to update the root (the entire value)
+   * @param roll when set the value is appended to arrays instead of replacing them while also
+   *     rolling (dropping the array head element when its size exceeds the given roll size)
    */
-  void updateEntry(DatastoreEntry entry) throws BadRequestException;
+  void updateEntry(
+      @Nonnull String ns,
+      @Nonnull String key,
+      @CheckForNull String value,
+      @CheckForNull String path,
+      @CheckForNull Integer roll)
+      throws BadRequestException;
 
   /**
    * Deletes an entry.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastore/DatastoreStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastore/DatastoreStore.java
@@ -31,6 +31,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 
 /**
@@ -109,4 +111,28 @@ public interface DatastoreStore extends IdentifiableObjectStore<DatastoreEntry> 
    * @return number of entries in the given namespace.
    */
   int countKeysInNamespace(String namespace);
+
+  /**
+   * Updates the entry value (path is undefined or empty) or updates the existing value the the
+   * provided path with the provided value.
+   *
+   * <p>If a roll size is provided and the exiting value (at path) is an array the array is not
+   * replaced with the value but the value is appended to the array. The head of the array is
+   * dropped if the size of the array is equal or larger than the roll size.
+   *
+   * @param ns namespace to update
+   * @param key key to update
+   * @param value the new JSON value, null to remove the entry or clear the property at the provided
+   *     path
+   * @param path to update, null or empty to update the root (the entire value)
+   * @param roll when set the value is appended to arrays instead of replacing them while also
+   *     rolling (dropping the array head element when its size exceeds the given roll size)
+   * @return true, if the update affects an existing row
+   */
+  boolean updateEntry(
+      @Nonnull String ns,
+      @Nonnull String key,
+      @CheckForNull String value,
+      @CheckForNull String path,
+      @CheckForNull Integer roll);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datastore/DefaultDatastoreService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datastore/DefaultDatastoreService.java
@@ -39,6 +39,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.datastore.DatastoreNamespaceProtection.ProtectionType;
 import org.hisp.dhis.feedback.BadRequestException;
@@ -59,6 +61,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Service
 public class DefaultDatastoreService implements DatastoreService {
+
   private final Map<String, DatastoreNamespaceProtection> protectionByNamespace =
       new ConcurrentHashMap<>();
 
@@ -131,10 +134,16 @@ public class DefaultDatastoreService implements DatastoreService {
 
   @Override
   @Transactional
-  public void updateEntry(DatastoreEntry entry) throws BadRequestException {
-    validateEntry(entry);
-    Runnable update = () -> store.updateNoAcl(entry);
-    writeProtectedIn(entry.getNamespace(), () -> singletonList(entry), update);
+  public void updateEntry(
+      @Nonnull String ns,
+      @Nonnull String key,
+      @CheckForNull String value,
+      @CheckForNull String path,
+      @CheckForNull Integer roll)
+      throws BadRequestException {
+    validateEntry(key, value);
+    Runnable update = () -> store.updateEntry(ns, key, value, path, roll);
+    writeProtectedIn(ns, () -> List.of(store.getEntry(ns, key)), update);
   }
 
   @Override
@@ -254,11 +263,15 @@ public class DefaultDatastoreService implements DatastoreService {
   }
 
   private void validateEntry(DatastoreEntry entry) throws BadRequestException {
+    validateEntry(entry.getKey(), entry.getValue());
+  }
+
+  private static void validateEntry(String key, String value) throws BadRequestException {
+    if (value == null) return;
     try {
-      JsonNode.of(entry.getValue()).visit(JsonNode::value);
+      JsonNode.of(value).visit(JsonNode::value);
     } catch (RuntimeException e) {
-      throw new BadRequestException(
-          String.format("Invalid JSON value for key '%s'", entry.getKey()));
+      throw new BadRequestException(String.format("Invalid JSON value for key '%s'", key));
     }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datastore/hibernate/HibernateDatastoreStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datastore/hibernate/HibernateDatastoreStore.java
@@ -36,6 +36,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import javax.persistence.EntityManager;
 import javax.persistence.criteria.CriteriaBuilder;
 import org.hibernate.query.Query;
@@ -172,15 +174,133 @@ public class HibernateDatastoreStore extends HibernateIdentifiableObjectStore<Da
   }
 
   @Override
-  public void deleteNamespace(String namespace) {
-    String hql = "delete from DatastoreEntry v where v.namespace = :namespace";
-    getSession().createQuery(hql).setParameter("namespace", namespace).executeUpdate();
+  public void deleteNamespace(String ns) {
+    // language=SQL
+    String sql = "delete from keyjsonvalue ds where ds.namespace = :ns";
+    getSession().createNativeQuery(sql).setParameter("ns", ns).executeUpdate();
   }
 
   @Override
-  public int countKeysInNamespace(String namespace) {
-    String hql = "select count(*) from DatastoreEntry v where v.namespace = :namespace";
-    Query<Long> count = getTypedQuery(hql);
-    return count.setParameter("namespace", namespace).getSingleResult().intValue();
+  public int countKeysInNamespace(String ns) {
+    // language=SQL
+    String sql = "select count(*) from keyjsonvalue v where v.namespace = :ns";
+    Object count = getSession().createNativeQuery(sql).setParameter("ns", ns).uniqueResult();
+    if (count == null) return 0;
+    if (count instanceof Number n) return n.intValue();
+    throw new IllegalStateException("Count did not return a number but: " + count);
+  }
+
+  @Override
+  public boolean updateEntry(
+      @Nonnull String ns,
+      @Nonnull String key,
+      @CheckForNull String value,
+      @CheckForNull String path,
+      @CheckForNull Integer roll) {
+    boolean rootIsTarget = path == null || path.isEmpty();
+    if (value == null && rootIsTarget)
+      // delete
+      return getSession()
+              .createNativeQuery(
+                  "delete from keyjsonvalue where namespace = :ns and namespacekey = :key")
+              .setParameter("ns", ns)
+              .setParameter("key", key)
+              .executeUpdate()
+          > 0;
+    if (value == null)
+      // delete value at path (set to null)
+      return getSession()
+              .createNativeQuery(
+                  "update keyjsonvalue set jbvalue = jsonb_set(jbvalue, cast(:path as text[]), 'null', false) where namespace = :ns and namespacekey = :key")
+              .setParameter("ns", ns)
+              .setParameter("key", key)
+              .setParameter("path", toJsonbPath(path))
+              .executeUpdate()
+          > 0;
+    if (roll == null && rootIsTarget)
+      // root value update (classic update)
+      return getSession()
+              .createNativeQuery(
+                  "update keyjsonvalue set jbvalue = cast(:value as jsonb) where namespace = :ns and namespacekey = :key")
+              .setParameter("ns", ns)
+              .setParameter("key", key)
+              .setParameter("value", value)
+              .executeUpdate()
+          > 0;
+    if (roll == null)
+      // partial value update (change existing value at path)
+      return getSession()
+              .createNativeQuery(
+                  "update keyjsonvalue set jbvalue = jsonb_set(jbvalue, cast(:path as text[]), cast(:value as jsonb), false) where namespace = :ns and namespacekey = :key")
+              .setParameter("ns", ns)
+              .setParameter("key", key)
+              .setParameter("value", value)
+              .setParameter("path", toJsonbPath(path))
+              .executeUpdate()
+          > 0;
+    if (rootIsTarget) {
+      // root value fixed size array insert (fixed collection root value)
+      String sql =
+          """
+        update keyjsonvalue
+        set jbvalue = case jsonb_typeof(jbvalue)
+          when 'null' then to_jsonb(ARRAY[cast(:value as jsonb)])
+          when 'array' then case
+            when :size < 0 or jsonb_array_length(jbvalue) >= :size
+              then (jbvalue - 0) || to_jsonb(ARRAY[cast(:value as jsonb)])
+            else jbvalue || to_jsonb(ARRAY[cast(:value as jsonb)])
+            end
+          else cast(:value as jsonb)
+          end
+        where namespace = :ns and namespacekey = :key""";
+      return getSession()
+              .createNativeQuery(sql)
+              .setParameter("ns", ns)
+              .setParameter("key", key)
+              .setParameter("value", value)
+              .setParameter("size", roll)
+              .executeUpdate()
+          > 0;
+    }
+    // partial path value fixed size array insert (fixed collection partial value)
+    String sql =
+        """
+          update keyjsonvalue
+          set jbvalue = case jsonb_typeof(jsonb_extract_path(jbvalue, VARIADIC cast(:path as text[])))
+            when 'null' then jsonb_set(jbvalue, cast(:path as text[]), to_jsonb(ARRAY[cast(:value as jsonb)]))
+            when 'array' then case
+              when :size < 0 or jsonb_array_length(jsonb_extract_path(jbvalue, VARIADIC cast(:path as text[]))) >= :size
+                then jsonb_set(jbvalue, cast(:path as text[]), (jsonb_extract_path(jbvalue, VARIADIC cast(:path as text[])) - 0) || to_jsonb(ARRAY[cast(:value as jsonb)]), false)
+              else jsonb_set(jbvalue, cast(:path as text[]), jsonb_extract_path(jbvalue, VARIADIC cast(:path as text[])) || to_jsonb(ARRAY[cast(:value as jsonb)]), false)
+              end
+            else jsonb_set(jbvalue, cast(:path as text[]), cast(:value as jsonb))
+            end
+          where namespace = :ns and namespacekey = :key""";
+    return getSession()
+            .createNativeQuery(sql)
+            .setParameter("ns", ns)
+            .setParameter("key", key)
+            .setParameter("value", value)
+            .setParameter("size", roll)
+            .setParameter("path", toJsonbPath(path))
+            .executeUpdate()
+        > 0;
+  }
+
+  /**
+   * Transforms Java/JSON property paths with paths as expected by jsonb functions, for example
+   *
+   * <p>{@code foo.bar.[0]} becomes {@code foo,bar,0}
+   *
+   * @param path a property path
+   * @return a jsonb path
+   */
+  private static String toJsonbPath(String path) {
+    if (path == null || path.isEmpty()) return "{}";
+    String jsonbPath =
+        path.replaceAll("\\[(\\d+)]", ",$1") // replace [#] with ,#
+            .replace('.', ',') // replace . with ,
+            .replace(",,", ","); // undo ,, that might originate from 1. replace with just ,
+    return String.format("{%s}", jsonbPath);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HibernateJobConfigurationStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HibernateJobConfigurationStore.java
@@ -108,7 +108,7 @@ public class HibernateJobConfigurationStore
         case jsonb_typeof(progress)
         when 'object' then progress #>> '{}'
         when 'array' then jsonb_build_object('sequence', progress) #>> '{}'
-       end
+        end
       from jobconfiguration
       where uid = :id
       """;
@@ -123,7 +123,7 @@ public class HibernateJobConfigurationStore
           select
             case jsonb_typeof(progress)
             when 'object' then progress #>> '{errors}'
-           end
+            end
           from jobconfiguration
           where uid = :id
           """;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datastore/DatastoreServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datastore/DatastoreServiceTest.java
@@ -47,7 +47,6 @@ class DatastoreServiceTest extends SingleSetupIntegrationTestBase {
   private final String namespace = "DOGS";
 
   @Autowired private DatastoreService service;
-
   @Autowired private ObjectMapper jsonMapper;
 
   @Test
@@ -64,26 +63,6 @@ class DatastoreServiceTest extends SingleSetupIntegrationTestBase {
     assertNotNull(dogB);
     assertEquals("2", dogB.getId());
     assertEquals("Aldo", dogB.getName());
-  }
-
-  @Test
-  void testAddUpdateObject() throws ConflictException, BadRequestException {
-    Dog dogA = new Dog("1", "Fido", "Brown");
-    Dog dogB = new Dog("2", "Aldo", "Black");
-    addValue(namespace, dogA.getId(), dogA);
-    addValue(namespace, dogB.getId(), dogB);
-    dogA = getValue(namespace, dogA.getId(), Dog.class);
-    dogB = getValue(namespace, dogB.getId(), Dog.class);
-    assertEquals("Fido", dogA.getName());
-    assertEquals("Aldo", dogB.getName());
-    dogA.setName("Lilly");
-    dogB.setName("Teddy");
-    updateValue(namespace, dogA.getId(), dogA);
-    updateValue(namespace, dogB.getId(), dogB);
-    dogA = getValue(namespace, dogA.getId(), Dog.class);
-    dogB = getValue(namespace, dogB.getId(), Dog.class);
-    assertEquals("Lilly", dogA.getName());
-    assertEquals("Teddy", dogB.getName());
   }
 
   private <T> T getValue(String namespace, String key, Class<T> type) {
@@ -103,8 +82,7 @@ class DatastoreServiceTest extends SingleSetupIntegrationTestBase {
       throw new IllegalStateException(
           String.format("No object found for namespace '%s' and key '%s'", namespace, key));
     }
-    entry.setValue(mapValueToJson(object));
-    service.updateEntry(entry);
+    service.updateEntry(entry.getNamespace(), entry.getKey(), mapValueToJson(object), null, null);
   }
 
   private <T> T mapJsonValueTo(Class<T> type, DatastoreEntry entry) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/DhisControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/DhisControllerIntegrationTest.java
@@ -48,7 +48,9 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.context.WebApplicationContext;
 
 /**
@@ -78,6 +80,8 @@ public class DhisControllerIntegrationTest extends DhisControllerTestBase {
   @Autowired protected DbmsManager dbmsManager;
 
   @Autowired protected DhisConfigurationProvider dhisConfigurationProvider;
+
+  @Autowired private TransactionTemplate txTemplate;
 
   @BeforeEach
   final void setup() throws Exception {
@@ -118,5 +122,17 @@ public class DhisControllerIntegrationTest extends DhisControllerTestBase {
     }
     if (!timeout.isNegative()) return true;
     return test.getAsBoolean();
+  }
+
+  protected final void doInTransaction(Runnable operation) {
+    final int defaultPropagationBehaviour = txTemplate.getPropagationBehavior();
+    txTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    txTemplate.execute(
+        status -> {
+          operation.run();
+          return null;
+        });
+    // restore original propagation behaviour
+    txTemplate.setPropagationBehavior(defaultPropagationBehaviour);
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerAndroidSettingsAppTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerAndroidSettingsAppTest.java
@@ -104,16 +104,6 @@ class DatastoreControllerAndroidSettingsAppTest extends DhisControllerConvenienc
   }
 
   @Test
-  void testUpdateKeyJsonValue() {
-    switchToNewUser("not-an-android-manager");
-    assertEquals(
-        "Namespace 'ANDROID_SETTINGS_APP' is protected, access denied",
-        PUT("/dataStore/" + NAMESPACE + "/key", "[]").error(HttpStatus.FORBIDDEN).getMessage());
-    switchToNewUser("andriod-manager", AUTHORITY);
-    assertStatus(HttpStatus.OK, PUT("/dataStore/" + NAMESPACE + "/key", "[]"));
-  }
-
-  @Test
   void testDeleteKeyJsonValue() {
     switchToNewUser("not-an-android-manager");
     assertEquals(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerAppTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerAppTest.java
@@ -131,18 +131,6 @@ class DatastoreControllerAppTest extends DhisControllerConvenienceTest {
   }
 
   @Test
-  void testUpdateKeyJsonValue() {
-    assertStatus(HttpStatus.CREATED, POST("/dataStore/test-app-ns/key1", "[]"));
-    assertStatus(HttpStatus.OK, PUT("/dataStore/test-app-ns/key1", "{}"));
-    switchToNewUser("just-test-app-admin", App.SEE_APP_AUTHORITY_PREFIX + "test");
-    assertStatus(HttpStatus.OK, PUT("/dataStore/test-app-ns/key1", "{}"));
-    switchToNewUser("has-no-app-authority");
-    assertEquals(
-        "Namespace 'test-app-ns' is protected, access denied",
-        PUT("/dataStore/test-app-ns/key1", "{}").error(HttpStatus.FORBIDDEN).getMessage());
-  }
-
-  @Test
   void testDeleteKeyJsonValue() {
     assertStatus(HttpStatus.CREATED, POST("/dataStore/test-app-ns/key1", "[]"));
     assertStatus(HttpStatus.OK, DELETE("/dataStore/test-app-ns/key1"));

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerIntegrationTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static java.util.Arrays.asList;
+import static org.hisp.dhis.appmanager.AndroidSettingsApp.AUTHORITY;
+import static org.hisp.dhis.appmanager.AndroidSettingsApp.NAMESPACE;
+import static org.hisp.dhis.web.WebClientUtils.assertStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import org.hisp.dhis.appmanager.App;
+import org.hisp.dhis.appmanager.AppManager;
+import org.hisp.dhis.appmanager.AppStatus;
+import org.hisp.dhis.datastore.DatastoreNamespaceProtection;
+import org.hisp.dhis.datastore.DatastoreService;
+import org.hisp.dhis.web.HttpStatus;
+import org.hisp.dhis.webapi.DhisControllerIntegrationTest;
+import org.hisp.dhis.webapi.json.domain.JsonDatastoreValue;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Update related tests that were moved over from in-memory DB controller tests as they now use SQL
+ * to perform the update that does not work with the H2 database.
+ *
+ * @author Jan Bernitt
+ */
+class DatastoreControllerIntegrationTest extends DhisControllerIntegrationTest {
+
+  @Autowired private AppManager appManager;
+
+  /**
+   * Only used directly to setup namespace protection as this is by intention not possible using the
+   * REST API.
+   */
+  @Autowired private DatastoreService service;
+
+  @Autowired private TransactionTemplate txTemplate;
+
+  @Test
+  void testUpdateKeyJsonValue_AndroidApp() {
+    switchToNewUser("not-an-android-manager");
+    assertEquals(
+        "Namespace 'ANDROID_SETTINGS_APP' is protected, access denied",
+        PUT("/dataStore/" + NAMESPACE + "/key", "[]").error(HttpStatus.FORBIDDEN).getMessage());
+    switchToNewUser("andriod-manager", AUTHORITY);
+    assertStatus(HttpStatus.CREATED, PUT("/dataStore/" + NAMESPACE + "/key", "[]"));
+  }
+
+  @Test
+  void testUpdateKeyJsonValue_App() throws IOException {
+    assertEquals(
+        AppStatus.OK,
+        appManager.installApp(new ClassPathResource("app/test-app.zip").getFile(), "test-app.zip"));
+    // by default we are an app manager
+    switchToNewUser("app-admin", AppManager.WEB_MAINTENANCE_APPMANAGER_AUTHORITY);
+
+    assertStatus(HttpStatus.CREATED, POST("/dataStore/test-app-ns/key1", "[]"));
+    assertStatus(HttpStatus.OK, PUT("/dataStore/test-app-ns/key1", "{}"));
+    switchToNewUser("just-test-app-admin", App.SEE_APP_AUTHORITY_PREFIX + "test");
+    assertStatus(HttpStatus.OK, PUT("/dataStore/test-app-ns/key1", "{}"));
+    switchToNewUser("has-no-app-authority");
+    assertEquals(
+        "Namespace 'test-app-ns' is protected, access denied",
+        PUT("/dataStore/test-app-ns/key1", "{}").error(HttpStatus.FORBIDDEN).getMessage());
+  }
+
+  @Test
+  void testPutEntry_EntryAlreadyExistsAndIsUpdated() {
+    doInTransaction(
+        () -> assertStatus(HttpStatus.CREATED, PUT("/dataStore/pets/emu", "{\"name\":\"harry\"}")));
+    doInTransaction(
+        () -> assertStatus(HttpStatus.OK, PUT("/dataStore/pets/emu", "{\"name\":\"james\"}")));
+    JsonDatastoreValue emu = GET("/dataStore/pets/emu").content().as(JsonDatastoreValue.class);
+    assertEquals("james", emu.getString("name").string());
+  }
+
+  @Test
+  void testUpdateKeyJsonValue_ProtectedNamespaceWhenRestricted() {
+    setUpNamespaceProtection(
+        "pets", DatastoreNamespaceProtection.ProtectionType.RESTRICTED, "pets-admin");
+    assertStatus(HttpStatus.CREATED, POST("/dataStore/pets/cat", "{}"));
+    switchToNewUser("anonymous");
+    assertStatus(HttpStatus.FORBIDDEN, PUT("/dataStore/pets/cat", "[]"));
+    switchToNewUser("someone", "pets-admin");
+    assertStatus(HttpStatus.OK, PUT("/dataStore/pets/cat", "[]"));
+  }
+
+  @Test
+  void testUpdateKeyJsonValue() {
+    doInTransaction(() -> assertStatus(HttpStatus.CREATED, POST("/dataStore/animals/cat", "[]")));
+    doInTransaction(() -> assertStatus(HttpStatus.OK, PUT("/dataStore/animals/cat", "[1,2,3]")));
+    assertEquals(asList(1, 2, 3), GET("/dataStore/animals/cat").content().numberValues());
+  }
+
+  @Test
+  void testPutKeyJsonValue_ProtectedNamespaceWhenHidden() {
+    setUpNamespaceProtection(
+        "pets", DatastoreNamespaceProtection.ProtectionType.HIDDEN, "pets-admin");
+    assertStatus(HttpStatus.CREATED, POST("/dataStore/pets/cat", "{}"));
+    switchToNewUser("anonymous");
+    assertStatus(HttpStatus.CREATED, PUT("/dataStore/pets/cat", "[]"));
+    switchToNewUser("someone", "pets-admin");
+    assertStatus(HttpStatus.OK, PUT("/dataStore/pets/cat", "[]"));
+  }
+
+  @Test
+  void testUpdateKeyJsonValue_ProtectedNamespaceWithSharing() {
+    setUpNamespaceProtectionWithSharing(
+        "pets", DatastoreNamespaceProtection.ProtectionType.HIDDEN, "pets-admin");
+    assertStatus(HttpStatus.CREATED, POST("/dataStore/pets/cat", "{}"));
+    String uid = GET("/dataStore/pets/cat/metaData").content().as(JsonDatastoreValue.class).getId();
+    assertStatus(
+        HttpStatus.OK,
+        POST("/sharing?type=dataStore&id=" + uid, "{'object':{'publicAccess':'r-------'}}"));
+    switchToNewUser("someone", "pets-admin");
+    assertEquals(
+        "Access denied for key 'cat' in namespace 'pets'",
+        PUT("/dataStore/pets/cat", "[]").error(HttpStatus.FORBIDDEN).getMessage());
+    switchToSuperuser();
+    assertStatus(HttpStatus.OK, PUT("/dataStore/pets/cat", "[]"));
+  }
+
+  private void setUpNamespaceProtection(
+      String namespace,
+      DatastoreNamespaceProtection.ProtectionType readWrite,
+      String... authorities) {
+    service.addProtection(new DatastoreNamespaceProtection(namespace, readWrite, authorities));
+  }
+
+  private void setUpNamespaceProtectionWithSharing(
+      String namespace,
+      DatastoreNamespaceProtection.ProtectionType readWrite,
+      String... authorities) {
+    service.addProtection(new DatastoreNamespaceProtection(namespace, readWrite, authorities));
+  }
+
+  /**
+   * The reason this is needed in this test is that we need the creation and update run in
+   * transactions that are closed as they use different technology stacks. Without this the update
+   * does not become visible when reading back the value, and it appears as if the value is still
+   * the value from creation.
+   */
+  private void doInTransaction(Runnable operation) {
+    final int defaultPropagationBehaviour = txTemplate.getPropagationBehavior();
+    txTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    txTemplate.execute(
+        status -> {
+          operation.run();
+          return null;
+        });
+    // restore original propagation behaviour
+    txTemplate.setPropagationBehavior(defaultPropagationBehaviour);
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerIntegrationTest.java
@@ -45,8 +45,6 @@ import org.hisp.dhis.webapi.json.domain.JsonDatastoreValue;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.transaction.TransactionDefinition;
-import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * Update related tests that were moved over from in-memory DB controller tests as they now use SQL
@@ -63,8 +61,6 @@ class DatastoreControllerIntegrationTest extends DhisControllerIntegrationTest {
    * REST API.
    */
   @Autowired private DatastoreService service;
-
-  @Autowired private TransactionTemplate txTemplate;
 
   @Test
   void testUpdateKeyJsonValue_AndroidApp() {
@@ -162,23 +158,5 @@ class DatastoreControllerIntegrationTest extends DhisControllerIntegrationTest {
       DatastoreNamespaceProtection.ProtectionType readWrite,
       String... authorities) {
     service.addProtection(new DatastoreNamespaceProtection(namespace, readWrite, authorities));
-  }
-
-  /**
-   * The reason this is needed in this test is that we need the creation and update run in
-   * transactions that are closed as they use different technology stacks. Without this the update
-   * does not become visible when reading back the value, and it appears as if the value is still
-   * the value from creation.
-   */
-  private void doInTransaction(Runnable operation) {
-    final int defaultPropagationBehaviour = txTemplate.getPropagationBehavior();
-    txTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
-    txTemplate.execute(
-        status -> {
-          operation.run();
-          return null;
-        });
-    // restore original propagation behaviour
-    txTemplate.setPropagationBehavior(defaultPropagationBehaviour);
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerTest.java
@@ -362,13 +362,6 @@ class DatastoreControllerTest extends DhisControllerConvenienceTest {
   }
 
   @Test
-  void testUpdateKeyJsonValue() {
-    assertStatus(HttpStatus.CREATED, POST("/dataStore/pets/cat", "{}"));
-    assertStatus(HttpStatus.OK, PUT("/dataStore/pets/cat", "[1,2,3]"));
-    assertEquals(asList(1, 2, 3), GET("/dataStore/pets/cat").content().numberValues());
-  }
-
-  @Test
   void testPutKeyJsonValue() {
     assertEquals(
         "Key created: 'cat'",
@@ -384,42 +377,6 @@ class DatastoreControllerTest extends DhisControllerConvenienceTest {
     assertEquals(
         "Invalid JSON value for key 'cat'",
         PUT("/dataStore/pets/cat", "+not JSON+").error(HttpStatus.BAD_REQUEST).getMessage());
-  }
-
-  @Test
-  void testUpdateKeyJsonValue_ProtectedNamespaceWhenRestricted() {
-    setUpNamespaceProtection("pets", ProtectionType.RESTRICTED, "pets-admin");
-    assertStatus(HttpStatus.CREATED, POST("/dataStore/pets/cat", "{}"));
-    switchToNewUser("anonymous");
-    assertStatus(HttpStatus.FORBIDDEN, PUT("/dataStore/pets/cat", "[]"));
-    switchToNewUser("someone", "pets-admin");
-    assertStatus(HttpStatus.OK, PUT("/dataStore/pets/cat", "[]"));
-  }
-
-  @Test
-  void testPutKeyJsonValue_ProtectedNamespaceWhenHidden() {
-    setUpNamespaceProtection("pets", ProtectionType.HIDDEN, "pets-admin");
-    assertStatus(HttpStatus.CREATED, POST("/dataStore/pets/cat", "{}"));
-    switchToNewUser("anonymous");
-    assertStatus(HttpStatus.CREATED, PUT("/dataStore/pets/cat", "[]"));
-    switchToNewUser("someone", "pets-admin");
-    assertStatus(HttpStatus.OK, PUT("/dataStore/pets/cat", "[]"));
-  }
-
-  @Test
-  void testUpdateKeyJsonValue_ProtectedNamespaceWithSharing() {
-    setUpNamespaceProtectionWithSharing("pets", ProtectionType.HIDDEN, "pets-admin");
-    assertStatus(HttpStatus.CREATED, POST("/dataStore/pets/cat", "{}"));
-    String uid = GET("/dataStore/pets/cat/metaData").content().as(JsonDatastoreValue.class).getId();
-    assertStatus(
-        HttpStatus.OK,
-        POST("/sharing?type=dataStore&id=" + uid, "{'object':{'publicAccess':'r-------'}}"));
-    switchToNewUser("someone", "pets-admin");
-    assertEquals(
-        "Access denied for key 'cat' in namespace 'pets'",
-        PUT("/dataStore/pets/cat", "[]").error(HttpStatus.FORBIDDEN).getMessage());
-    switchToSuperuser();
-    assertStatus(HttpStatus.OK, PUT("/dataStore/pets/cat", "[]"));
   }
 
   @Test
@@ -482,14 +439,6 @@ class DatastoreControllerTest extends DhisControllerConvenienceTest {
     assertStatus(HttpStatus.CREATED, PUT("/dataStore/pets/emu", "{\"name\":\"harry\"}"));
     JsonDatastoreValue emu = GET("/dataStore/pets/emu").content().as(JsonDatastoreValue.class);
     assertEquals("harry", emu.getString("name").string());
-  }
-
-  @Test
-  void testPutEntry_EntryAlreadyExistsAndIsUpdated() {
-    assertStatus(HttpStatus.CREATED, PUT("/dataStore/pets/emu", "{\"name\":\"harry\"}"));
-    assertStatus(HttpStatus.OK, PUT("/dataStore/pets/emu", "{\"name\":\"james\"}"));
-    JsonDatastoreValue emu = GET("/dataStore/pets/emu").content().as(JsonDatastoreValue.class);
-    assertEquals("james", emu.getString("name").string());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreUpdateControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreUpdateControllerIntegrationTest.java
@@ -27,43 +27,175 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.web.HttpStatus.NOT_FOUND;
+import static org.hisp.dhis.web.HttpStatus.OK;
+import static org.hisp.dhis.web.WebClient.Body;
+import static org.hisp.dhis.web.WebClientUtils.assertStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerIntegrationTest;
 import org.junit.jupiter.api.Test;
 
 /**
  * Tests the different scenarios for updating a datastore value.
  *
+ * <p>Adding keys, updating values and reading them back here need to be run in new transactions so
+ * that the changes become visible.
+ *
  * @author Jan Bernitt
  */
 public class DatastoreUpdateControllerIntegrationTest extends DhisControllerIntegrationTest {
 
   @Test
-  void testUpdateEntry_RootWithNullValue() {}
+  void testUpdateEntry_RootWithNullValue() {
+    addEntry("ns1", "key1", "42");
+    updateEntry("/dataStore/ns1/key1");
+    assertStatus(NOT_FOUND, GET("/dataStore/ns1/key1"));
+  }
 
   @Test
-  void testUpdateEntry_PathWithNullValue() {}
+  void testUpdateEntry_PathWithNullValue() {
+    addEntry("ns2", "key1", "{'a':42}");
+    updateEntry("/dataStore/ns2/key1?path=a");
+    assertEquals("{\"a\": null}", GET("/dataStore/ns2/key1").content().node().getDeclaration());
+  }
 
   @Test
-  void testUpdateEntry_RootWithNonNullValue() {}
+  void testUpdateEntry_RootWithNonNullValue() {
+    addEntry("ns3", "key1", "{'a':42}");
+    updateEntry("/dataStore/ns3/key1", Body("7"));
+    assertEquals("7", GET("/dataStore/ns3/key1").content().node().getDeclaration());
+  }
 
   @Test
-  void testUpdateEntry_PathWithNonNullValue() {}
+  void testUpdateEntry_PathWithNonNullValue() {
+    addEntry("ns4", "key1", "{'a':42}");
+    updateEntry("/dataStore/ns4/key1?path=a", Body("7"));
+    assertEquals("{\"a\": 7}", GET("/dataStore/ns4/key1").content().node().getDeclaration());
+  }
 
   @Test
-  void testUpdateEntry_RollRootValueIsNull() {}
+  void testUpdateEntry_RollRootValueIsNull() {
+    addEntry("ns5", "key1", "null");
+    updateEntry("/dataStore/ns5/key1?roll=3", Body("7"));
+    assertEquals("[7]", GET("/dataStore/ns5/key1").content().node().getDeclaration());
+  }
 
   @Test
-  void testUpdateEntry_RollRootValueIsArray() {}
+  void testUpdateEntry_RollRootValueIsArray() {
+    addEntry("ns6", "key1", "[]");
+    updateEntry("/dataStore/ns6/key1?roll=3", Body("7"));
+    assertEquals("[7]", GET("/dataStore/ns6/key1").content().node().getDeclaration());
+
+    updateEntry("/dataStore/ns6/key1?roll=3", Body("8"));
+    doInTransaction(
+        () -> assertEquals("[7, 8]", GET("/dataStore/ns6/key1").content().node().getDeclaration()));
+
+    updateEntry("/dataStore/ns6/key1?roll=3", Body("9"));
+    doInTransaction(
+        () ->
+            assertEquals(
+                "[7, 8, 9]", GET("/dataStore/ns6/key1").content().node().getDeclaration()));
+
+    updateEntry("/dataStore/ns6/key1?roll=3", Body("10"));
+    doInTransaction(
+        () ->
+            assertEquals(
+                "[8, 9, 10]", GET("/dataStore/ns6/key1").content().node().getDeclaration()));
+  }
 
   @Test
-  void testUpdateEntry_RollRootValueIsOther() {}
+  void testUpdateEntry_RollRootValueIsOther() {
+    addEntry("ns7", "key1", "{}");
+    updateEntry("/dataStore/ns7/key1?roll=3", Body("7"));
+    doInTransaction(
+        () -> assertEquals("7", GET("/dataStore/ns7/key1").content().node().getDeclaration()));
+    updateEntry("/dataStore/ns7/key1?roll=3", Body("\"hello\""));
+    doInTransaction(() -> assertEquals("hello", GET("/dataStore/ns7/key1").content().string()));
+    updateEntry("/dataStore/ns7/key1?roll=3", Body("true"));
+    doInTransaction(() -> assertTrue(GET("/dataStore/ns7/key1").content().booleanValue()));
+  }
 
   @Test
-  void testUpdateEntry_RollPathValueIsNull() {}
+  void testUpdateEntry_RollPathValueIsNull() {
+    addEntry("ns8", "key1", "{'a':null}");
+    updateEntry("/dataStore/ns8/key1?roll=3&path=a", Body("7"));
+    assertEquals("{\"a\": [7]}", GET("/dataStore/ns8/key1").content().node().getDeclaration());
+  }
 
   @Test
-  void testUpdateEntry_RollPathValueIsArray() {}
+  void testUpdateEntry_RollPathValueIsUndefined() {
+    addEntry("ns9", "key1", "{'a':null}");
+    updateEntry("/dataStore/ns9/key1?roll=3&path=b", Body("7"));
+    assertEquals(
+        "{\"a\": null, \"b\": [7]}", GET("/dataStore/ns9/key1").content().node().getDeclaration());
+  }
 
   @Test
-  void testUpdateEntry_RollPathValueIsOther() {}
+  void testUpdateEntry_RollPathValueIsArray() {
+    addEntry("ns10", "key1", "{'a':{'b':[]}}");
+    updateEntry("/dataStore/ns10/key1?roll=3&path=a.b", Body("7"));
+    assertEquals("[7]", GET("/dataStore/ns10/key1").content().get("a.b").node().getDeclaration());
+
+    updateEntry("/dataStore/ns10/key1?roll=3&path=a.b", Body("8"));
+    doInTransaction(
+        () ->
+            assertEquals(
+                "[7, 8]",
+                GET("/dataStore/ns10/key1").content().get("a.b").node().getDeclaration()));
+
+    updateEntry("/dataStore/ns10/key1?roll=3&path=a.b", Body("9"));
+    doInTransaction(
+        () ->
+            assertEquals(
+                "[7, 8, 9]",
+                GET("/dataStore/ns10/key1").content().get("a.b").node().getDeclaration()));
+
+    updateEntry("/dataStore/ns10/key1?roll=3&path=a.b", Body("10"));
+    doInTransaction(
+        () ->
+            assertEquals(
+                "[8, 9, 10]",
+                GET("/dataStore/ns10/key1").content().get("a.b").node().getDeclaration()));
+  }
+
+  @Test
+  void testUpdateEntry_RollPathValueIsOther() {
+    addEntry("ns11", "key1", "{'a':[{}]}");
+    updateEntry("/dataStore/ns11/key1?roll=3&path=a.[0]", Body("7"));
+    doInTransaction(
+        () ->
+            assertEquals(
+                "{\"a\": [7]}", GET("/dataStore/ns11/key1").content().node().getDeclaration()));
+
+    updateEntry("/dataStore/ns11/key1?roll=3&path=a.[0]", Body("\"hello\""));
+    doInTransaction(
+        () ->
+            assertEquals(
+                "{\"a\": [\"hello\"]}",
+                GET("/dataStore/ns11/key1").content().node().getDeclaration()));
+
+    updateEntry("/dataStore/ns11/key1?roll=3&path=a.[0]", Body("true"));
+    doInTransaction(
+        () ->
+            assertEquals(
+                "{\"a\": [true]}", GET("/dataStore/ns11/key1").content().node().getDeclaration()));
+  }
+
+  void updateEntry(String url, Object... args) {
+    doInTransaction(() -> assertStatus(OK, PUT(url, args)));
+  }
+
+  /**
+   * The reason this is needed in this test is that we need the creation and update run in
+   * transactions that are closed as they use different technology stacks. Without this the update
+   * does not become visible when reading back the value, and it appears as if the value is still
+   * the value from creation.
+   */
+  private void addEntry(String ns, String key, String value) {
+    doInTransaction(
+        () -> assertStatus(HttpStatus.CREATED, PUT("/dataStore/" + ns + "/" + key, value)));
+  }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreUpdateControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreUpdateControllerIntegrationTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import org.hisp.dhis.webapi.DhisControllerIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the different scenarios for updating a datastore value.
+ *
+ * @author Jan Bernitt
+ */
+public class DatastoreUpdateControllerIntegrationTest extends DhisControllerIntegrationTest {
+
+  @Test
+  void testUpdateEntry_RootWithNullValue() {}
+
+  @Test
+  void testUpdateEntry_PathWithNullValue() {}
+
+  @Test
+  void testUpdateEntry_RootWithNonNullValue() {}
+
+  @Test
+  void testUpdateEntry_PathWithNonNullValue() {}
+
+  @Test
+  void testUpdateEntry_RollRootValueIsNull() {}
+
+  @Test
+  void testUpdateEntry_RollRootValueIsArray() {}
+
+  @Test
+  void testUpdateEntry_RollRootValueIsOther() {}
+
+  @Test
+  void testUpdateEntry_RollPathValueIsNull() {}
+
+  @Test
+  void testUpdateEntry_RollPathValueIsArray() {}
+
+  @Test
+  void testUpdateEntry_RollPathValueIsOther() {}
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreUpdateControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreUpdateControllerIntegrationTest.java
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Jan Bernitt
  */
-public class DatastoreUpdateControllerIntegrationTest extends DhisControllerIntegrationTest {
+class DatastoreUpdateControllerIntegrationTest extends DhisControllerIntegrationTest {
 
   @Test
   void testUpdateEntry_RootWithNullValue() {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/AbstractDataIntegrityIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/AbstractDataIntegrityIntegrationTest.java
@@ -240,15 +240,6 @@ class AbstractDataIntegrityIntegrationTest extends DhisControllerIntegrationTest
 
   @Autowired private TransactionTemplate txTemplate;
 
-  protected void doInTransaction(Runnable operation) {
-
-    txTemplate.execute(
-        status -> {
-          operation.run();
-          return null;
-        });
-  }
-
   protected final HttpResponse postNewDataValue(
       String period,
       String value,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DatastoreController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DatastoreController.java
@@ -229,14 +229,17 @@ public class DatastoreController extends AbstractDatastoreController {
   public WebMessage putEntry(
       @PathVariable String namespace,
       @PathVariable String key,
-      @RequestBody String value,
+      @RequestBody(required = false) String value,
+      @RequestParam(required = false) String path,
+      @RequestParam(required = false) Integer roll,
       @RequestParam(defaultValue = "false") boolean encrypt)
       throws BadRequestException, ConflictException {
     DatastoreEntry dataEntry = service.getEntry(namespace, key);
 
-    return dataEntry != null
-        ? updateEntry(dataEntry, key, value)
-        : addEntry(namespace, key, value, encrypt);
+    if (dataEntry == null) return addEntry(namespace, key, value, encrypt);
+
+    service.updateEntry(namespace, key, value, path, roll);
+    return ok(String.format("Key updated: '%s'", key));
   }
 
   /** Delete a key from the given namespace. */
@@ -259,13 +262,5 @@ public class DatastoreController extends AbstractDatastoreController {
     }
 
     return entry;
-  }
-
-  private WebMessage updateEntry(DatastoreEntry entry, String key, String value)
-      throws BadRequestException {
-    entry.setValue(value);
-    service.updateEntry(entry);
-
-    return ok(String.format("Key updated: '%s'", key));
   }
 }


### PR DESCRIPTION
### Summary
Adds two (and a half) features to the datastore update API
* partial update of a complex JSON value providing a `path` to the part of the value that should be changed (no need to resend the entire value)
* fixed collection update of arrays providing a `roll` size. This means "atomic" insert at the end, discarding the head if the size is or exceeds the roll size
* delete values using undefined body

### Fixed Collections
Fixed collections is a term used for a list of a fixed size that allows an insert while the size is constant. Usually this is done by shifting the elements through the fixed window so that the oldest is removed in order to insert a new element.

With the existing JSONB functions it was easiest to insert via append (`||` concat operator) and remove via index (`- 0` operator). The size of the fixed collection is thereby supplied via the `roll` parameter. The presence of the roll parameter also triggers the fixed collection behaviour. 

### Edge Cases
* If the target value is not an array, null, or undefined but another JSON type this results in a simple override of the value with the new provided value. 
* If the rolled array is larger than the roll size this will **not** discard more then one of the existing elements and cut the array to the roll length. Instead the current length is maintained.
* If the provided roll size is negative the current size is simply maintained

### Automatic Testing
Moves any existing update related test to a class with a postgres setup as H2 will not support the new update via SQL.

Adds a new integration test class with one scenario for each possible update scenario. 

### Manual Testing
There are many scenarios from the combination of the `path` and `roll` parameters for a `PUT` `/api/dataStore/<ns>/<key>` endpoint in combination with the current and new value of the entry, such as:
* `PUT` `/api/dataStore/test/test?roll=2` on value `[1,2]` and new value `4`
* `PUT` `/api/dataStore/test/test?roll=2&path=a` on value `{"a": [1,2] }` and new value `4`

All cases are covered by this test https://github.com/dhis2/dhis2-core/blob/32e30e025b55a334ac3637629c08e739137abc07/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreUpdateControllerIntegrationTest.java