### PR TITLE
chore: fix warnings in tracker code

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentEventsParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentEventsParams.java
@@ -45,7 +45,7 @@ public class EnrollmentEventsParams {
   public static final EnrollmentEventsParams FALSE =
       new EnrollmentEventsParams(false, EventParams.FALSE);
 
-  private boolean includeEvents;
+  boolean includeEvents;
 
-  private EventParams eventParams;
+  EventParams eventParams;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/TrackerIdSchemeParam.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/TrackerIdSchemeParam.java
@@ -60,9 +60,9 @@ public class TrackerIdSchemeParam implements Serializable {
   public static final TrackerIdSchemeParam NAME =
       TrackerIdSchemeParam.of(TrackerIdScheme.NAME, null);
 
-  @JsonProperty private final TrackerIdScheme idScheme;
+  @JsonProperty TrackerIdScheme idScheme;
 
-  @JsonProperty private final String attributeUid;
+  @JsonProperty String attributeUid;
 
   /**
    * Creates a TrackerIdSchemeParam of idScheme ATTRIBUTE.
@@ -75,22 +75,16 @@ public class TrackerIdSchemeParam implements Serializable {
   }
 
   public <T extends IdentifiableObject> String getIdentifier(T object) {
-    switch (idScheme) {
-      case UID:
-        return object.getUid();
-      case CODE:
-        return object.getCode();
-      case NAME:
-        return object.getName();
-      case ATTRIBUTE:
-        return object.getAttributeValues().stream()
-            .filter(av -> av.getAttribute().getUid().equals(attributeUid))
-            .map(AttributeValue::getValue)
-            .findFirst()
-            .orElse(null);
-    }
-
-    throw new RuntimeException("Unhandled identifier type.");
+    return switch (idScheme) {
+      case UID -> object.getUid();
+      case CODE -> object.getCode();
+      case NAME -> object.getName();
+      case ATTRIBUTE -> object.getAttributeValues().stream()
+          .filter(av -> av.getAttribute().getUid().equals(attributeUid))
+          .map(AttributeValue::getValue)
+          .findFirst()
+          .orElse(null);
+    };
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/TrackerIdSchemeParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/TrackerIdSchemeParams.java
@@ -83,22 +83,15 @@ public class TrackerIdSchemeParams implements Serializable {
   private TrackerIdSchemeParam categoryOptionIdScheme = TrackerIdSchemeParam.UID;
 
   public TrackerIdSchemeParam getByClass(Class<?> klazz) {
-    switch (klazz.getSimpleName()) {
-      case "CategoryOptionCombo":
-        return categoryOptionComboIdScheme;
-      case "OrganisationUnit":
-        return orgUnitIdScheme;
-      case "CategoryOption":
-        return categoryOptionIdScheme;
-      case "DataElement":
-        return dataElementIdScheme;
-      case "Program":
-        return programIdScheme;
-      case "ProgramStage":
-        return programStageIdScheme;
-      default:
-        return idScheme;
-    }
+    return switch (klazz.getSimpleName()) {
+      case "CategoryOptionCombo" -> categoryOptionComboIdScheme;
+      case "OrganisationUnit" -> orgUnitIdScheme;
+      case "CategoryOption" -> categoryOptionIdScheme;
+      case "DataElement" -> dataElementIdScheme;
+      case "Program" -> programIdScheme;
+      case "ProgramStage" -> programStageIdScheme;
+      default -> idScheme;
+    };
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/TrackerImportParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/TrackerImportParams.java
@@ -58,7 +58,7 @@ public class TrackerImportParams implements JobParameters {
   @JsonProperty @Builder.Default
   private TrackerImportStrategy importStrategy = TrackerImportStrategy.CREATE_AND_UPDATE;
 
-  /** Should import be treated as a atomic import (all or nothing). */
+  /** Should import be treated as an atomic import (all or nothing). */
   @JsonProperty @Builder.Default private AtomicMode atomicMode = AtomicMode.ALL;
 
   /** Flush for every object or per type. */

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/TrackerBundle.java
@@ -219,18 +219,11 @@ public class TrackerBundle {
   public boolean exists(TrackerType type, String uid) {
     Objects.requireNonNull(type);
 
-    switch (type) {
-      case TRACKED_ENTITY:
-        return findTrackedEntityByUid(uid).isPresent();
-      case ENROLLMENT:
-        return findEnrollmentByUid(uid).isPresent();
-      case EVENT:
-        return findEventByUid(uid).isPresent();
-      case RELATIONSHIP:
-        return findRelationshipByUid(uid).isPresent();
-      default:
-        // only reached if a new TrackerDto implementation is added
-        throw new IllegalStateException("TrackerType " + type.getName() + " not yet supported.");
-    }
+    return switch (type) {
+      case TRACKED_ENTITY -> findTrackedEntityByUid(uid).isPresent();
+      case ENROLLMENT -> findEnrollmentByUid(uid).isPresent();
+      case EVENT -> findEventByUid(uid).isPresent();
+      case RELATIONSHIP -> findRelationshipByUid(uid).isPresent();
+    };
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/EnrollmentStatus.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/EnrollmentStatus.java
@@ -55,15 +55,10 @@ public enum EnrollmentStatus {
   }
 
   public static EnrollmentStatus fromProgramStatus(ProgramStatus programStatus) {
-    switch (programStatus) {
-      case ACTIVE:
-        return ACTIVE;
-      case CANCELLED:
-        return CANCELLED;
-      case COMPLETED:
-        return COMPLETED;
-    }
-
-    throw new IllegalArgumentException("Enum value not found: " + programStatus);
+    return switch (programStatus) {
+      case ACTIVE -> ACTIVE;
+      case CANCELLED -> CANCELLED;
+      case COMPLETED -> COMPLETED;
+    };
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/MetadataIdentifier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/domain/MetadataIdentifier.java
@@ -67,7 +67,7 @@ public class MetadataIdentifier implements Serializable {
   public static final MetadataIdentifier EMPTY_NAME = MetadataIdentifier.ofName((String) null);
 
   /** Represents the idScheme the {@link #identifier} is in. */
-  @JsonProperty private final TrackerIdScheme idScheme;
+  @JsonProperty TrackerIdScheme idScheme;
 
   /**
    * Represents the actual identifier of the metadata. UID for idScheme {@code UID} and {@code
@@ -77,13 +77,13 @@ public class MetadataIdentifier implements Serializable {
    * of which idScheme it is in, which was the source of many bugs. If you are doing equality
    * comparisons use {@link #isEqualTo(IdentifiableObject)} instead.
    */
-  @JsonProperty private final String identifier;
+  @JsonProperty String identifier;
 
   /**
    * Represents the value of a metadata attribute. It is only non-null if idScheme is {@code
    * ATTRIBUTE}.
    */
-  @JsonProperty private final String attributeValue;
+  @JsonProperty String attributeValue;
 
   /**
    * Creates an identifier for metadata. {@code attributeValue} only needs to be set if idScheme is
@@ -196,22 +196,16 @@ public class MetadataIdentifier implements Serializable {
    * @return identifier of given identifiable object
    */
   public <T extends IdentifiableObject> String identifierOf(T metadata) {
-    switch (idScheme) {
-      case UID:
-        return metadata.getUid();
-      case CODE:
-        return metadata.getCode();
-      case NAME:
-        return metadata.getName();
-      case ATTRIBUTE:
-        return metadata.getAttributeValues().stream()
-            .filter(av -> av.getAttribute().getUid().equals(this.identifier))
-            .map(AttributeValue::getValue)
-            .findFirst()
-            .orElse(null);
-    }
-
-    throw new RuntimeException("Unhandled identifier type.");
+    return switch (idScheme) {
+      case UID -> metadata.getUid();
+      case CODE -> metadata.getCode();
+      case NAME -> metadata.getName();
+      case ATTRIBUTE -> metadata.getAttributeValues().stream()
+          .filter(av -> av.getAttribute().getUid().equals(this.identifier))
+          .map(AttributeValue::getValue)
+          .findFirst()
+          .orElse(null);
+    };
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/TrackerPreheat.java
@@ -647,19 +647,12 @@ public class TrackerPreheat {
   public boolean exists(TrackerType type, String uid) {
     Objects.requireNonNull(type);
 
-    switch (type) {
-      case TRACKED_ENTITY:
-        return getTrackedEntity(uid) != null;
-      case ENROLLMENT:
-        return getEnrollment(uid) != null;
-      case EVENT:
-        return getEvent(uid) != null;
-      case RELATIONSHIP:
-        return getRelationship(uid) != null;
-      default:
-        // only reached if a new TrackerDto implementation is added
-        throw new IllegalStateException("TrackerType " + type.getName() + " not yet supported.");
-    }
+    return switch (type) {
+      case TRACKED_ENTITY -> getTrackedEntity(uid) != null;
+      case ENROLLMENT -> getEnrollment(uid) != null;
+      case EVENT -> getEvent(uid) != null;
+      case RELATIONSHIP -> getRelationship(uid) != null;
+    };
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/cache/DefaultPreheatCacheService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/cache/DefaultPreheatCacheService.java
@@ -105,13 +105,7 @@ public class DefaultPreheatCacheService implements PreheatCacheService {
   public List<IdentifiableObject> getAll(String cacheKey) {
     List<IdentifiableObject> res = new ArrayList<>();
     if (hasKey(cacheKey)) {
-      cache
-          .get(cacheKey)
-          .keys()
-          .forEach(
-              k -> {
-                res.add(cache.get(cacheKey).get(k));
-              });
+      cache.get(cacheKey).keys().forEach(k -> res.add(cache.get(cacheKey).get(k)));
     }
     return res;
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/report/Warning.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/report/Warning.java
@@ -38,13 +38,13 @@ import lombok.Value;
 @Value
 @Builder
 public class Warning {
-  private final String warningMessage;
+  String warningMessage;
 
-  private final String warningCode;
+  String warningCode;
 
-  private final String trackerType;
+  String trackerType;
 
-  private final String uid;
+  String uid;
 
   @JsonCreator
   public Warning(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/PersistablesFilter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/PersistablesFilter.java
@@ -316,7 +316,7 @@ class PersistablesFilter {
             .map(p -> p.apply(entity))
             .filter(this::isNotValid) // remove valid parents
             .map(p -> error(ValidationCode.E5000, entity, p))
-            .collect(Collectors.toList());
+            .toList();
     this.result.errors.addAll(errors);
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/TrackerImporterAssertErrors.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/TrackerImporterAssertErrors.java
@@ -44,16 +44,11 @@ public class TrackerImporterAssertErrors {
 
   public static final String TRACKED_ENTITY_INSTANCE_CANT_BE_NULL = "TrackedEntity can't be null";
 
-  public static final String ATTRIBUTE_VALUE_MAP_CANT_BE_NULL = "AttributeValueMap can't be null";
-
   public static final String ATTRIBUTE_CANT_BE_NULL = "Attribute can't be null";
 
   public static final String ENROLLMENT_CANT_BE_NULL = "Enrollment can't be null";
 
   public static final String ORGANISATION_UNIT_CANT_BE_NULL = "OrganisationUnit can't be null";
-
-  public static final String OWNER_ORGANISATION_UNIT_CANT_BE_NULL =
-      "Owner OrganisationUnit can't be null";
 
   public static final String TRACKED_ENTITY_ATTRIBUTE_VALUE_CANT_BE_NULL =
       "TrackedEntityAttributeValue can't be null";
@@ -65,8 +60,6 @@ public class TrackerImporterAssertErrors {
 
   public static final String CATEGORY_OPTION_COMBO_CANT_BE_NULL =
       "CategoryOptionCombo can't be null";
-
-  public static final String DATE_STRING_CANT_BE_NULL = "Date string can not be null";
 
   public static final String GEOMETRY_CANT_BE_NULL = "Geometry can not be null";
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/DateValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/DateValidator.java
@@ -91,7 +91,7 @@ class DateValidator implements Validator<Event> {
 
     if ((program.getCompleteEventsExpiryDays() > 0 && EventStatus.COMPLETED == event.getStatus())) {
       if (event.getCompletedAt() == null) {
-        reporter.addErrorIfNull(event.getCompletedAt(), event, E1042, event);
+        reporter.addError(event, E1042, event);
       } else {
         if (now()
             .isAfter(event.getCompletedAt().plus(ofDays(program.getCompleteEventsExpiryDays())))) {


### PR DESCRIPTION
* use switch expressions. They simplify our code. They also need to be exhaustive, so in case we add a new value to an enum we will get a compilation error that we are missing a case
* remove unused constants
* remove private and final if these are already provided by lombok