### PR TITLE
fix: Sorting validation and prevent NPE [DHIS2-16369]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalObject.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.common;
 
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -164,7 +166,7 @@ public interface DimensionalObject extends NameableObject, GroupableItem {
 
   /** Indicates whether this dimension has any dimension items. */
   default boolean hasItems() {
-    return !getItems().isEmpty();
+    return isNotEmpty(getItems());
   }
 
   /** Gets the legend set. */


### PR DESCRIPTION
This PR aims to fix the recently added validation of the `sorting` attribute, in `Visualization`.
It should also allow dimension's `uid` present in `columns -> items`.
I've also made a small improvement to prevent NPEs.