### PR TITLE
chore: Tighten int test assertion in case of test conflicts

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataentryform/DataEntryFormServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataentryform/DataEntryFormServiceTest.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.function.Predicate;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dataset.DataSet;
@@ -130,10 +131,15 @@ class DataEntryFormServiceTest extends SingleSetupIntegrationTestBase {
     dataEntryFormService.addDataEntryForm(dataEntryFormA);
     dataEntryFormService.addDataEntryForm(dataEntryFormB);
     List<DataEntryForm> dataEntryForms = dataEntryFormService.getAllDataEntryForms();
-    assertEquals(dataEntryForms.size(), 2);
+    List<DataEntryForm> matches =
+        dataEntryForms.stream().filter(equalsNames).toList();
+    assertEquals(2, matches.size());
     assertTrue(dataEntryForms.contains(dataEntryFormA));
     assertTrue(dataEntryForms.contains(dataEntryFormB));
   }
+
+  private final Predicate<DataEntryForm> equalsNames =
+      form -> form.getName().equals("DataEntryFormA") || form.getName().equals("DataEntryFormB");
 
   @Test
   void testPrepareForSave() {


### PR DESCRIPTION
Tightening an existing integration test assertion in case there is some interference with other integration tests.
Master failed this test after a recent feature was merged (which has tests which create DataEntryForms)