### PR TITLE
ci: allow connecting debugger, jmx in docker compose setup [2.38]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,9 @@ services:
   web:
     image: "${DHIS2_IMAGE:-dhis2/core-dev:local}"
     ports:
-      - "8080:8080"
+      - 127.0.0.1:8080:8080 # DHIS2
+      - 127.0.0.1:8081:8081 # Debugger: connect using commandline flag -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8081
+      - 127.0.0.1:9010:9010 # JMX port (for example for VisualVM)
     volumes:
       - ./docker/dhis.conf:/opt/dhis2/dhis.conf:ro
       - ./docker/log4j2.xml:/opt/dhis2/log4j2.xml:ro


### PR DESCRIPTION
backport of https://github.com/dhis2/dhis2-core/pull/12320