### PR TITLE
fix: json patch throw error when remove null property

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/jsonpatch/JsonPatchManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/jsonpatch/JsonPatchManager.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.common.EmbeddedObject;
 import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.commons.jackson.jsonpatch.JsonPatch;
 import org.hisp.dhis.commons.jackson.jsonpatch.JsonPatchException;
+import org.hisp.dhis.commons.jackson.jsonpatch.JsonPatchOperation;
 import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
@@ -86,6 +87,8 @@ public class JsonPatchManager {
     // we need to make another trip to make sure all collections are
     // correctly made into json nodes.
     handleCollectionUpdates(object, schema, (ObjectNode) node);
+
+    validatePatchPath(patch, schema);
 
     node = patch.apply(node);
     return (T)
@@ -136,5 +139,18 @@ public class JsonPatchManager {
     clone.setId(source.getId());
     clone.setUid(source.getUid());
     return clone;
+  }
+
+  /** Check if all patch paths are valid for the given schema. */
+  private void validatePatchPath(JsonPatch patch, Schema schema) throws JsonPatchException {
+    for (JsonPatchOperation op : patch.getOperations()) {
+      if (!schema.hasProperty(op.getPath().getMatchingProperty())) {
+        throw new JsonPatchException(
+            "Property "
+                + op.getPath().getMatchingProperty()
+                + " does not exist on "
+                + schema.getClass().getSimpleName());
+      }
+    }
   }
 }

--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/jackson/jsonpatch/operations/RemoveOperation.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/jackson/jsonpatch/operations/RemoveOperation.java
@@ -55,7 +55,7 @@ public class RemoveOperation extends JsonPatchOperation {
     }
 
     if (!nodePathExists(node)) {
-      throw new JsonPatchException(String.format("Invalid path %s", path));
+      return node;
     }
 
     final JsonNode parentNode = node.at(path.head());

--- a/dhis-2/dhis-support/dhis-support-commons/src/test/java/org/hisp/dhis/commons/jackson/RemoveOperationTest.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/test/java/org/hisp/dhis/commons/jackson/RemoveOperationTest.java
@@ -30,11 +30,9 @@ package org.hisp.dhis.commons.jackson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -51,17 +49,6 @@ import org.junit.jupiter.api.Test;
  */
 class RemoveOperationTest {
   private final ObjectMapper jsonMapper = JacksonObjectMapperConfig.staticJsonMapper();
-
-  @Test
-  void testRemoveInvalidKeyShouldThrowException() throws JsonProcessingException {
-    JsonPatch patch =
-        jsonMapper.readValue(
-            "[" + "{\"op\": \"remove\", \"path\": \"/aaa\"}" + "]", JsonPatch.class);
-    assertNotNull(patch);
-    JsonNode root = jsonMapper.createObjectNode();
-    assertFalse(root.has("aaa"));
-    assertThrows(JsonPatchException.class, () -> patch.apply(root));
-  }
 
   @Test
   void testRemoveProperty() throws JsonProcessingException, JsonPatchException {

--- a/dhis-2/dhis-support/dhis-support-commons/src/test/java/org/hisp/dhis/commons/jackson/ReplaceOperationTest.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/test/java/org/hisp/dhis/commons/jackson/ReplaceOperationTest.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.commons.jackson;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -63,21 +62,6 @@ class ReplaceOperationTest {
     root = (ObjectNode) patch.apply(root);
     assertTrue(root.has("aaa"));
     assertEquals("bbb", root.get("aaa").asText());
-  }
-
-  @Test
-  void testBasicReplaceNotExistProperty() throws JsonProcessingException {
-
-    JsonPatch patch =
-        jsonMapper.readValue(
-            "[" + "{\"op\": \"replace\", \"path\": \"/notExist\", \"value\": \"bbb\"}" + "]",
-            JsonPatch.class);
-    assertNotNull(patch);
-    ObjectNode root = jsonMapper.createObjectNode();
-    root.set("aaa", TextNode.valueOf("aaa"));
-    assertTrue(root.has("aaa"));
-    assertEquals("aaa", root.get("aaa").asText());
-    assertThrows(JsonPatchException.class, () -> patch.apply(root));
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/jsonpatch/JsonPatchManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/jsonpatch/JsonPatchManagerTest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.jsonpatch;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -42,6 +43,7 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementGroup;
 import org.hisp.dhis.test.integration.IntegrationTestBase;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserRole;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -197,5 +199,71 @@ class JsonPatchManagerTest extends IntegrationTestBase {
             JsonPatch.class);
     DataElement removedPatchedDE = jsonPatchManager.apply(removePatch, patchedDE);
     assertEquals(0, removedPatchedDE.getSharing().getUsers().size());
+  }
+
+  @Test
+  void testReplaceNullProperty() throws JsonProcessingException, JsonPatchException {
+    UserRole userRole = createUserRole("test", "ALL");
+    userRole.setCode(null);
+    manager.save(userRole);
+    JsonPatch patch =
+        jsonMapper.readValue(
+            "[" + "{\"op\": \"replace\", \"path\": \"/code\", \"value\": \"updated\"}" + "]",
+            JsonPatch.class);
+    assertNotNull(patch);
+    UserRole patchedUserRole = jsonPatchManager.apply(patch, userRole);
+    assertEquals("updated", patchedUserRole.getCode());
+  }
+
+  @Test
+  void testReplaceNotExistProperty() throws JsonProcessingException {
+    UserRole userRole = createUserRole("test", "ALL");
+    userRole.setCode(null);
+    manager.save(userRole);
+    JsonPatch patch =
+        jsonMapper.readValue(
+            "[" + "{\"op\": \"replace\", \"path\": \"/notexist\", \"value\": \"updated\"}" + "]",
+            JsonPatch.class);
+    assertNotNull(patch);
+    assertThrows(JsonPatchException.class, () -> jsonPatchManager.apply(patch, userRole));
+  }
+
+  @Test
+  void testAddNotExistProperty() throws JsonProcessingException {
+    UserRole userRole = createUserRole("test", "ALL");
+    userRole.setCode(null);
+    manager.save(userRole);
+    JsonPatch patch =
+        jsonMapper.readValue(
+            "[" + "{\"op\": \"add\", \"path\": \"/notexist\", \"value\": \"updated\"}" + "]",
+            JsonPatch.class);
+    assertNotNull(patch);
+    assertThrows(JsonPatchException.class, () -> jsonPatchManager.apply(patch, userRole));
+  }
+
+  @Test
+  void testRemoveNotExistProperty() throws JsonProcessingException {
+    UserRole userRole = createUserRole("test", "ALL");
+    userRole.setCode(null);
+    manager.save(userRole);
+    JsonPatch patch =
+        jsonMapper.readValue(
+            "[" + "{\"op\": \"remove\", \"path\": \"/notexist\", \"value\": \"updated\"}" + "]",
+            JsonPatch.class);
+    assertNotNull(patch);
+    assertThrows(JsonPatchException.class, () -> jsonPatchManager.apply(patch, userRole));
+  }
+
+  @Test
+  void testRemoveByIdNotExistProperty() throws JsonProcessingException {
+    UserRole userRole = createUserRole("test", "ALL");
+    userRole.setCode(null);
+    manager.save(userRole);
+    JsonPatch patch =
+        jsonMapper.readValue(
+            "[" + "{\"op\": \"remove\", \"path\": \"/notexist\", \"id\": \"uid\"}" + "]",
+            JsonPatch.class);
+    assertNotNull(patch);
+    assertThrows(JsonPatchException.class, () -> jsonPatchManager.apply(patch, userRole));
   }
 }


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-16299
### Issue

**Problem in JsonPatchManager**: 
The `JsonPatchManager` relies on the presence of properties within a `JsonNode` to validate patch paths. However, our Jackson ObjectMapper does not serialize properties with `null` values into `JsonNode`. This leads to an issue where patch paths referencing `null` properties are incorrectly deemed invalid, despite these properties existing in the original object.

### Fix

- Validate the patch path in `JsonpPatchManager` before applying the patch operators.
- Remove the path validation in `RemoveOperation` and related tests.


### Test

**Validation Procedure**:

1. **Initial Setup**: 
   Begin by creating a new UserGroup instance where the `code` property is intentionally set to `null`.

2. **Patch Request**: 
   Execute a JSON patch request to update the `code` property. Use the following `curl` command:

```
curl -X PATCH -v http://localhost:9090/api/userGroups/vAvEltyXGbD
-H "Content-Type: application/json-patch+json"
-d '[{ "op": "replace", "path": "/code", "value": "bonthe" }]'
-u admin:district
```


3. **Outcome Verification**: 
Confirm that the `code` property is correctly updated to "bonthe". 
