### PR TITLE
fix: Fix issue related to updating modifiable properties of a category combo

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CategoryComboModificationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CategoryComboModificationControllerTest.java
@@ -32,7 +32,6 @@ import static org.hisp.dhis.web.WebClient.Body;
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
 
 import org.hisp.dhis.common.ValueType;
-import org.hisp.dhis.datavalue.DataValueService;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.web.HttpStatus;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CategoryComboModificationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CategoryComboModificationControllerTest.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import static java.lang.String.format;
 import static org.hisp.dhis.web.WebClient.Body;
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
 
@@ -37,6 +36,7 @@ import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.webapi.json.domain.JsonCategoryOptionCombo;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class CategoryComboModificationControllerTest extends DhisControllerConvenienceTest {
@@ -51,43 +51,42 @@ class CategoryComboModificationControllerTest extends DhisControllerConvenienceT
 
   @Test
   void testModificationNoData() {
-    setupTest();
+
     setTestCatComboModifiableProperties();
     // Remove a category
     assertStatus(
         HttpStatus.OK,
         PUT(
             "/categoryCombos/" + testCatCombo + "?mergeMode=REPLACE",
-            "{ 'name' : 'COLOR AND TASTE', 'id' : '"
-                + testCatCombo
-                + "', "
-                + "'shortName': 'C_AND_T', 'skipTotals' : true, "
-                + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
-                + "{'id' : '"
-                + categoryColor
-                + "'} ]} "));
+            // language=JSON
+            """
+                { "name" : "COLOR AND TASTE",
+                "id" : "%s",
+                "shortName": "C_AND_T",
+                 "skipTotals" : true,
+                  "dataDimensionType" : "DISAGGREGATION",
+                  "categories" : [ {"id" : "%s"} ]} """
+                .formatted(testCatCombo, categoryColor)));
   }
 
   @Test
   void testModificationWithData() {
-    setupTest();
 
     JsonObject response =
         GET("/categoryCombos/" + testCatCombo + "?fields=categoryOptionCombos[id]").content();
     JsonList<JsonCategoryOptionCombo> catOptionCombos =
         response.getList("categoryOptionCombos", JsonCategoryOptionCombo.class);
     String categoryOptionComboId = catOptionCombos.get(0).getId();
-
+    // language=JSON
     String body =
-        format(
-            "{"
-                + "'dataElement':'%s',"
-                + "'categoryOptionCombo':'%s',"
-                + "'period':'20220102',"
-                + "'orgUnit':'%s',"
-                + "'value':'24',"
-                + "'comment':'OK'}",
-            dataElementId, categoryOptionComboId, orgUnitId);
+        """
+        {"dataElement": "%s",
+        "categoryOptionCombo": "%s",
+        "period": "20220102",
+        "orgUnit": "%s",
+        "value": "24",
+        "comment":"OK"}"""
+            .formatted(dataElementId, categoryOptionComboId, orgUnitId);
 
     assertStatus(HttpStatus.CREATED, POST("/dataValues", body));
 
@@ -96,14 +95,16 @@ class CategoryComboModificationControllerTest extends DhisControllerConvenienceT
         HttpStatus.CONFLICT,
         PUT(
             "/categoryCombos/" + testCatCombo + "?mergeMode=REPLACE",
-            "{ 'name' : 'COLOR AND TASTE', 'id' : '"
-                + testCatCombo
-                + "', "
-                + "'shortName': 'C_AND_T', 'skipTotals' : true, "
-                + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
-                + "{'id' : '"
-                + categoryColor
-                + "'} ]} "));
+            // language=JSON
+            """
+                { "name" : "COLOR AND TASTE",
+                "id" : "%s",
+                "shortName": "C_AND_T",
+                "skipTotals" : true,
+                "dataDimensionType" :
+                "DISAGGREGATION",
+                "categories" : [{"id" : "%s"} ]}"""
+                .formatted(testCatCombo, categoryColor)));
   }
 
   void setTestCatComboModifiableProperties() {
@@ -112,102 +113,99 @@ class CategoryComboModificationControllerTest extends DhisControllerConvenienceT
         HttpStatus.OK,
         PUT(
             "/categoryCombos/" + testCatCombo + "?mergeMode=REPLACE",
-            "{ 'name' : 'COLOR AND TASTE', 'id' : '"
-                + testCatCombo
-                + "', "
-                + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
-                + "{'id' : '"
-                + categoryColor
-                + "'} , {'id' : '"
-                + categoryTaste
-                + "'}]} "));
+            // language=JSON
+            """
+            { "name" : "COLOR AND TASTE",
+             "id" : "%s",
+             "dataDimensionType" : "DISAGGREGATION",
+             "categories" : [{"id" : "%s"} , {"id" : "%s"}]}"""
+                .formatted(testCatCombo, categoryColor, categoryTaste)));
     // Add a shortname
     assertStatus(
         HttpStatus.OK,
         PUT(
             "/categoryCombos/" + testCatCombo + "?mergeMode=REPLACE",
-            "{ 'name' : 'COLOR AND TASTE', 'id' : '"
-                + testCatCombo
-                + "', "
-                + "'shortName': 'C_AND_T', "
-                + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
-                + "{'id' : '"
-                + categoryColor
-                + "'} , {'id' : '"
-                + categoryTaste
-                + "'}]} "));
+            // language=JSON
+            """
+            { "name" : "COLOR AND TASTE",
+             "id" : "%s",
+             "shortName" : "C_AND_T",
+             "dataDimensionType" : "DISAGGREGATION",
+             "categories" : [{"id" : "%s"} , {"id" : "%s"}]}"""
+                .formatted(testCatCombo, categoryColor, categoryTaste)));
     // Skip totals
     assertStatus(
         HttpStatus.OK,
         PUT(
             "/categoryCombos/" + testCatCombo + "?mergeMode=REPLACE",
-            "{ 'name' : 'COLOR AND TASTE', 'id' : '"
-                + testCatCombo
-                + "', "
-                + "'shortName': 'C_AND_T', 'skipTotals' : true, "
-                + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
-                + "{'id' : '"
-                + categoryColor
-                + "'} , {'id' : '"
-                + categoryTaste
-                + "'}]} "));
+            // language=JSON
+            """
+            { "name" : "COLOR AND TASTE",
+             "id" : "%s",
+             "shortName" : "C_AND_T",
+             "skipTotals" : true,
+             "dataDimensionType" : "DISAGGREGATION",
+             "categories" : [{"id" : "%s"} , {"id" : "%s"}]}"""
+                .formatted(testCatCombo, categoryColor, categoryTaste)));
   }
 
+  private String createCategoryOptions(String name) {
+    return assertStatus(
+        HttpStatus.CREATED,
+        POST(
+            "/categoryOptions",
+            // language=JSON
+            """
+                { "name": "%s", "shortName": "%s" }""".formatted(name, name)));
+  }
+
+  private String createSimpleCategory(String name, String categoryOptionId) {
+    return assertStatus(
+        HttpStatus.CREATED,
+        POST(
+            "/categories",
+            // language=JSON
+            """
+                { "name": "%s", "shortName": "%s", "dataDimensionType": "DISAGGREGATION" ,
+                "categoryOptions" : [{"id" : "%s"} ] }"""
+                .formatted(name, name, categoryOptionId)));
+  }
+
+  @BeforeEach
   void setupTest() {
-    String categoryOptionSour =
-        assertStatus(
-            HttpStatus.CREATED,
-            POST("/categoryOptions", "{ 'name': 'Sour', 'shortName': 'Sour' }"));
-
-    String categoryOptionRed =
-        assertStatus(
-            HttpStatus.CREATED, POST("/categoryOptions", "{ 'name': 'Red', 'shortName': 'Red' }"));
-
-    categoryColor =
-        assertStatus(
-            HttpStatus.CREATED,
-            POST(
-                "/categories",
-                "{ 'name': 'Color', 'shortName': 'Color', 'dataDimensionType': 'DISAGGREGATION' ,"
-                    + "'categoryOptions' : [{'id' : '"
-                    + categoryOptionRed
-                    + "'} ] }"));
-
-    categoryTaste =
-        assertStatus(
-            HttpStatus.CREATED,
-            POST(
-                "/categories",
-                "{ 'name': 'Taste', 'shortName': 'Taste', 'dataDimensionType': 'DISAGGREGATION' ,"
-                    + "'categoryOptions' : [{'id' : '"
-                    + categoryOptionSour
-                    + "'} ] }"));
+    String categoryOptionSour = createCategoryOptions("Sour");
+    String categoryOptionRed = createCategoryOptions("Red");
+    categoryColor = createSimpleCategory("Color", categoryOptionRed);
+    categoryTaste = createSimpleCategory("Taste", categoryOptionSour);
 
     testCatCombo =
         assertStatus(
             HttpStatus.CREATED,
             POST(
                 "/categoryCombos",
-                "{ 'name' : 'Taste and color', "
-                    + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
-                    + "{'id' : '"
-                    + categoryColor
-                    + "'} , {'id' : '"
-                    + categoryTaste
-                    + "'}]} "));
+                // language=JSON
+                """
+                    { "name" : "Taste and color",
+                    "dataDimensionType" : "DISAGGREGATION", "categories" : [
+                    {"id" : "%s"} , {"id" : "%s"}]} """
+                    .formatted(categoryColor, categoryTaste)));
 
     orgUnitId =
         assertStatus(
             HttpStatus.CREATED,
             POST(
                 "/organisationUnits/",
-                "{'name':'My Unit', 'shortName':'OU1', 'openingDate': '2020-01-01'}"));
+                // language=JSON
+                """
+                    {"name":"My Unit", "shortName":"OU1", "openingDate": "2020-01-01"}"""));
     assertStatus(
         HttpStatus.OK,
         POST(
             "/users/{id}/organisationUnits",
             getCurrentUser().getUid(),
-            Body("{'additions':[{'id':'" + orgUnitId + "'}]}")));
+            Body( // language=JSON
+                """
+                    {"additions":[{"id":"%s"}]}""".formatted(orgUnitId))));
 
     dataElementId = addDataElement("My data element", "DE1", ValueType.INTEGER, null, testCatCombo);
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CategoryComboModificationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CategoryComboModificationControllerTest.java
@@ -39,7 +39,6 @@ import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.webapi.json.domain.JsonCategoryOptionCombo;
 import org.junit.jupiter.api.Test;
 
-
 class CategoryComboModificationControllerTest extends DhisControllerConvenienceTest {
 
   String testCatCombo;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CategoryComboModificationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CategoryComboModificationControllerTest.java
@@ -39,10 +39,9 @@ import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.webapi.json.domain.JsonCategoryOptionCombo;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+
 
 class CategoryComboModificationControllerTest extends DhisControllerConvenienceTest {
-  @Autowired private DataValueService dataValueService;
 
   String testCatCombo;
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CategoryComboModificationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CategoryComboModificationControllerTest.java
@@ -1,186 +1,217 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.webapi.controller;
+
+import static java.lang.String.format;
+import static org.hisp.dhis.web.WebClient.Body;
+import static org.hisp.dhis.web.WebClientUtils.assertStatus;
 
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.datavalue.DataValueService;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.web.HttpStatus;
-import org.hisp.dhis.web.WebClient;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
-
 import org.hisp.dhis.webapi.json.domain.JsonCategoryOptionCombo;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static java.lang.String.format;
-import static org.hisp.dhis.web.WebClientUtils.assertStatus;
-import static org.hisp.dhis.web.WebClient.Body;
+class CategoryComboModificationControllerTest extends DhisControllerConvenienceTest {
+  @Autowired private DataValueService dataValueService;
 
-class CategoryComboModificationControllerTest extends DhisControllerConvenienceTest
-{
-    @Autowired
-    private DataValueService dataValueService;
+  String testCatCombo;
 
-    String testCatCombo;
+  String dataElementId;
 
-    String dataElementId;
+  String orgUnitId;
+  String categoryColor;
+  String categoryTaste;
 
-    String orgUnitId;
-    String categoryColor;
-    String categoryTaste;
+  @Test
+  void testModificationNoData() {
+    setupTest();
+    setTestCatComboModifiableProperties();
+    // Remove a category
+    assertStatus(
+        HttpStatus.OK,
+        PUT(
+            "/categoryCombos/" + testCatCombo + "?mergeMode=REPLACE",
+            "{ 'name' : 'COLOR AND TASTE', 'id' : '"
+                + testCatCombo
+                + "', "
+                + "'shortName': 'C_AND_T', 'skipTotals' : true, "
+                + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
+                + "{'id' : '"
+                + categoryColor
+                + "'} ]} "));
+  }
 
+  @Test
+  void testModificationWithData() {
+    setupTest();
 
-    @Test
-    void testModificationNoData() {
-        setupTest();
-        setTestCatComboModifiableProperties();
-        //Remove a category
+    JsonObject response =
+        GET("/categoryCombos/" + testCatCombo + "?fields=categoryOptionCombos[id]").content();
+    JsonList<JsonCategoryOptionCombo> catOptionCombos =
+        response.getList("categoryOptionCombos", JsonCategoryOptionCombo.class);
+    String categoryOptionComboId = catOptionCombos.get(0).getId();
+
+    String body =
+        format(
+            "{"
+                + "'dataElement':'%s',"
+                + "'categoryOptionCombo':'%s',"
+                + "'period':'20220102',"
+                + "'orgUnit':'%s',"
+                + "'value':'24',"
+                + "'comment':'OK'}",
+            dataElementId, categoryOptionComboId, orgUnitId);
+
+    assertStatus(HttpStatus.CREATED, POST("/dataValues", body));
+
+    // We should not be able to remove a category here
+    assertStatus(
+        HttpStatus.CONFLICT,
+        PUT(
+            "/categoryCombos/" + testCatCombo + "?mergeMode=REPLACE",
+            "{ 'name' : 'COLOR AND TASTE', 'id' : '"
+                + testCatCombo
+                + "', "
+                + "'shortName': 'C_AND_T', 'skipTotals' : true, "
+                + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
+                + "{'id' : '"
+                + categoryColor
+                + "'} ]} "));
+  }
+
+  void setTestCatComboModifiableProperties() {
+    // Modify the initial name
+    assertStatus(
+        HttpStatus.OK,
+        PUT(
+            "/categoryCombos/" + testCatCombo + "?mergeMode=REPLACE",
+            "{ 'name' : 'COLOR AND TASTE', 'id' : '"
+                + testCatCombo
+                + "', "
+                + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
+                + "{'id' : '"
+                + categoryColor
+                + "'} , {'id' : '"
+                + categoryTaste
+                + "'}]} "));
+    // Add a shortname
+    assertStatus(
+        HttpStatus.OK,
+        PUT(
+            "/categoryCombos/" + testCatCombo + "?mergeMode=REPLACE",
+            "{ 'name' : 'COLOR AND TASTE', 'id' : '"
+                + testCatCombo
+                + "', "
+                + "'shortName': 'C_AND_T', "
+                + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
+                + "{'id' : '"
+                + categoryColor
+                + "'} , {'id' : '"
+                + categoryTaste
+                + "'}]} "));
+    // Skip totals
+    assertStatus(
+        HttpStatus.OK,
+        PUT(
+            "/categoryCombos/" + testCatCombo + "?mergeMode=REPLACE",
+            "{ 'name' : 'COLOR AND TASTE', 'id' : '"
+                + testCatCombo
+                + "', "
+                + "'shortName': 'C_AND_T', 'skipTotals' : true, "
+                + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
+                + "{'id' : '"
+                + categoryColor
+                + "'} , {'id' : '"
+                + categoryTaste
+                + "'}]} "));
+  }
+
+  void setupTest() {
+    String categoryOptionSour =
         assertStatus(
-            HttpStatus.OK,
-            PUT(
-                "/categoryCombos/" + testCatCombo + "?mergeMode=REPLACE",
-                "{ 'name' : 'COLOR AND TASTE', 'id' : '" + testCatCombo + "', "
-                    + "'shortName': 'C_AND_T', 'skipTotals' : true, "
-                    + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
-                    + "{'id' : '"
-                    + categoryColor
-                    + "'} ]} "));
-    }
+            HttpStatus.CREATED,
+            POST("/categoryOptions", "{ 'name': 'Sour', 'shortName': 'Sour' }"));
 
-    @Test
-    void testModificationWithData() {
-        setupTest();
-
-
-        JsonObject response = GET("/categoryCombos/" +testCatCombo + "?fields=categoryOptionCombos[id]").content();
-        JsonList<JsonCategoryOptionCombo> catOptionCombos =
-            response.getList("categoryOptionCombos", JsonCategoryOptionCombo.class);
-        String categoryOptionComboId = catOptionCombos.get(0).getId();
-
-        String body =
-            format(
-                "{"
-                    + "'dataElement':'%s',"
-                    + "'categoryOptionCombo':'%s',"
-                    + "'period':'20220102',"
-                    + "'orgUnit':'%s',"
-                    + "'value':'24',"
-                    + "'comment':'OK'}",
-                dataElementId, categoryOptionComboId, orgUnitId);
-
-        assertStatus(HttpStatus.CREATED, POST("/dataValues", body));
-
-        //We should not be able to remove a category here
+    String categoryOptionRed =
         assertStatus(
-            HttpStatus.CONFLICT,
-            PUT(
-                "/categoryCombos/" + testCatCombo + "?mergeMode=REPLACE",
-                "{ 'name' : 'COLOR AND TASTE', 'id' : '" + testCatCombo + "', "
-                    + "'shortName': 'C_AND_T', 'skipTotals' : true, "
-                    + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
-                    + "{'id' : '"
-                    + categoryColor
-                    + "'} ]} "));
-    }
+            HttpStatus.CREATED, POST("/categoryOptions", "{ 'name': 'Red', 'shortName': 'Red' }"));
 
-    void setTestCatComboModifiableProperties() {
-        //Modify the initial name
+    categoryColor =
         assertStatus(
-            HttpStatus.OK,
-            PUT(
-                "/categoryCombos/" + testCatCombo + "?mergeMode=REPLACE",
-                "{ 'name' : 'COLOR AND TASTE', 'id' : '" + testCatCombo + "', "
-                    + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
-                    + "{'id' : '"
-                    + categoryColor
-                    + "'} , {'id' : '"
-                    + categoryTaste
-                    + "'}]} "));
-        //Add a shortname
-        assertStatus(
-            HttpStatus.OK,
-            PUT(
-                "/categoryCombos/" + testCatCombo + "?mergeMode=REPLACE",
-                "{ 'name' : 'COLOR AND TASTE', 'id' : '" + testCatCombo + "', "
-                    + "'shortName': 'C_AND_T', "
-                    + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
-                    + "{'id' : '"
-                    + categoryColor
-                    + "'} , {'id' : '"
-                    + categoryTaste
-                    + "'}]} "));
-        //Skip totals
-        assertStatus(
-            HttpStatus.OK,
-            PUT(
-                "/categoryCombos/" + testCatCombo + "?mergeMode=REPLACE",
-                "{ 'name' : 'COLOR AND TASTE', 'id' : '" + testCatCombo + "', "
-                    + "'shortName': 'C_AND_T', 'skipTotals' : true, "
-                    + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
-                    + "{'id' : '"
-                    + categoryColor
-                    + "'} , {'id' : '"
-                    + categoryTaste
-                    + "'}]} "));
-    }
-    void setupTest() {
-        String categoryOptionSour =
-            assertStatus(
-                HttpStatus.CREATED,
-                POST("/categoryOptions", "{ 'name': 'Sour', 'shortName': 'Sour' }"));
-
-        String categoryOptionRed =
-            assertStatus(
-                HttpStatus.CREATED, POST("/categoryOptions", "{ 'name': 'Red', 'shortName': 'Red' }"));
-
-        categoryColor =
-            assertStatus(
-                HttpStatus.CREATED,
-                POST(
-                    "/categories",
-                    "{ 'name': 'Color', 'shortName': 'Color', 'dataDimensionType': 'DISAGGREGATION' ,"
-                        + "'categoryOptions' : [{'id' : '"
-                        + categoryOptionRed
-                        + "'} ] }"));
-
-        categoryTaste =
-            assertStatus(
-                HttpStatus.CREATED,
-                POST(
-                    "/categories",
-                    "{ 'name': 'Taste', 'shortName': 'Taste', 'dataDimensionType': 'DISAGGREGATION' ,"
-                        + "'categoryOptions' : [{'id' : '"
-                        + categoryOptionSour
-                        + "'} ] }"));
-
-        testCatCombo =
-            assertStatus(
-                HttpStatus.CREATED,
-                POST(
-                    "/categoryCombos",
-                    "{ 'name' : 'Taste and color', "
-                        + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
-                        + "{'id' : '"
-                        + categoryColor
-                        + "'} , {'id' : '"
-                        + categoryTaste
-                        + "'}]} "));
-
-        orgUnitId =
-            assertStatus(
-                HttpStatus.CREATED,
-                POST(
-                    "/organisationUnits/",
-                    "{'name':'My Unit', 'shortName':'OU1', 'openingDate': '2020-01-01'}"));
-        assertStatus(
-            HttpStatus.OK,
+            HttpStatus.CREATED,
             POST(
-                "/users/{id}/organisationUnits",
-                getCurrentUser().getUid(),
-                Body("{'additions':[{'id':'" + orgUnitId + "'}]}")));
+                "/categories",
+                "{ 'name': 'Color', 'shortName': 'Color', 'dataDimensionType': 'DISAGGREGATION' ,"
+                    + "'categoryOptions' : [{'id' : '"
+                    + categoryOptionRed
+                    + "'} ] }"));
 
-        dataElementId =
-            addDataElement("My data element", "DE1", ValueType.INTEGER, null, testCatCombo);
-    }
+    categoryTaste =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/categories",
+                "{ 'name': 'Taste', 'shortName': 'Taste', 'dataDimensionType': 'DISAGGREGATION' ,"
+                    + "'categoryOptions' : [{'id' : '"
+                    + categoryOptionSour
+                    + "'} ] }"));
+
+    testCatCombo =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/categoryCombos",
+                "{ 'name' : 'Taste and color', "
+                    + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
+                    + "{'id' : '"
+                    + categoryColor
+                    + "'} , {'id' : '"
+                    + categoryTaste
+                    + "'}]} "));
+
+    orgUnitId =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/organisationUnits/",
+                "{'name':'My Unit', 'shortName':'OU1', 'openingDate': '2020-01-01'}"));
+    assertStatus(
+        HttpStatus.OK,
+        POST(
+            "/users/{id}/organisationUnits",
+            getCurrentUser().getUid(),
+            Body("{'additions':[{'id':'" + orgUnitId + "'}]}")));
+
+    dataElementId = addDataElement("My data element", "DE1", ValueType.INTEGER, null, testCatCombo);
+  }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CategoryComboModificationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/CategoryComboModificationControllerTest.java
@@ -1,0 +1,186 @@
+package org.hisp.dhis.webapi.controller;
+
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.datavalue.DataValueService;
+import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.web.HttpStatus;
+import org.hisp.dhis.web.WebClient;
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+
+import org.hisp.dhis.webapi.json.domain.JsonCategoryOptionCombo;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static java.lang.String.format;
+import static org.hisp.dhis.web.WebClientUtils.assertStatus;
+import static org.hisp.dhis.web.WebClient.Body;
+
+class CategoryComboModificationControllerTest extends DhisControllerConvenienceTest
+{
+    @Autowired
+    private DataValueService dataValueService;
+
+    String testCatCombo;
+
+    String dataElementId;
+
+    String orgUnitId;
+    String categoryColor;
+    String categoryTaste;
+
+
+    @Test
+    void testModificationNoData() {
+        setupTest();
+        setTestCatComboModifiableProperties();
+        //Remove a category
+        assertStatus(
+            HttpStatus.OK,
+            PUT(
+                "/categoryCombos/" + testCatCombo + "?mergeMode=REPLACE",
+                "{ 'name' : 'COLOR AND TASTE', 'id' : '" + testCatCombo + "', "
+                    + "'shortName': 'C_AND_T', 'skipTotals' : true, "
+                    + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
+                    + "{'id' : '"
+                    + categoryColor
+                    + "'} ]} "));
+    }
+
+    @Test
+    void testModificationWithData() {
+        setupTest();
+
+
+        JsonObject response = GET("/categoryCombos/" +testCatCombo + "?fields=categoryOptionCombos[id]").content();
+        JsonList<JsonCategoryOptionCombo> catOptionCombos =
+            response.getList("categoryOptionCombos", JsonCategoryOptionCombo.class);
+        String categoryOptionComboId = catOptionCombos.get(0).getId();
+
+        String body =
+            format(
+                "{"
+                    + "'dataElement':'%s',"
+                    + "'categoryOptionCombo':'%s',"
+                    + "'period':'20220102',"
+                    + "'orgUnit':'%s',"
+                    + "'value':'24',"
+                    + "'comment':'OK'}",
+                dataElementId, categoryOptionComboId, orgUnitId);
+
+        assertStatus(HttpStatus.CREATED, POST("/dataValues", body));
+
+        //We should not be able to remove a category here
+        assertStatus(
+            HttpStatus.CONFLICT,
+            PUT(
+                "/categoryCombos/" + testCatCombo + "?mergeMode=REPLACE",
+                "{ 'name' : 'COLOR AND TASTE', 'id' : '" + testCatCombo + "', "
+                    + "'shortName': 'C_AND_T', 'skipTotals' : true, "
+                    + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
+                    + "{'id' : '"
+                    + categoryColor
+                    + "'} ]} "));
+    }
+
+    void setTestCatComboModifiableProperties() {
+        //Modify the initial name
+        assertStatus(
+            HttpStatus.OK,
+            PUT(
+                "/categoryCombos/" + testCatCombo + "?mergeMode=REPLACE",
+                "{ 'name' : 'COLOR AND TASTE', 'id' : '" + testCatCombo + "', "
+                    + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
+                    + "{'id' : '"
+                    + categoryColor
+                    + "'} , {'id' : '"
+                    + categoryTaste
+                    + "'}]} "));
+        //Add a shortname
+        assertStatus(
+            HttpStatus.OK,
+            PUT(
+                "/categoryCombos/" + testCatCombo + "?mergeMode=REPLACE",
+                "{ 'name' : 'COLOR AND TASTE', 'id' : '" + testCatCombo + "', "
+                    + "'shortName': 'C_AND_T', "
+                    + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
+                    + "{'id' : '"
+                    + categoryColor
+                    + "'} , {'id' : '"
+                    + categoryTaste
+                    + "'}]} "));
+        //Skip totals
+        assertStatus(
+            HttpStatus.OK,
+            PUT(
+                "/categoryCombos/" + testCatCombo + "?mergeMode=REPLACE",
+                "{ 'name' : 'COLOR AND TASTE', 'id' : '" + testCatCombo + "', "
+                    + "'shortName': 'C_AND_T', 'skipTotals' : true, "
+                    + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
+                    + "{'id' : '"
+                    + categoryColor
+                    + "'} , {'id' : '"
+                    + categoryTaste
+                    + "'}]} "));
+    }
+    void setupTest() {
+        String categoryOptionSour =
+            assertStatus(
+                HttpStatus.CREATED,
+                POST("/categoryOptions", "{ 'name': 'Sour', 'shortName': 'Sour' }"));
+
+        String categoryOptionRed =
+            assertStatus(
+                HttpStatus.CREATED, POST("/categoryOptions", "{ 'name': 'Red', 'shortName': 'Red' }"));
+
+        categoryColor =
+            assertStatus(
+                HttpStatus.CREATED,
+                POST(
+                    "/categories",
+                    "{ 'name': 'Color', 'shortName': 'Color', 'dataDimensionType': 'DISAGGREGATION' ,"
+                        + "'categoryOptions' : [{'id' : '"
+                        + categoryOptionRed
+                        + "'} ] }"));
+
+        categoryTaste =
+            assertStatus(
+                HttpStatus.CREATED,
+                POST(
+                    "/categories",
+                    "{ 'name': 'Taste', 'shortName': 'Taste', 'dataDimensionType': 'DISAGGREGATION' ,"
+                        + "'categoryOptions' : [{'id' : '"
+                        + categoryOptionSour
+                        + "'} ] }"));
+
+        testCatCombo =
+            assertStatus(
+                HttpStatus.CREATED,
+                POST(
+                    "/categoryCombos",
+                    "{ 'name' : 'Taste and color', "
+                        + "'dataDimensionType' : 'DISAGGREGATION', 'categories' : ["
+                        + "{'id' : '"
+                        + categoryColor
+                        + "'} , {'id' : '"
+                        + categoryTaste
+                        + "'}]} "));
+
+        orgUnitId =
+            assertStatus(
+                HttpStatus.CREATED,
+                POST(
+                    "/organisationUnits/",
+                    "{'name':'My Unit', 'shortName':'OU1', 'openingDate': '2020-01-01'}"));
+        assertStatus(
+            HttpStatus.OK,
+            POST(
+                "/users/{id}/organisationUnits",
+                getCurrentUser().getUid(),
+                Body("{'additions':[{'id':'" + orgUnitId + "'}]}")));
+
+        dataElementId =
+            addDataElement("My data element", "DE1", ValueType.INTEGER, null, testCatCombo);
+    }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryComboController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryComboController.java
@@ -28,8 +28,10 @@
 package org.hisp.dhis.webapi.controller.category;
 
 import java.util.Objects;
+import java.util.Set;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.datavalue.DataValueService;
 import org.hisp.dhis.dxf2.metadata.MetadataExportParams;
@@ -90,8 +92,11 @@ public class CategoryComboController extends AbstractCrudController<CategoryComb
 
   private void checkNoDataValueBecomesInaccessible(CategoryCombo entity, CategoryCombo newEntity)
       throws ConflictException {
-    if (!Objects.equals(entity.getCategories(), newEntity.getCategories())
-        && dataValueService.dataValueExists(entity)) {
+
+    Set<String> oldCategories = IdentifiableObjectUtils.getUidsAsSet(entity.getCategories());
+    Set<String> newCategories = IdentifiableObjectUtils.getUidsAsSet(newEntity.getCategories());
+
+    if (!Objects.equals(oldCategories, newCategories) && dataValueService.dataValueExists(entity)) {
       throw new ConflictException(ErrorCode.E1120);
     }
   }


### PR DESCRIPTION
- Users should be able to modify the name, short name, and totals properties of a category combo. However, they should not be able to modify the categories of a category combo if data exists in the system, as this would make the data "unreachable". 
- This PR corrects how the old and proposed objects are compared by using only the set of categories UIDs as the basis of comparison.
- Added an API test to test the modification of the category combo when it has data, and when it does not have data.