### PR TITLE
fix: validation of /tracker/trackedEntities?order TECH-1648 [2.39]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
@@ -998,11 +998,13 @@ public class TrackedEntityInstanceQueryParams {
   @Getter
   @AllArgsConstructor
   public enum OrderColumn {
-    TRACKEDENTITY("trackedEntityInstance", "uid", MAIN_QUERY_ALIAS),
+    TRACKEDENTITY_INSTANCE("trackedEntityInstance", "uid", MAIN_QUERY_ALIAS),
+    TRACKEDENTITY("trackedEntity", "uid", MAIN_QUERY_ALIAS),
     CREATED("created", CREATED_ID, MAIN_QUERY_ALIAS),
     CREATED_AT("createdAt", CREATED_ID, MAIN_QUERY_ALIAS),
     CREATED_AT_CLIENT("createdAtClient", "createdatclient", MAIN_QUERY_ALIAS),
-    UPDATED_AT("lastUpdated", "lastupdated", MAIN_QUERY_ALIAS),
+    LAST_UPDATED_AT("lastUpdated", "lastupdated", MAIN_QUERY_ALIAS),
+    UPDATED_AT("updatedAt", "lastupdated", MAIN_QUERY_ALIAS),
     UPDATED_AT_CLIENT("updatedAtClient", "lastupdatedatclient", MAIN_QUERY_ALIAS),
     ENROLLED_AT(
         "enrolledAt",

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/TrackedEntityCriteriaMapperTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/TrackedEntityCriteriaMapperTest.java
@@ -36,8 +36,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Sets;
-import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.common.AccessLevel;
 import org.hisp.dhis.common.AssignedUserSelectionMode;
@@ -61,6 +61,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.webapi.DhisWebSpringTest;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
+import org.hisp.dhis.webapi.controller.event.mapper.OrderParam.SortDirection;
 import org.hisp.dhis.webapi.controller.event.mapper.TrackedEntityCriteriaMapper;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.hisp.dhis.webapi.controller.event.webrequest.TrackedEntityInstanceCriteria;
@@ -165,9 +166,9 @@ class TrackedEntityCriteriaMapperTest extends DhisWebSpringTest {
     criteria.setSkipPaging(false);
     criteria.setIncludeDeleted(true);
     criteria.setIncludeAllAttributes(true);
-    criteria.setOrder(
-        Collections.singletonList(OrderCriteria.of("created", OrderParam.SortDirection.ASC)));
-    final TrackedEntityInstanceQueryParams queryParams = trackedEntityCriteriaMapper.map(criteria);
+
+    TrackedEntityInstanceQueryParams queryParams = trackedEntityCriteriaMapper.map(criteria);
+
     assertThat(queryParams.getQuery().getFilter(), is("query-test"));
     assertThat(queryParams.getQuery().getOperator(), is(QueryOperator.EQ));
     assertThat(queryParams.getProgram(), is(programA));
@@ -212,11 +213,23 @@ class TrackedEntityCriteriaMapperTest extends DhisWebSpringTest {
     assertThat(queryParams.getAssignedUsers().stream().anyMatch(u -> u.equals(userId3)), is(false));
     assertThat(queryParams.isIncludeDeleted(), is(true));
     assertThat(queryParams.isIncludeAllAttributes(), is(true));
-    assertTrue(
-        queryParams.getOrders().stream()
-            .anyMatch(
-                orderParam ->
-                    orderParam.equals(new OrderParam("created", OrderParam.SortDirection.ASC))));
+  }
+
+  @Test
+  void mapOrderParam() {
+    TrackedEntityInstanceCriteria criteria = new TrackedEntityInstanceCriteria();
+    criteria.setOrder(
+        List.of(
+            OrderCriteria.of("inactive", SortDirection.ASC),
+            OrderCriteria.of("createdAt", SortDirection.DESC)));
+
+    TrackedEntityInstanceQueryParams queryParams = trackedEntityCriteriaMapper.map(criteria);
+
+    assertEquals(
+        List.of(
+            new OrderParam("inactive", SortDirection.ASC),
+            new OrderParam("createdAt", SortDirection.DESC)),
+        queryParams.getOrders());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportControllerTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export;
 
+import static org.hisp.dhis.utils.Assertions.assertContains;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertFirstRelationship;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasMember;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasNoMember;
@@ -44,6 +45,7 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
@@ -407,6 +409,14 @@ class TrackerTrackedEntitiesExportControllerTest extends DhisControllerConvenien
     JsonObject event = assertDefaultEventResponse(enrollment, programStageInstance);
 
     assertHasNoMember(event, "relationships");
+  }
+
+  @Test
+  void shouldFailToGetTrackedEntitiesWhenOrderingByIllegalField() {
+    JsonResponse response =
+        GET("/tracker/trackedEntities?order=invalid").content(HttpStatus.BAD_REQUEST);
+
+    assertContains("Cannot order by 'invalid'", response.getString("message").string());
   }
 
   private ProgramStageInstance programStageInstanceWithDataValue(ProgramInstance programInstance) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/tracker/mapper/TrackerTrackedEntityCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/tracker/mapper/TrackerTrackedEntityCriteriaMapper.java
@@ -40,6 +40,7 @@ import org.mapstruct.Mapping;
  */
 @Mapper
 public interface TrackerTrackedEntityCriteriaMapper {
+  @Mapping(target = "rawOrder", ignore = true)
   @Mapping(source = "orgUnit", target = "ou")
   @Mapping(source = "updatedAfter", target = "lastUpdatedStartDate")
   @Mapping(source = "updatedBefore", target = "lastUpdatedEndDate")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
@@ -28,10 +28,12 @@
 package org.hisp.dhis.webapi.controller.tracker.export;
 
 import static org.hisp.dhis.webapi.controller.tracker.TrackerControllerSupport.RESOURCE_PATH;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateOrderParams;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.List;
+import java.util.Set;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.DhisApiVersion;
@@ -44,6 +46,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams;
 import org.hisp.dhis.webapi.controller.event.mapper.TrackedEntityCriteriaMapper;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
 import org.hisp.dhis.webapi.controller.event.webrequest.tracker.TrackerTrackedEntityCriteria;
+import org.hisp.dhis.webapi.controller.exception.BadRequestException;
 import org.hisp.dhis.webapi.controller.tracker.export.fieldsmapper.TrackedEntityFieldsParamMapper;
 import org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -61,6 +64,22 @@ import org.springframework.web.bind.annotation.RestController;
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
 @RequiredArgsConstructor
 public class TrackerTrackedEntitiesExportController {
+
+  /**
+   * Tracked entities can be ordered by given fields which correspond to fields on {@link
+   * org.hisp.dhis.trackedentity.TrackedEntityInstance}. These user facing field names are
+   * translated to internal ones in {@link TrackedEntityInstanceQueryParams.OrderColumn}.
+   */
+  private static final Set<String> ORDERABLE_FIELD_NAMES =
+      Set.of(
+          "trackedEntity",
+          "createdAt",
+          "createdAtClient",
+          "updatedAt",
+          "updatedAtClient",
+          "enrolledAt",
+          "inactive");
+
   protected static final String TRACKED_ENTITIES = "trackedEntities";
 
   private static final String DEFAULT_FIELDS_PARAM =
@@ -82,7 +101,11 @@ public class TrackerTrackedEntitiesExportController {
   @GetMapping(produces = APPLICATION_JSON_VALUE)
   PagingWrapper<ObjectNode> getInstances(
       TrackerTrackedEntityCriteria criteria,
-      @RequestParam(defaultValue = DEFAULT_FIELDS_PARAM) List<FieldPath> fields) {
+      @RequestParam(defaultValue = DEFAULT_FIELDS_PARAM) List<FieldPath> fields)
+      throws BadRequestException {
+    // validating order param field names here and not in mapper as the mapper is shared by old and
+    // new tracker
+    validateOrderParams(criteria.getRawOrder(), ORDERABLE_FIELD_NAMES, "attribute");
     TrackedEntityInstanceQueryParams queryParams = criteriaMapper.map(criteria);
 
     TrackedEntityInstanceParams trackedEntityInstanceParams =


### PR DESCRIPTION
backport of https://github.com/dhis2/dhis2-core/pull/16111

Important differences to the above PR in 2.40
* The same TrackedEntityCriteriaMapper class is used by old and new tracker in 2.39. Validation is thus done in the controller so we do not affect old tracker.
* TrackedEntityInstanceQueryParams.OrderColumn is slightly different than in 2.40. 2.39 did not have a mapping for `updatedAt` or `trackedEntity`.

https://github.com/dhis2/dhis2-core/blob/166191abac38a580ce58add4e1d4dcf92891a8c0/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java#L960-L966