### PR TITLE
fix: unified MODIFIED_Z_SCORE and relative period time

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/analytics/OutlierDetectionAlgorithm.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/analytics/OutlierDetectionAlgorithm.java
@@ -35,5 +35,5 @@ package org.hisp.dhis.analytics;
 public enum OutlierDetectionAlgorithm {
   Z_SCORE,
   MIN_MAX,
-  MOD_Z_SCORE;
+  MODIFIED_Z_SCORE;
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/Order.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/Order.java
@@ -46,7 +46,7 @@ import org.hisp.dhis.analytics.common.ColumnHeader;
 @RequiredArgsConstructor
 public enum Order {
   Z_SCORE(ZSCORE.getItem(), "z_score"),
-  MODIFIED_ZSCORE(ColumnHeader.MODIFIED_ZSCORE.getItem(), "z_score"),
+  MODIFIED_Z_SCORE(ColumnHeader.MODIFIED_Z_SCORE.getItem(), "z_score"),
   VALUE("value", "value"),
   MEDIAN(ColumnHeader.MEDIAN.getItem(), "middle_value"),
   MEAN(ColumnHeader.MEAN.getItem(), "middle_value"),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierQueryParams.java
@@ -70,6 +70,8 @@ public class OutlierQueryParams {
 
   private Date dataEndDate;
 
+  private Date relativePeriodDate;
+
   private Order orderBy;
 
   private SortOrder sortOrder;
@@ -89,6 +91,7 @@ public class OutlierQueryParams {
     key.add(dataEndDate);
     key.add(startDate);
     key.add(endDate);
+    key.add(relativePeriodDate);
     key.add(pe);
     key.add(maxResults);
     key.add(algorithm);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierQueryParser.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/data/OutlierQueryParser.java
@@ -31,6 +31,7 @@ import static java.util.stream.Collectors.toList;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -86,7 +87,7 @@ public class OutlierQueryParser {
             .dataElements(dataElements)
             .startDate(queryParams.getStartDate())
             .endDate(queryParams.getEndDate())
-            .periods(getPeriods(queryParams.getPe()))
+            .periods(getPeriods(queryParams.getPe(), queryParams.getRelativePeriodDate()))
             .orgUnits(getOrganisationUnits(queryParams))
             .analyzeOnly(analyzeOnly)
             .dataStartDate(queryParams.getDataStartDate())
@@ -152,12 +153,12 @@ public class OutlierQueryParser {
    * @param relativePeriod the {@link RelativePeriodEnum}.
    * @return list of the {@link Period}.
    */
-  private List<Period> getPeriods(RelativePeriodEnum relativePeriod) {
+  private List<Period> getPeriods(RelativePeriodEnum relativePeriod, Date relativePeriodDate) {
     if (relativePeriod == null) {
       return new ArrayList<>();
     }
     return dimensionalObjectProducer
-        .getPeriodDimension(List.of(relativePeriod.name()), null)
+        .getPeriodDimension(List.of(relativePeriod.name()), relativePeriodDate)
         .getItems()
         .stream()
         .map(pe -> (Period) pe)

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsOutlierService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsOutlierService.java
@@ -277,7 +277,7 @@ public class AnalyticsOutlierService {
   private void setMetaData(Grid grid, List<Outlier> outliers, OutlierRequest request) {
     grid.addMetaData("algorithm", request.getAlgorithm());
     grid.addMetaData("threshold", request.getThreshold());
-    grid.addMetaData("orderBy", request.getOrderBy().getColumnName());
+    grid.addMetaData("orderBy", request.getOrderBy());
     grid.addMetaData("maxResults", request.getMaxResults());
     grid.addMetaData("count", outliers.size());
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsOutlierService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsOutlierService.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.analytics.outlier.service;
 
-import static org.hisp.dhis.analytics.OutlierDetectionAlgorithm.MOD_Z_SCORE;
+import static org.hisp.dhis.analytics.OutlierDetectionAlgorithm.MODIFIED_Z_SCORE;
 import static org.hisp.dhis.analytics.common.ColumnHeader.ABSOLUTE_DEVIATION;
 import static org.hisp.dhis.analytics.common.ColumnHeader.ATTRIBUTE_OPTION_COMBO;
 import static org.hisp.dhis.analytics.common.ColumnHeader.ATTRIBUTE_OPTION_COMBO_NAME;
@@ -39,7 +39,6 @@ import static org.hisp.dhis.analytics.common.ColumnHeader.LOWER_BOUNDARY;
 import static org.hisp.dhis.analytics.common.ColumnHeader.MEAN;
 import static org.hisp.dhis.analytics.common.ColumnHeader.MEDIAN;
 import static org.hisp.dhis.analytics.common.ColumnHeader.MEDIAN_ABS_DEVIATION;
-import static org.hisp.dhis.analytics.common.ColumnHeader.MODIFIED_ZSCORE;
 import static org.hisp.dhis.analytics.common.ColumnHeader.ORG_UNIT;
 import static org.hisp.dhis.analytics.common.ColumnHeader.ORG_UNIT_NAME;
 import static org.hisp.dhis.analytics.common.ColumnHeader.ORG_UNIT_NAME_HIERARCHY;
@@ -63,6 +62,7 @@ import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.analytics.cache.OutliersCache;
+import org.hisp.dhis.analytics.common.ColumnHeader;
 import org.hisp.dhis.analytics.common.TableInfoReader;
 import org.hisp.dhis.analytics.data.DimensionalObjectProducer;
 import org.hisp.dhis.analytics.outlier.data.Outlier;
@@ -198,10 +198,12 @@ public class AnalyticsOutlierService {
   }
 
   private void setHeaders(Grid grid, OutlierRequest request) {
-    boolean isModifiedZScore = request.getAlgorithm() == MOD_Z_SCORE;
+    boolean isModifiedZScore = request.getAlgorithm() == MODIFIED_Z_SCORE;
 
-    String zScoreOrModZScoreItem = isModifiedZScore ? MODIFIED_ZSCORE.getItem() : ZSCORE.getItem();
-    String zScoreOrModZScoreName = isModifiedZScore ? MODIFIED_ZSCORE.getName() : ZSCORE.getName();
+    String zScoreOrModZScoreItem =
+        isModifiedZScore ? ColumnHeader.MODIFIED_Z_SCORE.getItem() : ZSCORE.getItem();
+    String zScoreOrModZScoreName =
+        isModifiedZScore ? ColumnHeader.MODIFIED_Z_SCORE.getName() : ZSCORE.getName();
 
     String meanOrMedianItem = isModifiedZScore ? MEDIAN.getItem() : MEAN.getItem();
     String meanOrMedianName = isModifiedZScore ? MEDIAN.getName() : MEAN.getName();
@@ -291,7 +293,7 @@ public class AnalyticsOutlierService {
     User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
     outliers.forEach(
         outlier -> {
-          boolean isModifiedZScore = outlierRequest.getAlgorithm() == MOD_Z_SCORE;
+          boolean isModifiedZScore = outlierRequest.getAlgorithm() == MODIFIED_Z_SCORE;
           OrganisationUnit ou = organisationUnitService.getOrganisationUnit(outlier.getOu());
           Collection<OrganisationUnit> roots =
               currentUser != null ? currentUser.getOrganisationUnits() : null;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreOutlierDetector.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreOutlierDetector.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.analytics.outlier.service;
 
 import static java.lang.Double.NaN;
 import static org.apache.commons.math3.util.Precision.round;
-import static org.hisp.dhis.analytics.OutlierDetectionAlgorithm.MOD_Z_SCORE;
+import static org.hisp.dhis.analytics.OutlierDetectionAlgorithm.MODIFIED_Z_SCORE;
 import static org.hisp.dhis.analytics.outlier.OutlierHelper.withExceptionHandling;
 import static org.hisp.dhis.period.PeriodType.getIsoPeriod;
 
@@ -57,8 +57,8 @@ import org.springframework.stereotype.Repository;
  * z-score.
  *
  * <p>This both implements the {@link OutlierDetectionAlgorithm#Z_SCORE} and {@link
- * OutlierDetectionAlgorithm#MOD_Z_SCORE}. Usual z-score uses the mean as middle value whereas the
- * modified z-score uses the median as middle value or more mathematically correct as the
+ * OutlierDetectionAlgorithm#MODIFIED_Z_SCORE}. Usual z-score uses the mean as middle value whereas
+ * the modified z-score uses the median as middle value or more mathematically correct as the
  * <em>measure of central tendency</em>.
  */
 @Slf4j
@@ -82,7 +82,7 @@ public class AnalyticsZScoreOutlierDetector {
     String sql = sqlStatementProcessor.getSqlStatement(request);
     SqlParameterSource params = sqlStatementProcessor.getSqlParameterSource(request);
     Calendar calendar = PeriodType.getCalendar();
-    boolean modifiedZ = request.getAlgorithm() == MOD_Z_SCORE;
+    boolean modifiedZ = request.getAlgorithm() == MODIFIED_Z_SCORE;
 
     return withExceptionHandling(
             () -> jdbcTemplate.query(sql, params, getRowMapper(calendar, modifiedZ)))

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreSqlStatementProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreSqlStatementProcessor.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.analytics.outlier.service;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.hisp.dhis.analytics.OutlierDetectionAlgorithm.MOD_Z_SCORE;
+import static org.hisp.dhis.analytics.OutlierDetectionAlgorithm.MODIFIED_Z_SCORE;
 import static org.hisp.dhis.analytics.outlier.Order.MEAN_ABS_DEV;
 import static org.hisp.dhis.analytics.outlier.data.OutlierSqlParams.DATA_ELEMENT_IDS;
 import static org.hisp.dhis.analytics.outlier.data.OutlierSqlParams.END_DATE;
@@ -51,8 +51,8 @@ import org.springframework.stereotype.Component;
  * analytics tables are used for it.
  *
  * <p>This both implements the {@link OutlierDetectionAlgorithm#Z_SCORE} and {@link
- * OutlierDetectionAlgorithm#MOD_Z_SCORE}. Usual z-score uses the mean as middle value whereas the
- * modified z-score uses the median as middle value or more mathematically correct as the
+ * OutlierDetectionAlgorithm#MODIFIED_Z_SCORE}. Usual z-score uses the mean as middle value whereas
+ * the modified z-score uses the median as middle value or more mathematically correct as the
  * <em>measure of central tendency</em>.
  */
 @Component
@@ -138,7 +138,7 @@ public class AnalyticsZScoreSqlStatementProcessor implements OutlierSqlStatement
 
     String ouPathClause = OutlierHelper.getOrgUnitPathClause(request.getOrgUnits(), "ax");
 
-    boolean modifiedZ = request.getAlgorithm() == MOD_Z_SCORE;
+    boolean modifiedZ = request.getAlgorithm() == MODIFIED_Z_SCORE;
 
     String middleValue = modifiedZ ? " ax.percentile_middle_value" : " ax.avg_middle_value";
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZscoreSqlStatementProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZscoreSqlStatementProcessorTest.java
@@ -30,7 +30,7 @@ package org.hisp.dhis.analytics.outlier.service;
 import static org.hisp.dhis.DhisConvenienceTest.createDataElement;
 import static org.hisp.dhis.DhisConvenienceTest.createOrganisationUnit;
 import static org.hisp.dhis.DhisConvenienceTest.getDate;
-import static org.hisp.dhis.analytics.OutlierDetectionAlgorithm.MOD_Z_SCORE;
+import static org.hisp.dhis.analytics.OutlierDetectionAlgorithm.MODIFIED_Z_SCORE;
 import static org.hisp.dhis.analytics.OutlierDetectionAlgorithm.Z_SCORE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -102,7 +102,7 @@ class AnalyticsZscoreSqlStatementProcessorTest {
         .startDate(getDate(2020, 1, 1))
         .endDate(getDate(2020, 3, 1))
         .orgUnits(Lists.newArrayList(ouA, ouB))
-        .algorithm(MOD_Z_SCORE)
+        .algorithm(MODIFIED_Z_SCORE)
         .build();
     String sql = subject.getSqlStatement(builder.build());
     assertTrue(sql.contains("percentile_middle_value"));

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/analytics/common/ColumnHeader.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/analytics/common/ColumnHeader.java
@@ -69,7 +69,7 @@ public enum ColumnHeader {
   MEDIAN_ABS_DEVIATION("medianabsdeviation", "Median absolute deviation"),
   STANDARD_DEVIATION("stddev", "Standard deviation"),
   ABSOLUTE_DEVIATION("absdev", "Absolute deviation"),
-  MODIFIED_ZSCORE("modifiedzscore", "Modified zScore"),
+  MODIFIED_Z_SCORE("modifiedzscore", "Modified zScore"),
   ZSCORE("zscore", "zScore"),
   LOWER_BOUNDARY("lowerbound", "Lower boundary"),
   UPPER_BOUNDARY("upperbound", "Upper boundary");

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/utils/DataGenerator.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/utils/DataGenerator.java
@@ -66,10 +66,13 @@ public class DataGenerator {
   public static JsonElement generateRandomValueMatchingSchema(SchemaProperty property) {
     JsonElement jsonElement;
     switch (property.getPropertyType()) {
-      case STRING -> jsonElement =
-          new JsonPrimitive(
-              generateStringByFieldName(
-                  property.getName(), property.getMin().intValue(), property.getMax().intValue()));
+      case STRING ->
+          jsonElement =
+              new JsonPrimitive(
+                  generateStringByFieldName(
+                      property.getName(),
+                      property.getMin().intValue(),
+                      property.getMax().intValue()));
       case DATE -> {
         Date date = faker.date().past(1000, TimeUnit.DAYS);
         jsonElement =
@@ -83,11 +86,12 @@ public class DataGenerator {
         jsonElement = new JsonPrimitive(String.valueOf(faker.bool().bool()));
       }
       case CONSTANT -> jsonElement = generateConstantValue(property);
-      case NUMBER -> jsonElement =
-          new JsonPrimitive(
-              faker
-                  .number()
-                  .numberBetween(property.getMin().intValue(), property.getMax().intValue()));
+      case NUMBER ->
+          jsonElement =
+              new JsonPrimitive(
+                  faker
+                      .number()
+                      .numberBetween(property.getMin().intValue(), property.getMax().intValue()));
       default -> jsonElement = new JsonPrimitive("Conversion not defined.");
     }
 

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/NoAnalyticsTablesErrorsScenariosTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/NoAnalyticsTablesErrorsScenariosTest.java
@@ -151,7 +151,7 @@ public class NoAnalyticsTablesErrorsScenariosTest {
             .add("ou=O6uvpzGd5pu,fdc6uOvgoji")
             .add("maxResults=100")
             .add("startDate=2020-10-01")
-            .add("algorithm=MOD_Z_SCORE");
+            .add("algorithm=MODIFIED_Z_SCORE");
 
     // When
     ApiResponse response = analyticsOutlierActions.query().get("", JSON, JSON, params);

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection1AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection1AutoTest.java
@@ -342,11 +342,11 @@ public class OutliersDetection1AutoTest extends AnalyticsApiTest {
             .add("endDate=2023-01-02")
             .add("ou=O6uvpzGd5pu,fdc6uOvgoji")
             .add("maxResults=30")
-            .add("orderBy=modified_zscore")
+            .add("orderBy=modified_z_score")
             .add("threshold=10")
             .add("startDate=2022-10-01")
             .add("ds=BfMAe6Itzgt")
-            .add("algorithm=MOD_Z_SCORE");
+            .add("algorithm=MODIFIED_Z_SCORE");
 
     // When
     ApiResponse response = actions.query().get("", JSON, JSON, params);
@@ -446,9 +446,9 @@ public class OutliersDetection1AutoTest extends AnalyticsApiTest {
             .add("endDate=2023-01-02")
             .add("ou=O6uvpzGd5pu,fdc6uOvgoji")
             .add("maxResults=30")
-            .add("orderBy=modified_zscore")
+            .add("orderBy=modified_z_score")
             .add("startDate=2022-10-01")
-            .add("algorithm=MOD_Z_SCORE");
+            .add("algorithm=MODIFIED_Z_SCORE");
 
     // When
     ApiResponse response = actions.query().get("", JSON, JSON, params);

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection1AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection1AutoTest.java
@@ -77,7 +77,7 @@ public class OutliersDetection1AutoTest extends AnalyticsApiTest {
 
     // Assert metaData.
     String expectedMetaData =
-        "{\"count\":5,\"orderBy\":\"z_score\",\"threshold\":\"3.0\",\"maxResults\":30,\"algorithm\":\"Z_SCORE\"}";
+        "{\"count\":5,\"orderBy\":\"Z_SCORE\",\"threshold\":\"3.0\",\"maxResults\":30,\"algorithm\":\"Z_SCORE\"}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
@@ -275,7 +275,7 @@ public class OutliersDetection1AutoTest extends AnalyticsApiTest {
 
     // Assert metaData.
     String expectedMetaData =
-        "{\"count\":0,\"orderBy\":\"z_score\",\"threshold\":\"5.0\",\"maxResults\":30,\"algorithm\":\"Z_SCORE\"}";
+        "{\"count\":0,\"orderBy\":\"Z_SCORE\",\"threshold\":\"5.0\",\"maxResults\":30,\"algorithm\":\"Z_SCORE\"}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
@@ -363,7 +363,7 @@ public class OutliersDetection1AutoTest extends AnalyticsApiTest {
 
     // Assert metaData.
     String expectedMetaData =
-        "{\"count\":0,\"orderBy\":\"z_score\",\"threshold\":\"10.0\",\"maxResults\":30,\"algorithm\":\"MOD_Z_SCORE\"}";
+        "{\"count\":0,\"orderBy\":\"MODIFIED_Z_SCORE\",\"threshold\":\"10.0\",\"maxResults\":30,\"algorithm\":\"MODIFIED_Z_SCORE\"}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
@@ -465,7 +465,7 @@ public class OutliersDetection1AutoTest extends AnalyticsApiTest {
 
     // Assert metaData.
     String expectedMetaData =
-        "{\"count\":0,\"orderBy\":\"z_score\",\"threshold\":\"3.0\",\"maxResults\":30,\"algorithm\":\"MOD_Z_SCORE\"}";
+        "{\"count\":0,\"orderBy\":\"MODIFIED_Z_SCORE\",\"threshold\":\"3.0\",\"maxResults\":30,\"algorithm\":\"MODIFIED_Z_SCORE\"}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection2AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection2AutoTest.java
@@ -57,9 +57,9 @@ public class OutliersDetection2AutoTest extends AnalyticsApiTest {
             .add("endDate=2023-01-02")
             .add("ou=O6uvpzGd5pu,fdc6uOvgoji")
             .add("maxResults=30")
-            .add("orderBy=modified_zscore")
+            .add("orderBy=modified_z_score")
             .add("startDate=2022-10-01")
-            .add("algorithm=MOD_Z_SCORE");
+            .add("algorithm=MODIFIED_Z_SCORE");
 
     // When
     ApiResponse response = actions.query().get("", JSON, JSON, params);
@@ -254,11 +254,11 @@ public class OutliersDetection2AutoTest extends AnalyticsApiTest {
             .add("endDate=2023-10-26")
             .add("ou=ImspTQPwCqd")
             .add("maxResults=5")
-            .add("orderBy=modified_zscore")
+            .add("orderBy=modified_z_score")
             .add("threshold=3.0")
             .add("startDate=2022-07-26")
             .add("ds=BfMAe6Itzgt")
-            .add("algorithm=MOD_Z_SCORE");
+            .add("algorithm=MODIFIED_Z_SCORE");
 
     // When
     ApiResponse response = actions.query().get("", JSON, JSON, params);

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection2AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection2AutoTest.java
@@ -76,7 +76,7 @@ public class OutliersDetection2AutoTest extends AnalyticsApiTest {
 
     // Assert metaData.
     String expectedMetaData =
-        "{\"count\":0,\"orderBy\":\"z_score\",\"threshold\":\"3.0\",\"maxResults\":30,\"algorithm\":\"MOD_Z_SCORE\"}";
+        "{\"count\":0,\"orderBy\":\"MODIFIED_Z_SCORE\",\"threshold\":\"3.0\",\"maxResults\":30,\"algorithm\":\"MODIFIED_Z_SCORE\"}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
@@ -120,7 +120,7 @@ public class OutliersDetection2AutoTest extends AnalyticsApiTest {
 
     // Assert metaData.
     String expectedMetaData =
-        "{\"count\":3,\"orderBy\":\"z_score\",\"threshold\":\"3.0\",\"maxResults\":30,\"algorithm\":\"Z_SCORE\"}";
+        "{\"count\":3,\"orderBy\":\"Z_SCORE\",\"threshold\":\"3.0\",\"maxResults\":30,\"algorithm\":\"Z_SCORE\"}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
@@ -275,7 +275,7 @@ public class OutliersDetection2AutoTest extends AnalyticsApiTest {
 
     // Assert metaData.
     String expectedMetaData =
-        "{\"count\":5,\"orderBy\":\"z_score\",\"threshold\":\"3.0\",\"maxResults\":5,\"algorithm\":\"MOD_Z_SCORE\"}";
+        "{\"count\":5,\"orderBy\":\"MODIFIED_Z_SCORE\",\"threshold\":\"3.0\",\"maxResults\":5,\"algorithm\":\"MODIFIED_Z_SCORE\"}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
@@ -330,7 +330,7 @@ public class OutliersDetection2AutoTest extends AnalyticsApiTest {
 
     // Assert metaData.
     String expectedMetaData =
-        "{\"count\":3,\"orderBy\":\"z_score\",\"threshold\":\"3.0\",\"maxResults\":30,\"algorithm\":\"Z_SCORE\"}";
+        "{\"count\":3,\"orderBy\":\"Z_SCORE\",\"threshold\":\"3.0\",\"maxResults\":30,\"algorithm\":\"Z_SCORE\"}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection3AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection3AutoTest.java
@@ -1,0 +1,1095 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.outlier;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hisp.dhis.analytics.ValidationHelper.validateHeader;
+import static org.hisp.dhis.analytics.ValidationHelper.validateRow;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+import org.hisp.dhis.AnalyticsApiTest;
+import org.hisp.dhis.actions.analytics.AnalyticsOutlierDetectionActions;
+import org.hisp.dhis.dto.ApiResponse;
+import org.hisp.dhis.helpers.QueryParamsBuilder;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+/** Groups e2e tests for "/analytics/outlierDetection" endpoint. */
+public class OutliersDetection3AutoTest extends AnalyticsApiTest {
+  private AnalyticsOutlierDetectionActions actions = new AnalyticsOutlierDetectionActions();
+
+  @Test
+  public void queryQueryoutliertest9() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("pe=THIS_YEAR")
+            .add("ou=ImspTQPwCqd")
+            .add("maxResults=20")
+            .add("orderBy=MODIFIED_Z_SCORE")
+            .add("threshold=2.5")
+            .add("ds=BfMAe6Itzgt")
+            .add("algorithm=MODIFIED_Z_SCORE")
+            .add("relativePeriodDate=2022-07-26");
+
+    // When
+    ApiResponse response = actions.query().get("", JSON, JSON, params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(18)))
+        .body("rows", hasSize(equalTo(20)))
+        .body("height", equalTo(20))
+        .body("width", equalTo(18))
+        .body("headerWidth", equalTo(18));
+
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"count\":20,\"orderBy\":\"MODIFIED_Z_SCORE\",\"threshold\":\"2.5\",\"maxResults\":20,\"algorithm\":\"MODIFIED_Z_SCORE\"}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // Assert headers.
+    validateHeader(response, 0, "dx", "Data", "TEXT", "java.lang.String", false, false);
+    validateHeader(response, 1, "dxname", "Data name", "TEXT", "java.lang.String", false, false);
+    validateHeader(response, 2, "pe", "Period", "TEXT", "java.lang.String", false, false);
+    validateHeader(response, 3, "pename", "Period name", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response, 4, "ou", "Organisation unit", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response, 5, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response,
+        6,
+        "ounamehierarchy",
+        "Organisation unit name hierarchy",
+        "TEXT",
+        "java.lang.String",
+        false,
+        false);
+    validateHeader(
+        response, 7, "coc", "Category option combo", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response,
+        8,
+        "cocname",
+        "Category option combo name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        false);
+    validateHeader(
+        response, 9, "aoc", "Attribute option combo", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response,
+        10,
+        "aocname",
+        "Attribute option combo name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        false);
+    validateHeader(response, 11, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(response, 12, "median", "Median", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response,
+        13,
+        "medianabsdeviation",
+        "Median absolute deviation",
+        "NUMBER",
+        "java.lang.Double",
+        false,
+        false);
+    validateHeader(
+        response, 14, "absdev", "Absolute deviation", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response,
+        15,
+        "modifiedzscore",
+        "Modified zScore",
+        "NUMBER",
+        "java.lang.Double",
+        false,
+        false);
+    validateHeader(
+        response, 16, "lowerbound", "Lower boundary", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 17, "upperbound", "Upper boundary", "NUMBER", "java.lang.Double", false, false);
+
+    // Assert rows.
+    validateRow(
+        response,
+        List.of(
+            "tU7GixyHhsv",
+            "Vitamin A given to < 5y",
+            "202206",
+            "202206",
+            "scc4QyxenJd",
+            "Makali CHC",
+            "/Sierra Leone/Tonkolili/Kunike Barina/Makali CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "714.0",
+            "10.0",
+            "3.0",
+            "704.0",
+            "158.28267",
+            "-559.88232",
+            "579.88232"));
+    validateRow(
+        response,
+        List.of(
+            "lVsbKXoF0zX",
+            "Weight for height below 70 percent",
+            "202206",
+            "202206",
+            "Qc9lf4VM9bD",
+            "Wellington Health Centre",
+            "/Sierra Leone/Western Area/Freetown/Wellington Health Centre",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "1540.0",
+            "27.0",
+            "7.0",
+            "1513.0",
+            "145.78836",
+            "-1075.7046",
+            "1129.7046"));
+    validateRow(
+        response,
+        List.of(
+            "bTcRDVjC66S",
+            "Weight for age below lower line (red)",
+            "202205",
+            "202205",
+            "OzjRQLn3G24",
+            "Koidu Govt. Hospital",
+            "/Sierra Leone/Kono/Gbense/Koidu Govt. Hospital",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "400.0",
+            "11.0",
+            "2.0",
+            "389.0",
+            "131.19025",
+            "-399.51583",
+            "421.51583"));
+    validateRow(
+        response,
+        List.of(
+            "O05mAByOgAv",
+            "OPV2 doses given",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "/Sierra Leone/Bo/Kakua/Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "451.0",
+            "13.0",
+            "3.0",
+            "438.0",
+            "98.477",
+            "-474.50881",
+            "500.50881"));
+    validateRow(
+        response,
+        List.of(
+            "lVsbKXoF0zX",
+            "Weight for height below 70 percent",
+            "202205",
+            "202205",
+            "OzjRQLn3G24",
+            "Koidu Govt. Hospital",
+            "/Sierra Leone/Kono/Gbense/Koidu Govt. Hospital",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "400.0",
+            "11.0",
+            "3.0",
+            "389.0",
+            "87.46017",
+            "-416.72601",
+            "438.72601"));
+    validateRow(
+        response,
+        List.of(
+            "Y53Jcc9LBYh",
+            "Children supplied with food supplemements",
+            "202202",
+            "202202",
+            "oLuhRyYPxRO",
+            "Senehun CHC",
+            "/Sierra Leone/Moyamba/Kamaje/Senehun CHC",
+            "psbwp3CQEhs",
+            "Fixed, >1y",
+            "HllvX50cXC0",
+            "default",
+            "130.0",
+            "11.0",
+            "1.0",
+            "119.0",
+            "80.2655",
+            "-84.2947",
+            "106.2947"));
+    validateRow(
+        response,
+        List.of(
+            "vI2csg55S9C",
+            "OPV3 doses given",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "/Sierra Leone/Bo/Kakua/Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "430.0",
+            "13.0",
+            "4.0",
+            "417.0",
+            "70.31663",
+            "-505.334",
+            "531.334"));
+    validateRow(
+        response,
+        List.of(
+            "n6aMJNLdvep",
+            "Penta3 doses given",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "/Sierra Leone/Bo/Kakua/Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "430.0",
+            "14.0",
+            "4.0",
+            "416.0",
+            "70.148",
+            "-463.21696",
+            "491.21696"));
+    validateRow(
+        response,
+        List.of(
+            "DUSpd8Jq3M7",
+            "Newborn protected at birth against tetanus (TT2+)",
+            "202207",
+            "202207",
+            "PQEpIeuSTCN",
+            "Tobanda CHC",
+            "/Sierra Leone/Kenema/Small Bo/Tobanda CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "111.0",
+            "10.0",
+            "1.0",
+            "101.0",
+            "68.1245",
+            "-63.42032",
+            "83.42032"));
+    validateRow(
+        response,
+        List.of(
+            "Y53Jcc9LBYh",
+            "Children supplied with food supplemements",
+            "202201",
+            "202201",
+            "agEKP19IUKI",
+            "Tambiama CHC",
+            "/Sierra Leone/Bombali/Gbendembu Ngowahun/Tambiama CHC",
+            "psbwp3CQEhs",
+            "Fixed, >1y",
+            "HllvX50cXC0",
+            "default",
+            "113.0",
+            "14.0",
+            "1.0",
+            "99.0",
+            "66.7755",
+            "-91.24442",
+            "119.24442"));
+    validateRow(
+        response,
+        List.of(
+            "Y53Jcc9LBYh",
+            "Children supplied with food supplemements",
+            "202202",
+            "202202",
+            "agEKP19IUKI",
+            "Tambiama CHC",
+            "/Sierra Leone/Bombali/Gbendembu Ngowahun/Tambiama CHC",
+            "psbwp3CQEhs",
+            "Fixed, >1y",
+            "HllvX50cXC0",
+            "default",
+            "113.0",
+            "14.0",
+            "1.0",
+            "99.0",
+            "66.7755",
+            "-91.24442",
+            "119.24442"));
+    validateRow(
+        response,
+        List.of(
+            "UOlfIjgN8X6",
+            "Fully Immunized child",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "/Sierra Leone/Bo/Kakua/Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "455.0",
+            "12.0",
+            "5.0",
+            "443.0",
+            "59.7607",
+            "-511.86253",
+            "535.86253"));
+    validateRow(
+        response,
+        List.of(
+            "I78gJm4KBo7",
+            "Penta2 doses given",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "/Sierra Leone/Bo/Kakua/Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "451.0",
+            "14.0",
+            "5.0",
+            "437.0",
+            "58.9513",
+            "-492.70519",
+            "520.70519"));
+    validateRow(
+        response,
+        List.of(
+            "l6byfWFUGaP",
+            "Yellow Fever doses given",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "/Sierra Leone/Bo/Kakua/Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "457.0",
+            "11.5",
+            "5.5",
+            "445.5",
+            "54.6345",
+            "-548.55269",
+            "571.55269"));
+    validateRow(
+        response,
+        List.of(
+            "fClA2Erf6IO",
+            "Penta1 doses given",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "/Sierra Leone/Bo/Kakua/Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "489.0",
+            "20.0",
+            "6.0",
+            "469.0",
+            "52.72342",
+            "-433.23351",
+            "473.23351"));
+    validateRow(
+        response,
+        List.of(
+            "l6byfWFUGaP",
+            "Yellow Fever doses given",
+            "202209",
+            "202209",
+            "RhJbg8UD75Q",
+            "Yemoh Town CHC",
+            "/Sierra Leone/Bo/Kakua/Yemoh Town CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "466.0",
+            "14.0",
+            "6.0",
+            "452.0",
+            "50.81233",
+            "-271.69916",
+            "299.69916"));
+    validateRow(
+        response,
+        List.of(
+            "YtbsuPPo010",
+            "Measles doses given",
+            "202209",
+            "202209",
+            "RhJbg8UD75Q",
+            "Yemoh Town CHC",
+            "/Sierra Leone/Bo/Kakua/Yemoh Town CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "466.0",
+            "14.0",
+            "6.0",
+            "452.0",
+            "50.81233",
+            "-345.66625",
+            "373.66625"));
+    validateRow(
+        response,
+        List.of(
+            "YtbsuPPo010",
+            "Measles doses given",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "/Sierra Leone/Bo/Kakua/Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "457.0",
+            "12.5",
+            "6.0",
+            "444.5",
+            "49.96921",
+            "-574.37108",
+            "599.37108"));
+    validateRow(
+        response,
+        List.of(
+            "Rmixc9wJl0G",
+            "Q_LLITN given at time of 2nd Vit A dose",
+            "202202",
+            "202202",
+            "EUUkKEDoNsf",
+            "Wilberforce CHC",
+            "/Sierra Leone/Western Area/Freetown/Wilberforce CHC",
+            "hEFKSsPV5et",
+            "Outreach, >1y",
+            "HllvX50cXC0",
+            "default",
+            "40.0",
+            "5.5",
+            "0.5",
+            "34.5",
+            "46.5405",
+            "-40.03334",
+            "51.03334"));
+    validateRow(
+        response,
+        List.of(
+            "Y53Jcc9LBYh",
+            "Children supplied with food supplemements",
+            "202201",
+            "202201",
+            "EXbPGmEUdnc",
+            "Mateboi CHC",
+            "/Sierra Leone/Bombali/Sanda Tendaren/Mateboi CHC",
+            "psbwp3CQEhs",
+            "Fixed, >1y",
+            "HllvX50cXC0",
+            "default",
+            "80.0",
+            "11.0",
+            "1.0",
+            "69.0",
+            "46.5405",
+            "-58.89506",
+            "80.89506"));
+  }
+
+  @Test
+  public void queryQueryoutliertest10() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("pe=LAST_YEAR")
+            .add("ou=ImspTQPwCqd")
+            .add("maxResults=20")
+            .add("orderBy=MODIFIED_Z_SCORE")
+            .add("threshold=2.5")
+            .add("ds=BfMAe6Itzgt")
+            .add("algorithm=MODIFIED_Z_SCORE")
+            .add("relativePeriodDate=2022-07-26");
+
+    // When
+    ApiResponse response = actions.query().get("", JSON, JSON, params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(18)))
+        .body("rows", hasSize(equalTo(20)))
+        .body("height", equalTo(20))
+        .body("width", equalTo(18))
+        .body("headerWidth", equalTo(18));
+
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"count\":20,\"orderBy\":\"MODIFIED_Z_SCORE\",\"threshold\":\"2.5\",\"maxResults\":20,\"algorithm\":\"MODIFIED_Z_SCORE\"}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // Assert headers.
+    validateHeader(response, 0, "dx", "Data", "TEXT", "java.lang.String", false, false);
+    validateHeader(response, 1, "dxname", "Data name", "TEXT", "java.lang.String", false, false);
+    validateHeader(response, 2, "pe", "Period", "TEXT", "java.lang.String", false, false);
+    validateHeader(response, 3, "pename", "Period name", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response, 4, "ou", "Organisation unit", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response, 5, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response,
+        6,
+        "ounamehierarchy",
+        "Organisation unit name hierarchy",
+        "TEXT",
+        "java.lang.String",
+        false,
+        false);
+    validateHeader(
+        response, 7, "coc", "Category option combo", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response,
+        8,
+        "cocname",
+        "Category option combo name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        false);
+    validateHeader(
+        response, 9, "aoc", "Attribute option combo", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response,
+        10,
+        "aocname",
+        "Attribute option combo name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        false);
+    validateHeader(response, 11, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(response, 12, "median", "Median", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response,
+        13,
+        "medianabsdeviation",
+        "Median absolute deviation",
+        "NUMBER",
+        "java.lang.Double",
+        false,
+        false);
+    validateHeader(
+        response, 14, "absdev", "Absolute deviation", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response,
+        15,
+        "modifiedzscore",
+        "Modified zScore",
+        "NUMBER",
+        "java.lang.Double",
+        false,
+        false);
+    validateHeader(
+        response, 16, "lowerbound", "Lower boundary", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 17, "upperbound", "Upper boundary", "NUMBER", "java.lang.Double", false, false);
+
+    // Assert rows.
+    validateRow(
+        response,
+        List.of(
+            "tU7GixyHhsv",
+            "Vitamin A given to < 5y",
+            "202106",
+            "202106",
+            "scc4QyxenJd",
+            "Makali CHC",
+            "/Sierra Leone/Tonkolili/Kunike Barina/Makali CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "714.0",
+            "10.0",
+            "3.0",
+            "704.0",
+            "158.28267",
+            "-559.88232",
+            "579.88232"));
+    validateRow(
+        response,
+        List.of(
+            "lVsbKXoF0zX",
+            "Weight for height below 70 percent",
+            "202106",
+            "202106",
+            "Qc9lf4VM9bD",
+            "Wellington Health Centre",
+            "/Sierra Leone/Western Area/Freetown/Wellington Health Centre",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "1540.0",
+            "27.0",
+            "7.0",
+            "1513.0",
+            "145.78836",
+            "-1075.7046",
+            "1129.7046"));
+    validateRow(
+        response,
+        List.of(
+            "l6byfWFUGaP",
+            "Yellow Fever doses given",
+            "202111",
+            "202111",
+            "mzsOsz0NwNY",
+            "New Police Barracks CHC",
+            "/Sierra Leone/Bo/Kakua/New Police Barracks CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "616.0",
+            "12.0",
+            "3.0",
+            "604.0",
+            "135.79933",
+            "-460.95185",
+            "484.95185"));
+    validateRow(
+        response,
+        List.of(
+            "O05mAByOgAv",
+            "OPV2 doses given",
+            "202110",
+            "202110",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "/Sierra Leone/Bo/Kakua/Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "598.0",
+            "13.0",
+            "3.0",
+            "585.0",
+            "131.5275",
+            "-474.50881",
+            "500.50881"));
+    validateRow(
+        response,
+        List.of(
+            "bTcRDVjC66S",
+            "Weight for age below lower line (red)",
+            "202105",
+            "202105",
+            "OzjRQLn3G24",
+            "Koidu Govt. Hospital",
+            "/Sierra Leone/Kono/Gbense/Koidu Govt. Hospital",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "400.0",
+            "11.0",
+            "2.0",
+            "389.0",
+            "131.19025",
+            "-399.51583",
+            "421.51583"));
+    validateRow(
+        response,
+        List.of(
+            "YtbsuPPo010",
+            "Measles doses given",
+            "202111",
+            "202111",
+            "mzsOsz0NwNY",
+            "New Police Barracks CHC",
+            "/Sierra Leone/Bo/Kakua/New Police Barracks CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "616.0",
+            "13.0",
+            "4.0",
+            "603.0",
+            "101.68088",
+            "-433.21008",
+            "459.21008"));
+    validateRow(
+        response,
+        List.of(
+            "vI2csg55S9C",
+            "OPV3 doses given",
+            "202110",
+            "202110",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "/Sierra Leone/Bo/Kakua/Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "600.0",
+            "13.0",
+            "4.0",
+            "587.0",
+            "98.98287",
+            "-505.334",
+            "531.334"));
+    validateRow(
+        response,
+        List.of(
+            "n6aMJNLdvep",
+            "Penta3 doses given",
+            "202110",
+            "202110",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "/Sierra Leone/Bo/Kakua/Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "600.0",
+            "14.0",
+            "4.0",
+            "586.0",
+            "98.81425",
+            "-463.21696",
+            "491.21696"));
+    validateRow(
+        response,
+        List.of(
+            "O05mAByOgAv",
+            "OPV2 doses given",
+            "202108",
+            "202108",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "/Sierra Leone/Bo/Kakua/Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "451.0",
+            "13.0",
+            "3.0",
+            "438.0",
+            "98.477",
+            "-474.50881",
+            "500.50881"));
+    validateRow(
+        response,
+        List.of(
+            "I78gJm4KBo7",
+            "Penta2 doses given",
+            "202111",
+            "202111",
+            "mzsOsz0NwNY",
+            "New Police Barracks CHC",
+            "/Sierra Leone/Bo/Kakua/New Police Barracks CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "580.0",
+            "19.0",
+            "4.0",
+            "561.0",
+            "94.59863",
+            "-466.05144",
+            "504.05144"));
+    validateRow(
+        response,
+        List.of(
+            "UOlfIjgN8X6",
+            "Fully Immunized child",
+            "202111",
+            "202111",
+            "mzsOsz0NwNY",
+            "New Police Barracks CHC",
+            "/Sierra Leone/Bo/Kakua/New Police Barracks CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "547.0",
+            "12.0",
+            "4.0",
+            "535.0",
+            "90.21438",
+            "-381.81919",
+            "405.81919"));
+    validateRow(
+        response,
+        List.of(
+            "lVsbKXoF0zX",
+            "Weight for height below 70 percent",
+            "202105",
+            "202105",
+            "OzjRQLn3G24",
+            "Koidu Govt. Hospital",
+            "/Sierra Leone/Kono/Gbense/Koidu Govt. Hospital",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "400.0",
+            "11.0",
+            "3.0",
+            "389.0",
+            "87.46017",
+            "-416.72601",
+            "438.72601"));
+    validateRow(
+        response,
+        List.of(
+            "vI2csg55S9C",
+            "OPV3 doses given",
+            "202111",
+            "202111",
+            "mzsOsz0NwNY",
+            "New Police Barracks CHC",
+            "/Sierra Leone/Bo/Kakua/New Police Barracks CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "530.0",
+            "12.0",
+            "4.0",
+            "518.0",
+            "87.34775",
+            "-341.38193",
+            "365.38193"));
+    validateRow(
+        response,
+        List.of(
+            "n6aMJNLdvep",
+            "Penta3 doses given",
+            "202111",
+            "202111",
+            "mzsOsz0NwNY",
+            "New Police Barracks CHC",
+            "/Sierra Leone/Bo/Kakua/New Police Barracks CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "530.0",
+            "13.0",
+            "4.0",
+            "517.0",
+            "87.17913",
+            "-351.52259",
+            "377.52259"));
+    validateRow(
+        response,
+        List.of(
+            "x3Do5e7g4Qo",
+            "OPV0 doses given",
+            "202112",
+            "202112",
+            "ui12Hyvn6jR",
+            "Wilberforce Military Hospital",
+            "/Sierra Leone/Western Area/Freetown/Wilberforce Military Hospital",
+            "V6L425pT3A0",
+            "Outreach, <1y",
+            "HllvX50cXC0",
+            "default",
+            "510.0",
+            "20.0",
+            "4.0",
+            "490.0",
+            "82.62625",
+            "-318.84634",
+            "358.84634"));
+    validateRow(
+        response,
+        List.of(
+            "Y53Jcc9LBYh",
+            "Children supplied with food supplemements",
+            "202102",
+            "202102",
+            "oLuhRyYPxRO",
+            "Senehun CHC",
+            "/Sierra Leone/Moyamba/Kamaje/Senehun CHC",
+            "psbwp3CQEhs",
+            "Fixed, >1y",
+            "HllvX50cXC0",
+            "default",
+            "130.0",
+            "11.0",
+            "1.0",
+            "119.0",
+            "80.2655",
+            "-84.2947",
+            "106.2947"));
+    validateRow(
+        response,
+        List.of(
+            "I78gJm4KBo7",
+            "Penta2 doses given",
+            "202110",
+            "202110",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "/Sierra Leone/Bo/Kakua/Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "598.0",
+            "14.0",
+            "5.0",
+            "584.0",
+            "78.7816",
+            "-492.70519",
+            "520.70519"));
+    validateRow(
+        response,
+        List.of(
+            "UOlfIjgN8X6",
+            "Fully Immunized child",
+            "202110",
+            "202110",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "/Sierra Leone/Bo/Kakua/Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "594.0",
+            "12.0",
+            "5.0",
+            "582.0",
+            "78.5118",
+            "-511.86253",
+            "535.86253"));
+    validateRow(
+        response,
+        List.of(
+            "l6byfWFUGaP",
+            "Yellow Fever doses given",
+            "202110",
+            "202110",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "/Sierra Leone/Bo/Kakua/Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "596.0",
+            "11.5",
+            "5.5",
+            "584.5",
+            "71.68095",
+            "-548.55269",
+            "571.55269"));
+    validateRow(
+        response,
+        List.of(
+            "vI2csg55S9C",
+            "OPV3 doses given",
+            "202108",
+            "202108",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "/Sierra Leone/Bo/Kakua/Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "430.0",
+            "13.0",
+            "4.0",
+            "417.0",
+            "70.31663",
+            "-505.334",
+            "531.334"));
+  }
+}


### PR DESCRIPTION
The mission of this fix is to unify the enumerators for the modified Z-score in the request and enhance the relative period data for the query parameter 'relativePeriodData.'