### PR TITLE
format: Fix formatting in e2e tests

### DIFF
--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/utils/DataGenerator.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/utils/DataGenerator.java
@@ -66,10 +66,13 @@ public class DataGenerator {
   public static JsonElement generateRandomValueMatchingSchema(SchemaProperty property) {
     JsonElement jsonElement;
     switch (property.getPropertyType()) {
-      case STRING -> jsonElement =
-          new JsonPrimitive(
-              generateStringByFieldName(
-                  property.getName(), property.getMin().intValue(), property.getMax().intValue()));
+      case STRING ->
+          jsonElement =
+              new JsonPrimitive(
+                  generateStringByFieldName(
+                      property.getName(),
+                      property.getMin().intValue(),
+                      property.getMax().intValue()));
       case DATE -> {
         Date date = faker.date().past(1000, TimeUnit.DAYS);
         jsonElement =
@@ -83,11 +86,12 @@ public class DataGenerator {
         jsonElement = new JsonPrimitive(String.valueOf(faker.bool().bool()));
       }
       case CONSTANT -> jsonElement = generateConstantValue(property);
-      case NUMBER -> jsonElement =
-          new JsonPrimitive(
-              faker
-                  .number()
-                  .numberBetween(property.getMin().intValue(), property.getMax().intValue()));
+      case NUMBER ->
+          jsonElement =
+              new JsonPrimitive(
+                  faker
+                      .number()
+                      .numberBetween(property.getMin().intValue(), property.getMax().intValue()));
       default -> jsonElement = new JsonPrimitive("Conversion not defined.");
     }
 


### PR DESCRIPTION
Last version of spotless add some changes and our formatting in e2e tests is not valid anymore.
Dependabot PR was approved and a failure in the formatting checks is not preventing the PR from being merged.