### PR TITLE
fix: Unable to store image in different sizes

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/events/ImageFileSavedEvent.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/events/ImageFileSavedEvent.java
@@ -29,17 +29,11 @@ package org.hisp.dhis.fileresource.events;
 
 import java.io.File;
 import java.util.Map;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.fileresource.ImageFileDimension;
 
 /**
- * @Author Zubair Asghar.
+ * @author Zubair Asghar.
+ * @author Luca Cambi convert to record.
  */
-@Getter
-@RequiredArgsConstructor
-public class ImageFileSavedEvent {
-
-  private final String fileResource;
-  private final Map<ImageFileDimension, File> imageFiles;
-}
+public record ImageFileSavedEvent(
+    String fileResource, Map<ImageFileDimension, File> imageFiles, String userUid) {}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/DefaultFileResourceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/DefaultFileResourceService.java
@@ -51,6 +51,7 @@ import org.hisp.dhis.fileresource.events.FileDeletedEvent;
 import org.hisp.dhis.fileresource.events.FileSavedEvent;
 import org.hisp.dhis.fileresource.events.ImageFileSavedEvent;
 import org.hisp.dhis.period.PeriodService;
+import org.hisp.dhis.user.CurrentUserUtil;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.Hours;
@@ -187,7 +188,9 @@ public class DefaultFileResourceService implements FileResourceService {
       Map<ImageFileDimension, File> imageFiles =
           imageProcessingService.createImages(fileResource, file);
 
-      fileEventPublisher.publishEvent(new ImageFileSavedEvent(fileResource.getUid(), imageFiles));
+      fileEventPublisher.publishEvent(
+          new ImageFileSavedEvent(
+              fileResource.getUid(), imageFiles, CurrentUserUtil.getCurrentUserDetails().getUid()));
       return;
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/FileResourceEventListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/FileResourceEventListener.java
@@ -30,12 +30,15 @@ package org.hisp.dhis.fileresource;
 import java.io.File;
 import java.util.Map;
 import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fileresource.events.BinaryFileSavedEvent;
 import org.hisp.dhis.fileresource.events.FileDeletedEvent;
 import org.hisp.dhis.fileresource.events.FileSavedEvent;
 import org.hisp.dhis.fileresource.events.ImageFileSavedEvent;
+import org.hisp.dhis.user.AuthenticationService;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
 import org.joda.time.format.PeriodFormat;
@@ -48,16 +51,13 @@ import org.springframework.transaction.event.TransactionalEventListener;
  */
 @Slf4j
 @Component("org.hisp.dhis.fileresource.FileResourceEventListener")
+@RequiredArgsConstructor
 public class FileResourceEventListener {
   private final FileResourceService fileResourceService;
 
   private final FileResourceContentStore fileResourceContentStore;
 
-  public FileResourceEventListener(
-      FileResourceService fileResourceService, FileResourceContentStore contentStore) {
-    this.fileResourceService = fileResourceService;
-    this.fileResourceContentStore = contentStore;
-  }
+  private final AuthenticationService authenticationService;
 
   @TransactionalEventListener
   @Async
@@ -78,18 +78,20 @@ public class FileResourceEventListener {
 
   @TransactionalEventListener
   @Async
-  public void saveImageFile(ImageFileSavedEvent imageFileSavedEvent) {
+  public void saveImageFile(ImageFileSavedEvent imageFileSavedEvent) throws NotFoundException {
     DateTime startTime = DateTime.now();
 
-    Map<ImageFileDimension, File> imageFiles = imageFileSavedEvent.getImageFiles();
+    Map<ImageFileDimension, File> imageFiles = imageFileSavedEvent.imageFiles();
 
     FileResource fileResource =
-        fileResourceService.getFileResource(imageFileSavedEvent.getFileResource());
+        fileResourceService.getFileResource(imageFileSavedEvent.fileResource());
 
     String storageId = fileResourceContentStore.saveFileResourceContent(fileResource, imageFiles);
 
     if (storageId != null) {
       fileResource.setHasMultipleStorageFiles(true);
+
+      authenticationService.obtainAuthentication(imageFileSavedEvent.userUid());
 
       fileResourceService.updateFileResource(fileResource);
     }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/fileresource/FileResourceEventListenerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/fileresource/FileResourceEventListenerTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.fileresource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import javax.persistence.EntityManager;
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.fileresource.events.ImageFileSavedEvent;
+import org.hisp.dhis.fileresource.hibernate.HibernateFileResourceStore;
+import org.hisp.dhis.test.integration.IntegrationTestBase;
+import org.hisp.dhis.user.CurrentUserUtil;
+import org.hisp.dhis.user.DefaultAuthenticationService;
+import org.hisp.dhis.user.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author Luca Cambi
+ */
+@ExtendWith(MockitoExtension.class)
+class FileResourceEventListenerTest extends IntegrationTestBase {
+
+  @InjectMocks private FileResourceEventListener fileResourceEventListener;
+
+  @Autowired private UserService _userService;
+
+  @Mock FileResourceContentStore fileResourceContentStore;
+
+  @Mock HibernateFileResourceStore fileResourceStore;
+
+  @BeforeEach
+  public void init() {
+    userService = _userService;
+    createAndAddUser("file_resource_user");
+    fileResourceEventListener =
+        new FileResourceEventListener(
+            new DefaultFileResourceService(
+                fileResourceStore,
+                null,
+                fileResourceContentStore,
+                null,
+                null,
+                mock(EntityManager.class)),
+            fileResourceContentStore,
+            new DefaultAuthenticationService(userService));
+  }
+
+  @Test
+  void shouldUpdateFileImageWithImageFileSaveEvent() throws IOException {
+    FileResource fileResource = new FileResource();
+    fileResource.setUid(CodeGenerator.generateUid());
+
+    File file = File.createTempFile("file-resource", "test");
+
+    Map<ImageFileDimension, File> map = Map.of(ImageFileDimension.LARGE, file);
+
+    when(fileResourceContentStore.saveFileResourceContent(fileResource, map)).thenReturn("uid");
+    when(fileResourceStore.getByUid(fileResource.getUid())).thenReturn(fileResource);
+    doCallRealMethod().when(fileResourceStore).update(any());
+
+    assertDoesNotThrow(
+        () ->
+            fileResourceEventListener.saveImageFile(
+                new ImageFileSavedEvent(
+                    fileResource.getUid(), map, CurrentUserUtil.getCurrentUserDetails().getUid())));
+
+    verify(fileResourceStore).update(any(), any());
+  }
+}


### PR DESCRIPTION
When sending an event to the `FileResourceEventListener`, if we update a file resource, we cannot get the `UserDetails` object.
With this issue, we save the user in the `ImageFileSavedEvent` and retrieve it  from the security context before updating the file resource object.

### Note

This is a quick solution for now. As discussed with @jbee, we should move the the Job scheduler and an issue is created for that :
https://dhis2.atlassian.net/browse/TECH-1687
