### PR TITLE
chore: Add API ping request ignoring config

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -70,6 +70,7 @@ import org.springframework.security.authentication.DefaultAuthenticationEventPub
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.ObjectPostProcessor;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.security.core.session.SessionRegistryImpl;
@@ -157,6 +158,12 @@ public class DhisWebApiWebSecurityConfig {
     providerManager.setAuthenticationEventPublisher(authenticationEventPublisher);
 
     return providerManager;
+  }
+
+  @Bean
+  public WebSecurityCustomizer webSecurityCustomizer() {
+    return web ->
+        web.ignoring().requestMatchers(new AntPathRequestMatcher(apiContextPath + "/ping"));
   }
 
   @Bean


### PR DESCRIPTION
# Summary

Adds back, configuration to ignore authentication on calls to `/api/ping` endpoint. This was lost during the migration to non deprecated Spring security config.

## Manual test
1. Call endpoint `/api/ping` (without being logged in first)
2. Observe call is executed and returns 200 