### PR TITLE
fix: job configurations keep enabled state for update [DHIS2-12017] (2.40)

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationControllerTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static java.lang.String.format;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -37,6 +38,7 @@ import java.util.List;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.webapi.json.domain.JsonIdentifiableObject;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -207,6 +209,34 @@ class JobConfigurationControllerTest extends DhisControllerConvenienceTest {
             "OWNERSHIP",
             "VALIDATION_RESULT"),
         param.getArray("constants").stringValues());
+  }
+
+  @Test
+  void testEnableIsReadOnly_Update() {
+    String json = "{'name':'%s','jobType':'DATA_INTEGRITY','cronExpression':'0 0 11 ? * MON-FRI'}";
+    String jobId =
+        assertStatus(HttpStatus.CREATED, POST("/jobConfigurations", format(json, "init_name")));
+    JsonIdentifiableObject config = getJsonJobConfiguration(jobId);
+    assertTrue(
+        config.getBoolean("enabled").booleanValue(), "newly created config should be enabled");
+    assertStatus(HttpStatus.NO_CONTENT, POST("/jobConfigurations/" + jobId + "/disable"));
+    config = getJsonJobConfiguration(jobId);
+    assertFalse(config.getBoolean("enabled").booleanValue());
+    assertStatus(HttpStatus.OK, PUT("/jobConfigurations/" + jobId, format(json, "new_name")));
+    config = getJsonJobConfiguration(jobId);
+    assertEquals("new_name", config.getName());
+    assertFalse(config.getBoolean("enabled").booleanValue(), "updating should not affect enabled");
+    assertStatus(HttpStatus.NO_CONTENT, POST("/jobConfigurations/" + jobId + "/enable"));
+    config = getJsonJobConfiguration(jobId);
+    assertTrue(config.getBoolean("enabled").booleanValue());
+    assertStatus(HttpStatus.OK, PUT("/jobConfigurations/" + jobId, format(json, "new_name2")));
+    config = getJsonJobConfiguration(jobId);
+    assertEquals("new_name2", config.getName());
+    assertTrue(config.getBoolean("enabled").booleanValue(), "updating should not affect enabled");
+  }
+
+  private JsonIdentifiableObject getJsonJobConfiguration(String jobId) {
+    return GET("/jobConfigurations/{id}", jobId).content().as(JsonIdentifiableObject.class);
   }
 
   private JsonObject assertJobConfigurationExists(String jobId, String expectedJobType) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -47,11 +47,13 @@ import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.schema.descriptors.JobConfigurationSchemaDescriptor;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.hisp.dhis.webapi.webdomain.JobTypes;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -110,6 +112,30 @@ public class JobConfigurationController extends AbstractCrudController<JobConfig
     return objectReport;
   }
 
+  @PostMapping("{uid}/enable")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void enable(@PathVariable("uid") String uid) throws NotFoundException, ConflictException {
+    JobConfiguration obj = jobConfigurationService.getJobConfigurationByUid(uid);
+    if (obj == null) throw new NotFoundException(JobConfiguration.class, uid);
+    checkConfigurable(obj, "Job %s is a system job that cannot be modified.");
+    if (!obj.isEnabled()) {
+      obj.setEnabled(true);
+      jobConfigurationService.updateJobConfiguration(obj);
+    }
+  }
+
+  @PostMapping("{uid}/disable")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void disable(@PathVariable("uid") String uid) throws NotFoundException, ConflictException {
+    JobConfiguration obj = jobConfigurationService.getJobConfigurationByUid(uid);
+    if (obj == null) throw new NotFoundException(JobConfiguration.class, uid);
+    checkConfigurable(obj, "Job %s is a system job that cannot be modified.");
+    if (obj.isEnabled()) {
+      obj.setEnabled(false);
+      jobConfigurationService.updateJobConfiguration(obj);
+    }
+  }
+
   @Override
   protected void preCreateEntity(JobConfiguration jobConfiguration) throws ConflictException {
     checkConfigurable(jobConfiguration, "Job %s must be configurable but was not.");
@@ -120,6 +146,7 @@ public class JobConfigurationController extends AbstractCrudController<JobConfig
       throws ConflictException {
     checkConfigurable(before, "Job %s is a system job that cannot be modified.");
     checkConfigurable(after, "Job %s can not be changed into a system job.");
+    after.setEnabled(before.isEnabled());
   }
 
   @Override


### PR DESCRIPTION
based on cherry-pick of #15913 with manual adjustments

I copied over the `/enable` and `/disable` endpoints from master as they are now needed since one cannot use update to change the `enabled` flag. 

Also the test needed some adjustment to work with what is available in 2.40.
The test will also use the added endpoints so they have coverage.