### PR TITLE
fix: Relationships are not filtered by deleted in tracker/relationships endpoint [2.40]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipService.java
@@ -98,34 +98,37 @@ public interface RelationshipService {
   List<Relationship> getRelationships(@Nonnull List<String> uids);
 
   default List<Relationship> getRelationshipsByTrackedEntityInstance(
-      TrackedEntityInstance tei, boolean skipAccessValidation) {
-    return getRelationshipsByTrackedEntityInstance(tei, null, skipAccessValidation);
+      TrackedEntityInstance tei, boolean skipAccessValidation, boolean includeDeleted) {
+    return getRelationshipsByTrackedEntityInstance(tei, null, skipAccessValidation, includeDeleted);
   }
 
   List<Relationship> getRelationshipsByTrackedEntityInstance(
       TrackedEntityInstance tei,
       PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean skipAccessValidation);
+      boolean skipAccessValidation,
+      boolean includeDeleted);
 
   default List<Relationship> getRelationshipsByProgramInstance(
-      ProgramInstance pi, boolean skipAccessValidation) {
-    return getRelationshipsByProgramInstance(pi, null, skipAccessValidation);
+      ProgramInstance pi, boolean skipAccessValidation, boolean includeDeleted) {
+    return getRelationshipsByProgramInstance(pi, null, skipAccessValidation, includeDeleted);
   }
 
   List<Relationship> getRelationshipsByProgramInstance(
       ProgramInstance pi,
       PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean skipAccessValidation);
+      boolean skipAccessValidation,
+      boolean includeDeleted);
 
   default List<Relationship> getRelationshipsByProgramStageInstance(
-      ProgramStageInstance psi, boolean skipAccessValidation) {
-    return getRelationshipsByProgramStageInstance(psi, null, skipAccessValidation);
+      ProgramStageInstance psi, boolean skipAccessValidation, boolean includeDeleted) {
+    return getRelationshipsByProgramStageInstance(psi, null, skipAccessValidation, includeDeleted);
   }
 
   List<Relationship> getRelationshipsByProgramStageInstance(
       ProgramStageInstance psi,
       PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean skipAccessValidation);
+      boolean skipAccessValidation,
+      boolean includeDeleted);
 
   List<Relationship> getRelationshipsByRelationshipType(RelationshipType relationshipType);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipStore.java
@@ -40,26 +40,20 @@ import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteria
 public interface RelationshipStore extends IdentifiableObjectStore<Relationship> {
   String ID = RelationshipStore.class.getName();
 
-  default List<Relationship> getByTrackedEntityInstance(TrackedEntityInstance tei) {
-    return getByTrackedEntityInstance(tei, null);
-  }
-
   List<Relationship> getByTrackedEntityInstance(
-      TrackedEntityInstance tei, PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter);
-
-  default List<Relationship> getByProgramInstance(ProgramInstance pi) {
-    return getByProgramInstance(pi, null);
-  }
+      TrackedEntityInstance tei,
+      PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
+      boolean includeDeleted);
 
   List<Relationship> getByProgramInstance(
-      ProgramInstance pi, PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter);
-
-  default List<Relationship> getByProgramStageInstance(ProgramStageInstance psi) {
-    return getByProgramStageInstance(psi, null);
-  }
+      ProgramInstance pi,
+      PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
+      boolean includeDeleted);
 
   List<Relationship> getByProgramStageInstance(
-      ProgramStageInstance psi, PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter);
+      ProgramStageInstance psi,
+      PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
+      boolean includeDeleted);
 
   List<Relationship> getByRelationshipType(RelationshipType relationshipType);
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/DefaultRelationshipService.java
@@ -115,8 +115,10 @@ public class DefaultRelationshipService implements RelationshipService {
   public List<Relationship> getRelationshipsByTrackedEntityInstance(
       TrackedEntityInstance tei,
       PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean skipAccessValidation) {
-    return relationshipStore.getByTrackedEntityInstance(tei, pagingAndSortingCriteriaAdapter);
+      boolean skipAccessValidation,
+      boolean includeDeleted) {
+    return relationshipStore.getByTrackedEntityInstance(
+        tei, pagingAndSortingCriteriaAdapter, includeDeleted);
   }
 
   @Override
@@ -124,8 +126,10 @@ public class DefaultRelationshipService implements RelationshipService {
   public List<Relationship> getRelationshipsByProgramInstance(
       ProgramInstance pi,
       PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean skipAccessValidation) {
-    return relationshipStore.getByProgramInstance(pi, pagingAndSortingCriteriaAdapter);
+      boolean skipAccessValidation,
+      boolean includeDeleted) {
+    return relationshipStore.getByProgramInstance(
+        pi, pagingAndSortingCriteriaAdapter, includeDeleted);
   }
 
   @Override
@@ -133,8 +137,10 @@ public class DefaultRelationshipService implements RelationshipService {
   public List<Relationship> getRelationshipsByProgramStageInstance(
       ProgramStageInstance psi,
       PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean skipAccessValidation) {
-    return relationshipStore.getByProgramStageInstance(psi, pagingAndSortingCriteriaAdapter);
+      boolean skipAccessValidation,
+      boolean includeDeleted) {
+    return relationshipStore.getByProgramStageInstance(
+        psi, pagingAndSortingCriteriaAdapter, includeDeleted);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/RelationshipDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/RelationshipDeletionHandler.java
@@ -58,7 +58,7 @@ public class RelationshipDeletionHandler extends DeletionHandler {
 
   private void deleteTrackedEntityInstance(TrackedEntityInstance entityInstance) {
     Collection<Relationship> relationships =
-        relationshipService.getRelationshipsByTrackedEntityInstance(entityInstance, false);
+        relationshipService.getRelationshipsByTrackedEntityInstance(entityInstance, false, false);
 
     if (relationships != null) {
       for (Relationship relationship : relationships) {
@@ -69,7 +69,8 @@ public class RelationshipDeletionHandler extends DeletionHandler {
 
   private void deleteProgramStageInstance(ProgramStageInstance programStageInstance) {
     Collection<Relationship> relationships =
-        relationshipService.getRelationshipsByProgramStageInstance(programStageInstance, false);
+        relationshipService.getRelationshipsByProgramStageInstance(
+            programStageInstance, false, false);
 
     if (relationships != null) {
       for (Relationship relationship : relationships) {
@@ -80,7 +81,7 @@ public class RelationshipDeletionHandler extends DeletionHandler {
 
   private void deleteProgramInstance(ProgramInstance programInstance) {
     Collection<Relationship> relationships =
-        relationshipService.getRelationshipsByProgramInstance(programInstance, false);
+        relationshipService.getRelationshipsByProgramInstance(programInstance, false, false);
 
     if (relationships != null) {
       for (Relationship relationship : relationships) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/hibernate/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/hibernate/HibernateRelationshipStore.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.relationship.hibernate;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -90,33 +91,41 @@ public class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<R
 
   @Override
   public List<Relationship> getByTrackedEntityInstance(
-      TrackedEntityInstance tei, PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter) {
+      TrackedEntityInstance tei,
+      PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
+      boolean includeDeleted) {
     TypedQuery<Relationship> relationshipTypedQuery =
-        getRelationshipTypedQuery(tei, pagingAndSortingCriteriaAdapter);
+        getRelationshipTypedQuery(tei, pagingAndSortingCriteriaAdapter, includeDeleted);
 
     return getList(relationshipTypedQuery);
   }
 
   @Override
   public List<Relationship> getByProgramInstance(
-      ProgramInstance pi, PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter) {
+      ProgramInstance pi,
+      PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
+      boolean includeDeleted) {
     TypedQuery<Relationship> relationshipTypedQuery =
-        getRelationshipTypedQuery(pi, pagingAndSortingCriteriaAdapter);
+        getRelationshipTypedQuery(pi, pagingAndSortingCriteriaAdapter, includeDeleted);
 
     return getList(relationshipTypedQuery);
   }
 
   @Override
   public List<Relationship> getByProgramStageInstance(
-      ProgramStageInstance psi, PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter) {
+      ProgramStageInstance psi,
+      PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
+      boolean includeDeleted) {
     TypedQuery<Relationship> relationshipTypedQuery =
-        getRelationshipTypedQuery(psi, pagingAndSortingCriteriaAdapter);
+        getRelationshipTypedQuery(psi, pagingAndSortingCriteriaAdapter, includeDeleted);
 
     return getList(relationshipTypedQuery);
   }
 
   private <T extends IdentifiableObject> TypedQuery<Relationship> getRelationshipTypedQuery(
-      T entity, PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter) {
+      T entity,
+      PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
+      boolean includeDeleted) {
     CriteriaBuilder builder = getCriteriaBuilder();
 
     CriteriaQuery<Relationship> relationshipItemCriteriaQuery =
@@ -124,7 +133,7 @@ public class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<R
     Root<Relationship> root = relationshipItemCriteriaQuery.from(Relationship.class);
 
     setRelationshipItemCriteriaQueryExistsCondition(
-        entity, builder, relationshipItemCriteriaQuery, root);
+        entity, builder, relationshipItemCriteriaQuery, root, includeDeleted);
 
     return getRelationshipTypedQuery(
         pagingAndSortingCriteriaAdapter, builder, relationshipItemCriteriaQuery, root);
@@ -134,7 +143,8 @@ public class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<R
       T entity,
       CriteriaBuilder builder,
       CriteriaQuery<Relationship> relationshipItemCriteriaQuery,
-      Root<Relationship> root) {
+      Root<Relationship> root,
+      boolean includeDeleted) {
     Subquery<RelationshipItem> fromSubQuery =
         relationshipItemCriteriaQuery.subquery(RelationshipItem.class);
     Root<RelationshipItem> fromRoot = fromSubQuery.from(RelationshipItem.class);
@@ -157,8 +167,14 @@ public class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<R
 
     toSubQuery.select(toRoot.get("id"));
 
-    relationshipItemCriteriaQuery.where(
-        builder.or(builder.exists(fromSubQuery), builder.exists(toSubQuery)));
+    List<Predicate> predicates = new ArrayList<>();
+    predicates.add(builder.or(builder.exists(fromSubQuery), builder.exists(toSubQuery)));
+
+    if (!includeDeleted) {
+      predicates.add(builder.equal(root.get("deleted"), false));
+    }
+
+    relationshipItemCriteriaQuery.where(predicates.toArray(Predicate[]::new));
 
     relationshipItemCriteriaQuery.select(root);
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/relationship/RelationshipDeletionHandlerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/relationship/RelationshipDeletionHandlerTest.java
@@ -87,7 +87,8 @@ class RelationshipDeletionHandlerTest {
 
   @Test
   void deleteTrackedEntityInstance() {
-    when(relationshipService.getRelationshipsByTrackedEntityInstance(any(), anyBoolean()))
+    when(relationshipService.getRelationshipsByTrackedEntityInstance(
+            any(), anyBoolean(), anyBoolean()))
         .thenReturn(singletonList(new Relationship()));
 
     ObjectDeletionRequestedEvent event =
@@ -95,7 +96,7 @@ class RelationshipDeletionHandlerTest {
     deletionManager.onDeletion(event);
 
     verify(relationshipService, atLeastOnce())
-        .getRelationshipsByTrackedEntityInstance(any(), anyBoolean());
+        .getRelationshipsByTrackedEntityInstance(any(), anyBoolean(), anyBoolean());
     verify(relationshipService, atLeastOnce()).deleteRelationship(any());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/relationship/AbstractRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/relationship/AbstractRelationshipService.java
@@ -118,12 +118,13 @@ public abstract class AbstractRelationshipService implements RelationshipService
   public List<Relationship> getRelationshipsByTrackedEntityInstance(
       TrackedEntityInstance tei,
       PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean skipAccessValidation) {
+      boolean skipAccessValidation,
+      boolean includeDeleted) {
     User user = currentUserService.getCurrentUser();
 
     return relationshipService
         .getRelationshipsByTrackedEntityInstance(
-            tei, pagingAndSortingCriteriaAdapter, skipAccessValidation)
+            tei, pagingAndSortingCriteriaAdapter, skipAccessValidation, includeDeleted)
         .stream()
         .filter((r) -> !skipAccessValidation && trackerAccessManager.canRead(user, r).isEmpty())
         .map(r -> getRelationship(r, user))
@@ -137,12 +138,13 @@ public abstract class AbstractRelationshipService implements RelationshipService
   public List<Relationship> getRelationshipsByProgramInstance(
       ProgramInstance pi,
       PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean skipAccessValidation) {
+      boolean skipAccessValidation,
+      boolean includeDeleted) {
     User user = currentUserService.getCurrentUser();
 
     return relationshipService
         .getRelationshipsByProgramInstance(
-            pi, pagingAndSortingCriteriaAdapter, skipAccessValidation)
+            pi, pagingAndSortingCriteriaAdapter, skipAccessValidation, includeDeleted)
         .stream()
         .filter((r) -> !skipAccessValidation && trackerAccessManager.canRead(user, r).isEmpty())
         .map(r -> getRelationship(r, user))
@@ -156,12 +158,13 @@ public abstract class AbstractRelationshipService implements RelationshipService
   public List<Relationship> getRelationshipsByProgramStageInstance(
       ProgramStageInstance psi,
       PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean skipAccessValidation) {
+      boolean skipAccessValidation,
+      boolean includeDeleted) {
     User user = currentUserService.getCurrentUser();
 
     return relationshipService
         .getRelationshipsByProgramStageInstance(
-            psi, pagingAndSortingCriteriaAdapter, skipAccessValidation)
+            psi, pagingAndSortingCriteriaAdapter, skipAccessValidation, includeDeleted)
         .stream()
         .filter((r) -> !skipAccessValidation && trackerAccessManager.canRead(user, r).isEmpty())
         .map(r -> getRelationship(r, user))

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/relationship/RelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/relationship/RelationshipService.java
@@ -56,15 +56,20 @@ public interface RelationshipService {
   List<Relationship> getRelationshipsByTrackedEntityInstance(
       TrackedEntityInstance tei,
       PagingAndSortingCriteriaAdapter criteria,
-      boolean skipAccessValidation);
+      boolean skipAccessValidation,
+      boolean includeDeleted);
 
   List<Relationship> getRelationshipsByProgramInstance(
-      ProgramInstance pi, PagingAndSortingCriteriaAdapter criteria, boolean skipAccessValidation);
+      ProgramInstance pi,
+      PagingAndSortingCriteriaAdapter criteria,
+      boolean skipAccessValidation,
+      boolean includeDeleted);
 
   List<Relationship> getRelationshipsByProgramStageInstance(
       ProgramStageInstance psi,
       PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean skipAccessValidation);
+      boolean skipAccessValidation,
+      boolean includeDeleted);
 
   // -------------------------------------------------------------------------
   // CREATE

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/relationship/hibernate/RelationshipStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/relationship/hibernate/RelationshipStoreTest.java
@@ -101,7 +101,8 @@ class RelationshipStoreTest extends TransactionalIntegrationTest {
     Relationship teiRelationship = addTeiToTeiRelationship();
 
     List<Relationship> relationshipList =
-        relationshipService.getRelationshipsByTrackedEntityInstance(trackedEntityInstanceA, true);
+        relationshipService.getRelationshipsByTrackedEntityInstance(
+            trackedEntityInstanceA, true, false);
 
     assertEquals(1, relationshipList.size());
     assertTrue(relationshipList.contains(teiRelationship));
@@ -125,7 +126,8 @@ class RelationshipStoreTest extends TransactionalIntegrationTest {
         addTeiToProgramStageInstanceRelationship(trackedEntityInstanceA, programStageInstance);
 
     List<Relationship> relationshipList =
-        relationshipService.getRelationshipsByProgramStageInstance(programStageInstance, true);
+        relationshipService.getRelationshipsByProgramStageInstance(
+            programStageInstance, true, false);
 
     assertEquals(1, relationshipList.size());
     assertTrue(relationshipList.contains(relationshipA));
@@ -146,7 +148,7 @@ class RelationshipStoreTest extends TransactionalIntegrationTest {
         addTeiToProgramInstanceRelationship(trackedEntityInstanceA, programInstance);
 
     List<Relationship> relationshipList =
-        relationshipService.getRelationshipsByProgramInstance(programInstance, true);
+        relationshipService.getRelationshipsByProgramInstance(programInstance, true, false);
 
     assertEquals(1, relationshipList.size());
     assertTrue(relationshipList.contains(relationshipA));

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/RelationshipControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/RelationshipControllerTest.java
@@ -33,8 +33,26 @@ import static org.hisp.dhis.web.WebClient.ContentType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Date;
+import java.util.Set;
+import org.hisp.dhis.jsontree.JsonArray;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramStatus;
+import org.hisp.dhis.relationship.Relationship;
+import org.hisp.dhis.relationship.RelationshipEntity;
+import org.hisp.dhis.relationship.RelationshipItem;
+import org.hisp.dhis.relationship.RelationshipType;
+import org.hisp.dhis.security.acl.AccessStringHelper;
+import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.user.User;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
@@ -45,6 +63,30 @@ import org.springframework.http.MediaType;
  * @author Jan Bernitt
  */
 class RelationshipControllerTest extends DhisControllerConvenienceTest {
+  private OrganisationUnit orgUnit;
+  private TrackedEntityType trackedEntityType;
+  private User owner;
+
+  private Program program;
+
+  private ProgramStage programStage;
+
+  @BeforeEach
+  void setUp() {
+    owner = makeUser("o");
+    orgUnit = createOrganisationUnit('A');
+    manager.save(orgUnit, false);
+
+    trackedEntityType = createTrackedEntityType('B');
+    manager.save(trackedEntityType, false);
+
+    program = createProgram('A');
+    program.addOrganisationUnit(orgUnit);
+    manager.save(program, false);
+
+    programStage = createProgramStage('A', program);
+    manager.save(programStage, false);
+  }
 
   @Test
   void testPostRelationshipJson() {
@@ -97,5 +139,233 @@ class RelationshipControllerTest extends DhisControllerConvenienceTest {
         "ERROR",
         "No relationship with id 'xyz' was found.",
         DELETE("/relationships/xyz").content(HttpStatus.NOT_FOUND));
+  }
+
+  @Test
+  void shouldNotGetRelationshipsByTrackedEntityWhenRelationshipIsDeleted() {
+    TrackedEntity to = trackedEntity();
+    Enrollment from = enrollment(to);
+    Relationship r = relationship(from, to);
+
+    r.setDeleted(true);
+    manager.update(r);
+
+    assertNoRelationships(
+        GET("/relationships?tei={te}", to.getUid()).content(HttpStatus.OK).as(JsonArray.class));
+  }
+
+  @Test
+  void shouldNotGetRelationshipsByEnrollmentWhenRelationshipIsDeleted() {
+    TrackedEntity to = trackedEntity();
+    Enrollment from = enrollment(to);
+    Relationship r = relationship(from, to);
+
+    r.setDeleted(true);
+    manager.update(r);
+
+    assertNoRelationships(
+        GET("/relationships?enrollment={en}", from.getUid())
+            .content(HttpStatus.OK)
+            .as(JsonArray.class));
+  }
+
+  @Test
+  void shouldNotGetRelationshipsByEventWhenRelationshipIsDeleted() {
+    TrackedEntity to = trackedEntity();
+    Event from = event(enrollment(to));
+    Relationship r = relationship(from, to);
+
+    r.setDeleted(true);
+    manager.update(r);
+
+    assertNoRelationships(
+        GET("/relationships?event={ev}", from.getUid()).content(HttpStatus.OK).as(JsonArray.class));
+  }
+
+  @Test
+  void shouldGetRelationshipsByTrackedEntityWhenRelationshipIsDeleted() {
+    TrackedEntity to = trackedEntity();
+    Enrollment from = enrollment(to);
+    Relationship r = relationship(from, to);
+
+    r.setDeleted(true);
+    manager.update(r);
+
+    JsonArray relationships =
+        GET("/relationships?tei={te}&includeDeleted=true", to.getUid())
+            .content(HttpStatus.OK)
+            .as(JsonArray.class);
+
+    assertRelationship(r, relationships);
+  }
+
+  @Test
+  void shouldGetRelationshipsByEventWhenRelationshipIsDeleted() {
+    TrackedEntity to = trackedEntity();
+    Event from = event(enrollment(to));
+    Relationship r = relationship(from, to);
+
+    r.setDeleted(true);
+    manager.update(r);
+
+    JsonArray relationships =
+        GET("/relationships?event={ev}&includeDeleted=true", from.getUid())
+            .content(HttpStatus.OK)
+            .as(JsonArray.class);
+
+    assertRelationship(r, relationships);
+  }
+
+  @Test
+  void shouldGetRelationshipsByEnrollmentWhenRelationshipIsDeleted() {
+    TrackedEntity to = trackedEntity();
+    Enrollment from = enrollment(to);
+    Relationship r = relationship(from, to);
+
+    r.setDeleted(true);
+    manager.update(r);
+
+    JsonArray relationships =
+        GET("/relationships?enrollment={en}&includeDeleted=true", from.getUid())
+            .content(HttpStatus.OK)
+            .as(JsonArray.class);
+
+    assertRelationship(r, relationships);
+  }
+
+  private TrackedEntity trackedEntity() {
+    TrackedEntity te = trackedEntity(orgUnit);
+    manager.save(te, false);
+    return te;
+  }
+
+  private TrackedEntity trackedEntity(OrganisationUnit orgUnit) {
+    TrackedEntity te = trackedEntity(orgUnit, trackedEntityType);
+    manager.save(te, false);
+    return te;
+  }
+
+  private TrackedEntity trackedEntity(
+      OrganisationUnit orgUnit, TrackedEntityType trackedEntityType) {
+    TrackedEntity te = createTrackedEntity(orgUnit);
+    te.setTrackedEntityType(trackedEntityType);
+    te.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
+    te.getSharing().setOwner(owner);
+    return te;
+  }
+
+  private Enrollment enrollment(TrackedEntity te) {
+    Enrollment enrollment = new Enrollment(program, te, orgUnit);
+    enrollment.setAutoFields();
+    enrollment.setEnrollmentDate(new Date());
+    enrollment.setOccurredDate(new Date());
+    enrollment.setStatus(ProgramStatus.COMPLETED);
+    manager.save(enrollment, false);
+    te.setEnrollments(Set.of(enrollment));
+    manager.save(te, false);
+    return enrollment;
+  }
+
+  private Event event(Enrollment enrollment) {
+    Event event = new Event(enrollment, programStage, orgUnit);
+    event.setAutoFields();
+    manager.save(event, false);
+    enrollment.setEvents(Set.of(event));
+    manager.save(enrollment, false);
+    return event;
+  }
+
+  private RelationshipType relationshipTypeAccessible(
+      RelationshipEntity from, RelationshipEntity to) {
+    RelationshipType type = relationshipType(from, to);
+    manager.save(type, false);
+    return type;
+  }
+
+  private RelationshipType relationshipType(RelationshipEntity from, RelationshipEntity to) {
+    RelationshipType type = createRelationshipType('A');
+    type.getFromConstraint().setRelationshipEntity(from);
+    type.getToConstraint().setRelationshipEntity(to);
+    type.getSharing().setOwner(owner);
+    type.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
+    manager.save(type, false);
+    return type;
+  }
+
+  private Relationship relationship(Event from, TrackedEntity to) {
+    Relationship r = new Relationship();
+
+    RelationshipItem fromItem = new RelationshipItem();
+    fromItem.setEvent(from);
+    from.getRelationshipItems().add(fromItem);
+    r.setFrom(fromItem);
+    fromItem.setRelationship(r);
+
+    RelationshipItem toItem = new RelationshipItem();
+    toItem.setTrackedEntity(to);
+    to.getRelationshipItems().add(toItem);
+    r.setTo(toItem);
+    toItem.setRelationship(r);
+
+    RelationshipType type =
+        relationshipTypeAccessible(
+            RelationshipEntity.PROGRAM_STAGE_INSTANCE, RelationshipEntity.TRACKED_ENTITY_INSTANCE);
+    r.setRelationshipType(type);
+    r.setKey(type.getUid());
+    r.setInvertedKey(type.getUid());
+
+    r.setAutoFields();
+    r.getSharing().setOwner(owner);
+    r.setCreatedAtClient(new Date());
+    manager.save(r, false);
+    return r;
+  }
+
+  private Relationship relationship(Enrollment from, TrackedEntity to) {
+    manager.save(from, false);
+    manager.save(to, false);
+
+    Relationship r = new Relationship();
+
+    RelationshipItem fromItem = new RelationshipItem();
+    fromItem.setEnrollment(from);
+    from.getRelationshipItems().add(fromItem);
+    r.setFrom(fromItem);
+    fromItem.setRelationship(r);
+
+    RelationshipItem toItem = new RelationshipItem();
+    toItem.setTrackedEntity(to);
+    to.getRelationshipItems().add(toItem);
+    r.setTo(toItem);
+    toItem.setRelationship(r);
+
+    RelationshipType type =
+        relationshipTypeAccessible(
+            RelationshipEntity.PROGRAM_INSTANCE, RelationshipEntity.TRACKED_ENTITY_INSTANCE);
+    r.setRelationshipType(type);
+    r.setKey(type.getUid());
+    r.setInvertedKey(type.getUid());
+
+    r.setAutoFields();
+    r.getSharing().setOwner(owner);
+    manager.save(r, false);
+    return r;
+  }
+
+  public void assertNoRelationships(JsonArray json) {
+    assertEquals(0, json.size(), "Response should have no relationship");
+  }
+
+  public static void assertRelationship(Relationship expected, JsonArray json) {
+    assertEquals(
+        1,
+        json.size(),
+        String.format("Relationship response should contain relationship %s", expected.getUid()));
+    assertEquals(
+        expected.getUid(),
+        json.get(0).asObject().getString("relationship").string(),
+        String.format(
+            "Relationship response should contain relationship %s but got %s",
+            expected.getUid(), json.get(0).asObject().getString("relationship").string()));
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/RelationshipControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/RelationshipControllerTest.java
@@ -37,17 +37,17 @@ import java.util.Date;
 import java.util.Set;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.relationship.RelationshipEntity;
 import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.security.acl.AccessStringHelper;
-import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.web.HttpStatus;
@@ -143,8 +143,8 @@ class RelationshipControllerTest extends DhisControllerConvenienceTest {
 
   @Test
   void shouldNotGetRelationshipsByTrackedEntityWhenRelationshipIsDeleted() {
-    TrackedEntity to = trackedEntity();
-    Enrollment from = enrollment(to);
+    TrackedEntityInstance to = trackedEntity();
+    ProgramInstance from = enrollment(to);
     Relationship r = relationship(from, to);
 
     r.setDeleted(true);
@@ -156,8 +156,8 @@ class RelationshipControllerTest extends DhisControllerConvenienceTest {
 
   @Test
   void shouldNotGetRelationshipsByEnrollmentWhenRelationshipIsDeleted() {
-    TrackedEntity to = trackedEntity();
-    Enrollment from = enrollment(to);
+    TrackedEntityInstance to = trackedEntity();
+    ProgramInstance from = enrollment(to);
     Relationship r = relationship(from, to);
 
     r.setDeleted(true);
@@ -171,8 +171,8 @@ class RelationshipControllerTest extends DhisControllerConvenienceTest {
 
   @Test
   void shouldNotGetRelationshipsByEventWhenRelationshipIsDeleted() {
-    TrackedEntity to = trackedEntity();
-    Event from = event(enrollment(to));
+    TrackedEntityInstance to = trackedEntity();
+    ProgramStageInstance from = event(enrollment(to));
     Relationship r = relationship(from, to);
 
     r.setDeleted(true);
@@ -184,8 +184,8 @@ class RelationshipControllerTest extends DhisControllerConvenienceTest {
 
   @Test
   void shouldGetRelationshipsByTrackedEntityWhenRelationshipIsDeleted() {
-    TrackedEntity to = trackedEntity();
-    Enrollment from = enrollment(to);
+    TrackedEntityInstance to = trackedEntity();
+    ProgramInstance from = enrollment(to);
     Relationship r = relationship(from, to);
 
     r.setDeleted(true);
@@ -201,8 +201,8 @@ class RelationshipControllerTest extends DhisControllerConvenienceTest {
 
   @Test
   void shouldGetRelationshipsByEventWhenRelationshipIsDeleted() {
-    TrackedEntity to = trackedEntity();
-    Event from = event(enrollment(to));
+    TrackedEntityInstance to = trackedEntity();
+    ProgramStageInstance from = event(enrollment(to));
     Relationship r = relationship(from, to);
 
     r.setDeleted(true);
@@ -218,8 +218,8 @@ class RelationshipControllerTest extends DhisControllerConvenienceTest {
 
   @Test
   void shouldGetRelationshipsByEnrollmentWhenRelationshipIsDeleted() {
-    TrackedEntity to = trackedEntity();
-    Enrollment from = enrollment(to);
+    TrackedEntityInstance to = trackedEntity();
+    ProgramInstance from = enrollment(to);
     Relationship r = relationship(from, to);
 
     r.setDeleted(true);
@@ -233,44 +233,44 @@ class RelationshipControllerTest extends DhisControllerConvenienceTest {
     assertRelationship(r, relationships);
   }
 
-  private TrackedEntity trackedEntity() {
-    TrackedEntity te = trackedEntity(orgUnit);
+  private TrackedEntityInstance trackedEntity() {
+    TrackedEntityInstance te = trackedEntity(orgUnit);
     manager.save(te, false);
     return te;
   }
 
-  private TrackedEntity trackedEntity(OrganisationUnit orgUnit) {
-    TrackedEntity te = trackedEntity(orgUnit, trackedEntityType);
+  private TrackedEntityInstance trackedEntity(OrganisationUnit orgUnit) {
+    TrackedEntityInstance te = trackedEntity(orgUnit, trackedEntityType);
     manager.save(te, false);
     return te;
   }
 
-  private TrackedEntity trackedEntity(
+  private TrackedEntityInstance trackedEntity(
       OrganisationUnit orgUnit, TrackedEntityType trackedEntityType) {
-    TrackedEntity te = createTrackedEntity(orgUnit);
+    TrackedEntityInstance te = createTrackedEntityInstance(orgUnit);
     te.setTrackedEntityType(trackedEntityType);
     te.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
     te.getSharing().setOwner(owner);
     return te;
   }
 
-  private Enrollment enrollment(TrackedEntity te) {
-    Enrollment enrollment = new Enrollment(program, te, orgUnit);
+  private ProgramInstance enrollment(TrackedEntityInstance te) {
+    ProgramInstance enrollment = new ProgramInstance(program, te, orgUnit);
     enrollment.setAutoFields();
     enrollment.setEnrollmentDate(new Date());
-    enrollment.setOccurredDate(new Date());
+    enrollment.setIncidentDate(new Date());
     enrollment.setStatus(ProgramStatus.COMPLETED);
     manager.save(enrollment, false);
-    te.setEnrollments(Set.of(enrollment));
+    te.setProgramInstances(Set.of(enrollment));
     manager.save(te, false);
     return enrollment;
   }
 
-  private Event event(Enrollment enrollment) {
-    Event event = new Event(enrollment, programStage, orgUnit);
+  private ProgramStageInstance event(ProgramInstance enrollment) {
+    ProgramStageInstance event = new ProgramStageInstance(enrollment, programStage, orgUnit);
     event.setAutoFields();
     manager.save(event, false);
-    enrollment.setEvents(Set.of(event));
+    enrollment.setProgramStageInstances(Set.of(event));
     manager.save(enrollment, false);
     return event;
   }
@@ -292,17 +292,17 @@ class RelationshipControllerTest extends DhisControllerConvenienceTest {
     return type;
   }
 
-  private Relationship relationship(Event from, TrackedEntity to) {
+  private Relationship relationship(ProgramStageInstance from, TrackedEntityInstance to) {
     Relationship r = new Relationship();
 
     RelationshipItem fromItem = new RelationshipItem();
-    fromItem.setEvent(from);
+    fromItem.setProgramStageInstance(from);
     from.getRelationshipItems().add(fromItem);
     r.setFrom(fromItem);
     fromItem.setRelationship(r);
 
     RelationshipItem toItem = new RelationshipItem();
-    toItem.setTrackedEntity(to);
+    toItem.setTrackedEntityInstance(to);
     to.getRelationshipItems().add(toItem);
     r.setTo(toItem);
     toItem.setRelationship(r);
@@ -316,25 +316,25 @@ class RelationshipControllerTest extends DhisControllerConvenienceTest {
 
     r.setAutoFields();
     r.getSharing().setOwner(owner);
-    r.setCreatedAtClient(new Date());
+    r.setCreated(new Date());
     manager.save(r, false);
     return r;
   }
 
-  private Relationship relationship(Enrollment from, TrackedEntity to) {
+  private Relationship relationship(ProgramInstance from, TrackedEntityInstance to) {
     manager.save(from, false);
     manager.save(to, false);
 
     Relationship r = new Relationship();
 
     RelationshipItem fromItem = new RelationshipItem();
-    fromItem.setEnrollment(from);
+    fromItem.setProgramInstance(from);
     from.getRelationshipItems().add(fromItem);
     r.setFrom(fromItem);
     fromItem.setRelationship(r);
 
     RelationshipItem toItem = new RelationshipItem();
-    toItem.setTrackedEntity(to);
+    toItem.setTrackedEntityInstance(to);
     to.getRelationshipItems().add(toItem);
     r.setTo(toItem);
     toItem.setRelationship(r);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportControllerTest.java
@@ -439,6 +439,36 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
   }
 
   @Test
+  void shouldNotGetRelationshipsByTrackedEntityWhenRelationshipIsDeleted() {
+    TrackedEntityInstance to = trackedEntityInstance();
+    ProgramInstance from = programInstance(to);
+    Relationship r = relationship(from, to);
+
+    r.setDeleted(true);
+    manager.update(r);
+
+    assertNoRelationships(
+        GET("/tracker/relationships?trackedEntity={tei}", to.getUid()).content(HttpStatus.OK));
+  }
+
+  @Test
+  void shouldGetRelationshipsByTrackedEntityWhenRelationshipIsDeleted() {
+    TrackedEntityInstance to = trackedEntityInstance();
+    ProgramInstance from = programInstance(to);
+    Relationship r = relationship(from, to);
+
+    r.setDeleted(true);
+    manager.update(r);
+
+    JsonList<JsonRelationship> relationships =
+        GET("/tracker/relationships?trackedEntity={tei}&includeDeleted=true", to.getUid())
+            .content(HttpStatus.OK)
+            .getList("instances", JsonRelationship.class);
+
+    assertFirstRelationship(r, relationships);
+  }
+
+  @Test
   void getRelationshipsByTei() {
     TrackedEntityInstance to = trackedEntityInstance();
     ProgramInstance from = programInstance(to);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportControllerTest.java
@@ -452,6 +452,32 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
   }
 
   @Test
+  void shouldNotGetRelationshipsByEnrollmentWhenRelationshipIsDeleted() {
+    TrackedEntityInstance to = trackedEntityInstance();
+    ProgramInstance from = programInstance(to);
+    Relationship r = relationship(from, to);
+
+    r.setDeleted(true);
+    manager.update(r);
+
+    assertNoRelationships(
+        GET("/tracker/relationships?enrollment={en}", from.getUid()).content(HttpStatus.OK));
+  }
+
+  @Test
+  void shouldNotGetRelationshipsByEventWhenRelationshipIsDeleted() {
+    TrackedEntityInstance to = trackedEntityInstance();
+    ProgramStageInstance from = programStageInstance(programInstance(to));
+    Relationship r = relationship(from, to);
+
+    r.setDeleted(true);
+    manager.update(r);
+
+    assertNoRelationships(
+        GET("/tracker/relationships?event={ev}", from.getUid()).content(HttpStatus.OK));
+  }
+
+  @Test
   void shouldGetRelationshipsByTrackedEntityWhenRelationshipIsDeleted() {
     TrackedEntityInstance to = trackedEntityInstance();
     ProgramInstance from = programInstance(to);
@@ -462,6 +488,40 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
 
     JsonList<JsonRelationship> relationships =
         GET("/tracker/relationships?trackedEntity={tei}&includeDeleted=true", to.getUid())
+            .content(HttpStatus.OK)
+            .getList("instances", JsonRelationship.class);
+
+    assertFirstRelationship(r, relationships);
+  }
+
+  @Test
+  void shouldGetRelationshipsByEventWhenRelationshipIsDeleted() {
+    TrackedEntityInstance to = trackedEntityInstance();
+    ProgramStageInstance from = programStageInstance(programInstance(to));
+    Relationship r = relationship(from, to);
+
+    r.setDeleted(true);
+    manager.update(r);
+
+    JsonList<JsonRelationship> relationships =
+        GET("/tracker/relationships?event={ev}&includeDeleted=true", from.getUid())
+            .content(HttpStatus.OK)
+            .getList("instances", JsonRelationship.class);
+
+    assertFirstRelationship(r, relationships);
+  }
+
+  @Test
+  void shouldGetRelationshipsByEnrollmentWhenRelationshipIsDeleted() {
+    TrackedEntityInstance to = trackedEntityInstance();
+    ProgramInstance from = programInstance(to);
+    Relationship r = relationship(from, to);
+
+    r.setDeleted(true);
+    manager.update(r);
+
+    JsonList<JsonRelationship> relationships =
+        GET("/tracker/relationships?enrollment={en}&includeDeleted=true", from.getUid())
             .content(HttpStatus.OK)
             .getList("instances", JsonRelationship.class);
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/RelationshipController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/RelationshipController.java
@@ -106,7 +106,7 @@ public class RelationshipController {
           .map(
               tei ->
                   relationshipService.getRelationshipsByTrackedEntityInstance(
-                      tei, relationshipCriteria, false))
+                      tei, relationshipCriteria, false, relationshipCriteria.isIncludeDeleted()))
           .orElseThrow(
               () ->
                   new WebMessageException(
@@ -120,7 +120,7 @@ public class RelationshipController {
           .map(
               pi ->
                   relationshipService.getRelationshipsByProgramInstance(
-                      pi, relationshipCriteria, false))
+                      pi, relationshipCriteria, false, relationshipCriteria.isIncludeDeleted()))
           .orElseThrow(
               () ->
                   new WebMessageException(
@@ -132,7 +132,7 @@ public class RelationshipController {
           .map(
               psi ->
                   relationshipService.getRelationshipsByProgramStageInstance(
-                      psi, relationshipCriteria, false))
+                      psi, relationshipCriteria, false, relationshipCriteria.isIncludeDeleted()))
           .orElseThrow(
               () ->
                   new WebMessageException(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/RelationshipCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/RelationshipCriteria.java
@@ -42,6 +42,8 @@ public class RelationshipCriteria extends PagingAndSortingCriteriaAdapter {
 
   private String event;
 
+  private boolean includeDeleted;
+
   /** TODO Add Pager */
   @Override
   public Boolean isSkipPaging() {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipCriteria.java
@@ -59,6 +59,8 @@ class TrackerRelationshipCriteria extends PagingAndSortingCriteriaAdapter {
 
   private Class<?> identifierClass;
 
+  @Setter @Getter private boolean includeDeleted;
+
   public void setTei(String tei) {
     // this setter is kept for backwards-compatibility
     // query parameter 'tei' should still be allowed, but 'trackedEntity' is

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/RelationshipControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/RelationshipControllerTest.java
@@ -111,7 +111,8 @@ class RelationshipControllerTest {
     mockMvc.perform(get(ENDPOINT).param("tei", TEI_ID)).andExpect(status().isOk());
 
     verify(trackedEntityInstanceService).getTrackedEntityInstance(TEI_ID);
-    verify(relationshipService).getRelationshipsByTrackedEntityInstance(eq(tei), any(), eq(false));
+    verify(relationshipService)
+        .getRelationshipsByTrackedEntityInstance(eq(tei), any(), eq(false), false);
   }
 
   @Test
@@ -127,7 +128,8 @@ class RelationshipControllerTest {
     mockMvc.perform(get(ENDPOINT).param("event", EVENT_ID)).andExpect(status().isOk());
 
     verify(programStageInstanceService).getProgramStageInstance(EVENT_ID);
-    verify(relationshipService).getRelationshipsByProgramStageInstance(eq(event), any(), eq(false));
+    verify(relationshipService)
+        .getRelationshipsByProgramStageInstance(eq(event), any(), eq(false), false);
   }
 
   @Test
@@ -143,7 +145,8 @@ class RelationshipControllerTest {
     mockMvc.perform(get(ENDPOINT).param("enrollment", ENROLLMENT_ID)).andExpect(status().isOk());
 
     verify(programInstanceService).getProgramInstance(ENROLLMENT_ID);
-    verify(relationshipService).getRelationshipsByProgramInstance(eq(enrollment), any(), eq(false));
+    verify(relationshipService)
+        .getRelationshipsByProgramInstance(eq(enrollment), any(), eq(false), false);
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/RelationshipControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/RelationshipControllerTest.java
@@ -112,7 +112,7 @@ class RelationshipControllerTest {
 
     verify(trackedEntityInstanceService).getTrackedEntityInstance(TEI_ID);
     verify(relationshipService)
-        .getRelationshipsByTrackedEntityInstance(eq(tei), any(), eq(false), false);
+        .getRelationshipsByTrackedEntityInstance(eq(tei), any(), eq(false), eq(false));
   }
 
   @Test
@@ -129,7 +129,7 @@ class RelationshipControllerTest {
 
     verify(programStageInstanceService).getProgramStageInstance(EVENT_ID);
     verify(relationshipService)
-        .getRelationshipsByProgramStageInstance(eq(event), any(), eq(false), false);
+        .getRelationshipsByProgramStageInstance(eq(event), any(), eq(false), eq(false));
   }
 
   @Test
@@ -146,7 +146,7 @@ class RelationshipControllerTest {
 
     verify(programInstanceService).getProgramInstance(ENROLLMENT_ID);
     verify(relationshipService)
-        .getRelationshipsByProgramInstance(eq(enrollment), any(), eq(false), false);
+        .getRelationshipsByProgramInstance(eq(enrollment), any(), eq(false), eq(false));
   }
 
   @Test


### PR DESCRIPTION
backport of https://github.com/dhis2/dhis2-core/pull/16382

Here, we just add the `includeDeleted` param for the old and new trackers.

### Note :

Some cleanup has been made. However, the old and new tracker uses the same request parameters and services. If required, a refactor of this part will be in a separate issue.