### PR TITLE
fix: Unchanged imported data values show as ignored in summary [DHIS2-15254]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
@@ -938,12 +938,10 @@ public class DefaultDataValueSetService implements DataValueSetService {
 
       importCount.incrementDeleted();
     } else {
-      importCount.incrementUpdated();
-    }
-    if (dataValueUpdateShouldBeIgnored(internalValue, existingValue)) {
-      importCount.incrementIgnored();
-      importCount.incrementUpdated(-1);
-      return;
+      if (dataValueUpdateShouldBeIgnored(internalValue, existingValue)) {
+        importCount.incrementIgnored();
+        return;
+      } else importCount.incrementUpdated();
     }
     if (!context.isDryRun()) {
       context.getDataValueBatchHandler().updateObject(internalValue);

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
@@ -940,11 +940,10 @@ public class DefaultDataValueSetService implements DataValueSetService {
     } else {
       importCount.incrementUpdated();
     }
-    if (!internalValue.isDeleted()
-        && Objects.equals(existingValue.getValue(), internalValue.getValue())
-        && Objects.equals(existingValue.getComment(), internalValue.getComment())
-        && existingValue.isFollowup() == internalValue.isFollowup()) {
-      return; // avoid performing unnecessary updates
+    if (dataValueUpdateShouldBeIgnored(internalValue, existingValue)) {
+      importCount.incrementIgnored();
+      importCount.incrementUpdated(-1);
+      return;
     }
     if (!context.isDryRun()) {
       context.getDataValueBatchHandler().updateObject(internalValue);
@@ -971,6 +970,14 @@ public class DefaultDataValueSetService implements DataValueSetService {
         }
       }
     }
+  }
+
+  private static boolean dataValueUpdateShouldBeIgnored(
+      DataValue internalValue, DataValue existingValue) {
+    return !internalValue.isDeleted()
+        && Objects.equals(existingValue.getValue(), internalValue.getValue())
+        && Objects.equals(existingValue.getComment(), internalValue.getComment())
+        && existingValue.isFollowup() == internalValue.isFollowup();
   }
 
   private void preheatCaches(ImportContext context) {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceTest.java
@@ -161,7 +161,7 @@ class DataValueSetServiceTest extends DhisConvenienceTest {
         dataValueSetService.importDataValueSetXml(
             readFile("datavalueset/dataValueSetA.xml"), new ImportOptions());
 
-    assertSuccessWithImportedUpdatedDeleted(0, 3, 0, summary);
+    assertSuccessWithImportedUpdatedDeleted(0, 0, 0, 3, summary);
     verify(batchHandler, never()).updateObject(any());
   }
 
@@ -174,7 +174,7 @@ class DataValueSetServiceTest extends DhisConvenienceTest {
   }
 
   private static void assertSuccessWithImportedUpdatedDeleted(
-      int imported, int updated, int deleted, ImportSummary summary) {
+      int imported, int updated, int deleted, int ignored, ImportSummary summary) {
     assertAll(
         () -> assertHasNoConflicts(summary),
         () ->
@@ -185,6 +185,9 @@ class DataValueSetServiceTest extends DhisConvenienceTest {
         () ->
             assertEquals(
                 deleted, summary.getImportCount().getDeleted(), "unexpected deleted count"),
+        () ->
+            assertEquals(
+                ignored, summary.getImportCount().getIgnored(), "unexpected ignored count"),
         () -> assertEquals(ImportStatus.SUCCESS, summary.getStatus(), summary.getDescription()));
   }
 

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/aggregate/DataImportTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/aggregate/DataImportTest.java
@@ -53,7 +53,7 @@ import org.hisp.dhis.dto.ApiResponse;
 import org.hisp.dhis.dto.ImportSummary;
 import org.hisp.dhis.helpers.QueryParamsBuilder;
 import org.hisp.dhis.helpers.file.JsonFileReader;
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -207,7 +207,7 @@ public class DataImportTest extends ApiTest {
     }
   }
 
-  @AfterAll
+  @AfterEach
   public void cleanUp() {
     QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder();
     queryParamsBuilder.addAll("importReportMode=FULL", "importStrategy=DELETE");

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceIntegrationTest.java
@@ -96,6 +96,7 @@ import org.hisp.dhis.security.acl.AccessStringHelper;
 import org.hisp.dhis.test.integration.IntegrationTestBase;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -555,7 +556,7 @@ class DataValueSetServiceIntegrationTest extends IntegrationTestBase {
 
   /**
    * Import 12 data values where 4 are marked as deleted. Then import 12 data values which reverse
-   * deletion of the 4 values and update the other 8 values.
+   * deletion of the 4 values and ignore the other 8 unchanged values.
    */
   @Test
   void testImportReverseDeletedValuesXml() {
@@ -569,13 +570,13 @@ class DataValueSetServiceIntegrationTest extends IntegrationTestBase {
     // Reverse deletion and update
     summary = dataValueSetService.importDataValueSetXml(readFile("datavalueset/dataValueSetB.xml"));
 
-    assertSuccessWithImportedUpdatedDeleted(4, 8, 0, summary);
+    assertSuccessWithImportedUpdatedDeleted(4, 0, 0, 8, summary);
     assertDataValuesCount(12);
   }
 
   /**
    * Import 12 data values where 4 are marked as deleted. Then import 12 data values which reverse
-   * deletion of the 4 values, update 4 values and add 4 values.
+   * deletion of the 4 values, ignore 4 unchanged values and add 4 values.
    */
   @Test
   void testImportAddAndReverseDeletedValuesXml() {
@@ -590,11 +591,11 @@ class DataValueSetServiceIntegrationTest extends IntegrationTestBase {
     summary =
         dataValueSetService.importDataValueSetXml(readFile("datavalueset/dataValueSetBNew.xml"));
 
-    assertSuccessWithImportedUpdatedDeleted(8, 4, 0, summary);
+    assertSuccessWithImportedUpdatedDeleted(8, 0, 0, 4, summary);
     assertDataValuesCount(16);
   }
 
-  /** Import 12 data values. Then import 12 values where 4 are marked as deleted. */
+  /** Import 12 data values. Then import 12 unchanged values where 4 are marked as deleted. */
   @Test
   void testDeleteValuesXml() {
     assertDataValuesCount(0);
@@ -608,12 +609,12 @@ class DataValueSetServiceIntegrationTest extends IntegrationTestBase {
         dataValueSetService.importDataValueSetXml(
             readFile("datavalueset/dataValueSetBDeleted.xml"));
 
-    assertSuccessWithImportedUpdatedDeleted(0, 8, 4, summary);
+    assertSuccessWithImportedUpdatedDeleted(0, 0, 4, 8, summary);
     assertDataValuesCount(8);
   }
 
   /**
-   * Import 12 data values. Then import 12 values where 4 are marked as deleted, 6 are updates and 2
+   * Import 12 data values. Then import 12 values where 4 are marked as deleted, 6 are ignored and 2
    * are new.
    */
   @Test
@@ -629,7 +630,7 @@ class DataValueSetServiceIntegrationTest extends IntegrationTestBase {
         dataValueSetService.importDataValueSetXml(
             readFile("datavalueset/dataValueSetBNewDeleted.xml"));
 
-    assertSuccessWithImportedUpdatedDeleted(2, 6, 4, summary);
+    assertSuccessWithImportedUpdatedDeleted(2, 0, 4, 6, summary);
     assertDataValuesCount(10);
   }
 
@@ -815,6 +816,53 @@ class DataValueSetServiceIntegrationTest extends IntegrationTestBase {
 
     assertSuccessWithImportedUpdatedDeleted(12, 0, 0, summary);
     assertImportDataValues(summary);
+  }
+
+  @Test
+  @DisplayName("Import summary should show correct ignore count when importing unchanged values")
+  void testImportDataValueSetIgnoreCount() {
+    // given 12 new data values are imported
+    ImportOptions importOptions = new ImportOptions();
+
+    List<org.hisp.dhis.dxf2.datavalue.DataValue> dataValues =
+        List.of(
+            getDataValue("f7n9E0hX8qk", "201201", "DiszpKrYNg8", "10001"),
+            getDataValue("f7n9E0hX8qk", "201201", "BdfsJfj87js", "10002"),
+            getDataValue("f7n9E0hX8qk", "201202", "DiszpKrYNg8", "10003"),
+            getDataValue("f7n9E0hX8qk", "201202", "BdfsJfj87js", "10004"),
+            getDataValue("Ix2HsbDMLea", "201201", "DiszpKrYNg8", "10005"),
+            getDataValue("Ix2HsbDMLea", "201201", "BdfsJfj87js", "10006"),
+            getDataValue("Ix2HsbDMLea", "201202", "DiszpKrYNg8", "10007"),
+            getDataValue("Ix2HsbDMLea", "201202", "BdfsJfj87js", "10008"),
+            getDataValue("eY5ehpbEsB7", "201201", "DiszpKrYNg8", "10009"),
+            getDataValue("eY5ehpbEsB7", "201201", "BdfsJfj87js", "10010"),
+            getDataValue("eY5ehpbEsB7", "201202", "DiszpKrYNg8", "10011"),
+            getDataValue("eY5ehpbEsB7", "201202", "BdfsJfj87js", "10012"));
+
+    DataValueSet dataValueSet = new DataValueSet();
+    dataValueSet.setDataValues(dataValues);
+
+    ImportSummary summary = dataValueSetService.importDataValueSet(dataValueSet, importOptions);
+
+    assertSuccessWithImportedUpdatedDeleted(12, 0, 0, summary);
+    assertImportDataValues(summary);
+
+    // when an import is processed including 1 new value & 2 unchanged values
+    List<org.hisp.dhis.dxf2.datavalue.DataValue> dataValuesUpdateIgnore =
+        List.of(
+            getDataValue("f7n9E0hX8qk", "201201", "DiszpKrYNg8", "20001"),
+            getDataValue("f7n9E0hX8qk", "201201", "BdfsJfj87js", "10002"),
+            getDataValue("f7n9E0hX8qk", "201202", "DiszpKrYNg8", "10003"));
+
+    DataValueSet dataValueSetUpdateIgnore = new DataValueSet();
+    dataValueSetUpdateIgnore.setDataValues(dataValuesUpdateIgnore);
+
+    ImportSummary summary2 =
+        dataValueSetService.importDataValueSet(dataValueSetUpdateIgnore, importOptions);
+
+    // then the ignore count should be 2 and the updated count should be 1
+    assertSuccessWithImportedUpdatedDeleted(0, 1, 0, 2, summary2);
+    assertImportDataValues(summary2);
   }
 
   @Test


### PR DESCRIPTION
# Summary

## Issue
When importing unchanged data values the import summary shows that they are `updated` when in fact they are not. They are `ignored`.

## Fix
Update the `ignored` count when the unchanged criteria we check is met, otherwise update the `updated` count

# Testing

## Automated
- added new integration test
- updated existing tests to reflect new behaviour

# Docs
docs PR with note about ignored behaviour https://github.com/dhis2/dhis2-docs/pull/1264