### PR TITLE
fix: Skip validation for null maxResults [DHIS2_16523]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/OutlierAnalysis.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/OutlierAnalysis.java
@@ -76,7 +76,6 @@ public class OutlierAnalysis implements Serializable {
   @JsonIgnore
   public boolean isValid() {
     return maxResults == null
-        || (maxResults != null
-            && (maxResults >= MAX_RESULTS_MIN_VALUE && maxResults <= MAX_RESULTS_MAX_VALUE));
+        || (maxResults >= MAX_RESULTS_MIN_VALUE && maxResults <= MAX_RESULTS_MAX_VALUE);
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/OutlierAnalysis.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/OutlierAnalysis.java
@@ -75,7 +75,8 @@ public class OutlierAnalysis implements Serializable {
    */
   @JsonIgnore
   public boolean isValid() {
-    return maxResults != null
-        && (maxResults >= MAX_RESULTS_MIN_VALUE && maxResults <= MAX_RESULTS_MAX_VALUE);
+    return maxResults == null
+        || (maxResults != null
+            && (maxResults >= MAX_RESULTS_MIN_VALUE && maxResults <= MAX_RESULTS_MAX_VALUE));
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/VisualizationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/VisualizationControllerTest.java
@@ -114,6 +114,40 @@ class VisualizationControllerTest extends DhisControllerConvenienceTest {
   }
 
   @Test
+  void testPostForNullOutlierMaxResults() {
+    // Given
+    String body =
+        """
+            {
+                "name": "Test Visualization",
+                "type": "LINE",
+                "program": {
+                    "id": "IpHINAT79UW"
+                },
+                "outlierAnalysis": {
+                    "enabled": true,
+                    "outlierMethod": "MODIFIED_Z_SCORE",
+                    "thresholdFactor": 3,
+                    "extremeLines": {
+                        "enabled": false,
+                        "value": 1
+                    },
+                    "maxResults": null
+                }
+            }
+        """;
+
+    // When
+    String uid = assertStatus(CREATED, POST("/visualizations/", body));
+
+    // Then
+    String getParams = "?fields=:all,columns[:all,items,sorting]";
+    JsonObject response = GET("/visualizations/" + uid + getParams).content();
+
+    assertThat(response.get("outlierAnalysis").toString(), not(containsString("maxResults")));
+  }
+
+  @Test
   void testPostInvalidSortingObject() {
     // Given
     String invalidDimension = "invalidOne";


### PR DESCRIPTION
Currently, the `maxResults` in the Visualization API (`outlierAnalysis` object), is mandatory.

In some situations, this property is not set by the client. Because of this, this property should not be mandatory.

This PR will validate the value when it's not null. Null values are now allowed.