### PR TITLE
fix: workaround compiler error for type variables

### DIFF
--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/notification/DefaultValidationNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/notification/DefaultValidationNotificationService.java
@@ -103,12 +103,13 @@ public class DefaultValidationNotificationService implements ValidationNotificat
     // order
     progress.startingStage("Filtering results with rule and template ");
     Set<ValidationResult> applicableResults =
-        progress.runStage(
-            Set.of(),
-            () ->
-                validationResults.stream()
-                    .filter(IS_APPLICABLE_RESULT)
-                    .collect(Collectors.toCollection(TreeSet::new)));
+        new TreeSet<>(
+            progress.runStage(
+                Set.of(),
+                () ->
+                    validationResults.stream()
+                        .filter(IS_APPLICABLE_RESULT)
+                        .collect(Collectors.toSet())));
 
     progress.startingStage(
         format("Creating notifications for %d validation results", applicableResults.size()));


### PR DESCRIPTION
**[Backport from master/2.41]** (#16352)

Note: the code as it was is not invalid Java, but a compiler bug leads to not "finding" the right substitute for the type variable of `runStage` method.