### PR TITLE
feat: corsAllowlist configuration property alias [DHIS2-16388]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/configuration/Configuration.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/configuration/Configuration.java
@@ -251,4 +251,9 @@ public class Configuration implements Serializable {
   public void setCorsWhitelist(Set<String> corsWhitelist) {
     this.corsWhitelist = corsWhitelist;
   }
+
+  @JsonProperty
+  public Set<String> getCorsAllowlist() {
+    return getCorsWhitelist(); // just an alias
+  }
 }


### PR DESCRIPTION
As per Jira ticket this adds an alias property `corsAllowlist` to the configuration.