### PR TITLE
feat: relative periods and pe dimension support

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -144,7 +144,7 @@ public enum ErrorCode {
 
   /* Outlier detection */
   E2200("At least one data element must be specified"),
-  E2201("Start date and end date must be specified"),
+  E2201("Start date and end date or relative period must be specified"),
   E2202("Start date must be before end date"),
   E2203(Constants.AT_LEAST_ONE_ORGANISATION_UNIT_MUST_BE_SPECIFIED),
   E2204("Threshold must be a positive number"),
@@ -155,6 +155,7 @@ public enum ErrorCode {
   E2209("Data start date not allowed"),
   E2210("Data end date not allowed"),
   E2211("Algorithm min-max values not allowed"),
+  E2212("Specifying both a start date/end date and a relative period is not allowed"),
 
   /* Followup analysis */
   E2300("At least one data element or data set must be specified"),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierQueryParams.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.analytics.QueryKey;
 import org.hisp.dhis.analytics.SortOrder;
 import org.hisp.dhis.analytics.outlier.Order;
 import org.hisp.dhis.common.IdScheme;
+import org.hisp.dhis.period.RelativePeriodEnum;
 
 /** Encapsulation of a web API request for outlier value detection. */
 @Data
@@ -48,6 +49,8 @@ public class OutlierQueryParams {
   private Set<String> dx = new HashSet<>();
 
   private Set<String> ou = new HashSet<>();
+
+  private RelativePeriodEnum pe;
 
   /**
    * This parameter selects the headers to be returned in the response. We use a LinkedHashSet
@@ -86,6 +89,7 @@ public class OutlierQueryParams {
     key.add(dataEndDate);
     key.add(startDate);
     key.add(endDate);
+    key.add(pe);
     key.add(maxResults);
     key.add(algorithm);
     key.add(threshold);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierQueryParser.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierQueryParser.java
@@ -136,6 +136,12 @@ public class OutlierQueryParser {
     return baseDimensionalObject.getItems().stream().map(ou -> (OrganisationUnit) ou).toList();
   }
 
+  /**
+   * The method retrieves the list of the periods
+   *
+   * @param relativePeriod the {@link RelativePeriodEnum}.
+   * @return list of the {@link Period}.
+   */
   private List<Period> getPeriods(RelativePeriodEnum relativePeriod) {
     if (relativePeriod == null) {
       return new ArrayList<>();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierQueryParser.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierQueryParser.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.analytics.outlier.data;
 
 import static java.util.stream.Collectors.toList;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
@@ -137,7 +138,7 @@ public class OutlierQueryParser {
 
   private List<Period> getPeriods(RelativePeriodEnum relativePeriod) {
     if (relativePeriod == null) {
-      return null;
+      return new ArrayList<>();
     }
     return dimensionalObjectProducer
         .getPeriodDimension(List.of(relativePeriod.name()), null)

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierQueryParser.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierQueryParser.java
@@ -41,6 +41,8 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.RelativePeriodEnum;
 import org.hisp.dhis.user.CurrentUserService;
 import org.springframework.stereotype.Component;
 
@@ -80,6 +82,7 @@ public class OutlierQueryParser {
             .dataElements(dataElements)
             .startDate(queryParams.getStartDate())
             .endDate(queryParams.getEndDate())
+            .periods(getPeriods(queryParams.getPe()))
             .orgUnits(getOrganisationUnits(queryParams))
             .analyzeOnly(analyzeOnly)
             .dataStartDate(queryParams.getDataStartDate())
@@ -130,5 +133,17 @@ public class OutlierQueryParser {
             IdScheme.UID);
 
     return baseDimensionalObject.getItems().stream().map(ou -> (OrganisationUnit) ou).toList();
+  }
+
+  private List<Period> getPeriods(RelativePeriodEnum relativePeriod) {
+    if (relativePeriod == null) {
+      return null;
+    }
+    return dimensionalObjectProducer
+        .getPeriodDimension(List.of(relativePeriod.name()), null)
+        .getItems()
+        .stream()
+        .map(pe -> (Period) pe)
+        .toList();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierRequest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierRequest.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.OrganisationUnitDescendants;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.Period;
 
 /**
  * Encapsulation of an outlier detection request.
@@ -56,6 +57,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 @Builder
 @With
 public class OutlierRequest {
+  private List<Period> periods;
 
   private Date startDate;
 
@@ -95,5 +97,13 @@ public class OutlierRequest {
 
   public boolean hasDataStartEndDate() {
     return dataStartDate != null && dataEndDate != null;
+  }
+
+  public boolean hasStartEndDate() {
+    return startDate != null && endDate != null;
+  }
+
+  public boolean hasPeriods() {
+    return periods != null && !periods.isEmpty();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierRequestValidator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierRequestValidator.java
@@ -39,6 +39,7 @@ import static org.hisp.dhis.feedback.ErrorCode.E2207;
 import static org.hisp.dhis.feedback.ErrorCode.E2209;
 import static org.hisp.dhis.feedback.ErrorCode.E2210;
 import static org.hisp.dhis.feedback.ErrorCode.E2211;
+import static org.hisp.dhis.feedback.ErrorCode.E2212;
 import static org.hisp.dhis.setting.SettingKey.ANALYTICS_MAX_LIMIT;
 
 import lombok.AllArgsConstructor;
@@ -113,9 +114,11 @@ public class OutlierRequestValidator {
 
     if (request.getDataElements().isEmpty()) {
       error = new ErrorMessage(E2200);
-    } else if (request.getStartDate() == null || request.getEndDate() == null) {
+    } else if (!request.hasStartEndDate() && !request.hasPeriods()) {
       error = new ErrorMessage(E2201);
-    } else if (request.getStartDate().after(request.getEndDate())) {
+    } else if (request.hasStartEndDate() && request.hasPeriods()) {
+      error = new ErrorMessage(E2212);
+    } else if (request.hasStartEndDate() && request.getStartDate().after(request.getEndDate())) {
       error = new ErrorMessage(E2202);
     } else if (request.getOrgUnits().isEmpty()) {
       error = new ErrorMessage(E2203);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsOutlierService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsOutlierService.java
@@ -44,6 +44,7 @@ import static org.hisp.dhis.analytics.common.ColumnHeader.ORG_UNIT;
 import static org.hisp.dhis.analytics.common.ColumnHeader.ORG_UNIT_NAME;
 import static org.hisp.dhis.analytics.common.ColumnHeader.ORG_UNIT_NAME_HIERARCHY;
 import static org.hisp.dhis.analytics.common.ColumnHeader.PERIOD;
+import static org.hisp.dhis.analytics.common.ColumnHeader.PERIOD_NAME;
 import static org.hisp.dhis.analytics.common.ColumnHeader.STANDARD_DEVIATION;
 import static org.hisp.dhis.analytics.common.ColumnHeader.UPPER_BOUNDARY;
 import static org.hisp.dhis.analytics.common.ColumnHeader.VALUE;
@@ -77,6 +78,7 @@ import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorMessage;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.period.Period;
 import org.hisp.dhis.system.grid.GridUtils;
 import org.hisp.dhis.system.grid.ListGrid;
 import org.hisp.dhis.user.CurrentUserService;
@@ -208,6 +210,8 @@ public class AnalyticsOutlierService {
     grid.addHeader(
         new GridHeader(DIMENSION_NAME.getItem(), DIMENSION_NAME.getName(), TEXT, false, false));
     grid.addHeader(new GridHeader(PERIOD.getItem(), PERIOD.getName(), TEXT, false, false));
+    grid.addHeader(
+        new GridHeader(PERIOD_NAME.getItem(), PERIOD_NAME.getName(), TEXT, false, false));
     grid.addHeader(new GridHeader(ORG_UNIT.getItem(), ORG_UNIT.getName(), TEXT, false, false));
     grid.addHeader(
         new GridHeader(ORG_UNIT_NAME.getItem(), ORG_UNIT_NAME.getName(), TEXT, false, false));
@@ -276,45 +280,48 @@ public class AnalyticsOutlierService {
    *
    * @param grid the {@link Grid}
    * @param outliers the list of {@link Outlier}
-   * @param request the {@link OutlierRequest}
+   * @param outlierRequest the {@link OutlierRequest}
    */
-  private void setRows(Grid grid, List<Outlier> outliers, OutlierRequest request) {
+  private void setRows(Grid grid, List<Outlier> outliers, OutlierRequest outlierRequest) {
     outliers.forEach(
-        v -> {
-          boolean isModifiedZScore = request.getAlgorithm() == MOD_Z_SCORE;
-          OrganisationUnit ou = organisationUnitService.getOrganisationUnit(v.getOu());
+        outlier -> {
+          boolean isModifiedZScore = outlierRequest.getAlgorithm() == MOD_Z_SCORE;
+          OrganisationUnit ou = organisationUnitService.getOrganisationUnit(outlier.getOu());
           User user = currentUserService.getCurrentUser();
           Collection<OrganisationUnit> roots = user != null ? user.getOrganisationUnits() : null;
 
           grid.addRow();
 
-          IdentifiableObject object = idObjectManager.get(DataElement.class, v.getDx());
-          grid.addValue(getIdProperty(object, v.getDx(), request.getOutputIdScheme()));
-          grid.addValue(getIdProperty(object, v.getDx(), IdScheme.NAME));
+          IdentifiableObject object = idObjectManager.get(DataElement.class, outlier.getDx());
+          grid.addValue(getIdProperty(object, outlier.getDx(), outlierRequest.getOutputIdScheme()));
+          grid.addValue(getIdProperty(object, outlier.getDx(), IdScheme.NAME));
 
-          grid.addValue(v.getPe());
+          grid.addValue(outlier.getPe());
+          grid.addValue(getPeriodName(outlierRequest, outlier));
 
-          object = idObjectManager.get(OrganisationUnit.class, v.getOu());
-          grid.addValue(getIdProperty(object, v.getOu(), request.getOutputIdScheme()));
-          grid.addValue(getIdProperty(object, v.getOu(), IdScheme.NAME));
+          object = idObjectManager.get(OrganisationUnit.class, outlier.getOu());
+          grid.addValue(getIdProperty(object, outlier.getOu(), outlierRequest.getOutputIdScheme()));
+          grid.addValue(getIdProperty(object, outlier.getOu(), IdScheme.NAME));
 
           grid.addValue(ou.getParentNameGraph(roots, true));
 
-          object = idObjectManager.get(CategoryOptionCombo.class, v.getCoc());
-          grid.addValue(getIdProperty(object, v.getCoc(), request.getOutputIdScheme()));
-          grid.addValue(getIdProperty(object, v.getCoc(), IdScheme.NAME));
+          object = idObjectManager.get(CategoryOptionCombo.class, outlier.getCoc());
+          grid.addValue(
+              getIdProperty(object, outlier.getCoc(), outlierRequest.getOutputIdScheme()));
+          grid.addValue(getIdProperty(object, outlier.getCoc(), IdScheme.NAME));
 
-          object = idObjectManager.get(CategoryOptionCombo.class, v.getAoc());
-          grid.addValue(getIdProperty(object, v.getAoc(), request.getOutputIdScheme()));
-          grid.addValue(getIdProperty(object, v.getAoc(), IdScheme.NAME));
+          object = idObjectManager.get(CategoryOptionCombo.class, outlier.getAoc());
+          grid.addValue(
+              getIdProperty(object, outlier.getAoc(), outlierRequest.getOutputIdScheme()));
+          grid.addValue(getIdProperty(object, outlier.getAoc(), IdScheme.NAME));
 
-          grid.addValue(v.getValue());
-          grid.addValue(isModifiedZScore ? v.getMedian() : v.getMean());
-          grid.addValue(v.getStdDev());
-          grid.addValue(v.getAbsDev());
-          grid.addValue(v.getZScore());
-          grid.addValue(v.getLowerBound());
-          grid.addValue(v.getUpperBound());
+          grid.addValue(outlier.getValue());
+          grid.addValue(isModifiedZScore ? outlier.getMedian() : outlier.getMean());
+          grid.addValue(outlier.getStdDev());
+          grid.addValue(outlier.getAbsDev());
+          grid.addValue(outlier.getZScore());
+          grid.addValue(outlier.getLowerBound());
+          grid.addValue(outlier.getUpperBound());
         });
   }
 
@@ -340,5 +347,27 @@ public class AnalyticsOutlierService {
     }
 
     return object.getName();
+  }
+
+  /**
+   * The method retrieves period name if available. The default name is iso period date (for example
+   * 202401).
+   *
+   * @param outlierRequest the {@link OutlierRequest}
+   * @param outlier the {@link Outlier}
+   * @return the period name based on iso date
+   */
+  private String getPeriodName(OutlierRequest outlierRequest, Outlier outlier) {
+    if (!outlierRequest.hasPeriods()) {
+      return outlier.getPe();
+    }
+
+    Period period =
+        outlierRequest.getPeriods().stream()
+            .filter(p -> outlier.getPe().equalsIgnoreCase(p.getIsoDate()))
+            .findFirst()
+            .orElse(null);
+
+    return period == null ? outlier.getPe() : period.getName();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreSqlStatementProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreSqlStatementProcessor.java
@@ -124,6 +124,13 @@ public class AnalyticsZScoreSqlStatementProcessor implements OutlierSqlStatement
     return sqlParameterSource;
   }
 
+  /**
+   * The method retrieves the sql query
+   *
+   * @param request the {@link OutlierRequest}.
+   * @param withParams indicates the parametrized sql query
+   * @return string with sql query
+   */
   private String getSqlStatement(OutlierRequest request, boolean withParams) {
     if (request == null) {
       return EMPTY;
@@ -208,6 +215,13 @@ public class AnalyticsZScoreSqlStatementProcessor implements OutlierSqlStatement
     return sql;
   }
 
+  /**
+   * The method retrieves the sql snippet of the period dedicated sql predicate
+   *
+   * @param request the {@link OutlierRequest}.
+   * @param withParams indicates the parametrized sql query
+   * @return period part of the where clause
+   */
   private String getPeriodSqlSnippet(OutlierRequest request, boolean withParams) {
     if (request.hasStartEndDate()) {
       return " and ax.pestartdate >= "
@@ -217,7 +231,7 @@ public class AnalyticsZScoreSqlStatementProcessor implements OutlierSqlStatement
     }
 
     if (!request.hasPeriods()) {
-      return "";
+      return EMPTY;
     }
 
     String sql = "";

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreSqlStatementProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreSqlStatementProcessor.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.analytics.OutlierDetectionAlgorithm;
 import org.hisp.dhis.analytics.outlier.OutlierHelper;
 import org.hisp.dhis.analytics.outlier.OutlierSqlStatementProcessor;
 import org.hisp.dhis.analytics.outlier.data.OutlierRequest;
+import org.hisp.dhis.commons.util.TextUtils;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Component;
@@ -102,12 +103,25 @@ public class AnalyticsZScoreSqlStatementProcessor implements OutlierSqlStatement
    */
   @Override
   public SqlParameterSource getSqlParameterSource(OutlierRequest request) {
-    return new MapSqlParameterSource()
-        .addValue(THRESHOLD.getKey(), request.getThreshold())
-        .addValue(DATA_ELEMENT_IDS.getKey(), request.getDataElementIds())
-        .addValue(START_DATE.getKey(), request.getStartDate())
-        .addValue(END_DATE.getKey(), request.getEndDate())
-        .addValue(MAX_RESULTS.getKey(), request.getMaxResults());
+    MapSqlParameterSource sqlParameterSource =
+        new MapSqlParameterSource()
+            .addValue(THRESHOLD.getKey(), request.getThreshold())
+            .addValue(DATA_ELEMENT_IDS.getKey(), request.getDataElementIds())
+            .addValue(MAX_RESULTS.getKey(), request.getMaxResults());
+
+    if (request.hasStartEndDate()) {
+      sqlParameterSource
+          .addValue(START_DATE.getKey(), request.getStartDate())
+          .addValue(END_DATE.getKey(), request.getEndDate());
+    } else if (request.hasPeriods()) {
+      for (int i = 0; i < request.getPeriods().size(); i++) {
+        sqlParameterSource
+            .addValue(START_DATE.getKey() + i, request.getPeriods().get(i).getStartDate())
+            .addValue(END_DATE.getKey() + i, request.getPeriods().get(i).getEndDate());
+      }
+    }
+
+    return sqlParameterSource;
   }
 
   private String getSqlStatement(OutlierRequest request, boolean withParams) {
@@ -179,10 +193,7 @@ public class AnalyticsZScoreSqlStatementProcessor implements OutlierSqlStatement
             + ") "
             + "and "
             + ouPathClause
-            + " and ax.pestartdate >= "
-            + (withParams ? ":" + START_DATE.getKey() : "'" + request.getStartDate() + "'")
-            + " and ax.peenddate <= "
-            + (withParams ? ":" + END_DATE.getKey() : "'" + request.getEndDate() + "'")
+            + getPeriodSqlSnippet(request, withParams)
             + ") t1 "
             + "where t1.z_score > "
             + thresholdParam
@@ -193,6 +204,37 @@ public class AnalyticsZScoreSqlStatementProcessor implements OutlierSqlStatement
             + " limit "
             + (withParams ? ":" + MAX_RESULTS.getKey() : request.getMaxResults())
             + " ";
+
+    return sql;
+  }
+
+  private String getPeriodSqlSnippet(OutlierRequest request, boolean withParams) {
+    if (request.hasStartEndDate()) {
+      return " and ax.pestartdate >= "
+          + (withParams ? ":" + START_DATE.getKey() : "'" + request.getStartDate() + "'")
+          + " and ax.peenddate <= "
+          + (withParams ? ":" + END_DATE.getKey() : "'" + request.getEndDate() + "'");
+    }
+
+    if (!request.hasPeriods()) {
+      return "";
+    }
+
+    String sql = "";
+    for (int i = 0; i < request.getPeriods().size(); i++) {
+      sql +=
+          " ax.pestartdate >= "
+              + (withParams
+                  ? ":" + START_DATE.getKey() + i
+                  : "'" + request.getPeriods().get(i).getStartDateString() + "'")
+              + " and ax.peenddate <= "
+              + (withParams
+                  ? ":" + END_DATE.getKey() + i
+                  : "'" + request.getPeriods().get(i).getEndDateString() + "'")
+              + " or ";
+    }
+
+    sql = " and (" + TextUtils.removeLastOr(sql) + ")";
 
     return sql;
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZscoreSqlStatementProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZscoreSqlStatementProcessorTest.java
@@ -36,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Lists;
+import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.outlier.OutlierSqlStatementProcessor;
@@ -43,6 +44,10 @@ import org.hisp.dhis.analytics.outlier.data.OutlierRequest;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.period.PeriodTypeEnum;
+import org.hisp.dhis.util.DateUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -76,21 +81,6 @@ class AnalyticsZscoreSqlStatementProcessorTest {
   }
 
   @Test
-  void testGetSqlStatement() {
-    OutlierRequest.OutlierRequestBuilder builder = OutlierRequest.builder();
-    builder
-        .dataElements(Lists.newArrayList(deA, deB, deC))
-        .startDate(getDate(2020, 1, 1))
-        .endDate(getDate(2020, 3, 1))
-        .orgUnits(Lists.newArrayList(ouA, ouB))
-        .build();
-    String sql = subject.getSqlStatement(builder.build());
-    String expected =
-        "select * from (select ax.dx as de_uid, ax.ou as ou_uid, ax.co as coc_uid, ax.ao as aoc_uid, ax.value, ax.pestartdate as pe_start_date, ax.petype as pt_name,  ax.avg_middle_value as middle_value, ax.std_dev, ax.mad, abs(ax.value::double precision -  ax.avg_middle_value) as middle_value_abs_dev, (case when ax.std_dev = 0 then 0       else abs(ax.value::double precision -  ax.avg_middle_value ) / ax.std_dev        end) as z_score,  ax.avg_middle_value - (ax.std_dev * :threshold) as lower_bound,  ax.avg_middle_value + (ax.std_dev * :threshold) as upper_bound from analytics ax where dataelementid in  (:data_element_ids) and (ax.\"path\" like '/ouabcdefghA%' or ax.\"path\" like '/ouabcdefghB%') and ax.pestartdate >= :start_date and ax.peenddate <= :end_date) t1 where t1.z_score > :threshold order by middle_value_abs_dev desc limit :max_results ";
-    assertEquals(expected, sql);
-  }
-
-  @Test
   void testGetSqlStatementWithZScore() {
     OutlierRequest.OutlierRequestBuilder builder = OutlierRequest.builder();
     builder
@@ -121,5 +111,39 @@ class AnalyticsZscoreSqlStatementProcessorTest {
   @Test
   void testGetSqlStatementWithNullRequest() {
     assertEquals(StringUtils.EMPTY, subject.getSqlStatement(null));
+  }
+
+  @Test
+  void testGetSqlStatementWithRelativePeriod() {
+    Period period = new Period();
+    period.setPeriodType(PeriodType.getPeriodType(PeriodTypeEnum.MONTHLY));
+    period.setStartDate(DateUtils.parseDate("2023-01-01"));
+    period.setEndDate(DateUtils.parseDate("2023-12-31"));
+    List<Period> periods = List.of(period);
+    OutlierRequest.OutlierRequestBuilder builder = OutlierRequest.builder();
+    builder
+        .dataElements(Lists.newArrayList(deA, deB, deC))
+        .periods(periods)
+        .orgUnits(Lists.newArrayList(ouA, ouB))
+        .build();
+    String sql = subject.getSqlStatement(builder.build());
+    String expected =
+        "select * from (select ax.dx as de_uid, ax.ou as ou_uid, ax.co as coc_uid, ax.ao as aoc_uid, ax.value, ax.pestartdate as pe_start_date, ax.petype as pt_name,  ax.avg_middle_value as middle_value, ax.std_dev, ax.mad, abs(ax.value::double precision -  ax.avg_middle_value) as middle_value_abs_dev, (case when ax.std_dev = 0 then 0       else abs(ax.value::double precision -  ax.avg_middle_value ) / ax.std_dev        end) as z_score,  ax.avg_middle_value - (ax.std_dev * :threshold) as lower_bound,  ax.avg_middle_value + (ax.std_dev * :threshold) as upper_bound from analytics ax where dataelementid in  (:data_element_ids) and (ax.\"path\" like '/ouabcdefghA%' or ax.\"path\" like '/ouabcdefghB%') and ( ax.pestartdate >= :start_date0 and ax.peenddate <= :end_date0 )) t1 where t1.z_score > :threshold order by middle_value_abs_dev desc limit :max_results ";
+    assertEquals(expected, sql);
+  }
+
+  @Test
+  void testGetSqlStatementWithStartEndDate() {
+    OutlierRequest.OutlierRequestBuilder builder = OutlierRequest.builder();
+    builder
+        .dataElements(Lists.newArrayList(deA, deB, deC))
+        .startDate(getDate(2020, 1, 1))
+        .endDate(getDate(2020, 3, 1))
+        .orgUnits(Lists.newArrayList(ouA, ouB))
+        .build();
+    String sql = subject.getSqlStatement(builder.build());
+    String expected =
+        "select * from (select ax.dx as de_uid, ax.ou as ou_uid, ax.co as coc_uid, ax.ao as aoc_uid, ax.value, ax.pestartdate as pe_start_date, ax.petype as pt_name,  ax.avg_middle_value as middle_value, ax.std_dev, ax.mad, abs(ax.value::double precision -  ax.avg_middle_value) as middle_value_abs_dev, (case when ax.std_dev = 0 then 0       else abs(ax.value::double precision -  ax.avg_middle_value ) / ax.std_dev        end) as z_score,  ax.avg_middle_value - (ax.std_dev * :threshold) as lower_bound,  ax.avg_middle_value + (ax.std_dev * :threshold) as upper_bound from analytics ax where dataelementid in  (:data_element_ids) and (ax.\"path\" like '/ouabcdefghA%' or ax.\"path\" like '/ouabcdefghB%') and ax.pestartdate >= :start_date and ax.peenddate <= :end_date) t1 where t1.z_score > :threshold order by middle_value_abs_dev desc limit :max_results ";
+    assertEquals(expected, sql);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/analytics/common/ColumnHeader.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/analytics/common/ColumnHeader.java
@@ -58,6 +58,7 @@ public enum ColumnHeader {
   DIMENSION("dx", "Data"),
   DIMENSION_NAME("dxname", "Data name"),
   PERIOD("pe", "Period"),
+  PERIOD_NAME("pename", "Period name"),
   CATEGORY_OPTION_COMBO("coc", "Category option combo"),
   CATEGORY_OPTION_COMBO_NAME("cocname", "Category option combo name"),
   ATTRIBUTE_OPTION_COMBO("aoc", "Attribute option combo"),


### PR DESCRIPTION
For full support of the period dimension, the relative periods had to be included in the incoming request using the format of the query parameter pe=RELATIVE_PERIOD. Common relative period names, such as THIS_YEAR and LAST_12_MONTH, are accepted. Please note that only one relative period is supported, and the combination of start/end dates with a relative period is not allowed.