### PR TITLE
fix: job configurations keep enabled state for update [DHIS2-12017]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -192,6 +192,7 @@ public class JobConfigurationController extends AbstractCrudController<JobConfig
       throws ConflictException {
     checkModifiable(before, "Job %s is a system job that cannot be modified.");
     checkModifiable(after, "Job %s can not be changed into a system job.");
+    after.setEnabled(before.isEnabled());
   }
 
   @Override


### PR DESCRIPTION
### Summary
Retains the `enabled` property state for updates by copying it from the old state in the `preUpdate` hook.

The cause it otherwise could be flipped to true is that the field is initialized to `true` for a new instance of `JobConfiguration` which the update creates as part of the de-serialisation from JSON.

### Alternatives
This solution can only be described as a workaround. 

Yet, other more "obvious" solutions have been proven problematic, for example
* not initializing the property to `true` causes the issue just the other way around as `false` is then the default, also the default of `true` for newly created job configurations must be encoded somewhere
* changing the property to a `Boolean` so _undefined_ can be distinguished from a specific value fails because it is still a required property for the schema and the update rejected for missing a required property
* using `setAutoFields` fails because it only is used for creation, not update
* using logic in getter/setters is problematic as it still must be symmetric and mapped to the database where the field is non-null

The proper fix would be to change the general mechanism of updating objects from JSON or XML.
Such update should naturally not change any property that is not defined in the payload nor should it require any property for an update as required properties can always be kept as is in the current object. But that is far to big of a change to address the direct problem at hand.

### Automatic Testing
A new test scenario was added to make sure updating the name does not change the enabled state. The scenario tests both ways, false stays false, true stays true and newly created configurations are initialised to true. 

### Manual Testing
See Jira description