### PR TITLE
chore: export tracker entities in key named after entity [DHIS2-16491]

### DIFF
--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/helpers/JsonObjectBuilder.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/helpers/JsonObjectBuilder.java
@@ -211,6 +211,11 @@ public class JsonObjectBuilder {
     return array;
   }
 
+  public JsonObjectBuilder deleteByJsonPath(String path) {
+    JsonPath.using(jsonPathConfiguration).parse(jsonObject).delete(path);
+    return this;
+  }
+
   public JsonObject build() {
     return this.jsonObject;
   }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/TrackerExportTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/TrackerExportTests.java
@@ -99,8 +99,7 @@ public class TrackerExportTests extends TrackerApiTest {
 
     TrackerApiResponse response =
         trackerImportExportActions.postAndGetJobReport(
-            new File(
-                "src/test/resources/tracker/importer/trackedEntities/trackedEntitysWithEnrollmentsAndEvents.json"));
+            new File("src/test/resources/tracker/importer/teis/teisWithEnrollmentsAndEvents.json"));
 
     trackedEntityA = response.validateSuccessfulImport().extractImportedTeis().get(0);
     trackedEntityB = response.validateSuccessfulImport().extractImportedTeis().get(1);
@@ -125,7 +124,7 @@ public class TrackerExportTests extends TrackerApiTest {
         new FileReaderUtils()
             .read(
                 new File(
-                    "src/test/resources/tracker/importer/trackedEntities/trackedEntityWithEnrollmentAndEventsNested.json"))
+                    "src/test/resources/tracker/importer/teis/teiWithEnrollmentAndEventsNested.json"))
             .get(JsonObject.class);
   }
 

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/TrackerExportTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/TrackerExportTests.java
@@ -77,21 +77,21 @@ public class TrackerExportTests extends TrackerApiTest {
 
   private static final String TE_POTENTIAL_DUPLICATE = "Nav6inZRw1u";
 
-  private static String teiA;
+  private static String trackedEntityA;
 
-  private static String teiB;
+  private static String trackedEntityB;
 
   private static String enrollment;
 
   private static String event;
 
-  private static String teiToTeiRelationship;
+  private static String trackedEntityToTeiRelationship;
 
   private static String enrollmentToTeiRelationship;
 
   private static String eventToTeiRelationship;
 
-  private static JsonObject teiWithEnrollmentAndEventsTemplate;
+  private static JsonObject trackedEntityWithEnrollmentAndEventsTemplate;
 
   @BeforeAll
   public void beforeAll() throws Exception {
@@ -99,28 +99,33 @@ public class TrackerExportTests extends TrackerApiTest {
 
     TrackerApiResponse response =
         trackerImportExportActions.postAndGetJobReport(
-            new File("src/test/resources/tracker/importer/teis/teisWithEnrollmentsAndEvents.json"));
+            new File(
+                "src/test/resources/tracker/importer/trackedEntities/trackedEntitysWithEnrollmentsAndEvents.json"));
 
-    teiA = response.validateSuccessfulImport().extractImportedTeis().get(0);
-    teiB = response.validateSuccessfulImport().extractImportedTeis().get(1);
+    trackedEntityA = response.validateSuccessfulImport().extractImportedTeis().get(0);
+    trackedEntityB = response.validateSuccessfulImport().extractImportedTeis().get(1);
 
     enrollment = response.extractImportedEnrollments().get(0);
 
     event = response.extractImportedEvents().get(0);
 
-    teiToTeiRelationship =
-        importRelationshipBetweenTeis(teiA, teiB).extractImportedRelationships().get(0);
+    trackedEntityToTeiRelationship =
+        importRelationshipBetweenTeis(trackedEntityA, trackedEntityB)
+            .extractImportedRelationships()
+            .get(0);
     enrollmentToTeiRelationship =
-        importRelationshipEnrollmentToTei(enrollment, teiB).extractImportedRelationships().get(0);
+        importRelationshipEnrollmentToTei(enrollment, trackedEntityB)
+            .extractImportedRelationships()
+            .get(0);
 
     eventToTeiRelationship =
-        importRelationshipEventToTei(event, teiB).extractImportedRelationships().get(0);
+        importRelationshipEventToTei(event, trackedEntityB).extractImportedRelationships().get(0);
 
-    teiWithEnrollmentAndEventsTemplate =
+    trackedEntityWithEnrollmentAndEventsTemplate =
         new FileReaderUtils()
             .read(
                 new File(
-                    "src/test/resources/tracker/importer/teis/teiWithEnrollmentAndEventsNested.json"))
+                    "src/test/resources/tracker/importer/trackedEntities/trackedEntityWithEnrollmentAndEventsNested.json"))
             .get(JsonObject.class);
   }
 
@@ -153,22 +158,22 @@ public class TrackerExportTests extends TrackerApiTest {
   private Stream<Arguments> shouldReturnRequestedFields() {
     return Stream.of(
         Arguments.of(
-            "/trackedEntities/" + teiA,
+            "/trackedEntities/" + trackedEntityA,
             "enrollments[createdAt],relationships[from[trackedEntity[trackedEntity]],to[trackedEntity[trackedEntity]]]",
             "enrollments.createdAt,relationships.from.trackedEntity.trackedEntity,relationships.to.trackedEntity.trackedEntity"),
-        Arguments.of("/trackedEntities/" + teiA, "trackedEntity,enrollments", null),
+        Arguments.of("/trackedEntities/" + trackedEntityA, "trackedEntity,enrollments", null),
         Arguments.of(
             "/enrollments/" + enrollment,
             "program,status,enrolledAt,relationships,attributes",
             null),
         Arguments.of(
-            "/trackedEntities/" + teiA,
+            "/trackedEntities/" + trackedEntityA,
             "*",
             "trackedEntity,trackedEntityType,createdAt,updatedAt,orgUnit,inactive,deleted,potentialDuplicate,updatedBy,attributes",
             null),
         Arguments.of("/events/" + event, "enrollment,createdAt", null),
         Arguments.of(
-            "/relationships/" + teiToTeiRelationship,
+            "/relationships/" + trackedEntityToTeiRelationship,
             "from,to[trackedEntity[trackedEntity]]",
             "from,to.trackedEntity.trackedEntity"),
         Arguments.of(
@@ -188,11 +193,11 @@ public class TrackerExportTests extends TrackerApiTest {
         fieldsToValidate == null ? splitFields(fields) : splitFields(fieldsToValidate);
 
     fieldList.forEach(
-        p -> {
-          response
-              .validate()
-              .body(p, allOf(not(nullValue()), not(contains(nullValue())), not(emptyIterable())));
-        });
+        p ->
+            response
+                .validate()
+                .body(
+                    p, allOf(not(nullValue()), not(contains(nullValue())), not(emptyIterable()))));
   }
 
   @Test
@@ -200,7 +205,8 @@ public class TrackerExportTests extends TrackerApiTest {
     TrackerApiResponse response =
         trackerImportExportActions
             .postAndGetJobReport(
-                teiWithEnrollmentAndEventsTemplate, new QueryParamsBuilder().add("async=false"))
+                trackedEntityWithEnrollmentAndEventsTemplate,
+                new QueryParamsBuilder().add("async=false"))
             .validateSuccessfulImport();
 
     assertEquals(1, response.extractImportedEvents().size());
@@ -220,7 +226,8 @@ public class TrackerExportTests extends TrackerApiTest {
     TrackerApiResponse response =
         trackerImportExportActions
             .postAndGetJobReport(
-                teiWithEnrollmentAndEventsTemplate, new QueryParamsBuilder().add("async=false"))
+                trackedEntityWithEnrollmentAndEventsTemplate,
+                new QueryParamsBuilder().add("async=false"))
             .validateSuccessfulImport();
 
     assertEquals(1, response.extractImportedEvents().size());
@@ -240,7 +247,8 @@ public class TrackerExportTests extends TrackerApiTest {
     TrackerApiResponse response =
         trackerImportExportActions
             .postAndGetJobReport(
-                teiWithEnrollmentAndEventsTemplate, new QueryParamsBuilder().add("async=false"))
+                trackedEntityWithEnrollmentAndEventsTemplate,
+                new QueryParamsBuilder().add("async=false"))
             .validateSuccessfulImport();
 
     assertEquals(1, response.extractImportedEvents().size());
@@ -279,7 +287,8 @@ public class TrackerExportTests extends TrackerApiTest {
     TrackerApiResponse response =
         trackerImportExportActions
             .postAndGetJobReport(
-                teiWithEnrollmentAndEventsTemplate, new QueryParamsBuilder().add("async=false"))
+                trackedEntityWithEnrollmentAndEventsTemplate,
+                new QueryParamsBuilder().add("async=false"))
             .validateSuccessfulImport();
 
     assertEquals(1, response.extractImportedEvents().size());
@@ -421,14 +430,14 @@ public class TrackerExportTests extends TrackerApiTest {
   @Test
   public void shouldReturnRelationshipsByTei() {
     trackerImportExportActions
-        .getRelationship("?trackedEntity=" + teiA)
+        .getRelationship("?trackedEntity=" + trackedEntityA)
         .validate()
         .statusCode(200)
         .body("relationships", hasSize(greaterThanOrEqualTo(1)))
         .rootPath("relationships[0]")
-        .body("relationship", equalTo(teiToTeiRelationship))
-        .body("from.trackedEntity.trackedEntity", equalTo(teiA))
-        .body("to.trackedEntity.trackedEntity", equalTo(teiB));
+        .body("relationship", equalTo(trackedEntityToTeiRelationship))
+        .body("from.trackedEntity.trackedEntity", equalTo(trackedEntityA))
+        .body("to.trackedEntity.trackedEntity", equalTo(trackedEntityB));
   }
 
   @Test
@@ -441,7 +450,7 @@ public class TrackerExportTests extends TrackerApiTest {
         .rootPath("events[0].relationships[0]")
         .body("relationship", equalTo(eventToTeiRelationship))
         .body("from.event.event", equalTo(event))
-        .body("to.trackedEntity.trackedEntity", equalTo(teiB));
+        .body("to.trackedEntity.trackedEntity", equalTo(trackedEntityB));
   }
 
   @Test
@@ -465,7 +474,7 @@ public class TrackerExportTests extends TrackerApiTest {
   }
 
   @Test
-  public void shouldReturnDescOrderedEventByTEIAttribute() {
+  public void shouldReturnDescOrderedEventByTrackedEntityAttribute() {
     ApiResponse response =
         trackerImportExportActions.get(
             "events?order=dIVt4l5vIOa:desc&event=olfXZzSGacW;ZwwuwNp6gVd");
@@ -476,7 +485,7 @@ public class TrackerExportTests extends TrackerApiTest {
   }
 
   @Test
-  public void shouldReturnAscOrderedEventByTEIAttribute() {
+  public void shouldReturnAscOrderedEventByTrackedEntityAttribute() {
     ApiResponse response =
         trackerImportExportActions.get(
             "events?order=dIVt4l5vIOa:asc&event=olfXZzSGacW;ZwwuwNp6gVd");

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/TrackerExportTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/TrackerExportTests.java
@@ -85,11 +85,11 @@ public class TrackerExportTests extends TrackerApiTest {
 
   private static String event;
 
-  private static String trackedEntityToTeiRelationship;
+  private static String trackedEntityToTrackedEntityRelationship;
 
-  private static String enrollmentToTeiRelationship;
+  private static String enrollmentToTrackedEntityRelationship;
 
-  private static String eventToTeiRelationship;
+  private static String eventToTrackedEntityRelationship;
 
   private static JsonObject trackedEntityWithEnrollmentAndEventsTemplate;
 
@@ -108,16 +108,16 @@ public class TrackerExportTests extends TrackerApiTest {
 
     event = response.extractImportedEvents().get(0);
 
-    trackedEntityToTeiRelationship =
+    trackedEntityToTrackedEntityRelationship =
         importRelationshipBetweenTeis(trackedEntityA, trackedEntityB)
             .extractImportedRelationships()
             .get(0);
-    enrollmentToTeiRelationship =
+    enrollmentToTrackedEntityRelationship =
         importRelationshipEnrollmentToTei(enrollment, trackedEntityB)
             .extractImportedRelationships()
             .get(0);
 
-    eventToTeiRelationship =
+    eventToTrackedEntityRelationship =
         importRelationshipEventToTei(event, trackedEntityB).extractImportedRelationships().get(0);
 
     trackedEntityWithEnrollmentAndEventsTemplate =
@@ -172,11 +172,11 @@ public class TrackerExportTests extends TrackerApiTest {
             null),
         Arguments.of("/events/" + event, "enrollment,createdAt", null),
         Arguments.of(
-            "/relationships/" + trackedEntityToTeiRelationship,
+            "/relationships/" + trackedEntityToTrackedEntityRelationship,
             "from,to[trackedEntity[trackedEntity]]",
             "from,to.trackedEntity.trackedEntity"),
         Arguments.of(
-            "/relationships/" + enrollmentToTeiRelationship,
+            "/relationships/" + enrollmentToTrackedEntityRelationship,
             "from,from[enrollment[enrollment]]",
             "from,from.enrollment.enrollment"));
   }
@@ -242,7 +242,7 @@ public class TrackerExportTests extends TrackerApiTest {
   }
 
   @Test
-  public void shouldGetTeisWithSofDeletedEventsWhenIncludeDeletedInRequest() {
+  public void shouldGetTrackedEntitiesWithSofDeletedEventsWhenIncludeDeletedInRequest() {
     TrackerApiResponse response =
         trackerImportExportActions
             .postAndGetJobReport(
@@ -326,7 +326,8 @@ public class TrackerExportTests extends TrackerApiTest {
   }
 
   @Test
-  public void singleTeiAndCollectionTeiShouldReturnSameResult() throws Exception {
+  public void singleTrackedEntitiesAndCollectionTrackedEntityShouldReturnSameResult()
+      throws Exception {
 
     TrackerApiResponse trackedEntity =
         trackerImportExportActions.getTrackedEntity(
@@ -373,7 +374,7 @@ public class TrackerExportTests extends TrackerApiTest {
   }
 
   @Test
-  public void shouldReturnSingleTeiGivenFilter() {
+  public void shouldReturnSingleTrackedEntityGivenFilter() {
     trackerImportExportActions
         .get("trackedEntities?orgUnit=O6uvpzGd5pu&program=f1AyMswryyQ&filter=kZeSYCgaHTk:in:Bravo")
         .validate()
@@ -384,7 +385,7 @@ public class TrackerExportTests extends TrackerApiTest {
             everyItem(is("Bravo")));
   }
 
-  Stream<Arguments> shouldReturnTeisMatchingAttributeCriteria() {
+  Stream<Arguments> shouldReturnTrackedEntitiesMatchingAttributeCriteria() {
     return Stream.of(
         Arguments.of("like", "av", containsString("av")),
         Arguments.of("sw", "Te", startsWith("Te")),
@@ -395,7 +396,7 @@ public class TrackerExportTests extends TrackerApiTest {
 
   @MethodSource()
   @ParameterizedTest
-  public void shouldReturnTeisMatchingAttributeCriteria(
+  public void shouldReturnTrackedEntitiesMatchingAttributeCriteria(
       String operator, String searchCriteria, Matcher<?> everyItemMatcher) {
     QueryParamsBuilder queryParamsBuilder =
         new QueryParamsBuilder()
@@ -414,7 +415,7 @@ public class TrackerExportTests extends TrackerApiTest {
   }
 
   @Test
-  public void shouldReturnSingleTeiGivenFilterWhileSkippingPaging() {
+  public void shouldReturnSingleTrackedEntityGivenFilterWhileSkippingPaging() {
     trackerImportExportActions
         .get(
             "trackedEntities?skipPaging=true&orgUnit=O6uvpzGd5pu&program=f1AyMswryyQ&filter=kZeSYCgaHTk:in:Bravo")
@@ -427,14 +428,14 @@ public class TrackerExportTests extends TrackerApiTest {
   }
 
   @Test
-  public void shouldReturnRelationshipsByTei() {
+  public void shouldReturnRelationshipsByTrackedEntity() {
     trackerImportExportActions
         .getRelationship("?trackedEntity=" + trackedEntityA)
         .validate()
         .statusCode(200)
         .body("relationships", hasSize(greaterThanOrEqualTo(1)))
         .rootPath("relationships[0]")
-        .body("relationship", equalTo(trackedEntityToTeiRelationship))
+        .body("relationship", equalTo(trackedEntityToTrackedEntityRelationship))
         .body("from.trackedEntity.trackedEntity", equalTo(trackedEntityA))
         .body("to.trackedEntity.trackedEntity", equalTo(trackedEntityB));
   }
@@ -447,7 +448,7 @@ public class TrackerExportTests extends TrackerApiTest {
         .statusCode(200)
         .body("events", hasSize(greaterThanOrEqualTo(1)))
         .rootPath("events[0].relationships[0]")
-        .body("relationship", equalTo(eventToTeiRelationship))
+        .body("relationship", equalTo(eventToTrackedEntityRelationship))
         .body("from.event.event", equalTo(event))
         .body("to.trackedEntity.trackedEntity", equalTo(trackedEntityB));
   }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/TrackerExportTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/TrackerExportTests.java
@@ -73,9 +73,9 @@ import org.skyscreamer.jsonassert.JSONAssert;
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */
 public class TrackerExportTests extends TrackerApiTest {
-  private static final String TEI = "Kj6vYde4LHh";
+  private static final String TE = "Kj6vYde4LHh";
 
-  private static final String TEI_POTENTIAL_DUPLICATE = "Nav6inZRw1u";
+  private static final String TE_POTENTIAL_DUPLICATE = "Nav6inZRw1u";
 
   private static String teiA;
 
@@ -125,7 +125,7 @@ public class TrackerExportTests extends TrackerApiTest {
   }
 
   @Test
-  public void shouldGetTeiWhenAttributeFilterValueContainsComma() {
+  public void shouldGetTrackedEntityWhenAttributeFilterValueContainsComma() {
     trackerImportExportActions
         .getTrackedEntities(
             new QueryParamsBuilder()
@@ -134,11 +134,11 @@ public class TrackerExportTests extends TrackerApiTest {
                 .add("filter", "kZeSYCgaHTk:eq:Test/,Test"))
         .validate()
         .statusCode(200)
-        .body("instances[0].attributes.value", hasItem("Test,Test"));
+        .body("trackedEntities[0].attributes.value", hasItem("Test,Test"));
   }
 
   @Test
-  public void shouldGetTeiWhenAttributeFilterValueContainsColon() {
+  public void shouldGetTrackedEntityWhenAttributeFilterValueContainsColon() {
     trackerImportExportActions
         .getTrackedEntities(
             new QueryParamsBuilder()
@@ -147,7 +147,7 @@ public class TrackerExportTests extends TrackerApiTest {
                 .add("filter", "dIVt4l5vIOa:eq:Test/:Test"))
         .validate()
         .statusCode(200)
-        .body("instances[0].attributes.value", hasItem("Test:Test"));
+        .body("trackedEntities[0].attributes.value", hasItem("Test:Test"));
   }
 
   private Stream<Arguments> shouldReturnRequestedFields() {
@@ -196,7 +196,7 @@ public class TrackerExportTests extends TrackerApiTest {
   }
 
   @Test
-  public void shouldGetSingleTeiWithNoEventsWhenEventsAreSoftDeleted() {
+  public void shouldGetSingleTrackedEntityWithNoEventsWhenEventsAreSoftDeleted() {
     TrackerApiResponse response =
         trackerImportExportActions
             .postAndGetJobReport(
@@ -256,7 +256,7 @@ public class TrackerExportTests extends TrackerApiTest {
         .validate()
         .statusCode(200)
         .body(
-            "instances.enrollments.flatten().findAll { it.trackedEntity == '"
+            "trackedEntities.enrollments.flatten().findAll { it.trackedEntity == '"
                 + response.extractImportedTeis().get(0)
                 + "' }.events.flatten()",
             empty());
@@ -271,7 +271,7 @@ public class TrackerExportTests extends TrackerApiTest {
                 .add("includeDeleted", "true"))
         .validate()
         .statusCode(200)
-        .body("instances[0].enrollments.events", hasSize(1));
+        .body("trackedEntities[0].enrollments.events", hasSize(1));
   }
 
   @Test
@@ -294,7 +294,7 @@ public class TrackerExportTests extends TrackerApiTest {
                 .add("enrollment", response.extractImportedEnrollments().get(0)))
         .validate()
         .statusCode(200)
-        .body("instances[0].events.flatten()", empty());
+        .body("enrollments[0].events.flatten()", empty());
 
     trackerImportExportActions
         .getEnrollments(
@@ -306,7 +306,7 @@ public class TrackerExportTests extends TrackerApiTest {
                 .add("includeDeleted", "true"))
         .validate()
         .statusCode(200)
-        .body("instances[0].events", hasSize(1));
+        .body("enrollments[0].events", hasSize(1));
   }
 
   private TrackerApiResponse deleteEvent(String eventToDelete) {
@@ -333,7 +333,7 @@ public class TrackerExportTests extends TrackerApiTest {
 
     JSONAssert.assertEquals(
         trackedEntity.getBody().toString(),
-        trackedEntities.extractJsonObject("instances[0]").toString(),
+        trackedEntities.extractJsonObject("trackedEntities[0]").toString(),
         false);
   }
 
@@ -370,9 +370,9 @@ public class TrackerExportTests extends TrackerApiTest {
         .get("trackedEntities?orgUnit=O6uvpzGd5pu&program=f1AyMswryyQ&filter=kZeSYCgaHTk:in:Bravo")
         .validate()
         .statusCode(200)
-        .body("instances.findAll { it.trackedEntity == 'Kj6vYde4LHh' }.size()", is(1))
+        .body("trackedEntities.findAll { it.trackedEntity == 'Kj6vYde4LHh' }.size()", is(1))
         .body(
-            "instances.attributes.flatten().findAll { it.attribute == 'kZeSYCgaHTk' }.value",
+            "trackedEntities.attributes.flatten().findAll { it.attribute == 'kZeSYCgaHTk' }.value",
             everyItem(is("Bravo")));
   }
 
@@ -399,9 +399,9 @@ public class TrackerExportTests extends TrackerApiTest {
         .getTrackedEntities(queryParamsBuilder)
         .validate()
         .statusCode(200)
-        .body("instances", hasSize(greaterThanOrEqualTo(1)))
+        .body("trackedEntities", hasSize(greaterThanOrEqualTo(1)))
         .body(
-            "instances.attributes.flatten().findAll { it.attribute == 'kZeSYCgaHTk' }.value",
+            "trackedEntities.attributes.flatten().findAll { it.attribute == 'kZeSYCgaHTk' }.value",
             everyItem(everyItemMatcher));
   }
 
@@ -412,9 +412,9 @@ public class TrackerExportTests extends TrackerApiTest {
             "trackedEntities?skipPaging=true&orgUnit=O6uvpzGd5pu&program=f1AyMswryyQ&filter=kZeSYCgaHTk:in:Bravo")
         .validate()
         .statusCode(200)
-        .body("instances.findAll { it.trackedEntity == 'Kj6vYde4LHh' }.size()", is(1))
+        .body("trackedEntities.findAll { it.trackedEntity == 'Kj6vYde4LHh' }.size()", is(1))
         .body(
-            "instances.attributes.flatten().findAll { it.attribute == 'kZeSYCgaHTk' }.value",
+            "trackedEntities.attributes.flatten().findAll { it.attribute == 'kZeSYCgaHTk' }.value",
             everyItem(is("Bravo")));
   }
 
@@ -424,8 +424,8 @@ public class TrackerExportTests extends TrackerApiTest {
         .getRelationship("?trackedEntity=" + teiA)
         .validate()
         .statusCode(200)
-        .body("instances", hasSize(greaterThanOrEqualTo(1)))
-        .rootPath("instances[0]")
+        .body("relationships", hasSize(greaterThanOrEqualTo(1)))
+        .rootPath("relationships[0]")
         .body("relationship", equalTo(teiToTeiRelationship))
         .body("from.trackedEntity.trackedEntity", equalTo(teiA))
         .body("to.trackedEntity.trackedEntity", equalTo(teiB));
@@ -437,8 +437,8 @@ public class TrackerExportTests extends TrackerApiTest {
         .get("events?event=" + event + "&fields=relationships")
         .validate()
         .statusCode(200)
-        .body("instances", hasSize(greaterThanOrEqualTo(1)))
-        .rootPath("instances[0].relationships[0]")
+        .body("events", hasSize(greaterThanOrEqualTo(1)))
+        .rootPath("events[0].relationships[0]")
         .body("relationship", equalTo(eventToTeiRelationship))
         .body("from.event.event", equalTo(event))
         .body("to.trackedEntity.trackedEntity", equalTo(teiB));
@@ -450,7 +450,7 @@ public class TrackerExportTests extends TrackerApiTest {
         .get("events?event=" + event)
         .validate()
         .statusCode(200)
-        .body("instances[0].relationships", emptyOrNullString());
+        .body("events[0].relationships", emptyOrNullString());
   }
 
   @Test
@@ -460,7 +460,7 @@ public class TrackerExportTests extends TrackerApiTest {
             "events?enrollmentOccurredAfter=2019-08-16&enrollmentOccurredBefore=2019-08-20&event=ZwwuwNp6gVd")
         .validate()
         .statusCode(200)
-        .rootPath("instances[0]")
+        .rootPath("events[0]")
         .body("event", equalTo("ZwwuwNp6gVd"));
   }
 
@@ -469,8 +469,8 @@ public class TrackerExportTests extends TrackerApiTest {
     ApiResponse response =
         trackerImportExportActions.get(
             "events?order=dIVt4l5vIOa:desc&event=olfXZzSGacW;ZwwuwNp6gVd");
-    response.validate().statusCode(200).body("instances", hasSize(equalTo(2)));
-    List<String> events = response.extractList("instances.event.flatten()");
+    response.validate().statusCode(200).body("events", hasSize(equalTo(2)));
+    List<String> events = response.extractList("events.event.flatten()");
     assertEquals(
         List.of("olfXZzSGacW", "ZwwuwNp6gVd"), events, "Events are not in the correct order");
   }
@@ -480,8 +480,8 @@ public class TrackerExportTests extends TrackerApiTest {
     ApiResponse response =
         trackerImportExportActions.get(
             "events?order=dIVt4l5vIOa:asc&event=olfXZzSGacW;ZwwuwNp6gVd");
-    response.validate().statusCode(200).body("instances", hasSize(equalTo(2)));
-    List<String> events = response.extractList("instances.event.flatten()");
+    response.validate().statusCode(200).body("events", hasSize(equalTo(2)));
+    List<String> events = response.extractList("events.event.flatten()");
     assertEquals(
         List.of("ZwwuwNp6gVd", "olfXZzSGacW"), events, "Events are not in the correct order");
   }
@@ -492,17 +492,17 @@ public class TrackerExportTests extends TrackerApiTest {
         trackerImportExportActions.getTrackedEntities(
             paramsForTrackedEntitiesIncludingPotentialDuplicate());
 
-    response.validate().statusCode(200).body("instances", iterableWithSize(2));
+    response.validate().statusCode(200).body("trackedEntities", iterableWithSize(2));
 
     assertThat(
         response.getBody().getAsJsonObject(),
         matchesJSON(
             new JsonObjectBuilder()
                 .addArray(
-                    "instances",
-                    new JsonObjectBuilder().addProperty("trackedEntity", TEI).build(),
+                    "trackedEntities",
+                    new JsonObjectBuilder().addProperty("trackedEntity", TE).build(),
                     new JsonObjectBuilder()
-                        .addProperty("trackedEntity", TEI_POTENTIAL_DUPLICATE)
+                        .addProperty("trackedEntity", TE_POTENTIAL_DUPLICATE)
                         .build())
                 .build()));
   }
@@ -516,9 +516,9 @@ public class TrackerExportTests extends TrackerApiTest {
     response
         .validate()
         .statusCode(200)
-        .body("instances", iterableWithSize(1))
-        .body("instances[0].trackedEntity", equalTo(TEI))
-        .body("instances[0].potentialDuplicate", equalTo(false));
+        .body("trackedEntities", iterableWithSize(1))
+        .body("trackedEntities[0].trackedEntity", equalTo(TE))
+        .body("trackedEntities[0].potentialDuplicate", equalTo(false));
   }
 
   @Test
@@ -530,15 +530,15 @@ public class TrackerExportTests extends TrackerApiTest {
     response
         .validate()
         .statusCode(200)
-        .body("instances", iterableWithSize(1))
-        .body("instances[0].trackedEntity", equalTo(TEI_POTENTIAL_DUPLICATE))
-        .body("instances[0].potentialDuplicate", equalTo(true));
+        .body("trackedEntities", iterableWithSize(1))
+        .body("trackedEntities[0].trackedEntity", equalTo(TE_POTENTIAL_DUPLICATE))
+        .body("trackedEntities[0].potentialDuplicate", equalTo(true));
   }
 
   private static QueryParamsBuilder paramsForTrackedEntitiesIncludingPotentialDuplicate() {
     return new QueryParamsBuilder()
         .addAll(
-            "trackedEntity=" + TEI + ";" + TEI_POTENTIAL_DUPLICATE,
+            "trackedEntity=" + TE + ";" + TE_POTENTIAL_DUPLICATE,
             "trackedEntityType=" + "Q9GufDoplCL",
             "orgUnit=" + "O6uvpzGd5pu");
   }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/events/UserAssignmentTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/events/UserAssignmentTests.java
@@ -104,7 +104,7 @@ public class UserAssignmentTests extends TrackerApiTest {
         trackerImportExportActions
             .get("/events?program=" + programId + "&assignedUserMode=CURRENT&ouMode=ACCESSIBLE")
             .validateStatus(200)
-            .extractJsonObject("instances[0]");
+            .extractJsonObject("events[0]");
 
     assertNotNull(eventBody, "no events matching the query.");
     String eventId = eventBody.get("event").getAsString();

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/relationships/RelationshipsTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/relationships/RelationshipsTests.java
@@ -309,7 +309,7 @@ public class RelationshipsTests extends TrackerApiTest {
     ApiResponse relationshipResponse =
         trackerImportExportActions.get("/relationships?tei=" + trackedEntity_1);
 
-    relationshipResponse.validate().statusCode(200).body("instances.size()", is(2));
+    relationshipResponse.validate().statusCode(200).body("relationships.size()", is(2));
   }
 
   @Test
@@ -349,8 +349,8 @@ public class RelationshipsTests extends TrackerApiTest {
     relationshipResponse
         .validate()
         .statusCode(200)
-        .body("instances[0].relationship", is(createdRelationshipUid))
-        .body("instances.size()", is(1));
+        .body("relationships[0].relationship", is(createdRelationshipUid))
+        .body("relationships.size()", is(1));
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/relationships/RelationshipsTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/relationships/RelationshipsTests.java
@@ -243,8 +243,8 @@ public class RelationshipsTests extends TrackerApiTest {
   @ParameterizedTest
   @ValueSource(
       strings = {
-        "src/test/resources/tracker/importer/trackedEntities/trackedEntitysAndRelationship.json",
-        "src/test/resources/tracker/importer/trackedEntities/trackedEntitysWithRelationship.json"
+        "src/test/resources/tracker/importer/teis/teisAndRelationship.json",
+        "src/test/resources/tracker/importer/teis/teisWithRelationship.json"
       })
   public void shouldImportObjectsWithRelationship(String file) throws Exception {
     JsonObject jsonObject = new FileReaderUtils().read(new File(file)).get(JsonObject.class);
@@ -368,8 +368,7 @@ public class RelationshipsTests extends TrackerApiTest {
     TrackerApiResponse response =
         trackerImportExportActions
             .postAndGetJobReport(
-                new File(
-                    "src/test/resources/tracker/importer/trackedEntities/trackedEntitysAndRelationship.json"))
+                new File("src/test/resources/tracker/importer/teis/teisAndRelationship.json"))
             .validateSuccessfulImport();
 
     List<String> trackedEntities = response.extractImportedTeis();

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/relationships/RelationshipsTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/relationships/RelationshipsTests.java
@@ -74,9 +74,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class RelationshipsTests extends TrackerApiTest {
   private static final String relationshipType = "TV9oB9LT3sh";
 
-  private static List<String> teis;
-
-  private static List<String> enrollments;
+  private static List<String> trackedEntities;
 
   private static List<String> events;
 
@@ -93,14 +91,24 @@ public class RelationshipsTests extends TrackerApiTest {
   private static Stream<Arguments> provideRelationshipData() {
     return Stream.of(
         /*
-         * Arguments.of( "WmNgnmedbQj", "trackedEntity", teis.get( 0 ),
-         * "enrollment", enrollments.get( 1 )), // tei to enrollment todo:
+         * Arguments.of( "WmNgnmedbQj", "trackedEntity", trackedEntities.get( 0 ),
+         * "enrollment", enrollments.get( 1 )), // trackedEntity to enrollment todo:
          * uncomment when DHIS2-12625 is fixed
          */
-        Arguments.of("HrS7b5Lis6E", "event", events.get(0), "trackedEntity", teis.get(0)), // event
+        Arguments.of(
+            "HrS7b5Lis6E",
+            "event",
+            events.get(0),
+            "trackedEntity",
+            trackedEntities.get(0)), // event
         // to
-        // tei
-        Arguments.of("HrS7b5Lis6w", "trackedEntity", teis.get(0), "event", events.get(0)), // tei
+        // trackedEntity
+        Arguments.of(
+            "HrS7b5Lis6w",
+            "trackedEntity",
+            trackedEntities.get(0),
+            "event",
+            events.get(0)), // trackedEntity
         // to
         // event
         Arguments.of("HrS7b5Lis6P", "event", events.get(0), "event", events.get(1)), // event
@@ -109,42 +117,42 @@ public class RelationshipsTests extends TrackerApiTest {
         Arguments.of(
             relationshipType,
             "trackedEntity",
-            teis.get(0),
+            trackedEntities.get(0),
             "trackedEntity",
-            teis.get(1))); // tei to tei
+            trackedEntities.get(1))); // trackedEntity to trackedEntity
   }
 
   private static Stream<Arguments> provideDuplicateRelationshipData() {
     return Stream.of(
         Arguments.of(
-            teis.get(0),
-            teis.get(1),
-            teis.get(1),
-            teis.get(0),
+            trackedEntities.get(0),
+            trackedEntities.get(1),
+            trackedEntities.get(1),
+            trackedEntities.get(0),
             true,
             1,
             "bi: reversed direction should import 1"),
         Arguments.of(
-            teis.get(0),
-            teis.get(1),
-            teis.get(0),
-            teis.get(1),
+            trackedEntities.get(0),
+            trackedEntities.get(1),
+            trackedEntities.get(0),
+            trackedEntities.get(1),
             false,
             1,
             "uni: same direction should import 1"),
         Arguments.of(
-            teis.get(0),
-            teis.get(1),
-            teis.get(0),
-            teis.get(1),
+            trackedEntities.get(0),
+            trackedEntities.get(1),
+            trackedEntities.get(0),
+            trackedEntities.get(1),
             true,
             1,
             "bi: same direction should import 1"),
         Arguments.of(
-            teis.get(0),
-            teis.get(1),
-            teis.get(1),
-            teis.get(0),
+            trackedEntities.get(0),
+            trackedEntities.get(1),
+            trackedEntities.get(1),
+            trackedEntities.get(0),
             false,
             2,
             "uni: reversed direction should import 2"));
@@ -164,8 +172,7 @@ public class RelationshipsTests extends TrackerApiTest {
 
     TrackerApiResponse importResponse =
         importTeisWithEnrollmentAndEvent().validateSuccessfulImport();
-    teis = importResponse.extractImportedTeis();
-    enrollments = importResponse.extractImportedEnrollments();
+    trackedEntities = importResponse.extractImportedTeis();
     events = importEvents();
   }
 
@@ -178,8 +185,8 @@ public class RelationshipsTests extends TrackerApiTest {
         new RelationshipDataBuilder()
             .setRelationshipId(relationshipId)
             .setRelationshipType(relationshipType)
-            .setToEntity("trackedEntity", teis.get(1))
-            .setFromEntity("trackedEntity", teis.get(0))
+            .setToEntity("trackedEntity", trackedEntities.get(1))
+            .setFromEntity("trackedEntity", trackedEntities.get(0))
             .array();
 
     trackerImportExportActions.postAndGetJobReport(originalRelationship).validateSuccessfulImport();
@@ -205,7 +212,9 @@ public class RelationshipsTests extends TrackerApiTest {
                                                 from.addObject(
                                                     "trackedEntity",
                                                     te ->
-                                                        te.addString("trackedEntity", teis.get(0))))
+                                                        te.addString(
+                                                            "trackedEntity",
+                                                            trackedEntities.get(0))))
                                         .addObject(
                                             "to",
                                             to ->
@@ -213,7 +222,8 @@ public class RelationshipsTests extends TrackerApiTest {
                                                     "trackedEntity",
                                                     te ->
                                                         te.addString(
-                                                            "trackedEntity", teis.get(1))))))));
+                                                            "trackedEntity",
+                                                            trackedEntities.get(1))))))));
 
     // act
     trackerImportExportActions
@@ -233,8 +243,8 @@ public class RelationshipsTests extends TrackerApiTest {
   @ParameterizedTest
   @ValueSource(
       strings = {
-        "src/test/resources/tracker/importer/teis/teisAndRelationship.json",
-        "src/test/resources/tracker/importer/teis/teisWithRelationship.json"
+        "src/test/resources/tracker/importer/trackedEntities/trackedEntitysAndRelationship.json",
+        "src/test/resources/tracker/importer/trackedEntities/trackedEntitysWithRelationship.json"
       })
   public void shouldImportObjectsWithRelationship(String file) throws Exception {
     JsonObject jsonObject = new FileReaderUtils().read(new File(file)).get(JsonObject.class);
@@ -258,13 +268,12 @@ public class RelationshipsTests extends TrackerApiTest {
     response
         .extractImportedTeis()
         .forEach(
-            tei -> {
-              trackedEntityInstancesAction
-                  .get(tei, new QueryParamsBuilder().add("fields=relationships"))
-                  .validate()
-                  .statusCode(200)
-                  .body("relationships.relationship", contains(createdRelationships.get(0)));
-            });
+            trackedEntity ->
+                trackedEntityInstancesAction
+                    .get(trackedEntity, new QueryParamsBuilder().add("fields=relationships"))
+                    .validate()
+                    .statusCode(200)
+                    .body("relationships.relationship", contains(createdRelationships.get(0))));
   }
 
   @Test
@@ -307,7 +316,7 @@ public class RelationshipsTests extends TrackerApiTest {
 
     // and there are 2 relationships for any of the tracked entities
     ApiResponse relationshipResponse =
-        trackerImportExportActions.get("/relationships?tei=" + trackedEntity_1);
+        trackerImportExportActions.get("/relationships?trackedEntity=" + trackedEntity_1);
 
     relationshipResponse.validate().statusCode(200).body("relationships.size()", is(2));
   }
@@ -344,7 +353,7 @@ public class RelationshipsTests extends TrackerApiTest {
 
     // and relationship is not duplicated
     ApiResponse relationshipResponse =
-        trackerImportExportActions.get("/relationships?tei=" + trackedEntity_1);
+        trackerImportExportActions.get("/relationships?trackedEntity=" + trackedEntity_1);
 
     relationshipResponse
         .validate()
@@ -359,16 +368,17 @@ public class RelationshipsTests extends TrackerApiTest {
     TrackerApiResponse response =
         trackerImportExportActions
             .postAndGetJobReport(
-                new File("src/test/resources/tracker/importer/teis/teisAndRelationship.json"))
+                new File(
+                    "src/test/resources/tracker/importer/trackedEntities/trackedEntitysAndRelationship.json"))
             .validateSuccessfulImport();
 
-    List<String> teis = response.extractImportedTeis();
+    List<String> trackedEntities = response.extractImportedTeis();
     String relationship = response.extractImportedRelationships().get(0);
 
     JsonObject obj =
         new JsonObjectBuilder()
-            .addObject("from", relationshipItem("trackedEntity", teis.get(0)))
-            .addObject("to", relationshipItem("trackedEntity", teis.get(1)))
+            .addObject("from", relationshipItem("trackedEntity", trackedEntities.get(0)))
+            .addObject("to", relationshipItem("trackedEntity", trackedEntities.get(1)))
             .addProperty("relationshipType", relationshipType)
             .addProperty("relationship", relationship)
             .wrapIntoArray("relationships");
@@ -384,7 +394,7 @@ public class RelationshipsTests extends TrackerApiTest {
     trackerImportExportActions.get("/relationships/" + relationship).validate().statusCode(404);
 
     trackerImportExportActions
-        .getTrackedEntity(teis.get(0) + "?fields=relationships")
+        .getTrackedEntity(trackedEntities.get(0) + "?fields=relationships")
         .validate()
         .body("relationships", Matchers.empty());
   }
@@ -395,7 +405,7 @@ public class RelationshipsTests extends TrackerApiTest {
         JsonObjectBuilder.jsonObject()
             .addProperty("relationshipType", relationshipType)
             .addObject("from", relationshipItem("event", events.get(0)))
-            .addObject("to", relationshipItem("trackedEntity", teis.get(0)))
+            .addObject("to", relationshipItem("trackedEntity", trackedEntities.get(0)))
             .wrapIntoArray("relationships");
 
     trackerImportExportActions
@@ -409,7 +419,7 @@ public class RelationshipsTests extends TrackerApiTest {
     JsonObject object =
         JsonObjectBuilder.jsonObject()
             .addProperty("relationshipType", "xLmPUYJX8Ks")
-            .addObject("from", relationshipItem("trackedEntity", "invalid-tei"))
+            .addObject("from", relationshipItem("trackedEntity", "invalid-trackedEntity"))
             .addObject("to", relationshipItem("trackedEntity", "more-invalid"))
             .wrapIntoArray("relationships");
 
@@ -482,8 +492,7 @@ public class RelationshipsTests extends TrackerApiTest {
       String fromTei2,
       String toTei2,
       boolean bidirectional,
-      int expectedCount,
-      String representation) {
+      int expectedCount) {
     // arrange
     String relationshipTypeId =
         relationshipTypeActions
@@ -600,26 +609,12 @@ public class RelationshipsTests extends TrackerApiTest {
 
   private ApiResponse getEntityInRelationship(String toOrFromInstance, String id) {
     String queryParams = "?fields=relationships";
-    switch (toOrFromInstance) {
-      case "trackedEntity":
-        {
-          return trackerImportExportActions.getTrackedEntity(id + queryParams);
-        }
-
-      case "event":
-        {
-          return trackerImportExportActions.getEvent(id + queryParams);
-        }
-
-      case "enrollment":
-        {
-          return trackerImportExportActions.getEnrollment(id + queryParams);
-        }
-      default:
-        {
-          return null;
-        }
-    }
+    return switch (toOrFromInstance) {
+      case "trackedEntity" -> trackerImportExportActions.getTrackedEntity(id + queryParams);
+      case "event" -> trackerImportExportActions.getEvent(id + queryParams);
+      case "enrollment" -> trackerImportExportActions.getEnrollment(id + queryParams);
+      default -> null;
+    };
   }
 
   private void validateRelationship(
@@ -649,10 +644,7 @@ public class RelationshipsTests extends TrackerApiTest {
 
   @AfterEach
   public void cleanup() {
-    createdRelationships.forEach(
-        rel -> {
-          new TestCleanUp().deleteEntity("relationships", rel);
-        });
+    createdRelationships.forEach(rel -> new TestCleanUp().deleteEntity("relationships", rel));
   }
 
   private JsonObjectBuilder relationshipItem(String type, String identifier) {

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/tei/TeiUpdateTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/tei/TeiUpdateTests.java
@@ -125,11 +125,11 @@ public class TeiUpdateTests extends TrackerApiTest {
 
   @Test
   public void shouldUpdateExportedTrackedEntity() throws Exception {
-    String teId = importTei();
+    String teUID = importTei();
     JsonObjectBuilder trackedEntities =
         trackerImportExportActions
             .getTrackedEntities(
-                new QueryParamsBuilder().add("fields", "*").add("trackedEntity", teId))
+                new QueryParamsBuilder().add("fields", "*").add("trackedEntity", teUID))
             .getBodyAsJsonBuilder()
             .addPropertyByJsonPath("trackedEntities[0].attributes[0].value", "Rabbit");
 

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/tei/TeiUpdateTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/tei/TeiUpdateTests.java
@@ -122,4 +122,25 @@ public class TeiUpdateTests extends TrackerApiTest {
         .body("errorCode", equalTo("E1063"))
         .body("message", containsStringIgnoringCase("does not exist"));
   }
+
+  @Test
+  public void shouldUpdateExportedTrackedEntity() throws Exception {
+    String teId = importTei();
+    JsonObjectBuilder trackedEntities =
+        trackerImportExportActions
+            .getTrackedEntities(
+                new QueryParamsBuilder().add("fields", "*").add("trackedEntity", teId))
+            .getBodyAsJsonBuilder()
+            .addPropertyByJsonPath("trackedEntities[0].attributes[0].value", "Rabbit");
+
+    ApiResponse response =
+        trackerImportExportActions.postAndGetJobReport(
+            trackedEntities.build(), new QueryParamsBuilder().add("importStrategy=UPDATE"));
+
+    response
+        .validate()
+        .statusCode(200)
+        .body("status", equalTo("OK"))
+        .body("stats.updated", equalTo(1));
+  }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerIntegrationTest.java
@@ -148,7 +148,7 @@ class ProgramControllerIntegrationTest extends DhisControllerIntegrationTest {
             .as(JsonWebMessage.class);
 
     JsonList<JsonEnrollment> enrollments =
-        enrollmentsForOrgUnit.getList("instances", JsonEnrollment.class);
+        enrollmentsForOrgUnit.getList("enrollments", JsonEnrollment.class);
     Set<JsonEnrollment> originalProgramEnrollments =
         enrollments.stream()
             .filter(enrollment -> enrollment.getProgram().equals(PROGRAM_UID))

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAssertions.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonAssertions.java
@@ -80,8 +80,8 @@ public class JsonAssertions {
 
   public static void assertNoRelationships(JsonObject json) {
     assertFalse(json.isEmpty());
-    JsonArray rels = json.getArray("instances");
-    assertTrue(rels.isEmpty(), "instances should not contain any relationships");
+    JsonArray rels = json.getArray("relationships");
+    assertTrue(rels.isEmpty(), "relationships should not contain any relationships");
   }
 
   public static void assertEventWithinRelationshipItem(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/ExportControllerPaginationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/ExportControllerPaginationTest.java
@@ -129,7 +129,7 @@ class ExportControllerPaginationTest extends DhisControllerConvenienceTest {
 
     assertContainsOnly(
         List.of(r1.getUid(), r2.getUid()),
-        page.getList("instances", JsonRelationship.class)
+        page.getList("relationships", JsonRelationship.class)
             .toList(JsonRelationship::getRelationship));
     assertEquals(1, page.getPager().getPage());
     assertEquals(50, page.getPager().getPageSize());
@@ -158,7 +158,7 @@ class ExportControllerPaginationTest extends DhisControllerConvenienceTest {
 
     assertContainsOnly(
         List.of(r1.getUid(), r2.getUid()),
-        page.getList("instances", JsonRelationship.class)
+        page.getList("relationships", JsonRelationship.class)
             .toList(JsonRelationship::getRelationship));
     assertEquals(1, page.getPager().getPage());
     assertEquals(50, page.getPager().getPageSize());
@@ -187,7 +187,7 @@ class ExportControllerPaginationTest extends DhisControllerConvenienceTest {
 
     assertContainsOnly(
         List.of(r1.getUid(), r2.getUid()),
-        page.getList("instances", JsonRelationship.class)
+        page.getList("relationships", JsonRelationship.class)
             .toList(JsonRelationship::getRelationship));
     assertEquals(1, page.getPager().getPage());
     assertEquals(50, page.getPager().getPageSize());
@@ -214,11 +214,13 @@ class ExportControllerPaginationTest extends DhisControllerConvenienceTest {
             .content(HttpStatus.OK)
             .asA(JsonPage.class);
 
-    JsonList<JsonRelationship> instances = page.getList("instances", JsonRelationship.class);
+    JsonList<JsonRelationship> relationships =
+        page.getList("relationships", JsonRelationship.class);
     assertEquals(
         1,
-        instances.size(),
-        () -> String.format("mismatch in number of expected relationship(s), got %s", instances));
+        relationships.size(),
+        () ->
+            String.format("mismatch in number of expected relationship(s), got %s", relationships));
     assertEquals(2, page.getPager().getPage());
     assertEquals(1, page.getPager().getPageSize());
     assertHasNoMember(page.getPager(), "total");
@@ -246,11 +248,13 @@ class ExportControllerPaginationTest extends DhisControllerConvenienceTest {
             .content(HttpStatus.OK)
             .asA(JsonPage.class);
 
-    JsonList<JsonRelationship> instances = page.getList("instances", JsonRelationship.class);
+    JsonList<JsonRelationship> relationships =
+        page.getList("relationships", JsonRelationship.class);
     assertEquals(
         1,
-        instances.size(),
-        () -> String.format("mismatch in number of expected relationship(s), got %s", instances));
+        relationships.size(),
+        () ->
+            String.format("mismatch in number of expected relationship(s), got %s", relationships));
     assertEquals(2, page.getPager().getPage());
     assertEquals(1, page.getPager().getPageSize());
     assertEquals(2, page.getPager().getTotal());
@@ -278,7 +282,7 @@ class ExportControllerPaginationTest extends DhisControllerConvenienceTest {
 
     assertContainsOnly(
         List.of(r1.getUid(), r2.getUid()),
-        page.getList("instances", JsonRelationship.class)
+        page.getList("relationships", JsonRelationship.class)
             .toList(JsonRelationship::getRelationship));
     assertHasNoMember(page, "pager");
 
@@ -304,7 +308,7 @@ class ExportControllerPaginationTest extends DhisControllerConvenienceTest {
 
     assertContainsOnly(
         List.of(r1.getUid(), r2.getUid()),
-        page.getList("instances", JsonRelationship.class)
+        page.getList("relationships", JsonRelationship.class)
             .toList(JsonRelationship::getRelationship));
     assertHasNoMember(page, "pager");
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -243,7 +243,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
     JsonList<JsonRelationship> relationships =
         GET("/tracker/relationships?event={uid}", from.getUid())
             .content(HttpStatus.OK)
-            .getList("instances", JsonRelationship.class);
+            .getList("relationships", JsonRelationship.class);
 
     JsonObject relationship = assertFirstRelationship(r, relationships);
     assertHasOnlyMembers(
@@ -261,7 +261,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
     JsonList<JsonRelationship> relationships =
         GET("/tracker/relationships?event={uid}&fields=*", from.getUid())
             .content(HttpStatus.OK)
-            .getList("instances", JsonRelationship.class);
+            .getList("relationships", JsonRelationship.class);
 
     JsonRelationship relationship = assertFirstRelationship(r, relationships);
     assertEventWithinRelationshipItem(from, relationship.getFrom());
@@ -277,7 +277,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
     JsonList<JsonRelationship> relationships =
         GET("/tracker/relationships?event={uid}&fields=relationship,from[event]", from.getUid())
             .content(HttpStatus.OK)
-            .getList("instances", JsonRelationship.class);
+            .getList("relationships", JsonRelationship.class);
 
     assertEquals(1, relationships.size(), "one relationship expected");
     JsonRelationship relationship = relationships.get(0).as(JsonRelationship.class);
@@ -297,7 +297,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
     JsonList<JsonRelationship> relationships =
         GET("/tracker/relationships?event={uid}&fields=from[event[assignedUser]]", from.getUid())
             .content(HttpStatus.OK)
-            .getList("instances", JsonRelationship.class);
+            .getList("relationships", JsonRelationship.class);
 
     JsonUser user = relationships.get(0).getFrom().getEvent().getAssignedUser();
     assertEquals(owner.getUid(), user.getUid());
@@ -316,7 +316,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
                 "/tracker/relationships?event={uid}&fields=from[event[dataValues[dataElement,value]]]",
                 from.getUid())
             .content(HttpStatus.OK)
-            .getList("instances", JsonRelationship.class);
+            .getList("relationships", JsonRelationship.class);
 
     JsonDataValue dataValue = relationships.get(0).getFrom().getEvent().getDataValues().get(0);
     assertEquals(dataElement.getUid(), dataValue.getDataElement());
@@ -333,7 +333,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
     JsonList<JsonRelationship> relationships =
         GET("/tracker/relationships?event={uid}&fields=from[event[notes]]", from.getUid())
             .content(HttpStatus.OK)
-            .getList("instances", JsonRelationship.class);
+            .getList("relationships", JsonRelationship.class);
 
     JsonNote note = relationships.get(0).getFrom().getEvent().getNotes().get(0);
     assertEquals("oqXG28h988k", note.getNote());
@@ -357,7 +357,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
     JsonList<JsonRelationship> relationships =
         GET("/tracker/relationships?enrollment=" + from.getUid())
             .content(HttpStatus.OK)
-            .getList("instances", JsonRelationship.class);
+            .getList("relationships", JsonRelationship.class);
 
     JsonObject relationship = assertFirstRelationship(r, relationships);
     assertHasOnlyMembers(relationship, "relationship", "relationshipType", "from", "to");
@@ -374,7 +374,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
     JsonList<JsonRelationship> relationships =
         GET("/tracker/relationships?enrollment={uid}&fields=*", from.getUid())
             .content(HttpStatus.OK)
-            .getList("instances", JsonRelationship.class);
+            .getList("relationships", JsonRelationship.class);
 
     JsonRelationship relationship = assertFirstRelationship(r, relationships);
     assertEnrollmentWithinRelationship(from, relationship.getFrom());
@@ -392,7 +392,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
                 "/tracker/relationships?enrollment={uid}&fields=from[enrollment[events[enrollment,event]]]",
                 from.getUid())
             .content(HttpStatus.OK)
-            .getList("instances", JsonRelationship.class);
+            .getList("relationships", JsonRelationship.class);
 
     JsonRelationshipItem.JsonEvent event =
         relationships.get(0).getFrom().getEnrollment().getEvents().get(0);
@@ -414,7 +414,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
                 "/tracker/relationships?enrollment={uid}&fields=from[enrollment[attributes[attribute,value]]]",
                 from.getUid())
             .content(HttpStatus.OK)
-            .getList("instances", JsonRelationship.class);
+            .getList("relationships", JsonRelationship.class);
 
     JsonAttribute attribute = relationships.get(0).getFrom().getEnrollment().getAttributes().get(0);
     assertEquals(tea.getUid(), attribute.getAttribute());
@@ -431,7 +431,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
     JsonList<JsonRelationship> relationships =
         GET("/tracker/relationships?enrollment={uid}&fields=from[enrollment[notes]]", from.getUid())
             .content(HttpStatus.OK)
-            .getList("instances", JsonRelationship.class);
+            .getList("relationships", JsonRelationship.class);
 
     JsonNote note = relationships.get(0).getFrom().getEnrollment().getNotes().get(0);
     assertEquals("oqXG28h988k", note.getNote());
@@ -457,7 +457,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
     JsonList<JsonRelationship> relationships =
         GET("/tracker/relationships?trackedEntity={tei}", to.getUid())
             .content(HttpStatus.OK)
-            .getList("instances", JsonRelationship.class);
+            .getList("relationships", JsonRelationship.class);
 
     JsonObject relationship = assertFirstRelationship(r, relationships);
     assertHasOnlyMembers(relationship, "relationship", "relationshipType", "from", "to");
@@ -474,7 +474,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
     JsonList<JsonRelationship> relationships =
         GET("/tracker/relationships?tei=" + to.getUid())
             .content(HttpStatus.OK)
-            .getList("instances", JsonRelationship.class);
+            .getList("relationships", JsonRelationship.class);
 
     JsonObject relationship = assertFirstRelationship(r, relationships);
     assertHasOnlyMembers(relationship, "relationship", "relationshipType", "from", "to");
@@ -493,7 +493,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
                 "/tracker/relationships?trackedEntity={tei}&fields=to[trackedEntity[enrollments[enrollment,trackedEntity]]",
                 to.getUid())
             .content(HttpStatus.OK)
-            .getList("instances", JsonRelationship.class);
+            .getList("relationships", JsonRelationship.class);
 
     JsonRelationshipItem.JsonEnrollment enrollment =
         relationships.get(0).getTo().getTrackedEntity().getEnrollments().get(0);
@@ -515,7 +515,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
                 "/tracker/relationships?trackedEntity={tei}&fields=from[enrollment[attributes[attribute,value]]],to[trackedEntity[attributes[attribute,value]]]",
                 to.getUid())
             .content(HttpStatus.OK)
-            .getList("instances", JsonRelationship.class);
+            .getList("relationships", JsonRelationship.class);
 
     JsonList<JsonAttribute> enrollmentAttr =
         relationships.get(0).getFrom().getEnrollment().getAttributes();
@@ -540,7 +540,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
                 "/tracker/relationships?trackedEntity={tei}&fields=to[trackedEntity[programOwners]",
                 to.getUid())
             .content(HttpStatus.OK)
-            .getList("instances", JsonRelationship.class);
+            .getList("relationships", JsonRelationship.class);
 
     JsonProgramOwner jsonProgramOwner =
         relationships.get(0).getTo().getTrackedEntity().getProgramOwners().get(0);
@@ -558,7 +558,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
     JsonList<JsonRelationship> relationships =
         GET("/tracker/relationships?trackedEntity={tei}", from.getUid())
             .content(HttpStatus.OK)
-            .getList("instances", JsonRelationship.class);
+            .getList("relationships", JsonRelationship.class);
 
     JsonObject relationship = assertFirstRelationship(r, relationships);
     assertHasOnlyMembers(relationship, "relationship", "relationshipType", "from", "to");
@@ -575,7 +575,7 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
     JsonList<JsonRelationship> relationships =
         GET("/tracker/relationships?trackedEntity={tei}", from.getUid())
             .content(HttpStatus.OK)
-            .getList("instances", JsonRelationship.class);
+            .getList("relationships", JsonRelationship.class);
 
     JsonObject relationship = assertFirstRelationship(r, relationships);
     assertHasOnlyMembers(relationship, "relationship", "relationshipType", "from", "to");

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -209,7 +209,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
                 + "&updatedAfter="
                 + futureDate)
             .content(HttpStatus.OK)
-            .getList("instances", JsonTrackedEntity.class);
+            .getList("trackedEntities", JsonTrackedEntity.class);
 
     assertEquals(0, instances.size());
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
@@ -112,7 +112,7 @@ class EnrollmentsExportController {
               ENROLLMENT_MAPPER.fromCollection(enrollmentsPage.getItems()),
               requestParams.getFields());
 
-      return Page.withPager(objectNodes, enrollmentsPage);
+      return Page.withPager(ENROLLMENTS, objectNodes, enrollmentsPage);
     }
 
     Collection<org.hisp.dhis.program.Enrollment> enrollments =
@@ -121,7 +121,7 @@ class EnrollmentsExportController {
         fieldFilterService.toObjectNodes(
             ENROLLMENT_MAPPER.fromCollection(enrollments), requestParams.getFields());
 
-    return Page.withoutPager(objectNodes);
+    return Page.withoutPager(ENROLLMENTS, objectNodes);
   }
 
   @OpenApi.Response(OpenApi.EntityType.class)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -133,7 +133,7 @@ class EventsExportController {
           fieldFilterService.toObjectNodes(
               EVENTS_MAPPER.fromCollection(eventsPage.getItems()), requestParams.getFields());
 
-      return Page.withPager(objectNodes, eventsPage);
+      return Page.withPager(EVENTS, objectNodes, eventsPage);
     }
 
     List<org.hisp.dhis.program.Event> events = eventService.getEvents(eventOperationParams);
@@ -141,7 +141,7 @@ class EventsExportController {
         fieldFilterService.toObjectNodes(
             EVENTS_MAPPER.fromCollection(events), requestParams.getFields());
 
-    return Page.withoutPager(objectNodes);
+    return Page.withoutPager(EVENTS, objectNodes);
   }
 
   @GetMapping(produces = CONTENT_TYPE_JSON_GZIP)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
@@ -111,7 +111,7 @@ class RelationshipsExportController {
               RELATIONSHIP_MAPPER.fromCollection(relationshipsPage.getItems()),
               requestParams.getFields());
 
-      return Page.withPager(objectNodes, relationshipsPage);
+      return Page.withPager(RELATIONSHIPS, objectNodes, relationshipsPage);
     }
 
     List<org.hisp.dhis.relationship.Relationship> relationships =
@@ -120,7 +120,7 @@ class RelationshipsExportController {
         fieldFilterService.toObjectNodes(
             RELATIONSHIP_MAPPER.fromCollection(relationships), requestParams.getFields());
 
-    return Page.withoutPager(objectNodes);
+    return Page.withoutPager(RELATIONSHIPS, objectNodes);
   }
 
   @GetMapping("/{uid}")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -145,7 +145,7 @@ class TrackedEntitiesExportController {
               TRACKED_ENTITY_MAPPER.fromCollection(trackedEntitiesPage.getItems()),
               requestParams.getFields());
 
-      return Page.withPager(objectNodes, trackedEntitiesPage);
+      return Page.withPager(TRACKED_ENTITIES, objectNodes, trackedEntitiesPage);
     }
 
     List<org.hisp.dhis.trackedentity.TrackedEntity> trackedEntities =
@@ -154,7 +154,7 @@ class TrackedEntitiesExportController {
         fieldFilterService.toObjectNodes(
             TRACKED_ENTITY_MAPPER.fromCollection(trackedEntities), requestParams.getFields());
 
-    return Page.withoutPager(objectNodes);
+    return Page.withoutPager(TRACKED_ENTITIES, objectNodes);
   }
 
   @GetMapping(produces = {CONTENT_TYPE_CSV, CONTENT_TYPE_TEXT_CSV})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Page.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Page.java
@@ -113,16 +113,6 @@ public class Page<T> {
   }
 
   /**
-   * Returns a page which will serialize the items into {@link #items} under key {@code instances}.
-   * Pagination details will be serialized as well including totals only if {@link
-   * org.hisp.dhis.tracker.export.Page#isPageTotal()} is true.
-   */
-  public static <T, U> Page<T> withPager(
-      List<T> items, org.hisp.dhis.tracker.export.Page<U> pager) {
-    return new Page<>("instances", items, pager.getPager(), pager.isPageTotal());
-  }
-
-  /**
    * Returns a page which will serialize the items into {@link #items} under given {@code key}.
    * Pagination details will be serialized as well including totals only if {@link
    * org.hisp.dhis.tracker.export.Page#isPageTotal()} is true.
@@ -130,14 +120,6 @@ public class Page<T> {
   public static <T, U> Page<T> withPager(
       String key, List<T> items, org.hisp.dhis.tracker.export.Page<U> pager) {
     return new Page<>(key, items, pager.getPager(), pager.isPageTotal());
-  }
-
-  /**
-   * Returns a page which will only serialize the items into {@link #items} under key {@code
-   * instances}. All other fields will be omitted from the JSON.
-   */
-  public static <T> Page<T> withoutPager(List<T> items) {
-    return Page.withoutPager("instances", items);
   }
 
   /**


### PR DESCRIPTION
DO NOT MERGE UNTIL: https://dhis2.atlassian.net/browse/DHIS2-16499 is ready

export tracker entities in key named after entity instead of `"instances"` as this breaks the promise of users being able to import what they exported. The exporter expects keys like `"trackedEntities"` and so on.

* added 2 e2e tests
  * export a TE, change an attribute value in its JSON response and import that straight away: dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/tei/TeiImportTests.java
  * export a TE with enrollment with event, remove any tracker UID fields, import that. This simulates importing into one instance what came from another: dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/tei/TeiImportTests.java
* renamed some TEI to TE in e2e tests. We will need to do more of that later 😅  