### PR TITLE
feat: return pagination fields in page objects in tracker exporter TECH-1679

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingWrapper.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingWrapper.java
@@ -84,17 +84,5 @@ public class PagingWrapper<T> {
     @JsonProperty private String nextPage;
 
     @JsonProperty private String prevPage;
-
-    public static Pager fromLegacy(
-        PagingCriteria pagingCriteria, org.hisp.dhis.common.Pager pager) {
-      return Pager.builder()
-          .prevPage(pager.getPrevPage())
-          .page(pager.getPage())
-          .pageSize(pager.getPageSize())
-          .pageCount(pagingCriteria.isTotalPages() ? pager.getPageCount() : null)
-          .total(pagingCriteria.isTotalPages() ? pager.getTotal() : null)
-          .nextPage(pager.getNextPage())
-          .build();
-    }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/Page.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/Page.java
@@ -41,4 +41,11 @@ import org.hisp.dhis.common.Pager;
 public class Page<T> {
   private final List<T> items;
   private final Pager pager;
+
+  /**
+   * Indicates if the {@link #pager} contains the total number of items. The current {@link #pager}
+   * does not reveal that information as it was meant for metadata that does not allow disabling the
+   * return of totals.
+   */
+  private final boolean pageTotal;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -213,7 +213,7 @@ class DefaultEnrollmentService
             params.isIncludeDeleted(),
             queryParams.getOrganisationUnitMode());
 
-    return Page.of(enrollments, enrollmentsPage.getPager());
+    return Page.of(enrollments, enrollmentsPage.getPager(), enrollmentsPage.isPageTotal());
   }
 
   private List<Enrollment> getEnrollments(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/HibernateEnrollmentStore.java
@@ -133,12 +133,12 @@ class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enrollment
     if (pageParams.isPageTotal()) {
       Pager pager =
           new Pager(pageParams.getPage(), enrollmentCount.getAsInt(), pageParams.getPageSize());
-      return Page.of(enrollments, pager);
+      return Page.of(enrollments, pager, pageParams.isPageTotal());
     }
 
     Pager pager = new Pager(pageParams.getPage(), 0, pageParams.getPageSize());
     pager.force(pageParams.getPage(), pageParams.getPageSize());
-    return Page.of(enrollments, pager);
+    return Page.of(enrollments, pager, pageParams.isPageTotal());
   }
 
   private QueryWithOrderBy buildEnrollmentHql(EnrollmentQueryParams params) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -438,12 +438,12 @@ class JdbcEventStore implements EventStore {
     if (pageParams.isPageTotal()) {
       Pager pager =
           new Pager(pageParams.getPage(), eventCount.getAsInt(), pageParams.getPageSize());
-      return Page.of(events, pager);
+      return Page.of(events, pager, pageParams.isPageTotal());
     }
 
     Pager pager = new Pager(pageParams.getPage(), 0, pageParams.getPageSize());
     pager.force(pageParams.getPage(), pageParams.getPageSize());
-    return Page.of(events, pager);
+    return Page.of(events, pager, pageParams.isPageTotal());
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -114,7 +114,7 @@ public class DefaultRelationshipService implements RelationshipService {
         relationshipPage.getItems().stream()
             .filter(r -> trackerAccessManager.canRead(currentUser, r).isEmpty())
             .toList();
-    return Page.of(map(relationships), relationshipPage.getPager());
+    return Page.of(map(relationships), relationshipPage.getPager(), relationshipPage.isPageTotal());
   }
 
   public List<Relationship> getRelationshipsByEnrollment(
@@ -136,7 +136,7 @@ public class DefaultRelationshipService implements RelationshipService {
         relationshipPage.getItems().stream()
             .filter(r -> trackerAccessManager.canRead(currentUser, r).isEmpty())
             .toList();
-    return Page.of(map(relationships), relationshipPage.getPager());
+    return Page.of(map(relationships), relationshipPage.getPager(), relationshipPage.isPageTotal());
   }
 
   public List<Relationship> getRelationshipsByEvent(
@@ -158,7 +158,7 @@ public class DefaultRelationshipService implements RelationshipService {
         relationshipPage.getItems().stream()
             .filter(r -> trackerAccessManager.canRead(currentUser, r).isEmpty())
             .toList();
-    return Page.of(map(relationships), relationshipPage.getPager());
+    return Page.of(map(relationships), relationshipPage.getPager(), relationshipPage.isPageTotal());
   }
 
   private List<Relationship> getRelationships(RelationshipQueryParams queryParams) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
@@ -278,12 +278,12 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
     if (pageParams.isPageTotal()) {
       Pager pager =
           new Pager(pageParams.getPage(), enrollmentCount.getAsInt(), pageParams.getPageSize());
-      return Page.of(relationships, pager);
+      return Page.of(relationships, pager, pageParams.isPageTotal());
     }
 
     Pager pager = new Pager(pageParams.getPage(), 0, pageParams.getPageSize());
     pager.force(pageParams.getPage(), pageParams.getPageSize());
-    return Page.of(relationships, pager);
+    return Page.of(relationships, pager, pageParams.isPageTotal());
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -331,7 +331,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
 
     addSearchAudit(trackedEntities, queryParams.getUser());
 
-    return Page.of(trackedEntities, ids.getPager());
+    return Page.of(trackedEntities, ids.getPager(), ids.isPageTotal());
   }
 
   public List<Long> getTrackedEntityIds(TrackedEntityQueryParams params) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -187,12 +187,12 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     if (pageParams.isPageTotal()) {
       Pager pager =
           new Pager(pageParams.getPage(), enrollmentCount.getAsInt(), pageParams.getPageSize());
-      return Page.of(teIds, pager);
+      return Page.of(teIds, pager, pageParams.isPageTotal());
     }
 
     Pager pager = new Pager(pageParams.getPage(), 0, pageParams.getPageSize());
     pager.force(pageParams.getPage(), pageParams.getPageSize());
-    return Page.of(teIds, pager);
+    return Page.of(teIds, pager, pageParams.isPageTotal());
   }
 
   @Override

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonPage.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonPage.java
@@ -25,29 +25,47 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.tracker.export;
+package org.hisp.dhis.webapi.controller.tracker;
 
-import java.util.List;
-import lombok.Value;
-import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.jsontree.JsonObject;
 
-/** OpenAPI specifications used across tracker export endpoints. */
-public class OpenApiExport {
-  private OpenApiExport() {
-    throw new IllegalStateException("Utility class");
+/** Representation of {@link org.hisp.dhis.webapi.controller.tracker.view.Page}. */
+public interface JsonPage extends JsonObject {
+  default JsonPager getPager() {
+    return get("pager").as(JsonPager.class);
   }
 
-  @Value
-  @OpenApi.Property
-  @OpenApi.Shared(value = false)
-  public static class ListResponse {
-    Integer page = 1;
+  default Integer getPage() {
+    return getNumber("page").integer();
+  }
 
-    Integer pageSize = org.hisp.dhis.common.Pager.DEFAULT_PAGE_SIZE;
+  default Integer getPageSize() {
+    return getNumber("pageSize").integer();
+  }
 
-    Long total;
+  default Integer getTotal() {
+    return getNumber("total").integer();
+  }
 
-    @OpenApi.Property(value = OpenApi.EntityType[].class)
-    List<Object> instances;
+  default Integer getPageCount() {
+    return getNumber("pageCount").integer();
+  }
+
+  interface JsonPager extends JsonObject {
+    default Integer getPage() {
+      return getNumber("page").integer();
+    }
+
+    default Integer getPageSize() {
+      return getNumber("pageSize").integer();
+    }
+
+    default Integer getTotal() {
+      return getNumber("total").integer();
+    }
+
+    default Integer getPageCount() {
+      return getNumber("pageCount").integer();
+    }
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/ExportControllerPaginationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/ExportControllerPaginationTest.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.export;
+
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasNoMember;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramStatus;
+import org.hisp.dhis.relationship.Relationship;
+import org.hisp.dhis.relationship.RelationshipEntity;
+import org.hisp.dhis.relationship.RelationshipItem;
+import org.hisp.dhis.relationship.RelationshipType;
+import org.hisp.dhis.security.acl.AccessStringHelper;
+import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.sharing.UserAccess;
+import org.hisp.dhis.web.HttpStatus;
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.webapi.controller.tracker.JsonPage;
+import org.hisp.dhis.webapi.controller.tracker.JsonRelationship;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Tests how {@link org.hisp.dhis.webapi.controller.tracker.export} controllers serialize {@link
+ * org.hisp.dhis.tracker.export.Page} to JSON. The tests use the {@link
+ * org.hisp.dhis.webapi.controller.tracker.export.relationship} controller but hold true for any of
+ * the export controllers.
+ */
+class ExportControllerPaginationTest extends DhisControllerConvenienceTest {
+
+  @Autowired private IdentifiableObjectManager manager;
+
+  private OrganisationUnit orgUnit;
+
+  private Program program;
+
+  private ProgramStage programStage;
+
+  private User owner;
+
+  private User user;
+
+  private TrackedEntityType trackedEntityType;
+
+  @BeforeEach
+  void setUp() {
+    owner = makeUser("o");
+    manager.save(owner, false);
+
+    orgUnit = createOrganisationUnit('A');
+    orgUnit.getSharing().setOwner(owner);
+    manager.save(orgUnit, false);
+
+    OrganisationUnit anotherOrgUnit = createOrganisationUnit('B');
+    anotherOrgUnit.getSharing().setOwner(owner);
+    manager.save(anotherOrgUnit, false);
+
+    user = createUserWithId("tester", CodeGenerator.generateUid());
+    user.addOrganisationUnit(orgUnit);
+    user.setTeiSearchOrganisationUnits(Set.of(orgUnit));
+    this.userService.updateUser(user);
+
+    program = createProgram('A');
+    program.addOrganisationUnit(orgUnit);
+    program.getSharing().setOwner(owner);
+    program.getSharing().addUserAccess(userAccess());
+    manager.save(program, false);
+
+    programStage = createProgramStage('A', program);
+    programStage.getSharing().setOwner(owner);
+    programStage.getSharing().addUserAccess(userAccess());
+    manager.save(programStage, false);
+
+    trackedEntityType = trackedEntityTypeAccessible();
+  }
+
+  @Test
+  void shouldGetPaginatedItemsWithDefaults() {
+    TrackedEntity to = trackedEntity();
+    Event from1 = event(enrollment(to));
+    Event from2 = event(enrollment(to));
+    Relationship r1 = relationship(from1, to);
+    Relationship r2 = relationship(from2, to);
+
+    JsonPage page =
+        GET("/tracker/relationships?trackedEntity={uid}", to.getUid())
+            .content(HttpStatus.OK)
+            .asObject(JsonPage.class);
+
+    assertContainsOnly(
+        List.of(r1.getUid(), r2.getUid()),
+        page.getList("instances", JsonRelationship.class)
+            .toList(JsonRelationship::getRelationship));
+    assertEquals(1, page.getPager().getPage());
+    assertEquals(50, page.getPager().getPageSize());
+    assertHasNoMember(page.getPager(), "total");
+    assertHasNoMember(page.getPager(), "pageCount");
+
+    // assert deprecated fields
+    assertEquals(1, page.getPage());
+    assertEquals(50, page.getPageSize());
+    assertHasNoMember(page, "total");
+    assertHasNoMember(page, "pageCount");
+  }
+
+  @Test
+  void shouldGetPaginatedItemsWithDefaultsAndTotals() {
+    TrackedEntity to = trackedEntity();
+    Event from1 = event(enrollment(to));
+    Event from2 = event(enrollment(to));
+    Relationship r1 = relationship(from1, to);
+    Relationship r2 = relationship(from2, to);
+
+    JsonPage page =
+        GET("/tracker/relationships?trackedEntity={uid}&totalPages=true", to.getUid())
+            .content(HttpStatus.OK)
+            .asObject(JsonPage.class);
+
+    assertContainsOnly(
+        List.of(r1.getUid(), r2.getUid()),
+        page.getList("instances", JsonRelationship.class)
+            .toList(JsonRelationship::getRelationship));
+    assertEquals(1, page.getPager().getPage());
+    assertEquals(50, page.getPager().getPageSize());
+    assertEquals(2, page.getPager().getTotal());
+    assertEquals(1, page.getPager().getPageCount());
+
+    // assert deprecated fields
+    assertEquals(1, page.getPage());
+    assertEquals(50, page.getPageSize());
+    assertEquals(2, page.getTotal());
+    assertEquals(1, page.getPageCount());
+  }
+
+  @Test
+  void shouldGetPaginatedItemsWithNonDefaults() {
+    TrackedEntity to = trackedEntity();
+    Event from1 = event(enrollment(to));
+    Event from2 = event(enrollment(to));
+    relationship(from1, to);
+    relationship(from2, to);
+
+    JsonPage page =
+        GET("/tracker/relationships?trackedEntity={uid}&page=2&pageSize=1", to.getUid())
+            .content(HttpStatus.OK)
+            .asObject(JsonPage.class);
+
+    JsonList<JsonRelationship> instances = page.getList("instances", JsonRelationship.class);
+    assertEquals(
+        1,
+        instances.size(),
+        () -> String.format("mismatch in number of expected relationship(s), got %s", instances));
+    assertEquals(2, page.getPager().getPage());
+    assertEquals(1, page.getPager().getPageSize());
+    assertHasNoMember(page.getPager(), "total");
+    assertHasNoMember(page.getPager(), "pageCount");
+
+    // assert deprecated fields
+    assertEquals(2, page.getPage());
+    assertEquals(1, page.getPageSize());
+    assertHasNoMember(page.getPager(), "total");
+    assertHasNoMember(page.getPager(), "pageCount");
+  }
+
+  @Test
+  void shouldGetPaginatedItemsWithNonDefaultsAndTotals() {
+    TrackedEntity to = trackedEntity();
+    Event from1 = event(enrollment(to));
+    Event from2 = event(enrollment(to));
+    relationship(from1, to);
+    relationship(from2, to);
+
+    JsonPage page =
+        GET(
+                "/tracker/relationships?trackedEntity={uid}&page=2&pageSize=1&totalPages=true",
+                to.getUid())
+            .content(HttpStatus.OK)
+            .asObject(JsonPage.class);
+
+    JsonList<JsonRelationship> instances = page.getList("instances", JsonRelationship.class);
+    assertEquals(
+        1,
+        instances.size(),
+        () -> String.format("mismatch in number of expected relationship(s), got %s", instances));
+    assertEquals(2, page.getPager().getPage());
+    assertEquals(1, page.getPager().getPageSize());
+    assertEquals(2, page.getPager().getTotal());
+    assertEquals(2, page.getPager().getPageCount());
+
+    // assert deprecated fields
+    assertEquals(2, page.getPage());
+    assertEquals(1, page.getPageSize());
+    assertEquals(2, page.getTotal());
+    assertEquals(2, page.getPageCount());
+  }
+
+  @Test
+  void shouldGetNonPaginatedItemsWithSkipPaging() {
+    TrackedEntity to = trackedEntity();
+    Event from1 = event(enrollment(to));
+    Event from2 = event(enrollment(to));
+    Relationship r1 = relationship(from1, to);
+    Relationship r2 = relationship(from2, to);
+
+    JsonPage page =
+        GET("/tracker/relationships?trackedEntity={uid}&skipPaging=true", to.getUid())
+            .content(HttpStatus.OK)
+            .asObject(JsonPage.class);
+
+    assertContainsOnly(
+        List.of(r1.getUid(), r2.getUid()),
+        page.getList("instances", JsonRelationship.class)
+            .toList(JsonRelationship::getRelationship));
+    assertHasNoMember(page, "pager");
+
+    // assert deprecated fields
+    assertHasNoMember(page, "page");
+    assertHasNoMember(page, "pageSize");
+    assertHasNoMember(page, "total");
+    assertHasNoMember(page, "pageCount");
+  }
+
+  private TrackedEntityType trackedEntityTypeAccessible() {
+    TrackedEntityType type = trackedEntityType();
+    type.getSharing().addUserAccess(userAccess());
+    manager.save(type, false);
+    return type;
+  }
+
+  private TrackedEntityType trackedEntityType() {
+    TrackedEntityType type = createTrackedEntityType('A');
+    type.getSharing().setOwner(owner);
+    type.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
+    return type;
+  }
+
+  private TrackedEntity trackedEntity() {
+    TrackedEntity te = trackedEntity(orgUnit);
+    manager.save(te, false);
+    return te;
+  }
+
+  private TrackedEntity trackedEntity(OrganisationUnit orgUnit) {
+    TrackedEntity te = trackedEntity(orgUnit, trackedEntityType);
+    manager.save(te, false);
+    return te;
+  }
+
+  private TrackedEntity trackedEntity(
+      OrganisationUnit orgUnit, TrackedEntityType trackedEntityType) {
+    TrackedEntity te = createTrackedEntity(orgUnit);
+    te.setTrackedEntityType(trackedEntityType);
+    te.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
+    te.getSharing().setOwner(owner);
+    return te;
+  }
+
+  private Enrollment enrollment(TrackedEntity te) {
+    Enrollment enrollment = new Enrollment(program, te, orgUnit);
+    enrollment.setAutoFields();
+    enrollment.setEnrollmentDate(new Date());
+    enrollment.setOccurredDate(new Date());
+    enrollment.setStatus(ProgramStatus.COMPLETED);
+    manager.save(enrollment, false);
+    te.setEnrollments(Set.of(enrollment));
+    manager.save(te, false);
+    return enrollment;
+  }
+
+  private Event event(Enrollment enrollment) {
+    Event event = new Event(enrollment, programStage, orgUnit);
+    event.setAutoFields();
+    manager.save(event, false);
+    enrollment.setEvents(Set.of(event));
+    manager.save(enrollment, false);
+    return event;
+  }
+
+  private UserAccess userAccess() {
+    UserAccess a = new UserAccess();
+    a.setUser(user);
+    a.setAccess(AccessStringHelper.FULL);
+    return a;
+  }
+
+  private RelationshipType relationshipTypeAccessible() {
+    RelationshipType type = relationshipType();
+    type.getSharing().addUserAccess(userAccess());
+    manager.save(type, false);
+    return type;
+  }
+
+  private RelationshipType relationshipType() {
+    RelationshipType type = createRelationshipType('A');
+    type.getFromConstraint().setRelationshipEntity(RelationshipEntity.PROGRAM_STAGE_INSTANCE);
+    type.getToConstraint().setRelationshipEntity(RelationshipEntity.TRACKED_ENTITY_INSTANCE);
+    type.getSharing().setOwner(owner);
+    type.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
+    manager.save(type, false);
+    return type;
+  }
+
+  private Relationship relationship(Event from, TrackedEntity to) {
+    Relationship r = new Relationship();
+
+    RelationshipItem fromItem = new RelationshipItem();
+    fromItem.setEvent(from);
+    from.getRelationshipItems().add(fromItem);
+    r.setFrom(fromItem);
+    fromItem.setRelationship(r);
+
+    RelationshipItem toItem = new RelationshipItem();
+    toItem.setTrackedEntity(to);
+    to.getRelationshipItems().add(toItem);
+    r.setTo(toItem);
+    toItem.setRelationship(r);
+
+    RelationshipType type = relationshipTypeAccessible();
+    r.setRelationshipType(type);
+    r.setKey(type.getUid());
+    r.setInvertedKey(type.getUid());
+
+    r.setAutoFields();
+    r.getSharing().setOwner(owner);
+    r.setCreatedAtClient(new Date());
+    manager.save(r, false);
+    return r;
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/PageRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/PageRequestParams.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller.tracker.export;
 
 import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.common.OpenApi.Shared.Pattern;
 
 /**
  * {@link PageRequestParams} represent the HTTP request parameters that configure whether it is
@@ -39,6 +40,7 @@ import org.hisp.dhis.common.OpenApi;
  *
  * <p>{@code totalPages=true} is only supported on paginated responses.
  */
+@OpenApi.Shared(pattern = Pattern.TRACKER)
 public interface PageRequestParams {
   /** Returns the page number to be returned. */
   Integer getPage();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
@@ -45,14 +45,12 @@ import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
-import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
-import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
-import org.hisp.dhis.webapi.controller.tracker.export.OpenApiExport;
 import org.hisp.dhis.webapi.controller.tracker.view.Enrollment;
+import org.hisp.dhis.webapi.controller.tracker.view.Page;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.mapstruct.factory.Mappers;
 import org.springframework.http.ResponseEntity;
@@ -95,50 +93,35 @@ class EnrollmentsExportController {
         "enrollment", EnrollmentMapper.ORDERABLE_FIELDS, enrollmentService.getOrderableFields());
   }
 
-  @OpenApi.Response(status = Status.OK, value = OpenApiExport.ListResponse.class)
+  @OpenApi.Response(status = Status.OK, value = Page.class)
   @GetMapping(produces = APPLICATION_JSON_VALUE)
-  PagingWrapper<ObjectNode> getEnrollments(EnrollmentRequestParams enrollmentRequestParams)
+  Page<ObjectNode> getEnrollments(EnrollmentRequestParams requestParams)
       throws BadRequestException, ForbiddenException {
-    validatePaginationParameters(enrollmentRequestParams);
-    EnrollmentOperationParams operationParams = paramsMapper.map(enrollmentRequestParams);
+    validatePaginationParameters(requestParams);
+    EnrollmentOperationParams operationParams = paramsMapper.map(requestParams);
 
-    if (enrollmentRequestParams.isPaged()) {
+    if (requestParams.isPaged()) {
       PageParams pageParams =
           new PageParams(
-              enrollmentRequestParams.getPage(),
-              enrollmentRequestParams.getPageSize(),
-              enrollmentRequestParams.getTotalPages());
+              requestParams.getPage(), requestParams.getPageSize(), requestParams.getTotalPages());
 
-      Page<org.hisp.dhis.program.Enrollment> enrollmentPage =
+      org.hisp.dhis.tracker.export.Page<org.hisp.dhis.program.Enrollment> enrollmentsPage =
           enrollmentService.getEnrollments(operationParams, pageParams);
-
-      PagingWrapper.Pager.PagerBuilder pagerBuilder =
-          PagingWrapper.Pager.builder()
-              .page(enrollmentPage.getPager().getPage())
-              .pageSize(enrollmentPage.getPager().getPageSize());
-
-      if (enrollmentRequestParams.isPageTotal()) {
-        pagerBuilder
-            .pageCount(enrollmentPage.getPager().getPageCount())
-            .total(enrollmentPage.getPager().getTotal());
-      }
-
-      PagingWrapper<ObjectNode> pagingWrapper = new PagingWrapper<>();
-      pagingWrapper = pagingWrapper.withPager(pagerBuilder.build());
       List<ObjectNode> objectNodes =
           fieldFilterService.toObjectNodes(
-              ENROLLMENT_MAPPER.fromCollection(enrollmentPage.getItems()),
-              enrollmentRequestParams.getFields());
-      return pagingWrapper.withInstances(objectNodes);
+              ENROLLMENT_MAPPER.fromCollection(enrollmentsPage.getItems()),
+              requestParams.getFields());
+
+      return Page.withPager(objectNodes, enrollmentsPage);
     }
 
     Collection<org.hisp.dhis.program.Enrollment> enrollments =
         enrollmentService.getEnrollments(operationParams);
     List<ObjectNode> objectNodes =
         fieldFilterService.toObjectNodes(
-            ENROLLMENT_MAPPER.fromCollection(enrollments), enrollmentRequestParams.getFields());
-    PagingWrapper<ObjectNode> pagingWrapper = new PagingWrapper<>();
-    return pagingWrapper.withInstances(objectNodes);
+            ENROLLMENT_MAPPER.fromCollection(enrollments), requestParams.getFields());
+
+    return Page.withoutPager(objectNodes);
   }
 
   @OpenApi.Response(OpenApi.EntityType.class)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -56,17 +56,13 @@ import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
-import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
 import org.hisp.dhis.tracker.export.event.EventOperationParams;
 import org.hisp.dhis.tracker.export.event.EventParams;
 import org.hisp.dhis.tracker.export.event.EventService;
-import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
-import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper.Pager;
-import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper.Pager.PagerBuilder;
 import org.hisp.dhis.webapi.controller.tracker.export.CsvService;
-import org.hisp.dhis.webapi.controller.tracker.export.OpenApiExport;
 import org.hisp.dhis.webapi.controller.tracker.view.Event;
+import org.hisp.dhis.webapi.controller.tracker.view.Page;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.mapstruct.factory.Mappers;
@@ -119,50 +115,34 @@ class EventsExportController {
         "event", EventMapper.ORDERABLE_FIELDS, eventService.getOrderableFields());
   }
 
-  @OpenApi.Response(status = Status.OK, value = OpenApiExport.ListResponse.class)
+  @OpenApi.Response(status = Status.OK, value = Page.class)
   @GetMapping(produces = "application/json")
-  PagingWrapper<ObjectNode> getEvents(EventRequestParams eventRequestParams)
+  Page<ObjectNode> getEvents(EventRequestParams requestParams)
       throws BadRequestException, ForbiddenException {
-    validatePaginationParameters(eventRequestParams);
+    validatePaginationParameters(requestParams);
 
-    EventOperationParams eventOperationParams = eventParamsMapper.map(eventRequestParams);
+    EventOperationParams eventOperationParams = eventParamsMapper.map(requestParams);
 
-    if (eventRequestParams.isPaged()) {
+    if (requestParams.isPaged()) {
       PageParams pageParams =
           new PageParams(
-              eventRequestParams.getPage(),
-              eventRequestParams.getPageSize(),
-              eventRequestParams.getTotalPages());
+              requestParams.getPage(), requestParams.getPageSize(), requestParams.getTotalPages());
 
-      Page<org.hisp.dhis.program.Event> events =
+      org.hisp.dhis.tracker.export.Page<org.hisp.dhis.program.Event> eventsPage =
           eventService.getEvents(eventOperationParams, pageParams);
-
-      PagerBuilder pagerBuilder =
-          Pager.builder()
-              .page(events.getPager().getPage())
-              .pageSize(events.getPager().getPageSize());
-
-      if (eventRequestParams.isPageTotal()) {
-        pagerBuilder
-            .pageCount(events.getPager().getPageCount())
-            .total(events.getPager().getTotal());
-      }
-
-      PagingWrapper<ObjectNode> pagingWrapper = new PagingWrapper<>();
-      pagingWrapper = pagingWrapper.withPager(pagerBuilder.build());
       List<ObjectNode> objectNodes =
           fieldFilterService.toObjectNodes(
-              EVENTS_MAPPER.fromCollection(events.getItems()), eventRequestParams.getFields());
-      return pagingWrapper.withInstances(objectNodes);
+              EVENTS_MAPPER.fromCollection(eventsPage.getItems()), requestParams.getFields());
+
+      return Page.withPager(objectNodes, eventsPage);
     }
 
     List<org.hisp.dhis.program.Event> events = eventService.getEvents(eventOperationParams);
     List<ObjectNode> objectNodes =
         fieldFilterService.toObjectNodes(
-            EVENTS_MAPPER.fromCollection(events), eventRequestParams.getFields());
+            EVENTS_MAPPER.fromCollection(events), requestParams.getFields());
 
-    PagingWrapper<ObjectNode> pagingWrapper = new PagingWrapper<>();
-    return pagingWrapper.withInstances(objectNodes);
+    return Page.withoutPager(objectNodes);
   }
 
   @GetMapping(produces = CONTENT_TYPE_JSON_GZIP)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
@@ -44,12 +44,10 @@ import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
-import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
 import org.hisp.dhis.tracker.export.relationship.RelationshipOperationParams;
 import org.hisp.dhis.tracker.export.relationship.RelationshipService;
-import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
-import org.hisp.dhis.webapi.controller.tracker.export.OpenApiExport;
+import org.hisp.dhis.webapi.controller.tracker.view.Page;
 import org.hisp.dhis.webapi.controller.tracker.view.Relationship;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.mapstruct.factory.Mappers;
@@ -94,52 +92,35 @@ class RelationshipsExportController {
         relationshipService.getOrderableFields());
   }
 
-  @OpenApi.Response(status = Status.OK, value = OpenApiExport.ListResponse.class)
+  @OpenApi.Response(status = Status.OK, value = Page.class)
   @GetMapping
-  PagingWrapper<ObjectNode> getRelationships(RelationshipRequestParams relationshipRequestParams)
+  Page<ObjectNode> getRelationships(RelationshipRequestParams requestParams)
       throws NotFoundException, BadRequestException, ForbiddenException {
-    validatePaginationParameters(relationshipRequestParams);
-    RelationshipOperationParams operationParams = mapper.map(relationshipRequestParams);
+    validatePaginationParameters(requestParams);
+    RelationshipOperationParams operationParams = mapper.map(requestParams);
 
-    if (relationshipRequestParams.isPaged()) {
+    if (requestParams.isPaged()) {
       PageParams pageParams =
           new PageParams(
-              relationshipRequestParams.getPage(),
-              relationshipRequestParams.getPageSize(),
-              relationshipRequestParams.getTotalPages());
+              requestParams.getPage(), requestParams.getPageSize(), requestParams.getTotalPages());
 
-      Page<org.hisp.dhis.relationship.Relationship> relationshipsPage =
+      org.hisp.dhis.tracker.export.Page<org.hisp.dhis.relationship.Relationship> relationshipsPage =
           relationshipService.getRelationships(operationParams, pageParams);
-
-      PagingWrapper.Pager.PagerBuilder pagerBuilder =
-          PagingWrapper.Pager.builder()
-              .page(relationshipsPage.getPager().getPage())
-              .pageSize(relationshipsPage.getPager().getPageSize());
-
-      if (relationshipRequestParams.isPageTotal()) {
-        pagerBuilder
-            .pageCount(relationshipsPage.getPager().getPageCount())
-            .total(relationshipsPage.getPager().getTotal());
-      }
-
-      PagingWrapper<ObjectNode> pagingWrapper = new PagingWrapper<>();
-      pagingWrapper = pagingWrapper.withPager(pagerBuilder.build());
       List<ObjectNode> objectNodes =
           fieldFilterService.toObjectNodes(
               RELATIONSHIP_MAPPER.fromCollection(relationshipsPage.getItems()),
-              relationshipRequestParams.getFields());
-      return pagingWrapper.withInstances(objectNodes);
+              requestParams.getFields());
+
+      return Page.withPager(objectNodes, relationshipsPage);
     }
 
     List<org.hisp.dhis.relationship.Relationship> relationships =
         relationshipService.getRelationships(operationParams);
     List<ObjectNode> objectNodes =
         fieldFilterService.toObjectNodes(
-            RELATIONSHIP_MAPPER.fromCollection(relationships),
-            relationshipRequestParams.getFields());
+            RELATIONSHIP_MAPPER.fromCollection(relationships), requestParams.getFields());
 
-    PagingWrapper<ObjectNode> pagingWrapper = new PagingWrapper<>();
-    return pagingWrapper.withInstances(objectNodes);
+    return Page.withoutPager(objectNodes);
   }
 
   @GetMapping("/{uid}")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -54,16 +54,14 @@ import org.hisp.dhis.fieldfiltering.FieldFilterParser;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityOperationParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityService;
 import org.hisp.dhis.user.CurrentUser;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
 import org.hisp.dhis.webapi.controller.tracker.export.CsvService;
-import org.hisp.dhis.webapi.controller.tracker.export.OpenApiExport;
+import org.hisp.dhis.webapi.controller.tracker.view.Page;
 import org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.ContextUtils;
@@ -126,52 +124,36 @@ class TrackedEntitiesExportController {
         trackedEntityService.getOrderableFields());
   }
 
-  @OpenApi.Response(status = Status.OK, value = OpenApiExport.ListResponse.class)
+  @OpenApi.Response(status = Status.OK, value = Page.class)
   @GetMapping(produces = APPLICATION_JSON_VALUE)
-  PagingWrapper<ObjectNode> getTrackedEntities(
-      TrackedEntityRequestParams trackedEntityRequestParams, @CurrentUser User currentUser)
+  Page<ObjectNode> getTrackedEntities(
+      TrackedEntityRequestParams requestParams, @CurrentUser User currentUser)
       throws BadRequestException, ForbiddenException, NotFoundException {
-    validatePaginationParameters(trackedEntityRequestParams);
-    TrackedEntityOperationParams operationParams =
-        paramsMapper.map(trackedEntityRequestParams, currentUser);
-    if (trackedEntityRequestParams.isPaged()) {
+    validatePaginationParameters(requestParams);
+    TrackedEntityOperationParams operationParams = paramsMapper.map(requestParams, currentUser);
+    if (requestParams.isPaged()) {
       PageParams pageParams =
           new PageParams(
-              trackedEntityRequestParams.getPage(),
-              trackedEntityRequestParams.getPageSize(),
-              trackedEntityRequestParams.getTotalPages());
+              requestParams.getPage(), requestParams.getPageSize(), requestParams.getTotalPages());
 
-      Page<org.hisp.dhis.trackedentity.TrackedEntity> trackedEntityPage =
-          trackedEntityService.getTrackedEntities(operationParams, pageParams);
-
-      PagingWrapper.Pager.PagerBuilder pagerBuilder =
-          PagingWrapper.Pager.builder()
-              .page(trackedEntityPage.getPager().getPage())
-              .pageSize(trackedEntityPage.getPager().getPageSize());
-
-      if (trackedEntityRequestParams.isPageTotal()) {
-        pagerBuilder
-            .pageCount(trackedEntityPage.getPager().getPageCount())
-            .total(trackedEntityPage.getPager().getTotal());
-      }
-
-      PagingWrapper<ObjectNode> pagingWrapper = new PagingWrapper<>();
-      pagingWrapper = pagingWrapper.withPager(pagerBuilder.build());
+      org.hisp.dhis.tracker.export.Page<org.hisp.dhis.trackedentity.TrackedEntity>
+          trackedEntitiesPage =
+              trackedEntityService.getTrackedEntities(operationParams, pageParams);
       List<ObjectNode> objectNodes =
           fieldFilterService.toObjectNodes(
-              TRACKED_ENTITY_MAPPER.fromCollection(trackedEntityPage.getItems()),
-              trackedEntityRequestParams.getFields());
-      return pagingWrapper.withInstances(objectNodes);
+              TRACKED_ENTITY_MAPPER.fromCollection(trackedEntitiesPage.getItems()),
+              requestParams.getFields());
+
+      return Page.withPager(objectNodes, trackedEntitiesPage);
     }
 
     List<org.hisp.dhis.trackedentity.TrackedEntity> trackedEntities =
         trackedEntityService.getTrackedEntities(operationParams);
     List<ObjectNode> objectNodes =
         fieldFilterService.toObjectNodes(
-            TRACKED_ENTITY_MAPPER.fromCollection(trackedEntities),
-            trackedEntityRequestParams.getFields());
-    PagingWrapper<ObjectNode> pagingWrapper = new PagingWrapper<>();
-    return pagingWrapper.withInstances(objectNodes);
+            TRACKED_ENTITY_MAPPER.fromCollection(trackedEntities), requestParams.getFields());
+
+    return Page.withoutPager(objectNodes);
   }
 
   @GetMapping(produces = {CONTENT_TYPE_CSV, CONTENT_TYPE_TEXT_CSV})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Page.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Page.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.view;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.common.OpenApi.Shared.Pattern;
+
+// TODO(tracker): revisit if we can create a Page class used by all products when we removed the
+// deprecated fields
+/**
+ * Translates {@link org.hisp.dhis.tracker.export.Page} to its JSON representation. Future changes
+ * need to be consistent with how pagination is done across products.
+ */
+@OpenApi.Shared(pattern = Pattern.TRACKER)
+@Getter
+@ToString
+@EqualsAndHashCode
+public class Page<T> {
+  @OpenApi.Property(value = OpenApi.EntityType[].class)
+  @JsonProperty
+  private final List<T> instances;
+
+  @JsonProperty private final Pager pager;
+
+  /**
+   * @deprecated in favor of {@link Pager#page}
+   */
+  @Deprecated(since = "2.41")
+  @JsonProperty
+  private final Integer page;
+
+  /**
+   * @deprecated in favor of {@link Pager#pageSize}
+   */
+  @Deprecated(since = "2.41")
+  @JsonProperty
+  private final Integer pageSize;
+
+  /**
+   * @deprecated in favor of {@link Pager#total}
+   */
+  @Deprecated(since = "2.41")
+  @JsonProperty
+  private final Long total;
+
+  /**
+   * @deprecated in favor of {@link Pager#pageCount}
+   */
+  @Deprecated(since = "2.41")
+  @JsonProperty
+  private final Integer pageCount;
+
+  private Page(List<T> instances, org.hisp.dhis.common.Pager pager, boolean showPageTotal) {
+    this.instances = instances;
+    if (pager == null) {
+      this.pager = null;
+      this.page = null;
+      this.pageSize = null;
+      this.total = null;
+      this.pageCount = null;
+      return;
+    }
+
+    this.page = pager.getPage();
+    this.pageSize = pager.getPageSize();
+    if (showPageTotal) {
+      this.total = pager.getTotal();
+      this.pageCount = pager.getPageCount();
+      this.pager =
+          new Pager(pager.getPage(), pager.getPageSize(), pager.getTotal(), pager.getPageCount());
+    } else {
+      this.total = null;
+      this.pageCount = null;
+      this.pager = new Pager(pager.getPage(), pager.getPageSize(), null, null);
+    }
+  }
+
+  /**
+   * Returns a page which will serialize the items into {@link #instances}. Pagination details will
+   * be serialized as well including totals only if {@link
+   * org.hisp.dhis.tracker.export.Page#isPageTotal()} is true.
+   */
+  public static <T, U> Page<T> withPager(
+      List<T> items, org.hisp.dhis.tracker.export.Page<U> pager) {
+    return new Page<>(items, pager.getPager(), pager.isPageTotal());
+  }
+
+  /**
+   * Returns a page which will only serialize the items into {@link #instances}. All other fields
+   * will be omitted from the JSON.
+   */
+  public static <T> Page<T> withoutPager(List<T> items) {
+    return new Page<>(items, null, false);
+  }
+
+  @OpenApi.Shared(pattern = Pattern.TRACKER)
+  @ToString
+  @EqualsAndHashCode
+  @AllArgsConstructor
+  public static class Pager {
+    @JsonProperty private Integer page;
+    @JsonProperty private Integer pageSize;
+    @JsonProperty private Long total;
+    @JsonProperty private Integer pageCount;
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Page.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Page.java
@@ -36,7 +36,7 @@ import lombok.ToString;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.OpenApi.Shared.Pattern;
 
-// TODO(tracker): revisit if we can create a Page class used by all products when we removed the
+// TODO(tracker): revisit if we can create a Page class used by all products when we remove the
 // deprecated fields
 /**
  * Translates {@link org.hisp.dhis.tracker.export.Page} to its JSON representation. Future changes

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiFinalise.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiFinalise.java
@@ -439,7 +439,8 @@ public class ApiFinalise {
                                     format("*.parameter.%s.description", parameter.getFullName()),
                                     format(
                                         "*.parameter.%s.description",
-                                        getSharedNameForDeclaringType(parameter)))
+                                        getSharedNameForDeclaringType(parameter)),
+                                    format("*.parameter.*.%s.description", parameter.getName()))
                                 : List.of(
                                     format(
                                         "%s.parameter.%s.description", name, parameter.getName()),

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/Descriptions.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/Descriptions.md
@@ -1,5 +1,25 @@
 ## Common for all endpoints
 
+### `*.parameter.*.page`
+
+Get given number of pages. Defaults to `1`.
+
+### `*.parameter.*.pageSize`
+
+Get given number of entries per page. Defaults to `50`.
+
+### `*.parameter.*.totalPages`
+
+Get the total number of pages and entries by specifying `totalPages=true`. Defaults to `false`.
+
+### `*.parameter.*.skipPaging`
+
+Get all entries by specifying `skipPaging=true`. Defaults to `false`, meaning that by default
+requests are paginated.
+
+**Be aware that the performance is directly related to the amount of data requested. Larger pages
+will take more time to return.**
+
 ### `*.parameter.PagingAndSortingCriteriaAdapter.page`
 
 Get given number of pages. Defaults to `1`.
@@ -14,14 +34,17 @@ Get the total number of pages by specifying `totalPages=true`. Defaults to `fals
 
 ### `*.parameter.PagingAndSortingCriteriaAdapter.skipPaging`
 
-Get all entries by specifying `skipPaging=true`. Defaults to `false`, meaning that by default requests are paginated.
+Get all entries by specifying `skipPaging=true`. Defaults to `false`, meaning that by default
+requests are paginated.
 
-**Be aware that the performance is directly related to the amount of data requested. Larger pages will take more time to
+**Be aware that the performance is directly related to the amount of data requested. Larger pages
+will take more time to
 return.**
 
 ### `*.parameter.PagingAndSortingCriteriaAdapter.order`
 
 `<propertyName1:sortDirection>[,<propertyName2:sortDirection>...]`
 
-Get entries in given order. Valid `sortDirection`s are `asc` and `desc`. `propName` is case-sensitive, `sortDirection`
+Get entries in given order. Valid `sortDirection`s are `asc` and `desc`. `propName` is
+case-sensitive, `sortDirection`
 is case-insensitive.


### PR DESCRIPTION
* Expose paging information in `pager` object as is done by all other products
* Deprecate flat/unwrapped paging related fields
* Test permutations as tracker exporters allow enabling/disabling pagination as well as showing totals when paging is enabled
* Remove unused `PagingWrapper.fromLegacy`
* Remove unused OpenApiExport.java (git shows it as moved to assertion class `test/java/org/hisp/dhis/webapi/controller/tracker/JsonPage.java` which is wrong)
* Document common paging parameters like `*.parameter.*.page`. This required adding a fallback into `OpenApiFinalize.describeController`. Done with help of @jbee 🥇 

## Design

Chose to follow our current approach in separating internal representations like `org.hisp.dhis.tracker.export.Page`/`org.hisp.dhis.common.Pager` from the view (JSON) `org.hisp.dhis.webapi.controller.tracker.view.Page`.
