### PR TITLE
fix: condition to check eligible headers [DHIS2-16191]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/TeiFields.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/TeiFields.java
@@ -191,16 +191,14 @@ public class TeiFields {
 
   /**
    * Checks if the given {@link DimensionIdentifier} is eligible to be added as a header. It is
-   * eligible if it is a static dimension and it is either an event or enrollment dimension, and it
-   * is not a TEI static field (which is already added to the grid headers).
+   * eligible if it is a static dimension and it is either an event or enrollment dimension.
    *
    * @param parsedHeader the {@link DimensionIdentifier}.
    * @return true if it is eligible, false otherwise.
    */
   private static boolean isEligible(DimensionIdentifier<DimensionParam> parsedHeader) {
     return parsedHeader.getDimension().isStaticDimension()
-        && (parsedHeader.isEventDimension() || parsedHeader.isEnrollmentDimension())
-        && !parsedHeader.getDimension().getStaticDimension().isTeiStaticField();
+        && (parsedHeader.isEventDimension() || parsedHeader.isEnrollmentDimension());
   }
 
   /**

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TrackedEntityQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TrackedEntityQueryTest.java
@@ -2889,4 +2889,33 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
 
     validateRow(response, 0, List.of("2022-01-01 12:05:00.0"));
   }
+
+  @Test
+  public void headerParamOunameIsPresent() {
+    // Given
+    QueryParamsBuilder params = new QueryParamsBuilder().add("headers=IpHINAT79UW.ouname");
+
+    // When
+    ApiResponse response = analyticsTeiActions.query().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("rows", hasSize(equalTo(50)))
+        .body("height", equalTo(50))
+        .body("width", equalTo(1))
+        .body("headerWidth", equalTo(1))
+        .body("headers", hasSize(equalTo(1)));
+
+    validateHeader(
+        response,
+        0,
+        "IpHINAT79UW.ouname",
+        "Enrollment Organisation unit name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        true);
+  }
 }


### PR DESCRIPTION
In a previous implementation on DHIS2-16191 we added a dedicated `parsedHeaders` collection to the `TeiParams` object, which represents a parsed version on the `headers` query parameter.
This was done to support properly all kind of dimensions as headers.
However, some static headers were not added back properly in the final list of headers, for example as in the following query:
`/analytics/trackedEntities/query/nEenWmSyUEp?headers=IpHINAT79UW.incidentdate`

This PR aims is to fix this error
