### PR TITLE
fix: program validation for related program property [DHIS2-15952]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -341,6 +341,7 @@ public enum ErrorCode {
   E6019("AttributeValue `{0}` is an invalid `{1}` ID"),
   E6020("AttributeValue `{0}` is an invalid username"),
   E6021("AttributeValue `{0}` is an invalid phone number"),
+  E6022("Object cannot reference itself by property `{0}`"),
 
   /* File resource */
   E6100("Filename not present"),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramType.java
@@ -27,11 +27,16 @@
  */
 package org.hisp.dhis.program;
 
+import lombok.Getter;
+
 /**
  * @author Chau Thu Tran
  */
+@Getter
 public enum ProgramType {
+  /** Aka tracker program */
   WITH_REGISTRATION("with_registration"),
+  /** Aka event program */
   WITHOUT_REGISTRATION("without_registration");
 
   private final String value;
@@ -50,7 +55,11 @@ public enum ProgramType {
     return null;
   }
 
-  public String getValue() {
-    return value;
+  public boolean isTrackerProgram() {
+    return this == WITH_REGISTRATION;
+  }
+
+  public boolean isEventProgram() {
+    return this == WITHOUT_REGISTRATION;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHook.java
@@ -78,6 +78,19 @@ public class ProgramObjectBundleHook extends AbstractObjectBundleHook<Program> {
     if (program.getId() != 0 && getProgramInstancesCount(program) > 1) {
       addReports.accept(new ErrorReport(Program.class, ErrorCode.E6000, program.getName()));
     }
+    Program relatedProgram = program.getRelatedProgram();
+    if (relatedProgram != null && Objects.equals(relatedProgram.getUid(), program.getUid())) {
+      addReports.accept(new ErrorReport(Program.class, ErrorCode.E6022, "relatedProgram"));
+    }
+    if (relatedProgram != null && program.getProgramType().isEventProgram()) {
+      addReports.accept(
+          new ErrorReport(
+              Program.class,
+              ErrorCode.E4023,
+              "relatedProgram",
+              "programType",
+              ProgramType.WITHOUT_REGISTRATION.name()));
+    }
     validateAttributeSecurity(program, bundle, addReports);
   }
 


### PR DESCRIPTION
### Summary
It was possible to set the `relatedProgram` property to the program itself. This then is a circular reference which causes all kinds of errors in other places but also in the app.

In addition I found that following the app UI it seems that only tracker programs should have this property but it was possible to set it for event programs as well. So an additional validation was added to prevent this.

### Automatic Testing
New scenario was added to verify that a program cannot reference itself as related program.


### Manual Testing
UI
* open maintenance app  
* edit a tracker program, try to select itself as the related program (2nd tab on enrollment details)
* try to save, check an error message is shown
* now try to select another program and save, check this works
* now try to clear the related program and save, check this works

REST API
* find a program to test with using the maintenance app or `/api/programs`
* try to update the program with PUT to update the `relatedProgram` property to itself `relatedProgram: { "id": "<uid>"}`
* check this gives error `E6022` for tracker programs and error `E4023` for event programs
* try to update the property to any other program and check it works
* try to clear the property and check it works