### PR TITLE
fix: reverts ElementWithOffset.toString [DHIS2-16692]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/ElementWithOffset.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/ElementWithOffset.java
@@ -79,7 +79,7 @@ public class ElementWithOffset<T extends UidObject> {
   @Override
   public String toString() {
     if (isPresent()) {
-      if (hasOffset() && offset != 0) {
+      if (hasOffset()) {
         return element.getUid() + "[" + offset + "]";
       }
       return element.getUid();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/query/StatusConditionTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/query/StatusConditionTest.java
@@ -63,7 +63,7 @@ class StatusConditionTest {
 
     String rendered = statusCondition.render();
 
-    assertEquals("\"programUid\".enrollmentstatus in (:1)", rendered);
+    assertEquals("\"programUid[0]\".enrollmentstatus in (:1)", rendered);
     assertEquals("COMPLETED", queryContext.getParametersPlaceHolder().get("1"));
   }
 
@@ -87,7 +87,7 @@ class StatusConditionTest {
 
     String rendered = statusCondition.render();
 
-    assertEquals("\"programUid\".enrollmentstatus in (:1)", rendered);
+    assertEquals("\"programUid[0]\".enrollmentstatus in (:1)", rendered);
     assertEquals(values, queryContext.getParametersPlaceHolder().get("1"));
   }
 
@@ -108,7 +108,7 @@ class StatusConditionTest {
 
     String rendered = statusCondition.render();
 
-    assertEquals("\"programUid.programStageUid\".status in (:1)", rendered);
+    assertEquals("\"programUid[0].programStageUid[0]\".status in (:1)", rendered);
     assertEquals("COMPLETED", queryContext.getParametersPlaceHolder().get("1"));
   }
 
@@ -129,7 +129,7 @@ class StatusConditionTest {
 
     String rendered = statusCondition.render();
 
-    assertEquals("\"programUid.programStageUid\".status in (:1)", rendered);
+    assertEquals("\"programUid[0].programStageUid[0]\".status in (:1)", rendered);
     assertEquals(values, queryContext.getParametersPlaceHolder().get("1"));
   }
 


### PR DESCRIPTION
Allows the usage of `element[0]`(index ZERO) again.