### PR TITLE
chore: remove paging parameter for Gist API [DHIS2-16401]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistParams.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistParams.java
@@ -66,9 +66,7 @@ public final class GistParams {
 
   boolean absoluteUrls = false;
 
-  Boolean headless;
-
-  Boolean paging;
+  boolean headless;
 
   boolean describe = false;
 
@@ -94,15 +92,5 @@ public final class GistParams {
     if (totalPages != null) return totalPages;
     if (total != null) return total;
     return false;
-  }
-
-  @JsonIgnore
-  public boolean isIncludePager() throws BadRequestException {
-    if (paging != null && headless != null && paging == headless)
-      throw new BadRequestException(
-          "paging and headless request parameters are contradicting each other");
-    if (paging != null) return paging;
-    if (headless != null) return !headless;
-    return true;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
@@ -182,7 +182,7 @@ public final class GistQuery {
         .inverse(params.isInverse())
         .total(params.isCountTotalPages())
         .absoluteUrls(params.isAbsoluteUrls())
-        .headless(!params.isIncludePager())
+        .headless(params.isHeadless())
         .describe(params.isDescribe())
         .references(params.isReferences())
         .anyFilter(params.getRootJunction() == Junction.Type.OR)

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistPagerControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistPagerControllerTest.java
@@ -119,22 +119,4 @@ class GistPagerControllerTest extends AbstractGistControllerTest {
         JsonNodeType.OBJECT,
         GET(baseUrl + "?headless=false", getSuperuserUid()).content().node().getType());
   }
-
-  @Test
-  void testPaging() {
-    String baseUrl = "/users/{uid}/userGroups/gist";
-    assertEquals(
-        JsonNodeType.OBJECT,
-        GET(baseUrl + "?paging=true", getSuperuserUid()).content().node().getType());
-    assertEquals(
-        JsonNodeType.ARRAY,
-        GET(baseUrl + "?paging=false", getSuperuserUid()).content().node().getType());
-
-    JsonWebMessage msg =
-        GET(baseUrl + "?paging=false&headless=false", getSuperuserUid())
-            .content(HttpStatus.BAD_REQUEST)
-            .as(JsonWebMessage.class);
-    assertEquals(
-        "paging and headless request parameters are contradicting each other", msg.getMessage());
-  }
 }


### PR DESCRIPTION
#16077 introduced the `paging` parameter as an alias for `headless` but these are not the same thing as assumed in that PR.
Gist API intentionally does not support to turn off paging and hence does not need a `paging` parameter.