### PR TITLE
ci(deps): potential fix to failed builds with corrupted node

### DIFF
--- a/dhis-2/dhis-web/dhis-web-apps/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-apps/pom.xml
@@ -31,7 +31,7 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>1.12.1</version>
+        <version>1.15.0</version>
         <configuration>
           <installDirectory>target</installDirectory>
           <environmentVariables>


### PR DESCRIPTION
We have not updated this dependency in a while. See https://github.com/eirslett/frontend-maven-plugin/blob/master/CHANGELOG.md#1142

The war build sometimes fails due to 

```
Error:  The archive file /home/runner/.m2/repository/com/github/eirslett/node/16.13.2/node-16.13.2-linux-x64.tar.gz is corrupted and will be deleted. Please try the build again.
```

This update could resolve the above issue.