### PR TITLE
feat: persistent errors for data value import [DHIS2-16531]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobRunErrorsParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobRunErrorsParams.java
@@ -34,7 +34,6 @@ import lombok.Data;
 import lombok.experimental.Accessors;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.UID;
-import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.user.User;
 
 /**
@@ -65,7 +64,7 @@ public class JobRunErrorsParams {
   @CheckForNull private Date to;
 
   /** The codes to select, any match combined */
-  @CheckForNull private List<ErrorCode> code;
+  @CheckForNull private List<String> code;
 
   /** The object with errors to select, any match combined */
   @CheckForNull private List<UID> object;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HibernateJobConfigurationStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HibernateJobConfigurationStore.java
@@ -45,7 +45,6 @@ import org.hibernate.query.NativeQuery;
 import org.hibernate.query.Query;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
-import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.security.acl.AclService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -270,9 +269,8 @@ public class HibernateJobConfigurationStore
     List<UID> objectList = params.getObject();
     List<String> errors =
         objectList == null ? List.of() : objectList.stream().map(UID::getValue).toList();
-    List<ErrorCode> codeList = params.getCode();
-    List<String> codes =
-        codeList == null ? List.of() : codeList.stream().map(ErrorCode::name).toList();
+    List<String> codeList = params.getCode();
+    List<String> codes = codeList == null ? List.of() : codeList;
     List<JobType> typeList = params.getType();
     List<String> types =
         typeList == null ? List.of() : typeList.stream().map(JobType::name).toList();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/tasks/DataValueSetImportJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/tasks/DataValueSetImportJob.java
@@ -33,6 +33,7 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.dxf2.adx.AdxDataService;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.datavalueset.DataValueSetService;
+import org.hisp.dhis.dxf2.importsummary.ImportConflict;
 import org.hisp.dhis.dxf2.importsummary.ImportCount;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.fileresource.FileResource;
@@ -98,12 +99,8 @@ public class DataValueSetImportJob implements Job {
       }
 
       if (summary.hasConflicts()) {
-        summary
-            .getConflicts()
-            .forEach(
-                c ->
-                    progress.addError(
-                        c.getErrorCode(), c.getObject(), c.getGroupingKey(), c.getArgs()));
+        for (ImportConflict c : summary.getConflicts())
+          progress.addError(c.getErrorCode(), c.getObject(), c.getGroupingKey(), c.getArgs());
       }
 
       ImportCount count = summary.getImportCount();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/tasks/DataValueSetImportJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/tasks/DataValueSetImportJob.java
@@ -33,7 +33,6 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.dxf2.adx.AdxDataService;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.datavalueset.DataValueSetService;
-import org.hisp.dhis.dxf2.importsummary.ImportConflict;
 import org.hisp.dhis.dxf2.importsummary.ImportCount;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.fileresource.FileResource;
@@ -99,9 +98,12 @@ public class DataValueSetImportJob implements Job {
       }
 
       if (summary.hasConflicts()) {
-        for (ImportConflict c : summary.getConflicts()) {
-          progress.addError(c.getErrorCode(), c.getObject(), c.getGroupingKey(), c.getArgs());
-        }
+        summary
+            .getConflicts()
+            .forEach(
+                c ->
+                    progress.addError(
+                        c.getErrorCode(), c.getObject(), c.getGroupingKey(), c.getArgs()));
       }
 
       ImportCount count = summary.getImportCount();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/tasks/DataValueSetImportJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/tasks/DataValueSetImportJob.java
@@ -33,6 +33,7 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.dxf2.adx.AdxDataService;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.datavalueset.DataValueSetService;
+import org.hisp.dhis.dxf2.importsummary.ImportConflict;
 import org.hisp.dhis.dxf2.importsummary.ImportCount;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.fileresource.FileResource;
@@ -96,6 +97,13 @@ public class DataValueSetImportJob implements Job {
         progress.failedProcess("Import failed, no summary available");
         return;
       }
+
+      if (summary.hasConflicts()) {
+        for (ImportConflict c : summary.getConflicts()) {
+          progress.addError(c.getErrorCode(), c.getObject(), c.getGroupingKey(), c.getArgs());
+        }
+      }
+
       ImportCount count = summary.getImportCount();
       progress.completedProcess(
           "Import complete with status %s, %d created, %d updated, %d deleted, %d ignored"

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/job/GeoJsonImportJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/job/GeoJsonImportJob.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import lombok.AllArgsConstructor;
 import org.hisp.dhis.dxf2.geojson.GeoJsonImportReport;
 import org.hisp.dhis.dxf2.geojson.GeoJsonService;
+import org.hisp.dhis.dxf2.importsummary.ImportConflict;
 import org.hisp.dhis.dxf2.importsummary.ImportCount;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.fileresource.FileResourceService;
@@ -76,12 +77,8 @@ public class GeoJsonImportJob implements Job {
         return;
       }
       if (report.hasConflicts()) {
-        report
-            .getConflicts()
-            .forEach(
-                c ->
-                    progress.addError(
-                        c.getErrorCode(), c.getObject(), c.getGroupingKey(), c.getArgs()));
+        for (ImportConflict c : report.getConflicts())
+          progress.addError(c.getErrorCode(), c.getObject(), c.getGroupingKey(), c.getArgs());
       }
 
       ImportCount count = report.getImportCount();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/importsummary/ImportConflict.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/importsummary/ImportConflict.java
@@ -39,9 +39,11 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.stream.Stream;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.feedback.ErrorCode;
@@ -103,7 +105,7 @@ public final class ImportConflict {
     }
     ErrorCode errorCode = descriptor.getErrorCode();
     String message = MessageFormat.format(errorCode.getMessage(), (Object[]) objects);
-    return new ImportConflict(objectsMap, message, errorCode, property, index);
+    return new ImportConflict(objectsMap, objects, message, errorCode, property, index);
   }
 
   /**
@@ -131,6 +133,8 @@ public final class ImportConflict {
   /** What type of object does {@link #object} refer to? Uses the singular from schema. */
   private final Map<String, String> objects;
 
+  private final List<String> args;
+
   /**
    * A list of indexes pointing out the index of the conflicting element in the set/list of imported
    * elements.
@@ -140,12 +144,13 @@ public final class ImportConflict {
   private int occurrenceCount;
 
   public ImportConflict(String object, String message) {
-    this(getGroupingKey(object, message), object, message, null, null, null, -1);
+    this(getGroupingKey(object, message), object, null, message, null, null, null, -1);
     requireNonNull(message);
   }
 
   public ImportConflict(
       Map<String, String> objects,
+      Object[] args,
       String message,
       ErrorCode errorCode,
       String property,
@@ -153,6 +158,7 @@ public final class ImportConflict {
     this(
         getGroupingKey(errorCode, objects),
         objects.isEmpty() ? null : objects.values().iterator().next(),
+        args,
         message,
         errorCode,
         objects,
@@ -163,6 +169,7 @@ public final class ImportConflict {
   private ImportConflict(
       String groupingKey,
       String object,
+      Object[] args,
       String message,
       ErrorCode errorCode,
       Map<String, String> objects,
@@ -172,6 +179,11 @@ public final class ImportConflict {
     this.errorCode = errorCode;
     this.object = object;
     this.message = message;
+    this.args =
+        args == null
+            ? List.of()
+            : Stream.of(args).map(obj -> obj == null ? null : obj.toString()).toList();
+    ;
     this.objects = objects;
     this.property = property;
     if (index >= 0) {
@@ -195,6 +207,7 @@ public final class ImportConflict {
     this.groupingKey =
         errorCode == null ? getGroupingKey(object, message) : getGroupingKey(errorCode, objects);
     this.object = object;
+    this.args = null;
     this.objects = objects;
     this.message = message;
     this.property = property;
@@ -209,6 +222,11 @@ public final class ImportConflict {
 
   private static String getGroupingKey(String object, String message) {
     return object + KEY_DELIMITER + message;
+  }
+
+  @JsonIgnore
+  public List<String> getArgs() {
+    return args;
   }
 
   @JsonIgnore

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/importsummary/ImportConflict.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/importsummary/ImportConflict.java
@@ -183,7 +183,6 @@ public final class ImportConflict {
         args == null
             ? List.of()
             : Stream.of(args).map(obj -> obj == null ? null : obj.toString()).toList();
-    ;
     this.objects = objects;
     this.property = property;
     if (index >= 0) {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/common/ImportSummaryJacksonTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/common/ImportSummaryJacksonTest.java
@@ -109,6 +109,11 @@ class ImportSummaryJacksonTest {
 
   private ImportConflict createImportConflictForIndex(int index) {
     return new ImportConflict(
-        singletonMap("key", "value"), "message", ErrorCode.E7600, "property", index);
+        singletonMap("key", "value"),
+        new Object[] {"value"},
+        "message",
+        ErrorCode.E7600,
+        "property",
+        index);
   }
 }


### PR DESCRIPTION
### Summary
Adds persistent errors to the data value import.

As the GeoJSON import is based on the same conflict model I also update the GeoJSON import to support this feature.

The PR also changes the `code` param from `ErrorCode` to `String` because internally multiple enums are used (tacker+metadata) so it is not correct to expect just `ErrorCode` values.

### Manual Testing
* open import/export app
* export some data (select so you get a small set)
* edit the file, change a UID of a referenced object, e.g. a data element to a non existing UID
* import the now broken data file
* check the issue is listed in the summary shown in the import/export app
* browse to `/api/jobConfigurations/errors` 
* look for the job created for the import and check its errors contain the same error information