### PR TITLE
fix: Value types of metadata [DHIS2-16315]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/MetadataItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/MetadataItem.java
@@ -29,8 +29,6 @@ package org.hisp.dhis.common;
 
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.appendIfMissing;
-import static org.hisp.dhis.common.ValueType.DATE;
-import static org.hisp.dhis.common.ValueType.ORGANISATION_UNIT;
 import static org.hisp.dhis.common.ValueType.TEXT;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -234,7 +232,8 @@ public class MetadataItem implements Serializable {
       }
     } else if (dimensionalItemObject instanceof ExpressionDimensionItem expressionDimensionItem) {
       this.expression = expressionDimensionItem.getExpression();
-    } else if (dimensionalItemObject instanceof ProgramDataElementDimensionItem programDataElementDimensionItem) {
+    } else if (dimensionalItemObject
+        instanceof ProgramDataElementDimensionItem programDataElementDimensionItem) {
       this.valueType = programDataElementDimensionItem.getValueType();
     } else if (dimensionalItemObject instanceof OrganisationUnit) {
       this.valueType = TEXT;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/MetadataItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/MetadataItem.java
@@ -29,6 +29,9 @@ package org.hisp.dhis.common;
 
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.appendIfMissing;
+import static org.hisp.dhis.common.ValueType.DATE;
+import static org.hisp.dhis.common.ValueType.ORGANISATION_UNIT;
+import static org.hisp.dhis.common.ValueType.TEXT;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -51,6 +54,7 @@ import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorType;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionSet;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramDataElementDimensionItem;
@@ -223,12 +227,17 @@ public class MetadataItem implements Serializable {
     } else if (dimensionalItemObject instanceof Period period) {
       this.startDate = period.getStartDate();
       this.endDate = period.getEndDate();
+      this.valueType = TEXT;
     } else if (dimensionalItemObject instanceof Indicator indicator) {
       if (indicator.getIndicatorType() != null) {
         this.indicatorType = HibernateProxyUtils.unproxy(indicator.getIndicatorType());
       }
     } else if (dimensionalItemObject instanceof ExpressionDimensionItem expressionDimensionItem) {
       this.expression = expressionDimensionItem.getExpression();
+    } else if (dimensionalItemObject instanceof ProgramDataElementDimensionItem programDataElementDimensionItem) {
+      this.valueType = programDataElementDimensionItem.getValueType();
+    } else if (dimensionalItemObject instanceof OrganisationUnit) {
+      this.valueType = TEXT;
     }
 
     addIconPathToStyle(getDimensionalItemObjectStyle(dimensionalItemObject));

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/aggregate/AnalyticsQueryDv10AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/aggregate/AnalyticsQueryDv10AutoTest.java
@@ -435,4 +435,51 @@ public class AnalyticsQueryDv10AutoTest extends AnalyticsApiTest {
     validateRow(response, List.of("202208", "6.8"));
     validateRow(response, List.of("202209", "6.2"));
   }
+
+  @Test
+  public void queryWithDifferentValueTypes() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("skipData=false")
+            .add("includeMetadataDetails=true")
+            .add("includeNumDen=true")
+            .add("displayProperty=NAME")
+            .add("skipMeta=false")
+            .add(
+                "dimension=dx:Uvn6LCg7dVU;sB79w2hiLp8;YgsAnqU3I7B;PBXQFnb2AOk;tUdBD1JDxpn;uF1DLnZNlWe;ytHQ7rfvIOe;lxAQ7Zs9VYR.sWoqcoByYmD;lxAQ7Zs9VYR.Ok9OQpitjQr,ou:USER_ORGUNIT;USER_ORGUNIT,pe:LAST_6_MONTHS");
+
+    // When
+    ApiResponse response = actions.get(params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(9)))
+        .body("rows", hasSize(equalTo(0)))
+        .body("height", equalTo(0))
+        .body("width", equalTo(0))
+        .body("headerWidth", equalTo(9));
+
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"items\":{\"ytHQ7rfvIOe\":{\"uid\":\"ytHQ7rfvIOe\",\"name\":\"Malaria test - microscopy 0-4 years female\",\"description\":\"The number of suspected malaria cases tested by Microscopy\",\"dimensionItemType\":\"PROGRAM_INDICATOR\",\"valueType\":\"NUMBER\",\"aggregationType\":\"COUNT\",\"totalAggregationType\":\"SUM\"},\"sB79w2hiLp8\":{\"uid\":\"sB79w2hiLp8\",\"name\":\"ANC 3 Coverage\",\"description\":\"Total 3rd ANC visits (Fixed and outreach) by expected number of pregnant women.\",\"legendSet\":\"fqs276KXCXi\",\"dimensionItemType\":\"INDICATOR\",\"valueType\":\"NUMBER\",\"totalAggregationType\":\"AVERAGE\",\"indicatorType\":{\"name\":\"Per cent\",\"displayName\":\"Per cent\",\"factor\":100,\"number\":false}},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"202309\":{\"uid\":\"202309\",\"code\":\"202309\",\"name\":\"September 2023\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2023-09-01T00:00:00.000\",\"endDate\":\"2023-09-30T00:00:00.000\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"PBXQFnb2AOk\":{\"uid\":\"PBXQFnb2AOk\",\"code\":\"DE_374647\",\"name\":\"Shift to ABC 300mg + ddI 200mg + LPV/r 133.3/33.3mg\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"NUMBER\",\"aggregationType\":\"SUM\",\"totalAggregationType\":\"SUM\"},\"202307\":{\"uid\":\"202307\",\"code\":\"202307\",\"name\":\"July 2023\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2023-07-01T00:00:00.000\",\"endDate\":\"2023-07-31T00:00:00.000\"},\"202308\":{\"uid\":\"202308\",\"code\":\"202308\",\"name\":\"August 2023\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2023-08-01T00:00:00.000\",\"endDate\":\"2023-08-31T00:00:00.000\"},\"uF1DLnZNlWe\":{\"uid\":\"uF1DLnZNlWe\",\"code\":\"DE_1152329\",\"name\":\"Additional notes related to facility\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"TEXT\",\"aggregationType\":\"SUM\",\"totalAggregationType\":\"SUM\"},\"202312\":{\"uid\":\"202312\",\"code\":\"202312\",\"name\":\"December 2023\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2023-12-01T00:00:00.000\",\"endDate\":\"2023-12-31T00:00:00.000\"},\"202310\":{\"uid\":\"202310\",\"code\":\"202310\",\"name\":\"October 2023\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2023-10-01T00:00:00.000\",\"endDate\":\"2023-10-31T00:00:00.000\"},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"202311\":{\"uid\":\"202311\",\"code\":\"202311\",\"name\":\"November 2023\",\"dimensionItemType\":\"PERIOD\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\",\"startDate\":\"2023-11-01T00:00:00.000\",\"endDate\":\"2023-11-30T00:00:00.000\"},\"LAST_6_MONTHS\":{\"name\":\"Last 6 months\"},\"dx\":{\"uid\":\"dx\",\"name\":\"Data\",\"dimensionType\":\"DATA_X\"},\"tUdBD1JDxpn\":{\"uid\":\"tUdBD1JDxpn\",\"name\":\"Average age of deaths\",\"dimensionItemType\":\"PROGRAM_INDICATOR\",\"valueType\":\"NUMBER\",\"aggregationType\":\"AVERAGE\",\"totalAggregationType\":\"SUM\"},\"lxAQ7Zs9VYR.Ok9OQpitjQr\":{\"name\":\"Antenatal care visit WHOMCH Smoking cessation counselling provided \",\"dimensionItemType\":\"PROGRAM_DATA_ELEMENT\",\"valueType\":\"BOOLEAN\",\"aggregationType\":\"SUM\",\"totalAggregationType\":\"SUM\"},\"pe\":{\"uid\":\"pe\",\"name\":\"Period\",\"dimensionType\":\"PERIOD\"},\"Uvn6LCg7dVU\":{\"uid\":\"Uvn6LCg7dVU\",\"code\":\"IN_52486\",\"name\":\"ANC 1 Coverage\",\"description\":\"Total 1st ANC visits (Fixed and outreach) by expected number of pregnant women.\",\"legendSet\":\"fqs276KXCXi\",\"dimensionItemType\":\"INDICATOR\",\"valueType\":\"NUMBER\",\"totalAggregationType\":\"AVERAGE\",\"indicatorType\":{\"name\":\"Per cent\",\"displayName\":\"Per cent\",\"factor\":100,\"number\":false}},\"YgsAnqU3I7B\":{\"uid\":\"YgsAnqU3I7B\",\"code\":\"DE_374657\",\"name\":\"Shift to AZT + 3TC + NVP 300mg + 150mg + 200mg\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"NUMBER\",\"aggregationType\":\"SUM\",\"totalAggregationType\":\"SUM\"},\"HllvX50cXC0\":{\"uid\":\"HllvX50cXC0\",\"code\":\"default\",\"name\":\"default\",\"valueType\":\"NUMBER\",\"totalAggregationType\":\"SUM\"},\"lxAQ7Zs9VYR.sWoqcoByYmD\":{\"name\":\"Antenatal care visit WHOMCH Smoking\",\"dimensionItemType\":\"PROGRAM_DATA_ELEMENT\",\"valueType\":\"BOOLEAN\",\"aggregationType\":\"SUM\",\"totalAggregationType\":\"SUM\"}},\"dimensions\":{\"dx\":[\"Uvn6LCg7dVU\",\"sB79w2hiLp8\",\"YgsAnqU3I7B\",\"PBXQFnb2AOk\",\"tUdBD1JDxpn\",\"uF1DLnZNlWe\",\"ytHQ7rfvIOe\",\"lxAQ7Zs9VYR.sWoqcoByYmD\",\"lxAQ7Zs9VYR.Ok9OQpitjQr\"],\"pe\":[\"202307\",\"202308\",\"202309\",\"202310\",\"202311\",\"202312\"],\"ou\":[\"ImspTQPwCqd\"],\"co\":[\"HllvX50cXC0\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // Assert headers.
+    validateHeader(response, 0, "dx", "Data", "TEXT", "java.lang.String", false, true);
+    validateHeader(response, 1, "ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
+    validateHeader(response, 2, "pe", "Period", "TEXT", "java.lang.String", false, true);
+    validateHeader(response, 3, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 4, "numerator", "Numerator", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 5, "denominator", "Denominator", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(response, 6, "factor", "Factor", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 7, "multiplier", "Multiplier", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(response, 8, "divisor", "Divisor", "NUMBER", "java.lang.Double", false, false);
+  }
 }


### PR DESCRIPTION
The Aggregate Analytics API always returns `NUMBER` for valueType in its metadata for some types of dimensional objects.

This change fixes this issue and returns the associated type.

A e2e test was also added to cover the change.