### PR TITLE
fix: attributes from TET are exported even when TET is not connected to programs [DHIS2-16397]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiAnalyticsTableManager.java
@@ -234,7 +234,7 @@ public class JdbcTeiAnalyticsTableManager extends AbstractJdbcTableManager {
             tet ->
                 new AnalyticsTable(
                     getAnalyticsTableType(), getTableColumns(params, tet), emptyList(), tet))
-        .collect(toList());
+        .toList();
   }
 
   private Map<String, List<Program>> getProgramsByTetUid(AnalyticsTableUpdateParams params) {
@@ -242,7 +242,7 @@ public class JdbcTeiAnalyticsTableManager extends AbstractJdbcTableManager {
         params.isSkipPrograms()
             ? idObjectManager.getAllNoAcl(Program.class).stream()
                 .filter(p -> !params.getSkipPrograms().contains(p.getUid()))
-                .collect(toList())
+                .toList()
             : idObjectManager.getAllNoAcl(Program.class);
 
     return programs.stream()
@@ -272,12 +272,14 @@ public class JdbcTeiAnalyticsTableManager extends AbstractJdbcTableManager {
                             + program.getId()
                             + ")")));
 
-    List<TrackedEntityAttribute> trackedEntityAttributes = new ArrayList<>();
-
-    if (programsByTetUid.containsKey(tet.getUid())) {
-      trackedEntityAttributes =
-          getAllTrackedEntityAttributes(tet, programsByTetUid.get(tet.getUid()));
-    }
+    List<TrackedEntityAttribute> trackedEntityAttributes =
+        programsByTetUid.containsKey(tet.getUid())
+            ?
+            // programs defined for TET -> get attr from program and TET
+            getAllTrackedEntityAttributes(tet, programsByTetUid.get(tet.getUid()))
+            :
+            // no programs defined for TET -> get only attributes from TET
+            getAllTrackedEntityAttributes(tet).toList();
 
     params.addExtraParam(tet.getUid(), ALL_TET_ATTRIBUTES, trackedEntityAttributes);
 
@@ -298,9 +300,13 @@ public class JdbcTeiAnalyticsTableManager extends AbstractJdbcTableManager {
             /* all attributes of programs */
             trackedEntityAttributeService.getProgramTrackedEntityAttributes(programs).stream(),
             /* all attributes of the trackedEntityType */
-            CollectionUtils.emptyIfNull(trackedEntityType.getTrackedEntityAttributes()).stream())
-        .distinct()
-        .collect(toList());
+            getAllTrackedEntityAttributes(trackedEntityType))
+        .toList();
+  }
+
+  private Stream<TrackedEntityAttribute> getAllTrackedEntityAttributes(
+      TrackedEntityType trackedEntityType) {
+    return CollectionUtils.emptyIfNull(trackedEntityType.getTrackedEntityAttributes()).stream();
   }
 
   /**


### PR DESCRIPTION
The current implementation of the analytic table export job has a limitation. When processing attributes, the job only exports columns for attributes that are connected to a program. However, this is not entirely accurate. There can be attributes for a Tracked Entity Type (TET) that are not referenced by any program but should still be exported. Fortunately, this issue has been addressed by this pull request (PR) that resolves the problem.