### PR TITLE
fix: prevent 500 when job input file is no longer available [DHIS2-16521]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
@@ -63,7 +63,9 @@ import org.hisp.dhis.common.NameableObject;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.fileresource.FileResourceService;
+import org.hisp.dhis.fileresource.FileResourceStorageStatus;
 import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.jsontree.JsonNode;
 import org.hisp.dhis.jsontree.JsonObject;
@@ -277,11 +279,11 @@ public class DefaultJobConfigurationService implements JobConfigurationService {
   private JsonNode getJobInput(JobRunErrorsParams params, String fileResourceId) {
     if (!params.isIncludeInput()) return JsonNode.of("null");
     try {
-      byte[] bytes =
-          fileResourceService.copyFileResourceContent(
-              fileResourceService.getFileResource(fileResourceId));
+      FileResource fr = fileResourceService.getFileResource(fileResourceId);
+      if (fr == null || fr.getStorageStatus() != FileResourceStorageStatus.STORED) return JsonNode.NULL;
+      byte[] bytes = fileResourceService.copyFileResourceContent(fr);
       return JsonNode.of(new String(bytes, StandardCharsets.UTF_8));
-    } catch (IOException ex) {
+    } catch (Exception ex) {
       log.warn("Could not copy file content to error info for file: " + fileResourceId, ex);
       return JsonNode.of("\"" + ex.getMessage() + "\"");
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
@@ -35,7 +35,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Maps;
 import com.google.common.primitives.Primitives;
 import java.beans.PropertyDescriptor;
-import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
@@ -280,7 +279,8 @@ public class DefaultJobConfigurationService implements JobConfigurationService {
     if (!params.isIncludeInput()) return JsonNode.of("null");
     try {
       FileResource fr = fileResourceService.getFileResource(fileResourceId);
-      if (fr == null || fr.getStorageStatus() != FileResourceStorageStatus.STORED) return JsonNode.NULL;
+      if (fr == null || fr.getStorageStatus() != FileResourceStorageStatus.STORED)
+        return JsonNode.NULL;
       byte[] bytes = fileResourceService.copyFileResourceContent(fr);
       return JsonNode.of(new String(bytes, StandardCharsets.UTF_8));
     } catch (Exception ex) {


### PR DESCRIPTION
Takes care of a possible exception that would end in a HTTP 500 in case the file for a file resource is not in the storage (even though it should be).