### PR TITLE
fix: validation of /tracker/trackedEntities?order TECH-1648 [2.40]

### DIFF
--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapperTest.java
@@ -43,12 +43,10 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -216,7 +214,6 @@ class TrackerTrackedEntityCriteriaMapperTest {
     criteria.setSkipPaging(false);
     criteria.setIncludeDeleted(true);
     criteria.setIncludeAllAttributes(true);
-    criteria.setOrder(Collections.singletonList(OrderCriteria.of("createdAt", SortDirection.ASC)));
 
     final TrackedEntityInstanceQueryParams params = mapper.map(criteria);
 
@@ -240,10 +237,22 @@ class TrackerTrackedEntityCriteriaMapperTest {
         params.getAssignedUserQueryParam().getMode(), is(AssignedUserSelectionMode.PROVIDED));
     assertThat(params.isIncludeDeleted(), is(true));
     assertThat(params.isIncludeAllAttributes(), is(true));
-    assertTrue(
-        params.getOrders().stream()
-            .anyMatch(
-                orderParam -> orderParam.equals(new OrderParam("createdAt", SortDirection.ASC))));
+  }
+
+  @Test
+  void mapOrderParam() throws ForbiddenException, BadRequestException {
+    criteria.setOrder(
+        List.of(
+            OrderCriteria.of("inactive", SortDirection.ASC),
+            OrderCriteria.of("createdAt", SortDirection.DESC)));
+
+    final TrackedEntityInstanceQueryParams params = mapper.map(criteria);
+
+    assertEquals(
+        List.of(
+            new OrderParam("inactive", SortDirection.ASC),
+            new OrderParam("createdAt", SortDirection.DESC)),
+        params.getOrders());
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapperTest.java
@@ -35,6 +35,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hisp.dhis.DhisConvenienceTest.getDate;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ALL;
 import static org.hisp.dhis.util.DateUtils.parseDate;
+import static org.hisp.dhis.utils.Assertions.assertContains;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.utils.Assertions.assertStartsWith;
@@ -215,7 +216,7 @@ class TrackerTrackedEntityCriteriaMapperTest {
     criteria.setSkipPaging(false);
     criteria.setIncludeDeleted(true);
     criteria.setIncludeAllAttributes(true);
-    criteria.setOrder(Collections.singletonList(OrderCriteria.of("created", SortDirection.ASC)));
+    criteria.setOrder(Collections.singletonList(OrderCriteria.of("createdAt", SortDirection.ASC)));
 
     final TrackedEntityInstanceQueryParams params = mapper.map(criteria);
 
@@ -242,7 +243,7 @@ class TrackerTrackedEntityCriteriaMapperTest {
     assertTrue(
         params.getOrders().stream()
             .anyMatch(
-                orderParam -> orderParam.equals(new OrderParam("created", SortDirection.ASC))));
+                orderParam -> orderParam.equals(new OrderParam("createdAt", SortDirection.ASC))));
   }
 
   @Test
@@ -552,7 +553,7 @@ class TrackerTrackedEntityCriteriaMapperTest {
     criteria.setOrder(List.of(order1));
 
     BadRequestException e = assertThrows(BadRequestException.class, () -> mapper.map(criteria));
-    assertEquals("Invalid order property: invalid", e.getMessage());
+    assertContains("Cannot order by 'invalid'", e.getMessage());
   }
 
   @Test


### PR DESCRIPTION
Similar to https://github.com/dhis2/dhis2-core/pull/16097 but for trackedEntities.

In https://dhis2.atlassian.net/browse/TECH-1611 we harmonized ordering trackedEntities in 2.41. This now allows ordering only by field names of new tracker. Previously, users could also order by 'created' since TrackedEntityInstanceQueryParams.OrderColumn is responsible for mapping field names and is used by new and old tracker.

This change rejects any order request for non supported fields with a 400 like in 2.41.

* supported field names comes from master at
https://github.com/dhis2/dhis2-core/blob/d9af17c0fdac03b318208f330a76ab95d4bba1ac/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityMapper.java#L56-L68
* mapping to internal field names is already done by `TrackedEntityInstanceQueryParams.OrderColumn` which contains an entry for every supported field
