### PR TITLE
chore: Revert DHIS2-15246 and new security config

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/OAuth2Client.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/OAuth2Client.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.security.oauth2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.DxfNamespaces;
+import org.hisp.dhis.common.MetadataObject;
+import org.hisp.dhis.schema.PropertyType;
+import org.hisp.dhis.schema.annotation.Property;
+import org.hisp.dhis.schema.annotation.PropertyRange;
+
+/**
+ * @author Morten Olav Hansen <mortenoh@gmail.com>
+ */
+@JacksonXmlRootElement(localName = "oAuth2Client", namespace = DxfNamespaces.DXF_2_0)
+public class OAuth2Client extends BaseIdentifiableObject implements MetadataObject {
+  /** client_id */
+  private String cid;
+
+  /** client_secret */
+  private String secret = UUID.randomUUID().toString();
+
+  /** List of allowed redirect URI targets for this client. */
+  private List<String> redirectUris = new ArrayList<>();
+
+  /** List of allowed grant types for this client. */
+  private List<String> grantTypes = new ArrayList<>();
+
+  public OAuth2Client() {}
+
+  @JsonProperty
+  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
+  @Property(PropertyType.IDENTIFIER)
+  public String getCid() {
+    return cid;
+  }
+
+  public void setCid(String cid) {
+    this.cid = cid;
+  }
+
+  @JsonProperty
+  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
+  @PropertyRange(min = 36, max = 36)
+  public String getSecret() {
+    return secret;
+  }
+
+  public void setSecret(String secret) {
+    this.secret = secret;
+  }
+
+  @JsonProperty
+  @JacksonXmlElementWrapper(localName = "redirectUris", namespace = DxfNamespaces.DXF_2_0)
+  @JacksonXmlProperty(localName = "redirectUri", namespace = DxfNamespaces.DXF_2_0)
+  public List<String> getRedirectUris() {
+    return redirectUris;
+  }
+
+  public void setRedirectUris(List<String> redirectUris) {
+    this.redirectUris = redirectUris;
+  }
+
+  @JsonProperty
+  @JacksonXmlElementWrapper(localName = "grantTypes", namespace = DxfNamespaces.DXF_2_0)
+  @JacksonXmlProperty(localName = "grantType", namespace = DxfNamespaces.DXF_2_0)
+  public List<String> getGrantTypes() {
+    return grantTypes;
+  }
+
+  public void setGrantTypes(List<String> grantTypes) {
+    this.grantTypes = grantTypes;
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * super.hashCode() + Objects.hash(cid, secret, redirectUris, grantTypes);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return this == obj
+        || obj instanceof OAuth2Client && super.equals(obj) && objectEquals((OAuth2Client) obj);
+  }
+
+  private boolean objectEquals(OAuth2Client other) {
+    return Objects.equals(cid, other.cid)
+        && Objects.equals(secret, other.secret)
+        && Objects.equals(redirectUris, other.redirectUris)
+        && Objects.equals(grantTypes, other.grantTypes);
+  }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/OAuth2ClientService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/OAuth2ClientService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.security.oauth2;
+
+import java.util.Collection;
+
+/**
+ * @author Morten Olav Hansen <mortenoh@gmail.com>
+ */
+public interface OAuth2ClientService {
+  void saveOAuth2Client(OAuth2Client oAuth2Client);
+
+  void updateOAuth2Client(OAuth2Client oAuth2Client);
+
+  void deleteOAuth2Client(OAuth2Client oAuth2Client);
+
+  OAuth2Client getOAuth2Client(int id);
+
+  OAuth2Client getOAuth2Client(String uid);
+
+  OAuth2Client getOAuth2ClientByClientId(String cid);
+
+  Collection<OAuth2Client> getOAuth2Clients();
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/OAuth2ClientStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/OAuth2ClientStore.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.security.oauth2;
+
+import org.hisp.dhis.common.IdentifiableObjectStore;
+
+/**
+ * @author Morten Olav Hansen <mortenoh@gmail.com>
+ */
+public interface OAuth2ClientStore extends IdentifiableObjectStore<OAuth2Client> {
+  String ID = OAuth2ClientStore.class.getName();
+
+  /**
+   * Get OAuth2 client by cid.
+   *
+   * @param cid ClientID
+   * @return Matched OAuth2Client or null if not found
+   */
+  OAuth2Client getByClientId(String cid);
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sqlview/SqlView.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sqlview/SqlView.java
@@ -51,7 +51,8 @@ public class SqlView extends BaseIdentifiableObject implements Cacheable, Metada
   public static final String PREFIX_VIEWNAME = "_view";
 
   public static final Set<String> PROTECTED_TABLES =
-      Set.of("users", "userinfo", "trackedentityattributevalue");
+      Set.of(
+          "users", "userinfo", "trackedentityattributevalue", "oauth_access_token", "oauth2client");
 
   public static final Set<String> ILLEGAL_KEYWORDS =
       Set.of(

--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -315,6 +315,10 @@
       <artifactId>spring-security-aspects</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.security.oauth</groupId>
+      <artifactId>spring-security-oauth2</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-oauth2-client</artifactId>
     </dependency>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/DefaultClientDetailsService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/DefaultClientDetailsService.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.security.oauth2;
+
+import com.google.common.collect.Sets;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.provider.ClientDetails;
+import org.springframework.security.oauth2.provider.ClientDetailsService;
+import org.springframework.security.oauth2.provider.ClientRegistrationException;
+import org.springframework.security.oauth2.provider.client.BaseClientDetails;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author Morten Olav Hansen <mortenoh@gmail.com>
+ */
+@RequiredArgsConstructor
+@Service("defaultClientDetailsService")
+public class DefaultClientDetailsService implements ClientDetailsService {
+  private static final Set<String> SCOPES = Sets.newHashSet("ALL");
+
+  private final OAuth2ClientService oAuth2ClientService;
+
+  @Override
+  public ClientDetails loadClientByClientId(String clientId) throws ClientRegistrationException {
+    ClientDetails clientDetails =
+        clientDetails(oAuth2ClientService.getOAuth2ClientByClientId(clientId));
+
+    if (clientDetails == null) {
+      throw new ClientRegistrationException("Invalid client_id");
+    }
+
+    return clientDetails;
+  }
+
+  private ClientDetails clientDetails(OAuth2Client client) {
+    if (client == null) {
+      return null;
+    }
+
+    BaseClientDetails clientDetails = new BaseClientDetails();
+    clientDetails.setClientId(client.getCid());
+    clientDetails.setClientSecret(client.getSecret());
+    clientDetails.setAuthorizedGrantTypes(new HashSet<>(client.getGrantTypes()));
+    clientDetails.setScope(SCOPES);
+    clientDetails.setRegisteredRedirectUri(new HashSet<>(client.getRedirectUris()));
+
+    return clientDetails;
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/DefaultClientDetailsUserDetailsService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/DefaultClientDetailsUserDetailsService.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.security.oauth2;
+
+import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserService;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.provider.ClientDetails;
+import org.springframework.security.oauth2.provider.NoSuchClientException;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author Morten Olav Hansen <mortenoh@gmail.com>
+ */
+@Service("defaultClientDetailsUserDetailsService")
+@RequiredArgsConstructor
+public class DefaultClientDetailsUserDetailsService implements UserDetailsService {
+  private final DefaultClientDetailsService clientDetailsService;
+
+  private final PasswordEncoder passwordEncoder;
+
+  private final UserService userService;
+
+  @Override
+  public UserDetails loadUserByUsername(String username) {
+    ClientDetails clientDetails = getClientDetails(username);
+
+    String clientSecret = clientDetails.getClientSecret();
+    if (clientSecret == null || clientSecret.trim().length() == 0) {
+      clientSecret = passwordEncoder.encode("");
+    }
+
+    User user = new User();
+    user.setUsername(username);
+    user.setPassword(clientSecret);
+    user.setDisabled(false);
+    user.setAccountNonLocked(true);
+    user.setCredentialsNonExpired(true);
+    user.setAccountExpiry(null);
+
+    return userService.createUserDetails(user);
+  }
+
+  private ClientDetails getClientDetails(String username) {
+    try {
+      return clientDetailsService.loadClientByClientId(username);
+    } catch (NoSuchClientException e) {
+      throw new UsernameNotFoundException(e.getMessage(), e);
+    }
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/DefaultOAuth2ClientService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/DefaultOAuth2ClientService.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.security.oauth2;
+
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author Morten Olav Hansen <mortenoh@gmail.com>
+ */
+@RequiredArgsConstructor
+@Service("oAuth2ClientService")
+public class DefaultOAuth2ClientService implements OAuth2ClientService {
+  private final OAuth2ClientStore oAuth2ClientStore;
+
+  // -------------------------------------------------------------------------
+  // OAuth2ClientService
+  // -------------------------------------------------------------------------
+
+  @Override
+  @Transactional
+  public void saveOAuth2Client(OAuth2Client oAuth2Client) {
+    oAuth2ClientStore.save(oAuth2Client);
+  }
+
+  @Override
+  @Transactional
+  public void updateOAuth2Client(OAuth2Client oAuth2Client) {
+    oAuth2ClientStore.update(oAuth2Client);
+  }
+
+  @Override
+  @Transactional
+  public void deleteOAuth2Client(OAuth2Client oAuth2Client) {
+    oAuth2ClientStore.delete(oAuth2Client);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public OAuth2Client getOAuth2Client(int id) {
+    return oAuth2ClientStore.get(id);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public OAuth2Client getOAuth2Client(String uid) {
+    return oAuth2ClientStore.getByUid(uid);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public OAuth2Client getOAuth2ClientByClientId(String cid) {
+    return oAuth2ClientStore.getByClientId(cid);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Collection<OAuth2Client> getOAuth2Clients() {
+    return oAuth2ClientStore.getAll();
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/OAuth2AuthorizationServerEnabledCondition.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/OAuth2AuthorizationServerEnabledCondition.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.security.oauth2;
+
+import org.hisp.dhis.condition.PropertiesAwareConfigurationCondition;
+import org.hisp.dhis.external.conf.ConfigurationKey;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+public class OAuth2AuthorizationServerEnabledCondition
+    extends PropertiesAwareConfigurationCondition {
+  @Override
+  public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+    if (isTestRun(context)) {
+      return false;
+    }
+
+    return getConfiguration().isEnabled(ConfigurationKey.ENABLE_OAUTH2_AUTHORIZATION_SERVER);
+  }
+
+  @Override
+  public ConfigurationPhase getConfigurationPhase() {
+    return ConfigurationPhase.PARSE_CONFIGURATION;
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/hibernate/HibernateOAuth2ClientStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oauth2/hibernate/HibernateOAuth2ClientStore.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.security.oauth2.hibernate;
+
+import javax.persistence.EntityManager;
+import javax.persistence.criteria.CriteriaBuilder;
+import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.security.oauth2.OAuth2Client;
+import org.hisp.dhis.security.oauth2.OAuth2ClientStore;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @author Morten Olav Hansen <mortenoh@gmail.com>
+ */
+@Repository("org.hisp.dhis.security.oauth2.OAuth2ClientStore")
+public class HibernateOAuth2ClientStore extends HibernateIdentifiableObjectStore<OAuth2Client>
+    implements OAuth2ClientStore {
+  public HibernateOAuth2ClientStore(
+      EntityManager entityManager,
+      JdbcTemplate jdbcTemplate,
+      ApplicationEventPublisher publisher,
+      AclService aclService) {
+    super(entityManager, jdbcTemplate, publisher, OAuth2Client.class, aclService, true);
+  }
+
+  @Override
+  public OAuth2Client getByClientId(String cid) {
+    CriteriaBuilder builder = getCriteriaBuilder();
+
+    return getSingleResult(
+        builder, newJpaParameters().addPredicate(root -> builder.equal(root.get("cid"), cid)));
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/security/oauth2/hibernate/OAuth2Client.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/security/oauth2/hibernate/OAuth2Client.hbm.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+  "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+  "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd"
+  [<!ENTITY identifiableProperties SYSTEM "classpath://org/hisp/dhis/common/identifiableProperties.hbm">]
+  >
+
+<hibernate-mapping>
+  <class name="org.hisp.dhis.security.oauth2.OAuth2Client" table="oauth2client">
+
+    <cache usage="read-write" />
+
+    <id name="id" column="oauth2clientid">
+      <generator class="native" />
+    </id>
+    &identifiableProperties;
+
+    <property name="name" column="name" not-null="true" unique="true" length="230" />
+
+    <property name="cid" column="cid" not-null="true" unique="true" length="230" />
+
+    <property name="secret" column="secret" not-null="true" unique="false" length="512" />
+
+    <list name="redirectUris" table="oauth2clientredirecturis" cascade="all-delete-orphan">
+      <cache usage="read-write" />
+      <key column="oauth2clientid" foreign-key="fk_oauth2clientredirecturis_oauth2clientid" />
+      <list-index column="sort_order" base="0" />
+      <element type="string" column="redirecturi" />
+    </list>
+
+    <list name="grantTypes" table="oauth2clientgranttypes" cascade="all-delete-orphan">
+      <cache usage="read-write" />
+      <key column="oauth2clientid" foreign-key="fk_oauth2clientgranttypes_oauth2clientid" />
+      <list-index column="sort_order" base="0" />
+      <element type="string" column="granttype" />
+    </list>
+
+  </class>
+</hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultSchemaService.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/DefaultSchemaService.java
@@ -120,6 +120,7 @@ import org.hisp.dhis.schema.descriptors.MapViewSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.MessageConversationSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.MetadataVersionSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.MinMaxDataElementSchemaDescriptor;
+import org.hisp.dhis.schema.descriptors.OAuth2ClientSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.ObjectStyleSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.OptionGroupSchemaDescriptor;
 import org.hisp.dhis.schema.descriptors.OptionGroupSetSchemaDescriptor;
@@ -250,6 +251,7 @@ public class DefaultSchemaService implements SchemaService {
     register(new MapViewSchemaDescriptor());
     register(new MessageConversationSchemaDescriptor());
     register(new MetadataVersionSchemaDescriptor());
+    register(new OAuth2ClientSchemaDescriptor());
     register(new OptionSchemaDescriptor());
     register(new OptionSetSchemaDescriptor());
     register(new OrganisationUnitGroupSchemaDescriptor());

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/OAuth2ClientSchemaDescriptor.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/OAuth2ClientSchemaDescriptor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.schema.descriptors;
+
+import com.google.common.collect.Lists;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.schema.SchemaDescriptor;
+import org.hisp.dhis.security.Authority;
+import org.hisp.dhis.security.AuthorityType;
+import org.hisp.dhis.security.oauth2.OAuth2Client;
+
+/**
+ * @author Morten Olav Hansen <mortenoh@gmail.com>
+ */
+public class OAuth2ClientSchemaDescriptor implements SchemaDescriptor {
+  public static final String SINGULAR = "oAuth2Client";
+
+  public static final String PLURAL = "oAuth2Clients";
+
+  public static final String API_ENDPOINT = "/" + PLURAL;
+
+  @Override
+  public Schema getSchema() {
+    Schema schema = new Schema(OAuth2Client.class, SINGULAR, PLURAL);
+    schema.setRelativeApiEndpoint(API_ENDPOINT);
+    schema.setOrder(1030);
+
+    schema.add(new Authority(AuthorityType.READ, Lists.newArrayList("F_OAUTH2_CLIENT_MANAGE")));
+    schema.add(new Authority(AuthorityType.CREATE, Lists.newArrayList("F_OAUTH2_CLIENT_MANAGE")));
+    schema.add(new Authority(AuthorityType.DELETE, Lists.newArrayList("F_OAUTH2_CLIENT_MANAGE")));
+
+    return schema;
+  }
+}

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/LoginActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/LoginActions.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.actions;
 
+import static io.restassured.RestAssured.oauth2;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 import io.restassured.RestAssured;
@@ -91,6 +92,15 @@ public class LoginActions {
   /** Removes authentication header */
   public static void removeAuthenticationHeader() {
     RestAssured.authentication = RestAssured.DEFAULT_AUTH;
+  }
+
+  /**
+   * Logs in with oAuth2 token
+   *
+   * @param token
+   */
+  public void loginWithToken(String token) {
+    RestAssured.authentication = oauth2(token);
   }
 
   public void loginAsAdmin() {

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/LoginTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/LoginTests.java
@@ -28,25 +28,123 @@
 package org.hisp.dhis;
 
 import org.hisp.dhis.actions.LoginActions;
+import org.hisp.dhis.actions.RestApiActions;
+import org.hisp.dhis.actions.UaaActions;
 import org.hisp.dhis.actions.UserActions;
+import org.hisp.dhis.dto.ApiResponse;
+import org.hisp.dhis.helpers.QueryParamsBuilder;
+import org.hisp.dhis.helpers.ResponseValidationHelper;
 import org.hisp.dhis.utils.DataGenerator;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */
-public class LoginTests extends ApiTest {
+public class LoginTests
+    extends ApiTest
+{
+    private LoginActions loginActions;
 
-  private final String userName = ("LoginTestsUser" + DataGenerator.randomString()).toLowerCase();
+    private RestApiActions oauth2Clients;
 
-  @BeforeAll
-  public void preconditions() {
-    LoginActions loginActions = new LoginActions();
-    UserActions userActions = new UserActions();
+    private UaaActions uaaActions;
+
+  private final String oauthClientId = "demo" + DataGenerator.randomString();
+
+    private String secret = "1e6db50c-0fee-11e5-98d0-3c15c2c6caf6";
+
+    private String userName = ("LoginTestsUser" + DataGenerator.randomString()).toLowerCase();
+
+    @BeforeAll
+    public void preconditions()
+    {
+        oauth2Clients = new RestApiActions( "/oAuth2Clients" );
+        uaaActions = new UaaActions();
+        loginActions = new LoginActions();
+        userActions = new UserActions();
 
     loginActions.loginAsSuperUser();
 
-    String password = Constants.USER_PASSWORD;
-    userActions.addUser(userName, password);
-  }
+        addOAuthClient();
+
+        userActions.addUser( userName, password );
+    }
+
+    @Test
+    @Disabled
+    public void shouldBeAbleToLoginWithOAuth2()
+    {
+
+        loginActions.addAuthenticationHeader( oauthClientId, secret );
+
+        ApiResponse response = uaaActions.post( "oauth/token", new JsonObject(),
+            new QueryParamsBuilder().addAll( "username=" + userName, "password=" + password, "grant_type=password" ) );
+
+        response.validate().statusCode( 200 )
+            .body( "access_token", notNullValue() )
+            .body( "token_type", notNullValue() )
+            .body( "refresh_token", notNullValue() )
+            .body( "expires_in", notNullValue() )
+            .body( "scope", notNullValue() );
+
+        loginActions.loginWithToken( response.extractString( "access_token" ) );
+
+        loginActions.getLoggedInUserInfo().validate()
+            .statusCode( 200 )
+            .body( "username", equalTo( userName ) );
+    }
+
+    @Test
+    @Disabled
+    public void shouldBeAbleToGetRefreshToken()
+    {
+        loginActions.addAuthenticationHeader( oauthClientId, secret );
+
+        JsonObject object = new JsonObject();
+        object.addProperty( "password", password );
+        object.addProperty( "grant_type", "password" );
+        object.addProperty( "username", userName );
+
+        ApiResponse passwordGrantTypeResponse = uaaActions.post( "oauth/token", new JsonObject(),
+            new QueryParamsBuilder().addAll( "password=" + password, "username=" + userName, "grant_type=password" ) );
+        passwordGrantTypeResponse.validate().statusCode( 200 );
+
+        loginActions.addAuthenticationHeader( oauthClientId, secret );
+        ApiResponse refreshTokenResponse = uaaActions.post( "oauth/token", new JsonObject(), new QueryParamsBuilder()
+            .addAll( "grant_type=refresh_token",
+                "refresh_token=" + passwordGrantTypeResponse.extractString( "refresh_token" ) ) );
+
+        refreshTokenResponse.validate().statusCode( 200 )
+            .body( "access_token", notNullValue() )
+            .body( "token_type", notNullValue() )
+            .body( "refresh_token", notNullValue() )
+            .body( "expires_in", notNullValue() )
+            .body( "scope", notNullValue() )
+            .body( "access_token", not( equalTo( passwordGrantTypeResponse.extractString( "access_token" ) ) ) );
+    }
+
+    private void addOAuthClient()
+    {
+        JsonObject client = new JsonObject();
+        client.addProperty( "name", "OAuth2 client" + DataGenerator.randomString() );
+        client.addProperty( "cid", oauthClientId );
+        client.addProperty( "secret", secret );
+
+        JsonArray grantTypes = new JsonArray();
+
+        grantTypes.add( "password" );
+        grantTypes.add( "refresh_token" );
+        grantTypes.add( "authorization_code" );
+
+        client.add( "grantTypes", grantTypes );
+
+        ApiResponse response = oauth2Clients.post( client );
+
+        ResponseValidationHelper.validateObjectCreation( response );
+    }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/LoginTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/LoginTests.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis;
 
+import static org.hamcrest.Matchers.*;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import org.hisp.dhis.actions.LoginActions;
@@ -51,11 +53,15 @@ public class LoginTests extends ApiTest {
 
   private UaaActions uaaActions;
 
-  private final String oauthClientId = "demo" + DataGenerator.randomString();
+  private UserActions userActions;
+
+  private String oauthClientId = "demo" + DataGenerator.randomString();
 
   private String secret = "1e6db50c-0fee-11e5-98d0-3c15c2c6caf6";
 
   private String userName = ("LoginTestsUser" + DataGenerator.randomString()).toLowerCase();
+
+  private String password = Constants.USER_PASSWORD;
 
   @BeforeAll
   public void preconditions() {

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/LoginTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/LoginTests.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import org.hisp.dhis.actions.LoginActions;
 import org.hisp.dhis.actions.RestApiActions;
 import org.hisp.dhis.actions.UaaActions;
@@ -39,112 +41,123 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */
-public class LoginTests
-    extends ApiTest
-{
-    private LoginActions loginActions;
+public class LoginTests extends ApiTest {
+  private LoginActions loginActions;
 
-    private RestApiActions oauth2Clients;
+  private RestApiActions oauth2Clients;
 
-    private UaaActions uaaActions;
+  private UaaActions uaaActions;
 
   private final String oauthClientId = "demo" + DataGenerator.randomString();
 
-    private String secret = "1e6db50c-0fee-11e5-98d0-3c15c2c6caf6";
+  private String secret = "1e6db50c-0fee-11e5-98d0-3c15c2c6caf6";
 
-    private String userName = ("LoginTestsUser" + DataGenerator.randomString()).toLowerCase();
+  private String userName = ("LoginTestsUser" + DataGenerator.randomString()).toLowerCase();
 
-    @BeforeAll
-    public void preconditions()
-    {
-        oauth2Clients = new RestApiActions( "/oAuth2Clients" );
-        uaaActions = new UaaActions();
-        loginActions = new LoginActions();
-        userActions = new UserActions();
+  @BeforeAll
+  public void preconditions() {
+    oauth2Clients = new RestApiActions("/oAuth2Clients");
+    uaaActions = new UaaActions();
+    loginActions = new LoginActions();
+    userActions = new UserActions();
 
     loginActions.loginAsSuperUser();
 
-        addOAuthClient();
+    addOAuthClient();
 
-        userActions.addUser( userName, password );
-    }
+    userActions.addUser(userName, password);
+  }
 
-    @Test
-    @Disabled
-    public void shouldBeAbleToLoginWithOAuth2()
-    {
+  @Test
+  @Disabled
+  public void shouldBeAbleToLoginWithOAuth2() {
 
-        loginActions.addAuthenticationHeader( oauthClientId, secret );
+    loginActions.addAuthenticationHeader(oauthClientId, secret);
 
-        ApiResponse response = uaaActions.post( "oauth/token", new JsonObject(),
-            new QueryParamsBuilder().addAll( "username=" + userName, "password=" + password, "grant_type=password" ) );
+    ApiResponse response =
+        uaaActions.post(
+            "oauth/token",
+            new JsonObject(),
+            new QueryParamsBuilder()
+                .addAll("username=" + userName, "password=" + password, "grant_type=password"));
 
-        response.validate().statusCode( 200 )
-            .body( "access_token", notNullValue() )
-            .body( "token_type", notNullValue() )
-            .body( "refresh_token", notNullValue() )
-            .body( "expires_in", notNullValue() )
-            .body( "scope", notNullValue() );
+    response
+        .validate()
+        .statusCode(200)
+        .body("access_token", notNullValue())
+        .body("token_type", notNullValue())
+        .body("refresh_token", notNullValue())
+        .body("expires_in", notNullValue())
+        .body("scope", notNullValue());
 
-        loginActions.loginWithToken( response.extractString( "access_token" ) );
+    loginActions.loginWithToken(response.extractString("access_token"));
 
-        loginActions.getLoggedInUserInfo().validate()
-            .statusCode( 200 )
-            .body( "username", equalTo( userName ) );
-    }
+    loginActions
+        .getLoggedInUserInfo()
+        .validate()
+        .statusCode(200)
+        .body("username", equalTo(userName));
+  }
 
-    @Test
-    @Disabled
-    public void shouldBeAbleToGetRefreshToken()
-    {
-        loginActions.addAuthenticationHeader( oauthClientId, secret );
+  @Test
+  @Disabled
+  public void shouldBeAbleToGetRefreshToken() {
+    loginActions.addAuthenticationHeader(oauthClientId, secret);
 
-        JsonObject object = new JsonObject();
-        object.addProperty( "password", password );
-        object.addProperty( "grant_type", "password" );
-        object.addProperty( "username", userName );
+    JsonObject object = new JsonObject();
+    object.addProperty("password", password);
+    object.addProperty("grant_type", "password");
+    object.addProperty("username", userName);
 
-        ApiResponse passwordGrantTypeResponse = uaaActions.post( "oauth/token", new JsonObject(),
-            new QueryParamsBuilder().addAll( "password=" + password, "username=" + userName, "grant_type=password" ) );
-        passwordGrantTypeResponse.validate().statusCode( 200 );
+    ApiResponse passwordGrantTypeResponse =
+        uaaActions.post(
+            "oauth/token",
+            new JsonObject(),
+            new QueryParamsBuilder()
+                .addAll("password=" + password, "username=" + userName, "grant_type=password"));
+    passwordGrantTypeResponse.validate().statusCode(200);
 
-        loginActions.addAuthenticationHeader( oauthClientId, secret );
-        ApiResponse refreshTokenResponse = uaaActions.post( "oauth/token", new JsonObject(), new QueryParamsBuilder()
-            .addAll( "grant_type=refresh_token",
-                "refresh_token=" + passwordGrantTypeResponse.extractString( "refresh_token" ) ) );
+    loginActions.addAuthenticationHeader(oauthClientId, secret);
+    ApiResponse refreshTokenResponse =
+        uaaActions.post(
+            "oauth/token",
+            new JsonObject(),
+            new QueryParamsBuilder()
+                .addAll(
+                    "grant_type=refresh_token",
+                    "refresh_token=" + passwordGrantTypeResponse.extractString("refresh_token")));
 
-        refreshTokenResponse.validate().statusCode( 200 )
-            .body( "access_token", notNullValue() )
-            .body( "token_type", notNullValue() )
-            .body( "refresh_token", notNullValue() )
-            .body( "expires_in", notNullValue() )
-            .body( "scope", notNullValue() )
-            .body( "access_token", not( equalTo( passwordGrantTypeResponse.extractString( "access_token" ) ) ) );
-    }
+    refreshTokenResponse
+        .validate()
+        .statusCode(200)
+        .body("access_token", notNullValue())
+        .body("token_type", notNullValue())
+        .body("refresh_token", notNullValue())
+        .body("expires_in", notNullValue())
+        .body("scope", notNullValue())
+        .body(
+            "access_token", not(equalTo(passwordGrantTypeResponse.extractString("access_token"))));
+  }
 
-    private void addOAuthClient()
-    {
-        JsonObject client = new JsonObject();
-        client.addProperty( "name", "OAuth2 client" + DataGenerator.randomString() );
-        client.addProperty( "cid", oauthClientId );
-        client.addProperty( "secret", secret );
+  private void addOAuthClient() {
+    JsonObject client = new JsonObject();
+    client.addProperty("name", "OAuth2 client" + DataGenerator.randomString());
+    client.addProperty("cid", oauthClientId);
+    client.addProperty("secret", secret);
 
-        JsonArray grantTypes = new JsonArray();
+    JsonArray grantTypes = new JsonArray();
 
-        grantTypes.add( "password" );
-        grantTypes.add( "refresh_token" );
-        grantTypes.add( "authorization_code" );
+    grantTypes.add("password");
+    grantTypes.add("refresh_token");
+    grantTypes.add("authorization_code");
 
-        client.add( "grantTypes", grantTypes );
+    client.add("grantTypes", grantTypes);
 
-        ApiResponse response = oauth2Clients.post( client );
+    ApiResponse response = oauth2Clients.post(client);
 
-        ResponseValidationHelper.validateObjectCreation( response );
-    }
+    ResponseValidationHelper.validateObjectCreation(response);
+  }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/oauth2/OAuth2ClientServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/oauth2/OAuth2ClientServiceTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.security.oauth2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Collection;
+import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author Morten Olav Hansen <mortenoh@gmail.com>
+ */
+class OAuth2ClientServiceTest extends TransactionalIntegrationTest {
+
+  @Autowired private OAuth2ClientService oAuth2ClientService;
+
+  private OAuth2Client clientA;
+
+  private OAuth2Client clientB;
+
+  private OAuth2Client clientC;
+
+  @Override
+  public void setUpTest() {
+    clientA = new OAuth2Client();
+    clientA.setName("clientA");
+    clientA.setCid("clientA");
+    clientB = new OAuth2Client();
+    clientB.setName("clientB");
+    clientB.setCid("clientB");
+    clientC = new OAuth2Client();
+    clientC.setName("clientC");
+    clientC.setCid("clientC");
+  }
+
+  @Test
+  void testGetAll() {
+    oAuth2ClientService.saveOAuth2Client(clientA);
+    oAuth2ClientService.saveOAuth2Client(clientB);
+    oAuth2ClientService.saveOAuth2Client(clientC);
+    Collection<OAuth2Client> all = oAuth2ClientService.getOAuth2Clients();
+    assertEquals(3, all.size());
+  }
+
+  @Test
+  void testGetByClientID() {
+    oAuth2ClientService.saveOAuth2Client(clientA);
+    oAuth2ClientService.saveOAuth2Client(clientB);
+    oAuth2ClientService.saveOAuth2Client(clientC);
+    assertNotNull(oAuth2ClientService.getOAuth2ClientByClientId("clientA"));
+    assertNotNull(oAuth2ClientService.getOAuth2ClientByClientId("clientB"));
+    assertNotNull(oAuth2ClientService.getOAuth2ClientByClientId("clientC"));
+  }
+}

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/oauth2/OAuth2ClientStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/oauth2/OAuth2ClientStoreTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.security.oauth2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Collection;
+import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author Morten Olav Hansen <mortenoh@gmail.com>
+ */
+class OAuth2ClientStoreTest extends TransactionalIntegrationTest {
+
+  @Autowired private OAuth2ClientStore oAuth2ClientStore;
+
+  private OAuth2Client clientA;
+
+  private OAuth2Client clientB;
+
+  private OAuth2Client clientC;
+
+  @Override
+  public void setUpTest() {
+    clientA = new OAuth2Client();
+    clientA.setName("clientA");
+    clientA.setCid("clientA");
+    clientB = new OAuth2Client();
+    clientB.setName("clientB");
+    clientB.setCid("clientB");
+    clientC = new OAuth2Client();
+    clientC.setName("clientC");
+    clientC.setCid("clientC");
+  }
+
+  @Test
+  void testGetAll() {
+    oAuth2ClientStore.save(clientA);
+    oAuth2ClientStore.save(clientB);
+    oAuth2ClientStore.save(clientC);
+    Collection<OAuth2Client> all = oAuth2ClientStore.getAll();
+    assertEquals(3, all.size());
+  }
+
+  @Test
+  void testGetByClientID() {
+    oAuth2ClientStore.save(clientA);
+    oAuth2ClientStore.save(clientB);
+    oAuth2ClientStore.save(clientC);
+    assertNotNull(oAuth2ClientStore.getByClientId("clientA"));
+    assertNotNull(oAuth2ClientStore.getByClientId("clientB"));
+    assertNotNull(oAuth2ClientStore.getByClientId("clientC"));
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
@@ -90,7 +90,7 @@ class OpenApiControllerTest extends DhisControllerConvenienceTest {
     assertTrue(
         doc.getObject("paths")
             .has("/users/gist", "/users/invite", "/users/invites", "/users/sharing"));
-    assertLessOrEqual(130, doc.getObject("paths").size());
+    assertLessOrEqual(147, doc.getObject("paths").size());
     assertLessOrEqual(60, doc.getObject("components.schemas").size());
   }
 

--- a/dhis-2/dhis-web-api/pom.xml
+++ b/dhis-2/dhis-web-api/pom.xml
@@ -98,6 +98,10 @@
       <artifactId>spring-security-config</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.security.oauth</groupId>
+      <artifactId>spring-security-oauth2</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-oauth2-core</artifactId>
     </dependency>

--- a/dhis-2/dhis-web-api/pom.xml
+++ b/dhis-2/dhis-web-api/pom.xml
@@ -118,10 +118,6 @@
       <artifactId>spring-security-ldap</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.mobile</groupId>
-      <artifactId>spring-mobile-device</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-core</artifactId>
     </dependency>

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/OAuth2ClientController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/OAuth2ClientController.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.schema.descriptors.OAuth2ClientSchemaDescriptor;
+import org.hisp.dhis.security.oauth2.OAuth2Client;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * @author Morten Olav Hansen <mortenoh@gmail.com>
+ */
+@OpenApi.Tags({"user", "login"})
+@Controller
+@RequestMapping(value = OAuth2ClientSchemaDescriptor.API_ENDPOINT)
+public class OAuth2ClientController extends AbstractCrudController<OAuth2Client> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/oprovider/DhisOauthAuthenticationProvider.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/oprovider/DhisOauthAuthenticationProvider.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.oprovider;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.SerializationUtils;
+import org.hisp.dhis.security.oauth2.DefaultClientDetailsUserDetailsService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Henning Håkonsen
+ */
+@Slf4j
+@Component
+public class DhisOauthAuthenticationProvider extends DaoAuthenticationProvider {
+  @Autowired
+  public DhisOauthAuthenticationProvider(
+      @Qualifier("defaultClientDetailsUserDetailsService")
+          DefaultClientDetailsUserDetailsService detailsService) {
+    setUserDetailsService(detailsService);
+    setPasswordEncoder(NoOpPasswordEncoder.getInstance());
+  }
+
+  @Override
+  public Authentication authenticate(Authentication auth) throws AuthenticationException {
+    log.info(
+        String.format(
+            "DhisOauthAuthenticationProvider authenticate attempt Authentication.getName(): %s",
+            auth.getName()));
+
+    String username = auth.getName();
+
+    UserDetails user = getUserDetailsService().loadUserByUsername(username);
+
+    if (user == null) {
+      throw new BadCredentialsException("Invalid username or password");
+    }
+
+    // -------------------------------------------------------------------------
+    // Delegate authentication downstream, using User as
+    // principal
+    // -------------------------------------------------------------------------
+
+    Authentication result = super.authenticate(auth);
+
+    // Put detached state of the user credentials into the session as user
+    // must not be updated during session execution
+    user = SerializationUtils.clone(user);
+
+    return new UsernamePasswordAuthenticationToken(
+        user, result.getCredentials(), result.getAuthorities());
+  }
+
+  @Override
+  public boolean supports(Class<?> authentication) {
+    return authentication.equals(UsernamePasswordAuthenticationToken.class);
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -28,13 +28,15 @@
 package org.hisp.dhis.webapi.security.config;
 
 import java.util.Arrays;
-import java.util.Map;
+import java.util.List;
 import java.util.Set;
 import javax.sql.DataSource;
+import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.security.ImpersonatingUserDetailsChecker;
+import org.hisp.dhis.security.apikey.ApiTokenService;
 import org.hisp.dhis.security.apikey.DhisApiTokenAuthenticationEntryPoint;
 import org.hisp.dhis.security.basic.HttpBasicWebAuthenticationDetailsSource;
 import org.hisp.dhis.security.jwt.Dhis2JwtAuthenticationManagerResolver;
@@ -44,46 +46,50 @@ import org.hisp.dhis.security.oidc.DhisAuthorizationCodeTokenResponseClient;
 import org.hisp.dhis.security.oidc.DhisCustomAuthorizationRequestResolver;
 import org.hisp.dhis.security.oidc.DhisOidcLogoutSuccessHandler;
 import org.hisp.dhis.security.oidc.DhisOidcProviderRepository;
+import org.hisp.dhis.security.oidc.OIDCLoginEnabledCondition;
 import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationProvider;
 import org.hisp.dhis.security.spring2fa.TwoFactorWebAuthenticationDetailsSource;
+import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.webapi.filter.CorsFilter;
 import org.hisp.dhis.webapi.filter.CspFilter;
 import org.hisp.dhis.webapi.filter.CustomAuthenticationFilter;
-import org.hisp.dhis.webapi.handler.DefaultAuthenticationSuccessHandler;
+import org.hisp.dhis.webapi.security.ExternalAccessVoter;
 import org.hisp.dhis.webapi.security.FormLoginBasicAuthenticationEntryPoint;
-import org.hisp.dhis.webapi.security.Http401LoginUrlAuthenticationEntryPoint;
 import org.hisp.dhis.webapi.security.apikey.ApiTokenAuthManager;
 import org.hisp.dhis.webapi.security.apikey.Dhis2ApiTokenFilter;
 import org.hisp.dhis.webapi.security.switchuser.DhisSwitchUserFilter;
+import org.hisp.dhis.webapi.security.vote.LogicalOrAccessDecisionManager;
+import org.hisp.dhis.webapi.security.vote.SimpleAccessVoter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.core.annotation.Order;
-import org.springframework.mobile.device.DeviceResolver;
-import org.springframework.mobile.device.LiteDeviceResolver;
+import org.springframework.security.access.AccessDecisionManager;
+import org.springframework.security.access.vote.AuthenticatedVoter;
+import org.springframework.security.access.vote.UnanimousBased;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
-import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
-import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.ObjectPostProcessor;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.security.core.session.SessionRegistryImpl;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationFilter;
 import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
-import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler;
+import org.springframework.security.web.access.expression.WebExpressionVoter;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.switchuser.SwitchUserFilter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.security.web.header.HeaderWriterFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.util.UrlPathHelper;
 
 /**
@@ -108,109 +114,345 @@ public class DhisWebApiWebSecurityConfig {
 
   @Autowired public DataSource dataSource;
 
-  @Autowired private ApplicationContext applicationContext;
-
-  @Autowired private DhisConfigurationProvider dhisConfig;
-
-  @Autowired private DefaultAuthenticationEventPublisher authenticationEventPublisher;
-
-  @Autowired private Dhis2JwtAuthenticationManagerResolver dhis2JwtAuthenticationManagerResolver;
-
-  @Autowired private DhisBearerJwtTokenAuthenticationEntryPoint bearerTokenEntryPoint;
-
-  @Autowired private DhisApiTokenAuthenticationEntryPoint apiTokenAuthenticationEntryPoint;
-
-  @Autowired
-  private TwoFactorWebAuthenticationDetailsSource twoFactorWebAuthenticationDetailsSource;
-
-  @Autowired private DhisOidcLogoutSuccessHandler dhisOidcLogoutSuccessHandler;
-
-  @Autowired
-  private HttpBasicWebAuthenticationDetailsSource httpBasicWebAuthenticationDetailsSource;
-
-  @Autowired private ConfigurationService configurationService;
-
-  @Autowired private ApiTokenAuthManager apiTokenAuthManager;
-
-  @Autowired private DhisOidcProviderRepository dhisOidcProviderRepository;
-
-  @Autowired private DhisCustomAuthorizationRequestResolver dhisCustomAuthorizationRequestResolver;
-
-  @Autowired private DhisAuthorizationCodeTokenResponseClient jwtPrivateCodeTokenResponseClient;
-
-  @Autowired private CustomAuthFailureHandler customAuthFailureHandler;
-
   @Bean
   public SessionRegistry sessionRegistry() {
     return new SessionRegistryImpl();
   }
 
-  @Bean
-  @Primary
-  protected AuthenticationManager authenticationManagers(
-      TwoFactorAuthenticationProvider twoFactorProvider,
-      @Qualifier("customLdapAuthenticationProvider")
-          CustomLdapAuthenticationProvider ldapProvider) {
+  /** This class is configuring the OIDC login endpoints */
+  @Configuration
+  @Order(1010)
+  @Conditional(value = OIDCLoginEnabledCondition.class)
+  public static class OidcSecurityConfig extends WebSecurityConfigurerAdapter {
+    @Autowired private DhisOidcProviderRepository dhisOidcProviderRepository;
 
-    ProviderManager providerManager =
-        new ProviderManager(Arrays.asList(twoFactorProvider, ldapProvider));
+    @Autowired
+    private DhisCustomAuthorizationRequestResolver dhisCustomAuthorizationRequestResolver;
 
-    providerManager.setAuthenticationEventPublisher(authenticationEventPublisher);
+    @Autowired private DefaultAuthenticationEventPublisher authenticationEventPublisher;
 
-    return providerManager;
-  }
+    @Autowired private DhisAuthorizationCodeTokenResponseClient jwtPrivateCodeTokenResponseClient;
 
-  @Bean
-  public WebSecurityCustomizer webSecurityCustomizer() {
-    return web ->
-        web.ignoring().requestMatchers(new AntPathRequestMatcher(apiContextPath + "/ping"));
-  }
+    @Override
+    public void configure(AuthenticationManagerBuilder auth) {
+      auth.authenticationEventPublisher(authenticationEventPublisher);
+    }
 
-  @Bean
-  protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+      Set<String> providerIds = dhisOidcProviderRepository.getAllRegistrationId();
 
-    http.csrf().disable();
+      http.antMatcher("/oauth2/**")
+          .authorizeRequests(
+              authorize -> {
+                providerIds.forEach(
+                    providerId ->
+                        authorize
+                            .antMatchers("/oauth2/authorization/" + providerId)
+                            .permitAll()
+                            .antMatchers("/oauth2/code/" + providerId)
+                            .permitAll());
+                authorize.anyRequest().authenticated();
+              })
+          .oauth2Login(
+              oauth2 ->
+                  oauth2
+                      .tokenEndpoint()
+                      .accessTokenResponseClient(jwtPrivateCodeTokenResponseClient)
+                      .and()
+                      .failureUrl("/dhis-web-commons/security/login.action?oidcFailure=true")
+                      .clientRegistrationRepository(dhisOidcProviderRepository)
+                      .loginProcessingUrl("/oauth2/code/*")
+                      .authorizationEndpoint()
+                      .authorizationRequestResolver(dhisCustomAuthorizationRequestResolver))
+          .csrf()
+          .disable();
 
-    configureMatchers(http);
-    configureFormLogin(http);
-    configureCspFilter(http, dhisConfig, configurationService);
-    configureCorsFilter(http);
-    configureMobileAuthFilter(http);
-    configureApiTokenAuthorizationFilter(http);
-    configureOAuthTokenFilters(http);
-
-    setHttpHeaders(http);
-
-    return http.build();
-  }
-
-  private void configureFormLogin(HttpSecurity http) throws Exception {
-
-    String[] activeProfiles = applicationContext.getEnvironment().getActiveProfiles();
-    if (Arrays.asList(activeProfiles).contains("embeddedJetty")) {
-      http.formLogin()
-          .authenticationDetailsSource(twoFactorWebAuthenticationDetailsSource)
-          .loginPage("/index.html")
-          .usernameParameter("j_username")
-          .passwordParameter("j_password")
-          .loginProcessingUrl("/api/authentication/login")
-          .failureUrl("/index.html?error=true")
-          .defaultSuccessUrl("/dhis-web-dashboard", true)
-          .permitAll();
-
-    } else {
-      http.formLogin()
-          .authenticationDetailsSource(twoFactorWebAuthenticationDetailsSource)
-          .loginPage("/dhis-web-commons/security/login.action")
-          .usernameParameter("j_username")
-          .passwordParameter("j_password")
-          .loginProcessingUrl("/dhis-web-commons-security/login.action")
-          .failureHandler(customAuthFailureHandler)
-          .successHandler(authenticationSuccessHandler())
-          .permitAll();
+      setHttpHeaders(http);
     }
   }
 
+  /** This configuration class is responsible for setting up the /api endpoints */
+  @Configuration
+  @Order(1100)
+  public static class ApiWebSecurityConfigurationAdapter extends WebSecurityConfigurerAdapter {
+    @Autowired private DhisConfigurationProvider dhisConfig;
+
+    @Autowired private TwoFactorAuthenticationProvider twoFactorAuthenticationProvider;
+
+    @Autowired
+    @Qualifier("customLdapAuthenticationProvider")
+    private CustomLdapAuthenticationProvider customLdapAuthenticationProvider;
+
+    @Autowired private DefaultAuthenticationEventPublisher authenticationEventPublisher;
+
+    @Autowired private Dhis2JwtAuthenticationManagerResolver dhis2JwtAuthenticationManagerResolver;
+
+    @Autowired private DhisBearerJwtTokenAuthenticationEntryPoint bearerTokenEntryPoint;
+
+    @Autowired private DhisApiTokenAuthenticationEntryPoint apiTokenAuthenticationEntryPoint;
+
+    @Autowired private ApiTokenService apiTokenService;
+
+    @Autowired private UserService userService;
+
+    @Autowired private CacheProvider cacheProvider;
+
+    @Autowired private ExternalAccessVoter externalAccessVoter;
+
+    @Autowired
+    private TwoFactorWebAuthenticationDetailsSource twoFactorWebAuthenticationDetailsSource;
+
+    @Autowired private DhisOidcLogoutSuccessHandler dhisOidcLogoutSuccessHandler;
+
+    @Autowired
+    private HttpBasicWebAuthenticationDetailsSource httpBasicWebAuthenticationDetailsSource;
+
+    @Autowired private ConfigurationService configurationService;
+
+    @Autowired private ApiTokenAuthManager apiTokenAuthManager;
+
+    @Override
+    public void configure(AuthenticationManagerBuilder auth) {
+      auth.authenticationProvider(customLdapAuthenticationProvider);
+      auth.authenticationProvider(twoFactorAuthenticationProvider);
+
+      auth.authenticationEventPublisher(authenticationEventPublisher);
+    }
+
+    public WebExpressionVoter apiWebExpressionVoter() {
+      WebExpressionVoter voter = new WebExpressionVoter();
+
+      DefaultWebSecurityExpressionHandler handler = new DefaultWebSecurityExpressionHandler();
+      handler.setDefaultRolePrefix("");
+
+      voter.setExpressionHandler(handler);
+
+      return voter;
+    }
+
+    public LogicalOrAccessDecisionManager apiAccessDecisionManager() {
+      List<AccessDecisionManager> decisionVoters =
+          Arrays.asList(
+              new UnanimousBased(List.of(new SimpleAccessVoter("ALL"))),
+              new UnanimousBased(List.of(apiWebExpressionVoter())),
+              new UnanimousBased(List.of(externalAccessVoter)),
+              new UnanimousBased(List.of(new AuthenticatedVoter())));
+
+      return new LogicalOrAccessDecisionManager(decisionVoters);
+    }
+
+    private void configureAccessRestrictions(
+        ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry
+            authorize) {
+      authorize
+          .antMatchers("/impersonate")
+          .hasAnyAuthority("ALL", "F_IMPERSONATE_USER")
+
+          // Temporary solution for Struts less login page, will be removed when apps are fully
+          // migrated
+          .antMatchers("/index.html")
+          .permitAll()
+          .antMatchers("/external-static/**")
+          .permitAll()
+          .antMatchers("/favicon.ico")
+          .permitAll()
+          .antMatchers("/oauth2/**")
+          .permitAll()
+          .antMatchers(apiContextPath + "/authentication/login")
+          .permitAll()
+          .antMatchers(apiContextPath + "/account/recovery")
+          .permitAll()
+          .antMatchers(apiContextPath + "/account/restore")
+          .permitAll()
+          .antMatchers(apiContextPath + "/account")
+          .permitAll()
+          .antMatchers(apiContextPath + "/staticContent/**")
+          .permitAll()
+          .antMatchers(apiContextPath + "/externalFileResources/**")
+          .permitAll()
+          .antMatchers(apiContextPath + "/icons/*/icon.svg")
+          .permitAll()
+          .antMatchers(apiContextPath + "/files/style/external")
+          .permitAll()
+          .antMatchers(apiContextPath + "/publicKeys/**")
+          .permitAll()
+          .anyRequest()
+          .authenticated()
+          .accessDecisionManager(apiAccessDecisionManager());
+    }
+
+    /** This method configures almost everything security related to /api endpoints */
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+      http.csrf().disable();
+
+      configureMatchers(http);
+      configureCspFilter(http, dhisConfig, configurationService);
+      configureCorsFilter(http);
+      configureMobileAuthFilter(http);
+      configureApiTokenAuthorizationFilter(http);
+      configureOAuthTokenFilters(http);
+
+      setHttpHeaders(http);
+    }
+
+    private void configureMatchers(HttpSecurity http) throws Exception {
+      String[] activeProfiles = getApplicationContext().getEnvironment().getActiveProfiles();
+
+      http.securityContext(
+          httpSecuritySecurityContextConfigurer ->
+              httpSecuritySecurityContextConfigurer.requireExplicitSave(true));
+
+      http.antMatcher(apiContextPath + "/**")
+          .authorizeRequests(this::configureAccessRestrictions)
+          .httpBasic()
+          .authenticationDetailsSource(httpBasicWebAuthenticationDetailsSource)
+          .authenticationEntryPoint(formLoginBasicAuthenticationEntryPoint())
+          .addObjectPostProcessor(
+              new ObjectPostProcessor<BasicAuthenticationFilter>() {
+                @Override
+                public <O extends BasicAuthenticationFilter> O postProcess(O filter) {
+                  // Explicitly set security context repository on http basic, is
+                  // NullSecurityContextRepository by default now.
+                  filter.setSecurityContextRepository(new HttpSessionSecurityContextRepository());
+                  return filter;
+                }
+              });
+      // Special handling if we are running in embedded Jetty mode
+      if (Arrays.asList(activeProfiles).contains("embeddedJetty")) {
+        http.formLogin()
+            .authenticationDetailsSource(twoFactorWebAuthenticationDetailsSource)
+            .loginPage("/index.html")
+            .usernameParameter("j_username")
+            .passwordParameter("j_password")
+            .loginProcessingUrl("/api/authentication/login")
+            .defaultSuccessUrl("/dhis-web-dashboard", true)
+            .failureUrl("/index.html?error=true")
+            .permitAll()
+            .and()
+            .logout()
+            .logoutUrl("/dhis-web-commons-security/logout.action")
+            .logoutSuccessUrl("/")
+            .logoutSuccessHandler(dhisOidcLogoutSuccessHandler)
+            .deleteCookies("JSESSIONID")
+            .and()
+            .sessionManagement()
+            .requireExplicitAuthenticationStrategy(true)
+            .sessionFixation()
+            .migrateSession()
+            .sessionCreationPolicy(SessionCreationPolicy.ALWAYS)
+            .enableSessionUrlRewriting(false)
+            .maximumSessions(
+                Integer.parseInt(dhisConfig.getProperty(ConfigurationKey.MAX_SESSIONS_PER_USER)))
+            .expiredUrl("/dhis-web-commons-security/logout.action");
+      }
+    }
+
+    private void configureCspFilter(
+        HttpSecurity http,
+        DhisConfigurationProvider dhisConfig,
+        ConfigurationService configurationService) {
+      http.addFilterBefore(
+          new CspFilter(dhisConfig, configurationService), HeaderWriterFilter.class);
+    }
+
+    private void configureCorsFilter(HttpSecurity http) {
+      http.addFilterBefore(CorsFilter.get(), BasicAuthenticationFilter.class);
+    }
+
+    private void configureMobileAuthFilter(HttpSecurity http) {
+      http.addFilterBefore(
+          CustomAuthenticationFilter.get(), UsernamePasswordAuthenticationFilter.class);
+    }
+
+    private void configureApiTokenAuthorizationFilter(HttpSecurity http) {
+      if (dhisConfig.isEnabled(ConfigurationKey.ENABLE_API_TOKEN_AUTHENTICATION)) {
+        Dhis2ApiTokenFilter tokenFilter =
+            new Dhis2ApiTokenFilter(
+                apiTokenAuthManager,
+                apiTokenAuthenticationEntryPoint,
+                authenticationEventPublisher);
+
+        http.addFilterBefore(tokenFilter, BasicAuthenticationFilter.class);
+      }
+    }
+
+    /**
+     * Enable either deprecated OAuth2 authorization filter or the new JWT OIDC token filter. They
+     * are mutually exclusive and can not both be added to the chain at the same time.
+     *
+     * @param http HttpSecurity config
+     */
+    private void configureOAuthTokenFilters(HttpSecurity http) {
+      if (dhisConfig.isEnabled(ConfigurationKey.ENABLE_JWT_OIDC_TOKEN_AUTHENTICATION)) {
+        http.addFilterAfter(
+            getJwtBearerTokenAuthenticationFilter(), BasicAuthenticationFilter.class);
+      }
+    }
+
+    /**
+     * Creates and configures the JWT OIDC bearer token filter
+     *
+     * @return BearerTokenAuthenticationFilter to be added to the filter chain
+     */
+    private BearerTokenAuthenticationFilter getJwtBearerTokenAuthenticationFilter() {
+      BearerTokenAuthenticationFilter jwtFilter =
+          new BearerTokenAuthenticationFilter(dhis2JwtAuthenticationManagerResolver);
+
+      jwtFilter.setAuthenticationEntryPoint(bearerTokenEntryPoint);
+      jwtFilter.setBearerTokenResolver(new DefaultBearerTokenResolver());
+
+      // Placeholder failure handler to "activate" the sending of auth failed
+      // messages
+      // to the central auth logger in DHIS2:
+      // "AuthenticationLoggerListener"
+      jwtFilter.setAuthenticationFailureHandler(
+          (request, response, exception) -> {
+            authenticationEventPublisher.publishAuthenticationFailure(
+                exception,
+                new AbstractAuthenticationToken(null) {
+                  @Override
+                  public Object getCredentials() {
+                    return null;
+                  }
+
+                  @Override
+                  public Object getPrincipal() {
+                    return null;
+                  }
+                });
+
+            bearerTokenEntryPoint.commence(request, response, exception);
+          });
+
+      return jwtFilter;
+    }
+
+    /**
+     * Entrypoint to "re-direct" http basic authentications to the login form page. Without this,
+     * the default http basic pop-up window in the browser will be used.
+     *
+     * @return DHIS2BasicAuthenticationEntryPoint entryPoint to use in http config.
+     */
+    @Bean
+    public FormLoginBasicAuthenticationEntryPoint formLoginBasicAuthenticationEntryPoint() {
+      return new FormLoginBasicAuthenticationEntryPoint("/dhis-web-commons/security/login.action");
+    }
+
+    @Bean
+    public FormLoginBasicAuthenticationEntryPoint
+        strutsLessFormLoginBasicAuthenticationEntryPoint() {
+      return new FormLoginBasicAuthenticationEntryPoint("/login.html");
+    }
+  }
+
+  /**
+   * Customizes various "global" security related headers.
+   *
+   * @param http http security config builder
+   * @throws Exception
+   */
   public static void setHttpHeaders(HttpSecurity http) throws Exception {
     http.headers()
         .defaultsDisabled()
@@ -221,376 +463,10 @@ public class DhisWebApiWebSecurityConfig {
         .httpStrictTransportSecurity();
   }
 
-  private void configureMatchers(HttpSecurity http) throws Exception {
-
-    http.securityContext(
-        httpSecuritySecurityContextConfigurer ->
-            httpSecuritySecurityContextConfigurer.requireExplicitSave(true));
-
-    Set<String> providerIds = dhisOidcProviderRepository.getAllRegistrationId();
-    http.authorizeHttpRequests(
-            authorize -> {
-              providerIds.forEach(
-                  providerId ->
-                      authorize
-                          .requestMatchers(
-                              new AntPathRequestMatcher("/oauth2/authorization/" + providerId))
-                          .permitAll()
-                          .requestMatchers(new AntPathRequestMatcher("/oauth2/code/" + providerId))
-                          .permitAll());
-
-              authorize
-                  .requestMatchers(analyticsPluginResources())
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/impersonate"))
-                  .hasAnyAuthority("ALL", "F_IMPERSONATE_USER")
-                  ///////////////////////////////////////////////
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-commons/oidc/**"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-commons/javascripts/**"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-commons/css/**"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-commons/flags/**"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-commons/fonts/**"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/external-static/**"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/favicon.ico"))
-                  .permitAll()
-                  // Dynamic content
-                  .requestMatchers(
-                      new AntPathRequestMatcher("/dhis-web-commons/i18nJavaScript.action"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/oauth2/**"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher("/dhis-web-commons/security/enrolTwoFa.action"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher("/dhis-web-commons/security/login.action"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher("/dhis-web-commons/security/logout.action"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher("/dhis-web-commons/security/expired.action"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher("/dhis-web-commons/security/invite.action"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher("/dhis-web-commons/security/restore.action"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher("/dhis-web-commons/security/recovery.action"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher("/dhis-web-commons/security/account.action"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher("/dhis-web-commons/security/recovery.action"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher("/dhis-web-commons/security/loginStrings.action"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher("/dhis-web-commons/security/accountStrings.action"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher(
-                          "/dhis-web-commons/security/recoveryStrings.action"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher("/dhis-web-commons/security/logo_front.png"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher("/dhis-web-commons/security/logo_mobile.png"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-dashboard/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-dashboard")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-pivot/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-pivot")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-visualizer/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-visualizer")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-data-visualizer/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-data-visualizer")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-mapping/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-mapping")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-maps/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-maps")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-event-reports/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-event-reports")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-event-visualizer/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-event-visualizer")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-interpretation/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-interpretation")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-settings/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-settings")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-maintenance/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-maintenance")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-app-management/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-app-management")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-usage-analytics/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-usage-analytics")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-event-capture/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-event-capture")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-tracker-capture/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-tracker-capture")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-cache-cleaner/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-cache-cleaner")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-data-administration/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-data-administration")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-data-quality/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-data-quality")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-messaging/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-messaging")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-datastore/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-datastore")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-scheduler/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-scheduler")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-sms-configuration/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-sms-configuration")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-user/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-user")
-                  .requestMatchers(new AntPathRequestMatcher("/dhis-web-aggregate-data-entry/**"))
-                  .hasAnyAuthority("ALL", "M_dhis-web-aggregate-data-entry")
-                  ///////////////////////////////////////////////////////////////
-                  // Temporary solution for Struts less login page
-                  .requestMatchers(new AntPathRequestMatcher("/index.html"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/external-static/**"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/favicon.ico"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/oauth2/**"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher(apiContextPath + "/authentication/login"))
-                  .permitAll()
-                  // Needs to be here because this overrides the previous one
-                  .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/account/password"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/account/recovery"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/account/restore"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/account"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/staticContent/**"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher(apiContextPath + "/externalFileResources/**"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/icons/*/icon.svg"))
-                  .permitAll()
-                  .requestMatchers(
-                      new AntPathRequestMatcher(apiContextPath + "/files/style/external"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher(apiContextPath + "/publicKeys/**"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/**"))
-                  .authenticated();
-            })
-        /// HTTP BASIC///////////////////////////////////////
-        .httpBasic()
-        .authenticationDetailsSource(httpBasicWebAuthenticationDetailsSource)
-        .authenticationEntryPoint(formLoginBasicAuthenticationEntryPoint())
-        /// OAUTH/////////
-        .and()
-        .oauth2Login(
-            oauth2 ->
-                oauth2
-                    .tokenEndpoint()
-                    .accessTokenResponseClient(jwtPrivateCodeTokenResponseClient)
-                    .and()
-                    .failureUrl("/dhis-web-commons/security/login.action?oidcFailure=true")
-                    .clientRegistrationRepository(dhisOidcProviderRepository)
-                    .loginProcessingUrl("/oauth2/code/*")
-                    .authorizationEndpoint()
-                    .authorizationRequestResolver(dhisCustomAuthorizationRequestResolver))
-
-        ///////////////
-        .exceptionHandling()
-        .authenticationEntryPoint(entryPoint())
-        .and()
-        /// SESSION ////////////////
-        /// LOGOUT //////////////////
-        .logout()
-        .logoutUrl("/dhis-web-commons-security/logout.action")
-        .logoutSuccessUrl("/")
-        .logoutSuccessHandler(dhisOidcLogoutSuccessHandler)
-        .deleteCookies("JSESSIONID")
-        .and()
-        ////////////////////
-        .sessionManagement()
-        .requireExplicitAuthenticationStrategy(true)
-        .sessionFixation()
-        .migrateSession()
-        .sessionCreationPolicy(SessionCreationPolicy.ALWAYS)
-        .enableSessionUrlRewriting(false)
-        .maximumSessions(
-            Integer.parseInt(dhisConfig.getProperty(ConfigurationKey.MAX_SESSIONS_PER_USER)))
-        .expiredUrl("/dhis-web-commons-security/logout.action")
-        .and()
-        //////////////////////////////
-        .addObjectPostProcessor(
-            new ObjectPostProcessor<BasicAuthenticationFilter>() {
-              @Override
-              public <O extends BasicAuthenticationFilter> O postProcess(O filter) {
-                // Explicitly set security context repository on http basic, is
-                // NullSecurityContextRepository by default now.
-                filter.setSecurityContextRepository(new HttpSessionSecurityContextRepository());
-                return filter;
-              }
-            });
-  }
-
-  @Bean
-  public Http401LoginUrlAuthenticationEntryPoint entryPoint() {
-    // Converts to a HTTP basic login if "XMLHttpRequest".equals(
-    // request.getHeader( "X-Requested-With" ) )
-    return new Http401LoginUrlAuthenticationEntryPoint("/dhis-web-commons/security/login.action");
-  }
-
-  @Bean
-  public RequestMatcher analyticsPluginResources() {
-    String pattern =
-        ".*(dhis-web-mapping\\/map.js|dhis-web-visualizer\\/chart.js|dhis-web-maps\\"
-            + "/map.js|dhis-web-event-reports\\/eventreport.js|dhis-web-event-visualizer\\/eventchart.js|dhis-web-pivot\\/reporttable.js)";
-
-    return new org.springframework.security.web.util.matcher.RegexRequestMatcher(pattern, "GET");
-  }
-
-  private void configureCspFilter(
-      HttpSecurity http,
-      DhisConfigurationProvider dhisConfig,
-      ConfigurationService configurationService) {
-    http.addFilterBefore(new CspFilter(dhisConfig, configurationService), HeaderWriterFilter.class);
-  }
-
-  private void configureCorsFilter(HttpSecurity http) {
-    http.addFilterBefore(CorsFilter.get(), BasicAuthenticationFilter.class);
-  }
-
-  private void configureMobileAuthFilter(HttpSecurity http) {
-    http.addFilterBefore(
-        CustomAuthenticationFilter.get(), UsernamePasswordAuthenticationFilter.class);
-  }
-
-  private void configureApiTokenAuthorizationFilter(HttpSecurity http) {
-    if (dhisConfig.isEnabled(ConfigurationKey.ENABLE_API_TOKEN_AUTHENTICATION)) {
-      Dhis2ApiTokenFilter tokenFilter =
-          new Dhis2ApiTokenFilter(
-              apiTokenAuthManager, apiTokenAuthenticationEntryPoint, authenticationEventPublisher);
-
-      http.addFilterBefore(tokenFilter, BasicAuthenticationFilter.class);
-    }
-  }
-
-  /**
-   * Enable either deprecated OAuth2 authorization filter or the new JWT OIDC token filter. They are
-   * mutually exclusive and can not both be added to the chain at the same time.
-   *
-   * @param http HttpSecurity config
-   */
-  private void configureOAuthTokenFilters(HttpSecurity http) {
-    if (dhisConfig.isEnabled(ConfigurationKey.ENABLE_JWT_OIDC_TOKEN_AUTHENTICATION)) {
-      http.addFilterAfter(getJwtBearerTokenAuthenticationFilter(), BasicAuthenticationFilter.class);
-    }
-  }
-
-  /**
-   * Creates and configures the JWT OIDC bearer token filter
-   *
-   * @return BearerTokenAuthenticationFilter to be added to the filter chain
-   */
-  private org.springframework.security.oauth2.server.resource.web.authentication
-          .BearerTokenAuthenticationFilter
-      getJwtBearerTokenAuthenticationFilter() {
-
-    org.springframework.security.oauth2.server.resource.web.authentication
-            .BearerTokenAuthenticationFilter
-        jwtFilter =
-            new org.springframework.security.oauth2.server.resource.web.authentication
-                .BearerTokenAuthenticationFilter(dhis2JwtAuthenticationManagerResolver);
-
-    jwtFilter.setAuthenticationEntryPoint(bearerTokenEntryPoint);
-    jwtFilter.setBearerTokenResolver(new DefaultBearerTokenResolver());
-
-    // Placeholder failure handler to "activate" the sending of auth failed
-    // messages
-    // to the central auth logger in DHIS2:
-    // "AuthenticationLoggerListener"
-    jwtFilter.setAuthenticationFailureHandler(
-        (request, response, exception) -> {
-          authenticationEventPublisher.publishAuthenticationFailure(
-              exception,
-              new AbstractAuthenticationToken(null) {
-                @Override
-                public Object getCredentials() {
-                  return null;
-                }
-
-                @Override
-                public Object getPrincipal() {
-                  return null;
-                }
-              });
-
-          bearerTokenEntryPoint.commence(request, response, exception);
-        });
-
-    return jwtFilter;
-  }
-
-  /**
-   * Entrypoint to "re-direct" http basic authentications to the login form page. Without this, the
-   * default http basic pop-up window in the browser will be used.
-   *
-   * @return DHIS2BasicAuthenticationEntryPoint entryPoint to use in http config.
-   */
-  @Bean
-  public FormLoginBasicAuthenticationEntryPoint formLoginBasicAuthenticationEntryPoint() {
-    return new FormLoginBasicAuthenticationEntryPoint("/dhis-web-commons/security/login.action");
-  }
-
-  @Bean
-  public FormLoginBasicAuthenticationEntryPoint strutsLessFormLoginBasicAuthenticationEntryPoint() {
-    return new FormLoginBasicAuthenticationEntryPoint("/login.html");
-  }
-
-  @Bean
-  public DefaultAuthenticationSuccessHandler authenticationSuccessHandler() {
-    DefaultAuthenticationSuccessHandler successHandler = new DefaultAuthenticationSuccessHandler();
-    successHandler.setRedirectStrategy(mappedRedirectStrategy());
-    return successHandler;
-  }
-
-  @Bean
-  public MappedRedirectStrategy mappedRedirectStrategy() {
-    Map<String, String> ignoredRedirectsAfterLoginMap =
-        Map.of(
-            "/dhis-web-commons-stream/ping.action", "/",
-            "/api/files/style/external", "/");
-
-    MappedRedirectStrategy mappedRedirectStrategy = new MappedRedirectStrategy();
-    mappedRedirectStrategy.setRedirectMap(ignoredRedirectsAfterLoginMap);
-    mappedRedirectStrategy.setDeviceResolver(deviceResolver());
-    return mappedRedirectStrategy;
-  }
-
-  @Bean
-  public DeviceResolver deviceResolver() {
-    return new LiteDeviceResolver();
-  }
-
   @Bean("switchUserProcessingFilter")
   public SwitchUserFilter switchUserFilter(
       @Qualifier("userDetailsService") UserDetailsService userDetailsService,
       @Qualifier("dhisConfigurationProvider") DhisConfigurationProvider config) {
-
     DhisSwitchUserFilter filter = new DhisSwitchUserFilter(config);
     filter.setUserDetailsService(userDetailsService);
     filter.setUserDetailsChecker(new ImpersonatingUserDetailsChecker());

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/OAuth2ConfirmAccessController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/OAuth2ConfirmAccessController.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.security.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.system.velocity.VelocityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
+import org.springframework.security.oauth2.provider.AuthorizationRequest;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.SessionAttributes;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.View;
+import org.springframework.web.util.HtmlUtils;
+
+@OpenApi.Tags({"user", "login"})
+@Controller
+@SessionAttributes("authorizationRequest")
+public class OAuth2ConfirmAccessController {
+  @Autowired
+  @Qualifier("org.hisp.dhis.system.velocity.VelocityManager")
+  VelocityManager velocityManager;
+
+  @GetMapping("/oauth/confirm_access")
+  public ModelAndView getAccessConfirmationB(Map<String, Object> model, HttpServletRequest request)
+      throws Exception {
+    Map<String, Object> vars = new HashMap<>();
+
+    AuthorizationRequest authorizationRequest =
+        (AuthorizationRequest) model.get("authorizationRequest");
+    if (authorizationRequest != null) {
+      String clientId = authorizationRequest.getClientId();
+      vars.put("client_id", clientId);
+    }
+
+    String approvalContent = velocityManager.render(vars, "confirm_access");
+
+    if (request.getAttribute("_csrf") != null) {
+      model.put("_csrf", request.getAttribute("_csrf"));
+    }
+
+    View approvalView =
+        new View() {
+          @Override
+          public String getContentType() {
+            return "text/html";
+          }
+
+          @Override
+          public void render(
+              Map<String, ?> model, HttpServletRequest request, HttpServletResponse response)
+              throws Exception {
+            response.setContentType(getContentType());
+            response.getWriter().append(approvalContent);
+          }
+        };
+
+    return new ModelAndView(approvalView, model);
+  }
+
+  @GetMapping("/oauth/error")
+  public ModelAndView handleError(HttpServletRequest request) {
+    String errorSummary;
+
+    // The error summary may contain malicious user input,
+    // it needs to be escaped to prevent XSS
+    Object error = request.getAttribute("error");
+    if (error instanceof OAuth2Exception) {
+      OAuth2Exception oauthError = (OAuth2Exception) error;
+      errorSummary = HtmlUtils.htmlEscape(oauthError.getSummary());
+    } else {
+      errorSummary = "Unknown error";
+    }
+
+    Map<String, Object> vars = new HashMap<>();
+    vars.put("error_summary", errorSummary);
+
+    String errorContent = velocityManager.render(vars, "error");
+
+    View errorView =
+        new View() {
+          @Override
+          public String getContentType() {
+            return "text/html";
+          }
+
+          @Override
+          public void render(
+              Map<String, ?> model, HttpServletRequest request, HttpServletResponse response)
+              throws Exception {
+            response.setContentType(getContentType());
+            response.getWriter().append(errorContent);
+          }
+        };
+
+    return new ModelAndView(errorView, new HashMap<>());
+  }
+}

--- a/dhis-2/dhis-web/dhis-web-commons/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-commons/pom.xml
@@ -44,6 +44,10 @@
     </dependency>
     <dependency>
       <groupId>org.hisp.dhis</groupId>
+      <artifactId>dhis-support-external</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-web-api</artifactId>
     </dependency>
     <dependency>
@@ -87,6 +91,10 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-config</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/MappedRedirectStrategy.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/MappedRedirectStrategy.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.security.config;
+package org.hisp.dhis.security;
 
 import static org.hisp.dhis.webapi.filter.CustomAuthenticationFilter.PARAM_AUTH_ONLY;
 

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/authentication/CustomAuthFailureHandler.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/authentication/CustomAuthFailureHandler.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.security.config;
+package org.hisp.dhis.security.authentication;
 
 import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
@@ -27,9 +27,54 @@
  */
 package org.hisp.dhis.security.config;
 
+import static org.hisp.dhis.webapi.security.config.DhisWebApiWebSecurityConfig.setHttpHeaders;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.hisp.dhis.configuration.ConfigurationService;
+import org.hisp.dhis.external.conf.ConfigurationKey;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.security.MappedRedirectStrategy;
+import org.hisp.dhis.security.authentication.CustomAuthFailureHandler;
+import org.hisp.dhis.security.ldap.authentication.CustomLdapAuthenticationProvider;
+import org.hisp.dhis.security.oidc.DhisOidcLogoutSuccessHandler;
+import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationProvider;
+import org.hisp.dhis.security.spring2fa.TwoFactorWebAuthenticationDetailsSource;
+import org.hisp.dhis.security.vote.ActionAccessVoter;
+import org.hisp.dhis.security.vote.ModuleAccessVoter;
+import org.hisp.dhis.webapi.filter.CorsFilter;
+import org.hisp.dhis.webapi.filter.CspFilter;
+import org.hisp.dhis.webapi.filter.CustomAuthenticationFilter;
+import org.hisp.dhis.webapi.handler.DefaultAuthenticationSuccessHandler;
+import org.hisp.dhis.webapi.security.ExternalAccessVoter;
+import org.hisp.dhis.webapi.security.Http401LoginUrlAuthenticationEntryPoint;
+import org.hisp.dhis.webapi.security.vote.LogicalOrAccessDecisionManager;
+import org.hisp.dhis.webapi.security.vote.SimpleAccessVoter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
 import org.springframework.core.annotation.Order;
+import org.springframework.mobile.device.DeviceResolver;
+import org.springframework.mobile.device.LiteDeviceResolver;
+import org.springframework.security.access.AccessDecisionManager;
+import org.springframework.security.access.vote.AuthenticatedVoter;
+import org.springframework.security.access.vote.UnanimousBased;
+import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler;
+import org.springframework.security.web.access.expression.WebExpressionVoter;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.security.web.header.HeaderWriterFilter;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 
 /**
  * The {@code DhisWebCommonsWebSecurityConfig} class configures mostly all authentication and
@@ -47,5 +92,293 @@ import org.springframework.core.annotation.Order;
     locations = {
       "classpath*:/META-INF/dhis/beans.xml",
       "classpath*:/META-INF/dhis/beans-dataentry.xml",
+      "classpath*:/META-INF/dhis/beans-maintenance-mobile.xml",
+      "classpath*:/META-INF/dhis/beans-approval.xml"
     })
-public class DhisWebCommonsWebSecurityConfig {}
+public class DhisWebCommonsWebSecurityConfig {
+  public static final Map<String, String> IGNORED_REDIRECTS_AFTER_LOGIN_MAP =
+      Map.of(
+          "/dhis-web-commons-stream/ping.action", "/",
+          "/api/files/style/external", "/");
+
+  /**
+   * This configuration class is responsible for setting up the form login and everything related to
+   * the web pages.
+   */
+  @Configuration
+  @Order(2200)
+  public static class FormLoginWebSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter {
+    @Autowired
+    private TwoFactorWebAuthenticationDetailsSource twoFactorWebAuthenticationDetailsSource;
+
+    @Autowired private DhisConfigurationProvider dhisConfig;
+
+    @Autowired private ExternalAccessVoter externalAccessVoter;
+
+    @Autowired TwoFactorAuthenticationProvider twoFactorAuthenticationProvider;
+
+    @Autowired private DhisOidcLogoutSuccessHandler dhisOidcLogoutSuccessHandler;
+
+    @Autowired
+    @Qualifier("customLdapAuthenticationProvider")
+    private CustomLdapAuthenticationProvider customLdapAuthenticationProvider;
+
+    @Autowired private CustomAuthFailureHandler customAuthFailureHandler;
+
+    @Autowired private DefaultAuthenticationEventPublisher authenticationEventPublisher;
+
+    @Autowired private ConfigurationService configurationService;
+
+    @Override
+    public void configure(AuthenticationManagerBuilder auth) throws Exception {
+      auth.authenticationProvider(customLdapAuthenticationProvider);
+      auth.authenticationProvider(twoFactorAuthenticationProvider);
+      auth.authenticationEventPublisher(authenticationEventPublisher);
+    }
+
+    @Override
+    public void configure(WebSecurity web) {
+      web.ignoring().antMatchers("/api/ping");
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+      http.authorizeRequests()
+          .accessDecisionManager(accessDecisionManager())
+          .requestMatchers(analyticsPluginResources())
+          .permitAll()
+          .antMatchers("/impersonate")
+          .hasAnyAuthority("ALL", "F_IMPERSONATE_USER")
+          .antMatchers("/dhis-web-commons/oidc/**")
+          .permitAll()
+          .antMatchers("/dhis-web-commons/javascripts/**")
+          .permitAll()
+          .antMatchers("/dhis-web-commons/css/**")
+          .permitAll()
+          .antMatchers("/dhis-web-commons/flags/**")
+          .permitAll()
+          .antMatchers("/dhis-web-commons/fonts/**")
+          .permitAll()
+          .antMatchers("/external-static/**")
+          .permitAll()
+          .antMatchers("/favicon.ico")
+          .permitAll()
+          // Dynamic content
+          .antMatchers("/dhis-web-commons/i18nJavaScript.action")
+          .permitAll()
+          .antMatchers("/oauth2/**")
+          .permitAll()
+          .antMatchers("/dhis-web-commons/security/enrolTwoFa.action")
+          .permitAll()
+          .antMatchers("/dhis-web-commons/security/login.action")
+          .permitAll()
+          .antMatchers("/dhis-web-commons/security/logout.action")
+          .permitAll()
+          .antMatchers("/dhis-web-commons/security/expired.action")
+          .permitAll()
+          .antMatchers("/dhis-web-commons/security/invite.action")
+          .permitAll()
+          .antMatchers("/dhis-web-commons/security/restore.action")
+          .permitAll()
+          .antMatchers("/dhis-web-commons/security/recovery.action")
+          .permitAll()
+          .antMatchers("/dhis-web-commons/security/account.action")
+          .permitAll()
+          .antMatchers("/dhis-web-commons/security/recovery.action")
+          .permitAll()
+          .antMatchers("/dhis-web-commons/security/loginStrings.action")
+          .permitAll()
+          .antMatchers("/dhis-web-commons/security/accountStrings.action")
+          .permitAll()
+          .antMatchers("/dhis-web-commons/security/recoveryStrings.action")
+          .permitAll()
+          .antMatchers("/dhis-web-commons/security/logo_front.png")
+          .permitAll()
+          .antMatchers("/dhis-web-commons/security/logo_mobile.png")
+          .permitAll()
+          .antMatchers("/dhis-web-dashboard/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-dashboard")
+          .antMatchers("/dhis-web-pivot/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-pivot")
+          .antMatchers("/dhis-web-visualizer/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-visualizer")
+          .antMatchers("/dhis-web-data-visualizer/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-data-visualizer")
+          .antMatchers("/dhis-web-mapping/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-mapping")
+          .antMatchers("/dhis-web-maps/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-maps")
+          .antMatchers("/dhis-web-event-reports/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-event-reports")
+          .antMatchers("/dhis-web-event-visualizer/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-event-visualizer")
+          .antMatchers("/dhis-web-interpretation/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-interpretation")
+          .antMatchers("/dhis-web-settings/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-settings")
+          .antMatchers("/dhis-web-maintenance/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-maintenance")
+          .antMatchers("/dhis-web-app-management/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-app-management")
+          .antMatchers("/dhis-web-usage-analytics/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-usage-analytics")
+          .antMatchers("/dhis-web-event-capture/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-event-capture")
+          .antMatchers("/dhis-web-tracker-capture/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-tracker-capture")
+          .antMatchers("/dhis-web-cache-cleaner/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-cache-cleaner")
+          .antMatchers("/dhis-web-data-administration/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-data-administration")
+          .antMatchers("/dhis-web-data-quality/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-data-quality")
+          .antMatchers("/dhis-web-messaging/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-messaging")
+          .antMatchers("/dhis-web-datastore/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-datastore")
+          .antMatchers("/dhis-web-scheduler/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-scheduler")
+          .antMatchers("/dhis-web-sms-configuration/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-sms-configuration")
+          .antMatchers("/dhis-web-user/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-user")
+          .antMatchers("/dhis-web-aggregate-data-entry/**")
+          .hasAnyAuthority("ALL", "M_dhis-web-aggregate-data-entry")
+          .antMatchers("/**")
+          .authenticated()
+          .and()
+          .formLogin()
+          .authenticationDetailsSource(twoFactorWebAuthenticationDetailsSource)
+          .loginPage("/dhis-web-commons/security/login.action")
+          .usernameParameter("j_username")
+          .passwordParameter("j_password")
+          .loginProcessingUrl("/dhis-web-commons-security/login.action")
+          .failureHandler(customAuthFailureHandler)
+          .successHandler(authenticationSuccessHandler())
+          .permitAll()
+          .and()
+          .logout()
+          .logoutUrl("/dhis-web-commons-security/logout.action")
+          .logoutSuccessUrl("/")
+          .logoutSuccessHandler(dhisOidcLogoutSuccessHandler)
+          .deleteCookies("JSESSIONID")
+          .permitAll()
+          .and()
+          .exceptionHandling()
+          .authenticationEntryPoint(entryPoint())
+          .and()
+          .csrf()
+          .disable()
+          .addFilterBefore(
+              new CspFilter(dhisConfig, configurationService), HeaderWriterFilter.class)
+          .addFilterBefore(CorsFilter.get(), BasicAuthenticationFilter.class)
+          .addFilterBefore(
+              CustomAuthenticationFilter.get(), UsernamePasswordAuthenticationFilter.class)
+          .sessionManagement()
+          .requireExplicitAuthenticationStrategy(true)
+          .sessionFixation()
+          .migrateSession()
+          .sessionCreationPolicy(SessionCreationPolicy.ALWAYS)
+          .enableSessionUrlRewriting(false)
+          .maximumSessions(
+              Integer.parseInt(dhisConfig.getProperty(ConfigurationKey.MAX_SESSIONS_PER_USER)))
+          .expiredUrl("/dhis-web-commons-security/logout.action");
+
+      setHttpHeaders(http);
+    }
+
+    @Bean
+    public Http401LoginUrlAuthenticationEntryPoint entryPoint() {
+      // Converts to a HTTP basic login if "XMLHttpRequest".equals(
+      // request.getHeader( "X-Requested-With" ) )
+      return new Http401LoginUrlAuthenticationEntryPoint("/dhis-web-commons/security/login.action");
+    }
+
+    @Bean
+    public DefaultAuthenticationSuccessHandler authenticationSuccessHandler() {
+      DefaultAuthenticationSuccessHandler successHandler =
+          new DefaultAuthenticationSuccessHandler();
+      successHandler.setRedirectStrategy(mappedRedirectStrategy());
+
+      return successHandler;
+    }
+
+    @Bean
+    public MappedRedirectStrategy mappedRedirectStrategy() {
+      MappedRedirectStrategy mappedRedirectStrategy = new MappedRedirectStrategy();
+      mappedRedirectStrategy.setRedirectMap(IGNORED_REDIRECTS_AFTER_LOGIN_MAP);
+      mappedRedirectStrategy.setDeviceResolver(deviceResolver());
+
+      return mappedRedirectStrategy;
+    }
+
+    @Bean
+    public DeviceResolver deviceResolver() {
+      return new LiteDeviceResolver();
+    }
+
+    @Bean
+    public RequestMatcher analyticsPluginResources() {
+      String pattern =
+          ".*(dhis-web-mapping\\/map.js|dhis-web-visualizer\\/chart.js|dhis-web-maps\\"
+              + "/map.js|dhis-web-event-reports\\/eventreport.js|dhis-web-event-visualizer\\/eventchart.js|dhis-web-pivot\\/reporttable.js)";
+
+      return new org.springframework.security.web.util.matcher.RegexRequestMatcher(pattern, "GET");
+    }
+
+    @Bean
+    public ModuleAccessVoter moduleAccessVoter() {
+      ModuleAccessVoter voter = new ModuleAccessVoter();
+      voter.setAttributePrefix("M_");
+      voter.setAlwaysAccessible(
+          Set.of(
+              "dhis-web-commons-menu",
+              "dhis-web-commons-oust",
+              "dhis-web-commons-ouwt",
+              "dhis-web-commons-security",
+              "dhis-web-commons-i18n",
+              "dhis-web-commons-ajax",
+              "dhis-web-commons-ajax-json",
+              "dhis-web-commons-ajax-html",
+              "dhis-web-commons-stream",
+              "dhis-web-commons-help",
+              "dhis-web-commons-about",
+              "dhis-web-menu-management",
+              "dhis-web-apps",
+              "dhis-web-api-mobile",
+              "dhis-web-portal",
+              "dhis-web-uaa"));
+      return voter;
+    }
+
+    @Bean
+    public ActionAccessVoter actionAccessVoter() {
+      ActionAccessVoter voter = new ActionAccessVoter();
+      voter.setAttributePrefix("F_");
+      voter.setRequiredAuthoritiesKey("requiredAuthorities");
+      voter.setAnyAuthoritiesKey("anyAuthorities");
+      return voter;
+    }
+
+    @Bean
+    public WebExpressionVoter webExpressionVoter() {
+      DefaultWebSecurityExpressionHandler h = new DefaultWebSecurityExpressionHandler();
+      h.setDefaultRolePrefix("");
+      WebExpressionVoter voter = new WebExpressionVoter();
+      voter.setExpressionHandler(h);
+      return voter;
+    }
+
+    @Bean("accessDecisionManager")
+    public LogicalOrAccessDecisionManager accessDecisionManager() {
+      List<AccessDecisionManager> decisionVoters =
+          Arrays.asList(
+              new UnanimousBased(List.of(new SimpleAccessVoter("ALL"))),
+              new UnanimousBased(List.of(actionAccessVoter(), moduleAccessVoter())),
+              new UnanimousBased(List.of(webExpressionVoter())),
+              new UnanimousBased(List.of(externalAccessVoter)),
+              new UnanimousBased(List.of(new AuthenticatedVoter())));
+      return new LogicalOrAccessDecisionManager(decisionVoters);
+    }
+  }
+}

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -90,7 +90,7 @@
 
     <!-- Security -->
     <spring-security.version>5.8.9</spring-security.version>
-
+    <spring-security-oauth2.version>2.5.2.RELEASE</spring-security-oauth2.version>
     <spring-security-jwt.version>1.1.1.RELEASE</spring-security-jwt.version>
     <bcprov-jdk15on.version>1.70</bcprov-jdk15on.version>
     <jasypt.version>1.9.3</jasypt.version>
@@ -586,6 +586,11 @@
       </dependency>
 
       <!-- OAuth 2.0 -->
+      <dependency>
+        <groupId>org.springframework.security.oauth</groupId>
+        <artifactId>spring-security-oauth2</artifactId>
+        <version>${spring-security-oauth2.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-oauth2-core</artifactId>
@@ -2205,8 +2210,8 @@ jasperreports.version=${jasperreports.version}
         </executions>
       </plugin>
     </plugins>
-    <!-- <build><sourceDirectory> cannot be set in a profile, so it needs 
-      a custom property for overwriting it, see 
+    <!-- <build><sourceDirectory> cannot be set in a profile, so it needs
+      a custom property for overwriting it, see
       https://github.com/awhitford/lombok.maven/issues/17#issuecomment-136606104 -->
     <sourceDirectory>${sourceDir}</sourceDirectory>
   </build>
@@ -2263,7 +2268,7 @@ jasperreports.version=${jasperreports.version}
       </build>
     </profile>
 
-    <!-- Integration test profile, runs all integrations tests, not unit 
+    <!-- Integration test profile, runs all integrations tests, not unit
       tests -->
     <profile>
       <id>integration</id>
@@ -2289,7 +2294,7 @@ jasperreports.version=${jasperreports.version}
       </build>
     </profile>
 
-    <!-- IntegrationH2 test profile, runs all integrations tests with H2, 
+    <!-- IntegrationH2 test profile, runs all integrations tests with H2,
       not unit tests -->
     <profile>
       <id>integrationH2</id>


### PR DESCRIPTION
# Summary
This PR reverts the removal of OAuth2 in 2.41 from Jira [DHIS2-15246].
It also reverts the changes made in the #15727, related to migration of the Spring security deprecated configuration methods, since this is not compatible with the now reverted removal of the deprecated OAuth2 features. 

[DHIS2-15246]: https://dhis2.atlassian.net/browse/DHIS2-15246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ