### PR TITLE
refactor: Decouple outliers API [DHIS2-16065]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/analytics/OutlierDetectionAlgorithm.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/analytics/OutlierDetectionAlgorithm.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics;
+
+/**
+ * Algorithm for outlier value detection.
+ *
+ * @author Lars Helge Overland
+ */
+public enum OutlierDetectionAlgorithm {
+  Z_SCORE,
+  MIN_MAX,
+  MOD_Z_SCORE;
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/Order.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/Order.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.outlier;
+
+/**
+ * Candidate on which to order an outlier detection result set.
+ *
+ * @author Lars Helge Overland
+ */
+public enum Order {
+  MEAN_ABS_DEV("mean_abs_dev"),
+  Z_SCORE("z_score");
+
+  private String key;
+
+  Order(String key) {
+    this.key = key;
+  }
+
+  public String getKey() {
+    return key;
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/OutlierHelper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/OutlierHelper.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.outlier;
+
+import static org.hisp.dhis.feedback.ErrorCode.E2208;
+import static org.hisp.dhis.feedback.ErrorCode.E7131;
+import static org.hisp.dhis.util.SqlExceptionUtils.ERR_MSG_SILENT_FALLBACK;
+import static org.hisp.dhis.util.SqlExceptionUtils.ERR_MSG_TABLE_NOT_EXISTING;
+import static org.hisp.dhis.util.SqlExceptionUtils.relationDoesNotExist;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.common.QueryRuntimeException;
+import org.hisp.dhis.commons.util.TextUtils;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.BadSqlGrammarException;
+
+/**
+ * Helper class that provides specific utility methods to be used in outliers.
+ *
+ * @author Lars Helge Overland
+ */
+@Slf4j
+public class OutlierHelper {
+
+  /**
+   * Returns an organisation unit 'path' "like" clause for the given list of {@link
+   * OrganisationUnit}.
+   *
+   * @param orgUnits the list of {@link OrganisationUnit}.
+   * @return an organisation unit 'path' "like" clause.
+   */
+  public static String getOrgUnitPathClause(List<OrganisationUnit> orgUnits, String pathAlias) {
+    StringBuilder sql = new StringBuilder("(");
+    orgUnits.forEach(
+        ou ->
+            sql.append(pathAlias).append(".\"path\" like '").append(ou.getPath()).append("%' or "));
+
+    return StringUtils.trim(TextUtils.removeLastOr(sql.toString())) + ")";
+  }
+
+  /**
+   * Wraps the provided interface around a common exception handling strategy.
+   *
+   * @param supplier the {@link Supplier} containing the code block to execute and wrap around the
+   *     exception handling.
+   * @return the {@link Optional} wrapping th result of the supplier execution.
+   */
+  public static <T> Optional<T> withExceptionHandling(Supplier<T> supplier) {
+    try {
+      return Optional.ofNullable(supplier.get());
+    } catch (BadSqlGrammarException ex) {
+      if (relationDoesNotExist(ex.getSQLException())) {
+        log.info(ERR_MSG_TABLE_NOT_EXISTING, ex);
+        throw ex;
+      } else {
+        log.info(ERR_MSG_SILENT_FALLBACK, ex);
+        throw ex;
+      }
+    } catch (QueryRuntimeException ex) {
+      log.error("Internal runtime exception", ex);
+      throw ex;
+    } catch (DataIntegrityViolationException ex) {
+      log.error(E2208.getMessage(), ex);
+      throw new IllegalQueryException(E2208);
+    } catch (DataAccessResourceFailureException ex) {
+      log.error(E7131.getMessage(), ex);
+      throw new QueryRuntimeException(E7131);
+    }
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/OutlierSqlStatementProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/OutlierSqlStatementProcessor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.outlier;
+
+import org.hisp.dhis.analytics.outlier.data.OutlierRequest;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+
+public interface OutlierSqlStatementProcessor {
+
+  /**
+   * Creates a parametrised SQL statement for outliers.
+   *
+   * @param request the instance of {@link OutlierRequest}.
+   * @return SQL statement as a string.
+   */
+  String getSqlStatement(OutlierRequest request);
+
+  /**
+   * Retrieve SQL parameters for outliers SQL statement
+   *
+   * @param request the instance of {@link OutlierRequest}.
+   * @return teh instance of {@link SqlParameterSource}.
+   */
+  SqlParameterSource getSqlParameterSource(OutlierRequest request);
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/Outlier.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/Outlier.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.outlier.data;
+
+import java.util.Date;
+import lombok.Data;
+
+/** Represent the outlier object. */
+@Data
+public class Outlier {
+  private String de;
+
+  private String deName;
+
+  private String pe;
+
+  private String ou;
+
+  private String ouName;
+
+  private String coc;
+
+  private String cocName;
+
+  private String aoc;
+
+  private String aocName;
+
+  private Date lastUpdated;
+
+  private Double value;
+
+  private Double mean;
+
+  private Double median;
+
+  private Double stdDev;
+
+  private Double absDev;
+
+  private Double zScore;
+
+  private Double lowerBound;
+
+  private Double upperBound;
+
+  private Boolean followup;
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierQuery.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierQuery.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.outlier.data;
+
+import static org.hisp.dhis.analytics.OutlierDetectionAlgorithm.Z_SCORE;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import lombok.Data;
+import org.hisp.dhis.analytics.OutlierDetectionAlgorithm;
+import org.hisp.dhis.analytics.outlier.Order;
+
+/**
+ * Encapsulation of a web API request for outlier value detection.
+ *
+ * @author Lars Helge Overland
+ */
+@Data
+public class OutlierQuery {
+  private Set<String> ds = new HashSet<>();
+
+  private Set<String> dx = new HashSet<>();
+
+  private Date startDate;
+
+  private Date endDate;
+
+  private Set<String> ou = new HashSet<>();
+
+  private OutlierDetectionAlgorithm algorithm = Z_SCORE;
+
+  private Double threshold;
+
+  private Date dataStartDate;
+
+  private Date dataEndDate;
+
+  private Order orderBy;
+
+  private Integer maxResults;
+
+  /**
+   * This parameter selects the headers to be returned in the response. We use a LinkedHashSet
+   * because the other matters.
+   */
+  private Set<String> headers = new LinkedHashSet<>();
+
+  public boolean hasHeaders() {
+    return headers != null && !headers.isEmpty();
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierQueryParser.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierQueryParser.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.outlier.data;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.springframework.stereotype.Component;
+
+/** Parse and transform the incoming query params into the OutlierDetectionRequest. */
+@Component
+@AllArgsConstructor
+public class OutlierQueryParser {
+  private final IdentifiableObjectManager idObjectManager;
+
+  /**
+   * Creates a {@link OutlierRequest} from the given query.
+   *
+   * @param query the {@link OutlierQuery}.
+   * @return a {@link OutlierRequest}.
+   */
+  public OutlierRequest getFromQuery(OutlierQuery query) {
+    OutlierRequest.Builder request = new OutlierRequest.Builder();
+
+    List<DataSet> dataSets = idObjectManager.getByUid(DataSet.class, query.getDs());
+
+    // Re-fetch data elements to maintain access control
+    List<String> de =
+        dataSets.stream()
+            .map(DataSet::getDataElements)
+            .flatMap(Collection::stream)
+            .filter(d -> d.getValueType().isNumeric())
+            .map(DataElement::getUid)
+            .collect(Collectors.toList());
+
+    de.addAll(query.getDx());
+
+    List<DataElement> dataElements = idObjectManager.getByUid(DataElement.class, de);
+    List<OrganisationUnit> orgUnits =
+        idObjectManager.getByUid(OrganisationUnit.class, query.getOu());
+
+    request
+        .withDataElements(dataElements)
+        .withStartEndDate(query.getStartDate(), query.getEndDate())
+        .withOrgUnits(orgUnits)
+        .withDataStartDate(query.getDataStartDate())
+        .withDataEndDate(query.getDataEndDate());
+
+    if (query.getAlgorithm() != null) {
+      request.withAlgorithm(query.getAlgorithm());
+    }
+
+    if (query.getThreshold() != null) {
+      request.withThreshold(query.getThreshold());
+    }
+
+    if (query.getOrderBy() != null) {
+      request.withOrderBy(query.getOrderBy());
+    }
+
+    if (query.getMaxResults() != null) {
+      request.withMaxResults(query.getMaxResults());
+    }
+
+    return request.build();
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierRequest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierRequest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.outlier.data;
+
+import static java.util.stream.Collectors.toList;
+import static org.hisp.dhis.analytics.OutlierDetectionAlgorithm.Z_SCORE;
+import static org.hisp.dhis.analytics.outlier.Order.MEAN_ABS_DEV;
+import static org.hisp.dhis.common.OrganisationUnitDescendants.DESCENDANTS;
+import static org.springframework.util.Assert.notNull;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import lombok.Getter;
+import org.hisp.dhis.analytics.OutlierDetectionAlgorithm;
+import org.hisp.dhis.analytics.outlier.Order;
+import org.hisp.dhis.common.OrganisationUnitDescendants;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+
+/**
+ * Encapsulation of an outlier detection request.
+ *
+ * @author Lars Helge Overland
+ */
+@Getter
+public class OutlierRequest {
+  private List<DataElement> dataElements = new ArrayList<>();
+
+  private Date startDate;
+
+  private Date endDate;
+
+  private List<OrganisationUnit> orgUnits = new ArrayList<>();
+
+  private OrganisationUnitDescendants orgUnitSelection;
+
+  private OutlierDetectionAlgorithm algorithm;
+
+  private double threshold;
+
+  private Date dataStartDate;
+
+  private Date dataEndDate;
+
+  private Order orderBy;
+
+  private int maxResults;
+
+  public List<Long> getDataElementIds() {
+    return dataElements.stream().map(DataElement::getId).collect(toList());
+  }
+
+  private OutlierRequest() {}
+
+  public boolean hasDataStartEndDate() {
+    return dataStartDate != null && dataEndDate != null;
+  }
+
+  public static class Builder {
+    private OutlierRequest request;
+
+    /** Initializes the {@link OutlierRequest} with default values. */
+    public Builder() {
+      this.request = new OutlierRequest();
+
+      this.request.orgUnitSelection = DESCENDANTS;
+      this.request.algorithm = Z_SCORE;
+      this.request.threshold = 3.0d;
+      this.request.orderBy = MEAN_ABS_DEV;
+      this.request.maxResults = 500;
+    }
+
+    public Builder withDataElements(List<DataElement> dataElements) {
+      this.request.dataElements = dataElements;
+      return this;
+    }
+
+    public Builder withStartEndDate(Date startDate, Date endDate) {
+      this.request.startDate = startDate;
+      this.request.endDate = endDate;
+      return this;
+    }
+
+    public Builder withOrgUnits(List<OrganisationUnit> orgUnits) {
+      this.request.orgUnits = orgUnits;
+      return this;
+    }
+
+    public Builder withAlgorithm(OutlierDetectionAlgorithm algorithm) {
+      this.request.algorithm = algorithm;
+      return this;
+    }
+
+    public Builder withThreshold(double threshold) {
+      this.request.threshold = threshold;
+      return this;
+    }
+
+    public Builder withDataStartDate(Date dataStartDate) {
+      this.request.dataStartDate = dataStartDate;
+      return this;
+    }
+
+    public Builder withDataEndDate(Date dataEndDate) {
+      this.request.dataEndDate = dataEndDate;
+      return this;
+    }
+
+    public Builder withOrderBy(Order orderBy) {
+      this.request.orderBy = orderBy;
+      return this;
+    }
+
+    public Builder withMaxResults(int maxResults) {
+      this.request.maxResults = maxResults;
+      return this;
+    }
+
+    public OutlierRequest build() {
+      notNull(this.request.orgUnitSelection, "Attribute orgUnitSelection cannot be null");
+      notNull(this.request.algorithm, "Attribute algorithm cannot be null");
+      notNull(this.request.orderBy, "Attribute orderBy cannot be null");
+      return this.request;
+    }
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierRequestValidator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierRequestValidator.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.outlier.data;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hisp.dhis.analytics.OutlierDetectionAlgorithm;
+import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorMessage;
+import org.hisp.dhis.setting.SettingKey;
+import org.hisp.dhis.setting.SystemSettingManager;
+import org.springframework.stereotype.Component;
+
+/** OutlierDetectionRequest validator. */
+@Component
+@AllArgsConstructor
+@Slf4j
+public class OutlierRequestValidator {
+  private final SystemSettingManager systemSettingManager;
+
+  /**
+   * Validates the given request.
+   *
+   * @param request the {@link OutlierRequest}.
+   * @throws IllegalQueryException if request is invalid.
+   */
+  public void validate(OutlierRequest request, boolean isAnalytics) throws IllegalQueryException {
+    ErrorMessage errorMessage = validateForErrorMessage(request, isAnalytics);
+
+    if (errorMessage != null) {
+      log.warn(
+          String.format(
+              "Outlier detection request validation failed, code: '%s', message: '%s'",
+              errorMessage.getErrorCode(), errorMessage.getMessage()));
+
+      throw new IllegalQueryException(errorMessage);
+    }
+  }
+
+  private ErrorMessage validateForErrorMessage(OutlierRequest request, boolean isAnalytics) {
+    int maxLimit =
+        isAnalytics
+            ? systemSettingManager.getSystemSetting(SettingKey.ANALYTICS_MAX_LIMIT, Integer.class)
+            : 500;
+    ErrorMessage errorMessage = getErrorMessage(request, maxLimit);
+
+    if (errorMessage != null) {
+      return errorMessage;
+    }
+
+    if (isAnalytics) {
+      if (request.getDataStartDate() != null) {
+        return new ErrorMessage(ErrorCode.E2209);
+      }
+      if (request.getDataEndDate() != null) {
+        return new ErrorMessage(ErrorCode.E2210);
+      }
+      if (request.getAlgorithm() == OutlierDetectionAlgorithm.MIN_MAX) {
+        return new ErrorMessage(ErrorCode.E2211);
+      }
+    }
+
+    if (request.hasDataStartEndDate()
+        && request.getDataStartDate().after(request.getDataEndDate())) {
+      return new ErrorMessage(ErrorCode.E2207);
+    }
+
+    return null;
+  }
+
+  private ErrorMessage getErrorMessage(OutlierRequest request, int maxLimit) {
+    ErrorMessage error = null;
+
+    if (request.getDataElements().isEmpty()) {
+      error = new ErrorMessage(ErrorCode.E2200);
+    } else if (request.getStartDate() == null || request.getEndDate() == null) {
+      error = new ErrorMessage(ErrorCode.E2201);
+    } else if (request.getStartDate().after(request.getEndDate())) {
+      error = new ErrorMessage(ErrorCode.E2202);
+    } else if (request.getOrgUnits().isEmpty()) {
+      error = new ErrorMessage(ErrorCode.E2203);
+    } else if (request.getThreshold() <= 0) {
+      error = new ErrorMessage(ErrorCode.E2204);
+    } else if (request.getMaxResults() <= 0) {
+      error = new ErrorMessage(ErrorCode.E2205);
+    } else if (request.getMaxResults() > maxLimit) {
+      error = new ErrorMessage(ErrorCode.E2206, maxLimit);
+    }
+
+    return error;
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierSqlParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierSqlParams.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.outlier.data;
+
+/** Enum for named params of parametrized sql query */
+public enum OutlierSqlParams {
+  // ZScore (modified ZScore) factor.
+  // For example the threshold=3 means all data lying outside 3 sigma (3 * standard deviation)
+  // are considered as the outliers
+  THRESHOLD("threshold"),
+  DATA_ELEMENT_IDS("data_element_ids"),
+  START_DATE("start_date"),
+  END_DATE("end_date"),
+  // start date criteria of statistic data collection (the stats will be based on data starting on
+  // this date)
+  DATA_START_DATE("data_start_date"),
+  // start date criteria of statistic data collection (the stats will be based on data ending on
+  // this date)
+  DATA_END_DATE("data_end_date"),
+  MAX_RESULTS("max_results");
+  private final String key;
+
+  OutlierSqlParams(String key) {
+    this.key = key;
+  }
+
+  public String getKey() {
+    return key;
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AbstractOutlierManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AbstractOutlierManager.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.outlier.service;
+
+import static java.lang.Double.NaN;
+import static org.hisp.dhis.analytics.OutlierDetectionAlgorithm.MOD_Z_SCORE;
+import static org.hisp.dhis.analytics.outlier.OutlierHelper.withExceptionHandling;
+import static org.hisp.dhis.period.PeriodType.getIsoPeriod;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.hisp.dhis.analytics.outlier.OutlierSqlStatementProcessor;
+import org.hisp.dhis.analytics.outlier.data.Outlier;
+import org.hisp.dhis.analytics.outlier.data.OutlierRequest;
+import org.hisp.dhis.calendar.Calendar;
+import org.hisp.dhis.period.PeriodType;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+
+/**
+ * Manager for database queries related to outlier data detection (Z-Score, modified Z-Score,
+ * Min-Max values).
+ */
+@Slf4j
+public abstract class AbstractOutlierManager {
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+  private final OutlierSqlStatementProcessor sqlStatementProcessor;
+
+  protected AbstractOutlierManager(
+      NamedParameterJdbcTemplate jdbcTemplate, OutlierSqlStatementProcessor sqlStatementProcessor) {
+    this.jdbcTemplate = jdbcTemplate;
+    this.sqlStatementProcessor = sqlStatementProcessor;
+  }
+
+  /**
+   * Retrieves all outliers.
+   *
+   * @param request the {@link OutlierRequest}.
+   * @return list of the OutlierValue instances for api response
+   */
+  public List<Outlier> getOutlierValues(OutlierRequest request) {
+    String sql = sqlStatementProcessor.getSqlStatement(request);
+    SqlParameterSource params = sqlStatementProcessor.getSqlParameterSource(request);
+    Calendar calendar = PeriodType.getCalendar();
+    boolean modifiedZ = request.getAlgorithm() == MOD_Z_SCORE;
+
+    return withExceptionHandling(
+            () -> jdbcTemplate.query(sql, params, getRowMapper(calendar, modifiedZ)))
+        .orElse(List.of());
+  }
+
+  /**
+   * Returns a {@link RowMapper} for {@link Outlier}.
+   *
+   * @param calendar the {@link Calendar}.
+   * @return a {@link RowMapper}.
+   */
+  protected abstract RowMapper<Outlier> getRowMapper(final Calendar calendar, boolean modifiedZ);
+
+  /**
+   * Maps incoming database set into the api response element.
+   *
+   * @param calendar the {@link Calendar}.
+   * @param rs the {@link ResultSet}.
+   * @return single OutlierValue instance
+   * @throws SQLException
+   */
+  protected Outlier getOutlierValue(Calendar calendar, ResultSet rs) throws SQLException {
+    String isoPeriod = getIsoPeriod(calendar, rs.getString("pt_name"), rs.getDate("pe_start_date"));
+
+    Outlier outlier = new Outlier();
+    outlier.setDe(rs.getString("de_uid"));
+    outlier.setDeName(rs.getString("de_name"));
+    outlier.setPe(isoPeriod);
+    outlier.setOu(rs.getString("ou_uid"));
+    outlier.setOuName(rs.getString("ou_name"));
+    outlier.setCoc(rs.getString("coc_uid"));
+    outlier.setCocName(rs.getString("coc_name"));
+    outlier.setAoc(rs.getString("aoc_uid"));
+    outlier.setAocName(rs.getString("aoc_name"));
+    outlier.setValue(rs.getDouble("value"));
+
+    return outlier;
+  }
+
+  /**
+   * The values for outlier identification are added to OutlierValue instance.
+   *
+   * @param outlier the {@link Outlier}
+   * @param rs the {@link ResultSet}
+   * @param modifiedZ boolean flag (false means z-score to be applied)
+   * @throws SQLException
+   */
+  protected void addZScoreBasedParamsToOutlierValue(
+      Outlier outlier, ResultSet rs, boolean modifiedZ) throws SQLException {
+    if (modifiedZ) {
+      outlier.setMedian(rs.getDouble("middle_value"));
+    } else {
+      outlier.setMean(rs.getDouble("middle_value"));
+    }
+
+    outlier.setAbsDev(rs.getDouble("middle_value_abs_dev"));
+    outlier.setZScore(outlier.getStdDev() == 0 ? NaN : rs.getDouble("z_score"));
+    outlier.setLowerBound(rs.getDouble("lower_bound"));
+    outlier.setUpperBound(rs.getDouble("upper_bound"));
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsOutlierService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsOutlierService.java
@@ -25,8 +25,9 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.outlierdetection.service;
+package org.hisp.dhis.analytics.outlier.service;
 
+import static org.hisp.dhis.analytics.OutlierDetectionAlgorithm.MOD_Z_SCORE;
 import static org.hisp.dhis.analytics.common.ColumnHeader.ABSOLUTE_DEVIATION;
 import static org.hisp.dhis.analytics.common.ColumnHeader.ATTRIBUTE_OPTION_COMBO;
 import static org.hisp.dhis.analytics.common.ColumnHeader.ATTRIBUTE_OPTION_COMBO_NAME;
@@ -35,17 +36,19 @@ import static org.hisp.dhis.analytics.common.ColumnHeader.CATEGORY_OPTION_COMBO_
 import static org.hisp.dhis.analytics.common.ColumnHeader.DIMENSION;
 import static org.hisp.dhis.analytics.common.ColumnHeader.DIMENSION_NAME;
 import static org.hisp.dhis.analytics.common.ColumnHeader.LOWER_BOUNDARY;
+import static org.hisp.dhis.analytics.common.ColumnHeader.MEAN;
 import static org.hisp.dhis.analytics.common.ColumnHeader.MEDIAN;
 import static org.hisp.dhis.analytics.common.ColumnHeader.MEDIAN_ABS_DEVIATION;
+import static org.hisp.dhis.analytics.common.ColumnHeader.MODIFIED_ZSCORE;
 import static org.hisp.dhis.analytics.common.ColumnHeader.ORG_UNIT;
 import static org.hisp.dhis.analytics.common.ColumnHeader.ORG_UNIT_NAME;
 import static org.hisp.dhis.analytics.common.ColumnHeader.PERIOD;
 import static org.hisp.dhis.analytics.common.ColumnHeader.STANDARD_DEVIATION;
 import static org.hisp.dhis.analytics.common.ColumnHeader.UPPER_BOUNDARY;
 import static org.hisp.dhis.analytics.common.ColumnHeader.VALUE;
+import static org.hisp.dhis.analytics.common.ColumnHeader.ZSCORE;
 import static org.hisp.dhis.common.ValueType.NUMBER;
 import static org.hisp.dhis.common.ValueType.TEXT;
-import static org.hisp.dhis.outlierdetection.OutlierDetectionAlgorithm.MOD_Z_SCORE;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -53,13 +56,12 @@ import java.io.Writer;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hisp.dhis.analytics.common.ColumnHeader;
+import org.hisp.dhis.analytics.common.processing.MetadataParamsHandler;
+import org.hisp.dhis.analytics.outlier.data.Outlier;
+import org.hisp.dhis.analytics.outlier.data.OutlierRequest;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
 import org.hisp.dhis.common.IllegalQueryException;
-import org.hisp.dhis.outlierdetection.OutlierDetectionRequest;
-import org.hisp.dhis.outlierdetection.OutlierDetectionResponse;
-import org.hisp.dhis.outlierdetection.OutlierValue;
 import org.hisp.dhis.system.grid.GridUtils;
 import org.hisp.dhis.system.grid.ListGrid;
 import org.springframework.stereotype.Service;
@@ -67,23 +69,25 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @AllArgsConstructor
 @Service
-public class AnalyticsOutlierDetectionService {
+public class AnalyticsOutlierService {
 
-  private final AnalyticsZScoreOutlierDetectionManager zScoreOutlierDetection;
+  private final AnalyticsZScoreOutlierManager zScoreOutlierDetection;
+
+  private final MetadataParamsHandler metadataParamsHandler;
 
   /**
    * Transform the incoming request into api response (json).
    *
-   * @param request the {@link OutlierDetectionRequest}.
-   * @return the {@link OutlierDetectionResponse}.
+   * @param request the {@link OutlierRequest}.
+   * @return the {@link Grid}.
    */
-  public Grid getOutlierValues(OutlierDetectionRequest request) throws IllegalQueryException {
-    List<OutlierValue> outlierValues = zScoreOutlierDetection.getOutlierValues(request);
+  public Grid getOutlierValues(OutlierRequest request) throws IllegalQueryException {
+    List<Outlier> outliers = zScoreOutlierDetection.getOutlierValues(request);
 
     Grid grid = new ListGrid();
     setHeaders(grid, request);
-    setMetaData(grid, request, outlierValues);
-    setRows(grid, outlierValues, request);
+    setMetaData(grid, request, outliers);
+    setRows(grid, outliers, request);
 
     return grid;
   }
@@ -91,10 +95,9 @@ public class AnalyticsOutlierDetectionService {
   /**
    * Transform the incoming request into api response (csv download).
    *
-   * @param request the {@link OutlierDetectionRequest}.
-   * @return the {@link OutlierDetectionResponse}.
+   * @param request the {@link OutlierRequest}.
    */
-  public void getOutlierValuesAsCsv(OutlierDetectionRequest request, Writer writer)
+  public void getOutlierValuesAsCsv(OutlierRequest request, Writer writer)
       throws IllegalQueryException, IOException {
     GridUtils.toCsv(getOutlierValues(request), writer);
   }
@@ -102,10 +105,9 @@ public class AnalyticsOutlierDetectionService {
   /**
    * Transform the incoming request into api response (xml).
    *
-   * @param request the {@link OutlierDetectionRequest}.
-   * @return the {@link OutlierDetectionResponse}.
+   * @param request the {@link OutlierRequest}.
    */
-  public void getOutlierValuesAsXml(OutlierDetectionRequest request, OutputStream outputStream)
+  public void getOutlierValuesAsXml(OutlierRequest request, OutputStream outputStream)
       throws IllegalQueryException {
     GridUtils.toXml(getOutlierValues(request), outputStream);
   }
@@ -113,10 +115,9 @@ public class AnalyticsOutlierDetectionService {
   /**
    * Transform the incoming request into api response (xls download).
    *
-   * @param request the {@link OutlierDetectionRequest}.
-   * @return the {@link OutlierDetectionResponse}.
+   * @param request the {@link OutlierRequest}.
    */
-  public void getOutlierValuesAsXls(OutlierDetectionRequest request, OutputStream outputStream)
+  public void getOutlierValuesAsXls(OutlierRequest request, OutputStream outputStream)
       throws IllegalQueryException, IOException {
     GridUtils.toXls(getOutlierValues(request), outputStream);
   }
@@ -124,10 +125,9 @@ public class AnalyticsOutlierDetectionService {
   /**
    * Transform the incoming request into api response (html).
    *
-   * @param request the {@link OutlierDetectionRequest}.
-   * @return the {@link OutlierDetectionResponse}.
+   * @param request the {@link OutlierRequest}.
    */
-  public void getOutlierValuesAsHtml(OutlierDetectionRequest request, Writer writer)
+  public void getOutlierValuesAsHtml(OutlierRequest request, Writer writer)
       throws IllegalQueryException {
     GridUtils.toHtml(getOutlierValues(request), writer);
   }
@@ -135,19 +135,23 @@ public class AnalyticsOutlierDetectionService {
   /**
    * Transform the incoming request into api response (html with css).
    *
-   * @param request the {@link OutlierDetectionRequest}.
-   * @return the {@link OutlierDetectionResponse}.
+   * @param request the {@link OutlierRequest}.
    */
-  public void getOutlierValuesAsHtmlCss(OutlierDetectionRequest request, Writer writer)
+  public void getOutlierValuesAsHtmlCss(OutlierRequest request, Writer writer)
       throws IllegalQueryException {
     GridUtils.toHtmlCss(getOutlierValues(request), writer);
   }
 
-  private void setHeaders(Grid grid, OutlierDetectionRequest request) {
+  private void setHeaders(Grid grid, OutlierRequest request) {
     boolean isModifiedZScore = request.getAlgorithm() == MOD_Z_SCORE;
 
-    String meanOrMedianItem = isModifiedZScore ? MEDIAN.getItem() : ColumnHeader.MEAN.getItem();
-    String meanOrMedianName = isModifiedZScore ? MEDIAN.getName() : ColumnHeader.MEAN.getName();
+    String zScoreOrModZscoreItem =
+        isModifiedZScore ? MODIFIED_ZSCORE.getItem() : ZSCORE.getItem();
+    String zScoreOrModZscoreName =
+        isModifiedZScore ? MODIFIED_ZSCORE.getName() : ZSCORE.getName();
+
+    String meanOrMedianItem = isModifiedZScore ? MEDIAN.getItem() : MEAN.getItem();
+    String meanOrMedianName = isModifiedZScore ? MEDIAN.getName() : MEAN.getName();
 
     String deviationItem =
         isModifiedZScore ? MEDIAN_ABS_DEVIATION.getItem() : STANDARD_DEVIATION.getItem();
@@ -191,25 +195,24 @@ public class AnalyticsOutlierDetectionService {
     grid.addHeader(
         new GridHeader(
             ABSOLUTE_DEVIATION.getItem(), ABSOLUTE_DEVIATION.getName(), NUMBER, false, false));
-    grid.addHeader(new GridHeader(isModifiedZScore ? "modifiedzscore" : "zscore", NUMBER));
+    grid.addHeader(
+        new GridHeader(zScoreOrModZscoreItem, zScoreOrModZscoreName, NUMBER, false, false));
     grid.addHeader(
         new GridHeader(LOWER_BOUNDARY.getItem(), LOWER_BOUNDARY.getName(), NUMBER, false, false));
     grid.addHeader(
         new GridHeader(UPPER_BOUNDARY.getItem(), UPPER_BOUNDARY.getName(), NUMBER, false, false));
   }
 
-  private void setMetaData(
-      Grid grid, OutlierDetectionRequest request, List<OutlierValue> outlierValues) {
+  private void setMetaData(Grid grid, OutlierRequest request, List<Outlier> outliers) {
     grid.addMetaData("algorithm", request.getAlgorithm());
     grid.addMetaData("threshold", request.getThreshold());
     grid.addMetaData("orderBy", request.getOrderBy().getKey());
     grid.addMetaData("maxResults", request.getMaxResults());
-    grid.addMetaData("count", outlierValues.size());
+    grid.addMetaData("count", outliers.size());
   }
 
-  private void setRows(
-      Grid grid, List<OutlierValue> outlierValues, OutlierDetectionRequest request) {
-    outlierValues.forEach(
+  private void setRows(Grid grid, List<Outlier> outliers, OutlierRequest request) {
+    outliers.forEach(
         v -> {
           boolean isModifiedZScore = request.getAlgorithm() == MOD_Z_SCORE;
           grid.addRow();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreOutlierManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreOutlierManager.java
@@ -25,15 +25,15 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.outlierdetection.service;
+package org.hisp.dhis.analytics.outlier.service;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import lombok.extern.slf4j.Slf4j;
+import org.hisp.dhis.analytics.OutlierDetectionAlgorithm;
+import org.hisp.dhis.analytics.outlier.OutlierSqlStatementProcessor;
+import org.hisp.dhis.analytics.outlier.data.Outlier;
 import org.hisp.dhis.calendar.Calendar;
-import org.hisp.dhis.outlierdetection.OutlierDetectionAlgorithm;
-import org.hisp.dhis.outlierdetection.OutlierValue;
-import org.hisp.dhis.outlierdetection.processor.OutlierSqlStatementProcessor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -50,8 +50,8 @@ import org.springframework.stereotype.Repository;
  */
 @Slf4j
 @Repository
-public class AnalyticsZScoreOutlierDetectionManager extends AbstractOutlierDetectionManager {
-  protected AnalyticsZScoreOutlierDetectionManager(
+public class AnalyticsZScoreOutlierManager extends AbstractOutlierManager {
+  protected AnalyticsZScoreOutlierManager(
       NamedParameterJdbcTemplate jdbcTemplate,
       @Qualifier("analyticsZScoreSqlStatementProcessor")
           OutlierSqlStatementProcessor sqlStatementProcessor) {
@@ -60,25 +60,25 @@ public class AnalyticsZScoreOutlierDetectionManager extends AbstractOutlierDetec
 
   /** {@inheritDoc} */
   @Override
-  protected RowMapper<OutlierValue> getRowMapper(Calendar calendar, boolean modifiedZ) {
+  protected RowMapper<Outlier> getRowMapper(Calendar calendar, boolean modifiedZ) {
     return (rs, rowNum) -> {
-      OutlierValue outlierValue = getOutlierValue(calendar, rs);
-      addZScoreBasedParamsToOutlierValue(outlierValue, rs, modifiedZ);
+      Outlier outlier = getOutlierValue(calendar, rs);
+      addZScoreBasedParamsToOutlierValue(outlier, rs, modifiedZ);
 
-      return outlierValue;
+      return outlier;
     };
   }
 
   /** {@inheritDoc} */
   @Override
   protected void addZScoreBasedParamsToOutlierValue(
-      OutlierValue outlierValue, ResultSet rs, boolean modifiedZ) throws SQLException {
+      Outlier outlier, ResultSet rs, boolean modifiedZ) throws SQLException {
     if (modifiedZ) {
-      outlierValue.setStdDev(rs.getDouble("mad"));
+      outlier.setStdDev(rs.getDouble("mad"));
     } else {
-      outlierValue.setStdDev(rs.getDouble("stddev"));
+      outlier.setStdDev(rs.getDouble("std_dev"));
     }
 
-    super.addZScoreBasedParamsToOutlierValue(outlierValue, rs, modifiedZ);
+    super.addZScoreBasedParamsToOutlierValue(outlier, rs, modifiedZ);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreSqlStatementProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreSqlStatementProcessor.java
@@ -25,20 +25,21 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.outlierdetection.processor;
+package org.hisp.dhis.analytics.outlier.service;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.hisp.dhis.outlierdetection.Order.MEAN_ABS_DEV;
-import static org.hisp.dhis.outlierdetection.OutlierDetectionAlgorithm.MOD_Z_SCORE;
-import static org.hisp.dhis.outlierdetection.OutliersSqlParamName.DATA_ELEMENT_IDS;
-import static org.hisp.dhis.outlierdetection.OutliersSqlParamName.END_DATE;
-import static org.hisp.dhis.outlierdetection.OutliersSqlParamName.MAX_RESULTS;
-import static org.hisp.dhis.outlierdetection.OutliersSqlParamName.START_DATE;
-import static org.hisp.dhis.outlierdetection.OutliersSqlParamName.THRESHOLD;
+import static org.hisp.dhis.analytics.OutlierDetectionAlgorithm.MOD_Z_SCORE;
+import static org.hisp.dhis.analytics.outlier.Order.MEAN_ABS_DEV;
+import static org.hisp.dhis.analytics.outlier.data.OutlierSqlParams.DATA_ELEMENT_IDS;
+import static org.hisp.dhis.analytics.outlier.data.OutlierSqlParams.END_DATE;
+import static org.hisp.dhis.analytics.outlier.data.OutlierSqlParams.MAX_RESULTS;
+import static org.hisp.dhis.analytics.outlier.data.OutlierSqlParams.START_DATE;
+import static org.hisp.dhis.analytics.outlier.data.OutlierSqlParams.THRESHOLD;
 
-import org.hisp.dhis.outlierdetection.OutlierDetectionAlgorithm;
-import org.hisp.dhis.outlierdetection.OutlierDetectionRequest;
-import org.hisp.dhis.outlierdetection.util.OutlierDetectionUtils;
+import org.hisp.dhis.analytics.OutlierDetectionAlgorithm;
+import org.hisp.dhis.analytics.outlier.OutlierHelper;
+import org.hisp.dhis.analytics.outlier.OutlierSqlStatementProcessor;
+import org.hisp.dhis.analytics.outlier.data.OutlierRequest;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Component;
@@ -65,16 +66,16 @@ public class AnalyticsZScoreSqlStatementProcessor implements OutlierSqlStatement
    * of the dataset MAD: The median absolute deviation of the dataset 0.6745: conversion factor
    * (0.75 percentiles) *
    *
-   * @param request the instance of {@link OutlierDetectionRequest}.
+   * @param request the instance of {@link OutlierRequest}.
    * @return sql statement for the outlier detection and related data
    */
   @Override
-  public String getSqlStatement(OutlierDetectionRequest request) {
+  public String getSqlStatement(OutlierRequest request) {
     if (request == null) {
       return EMPTY;
     }
 
-    String ouPathClause = OutlierDetectionUtils.getOrgUnitPathClause(request.getOrgUnits(), "ax");
+    String ouPathClause = OutlierHelper.getOrgUnitPathClause(request.getOrgUnits(), "ax");
 
     boolean modifiedZ = request.getAlgorithm() == MOD_Z_SCORE;
 
@@ -157,11 +158,11 @@ public class AnalyticsZScoreSqlStatementProcessor implements OutlierSqlStatement
    * To avoid the sql injection and decrease the load of the database engine (query plan caching)
    * the named params are in use.
    *
-   * @param request the instance of {@link OutlierDetectionRequest}.
+   * @param request the instance of {@link OutlierRequest}.
    * @return named params for parametrized sql query
    */
   @Override
-  public SqlParameterSource getSqlParameterSource(OutlierDetectionRequest request) {
+  public SqlParameterSource getSqlParameterSource(OutlierRequest request) {
     return new MapSqlParameterSource()
         .addValue(THRESHOLD.getKey(), request.getThreshold())
         .addValue(DATA_ELEMENT_IDS.getKey(), request.getDataElementIds())

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZscoreSqlStatementProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZscoreSqlStatementProcessorTest.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.outlierdetection.processor;
+package org.hisp.dhis.analytics.outlier.service;
 
 import static org.hisp.dhis.DhisConvenienceTest.createDataElement;
 import static org.hisp.dhis.DhisConvenienceTest.createOrganisationUnit;
@@ -36,11 +36,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.AggregationType;
+import org.hisp.dhis.analytics.OutlierDetectionAlgorithm;
+import org.hisp.dhis.analytics.outlier.OutlierSqlStatementProcessor;
+import org.hisp.dhis.analytics.outlier.data.OutlierRequest;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.outlierdetection.OutlierDetectionAlgorithm;
-import org.hisp.dhis.outlierdetection.OutlierDetectionRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -75,8 +76,8 @@ class AnalyticsZscoreSqlStatementProcessorTest {
 
   @Test
   void testGetSqlStatement() {
-    OutlierDetectionRequest request =
-        new OutlierDetectionRequest.Builder()
+    OutlierRequest request =
+        new OutlierRequest.Builder()
             .withDataElements(Lists.newArrayList(deA, deB, deC))
             .withStartEndDate(getDate(2020, 1, 1), getDate(2020, 3, 1))
             .withOrgUnits(Lists.newArrayList(ouA, ouB))
@@ -89,8 +90,8 @@ class AnalyticsZscoreSqlStatementProcessorTest {
 
   @Test
   void testGetSqlStatementWithZScore() {
-    OutlierDetectionRequest request =
-        new OutlierDetectionRequest.Builder()
+    OutlierRequest request =
+        new OutlierRequest.Builder()
             .withDataElements(Lists.newArrayList(deA, deB, deC))
             .withStartEndDate(getDate(2020, 1, 1), getDate(2020, 3, 1))
             .withOrgUnits(Lists.newArrayList(ouA, ouB))
@@ -102,8 +103,8 @@ class AnalyticsZscoreSqlStatementProcessorTest {
 
   @Test
   void testGetSqlStatementWithModifiedZScore() {
-    OutlierDetectionRequest request =
-        new OutlierDetectionRequest.Builder()
+    OutlierRequest request =
+        new OutlierRequest.Builder()
             .withDataElements(Lists.newArrayList(deA, deB, deC))
             .withStartEndDate(getDate(2020, 1, 1), getDate(2020, 3, 1))
             .withOrgUnits(Lists.newArrayList(ouA, ouB))

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/analytics/common/ColumnHeader.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/analytics/common/ColumnHeader.java
@@ -56,7 +56,7 @@ public enum ColumnHeader {
   POINTS("points", "Points"),
   EVENT_STATUS("eventstatus", "Event status"),
   DIMENSION("dx", "Data"),
-  DIMENSION_NAME("dxname", "Event status"),
+  DIMENSION_NAME("dxname", "Data name"),
   PERIOD("pe", "Event status"),
   CATEGORY_OPTION_COMBO("coc", "Category option combo"),
   CATEGORY_OPTION_COMBO_NAME("cocname", "Category option combo name"),

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/outlierdetection/processor/ZscoreSqlStatementProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/outlierdetection/processor/ZscoreSqlStatementProcessor.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.outlierdetection.processor;
 
+import static org.hisp.dhis.outlierdetection.OutlierDetectionAlgorithm.MOD_Z_SCORE;
 import static org.hisp.dhis.outlierdetection.OutliersSqlParamName.DATA_ELEMENT_IDS;
 import static org.hisp.dhis.outlierdetection.OutliersSqlParamName.DATA_END_DATE;
 import static org.hisp.dhis.outlierdetection.OutliersSqlParamName.DATA_START_DATE;
@@ -38,7 +39,6 @@ import static org.hisp.dhis.outlierdetection.OutliersSqlParamName.THRESHOLD;
 import java.util.Date;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.outlierdetection.Order;
-import org.hisp.dhis.outlierdetection.OutlierDetectionAlgorithm;
 import org.hisp.dhis.outlierdetection.OutlierDetectionRequest;
 import org.hisp.dhis.outlierdetection.util.OutlierDetectionUtils;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -65,7 +65,7 @@ public class ZscoreSqlStatementProcessor implements OutlierSqlStatementProcessor
     String dataStartDateClause = getDataStartDateClause(request.getDataStartDate());
     String dataEndDateClause = getDataEndDateClause(request.getDataEndDate());
 
-    boolean modifiedZ = request.getAlgorithm() == OutlierDetectionAlgorithm.MOD_Z_SCORE;
+    boolean modifiedZ = request.getAlgorithm() == MOD_Z_SCORE;
     String middleStatsCalc =
         modifiedZ
             ? "percentile_cont(0.5) within group(order by dv.value::double precision)"

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/outlierdetection/AnalyticsOutlierDetectionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/outlierdetection/AnalyticsOutlierDetectionController.java
@@ -37,14 +37,14 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import java.io.IOException;
 import javax.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
+import org.hisp.dhis.analytics.outlier.data.OutlierQuery;
+import org.hisp.dhis.analytics.outlier.data.OutlierQueryParser;
+import org.hisp.dhis.analytics.outlier.data.OutlierRequest;
+import org.hisp.dhis.analytics.outlier.data.OutlierRequestValidator;
+import org.hisp.dhis.analytics.outlier.service.AnalyticsOutlierService;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.outlierdetection.OutlierDetectionQuery;
-import org.hisp.dhis.outlierdetection.OutlierDetectionRequest;
-import org.hisp.dhis.outlierdetection.parser.OutlierDetectionQueryParser;
-import org.hisp.dhis.outlierdetection.service.AnalyticsOutlierDetectionService;
-import org.hisp.dhis.validation.outlierdetection.ValidationOutlierDetectionRequest;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -63,14 +63,14 @@ import org.springframework.web.bind.annotation.RestController;
 @PreAuthorize("hasRole('ALL') or hasRole('F_RUN_VALIDATION')")
 public class AnalyticsOutlierDetectionController {
   private static final String RESOURCE_PATH = "/analytics/outlierDetection";
-  private final AnalyticsOutlierDetectionService outlierService;
+  private final AnalyticsOutlierService outlierService;
   private final ContextUtils contextUtils;
-  private final OutlierDetectionQueryParser queryParser;
-  private final ValidationOutlierDetectionRequest validator;
+  private final OutlierQueryParser queryParser;
+  private final OutlierRequestValidator validator;
 
   @GetMapping(value = RESOURCE_PATH, produces = APPLICATION_JSON_VALUE)
-  public Grid getOutliersJson(OutlierDetectionQuery query) {
-    OutlierDetectionRequest request = getFromQuery(query);
+  public Grid getOutliersJson(OutlierQuery query) {
+    OutlierRequest request = getFromQuery(query);
 
     Grid grid = outlierService.getOutlierValues(request);
 
@@ -82,36 +82,32 @@ public class AnalyticsOutlierDetectionController {
   }
 
   @GetMapping(value = RESOURCE_PATH + ".csv")
-  public void getOutliersCsv(OutlierDetectionQuery query, HttpServletResponse response)
-      throws IOException {
-    OutlierDetectionRequest request = getFromQuery(query);
+  public void getOutliersCsv(OutlierQuery query, HttpServletResponse response) throws IOException {
+    OutlierRequest request = getFromQuery(query);
     contextUtils.configureResponse(response, CONTENT_TYPE_CSV, NO_CACHE, "outlierdata.csv", true);
 
     outlierService.getOutlierValuesAsCsv(request, response.getWriter());
   }
 
   @GetMapping(value = RESOURCE_PATH + ".xml")
-  public void getOutliersXml(OutlierDetectionQuery query, HttpServletResponse response)
-      throws IOException {
-    OutlierDetectionRequest request = getFromQuery(query);
+  public void getOutliersXml(OutlierQuery query, HttpServletResponse response) throws IOException {
+    OutlierRequest request = getFromQuery(query);
     contextUtils.configureResponse(response, CONTENT_TYPE_XML, NO_CACHE);
 
     outlierService.getOutlierValuesAsXml(request, response.getOutputStream());
   }
 
   @GetMapping(value = RESOURCE_PATH + ".xls")
-  public void getOutliersXls(OutlierDetectionQuery query, HttpServletResponse response)
-      throws IOException {
-    OutlierDetectionRequest request = getFromQuery(query);
+  public void getOutliersXls(OutlierQuery query, HttpServletResponse response) throws IOException {
+    OutlierRequest request = getFromQuery(query);
     contextUtils.configureResponse(response, CONTENT_TYPE_EXCEL, NO_CACHE, "outlierdata.xls", true);
 
     outlierService.getOutlierValuesAsXls(request, response.getOutputStream());
   }
 
   @GetMapping(value = RESOURCE_PATH + ".html")
-  public void getOutliersHtml(OutlierDetectionQuery query, HttpServletResponse response)
-      throws IOException {
-    OutlierDetectionRequest request = getFromQuery(query);
+  public void getOutliersHtml(OutlierQuery query, HttpServletResponse response) throws IOException {
+    OutlierRequest request = getFromQuery(query);
 
     contextUtils.configureResponse(response, CONTENT_TYPE_HTML, NO_CACHE);
 
@@ -119,16 +115,16 @@ public class AnalyticsOutlierDetectionController {
   }
 
   @GetMapping(value = RESOURCE_PATH + ".html+css")
-  public void getOutliersHtmlCss(OutlierDetectionQuery query, HttpServletResponse response)
+  public void getOutliersHtmlCss(OutlierQuery query, HttpServletResponse response)
       throws IOException {
-    OutlierDetectionRequest request = getFromQuery(query);
+    OutlierRequest request = getFromQuery(query);
     contextUtils.configureResponse(response, CONTENT_TYPE_HTML, NO_CACHE);
 
     outlierService.getOutlierValuesAsHtmlCss(request, response.getWriter());
   }
 
-  private OutlierDetectionRequest getFromQuery(OutlierDetectionQuery query) {
-    OutlierDetectionRequest request = queryParser.getFromQuery(query);
+  private OutlierRequest getFromQuery(OutlierQuery query) {
+    OutlierRequest request = queryParser.getFromQuery(query);
     validator.validate(request, true);
 
     return request;


### PR DESCRIPTION
After having a better look at the code because of some issues, I realized that the current implementation was completely coupled with the existing (deprecated) endpoint for outliers.
Changes in one endpoint could affect the other. This is not a desirable behavior. This set of changes aims to address it before is too late.

Also, I found a typo in the headers, which has been fixed.