### PR TITLE
chore: Prevent XXE XML attack, sonar issue

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/gml/DefaultGmlImportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/gml/DefaultGmlImportService.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.dxf2.gml;
 
 import static javax.xml.XMLConstants.ACCESS_EXTERNAL_DTD;
 import static javax.xml.XMLConstants.ACCESS_EXTERNAL_STYLESHEET;
-import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterators;
@@ -252,7 +251,6 @@ public class DefaultGmlImportService implements GmlImportService {
     // prevent XXE attack
     // sonar vulnerability:
     // https://sonarcloud.io/organizations/dhis2/rules?open=java%3AS2755&rule_key=java%3AS2755
-    tf.setFeature(FEATURE_SECURE_PROCESSING, true);
     tf.setAttribute(ACCESS_EXTERNAL_DTD, "");
     tf.setAttribute(ACCESS_EXTERNAL_STYLESHEET, "");
     tf.newTransformer(xsl).transform(gml, new StreamResult(output));

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/gml/DefaultGmlImportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/gml/DefaultGmlImportService.java
@@ -27,6 +27,10 @@
  */
 package org.hisp.dhis.dxf2.gml;
 
+import static javax.xml.XMLConstants.ACCESS_EXTERNAL_DTD;
+import static javax.xml.XMLConstants.ACCESS_EXTERNAL_STYLESHEET;
+import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
+
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
@@ -244,7 +248,14 @@ public class DefaultGmlImportService implements GmlImportService {
 
     ByteArrayOutputStream output = new ByteArrayOutputStream();
 
-    TransformerFactory.newInstance().newTransformer(xsl).transform(gml, new StreamResult(output));
+    TransformerFactory tf = TransformerFactory.newInstance();
+    // prevent XXE attack
+    // sonar vulnerability:
+    // https://sonarcloud.io/organizations/dhis2/rules?open=java%3AS2755&rule_key=java%3AS2755
+    tf.setFeature(FEATURE_SECURE_PROCESSING, true);
+    tf.setAttribute(ACCESS_EXTERNAL_DTD, "");
+    tf.setAttribute(ACCESS_EXTERNAL_STYLESHEET, "");
+    tf.newTransformer(xsl).transform(gml, new StreamResult(output));
 
     xsl.getInputStream().close();
     gml.getInputStream().close();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/gml/GmlImportServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/gml/GmlImportServiceTest.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.common.coordinate.CoordinateUtils.getCoordinatesAsLi
 import static org.hisp.dhis.system.util.GeoUtils.getCoordinatesFromGeometry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,6 +39,8 @@ import java.util.List;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.metadata.MetadataImportParams;
+import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
+import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.organisationunit.CoordinatesTuple;
 import org.hisp.dhis.organisationunit.FeatureType;
@@ -59,6 +62,7 @@ import org.springframework.core.io.ClassPathResource;
 class GmlImportServiceTest extends TransactionalIntegrationTest {
 
   private InputStream inputStream;
+  private InputStream maliciousInputStream;
 
   private User user;
 
@@ -80,6 +84,8 @@ class GmlImportServiceTest extends TransactionalIntegrationTest {
   @Override
   public void setUpTest() throws IOException {
     inputStream = new ClassPathResource("dxf2/gml/testGmlPayload.gml").getInputStream();
+    maliciousInputStream =
+        new ClassPathResource("dxf2/gml/testMaliciousGmlPayload.gml").getInputStream();
     /*
      * Create orgunits present in testGmlPayload.gml and set ID properties.
      * Name - FeatureType - ID property Bo - Poly - Name Bonthe - Multi -
@@ -142,6 +148,30 @@ class GmlImportServiceTest extends TransactionalIntegrationTest {
     assertEquals(1, getCoordinates(ojdOrgUnit).get(0).getNumberOfCoordinates());
     assertEquals(1, getCoordinates(bliOrgUnit).get(0).getNumberOfCoordinates());
     assertEquals(76, getCoordinates(forskOrgUnit).get(0).getNumberOfCoordinates());
+  }
+
+  @Test
+  void testMaliciousImportGml() {
+    MetadataImportParams importParams = new MetadataImportParams();
+    importParams.setUser(UID.of(user));
+
+    ImportReport importReport =
+                gmlImportService.importGml(
+                    maliciousInputStream, importParams, NoopJobProgress.INSTANCE);
+
+    ErrorReport errorReport = importReport.getFirstObjectReport().getErrorReports().get(0);
+    assertTrue(
+        errorReport
+            .getMessage()
+            .contains(
+                "GML import failed: External Entity: Failed to read external document &#39;passwd&#39"));
+    assertTrue(
+        errorReport
+            .getMessage()
+            .contains(
+                "access is not allowed due to restriction set by the accessExternalDTD property"));
+    assertEquals("ERROR", importReport.getStatus().name());
+    assertTrue(importReport.hasErrorReports());
   }
 
   private List<CoordinatesTuple> getCoordinates(OrganisationUnit orgUnit) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/gml/GmlImportServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/gml/GmlImportServiceTest.java
@@ -156,8 +156,7 @@ class GmlImportServiceTest extends TransactionalIntegrationTest {
     importParams.setUser(UID.of(user));
 
     ImportReport importReport =
-                gmlImportService.importGml(
-                    maliciousInputStream, importParams, NoopJobProgress.INSTANCE);
+        gmlImportService.importGml(maliciousInputStream, importParams, NoopJobProgress.INSTANCE);
 
     ErrorReport errorReport = importReport.getFirstObjectReport().getErrorReports().get(0);
     assertTrue(

--- a/dhis-2/dhis-test-integration/src/test/resources/dxf2/gml/testMaliciousGmlPayload.gml
+++ b/dhis-2/dhis-test-integration/src/test/resources/dxf2/gml/testMaliciousGmlPayload.gml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--supply malicious content - START-->
+<!DOCTYPE foo [ <!ENTITY xxe SYSTEM "file:///etc/passwd"> ]>
+<!--supply malicious content - END-->
+<ogr:FeatureCollection
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://ogr.maptools.org/ admin2.xsd"
+  xmlns:ogr="http://ogr.maptools.org/"
+  xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord>
+        <gml:X>&xxe;</gml:X>
+        <gml:Y>6.928689</gml:Y>
+      </gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+</ogr:FeatureCollection>

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetController.java
@@ -164,9 +164,9 @@ public class DataSetController extends AbstractCrudController<DataSet> {
         new ByteArrayInputStream(xmlMapper.writeValueAsString(metadata).getBytes("UTF-8"));
 
     TransformerFactory tf = TransformerFactory.newInstance();
-    //    // prevent XXE attack
-    //    // sonar vulnerability:
-    //    // https://sonarcloud.io/organizations/dhis2/rules?open=java%3AS2755&rule_key=java%3AS2755
+    // prevent XXE attack
+    // sonar vulnerability:
+    // https://sonarcloud.io/organizations/dhis2/rules?open=java%3AS2755&rule_key=java%3AS2755
     tf.setAttribute(ACCESS_EXTERNAL_DTD, "");
     tf.setAttribute(ACCESS_EXTERNAL_STYLESHEET, "");
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetController.java
@@ -28,6 +28,9 @@
 package org.hisp.dhis.webapi.controller;
 
 import static java.util.Collections.singletonMap;
+import static javax.xml.XMLConstants.ACCESS_EXTERNAL_DTD;
+import static javax.xml.XMLConstants.ACCESS_EXTERNAL_STYLESHEET;
+import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.badRequest;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
@@ -162,6 +165,13 @@ public class DataSetController extends AbstractCrudController<DataSet> {
         new ByteArrayInputStream(xmlMapper.writeValueAsString(metadata).getBytes("UTF-8"));
 
     TransformerFactory tf = TransformerFactory.newInstance();
+    //    // prevent XXE attack
+    //    // sonar vulnerability:
+    //    // https://sonarcloud.io/organizations/dhis2/rules?open=java%3AS2755&rule_key=java%3AS2755
+    tf.setFeature(FEATURE_SECURE_PROCESSING, true);
+    tf.setAttribute(ACCESS_EXTERNAL_DTD, "");
+    tf.setAttribute(ACCESS_EXTERNAL_STYLESHEET, "");
+
     tf.setURIResolver(new ClassPathUriResolver());
 
     Transformer transformer =

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetController.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.webapi.controller;
 import static java.util.Collections.singletonMap;
 import static javax.xml.XMLConstants.ACCESS_EXTERNAL_DTD;
 import static javax.xml.XMLConstants.ACCESS_EXTERNAL_STYLESHEET;
-import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.badRequest;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
@@ -168,7 +167,6 @@ public class DataSetController extends AbstractCrudController<DataSet> {
     //    // prevent XXE attack
     //    // sonar vulnerability:
     //    // https://sonarcloud.io/organizations/dhis2/rules?open=java%3AS2755&rule_key=java%3AS2755
-    tf.setFeature(FEATURE_SECURE_PROCESSING, true);
     tf.setAttribute(ACCESS_EXTERNAL_DTD, "");
     tf.setAttribute(ACCESS_EXTERNAL_STYLESHEET, "");
 


### PR DESCRIPTION
# Summary
## Issue
Sonar identified 2 possible areas where [XXE XML attacks](https://sonarcloud.io/organizations/dhis2/rules?open=java%3AS2755&rule_key=java%3AS2755) could be executed.

## Fix
Ensure that we don't allow processing of external DTD or stylesheet by disabling those features.

# Testing
## Automated
Int test added confirming malicious xml is not processed

# Info
There are only 2 places where this was identified in the PRD code. We are also moving away from supporting XML. If there were any more instances of this or if we intended on supporting XML then we could just create a wrapper around the code in question (and implement these safe settings) to reduce the possibility of it popping up somewhere else in code in future.