### PR TITLE
fix: Value types of metadata [DHIS2-16315]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/MetadataItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/MetadataItem.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.common;
 
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.hisp.dhis.common.ValueType.TEXT;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -48,8 +49,10 @@ import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorType;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionSet;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramDataElementDimensionItem;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 
@@ -209,12 +212,19 @@ public class MetadataItem implements Serializable {
       Period period = (Period) dimensionalItemObject;
       this.startDate = period.getStartDate();
       this.endDate = period.getEndDate();
+      this.valueType = TEXT;
     } else if (dimensionalItemObject instanceof Indicator) {
       Indicator indicator = (Indicator) dimensionalItemObject;
 
       if (indicator.getIndicatorType() != null) {
         this.indicatorType = HibernateProxyUtils.unproxy(indicator.getIndicatorType());
       }
+    } else if (dimensionalItemObject instanceof ProgramDataElementDimensionItem) {
+      ProgramDataElementDimensionItem programDataElementDimensionItem =
+          (ProgramDataElementDimensionItem) dimensionalItemObject;
+      this.valueType = programDataElementDimensionItem.getValueType();
+    } else if (dimensionalItemObject instanceof OrganisationUnit) {
+      this.valueType = TEXT;
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/notification/DefaultValidationNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/notification/DefaultValidationNotificationService.java
@@ -105,12 +105,13 @@ public class DefaultValidationNotificationService implements ValidationNotificat
     // order
     progress.startingStage("Filtering results with rule and template ");
     Set<ValidationResult> applicableResults =
-        progress.runStage(
-            Set.of(),
-            () ->
-                validationResults.stream()
-                    .filter(IS_APPLICABLE_RESULT)
-                    .collect(Collectors.toCollection(TreeSet::new)));
+        new TreeSet<>(
+            progress.runStage(
+                Set.of(),
+                () ->
+                    validationResults.stream()
+                        .filter(IS_APPLICABLE_RESULT)
+                        .collect(Collectors.toSet())));
 
     progress.startingStage(
         format("Creating notifications for %d validation results", applicableResults.size()));


### PR DESCRIPTION
**[Backport from master/2.41]** (#16337)

The Aggregate Analytics API always returns `NUMBER` for valueType in its metadata for some types of dimensional objects.

This change fixes this issue and returns the associated type.

An e2e test was also added to cover the change.