### PR TITLE
chore: sonar warnings on equals methods not being sufficient

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeDimension.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeDimension.java
@@ -31,6 +31,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.legend.LegendSet;
@@ -39,13 +44,14 @@ import org.hisp.dhis.legend.LegendSet;
  * @author Lars Helge Overland
  */
 @JacksonXmlRootElement(localName = "attributeDimension", namespace = DxfNamespaces.DXF_2_0)
+@Setter
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
 public class TrackedEntityAttributeDimension {
-  private int id;
 
-  /** Attribute. */
+  @Getter @EqualsAndHashCode.Exclude private int id;
   private TrackedEntityAttribute attribute;
-
-  /** Legend set. */
   private LegendSet legendSet;
 
   /**
@@ -54,22 +60,12 @@ public class TrackedEntityAttributeDimension {
    */
   private String filter;
 
-  // -------------------------------------------------------------------------
-  // Constructors
-  // -------------------------------------------------------------------------
-
-  public TrackedEntityAttributeDimension() {}
-
   public TrackedEntityAttributeDimension(
       TrackedEntityAttribute attribute, LegendSet legendSet, String filter) {
     this.attribute = attribute;
     this.legendSet = legendSet;
     this.filter = filter;
   }
-
-  // -------------------------------------------------------------------------
-  // Logic
-  // -------------------------------------------------------------------------
 
   public String getUid() {
     return attribute != null ? attribute.getUid() : null;
@@ -79,89 +75,11 @@ public class TrackedEntityAttributeDimension {
     return attribute != null ? attribute.getDisplayName() : null;
   }
 
-  @Override
-  public String toString() {
-    return "{"
-        + "\"class\":\""
-        + getClass()
-        + "\", "
-        + "\"id\":\""
-        + id
-        + "\", "
-        + "\"attribute\":"
-        + attribute
-        + ", "
-        + "\"legendSet\":"
-        + legendSet
-        + ", "
-        + "\"filter\":\""
-        + filter
-        + "\" "
-        + "}";
-  }
-
-  @Override
-  public int hashCode() {
-    int result = id;
-    result = 31 * result + (attribute != null ? attribute.hashCode() : 0);
-    result = 31 * result + (legendSet != null ? legendSet.hashCode() : 0);
-    result = 31 * result + (filter != null ? filter.hashCode() : 0);
-
-    return result;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-
-    if (o == null) {
-      return false;
-    }
-
-    if (!getClass().isAssignableFrom(o.getClass())) {
-      return false;
-    }
-
-    final TrackedEntityAttributeDimension other = (TrackedEntityAttributeDimension) o;
-
-    if (attribute != null ? !attribute.equals(other.attribute) : other.attribute != null) {
-      return false;
-    }
-
-    if (legendSet != null ? !legendSet.equals(other.legendSet) : other.legendSet != null) {
-      return false;
-    }
-
-    if (filter != null ? !filter.equals(other.filter) : other.filter != null) {
-      return false;
-    }
-
-    return true;
-  }
-
-  // -------------------------------------------------------------------------
-  // Getters and setters
-  // -------------------------------------------------------------------------
-
-  public int getId() {
-    return id;
-  }
-
-  public void setId(int id) {
-    this.id = id;
-  }
-
   @JsonProperty
   @JsonSerialize(as = BaseIdentifiableObject.class)
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public TrackedEntityAttribute getAttribute() {
     return attribute;
-  }
-
-  public void setAttribute(TrackedEntityAttribute attribute) {
-    this.attribute = attribute;
   }
 
   @JsonProperty
@@ -171,17 +89,9 @@ public class TrackedEntityAttributeDimension {
     return legendSet;
   }
 
-  public void setLegendSet(LegendSet legendSet) {
-    this.legendSet = legendSet;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public String getFilter() {
     return filter;
-  }
-
-  public void setFilter(String filter) {
-    this.filter = filter;
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityDataElementDimension.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityDataElementDimension.java
@@ -31,6 +31,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.dataelement.DataElement;
@@ -41,16 +46,15 @@ import org.hisp.dhis.program.ProgramStage;
  * @author Lars Helge Overland
  */
 @JacksonXmlRootElement(localName = "dataElementDimension", namespace = DxfNamespaces.DXF_2_0)
+@Setter
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
 public class TrackedEntityDataElementDimension {
-  private int id;
 
-  /** Data element. */
+  @Getter @EqualsAndHashCode.Exclude private int id;
   private DataElement dataElement;
-
-  /** Legend set. */
   private LegendSet legendSet;
-
-  /** Program stage. */
   private ProgramStage programStage;
 
   /**
@@ -58,12 +62,6 @@ public class TrackedEntityDataElementDimension {
    * pairs can be repeated any number of times.
    */
   private String filter;
-
-  // -------------------------------------------------------------------------
-  // Constructors
-  // -------------------------------------------------------------------------
-
-  public TrackedEntityDataElementDimension() {}
 
   public TrackedEntityDataElementDimension(
       DataElement dataElement, LegendSet legendSet, ProgramStage programStage, String filter) {
@@ -73,100 +71,12 @@ public class TrackedEntityDataElementDimension {
     this.filter = filter;
   }
 
-  // -------------------------------------------------------------------------
-  // Logic
-  // -------------------------------------------------------------------------
-
   public String getUid() {
     return dataElement != null ? dataElement.getUid() : null;
   }
 
   public String getDisplayName() {
     return dataElement != null ? dataElement.getDisplayName() : null;
-  }
-
-  @Override
-  public String toString() {
-    return "{"
-        + "\"class\":\""
-        + getClass()
-        + "\", "
-        + "\"id\":\""
-        + id
-        + "\", "
-        + "\"dataElement\":"
-        + dataElement
-        + ", "
-        + "\"legendSet\":"
-        + legendSet
-        + ", "
-        + "\"programStage\":"
-        + programStage
-        + ", "
-        + "\"filter\":\""
-        + filter
-        + "\" "
-        + "}";
-  }
-
-  @Override
-  public int hashCode() {
-    int result = id;
-    result = 31 * result + (dataElement != null ? dataElement.hashCode() : 0);
-    result = 31 * result + (legendSet != null ? legendSet.hashCode() : 0);
-    result = 31 * result + (programStage != null ? programStage.hashCode() : 0);
-    result = 31 * result + (filter != null ? filter.hashCode() : 0);
-
-    return result;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-
-    if (o == null) {
-      return false;
-    }
-
-    if (!getClass().isAssignableFrom(o.getClass())) {
-      return false;
-    }
-
-    final TrackedEntityDataElementDimension other = (TrackedEntityDataElementDimension) o;
-
-    if (dataElement != null ? !dataElement.equals(other.dataElement) : other.dataElement != null) {
-      return false;
-    }
-
-    if (legendSet != null ? !legendSet.equals(other.legendSet) : other.legendSet != null) {
-      return false;
-    }
-
-    if (programStage != null
-        ? !programStage.equals(other.programStage)
-        : other.programStage != null) {
-      return false;
-    }
-
-    if (filter != null ? !filter.equals(other.filter) : other.filter != null) {
-      return false;
-    }
-
-    return true;
-  }
-
-  // -------------------------------------------------------------------------
-  // Getters and setters
-  // -------------------------------------------------------------------------
-
-  public int getId() {
-    return id;
-  }
-
-  public void setId(int id) {
-    this.id = id;
   }
 
   @JsonProperty
@@ -176,19 +86,11 @@ public class TrackedEntityDataElementDimension {
     return dataElement;
   }
 
-  public void setDataElement(DataElement dataElement) {
-    this.dataElement = dataElement;
-  }
-
   @JsonProperty
   @JsonSerialize(as = BaseIdentifiableObject.class)
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public LegendSet getLegendSet() {
     return legendSet;
-  }
-
-  public void setLegendSet(LegendSet legendSet) {
-    this.legendSet = legendSet;
   }
 
   @JsonProperty
@@ -198,17 +100,9 @@ public class TrackedEntityDataElementDimension {
     return programStage;
   }
 
-  public void setProgramStage(ProgramStage programStage) {
-    this.programStage = programStage;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public String getFilter() {
     return filter;
-  }
-
-  public void setFilter(String filter) {
-    this.filter = filter;
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityProgramIndicatorDimension.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityProgramIndicatorDimension.java
@@ -31,6 +31,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.legend.LegendSet;
@@ -40,13 +45,14 @@ import org.hisp.dhis.program.ProgramIndicator;
  * @author Lars Helge Overland
  */
 @JacksonXmlRootElement(localName = "programIndicatorDimension", namespace = DxfNamespaces.DXF_2_0)
+@Setter
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
 public class TrackedEntityProgramIndicatorDimension {
-  private int id;
 
-  /** Program indicator. */
+  @Getter @EqualsAndHashCode.Exclude private int id;
   private ProgramIndicator programIndicator;
-
-  /** Legend set. */
   private LegendSet legendSet;
 
   /**
@@ -55,22 +61,12 @@ public class TrackedEntityProgramIndicatorDimension {
    */
   private String filter;
 
-  // -------------------------------------------------------------------------
-  // Constructors
-  // -------------------------------------------------------------------------
-
-  public TrackedEntityProgramIndicatorDimension() {}
-
   public TrackedEntityProgramIndicatorDimension(
       ProgramIndicator programIndicator, LegendSet legendSet, String filter) {
     this.programIndicator = programIndicator;
     this.legendSet = legendSet;
     this.filter = filter;
   }
-
-  // -------------------------------------------------------------------------
-  // Logic
-  // -------------------------------------------------------------------------
 
   public String getUid() {
     return programIndicator != null ? programIndicator.getUid() : null;
@@ -80,83 +76,11 @@ public class TrackedEntityProgramIndicatorDimension {
     return programIndicator != null ? programIndicator.getDisplayName() : null;
   }
 
-  @Override
-  public String toString() {
-    return "[Id: "
-        + id
-        + ", program indicator: "
-        + programIndicator
-        + ", legend set: "
-        + legendSet
-        + ", filter: "
-        + filter
-        + "]";
-  }
-
-  @Override
-  public int hashCode() {
-    int result = id;
-    result = 31 * result + (programIndicator != null ? programIndicator.hashCode() : 0);
-    result = 31 * result + (legendSet != null ? legendSet.hashCode() : 0);
-    result = 31 * result + (filter != null ? filter.hashCode() : 0);
-
-    return result;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-
-    if (o == null) {
-      return false;
-    }
-
-    if (!getClass().isAssignableFrom(o.getClass())) {
-      return false;
-    }
-
-    final TrackedEntityProgramIndicatorDimension other = (TrackedEntityProgramIndicatorDimension) o;
-
-    if (programIndicator != null
-        ? !programIndicator.equals(other.programIndicator)
-        : other.programIndicator != null) {
-      return false;
-    }
-
-    if (legendSet != null ? !legendSet.equals(other.legendSet) : other.legendSet != null) {
-      return false;
-    }
-
-    if (filter != null ? !filter.equals(other.filter) : other.filter != null) {
-      return false;
-    }
-
-    return true;
-  }
-
-  // -------------------------------------------------------------------------
-  // Getters and setters
-  // -------------------------------------------------------------------------
-
-  public int getId() {
-    return id;
-  }
-
-  public void setId(int id) {
-    this.id = id;
-  }
-
   @JsonProperty
   @JsonSerialize(as = BaseIdentifiableObject.class)
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public ProgramIndicator getProgramIndicator() {
     return programIndicator;
-  }
-
-  public void setProgramIndicator(ProgramIndicator programIndicator) {
-    this.programIndicator = programIndicator;
   }
 
   @JsonProperty
@@ -166,17 +90,9 @@ public class TrackedEntityProgramIndicatorDimension {
     return legendSet;
   }
 
-  public void setLegendSet(LegendSet legendSet) {
-    this.legendSet = legendSet;
-  }
-
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public String getFilter() {
     return filter;
-  }
-
-  public void setFilter(String filter) {
-    this.filter = filter;
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityProgramOwner.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityProgramOwner.java
@@ -33,6 +33,10 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.io.Serializable;
 import java.util.Date;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -42,24 +46,18 @@ import org.hisp.dhis.program.Program;
  * @author Ameen Mohamed
  */
 @JacksonXmlRootElement(localName = "trackedEntityProgramOwner", namespace = DxfNamespaces.DXF_2_0)
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class TrackedEntityProgramOwner implements Serializable {
-  private int id;
 
-  private TrackedEntity trackedEntity;
-
-  private Program program;
-
+  @Getter private int id;
+  @EqualsAndHashCode.Include private TrackedEntity trackedEntity;
+  @EqualsAndHashCode.Include private Program program;
   private OrganisationUnit organisationUnit;
-
-  private Date created;
-
-  private Date lastUpdated;
-
-  private String createdBy;
-
-  // -------------------------------------------------------------------------
-  // Constructors
-  // -------------------------------------------------------------------------
+  @Getter private Date created;
+  @Getter private Date lastUpdated;
+  @Getter private String createdBy;
 
   public TrackedEntityProgramOwner() {
     this.createdBy = "internal";
@@ -73,77 +71,15 @@ public class TrackedEntityProgramOwner implements Serializable {
     this.createdBy = "internal";
   }
 
-  // -------------------------------------------------------------------------
-  // Logic
-  // -------------------------------------------------------------------------
-
   public void changeOwner(OrganisationUnit newOwnerOu) {
     this.organisationUnit = newOwnerOu;
   }
-
-  // -------------------------------------------------------------------------
-  // equals and hashCode
-  // -------------------------------------------------------------------------
-
-  @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = super.hashCode();
-
-    result = prime * result + ((trackedEntity == null) ? 0 : trackedEntity.hashCode());
-    result = prime * result + ((program == null) ? 0 : program.hashCode());
-
-    return result;
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (this == object) {
-      return true;
-    }
-
-    if (object == null) {
-      return false;
-    }
-
-    if (!getClass().isAssignableFrom(object.getClass())) {
-      return false;
-    }
-
-    final TrackedEntityProgramOwner other = (TrackedEntityProgramOwner) object;
-
-    if (trackedEntity == null) {
-      if (other.trackedEntity != null) {
-        return false;
-      }
-    } else if (!trackedEntity.equals(other.trackedEntity)) {
-      return false;
-    }
-
-    if (program == null) {
-      if (other.program != null) {
-        return false;
-      }
-    } else if (!program.equals(other.program)) {
-      return false;
-    }
-
-    return true;
-  }
-
-  // -------------------------------------------------------------------------
-  // Getters and setters
-  // -------------------------------------------------------------------------
 
   @JsonProperty
   @JsonSerialize(as = BaseIdentifiableObject.class)
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public OrganisationUnit getOrganisationUnit() {
     return organisationUnit;
-  }
-
-  public void setOrganisationUnit(OrganisationUnit organisationUnit) {
-    this.organisationUnit = organisationUnit;
   }
 
   @JsonProperty("trackedEntityInstance")
@@ -153,51 +89,11 @@ public class TrackedEntityProgramOwner implements Serializable {
     return trackedEntity;
   }
 
-  public void setTrackedEntity(TrackedEntity trackedEntity) {
-    this.trackedEntity = trackedEntity;
-  }
-
   @JsonProperty
   @JsonSerialize(as = BaseIdentifiableObject.class)
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public Program getProgram() {
     return program;
-  }
-
-  public void setProgram(Program program) {
-    this.program = program;
-  }
-
-  public Date getCreated() {
-    return created;
-  }
-
-  public void setCreated(Date created) {
-    this.created = created;
-  }
-
-  public Date getLastUpdated() {
-    return lastUpdated;
-  }
-
-  public void setLastUpdated(Date lastUpdated) {
-    this.lastUpdated = lastUpdated;
-  }
-
-  public String getCreatedBy() {
-    return createdBy;
-  }
-
-  public void setCreatedBy(String createdBy) {
-    this.createdBy = createdBy;
-  }
-
-  public int getId() {
-    return id;
-  }
-
-  public void setId(int id) {
-    this.id = id;
   }
 
   public void updateDates() {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentityattributevalue/TrackedEntityAttributeValue.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentityattributevalue/TrackedEntityAttributeValue.java
@@ -66,13 +66,11 @@ public class TrackedEntityAttributeValue implements Serializable {
   private TrackedEntityAttribute attribute;
 
   @Setter @ToString.Include @AuditAttribute private TrackedEntity trackedEntity;
-
   @Setter @ToString.Include private Date created;
-
   @Setter @ToString.Include private Date lastUpdated;
+  @Setter @ToString.Include private String storedBy;
 
   private String encryptedValue;
-
   private String plainValue;
 
   /**
@@ -80,8 +78,6 @@ public class TrackedEntityAttributeValue implements Serializable {
    * not.
    */
   @ToString.Include private String value;
-
-  @Setter @ToString.Include private String storedBy;
 
   private transient boolean auditValueIsSet = false;
   private transient boolean valueIsSet = false;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentityattributevalue/TrackedEntityAttributeValue.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentityattributevalue/TrackedEntityAttributeValue.java
@@ -32,8 +32,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
 import org.hisp.dhis.audit.AuditAttribute;
 import org.hisp.dhis.audit.AuditScope;
 import org.hisp.dhis.audit.Auditable;
@@ -49,17 +55,21 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
  */
 @Auditable(scope = AuditScope.TRACKER)
 @JacksonXmlRootElement(localName = "trackedEntityAttributeValue", namespace = DxfNamespaces.DXF_2_0)
+@Accessors(chain = true)
+@ToString(onlyExplicitlyIncluded = true)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class TrackedEntityAttributeValue implements Serializable {
   /** Determines if a de-serialized file is compatible with this class. */
-  private static final long serialVersionUID = -4469496681709547707L;
+  @Serial private static final long serialVersionUID = -4469496681709547707L;
 
-  @AuditAttribute private TrackedEntityAttribute attribute;
+  @Setter @ToString.Include @EqualsAndHashCode.Include @AuditAttribute
+  private TrackedEntityAttribute attribute;
 
-  @AuditAttribute private TrackedEntity trackedEntity;
+  @Setter @ToString.Include @AuditAttribute private TrackedEntity trackedEntity;
 
-  private Date created;
+  @Setter @ToString.Include private Date created;
 
-  private Date lastUpdated;
+  @Setter @ToString.Include private Date lastUpdated;
 
   private String encryptedValue;
 
@@ -69,23 +79,13 @@ public class TrackedEntityAttributeValue implements Serializable {
    * This value is only used to store values from setValue when we don't know if attribute is set or
    * not.
    */
-  private String value;
+  @ToString.Include private String value;
 
-  private String storedBy;
-
-  // -------------------------------------------------------------------------
-  // Transient properties
-  // -------------------------------------------------------------------------
+  @Setter @ToString.Include private String storedBy;
 
   private transient boolean auditValueIsSet = false;
-
   private transient boolean valueIsSet = false;
-
-  private transient String auditValue;
-
-  // -------------------------------------------------------------------------
-  // Constructors
-  // -------------------------------------------------------------------------
+  @Getter private transient String auditValue;
 
   public TrackedEntityAttributeValue() {
     setAutoFields();
@@ -114,87 +114,6 @@ public class TrackedEntityAttributeValue implements Serializable {
     setLastUpdated(date);
   }
 
-  // -------------------------------------------------------------------------
-  // hashCode and equals
-  // -------------------------------------------------------------------------
-
-  @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((trackedEntity == null) ? 0 : trackedEntity.hashCode());
-    result = prime * result + ((attribute == null) ? 0 : attribute.hashCode());
-    result = prime * result + ((getValue() == null) ? 0 : getValue().hashCode());
-    return result;
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (this == object) {
-      return true;
-    }
-
-    if (object == null) {
-      return false;
-    }
-
-    if (!getClass().isAssignableFrom(object.getClass())) {
-      return false;
-    }
-
-    final TrackedEntityAttributeValue other = (TrackedEntityAttributeValue) object;
-
-    if (trackedEntity == null) {
-      if (other.trackedEntity != null) {
-        return false;
-      }
-    } else if (!trackedEntity.equals(other.trackedEntity)) {
-      return false;
-    }
-
-    if (attribute == null) {
-      if (other.attribute != null) {
-        return false;
-      }
-    } else if (!attribute.equals(other.attribute)) {
-      return false;
-    }
-
-    if (getValue() == null) {
-      if (other.getValue() != null) {
-        return false;
-      }
-    } else if (!getValue().equals(other.getValue())) {
-      return false;
-    }
-
-    return true;
-  }
-
-  @Override
-  public String toString() {
-    return "TrackedEntityAttributeValue{"
-        + "attribute="
-        + attribute
-        + ", entityInstance="
-        + (trackedEntity != null ? trackedEntity.getUid() : "null")
-        + ", value='"
-        + value
-        + '\''
-        + ", created="
-        + created
-        + ", lastUpdated="
-        + lastUpdated
-        + ", storedBy='"
-        + storedBy
-        + '\''
-        + '}';
-  }
-
-  // -------------------------------------------------------------------------
-  // Getters and setters
-  // -------------------------------------------------------------------------
-
   @AuditAttribute
   @JsonProperty
   @JacksonXmlProperty(isAttribute = true)
@@ -202,21 +121,11 @@ public class TrackedEntityAttributeValue implements Serializable {
     return created;
   }
 
-  public TrackedEntityAttributeValue setCreated(Date created) {
-    this.created = created;
-    return this;
-  }
-
   @AuditAttribute
   @JsonProperty
   @JacksonXmlProperty(isAttribute = true)
   public Date getLastUpdated() {
     return lastUpdated;
-  }
-
-  public TrackedEntityAttributeValue setLastUpdated(Date lastUpdated) {
-    this.lastUpdated = lastUpdated;
-    return this;
   }
 
   /**
@@ -269,6 +178,7 @@ public class TrackedEntityAttributeValue implements Serializable {
   @AuditAttribute
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
+  @EqualsAndHashCode.Include
   public String getValue() {
     return (getAttribute().getConfidential() ? this.getEncryptedValue() : this.getPlainValue());
   }
@@ -300,11 +210,6 @@ public class TrackedEntityAttributeValue implements Serializable {
     return storedBy;
   }
 
-  public TrackedEntityAttributeValue setStoredBy(String storedBy) {
-    this.storedBy = storedBy;
-    return this;
-  }
-
   @JsonProperty("trackedEntityAttribute")
   @JsonSerialize(as = BaseIdentifiableObject.class)
   @JacksonXmlProperty(localName = "trackedEntityAttribute", namespace = DxfNamespaces.DXF_2_0)
@@ -312,24 +217,10 @@ public class TrackedEntityAttributeValue implements Serializable {
     return attribute;
   }
 
-  public TrackedEntityAttributeValue setAttribute(TrackedEntityAttribute attribute) {
-    this.attribute = attribute;
-    return this;
-  }
-
   @JsonProperty("trackedEntityInstance")
   @JsonSerialize(as = BaseIdentifiableObject.class)
   @JacksonXmlProperty(localName = "trackedEntityInstance", namespace = DxfNamespaces.DXF_2_0)
   public TrackedEntity getTrackedEntity() {
     return trackedEntity;
-  }
-
-  public TrackedEntityAttributeValue setTrackedEntity(TrackedEntity trackedEntity) {
-    this.trackedEntity = trackedEntity;
-    return this;
-  }
-
-  public String getAuditValue() {
-    return auditValue;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsAggregationType.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsAggregationType.java
@@ -27,8 +27,10 @@
  */
 package org.hisp.dhis.analytics;
 
-import com.google.common.base.MoreObjects;
 import java.util.Objects;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 import org.hisp.dhis.util.ObjectUtils;
 
 /**
@@ -36,40 +38,33 @@ import org.hisp.dhis.util.ObjectUtils;
  *
  * @author Lars Helge Overland
  */
+@ToString
+@EqualsAndHashCode
 public class AnalyticsAggregationType {
-  public static final AnalyticsAggregationType SUM =
-      new AnalyticsAggregationType(AggregationType.SUM, AggregationType.SUM);
-
-  public static final AnalyticsAggregationType AVERAGE =
-      new AnalyticsAggregationType(AggregationType.AVERAGE, AggregationType.AVERAGE);
-
-  public static final AnalyticsAggregationType COUNT =
-      new AnalyticsAggregationType(AggregationType.COUNT, AggregationType.COUNT);
-
-  public static final AnalyticsAggregationType FIRST =
-      new AnalyticsAggregationType(AggregationType.SUM, AggregationType.FIRST);
-
-  public static final AnalyticsAggregationType LAST =
-      new AnalyticsAggregationType(AggregationType.SUM, AggregationType.LAST);
-
-  public static final AnalyticsAggregationType LAST_IN_PERIOD =
-      new AnalyticsAggregationType(AggregationType.SUM, AggregationType.LAST_IN_PERIOD);
+  public static final AnalyticsAggregationType //
+      SUM = of(AggregationType.SUM, AggregationType.SUM),
+      AVERAGE = of(AggregationType.AVERAGE, AggregationType.AVERAGE),
+      COUNT = of(AggregationType.COUNT, AggregationType.COUNT),
+      FIRST = of(AggregationType.SUM, AggregationType.FIRST),
+      LAST = of(AggregationType.SUM, AggregationType.LAST),
+      LAST_IN_PERIOD = of(AggregationType.SUM, AggregationType.LAST_IN_PERIOD);
 
   /** General aggregation type. */
-  private final AggregationType aggregationType;
+  @Getter private final AggregationType aggregationType;
 
   /** Aggregation type for the period dimension. */
   private final AggregationType periodAggregationType;
 
   /** Analytics data type. */
-  private DataType dataType;
+  @Getter private DataType dataType;
 
   /** Indicates whether to perform data disaggregation. */
-  private boolean disaggregation;
+  @Getter private boolean disaggregation;
 
-  // -------------------------------------------------------------------------
-  // Constructors
-  // -------------------------------------------------------------------------
+  public static AnalyticsAggregationType of(
+      AggregationType aggregationType, AggregationType periodAggregationType) {
+    return new AnalyticsAggregationType(aggregationType, periodAggregationType);
+  }
 
   /**
    * Constructor.
@@ -109,63 +104,22 @@ public class AnalyticsAggregationType {
         this.aggregationType, this.periodAggregationType, this.dataType, this.disaggregation);
   }
 
-  // -------------------------------------------------------------------------
-  // Logic methods
-  // -------------------------------------------------------------------------
-
   public static AnalyticsAggregationType fromAggregationType(AggregationType aggregationType) {
-    AnalyticsAggregationType analyticsAggregationType;
-
-    switch (aggregationType) {
-      case AVERAGE_SUM_ORG_UNIT:
-        analyticsAggregationType =
-            new AnalyticsAggregationType(AggregationType.SUM, AggregationType.AVERAGE);
-        break;
-      case LAST:
-        analyticsAggregationType =
-            new AnalyticsAggregationType(AggregationType.SUM, AggregationType.LAST);
-        break;
-      case LAST_AVERAGE_ORG_UNIT:
-        analyticsAggregationType =
-            new AnalyticsAggregationType(AggregationType.AVERAGE, AggregationType.LAST);
-        break;
-      case LAST_LAST_ORG_UNIT:
-        analyticsAggregationType =
-            new AnalyticsAggregationType(AggregationType.LAST, AggregationType.LAST);
-        break;
-      case LAST_IN_PERIOD:
-        analyticsAggregationType =
-            new AnalyticsAggregationType(AggregationType.SUM, AggregationType.LAST_IN_PERIOD);
-        break;
-      case LAST_IN_PERIOD_AVERAGE_ORG_UNIT:
-        analyticsAggregationType =
-            new AnalyticsAggregationType(AggregationType.AVERAGE, AggregationType.LAST_IN_PERIOD);
-        break;
-      case FIRST:
-        analyticsAggregationType =
-            new AnalyticsAggregationType(AggregationType.SUM, AggregationType.FIRST);
-        break;
-      case FIRST_AVERAGE_ORG_UNIT:
-        analyticsAggregationType =
-            new AnalyticsAggregationType(AggregationType.AVERAGE, AggregationType.FIRST);
-        break;
-      case FIRST_FIRST_ORG_UNIT:
-        analyticsAggregationType =
-            new AnalyticsAggregationType(AggregationType.FIRST, AggregationType.FIRST);
-        break;
-      case MAX_SUM_ORG_UNIT:
-        analyticsAggregationType =
-            new AnalyticsAggregationType(AggregationType.SUM, AggregationType.MAX);
-        break;
-      case MIN_SUM_ORG_UNIT:
-        analyticsAggregationType =
-            new AnalyticsAggregationType(AggregationType.SUM, AggregationType.MIN);
-        break;
-      default:
-        analyticsAggregationType = new AnalyticsAggregationType(aggregationType, aggregationType);
-    }
-
-    return analyticsAggregationType;
+    return switch (aggregationType) {
+      case AVERAGE_SUM_ORG_UNIT -> of(AggregationType.SUM, AggregationType.AVERAGE);
+      case LAST -> of(AggregationType.SUM, AggregationType.LAST);
+      case LAST_AVERAGE_ORG_UNIT -> of(AggregationType.AVERAGE, AggregationType.LAST);
+      case LAST_LAST_ORG_UNIT -> of(AggregationType.LAST, AggregationType.LAST);
+      case LAST_IN_PERIOD -> of(AggregationType.SUM, AggregationType.LAST_IN_PERIOD);
+      case LAST_IN_PERIOD_AVERAGE_ORG_UNIT ->
+          of(AggregationType.AVERAGE, AggregationType.LAST_IN_PERIOD);
+      case FIRST -> of(AggregationType.SUM, AggregationType.FIRST);
+      case FIRST_AVERAGE_ORG_UNIT -> of(AggregationType.AVERAGE, AggregationType.FIRST);
+      case FIRST_FIRST_ORG_UNIT -> of(AggregationType.FIRST, AggregationType.FIRST);
+      case MAX_SUM_ORG_UNIT -> of(AggregationType.SUM, AggregationType.MAX);
+      case MIN_SUM_ORG_UNIT -> of(AggregationType.SUM, AggregationType.MIN);
+      default -> of(aggregationType, aggregationType);
+    };
   }
 
   public boolean isAggregationType(AggregationType type) {
@@ -213,71 +167,11 @@ public class AnalyticsAggregationType {
     return this.dataType == DataType.BOOLEAN;
   }
 
-  // -------------------------------------------------------------------------
-  // Get methods
-  // -------------------------------------------------------------------------
-
-  /** Returns the general {@link AggregationType}. */
-  public AggregationType getAggregationType() {
-    return aggregationType;
-  }
-
   /**
    * Returns the period {@link AggregationType}, with fallback to the general {@link
    * AggregationType} if not specified.
    */
   public AggregationType getPeriodAggregationType() {
     return ObjectUtils.firstNonNull(periodAggregationType, aggregationType);
-  }
-
-  /** Returns the {@link DataType}. */
-  public DataType getDataType() {
-    return dataType;
-  }
-
-  /** Indicates whether disaggregation is involved. */
-  public boolean isDisaggregation() {
-    return disaggregation;
-  }
-
-  // -------------------------------------------------------------------------
-  // toString, equals, hash code
-  // -------------------------------------------------------------------------
-
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("aggregation type", aggregationType)
-        .add("period dim aggregation type", periodAggregationType)
-        .add("data type", dataType)
-        .add("disaggregation", disaggregation)
-        .toString();
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    if (this == object) {
-      return true;
-    }
-
-    if (object == null) {
-      return false;
-    }
-
-    if (!getClass().isAssignableFrom(object.getClass())) {
-      return false;
-    }
-
-    AnalyticsAggregationType other = (AnalyticsAggregationType) object;
-
-    return Objects.equals(this.aggregationType, other.aggregationType)
-        && Objects.equals(this.periodAggregationType, other.periodAggregationType)
-        && Objects.equals(this.dataType, other.dataType)
-        && Objects.equals(this.disaggregation, other.disaggregation);
-  }
-
-  @Override
-  public int hashCode() {
-    return 31 * Objects.hash(aggregationType, periodAggregationType, dataType, disaggregation);
   }
 }


### PR DESCRIPTION
The issue(s) indicated by sonar was the equals method. 

I went ahead and used lombok generated methods for `equals`, `hashCode`, `toString` and getter/setters where possible.

In some cases this slightly changed the equals/hashCode as they were wrongly inconsistent using `id` in one but not the other.
I then removed use of `id` in `hashCode` so it is consistent with `equals`. 