### PR TITLE
feat: deprecate skipPaging in favor of paging in deduplication TECH-1681

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/deduplication/PotentialDuplicateCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/deduplication/PotentialDuplicateCriteria.java
@@ -30,11 +30,38 @@ package org.hisp.dhis.deduplication;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
+import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
 
 @Data
 public class PotentialDuplicateCriteria extends PagingAndSortingCriteriaAdapter {
+  // TODO(tracker): set paging=true once skipPaging is removed. Both cannot have a default right
+  // now. This would lead to invalid parameters if the user passes the other param i.e.
+  // skipPaging==paging.
+  // isPaged() handles the default case of skipPaging==paging==null => paging enabled
+  @OpenApi.Property(defaultValue = "true")
+  private Boolean paging;
+
   private List<String> trackedEntities = new ArrayList<>();
 
   private DeduplicationStatus status = DeduplicationStatus.OPEN;
+
+  /**
+   * Indicates whether to return a page of items or all items. By default, responses are paginated.
+   *
+   * <p>Note: this assumes {@link #getPaging()} and {@link #getSkipPaging()} have been validated.
+   * Preference is given to {@link #getPaging()} as the other parameter is deprecated.
+   */
+  @OpenApi.Ignore
+  public boolean isPaged() {
+    if (getPaging() != null) {
+      return Boolean.TRUE.equals(getPaging());
+    }
+
+    if (getSkipPaging() != null) {
+      return Boolean.FALSE.equals(getSkipPaging());
+    }
+
+    return true;
+  }
 }


### PR DESCRIPTION
Similar to https://github.com/dhis2/dhis2-core/pull/16196 we are deprecating the `skipPaging` query parameter in favor of `paging` used in most endpoints.

We will align the controller and its request parameters with tracker exporters at a later stage. Right now we have to duplicate some of the validation logic we have in the RequestParamsValidator as the `PotentialDuplicateCriteria extends PagingAndSortingCriteriaAdapter`.