### PR TITLE
chore: return pagination fields in page objects in tracker deduplication endpoint TECH-1681

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationController.java
@@ -37,6 +37,7 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.deduplication.DeduplicationMergeParams;
 import org.hisp.dhis.deduplication.DeduplicationService;
 import org.hisp.dhis.deduplication.DeduplicationStatus;
@@ -58,7 +59,7 @@ import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
-import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
+import org.hisp.dhis.webapi.controller.tracker.view.Page;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -93,29 +94,25 @@ public class DeduplicationController {
 
   @OpenApi.Response(PotentialDuplicate[].class)
   @GetMapping
-  public PagingWrapper<ObjectNode> getPotentialDuplicates(
-      PotentialDuplicateCriteria potentialDuplicateCriteria,
+  public Page<ObjectNode> getPotentialDuplicates(
+      PotentialDuplicateCriteria criteria,
       HttpServletResponse response,
       @RequestParam(defaultValue = DEFAULT_FIELDS_PARAM) List<FieldPath> fields) {
-    PagingWrapper<ObjectNode> pagingWrapper = new PagingWrapper<>("potentialDuplicates");
-
-    if (potentialDuplicateCriteria.isPagingRequest()) {
-      pagingWrapper =
-          pagingWrapper.withPager(
-              PagingWrapper.Pager.builder()
-                  .page(potentialDuplicateCriteria.getPage())
-                  .pageSize(potentialDuplicateCriteria.getPageSize())
-                  .build());
-    }
-
     List<PotentialDuplicate> potentialDuplicates =
-        deduplicationService.getPotentialDuplicates(potentialDuplicateCriteria);
-
+        deduplicationService.getPotentialDuplicates(criteria);
     List<ObjectNode> objectNodes = fieldFilterService.toObjectNodes(potentialDuplicates, fields);
 
     setNoStore(response);
 
-    return pagingWrapper.withInstances(objectNodes);
+    if (criteria.isPagingRequest()) {
+      Pager pager = new Pager(criteria.getPageWithDefault(), 0, criteria.getPageSizeWithDefault());
+      pager.force(criteria.getPageWithDefault(), criteria.getPageSizeWithDefault());
+      org.hisp.dhis.tracker.export.Page<PotentialDuplicate> page =
+          org.hisp.dhis.tracker.export.Page.of(potentialDuplicates, pager, false);
+      return Page.withPager("potentialDuplicates", objectNodes, page);
+    }
+
+    return Page.withoutPager("potentialDuplicates", objectNodes);
   }
 
   @GetMapping(value = "/{id}")
@@ -167,8 +164,8 @@ public class DeduplicationController {
           "PotentialDuplicate is missing references and cannot be merged.");
     }
 
-    TrackedEntity original = getTei(potentialDuplicate.getOriginal());
-    TrackedEntity duplicate = getTei(potentialDuplicate.getDuplicate());
+    TrackedEntity original = getTrackedEntity(potentialDuplicate.getOriginal());
+    TrackedEntity duplicate = getTrackedEntity(potentialDuplicate.getDuplicate());
 
     if (mergeObject == null) {
       mergeObject = new MergeObject();
@@ -214,13 +211,13 @@ public class DeduplicationController {
           NotFoundException,
           BadRequestException,
           PotentialDuplicateConflictException {
-    checkValidTei(potentialDuplicate.getOriginal(), "original");
+    checkValidTrackedEntity(potentialDuplicate.getOriginal(), "original");
 
-    checkValidTei(potentialDuplicate.getDuplicate(), "duplicate");
+    checkValidTrackedEntity(potentialDuplicate.getDuplicate(), "duplicate");
 
-    canReadTei(getTei(potentialDuplicate.getOriginal()));
+    canReadTrackedEntity(getTrackedEntity(potentialDuplicate.getOriginal()));
 
-    canReadTei(getTei(potentialDuplicate.getDuplicate()));
+    canReadTrackedEntity(getTrackedEntity(potentialDuplicate.getDuplicate()));
 
     checkAlreadyExistingDuplicate(potentialDuplicate);
   }
@@ -238,24 +235,31 @@ public class DeduplicationController {
     }
   }
 
-  private void checkValidTei(String tei, String teiFieldName) throws BadRequestException {
-    if (tei == null) {
-      throw new BadRequestException("Missing required input property '" + teiFieldName + "'");
-    }
-
-    if (!CodeGenerator.isValidUid(tei)) {
+  private void checkValidTrackedEntity(String trackedEntity, String trackedEntityFieldName)
+      throws BadRequestException {
+    if (trackedEntity == null) {
       throw new BadRequestException(
-          "'" + tei + "' is not valid value for property '" + teiFieldName + "'");
+          "Missing required input property '" + trackedEntityFieldName + "'");
+    }
+
+    if (!CodeGenerator.isValidUid(trackedEntity)) {
+      throw new BadRequestException(
+          "'"
+              + trackedEntity
+              + "' is not valid value for property '"
+              + trackedEntityFieldName
+              + "'");
     }
   }
 
-  private TrackedEntity getTei(String tei) throws NotFoundException {
-    return Optional.ofNullable(trackedEntityService.getTrackedEntity(tei))
+  private TrackedEntity getTrackedEntity(String trackedEntity) throws NotFoundException {
+    return Optional.ofNullable(trackedEntityService.getTrackedEntity(trackedEntity))
         .orElseThrow(
-            () -> new NotFoundException("No tracked entity instance found with id '" + tei + "'."));
+            () ->
+                new NotFoundException("No tracked entity found with id '" + trackedEntity + "'."));
   }
 
-  private void canReadTei(TrackedEntity trackedEntity) throws ForbiddenException {
+  private void canReadTrackedEntity(TrackedEntity trackedEntity) throws ForbiddenException {
     User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
     if (!trackerAccessManager.canRead(currentUser, trackedEntity).isEmpty()) {
       throw new ForbiddenException(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Page.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Page.java
@@ -27,8 +27,12 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.view;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -48,8 +52,9 @@ import org.hisp.dhis.common.OpenApi.Shared.Pattern;
 @EqualsAndHashCode
 public class Page<T> {
   @OpenApi.Property(value = OpenApi.EntityType[].class)
-  @JsonProperty
-  private final List<T> instances;
+  @JsonIgnore
+  @JsonAnyGetter
+  private final Map<String, List<T>> items = new LinkedHashMap<>();
 
   @JsonProperty private final Pager pager;
 
@@ -81,8 +86,9 @@ public class Page<T> {
   @JsonProperty
   private final Integer pageCount;
 
-  private Page(List<T> instances, org.hisp.dhis.common.Pager pager, boolean showPageTotal) {
-    this.instances = instances;
+  private Page(
+      String key, List<T> values, org.hisp.dhis.common.Pager pager, boolean showPageTotal) {
+    this.items.put(key, values);
     if (pager == null) {
       this.pager = null;
       this.page = null;
@@ -107,21 +113,39 @@ public class Page<T> {
   }
 
   /**
-   * Returns a page which will serialize the items into {@link #instances}. Pagination details will
-   * be serialized as well including totals only if {@link
+   * Returns a page which will serialize the items into {@link #items} under key {@code instances}.
+   * Pagination details will be serialized as well including totals only if {@link
    * org.hisp.dhis.tracker.export.Page#isPageTotal()} is true.
    */
   public static <T, U> Page<T> withPager(
       List<T> items, org.hisp.dhis.tracker.export.Page<U> pager) {
-    return new Page<>(items, pager.getPager(), pager.isPageTotal());
+    return new Page<>("instances", items, pager.getPager(), pager.isPageTotal());
   }
 
   /**
-   * Returns a page which will only serialize the items into {@link #instances}. All other fields
-   * will be omitted from the JSON.
+   * Returns a page which will serialize the items into {@link #items} under given {@code key}.
+   * Pagination details will be serialized as well including totals only if {@link
+   * org.hisp.dhis.tracker.export.Page#isPageTotal()} is true.
+   */
+  public static <T, U> Page<T> withPager(
+      String key, List<T> items, org.hisp.dhis.tracker.export.Page<U> pager) {
+    return new Page<>(key, items, pager.getPager(), pager.isPageTotal());
+  }
+
+  /**
+   * Returns a page which will only serialize the items into {@link #items} under key {@code
+   * instances}. All other fields will be omitted from the JSON.
    */
   public static <T> Page<T> withoutPager(List<T> items) {
-    return new Page<>(items, null, false);
+    return Page.withoutPager("instances", items);
+  }
+
+  /**
+   * Returns a page which will only serialize the items into {@link #items} under given {@code key}.
+   * All other fields will be omitted from the JSON.
+   */
+  public static <T> Page<T> withoutPager(String key, List<T> items) {
+    return new Page<>(key, items, null, false);
   }
 
   @OpenApi.Shared(pattern = Pattern.TRACKER)


### PR DESCRIPTION
Similar to https://github.com/dhis2/dhis2-core/pull/16164 we are deprecating the flat pagination related fields in favor of the pager used in most endpoints.

This controller, service and store do not yet follow the same approach we use in the refactored tracker exporters. We will align the controller at a later point. We are also in a transition when it comes to the different pagination/pager types. Right now it's pretty awkward instantiating/translating them. We will clean this up soon and try to rely almost exclusively on the `common.Pager`.

* note that this endpoint does not implement returning any page totals while it does accept the query parameters via the `PagingAndSortingCriteriaAdapter`
* use TE and trackedEntity instead of suffix instance
