### PR TITLE
feat: Add maxResults in Visualization [DHIS2-16323]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -437,7 +437,6 @@ public enum ErrorCode {
   E7144(
       "Query failed because a referenced table does not exist. Please ensure analytics job was run"),
   E7145("Query failed because of a syntax error"),
-  E7146("Property 'maxResults' is out range. Allowed range: [1..500]"),
 
   /* Event analytics */
   E7200(Constants.AT_LEAST_ONE_ORGANISATION_UNIT_MUST_BE_SPECIFIED),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -437,6 +437,7 @@ public enum ErrorCode {
   E7144(
       "Query failed because a referenced table does not exist. Please ensure analytics job was run"),
   E7145("Query failed because of a syntax error"),
+  E7146("Property 'maxResults' is out range. Allowed range: [1..500]"),
 
   /* Event analytics */
   E7200(Constants.AT_LEAST_ONE_ORGANISATION_UNIT_MUST_BE_SPECIFIED),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/OutlierAnalysis.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/OutlierAnalysis.java
@@ -29,11 +29,11 @@ package org.hisp.dhis.visualization;
 
 import static org.hisp.dhis.common.DxfNamespaces.DXF_2_0;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import java.io.Serializable;
 import lombok.Data;
-import org.hisp.dhis.schema.annotation.PropertyRange;
 
 /** Class responsible for keeping the settings related to outlier analysis in Visualization. */
 @Data
@@ -60,6 +60,19 @@ public class OutlierAnalysis implements Serializable {
 
   @JsonProperty
   @JacksonXmlProperty(namespace = DXF_2_0)
-  @PropertyRange(min = 1, max = 500)
   private Integer maxResults;
+
+  /**
+   * Checks basic rules o ensure this object is valid. The usual validation annotations do not work
+   * for this object because this is used as a Json/nested object. This kind of object does not
+   * trigger the usual validation through @PropertyRange.
+   *
+   * @return true if this object is valid, false otherwise.
+   */
+  @JsonIgnore
+  public boolean isValid() {
+    int min = 1;
+    int max = 500;
+    return maxResults != null && (maxResults >= min && maxResults <= max);
+  }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/OutlierAnalysis.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/OutlierAnalysis.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import java.io.Serializable;
 import lombok.Data;
+import org.hisp.dhis.schema.annotation.PropertyRange;
 
 /** Class responsible for keeping the settings related to outlier analysis in Visualization. */
 @Data
@@ -56,4 +57,9 @@ public class OutlierAnalysis implements Serializable {
   @JsonProperty
   @JacksonXmlProperty(namespace = DXF_2_0)
   private OutlierLine extremeLines;
+
+  @JsonProperty
+  @JacksonXmlProperty(namespace = DXF_2_0)
+  @PropertyRange(min = 1, max = 500)
+  private Integer maxResults;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/OutlierAnalysis.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/OutlierAnalysis.java
@@ -38,6 +38,10 @@ import lombok.Data;
 /** Class responsible for keeping the settings related to outlier analysis in Visualization. */
 @Data
 public class OutlierAnalysis implements Serializable {
+
+  public static final int MAX_RESULTS_MIN_VALUE = 1;
+  public static final int MAX_RESULTS_MAX_VALUE = 500;
+
   @JsonProperty
   @JacksonXmlProperty(namespace = DXF_2_0)
   private boolean enabled;
@@ -71,8 +75,7 @@ public class OutlierAnalysis implements Serializable {
    */
   @JsonIgnore
   public boolean isValid() {
-    int min = 1;
-    int max = 500;
-    return maxResults != null && (maxResults >= min && maxResults <= max);
+    return maxResults != null
+        && (maxResults >= MAX_RESULTS_MIN_VALUE && maxResults <= MAX_RESULTS_MAX_VALUE);
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/VisualizationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/VisualizationControllerTest.java
@@ -88,7 +88,7 @@ class VisualizationControllerTest extends DhisControllerConvenienceTest {
 
     // Then
     assertEquals(
-        "Property 'maxResults' is out range. Allowed range: [1..500]",
+        "Allowed length range for property `maxResults` is [1 to 500], but given length was 501",
         response.error(CONFLICT).getMessage());
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationController.java
@@ -29,8 +29,10 @@ package org.hisp.dhis.webapi.controller;
 
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getDimensions;
-import static org.hisp.dhis.feedback.ErrorCode.E7146;
+import static org.hisp.dhis.feedback.ErrorCode.E4002;
 import static org.hisp.dhis.schema.descriptors.VisualizationSchemaDescriptor.API_ENDPOINT;
+import static org.hisp.dhis.visualization.OutlierAnalysis.MAX_RESULTS_MAX_VALUE;
+import static org.hisp.dhis.visualization.OutlierAnalysis.MAX_RESULTS_MIN_VALUE;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -94,7 +96,12 @@ public class VisualizationController extends AbstractCrudController<Visualizatio
     if (visualization != null
         && visualization.getOutlierAnalysis() != null
         && !visualization.getOutlierAnalysis().isValid()) {
-      throw new IllegalQueryException(E7146);
+      throw new IllegalQueryException(
+          E4002,
+          "maxResults",
+          MAX_RESULTS_MIN_VALUE,
+          MAX_RESULTS_MAX_VALUE,
+          visualization.getOutlierAnalysis().getMaxResults());
     }
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationController.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.webapi.controller;
 
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getDimensions;
+import static org.hisp.dhis.feedback.ErrorCode.E7146;
 import static org.hisp.dhis.schema.descriptors.VisualizationSchemaDescriptor.API_ENDPOINT;
 
 import java.io.IOException;
@@ -41,6 +42,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.DataDimensionItem;
 import org.hisp.dhis.common.DimensionService;
+import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;
@@ -82,9 +84,18 @@ public class VisualizationController extends AbstractCrudController<Visualizatio
   protected Visualization deserializeJsonEntity(HttpServletRequest request) throws IOException {
     Visualization visualization = super.deserializeJsonEntity(request);
 
+    validate(visualization);
     addDimensionsInto(visualization);
 
     return visualization;
+  }
+
+  private void validate(Visualization visualization) {
+    if (visualization != null
+        && visualization.getOutlierAnalysis() != null
+        && !visualization.getOutlierAnalysis().isValid()) {
+      throw new IllegalQueryException(E7146);
+    }
   }
 
   private void addDimensionsInto(Visualization visualization) {


### PR DESCRIPTION
This PR adds a new attribute (named `maxResults`) into the `OutlierAnalysis` object, which is part of the `Visualization`.

```
...
    "outlierAnalysis": {
        "enabled": true,
        "outlierMethod": "MODIFIED_Z_SCORE",
        "thresholdFactor": 3,
        "extremeLines": {
            "enabled": false,
            "value": 1
        },
        "maxResults": 501
    },
...
```