### PR TITLE
fix: relationship used enrollment mapper for order DHIS2-15666

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipRequestParamsMapper.java
@@ -45,7 +45,6 @@ import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.export.relationship.RelationshipOperationParams;
 import org.hisp.dhis.tracker.export.relationship.RelationshipOperationParams.RelationshipOperationParamsBuilder;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
-import org.hisp.dhis.webapi.controller.tracker.export.enrollment.EnrollmentMapper;
 import org.springframework.stereotype.Component;
 
 /**
@@ -128,9 +127,9 @@ class RelationshipRequestParamsMapper {
     }
 
     for (OrderCriteria order : orders) {
-      if (EnrollmentMapper.ORDERABLE_FIELDS.containsKey(order.getField())) {
+      if (RelationshipMapper.ORDERABLE_FIELDS.containsKey(order.getField())) {
         builder.orderBy(
-            EnrollmentMapper.ORDERABLE_FIELDS.get(order.getField()), order.getDirection());
+            RelationshipMapper.ORDERABLE_FIELDS.get(order.getField()), order.getDirection());
       }
     }
   }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/PageRequestParamsTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/PageRequestParamsTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import lombok.Data;
 import org.junit.jupiter.api.Test;
 
-class PageImportRequestParamsTest {
+class PageRequestParamsTest {
 
   @Data
   private static class PaginationParameters implements PageRequestParams {

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamsValidatorTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamsValidatorTest.java
@@ -64,7 +64,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /** Tests {@link RequestParamsValidator}. */
-class ImportRequestParamsValidatorTest {
+class RequestParamsValidatorTest {
 
   private static final String TEA_1_UID = "TvjwTPToKHO";
 


### PR DESCRIPTION
* fix relationship used enrollment mapper for order

  We used the relationship mapper to validate any order field can be ordered by. We then
  accidentally used the enrollment mapper to map from view names to internal domain names.
  That worked in this case since relationships can only be ordered by createdAt/Client
  which is also supported by enrollment

* fix test names. these tests are in the export package and have nothing to do with import. Remove Import from their names. This allows IntelliJ to find their implementation again.

