### PR TITLE
fix: exception is not propagated in getDataValueSet()

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataValueSetControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataValueSetControllerTest.java
@@ -38,10 +38,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.http.MediaType.APPLICATION_XML;
 
+import java.util.Set;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerIntegrationTest;
 import org.hisp.dhis.webapi.json.domain.JsonImportSummary;
 import org.hisp.dhis.webapi.json.domain.JsonWebMessage;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -202,5 +205,35 @@ class DataValueSetControllerTest extends DhisControllerIntegrationTest {
             .as(JsonWebMessage.class);
     assertEquals(
         String.format("User is not allowed to view org unit: `%s`", ouId), response.getMessage());
+  }
+
+  @Test
+  @DisplayName("Should return error message when user does not have DATA_READ to DataSet")
+  void testGetDataValueSetJsonWithNonAccessibleDataSet() {
+    String orgUnitId =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/organisationUnits/",
+                "{'name':'My Unit', 'shortName':'OU1', 'openingDate': '2020-01-01', 'code':'OU1'}"));
+    String dsId =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/dataSets/",
+                "{'name':'My data set', 'shortName': 'MDS', 'periodType':'Monthly'}"));
+
+    switchToNewUser(
+        createAndAddUser(Set.of(), Set.of(manager.get(OrganisationUnit.class, orgUnitId))));
+    JsonWebMessage response =
+        GET(
+                "/dataValueSets/?inputOrgUnitIdScheme=code&idScheme=name&orgUnit={ou}&period=2022-01&dataSet={ds}&async=true",
+                "OU1",
+                dsId)
+            .content(HttpStatus.CONFLICT)
+            .as(JsonWebMessage.class);
+    assertEquals(
+        String.format("User is not allowed to read data for data set: `%s`", dsId),
+        response.getMessage());
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
@@ -212,8 +212,9 @@ public class DataValueSetController {
     response.setContentType(contentType);
     setNoStore(response);
 
-    try (OutputStream out =
-        compress(params, response, attachment, Compression.fromValue(compression), format)) {
+    try {
+      OutputStream out =
+          compress(params, response, attachment, Compression.fromValue(compression), format);
       writeOutput.accept(params, out);
     } catch (IOException ex) {
       throw new UncheckedIOException(ex);


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-12540

### Issue
- The try with resource  will  commit/close the response outputstream  so the WebMessage from CrudControllerAdvice is failed to be written to response body.

### Fix
- Do not use try with resource, let the controller auto close the response outputstream.
