### PR TITLE
chore: Use Java 17 to resolve Sonar failure in CI pipeline

### DIFF
--- a/.github/workflows/analyse-pr.yml
+++ b/.github/workflows/analyse-pr.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
           cache: maven
 


### PR DESCRIPTION
The CI pipeline is failing for 2.40 because Sonar no longer allows use of Java 11 it seems.