### PR TITLE
feat: marker annotations to indicate non standard tx management [DHIS2-16402]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IndirectTransactional.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IndirectTransactional.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A marker annotation to indicate that the annotated method (although it being a service method)
+ * should not be annotated with spring's {@code @Transactional} annotation as it uses a different
+ * transaction management.
+ *
+ * @see NonTransactional
+ * @author Jan Bernitt
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.METHOD)
+public @interface IndirectTransactional {}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/NonTransactional.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/NonTransactional.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation to indicate that a service method does not need transactions at all. Such a method
+ * should not be annotated with spring's {@code @Transactional}.
+ *
+ * @see IndirectTransactional
+ * @author Jan Bernitt
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.METHOD)
+public @interface NonTransactional {}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/calendar/DefaultCalendarService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/calendar/DefaultCalendarService.java
@@ -36,6 +36,8 @@ import java.util.Set;
 import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.calendar.impl.Iso8601Calendar;
+import org.hisp.dhis.common.IndirectTransactional;
+import org.hisp.dhis.common.NonTransactional;
 import org.hisp.dhis.period.Cal;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.setting.SettingKey;
@@ -75,6 +77,7 @@ public class DefaultCalendarService implements CalendarService {
   }
 
   @Override
+  @NonTransactional
   public List<Calendar> getAllCalendars() {
     List<Calendar> sortedCalendars = Lists.newArrayList(calendarMap.values());
     Collections.sort(sortedCalendars, CalendarComparator.INSTANCE);
@@ -87,6 +90,7 @@ public class DefaultCalendarService implements CalendarService {
   }
 
   @Override
+  @IndirectTransactional
   public Calendar getSystemCalendar() {
     String calendarKey = settingManager.getStringSetting(SettingKey.CALENDAR);
     String dateFormat = settingManager.getStringSetting(SettingKey.DATE_FORMAT);
@@ -105,6 +109,7 @@ public class DefaultCalendarService implements CalendarService {
   }
 
   @Override
+  @IndirectTransactional
   public DateFormat getSystemDateFormat() {
     String dateFormatKey = settingManager.getStringSetting(SettingKey.DATE_FORMAT);
 

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/DefaultSystemSettingManager.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/DefaultSystemSettingManager.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
+import org.hisp.dhis.common.IndirectTransactional;
 import org.hisp.dhis.system.util.SerializableOptional;
 import org.jasypt.encryption.pbe.PBEStringEncryptor;
 import org.jasypt.exceptions.EncryptionOperationNotPossibleException;
@@ -163,6 +164,7 @@ public class DefaultSystemSettingManager implements SystemSettingManager {
    * behind the cache to avoid the transaction overhead for cache hits.
    */
   @Override
+  @IndirectTransactional
   @SuppressWarnings("unchecked")
   public <T extends Serializable> T getSystemSetting(SettingKey key, T defaultValue) {
     SerializableOptional value =


### PR DESCRIPTION
Introduces two marker annotations that are used instead of spring's `@Transactional` to document that although the annotated methods being service level methods they should not be annotated with `@Transactional` because ...
* `NonTransactional`: ... the method is not doing database access (at all)
* `IndirectTransactional`: ... the method uses other means to access the database, e.g. TX templates or JDBC level