### PR TITLE
chore: Replace Java based check for excess data element group membership

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityCheckType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityCheckType.java
@@ -39,7 +39,6 @@ public enum DataIntegrityCheckType {
    */
 
   // DataElements
-  DATA_ELEMENTS_VIOLATING_EXCLUSIVE_GROUP_SETS,
   DATA_ELEMENTS_IN_DATA_SET_NOT_IN_FORM,
 
   // CategoryOptionCombos

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/FlattenedDataIntegrityReport.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/FlattenedDataIntegrityReport.java
@@ -189,8 +189,7 @@ public class FlattenedDataIntegrityReport implements WebMessageResponse {
             detailsByName.get("data_elements_aggregate_with_different_period_types"));
     this.dataElementsViolatingExclusiveGroupSets =
         mapOfRefsByDisplayNameOrUid(
-            detailsByName.get(
-                DataIntegrityCheckType.DATA_ELEMENTS_VIOLATING_EXCLUSIVE_GROUP_SETS.getName()));
+            detailsByName.get("data_elements_violating_exclusive_group_sets"));
     this.dataElementsInDataSetNotInForm =
         mapOfRefsByDisplayNameOrUid(
             detailsByName.get(

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
@@ -642,7 +642,6 @@ public class DefaultDataIntegrityService implements DataIntegrityService {
       checks.add("datasets_not_assigned_to_org_units");
       checks.add("data_elements_violating_exclusive_group_sets");
       checks.add("invalid_category_combos");
-
     }
     runDetailsChecks(checks, progress);
     return new FlattenedDataIntegrityReport(getDetails(checks, -1L));

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
@@ -516,10 +516,6 @@ public class DefaultDataIntegrityService implements DataIntegrityService {
   public void initIntegrityChecks() {
 
     registerNonDatabaseIntegrityCheck(
-        DataIntegrityCheckType.DATA_ELEMENTS_VIOLATING_EXCLUSIVE_GROUP_SETS,
-        DataElement.class,
-        this::getDataElementsViolatingExclusiveGroupSets);
-    registerNonDatabaseIntegrityCheck(
         DataIntegrityCheckType.DATA_ELEMENTS_IN_DATA_SET_NOT_IN_FORM,
         DataSet.class,
         this::getDataElementsInDataSetNotInForm);
@@ -649,6 +645,7 @@ public class DefaultDataIntegrityService implements DataIntegrityService {
       checks.add("data_elements_aggregate_with_different_period_types");
       checks.add("data_elements_without_datasets");
       checks.add("datasets_not_assigned_to_org_units");
+      checks.add("data_elements_violating_exclusive_group_sets");
     }
     runDetailsChecks(checks, progress);
     return new FlattenedDataIntegrityReport(getDetails(checks, -1L));

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/data_elements/aggregate_des_excess_groupset_membership.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/data_elements/aggregate_des_excess_groupset_membership.yaml
@@ -25,7 +25,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 ---
-name: data_elements_excess_groupset_membership
+name: data_elements_violating_exclusive_group_sets
 description: Data elements which belong to multiple groups in a group set.
 section: data_elements
 section_order: 10
@@ -58,8 +58,10 @@ summary_sql: >-
   FROM des_multiple_groups;
 details_sql: >-
   SELECT x.uid,x.name, x.degs_name || ' :{'||
-  string_agg(x.deg_name,',') || '}' as comment from (
-  SELECT de.uid,de.name,degs.name as degs_name,deg.name as deg_name
+  string_agg(x.deg_name,',') || '}' as comment,
+  array_agg(x.deg_name || ':' || x.deg_uid) as refs
+  from (
+  SELECT de.uid,de.name,degs.name as degs_name,deg.name as deg_name, deg.uid as deg_uid
   from (
   SELECT d.dataelementid,d.dataelementgroupsetid,
   unnest(d.groupids) as dataelementgroupid
@@ -77,7 +79,7 @@ details_sql: >-
   INNER JOIN dataelement de on e.dataelementid = de.dataelementid
   INNER JOIN dataelementgroupset degs on e.dataelementgroupsetid = degs.dataelementgroupsetid
   INNER JOIN dataelementgroup deg on e.dataelementgroupid = deg.dataelementgroupid ) x
-  GROUP BY x.uid,x.name,x.degs_name
+  GROUP BY x.uid,x.name,x.degs_name;
 details_id_type: data_elements_aggregate
 severity: SEVERE
 introduction: >

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityDataElementsAggregateExcessGroupMembershipControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityDataElementsAggregateExcessGroupMembershipControllerTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
  */
 class DataIntegrityDataElementsAggregateExcessGroupMembershipControllerTest
     extends AbstractDataIntegrityIntegrationTest {
-  private final String check = "data_elements_excess_groupset_membership";
+  private final String check = "data_elements_violating_exclusive_group_sets";
 
   private String dataElementA;
 


### PR DESCRIPTION
- Changes name of the SQL check to match the legacy Java check
- Adds additional references in array format to the SQL check to match the flattened report