### PR TITLE
chore: Improve org unit hierarchy check, removing DB call

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/DefaultOrganisationUnitService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/DefaultOrganisationUnitService.java
@@ -401,18 +401,12 @@ public class DefaultOrganisationUnitService implements OrganisationUnitService {
 
   @Override
   @Transactional(readOnly = true)
-  public boolean isInUserHierarchy(User user, OrganisationUnit organisationUnit) {
-    if (user == null || isEmpty(user.getOrganisationUnits())) {
+  public boolean isInUserHierarchy(User user, OrganisationUnit orgUnit) {
+    if (user == null || isEmpty(user.getOrganisationUnits()) || orgUnit == null) {
       return false;
     }
 
-    OrganisationUnit unit = organisationUnitStore.getByUid(organisationUnit.getUid());
-
-    if (unit == null) {
-      return false;
-    }
-
-    return unit.isDescendant(user.getOrganisationUnits());
+    return orgUnit.isDescendant(user.getOrganisationUnits());
   }
 
   @Override


### PR DESCRIPTION
While reviewing a separate PR it was noticed that in `OrganisationUnitService#isInUserHierarchy` we:
- take in an `OrgUnit`
- use its `UID` to retrieve the same `OrgUnit` from the DB

This seems like a redundant step. If all tests pass this feels like a safe update.