### PR TITLE
fix: Filter null in enrollment list [2.40]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportController.java
@@ -33,6 +33,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -113,6 +114,7 @@ public class TrackerEnrollmentsExportController {
           enrollmentIds != null
               ? enrollmentIds.stream()
                   .map(e -> enrollmentService.getEnrollment(e, enrollmentParams))
+                  .filter(Objects::nonNull)
                   .collect(Collectors.toList())
               : Collections.emptyList();
     }


### PR DESCRIPTION
If we delete an enrollment and we then search through the request:

`<host>/api/tracker/enrollments?enrollment=HYGryIKdtFS&includeDeleted=true
`
we get a 500 because we go through the same method as to get the single enrollment, but then we try to collect and add to the response a list with null elements.
With this PR, we filter null values in the response. This way, we also have the same behavior as in the master branch. Add MVC test



