### PR TITLE
fix: Event import using CSV cannot have empty "Due Date"Column [DHIS2-12352]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/shared/validation/EventBaseCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/shared/validation/EventBaseCheck.java
@@ -37,7 +37,7 @@ import static org.hisp.dhis.util.DateUtils.removeTimeStamp;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import org.apache.logging.log4j.util.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.deprecated.tracker.importer.Checker;
 import org.hisp.dhis.dxf2.deprecated.tracker.importer.context.WorkContext;
@@ -76,7 +76,7 @@ public class EventBaseCheck implements Checker {
   }
 
   private void validateDates(ImmutableEvent event, List<String> errors) {
-    if (!Strings.isEmpty(
+    if (!StringUtils.isEmpty(
             event.getDueDate()) // The due date is not mandatory and can be an empty string in the
         // CSV import.
         && !dateIsValid(event.getDueDate())) {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/shared/validation/EventBaseCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/shared/validation/EventBaseCheck.java
@@ -37,6 +37,7 @@ import static org.hisp.dhis.util.DateUtils.removeTimeStamp;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import org.apache.logging.log4j.util.Strings;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.deprecated.tracker.importer.Checker;
 import org.hisp.dhis.dxf2.deprecated.tracker.importer.context.WorkContext;
@@ -75,7 +76,10 @@ public class EventBaseCheck implements Checker {
   }
 
   private void validateDates(ImmutableEvent event, List<String> errors) {
-    if (event.getDueDate() != null && !dateIsValid(event.getDueDate())) {
+    if (!Strings.isEmpty(
+            event.getDueDate()) // The due date is not mandatory and can be an empty string in the
+        // CSV import.
+        && !dateIsValid(event.getDueDate())) {
       errors.add("Invalid event due date: " + event.getDueDate());
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/shared/validation/EventBaseCheckTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/shared/validation/EventBaseCheckTest.java
@@ -68,6 +68,22 @@ class EventBaseCheckTest extends BaseValidationTest {
   }
 
   @Test
+  void shouldReportNoErrorsWhenInvalidDueDateIsEmpty() {
+    when(workContext.getProgramInstanceMap()).thenReturn(Map.of(event.getUid(), new Enrollment()));
+    event.setDueDate("");
+    ImportSummary importSummary = rule.check(new ImmutableEvent(event), workContext);
+    assertNoError(importSummary);
+  }
+
+  @Test
+  void shouldReportNoErrorsWhenInvalidDueDateIsNull() {
+    when(workContext.getProgramInstanceMap()).thenReturn(Map.of(event.getUid(), new Enrollment()));
+    event.setDueDate(null);
+    ImportSummary importSummary = rule.check(new ImmutableEvent(event), workContext);
+    assertNoError(importSummary);
+  }
+
+  @Test
   void verifyErrorOnInvalidEventDate() {
     event.setEvent(event.getUid());
     event.setEventDate("111-12-122");

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/shared/validation/EventBaseCheckTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/shared/validation/EventBaseCheckTest.java
@@ -68,7 +68,7 @@ class EventBaseCheckTest extends BaseValidationTest {
   }
 
   @Test
-  void shouldReportNoErrorsWhenInvalidDueDateIsEmpty() {
+  void shouldReportNoErrorsWhenDueDateIsEmpty() {
     when(workContext.getProgramInstanceMap()).thenReturn(Map.of(event.getUid(), new Enrollment()));
     event.setDueDate("");
     ImportSummary importSummary = rule.check(new ImmutableEvent(event), workContext);
@@ -76,7 +76,7 @@ class EventBaseCheckTest extends BaseValidationTest {
   }
 
   @Test
-  void shouldReportNoErrorsWhenInvalidDueDateIsNull() {
+  void shouldReportNoErrorsWhenDueDateIsNull() {
     when(workContext.getProgramInstanceMap()).thenReturn(Map.of(event.getUid(), new Enrollment()));
     event.setDueDate(null);
     ImportSummary importSummary = rule.check(new ImmutableEvent(event), workContext);


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-12352

[ Deprecated Tracker]

The due date in the Event payload is not mandatory, though it can be converted as an empty string in the CSV import during serialization. Therefore, we do not report an error during validation in that case.
