### PR TITLE
chore: return pagination fields in page objects in /programNotificationInstances TECH-1683

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/BaseNotificationParam.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/BaseNotificationParam.java
@@ -40,7 +40,7 @@ import lombok.NoArgsConstructor;
 public class BaseNotificationParam {
   public static final int DEFAULT_PAGE_SIZE = 50;
 
-  public static final int DEFAULT_PAGE = 0;
+  public static final int DEFAULT_PAGE = 1;
 
   private Integer page;
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/HibernateProgramNotificationInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/HibernateProgramNotificationInstanceStore.java
@@ -37,6 +37,7 @@ import javax.persistence.criteria.Root;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
 import org.hisp.dhis.hibernate.JpaQueryParameters;
 import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.util.ObjectUtils;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -73,11 +74,13 @@ public class HibernateProgramNotificationInstanceStore
             .addOrder(root -> builder.desc(root.get("created")));
 
     if (!params.isSkipPaging()) {
+      // javax.persistence.TypedQuery position of the first result is numbered from 0 while
+      // user-facing pagination parameters start at 1
+      int firstResult =
+          ObjectUtils.firstNonNull(params.getPage(), ProgramNotificationInstanceParam.DEFAULT_PAGE)
+              - 1;
       jpaParameters
-          .setFirstResult(
-              params.getPage() != null
-                  ? params.getPage()
-                  : ProgramNotificationInstanceParam.DEFAULT_PAGE)
+          .setFirstResult(firstResult)
           .setMaxResults(
               params.getPageSize() != null
                   ? params.getPageSize()

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationControllerTest.java
@@ -134,7 +134,7 @@ class DeduplicationControllerTest extends DhisControllerConvenienceTest {
     save(potentialDuplicate2);
 
     JsonPage page =
-        GET("/potentialDuplicates?&page=2&pageSize=1")
+        GET("/potentialDuplicates?page=2&pageSize=1")
             .content(HttpStatus.OK)
             .asObject(JsonPage.class);
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceControllerTest.java
@@ -27,10 +27,13 @@
  */
 package org.hisp.dhis.webapi.controller.event;
 
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.utils.Assertions.assertStartsWith;
+import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasNoMember;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.Sets;
+import java.util.List;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -46,6 +49,7 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.webapi.controller.tracker.JsonPage;
 import org.hisp.dhis.webapi.json.domain.JsonIdentifiableObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,10 +66,11 @@ class ProgramNotificationInstanceControllerTest extends DhisControllerConvenienc
   @Autowired private TrackedEntityService teiService;
 
   @Autowired private IdentifiableObjectManager idObjectManager;
-  private Enrollment enrollmentA;
-
-  private Event eventA;
-  private ProgramNotificationInstance programNotification;
+  private Enrollment enrollment;
+  private Event event;
+  private ProgramNotificationInstance enrollmentNotification1;
+  private ProgramNotificationInstance enrollmentNotification2;
+  private ProgramNotificationInstance eventNotification;
 
   @BeforeEach
   void setUp() {
@@ -76,41 +81,39 @@ class ProgramNotificationInstanceControllerTest extends DhisControllerConvenienc
     idObjectManager.save(prA);
     ProgramStage psA = createProgramStage('A', prA);
     idObjectManager.save(psA);
-
     TrackedEntity teiA = createTrackedEntity('A', ouA);
     teiService.addTrackedEntity(teiA);
+    enrollment = createEnrollment(prA, teiA, ouA);
+    enrollmentService.addEnrollment(enrollment);
 
-    enrollmentA = createEnrollment(prA, teiA, ouA);
-    enrollmentService.addEnrollment(enrollmentA);
+    enrollmentNotification1 = new ProgramNotificationInstance();
+    enrollmentNotification1.setName("enrollment A notification 1");
+    enrollmentNotification1.setEnrollment(enrollment);
+    programNotificationInstanceService.save(enrollmentNotification1);
 
-    eventA = createEvent(psA, enrollmentA, ouA);
-    eventService.addEvent(eventA);
+    enrollmentNotification2 = new ProgramNotificationInstance();
+    enrollmentNotification2.setName("enrollment A notification 2");
+    enrollmentNotification2.setEnrollment(enrollment);
+    programNotificationInstanceService.save(enrollmentNotification2);
 
-    programNotification = new ProgramNotificationInstance();
-    programNotification.setName("notify");
-    programNotification.setEnrollment(enrollmentA);
-    programNotification.setEvent(eventA);
-    programNotificationInstanceService.save(programNotification);
+    event = createEvent(psA, enrollment, ouA);
+    eventService.addEvent(event);
+    eventNotification = new ProgramNotificationInstance();
+    eventNotification.setName("event A notification");
+    eventNotification.setEvent(event);
+    programNotificationInstanceService.save(eventNotification);
   }
 
   @Test
   void shouldGetProgramNotificationWhenPassingDeprecatedProgramInstanceParam() {
     JsonList<JsonIdentifiableObject> list =
-        GET("/programNotificationInstances?programInstance={uid}", enrollmentA.getUid())
+        GET("/programNotificationInstances?programInstance={uid}", enrollment.getUid())
             .content(HttpStatus.OK)
             .getList("instances", JsonIdentifiableObject.class);
 
-    assertEquals(programNotification.getName(), list.get(0).getName());
-  }
-
-  @Test
-  void shouldGetProgramNotificationWhenPassingEnrollmentParam() {
-    JsonList<JsonIdentifiableObject> list =
-        GET("/programNotificationInstances?enrollment={uid}", enrollmentA.getUid())
-            .content(HttpStatus.OK)
-            .getList("instances", JsonIdentifiableObject.class);
-
-    assertEquals(programNotification.getName(), list.get(0).getName());
+    assertContainsOnly(
+        List.of(enrollmentNotification1.getName(), enrollmentNotification2.getName()),
+        list.toList(JsonIdentifiableObject::getName));
   }
 
   @Test
@@ -119,8 +122,8 @@ class ProgramNotificationInstanceControllerTest extends DhisControllerConvenienc
         "Only one parameter of 'programInstance' and 'enrollment'",
         GET(
                 "/programNotificationInstances?enrollment={uid}&programInstance={uid}",
-                enrollmentA.getUid(),
-                enrollmentA.getUid())
+                enrollment.getUid(),
+                enrollment.getUid())
             .error(HttpStatus.BAD_REQUEST)
             .getMessage());
   }
@@ -128,21 +131,21 @@ class ProgramNotificationInstanceControllerTest extends DhisControllerConvenienc
   @Test
   void shouldGetProgramNotificationWhenPassingDeprecatedProgramStageInstanceParam() {
     JsonList<JsonIdentifiableObject> list =
-        GET("/programNotificationInstances?programStageInstance={uid}", eventA.getUid())
+        GET("/programNotificationInstances?programStageInstance={uid}", event.getUid())
             .content(HttpStatus.OK)
             .getList("instances", JsonIdentifiableObject.class);
 
-    assertEquals(programNotification.getName(), list.get(0).getName());
+    assertEquals(eventNotification.getName(), list.get(0).getName());
   }
 
   @Test
   void shouldGetProgramNotificationWhenPassingEventParams() {
     JsonList<JsonIdentifiableObject> list =
-        GET("/programNotificationInstances?event={uid}", eventA.getUid())
+        GET("/programNotificationInstances?event={uid}", event.getUid())
             .content(HttpStatus.OK)
             .getList("instances", JsonIdentifiableObject.class);
 
-    assertEquals(programNotification.getName(), list.get(0).getName());
+    assertEquals(eventNotification.getName(), list.get(0).getName());
   }
 
   @Test
@@ -151,10 +154,123 @@ class ProgramNotificationInstanceControllerTest extends DhisControllerConvenienc
         "Only one parameter of 'programStageInstance' and 'event'",
         GET(
                 "/programNotificationInstances?event={uid}&programStageInstance={uid}",
-                eventA.getUid(),
-                eventA.getUid())
+                event.getUid(),
+                event.getUid())
             .error(HttpStatus.BAD_REQUEST)
             .getMessage());
+  }
+
+  @Test
+  void shouldGetPaginatedItemsWithDefaults() {
+    JsonPage page =
+        GET("/programNotificationInstances?enrollment={uid}", enrollment.getUid())
+            .content(HttpStatus.OK)
+            .asObject(JsonPage.class);
+
+    JsonList<JsonIdentifiableObject> list = page.getList("instances", JsonIdentifiableObject.class);
+    assertContainsOnly(
+        List.of(enrollmentNotification1.getName(), enrollmentNotification2.getName()),
+        list.toList(JsonIdentifiableObject::getName));
+
+    assertEquals(1, page.getPager().getPage());
+    assertEquals(50, page.getPager().getPageSize());
+    assertEquals(2, page.getPager().getTotal());
+    assertEquals(1, page.getPager().getPageCount());
+
+    // assert deprecated fields
+    assertEquals(1, page.getPage());
+    assertEquals(50, page.getPageSize());
+    assertEquals(2, page.getTotal());
+    assertEquals(1, page.getPageCount());
+  }
+
+  @Test
+  void shouldGetPaginatedItemsWithNonDefaults() {
+    JsonPage page =
+        GET("/programNotificationInstances?enrollment={uid}&page=2&pageSize=1", enrollment.getUid())
+            .content(HttpStatus.OK)
+            .asObject(JsonPage.class);
+
+    JsonList<JsonIdentifiableObject> list = page.getList("instances", JsonIdentifiableObject.class);
+    assertEquals(
+        1,
+        list.size(),
+        () -> String.format("mismatch in number of expected notification(s), got %s", list));
+
+    assertEquals(2, page.getPager().getPage());
+    assertEquals(1, page.getPager().getPageSize());
+    assertEquals(2, page.getPager().getTotal());
+    assertEquals(2, page.getPager().getPageCount());
+
+    // assert deprecated fields
+    assertEquals(2, page.getPage());
+    assertEquals(1, page.getPageSize());
+    assertEquals(2, page.getTotal());
+    assertEquals(2, page.getPageCount());
+  }
+
+  @Test
+  void shouldGetPaginatedItemsWithPagingSetToTrue() {
+    JsonPage page =
+        GET("/programNotificationInstances?enrollment={uid}&paging=true", enrollment.getUid())
+            .content(HttpStatus.OK)
+            .asObject(JsonPage.class);
+
+    JsonList<JsonIdentifiableObject> list = page.getList("instances", JsonIdentifiableObject.class);
+    assertContainsOnly(
+        List.of(enrollmentNotification1.getName(), enrollmentNotification2.getName()),
+        list.toList(JsonIdentifiableObject::getName));
+
+    assertEquals(1, page.getPager().getPage());
+    assertEquals(50, page.getPager().getPageSize());
+    assertEquals(2, page.getPager().getTotal());
+    assertEquals(1, page.getPager().getPageCount());
+
+    // assert deprecated fields
+    assertEquals(1, page.getPage());
+    assertEquals(50, page.getPageSize());
+    assertEquals(2, page.getTotal());
+    assertEquals(1, page.getPageCount());
+  }
+
+  @Test
+  void shouldGetNonPaginatedItemsWithSkipPaging() {
+    JsonPage page =
+        GET("/programNotificationInstances?enrollment={uid}&skipPaging=true", enrollment.getUid())
+            .content(HttpStatus.OK)
+            .asObject(JsonPage.class);
+
+    JsonList<JsonIdentifiableObject> list = page.getList("instances", JsonIdentifiableObject.class);
+    assertContainsOnly(
+        List.of(enrollmentNotification1.getName(), enrollmentNotification2.getName()),
+        list.toList(JsonIdentifiableObject::getName));
+    assertHasNoMember(page, "pager");
+
+    // assert deprecated fields
+    assertHasNoMember(page, "page");
+    assertHasNoMember(page, "pageSize");
+    assertHasNoMember(page, "total");
+    assertHasNoMember(page, "pageCount");
+  }
+
+  @Test
+  void shouldGetNonPaginatedItemsWithPagingSetToFalse() {
+    JsonPage page =
+        GET("/programNotificationInstances?enrollment={uid}&paging=false", enrollment.getUid())
+            .content(HttpStatus.OK)
+            .asObject(JsonPage.class);
+
+    JsonList<JsonIdentifiableObject> list = page.getList("instances", JsonIdentifiableObject.class);
+    assertContainsOnly(
+        List.of(enrollmentNotification1.getName(), enrollmentNotification2.getName()),
+        list.toList(JsonIdentifiableObject::getName));
+    assertHasNoMember(page, "pager");
+
+    // assert deprecated fields
+    assertHasNoMember(page, "page");
+    assertHasNoMember(page, "pageSize");
+    assertHasNoMember(page, "total");
+    assertHasNoMember(page, "pageCount");
   }
 
   @Test
@@ -162,7 +278,7 @@ class ProgramNotificationInstanceControllerTest extends DhisControllerConvenienc
     String message =
         GET(
                 "/programNotificationInstances?enrollment={uid}&paging=false&skipPaging=false",
-                enrollmentA.getUid())
+                enrollment.getUid())
             .content(HttpStatus.BAD_REQUEST)
             .getString("message")
             .string();
@@ -175,7 +291,7 @@ class ProgramNotificationInstanceControllerTest extends DhisControllerConvenienc
     String message =
         GET(
                 "/programNotificationInstances?enrollment={uid}&paging=true&skipPaging=true",
-                enrollmentA.getUid())
+                enrollment.getUid())
             .content(HttpStatus.BAD_REQUEST)
             .getString("message")
             .string();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceControllerTest.java
@@ -156,4 +156,30 @@ class ProgramNotificationInstanceControllerTest extends DhisControllerConvenienc
             .error(HttpStatus.BAD_REQUEST)
             .getMessage());
   }
+
+  @Test
+  void shouldFailWhenSkipPagingAndPagingAreFalse() {
+    String message =
+        GET(
+                "/programNotificationInstances?enrollment={uid}&paging=false&skipPaging=false",
+                enrollmentA.getUid())
+            .content(HttpStatus.BAD_REQUEST)
+            .getString("message")
+            .string();
+
+    assertStartsWith("Paging can either be enabled or disabled", message);
+  }
+
+  @Test
+  void shouldFailWhenSkipPagingAndPagingAreTrue() {
+    String message =
+        GET(
+                "/programNotificationInstances?enrollment={uid}&paging=true&skipPaging=true",
+                enrollmentA.getUid())
+            .content(HttpStatus.BAD_REQUEST)
+            .getString("message")
+            .string();
+
+    assertStartsWith("Paging can either be enabled or disabled", message);
+  }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceController.java
@@ -33,6 +33,7 @@ import java.util.Date;
 import java.util.List;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.program.EnrollmentService;
@@ -41,7 +42,7 @@ import org.hisp.dhis.program.notification.ProgramNotificationInstance;
 import org.hisp.dhis.program.notification.ProgramNotificationInstanceParam;
 import org.hisp.dhis.program.notification.ProgramNotificationInstanceService;
 import org.hisp.dhis.schema.descriptors.ProgramNotificationInstanceSchemaDescriptor;
-import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
+import org.hisp.dhis.webapi.controller.tracker.view.Page;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
@@ -75,21 +76,19 @@ public class ProgramNotificationInstanceController {
 
   @PreAuthorize("hasRole('ALL')")
   @GetMapping(produces = {"application/json"})
-  public @ResponseBody PagingWrapper<ProgramNotificationInstance> getScheduledMessage(
+  public @ResponseBody Page<ProgramNotificationInstance> getScheduledMessage(
       @Deprecated(since = "2.41") @RequestParam(required = false) UID programInstance,
       @RequestParam(required = false) UID enrollment,
       @Deprecated(since = "2.41") @RequestParam(required = false) UID programStageInstance,
       @RequestParam(required = false) UID event,
       @RequestParam(required = false) Date scheduledAt,
-      /**
-       * @deprecated use {@code paging} instead
-       */
+      // @deprecated use {@code paging} instead
       @Deprecated(since = "2.41") @RequestParam(required = false) Boolean skipPaging,
       // TODO(tracker): set paging=true once skipPaging is removed. Both cannot have a default right
       // now. This would lead to invalid parameters if the user passes the other param i.e.
       // skipPaging==paging.
       @RequestParam(required = false) Boolean paging,
-      @RequestParam(required = false, defaultValue = "0") int page,
+      @RequestParam(required = false, defaultValue = "1") int page,
       @RequestParam(required = false, defaultValue = "50") int pageSize)
       throws BadRequestException {
     if (paging != null && skipPaging != null && paging.equals(skipPaging)) {
@@ -114,23 +113,21 @@ public class ProgramNotificationInstanceController {
             .pageSize(pageSize)
             .scheduledAt(scheduledAt)
             .build();
-
-    PagingWrapper<ProgramNotificationInstance> instancePagingWrapper = new PagingWrapper<>();
-
-    if (isPaged) {
-      long total = programNotificationInstanceService.countProgramNotificationInstances(params);
-
-      instancePagingWrapper =
-          instancePagingWrapper.withPager(
-              PagingWrapper.Pager.builder().page(page).pageSize(pageSize).total(total).build());
-    }
-
     programNotificationInstanceService.validateQueryParameters(params);
 
     List<ProgramNotificationInstance> instances =
         programNotificationInstanceService.getProgramNotificationInstances(params);
 
-    return instancePagingWrapper.withInstances(instances);
+    if (isPaged) {
+      long total = programNotificationInstanceService.countProgramNotificationInstances(params);
+
+      Pager pager = new Pager(page, total, pageSize);
+      pager.force(page, pageSize);
+      return Page.withPager(
+          instances, org.hisp.dhis.tracker.export.Page.of(instances, pager, true));
+    }
+
+    return Page.withoutPager(instances);
   }
 
   /**

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceController.java
@@ -81,10 +81,23 @@ public class ProgramNotificationInstanceController {
       @Deprecated(since = "2.41") @RequestParam(required = false) UID programStageInstance,
       @RequestParam(required = false) UID event,
       @RequestParam(required = false) Date scheduledAt,
-      @RequestParam(required = false) boolean skipPaging,
+      /**
+       * @deprecated use {@code paging} instead
+       */
+      @Deprecated(since = "2.41") @RequestParam(required = false) Boolean skipPaging,
+      // TODO(tracker): set paging=true once skipPaging is removed. Both cannot have a default right
+      // now. This would lead to invalid parameters if the user passes the other param i.e.
+      // skipPaging==paging.
+      @RequestParam(required = false) Boolean paging,
       @RequestParam(required = false, defaultValue = "0") int page,
       @RequestParam(required = false, defaultValue = "50") int pageSize)
       throws BadRequestException {
+    if (paging != null && skipPaging != null && paging.equals(skipPaging)) {
+      throw new BadRequestException(
+          "Paging can either be enabled or disabled. Prefer 'paging' as 'skipPaging' will be removed.");
+    }
+    boolean isPaged = isPaged(paging, skipPaging);
+
     UID enrollmentUid =
         validateDeprecatedParameter("programInstance", programInstance, "enrollment", enrollment);
     UID eventUid =
@@ -96,7 +109,7 @@ public class ProgramNotificationInstanceController {
                 enrollmentService.getEnrollment(
                     enrollmentUid == null ? null : enrollmentUid.getValue()))
             .event(eventService.getEvent(eventUid == null ? null : eventUid.getValue()))
-            .skipPaging(skipPaging)
+            .skipPaging(!isPaged)
             .page(page)
             .pageSize(pageSize)
             .scheduledAt(scheduledAt)
@@ -104,7 +117,7 @@ public class ProgramNotificationInstanceController {
 
     PagingWrapper<ProgramNotificationInstance> instancePagingWrapper = new PagingWrapper<>();
 
-    if (!skipPaging) {
+    if (isPaged) {
       long total = programNotificationInstanceService.countProgramNotificationInstances(params);
 
       instancePagingWrapper =
@@ -118,5 +131,23 @@ public class ProgramNotificationInstanceController {
         programNotificationInstanceService.getProgramNotificationInstances(params);
 
     return instancePagingWrapper.withInstances(instances);
+  }
+
+  /**
+   * Indicates whether to return a page of items or all items. By default, responses are paginated.
+   *
+   * <p>Note: this assumes {@code paging} and {@code skipPaging} have been validated. Preference is
+   * given to {@code paging} as the other parameter is deprecated.
+   */
+  private static boolean isPaged(Boolean paging, Boolean skipPaging) {
+    if (paging != null) {
+      return Boolean.TRUE.equals(paging);
+    }
+
+    if (skipPaging != null) {
+      return Boolean.FALSE.equals(skipPaging);
+    }
+
+    return true;
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationTemplateController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationTemplateController.java
@@ -82,7 +82,7 @@ public class ProgramNotificationTemplateController
       @RequestParam(required = false) String program,
       @RequestParam(required = false) String programStage,
       @RequestParam(required = false) boolean skipPaging,
-      @RequestParam(required = false, defaultValue = "0") int page,
+      @RequestParam(required = false, defaultValue = "1") int page,
       @RequestParam(required = false, defaultValue = "50") int pageSize) {
     ProgramNotificationTemplateParam params =
         ProgramNotificationTemplateParam.builder()


### PR DESCRIPTION
* Similar to https://github.com/dhis2/dhis2-core/pull/16196 we are deprecating the `skipPaging` query parameter in favor of `paging` used in most endpoints.
* Similar to https://github.com/dhis2/dhis2-core/pull/16164 we are deprecating the flat pagination related fields in favor of the pager used in most endpoints.

We will align the controller and its request parameters with tracker exporters at a later stage. Right now we have to duplicate some of the validation logic we have in the RequestParamsValidator as the `PotentialDuplicateCriteria extends PagingAndSortingCriteriaAdapter`.