### PR TITLE
fix: job configurations keep enabled state for update [DHIS2-12017] (2.39)

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationControllerTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static java.lang.String.format;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -37,6 +38,7 @@ import java.util.List;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.webapi.json.domain.JsonIdentifiableObject;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -209,6 +211,34 @@ class JobConfigurationControllerTest extends DhisControllerConvenienceTest {
             "OWNERSHIP",
             "VALIDATION_RESULT"),
         param.getArray("constants").stringValues());
+  }
+
+  @Test
+  void testEnableIsReadOnly_Update() {
+    String json = "{'name':'%s','jobType':'DATA_INTEGRITY','cronExpression':'0 0 11 ? * MON-FRI'}";
+    String jobId =
+        assertStatus(HttpStatus.CREATED, POST("/jobConfigurations", format(json, "init_name")));
+    JsonIdentifiableObject config = getJsonJobConfiguration(jobId);
+    assertTrue(
+        config.getBoolean("enabled").booleanValue(), "newly created config should be enabled");
+    assertStatus(HttpStatus.NO_CONTENT, POST("/jobConfigurations/" + jobId + "/disable"));
+    config = getJsonJobConfiguration(jobId);
+    assertFalse(config.getBoolean("enabled").booleanValue());
+    assertStatus(HttpStatus.OK, PUT("/jobConfigurations/" + jobId, format(json, "new_name")));
+    config = getJsonJobConfiguration(jobId);
+    assertEquals("new_name", config.getName());
+    assertFalse(config.getBoolean("enabled").booleanValue(), "updating should not affect enabled");
+    assertStatus(HttpStatus.NO_CONTENT, POST("/jobConfigurations/" + jobId + "/enable"));
+    config = getJsonJobConfiguration(jobId);
+    assertTrue(config.getBoolean("enabled").booleanValue());
+    assertStatus(HttpStatus.OK, PUT("/jobConfigurations/" + jobId, format(json, "new_name2")));
+    config = getJsonJobConfiguration(jobId);
+    assertEquals("new_name2", config.getName());
+    assertTrue(config.getBoolean("enabled").booleanValue(), "updating should not affect enabled");
+  }
+
+  private JsonIdentifiableObject getJsonJobConfiguration(String jobId) {
+    return GET("/jobConfigurations/{id}", jobId).content().as(JsonIdentifiableObject.class);
   }
 
   private JsonObject assertJobConfigurationExists(String jobId, String expectedJobType) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -53,6 +53,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -110,6 +111,32 @@ public class JobConfigurationController extends AbstractCrudController<JobConfig
     return objectReport;
   }
 
+  @PostMapping("{uid}/enable")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void enable(@PathVariable("uid") String uid)
+      throws NotFoundException, WebMessageException {
+    JobConfiguration obj = jobConfigurationService.getJobConfigurationByUid(uid);
+    if (obj == null) throw NotFoundException.notFoundUid(uid);
+    checkConfigurable(obj, HttpStatus.CONFLICT, "Job %s is a system job that cannot be modified.");
+    if (!obj.isEnabled()) {
+      obj.setEnabled(true);
+      jobConfigurationService.updateJobConfiguration(obj);
+    }
+  }
+
+  @PostMapping("{uid}/disable")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void disable(@PathVariable("uid") String uid)
+      throws NotFoundException, WebMessageException {
+    JobConfiguration obj = jobConfigurationService.getJobConfigurationByUid(uid);
+    if (obj == null) throw NotFoundException.notFoundUid(uid);
+    checkConfigurable(obj, HttpStatus.CONFLICT, "Job %s is a system job that cannot be modified.");
+    if (obj.isEnabled()) {
+      obj.setEnabled(false);
+      jobConfigurationService.updateJobConfiguration(obj);
+    }
+  }
+
   @Override
   protected void preCreateEntity(JobConfiguration jobConfiguration) throws WebMessageException {
     checkConfigurable(
@@ -122,6 +149,7 @@ public class JobConfigurationController extends AbstractCrudController<JobConfig
     checkConfigurable(
         before, HttpStatus.UNPROCESSABLE_ENTITY, "Job %s is a system job that cannot be modified.");
     checkConfigurable(after, HttpStatus.CONFLICT, "Job %s can not be changed into a system job.");
+    after.setEnabled(before.isEnabled());
   }
 
   @Override


### PR DESCRIPTION
based on cherry-pick from #15913 (2.40)

Further adjustments to 2.40 were needed because of error handling being different in 2.39