### PR TITLE
fix: do not remove pager wrapper for paging=false [DHIS2-16422]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastore/DatastoreQuery.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastore/DatastoreQuery.java
@@ -235,14 +235,14 @@ public final class DatastoreQuery {
     ENDS_WITH("ilike$", "endswith"),
     NOT_ENDS_WITH("!ilike$", "!endswith");
 
-    private Set<String> operators;
+    private final Set<String> operators;
 
     Comparison(String... operators) {
       this.operators = Set.of(operators);
     }
 
     public boolean isUnary() {
-      return ordinal() >= NULL.ordinal() && ordinal() <= NOT_EMPTY.ordinal();
+      return ordinal() <= NOT_EMPTY.ordinal();
     }
 
     public boolean isCaseInsensitive() {
@@ -292,7 +292,7 @@ public final class DatastoreQuery {
     int size = max(1, min(1000, params.getPageSize()));
     boolean isPaging = params.isPaging();
     return toBuilder()
-        .headless(params.isHeadless() || !isPaging)
+        .headless(params.isHeadless())
         .anyFilter(params.getRootJunction() == DatastoreParams.Junction.OR)
         .order(Order.parse(params.getOrder()))
         .paging(isPaging)

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreFieldsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatastoreFieldsControllerTest.java
@@ -28,10 +28,13 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.utils.JavaToJson.toJson;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.datastore.DatastoreParams;
+import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.web.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -113,6 +116,17 @@ class DatastoreFieldsControllerTest extends AbstractDatastoreControllerTest {
   void testFields_PathNumber() {
     assertJson(
         "[{'key':'cat','age':9}]", GET("/dataStore/pets?fields=age&headless=true&filter=_:eq:cat"));
+  }
+
+  @Test
+  void testFields_Paging() {
+    JsonObject list = GET("/dataStore/pets?fields=age&paging=false").content();
+    assertTrue(list.isObject());
+    assertEquals(4, list.getArray("entries").size());
+
+    list = GET("/dataStore/pets?fields=age&paging=false&headless=true").content();
+    assertTrue(list.isArray());
+    assertEquals(4, list.size());
   }
 
   @Test


### PR DESCRIPTION
### Summary
Stripping the pager object wrapper without paging was a "feature" but for consistency the wrapper is now kept unless `headless=true` is used. 

### Automatic Testing
New test scenario was added to list without paging with and without `headless

### Manual Testing
* using `/api/dataStore/<ns>?fields=.?paging=false` should have an object wrapper (`{....}` )
* using `/api/dataStore/<ns>?fields=.?paging=false&headless=true` should not have an object wrapper (`[...]`)