### PR TITLE
fix: dont repeat dimensions in metaData item for repeatable stages [DHIS2-16379]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/CommonParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/CommonParams.java
@@ -227,7 +227,7 @@ public class CommonParams {
             parsedHeaders.stream(),
             orderParams.stream().map(AnalyticsSortingParams::getOrderBy))
         .flatMap(Function.identity())
-        .collect(Collectors.groupingBy(DimensionIdentifier::getKey))
+        .collect(Collectors.groupingBy(DimensionIdentifier::getKeyNoOffset))
         .values()
         .stream()
         .map(identifiers -> identifiers.get(0))

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/DimensionIdentifier.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/DimensionIdentifier.java
@@ -126,8 +126,20 @@ public class DimensionIdentifier<D extends UidObject> implements IdentifiableKey
     EVENT
   }
 
+  public DimensionIdentifier<D> withoutOffset() {
+    return DimensionIdentifier.of(
+        ElementWithOffset.of(this.getProgram().getElement()),
+        ElementWithOffset.of(this.getProgramStage().getElement()),
+        this.getDimension(),
+        this.getGroupId());
+  }
+
   @Override
   public String getKey() {
     return toString();
+  }
+
+  public String getKeyNoOffset() {
+    return withoutOffset().toString();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/ElementWithOffset.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/ElementWithOffset.java
@@ -50,6 +50,10 @@ public class ElementWithOffset<T extends UidObject> {
 
   private final Integer offset;
 
+  public static <T extends UidObject> ElementWithOffset<T> of(T element) {
+    return ElementWithOffset.of(element, null);
+  }
+
   public boolean hasOffset() {
     return Objects.nonNull(offset);
   }
@@ -75,7 +79,7 @@ public class ElementWithOffset<T extends UidObject> {
   @Override
   public String toString() {
     if (isPresent()) {
-      if (hasOffset()) {
+      if (hasOffset() && offset != 0) {
         return element.getUid() + "[" + offset + "]";
       }
       return element.getUid();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/processing/MetadataParamsHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/processing/MetadataParamsHandler.java
@@ -163,7 +163,7 @@ public class MetadataParamsHandler {
     // for dates supporting custom labels, it will add the custom label to items using the full
     // dimension uid as key
     if (supportsCustomLabel(dimensionIdentifier)) {
-      items.put(dimensionIdentifier.getKey(), getCustomLabel(dimensionIdentifier));
+      items.put(dimensionIdentifier.getKeyNoOffset(), getCustomLabel(dimensionIdentifier));
     }
 
     // for entries like "abc", it will add a duplicate using dimensionuid (example
@@ -207,7 +207,7 @@ public class MetadataParamsHandler {
 
   private static Entry<String, Object> asEntryWithFullPrefix(
       DimensionIdentifier<DimensionParam> dimensionIdentifier, Entry<String, Object> entry) {
-    return Map.entry(dimensionIdentifier.getKey(), entry.getValue());
+    return Map.entry(dimensionIdentifier.getKeyNoOffset(), entry.getValue());
   }
 
   private static boolean isSameDimension(


### PR DESCRIPTION
When a request specify the same dimensions multiple times, with different offsets, then it should be reported in metadata items just once, without offsets