### PR TITLE
fix: returns 1 for booleans DV in CPL [DHIS2-16513]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/RenderableDataValue.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/RenderableDataValue.java
@@ -58,10 +58,10 @@ public class RenderableDataValue extends BaseRenderable {
   @Override
   public String render() {
     return "("
-            + Field.of(alias, () -> "eventdatavalues", EMPTY).render()
-            + " -> '"
-            + dataValue
-            + "' ->> 'value')::"
-            + valueTypeMapping.name();
+        + Field.of(alias, () -> "eventdatavalues", EMPTY).render()
+        + " -> '"
+        + dataValue
+        + "' ->> 'value')::"
+        + valueTypeMapping.name();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/RenderableDataValue.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/RenderableDataValue.java
@@ -57,14 +57,11 @@ public class RenderableDataValue extends BaseRenderable {
 
   @Override
   public String render() {
-    String rendered =
-        "("
+    return "("
             + Field.of(alias, () -> "eventdatavalues", EMPTY).render()
             + " -> '"
             + dataValue
             + "' ->> 'value')::"
             + valueTypeMapping.name();
-
-    return rendered;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/context/querybuilder/DataElementQueryBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/context/querybuilder/DataElementQueryBuilder.java
@@ -86,9 +86,10 @@ public class DataElementQueryBuilder implements SqlQueryBuilder {
                 Field.ofUnquoted(
                     StringUtils.EMPTY,
                     RenderableDataValue.of(
-                        doubleQuote(dimensionIdentifier.getPrefix()),
-                        dimensionIdentifier.getDimension().getUid(),
-                        fromValueType(dimensionIdentifier.getDimension().getValueType())),
+                            doubleQuote(dimensionIdentifier.getPrefix()),
+                            dimensionIdentifier.getDimension().getUid(),
+                            fromValueType(dimensionIdentifier.getDimension().getValueType()))
+                        .transformedIfNecessary(),
                     dimensionIdentifier.toString()))
         .forEach(builder::selectField);
     dimensions.stream()

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/query/RenderableDataValueTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/query/RenderableDataValueTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.hisp.dhis.analytics.common.ValueTypeMapping;
 import org.junit.jupiter.api.Test;
 
-public class RenderableDataValueTest {
+class RenderableDataValueTest {
 
   @Test
   void testRender() {


### PR DESCRIPTION
This PR aims to fix 2 issues:
- returning `1` instead of `true` in CPL response, when event data value is of type `BOOLEAN` or `TRUE_ONLY`
- accept `1` as value (or `true`, case insensitive) to add a restriction on event data values of type `BOOLEAN` or `TRUE_ONLY`