### PR TITLE
chore: Log (debug) operation return code, sonar vulnerability

### DIFF
--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/AuditScheduler.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/AuditScheduler.java
@@ -75,7 +75,11 @@ public class AuditScheduler {
       auditProducerSupplier.publish(auditItem);
     } else {
       if (!delayed.contains(postponed)) {
-        delayed.offer(postponed);
+        boolean wasAddedToQueue = delayed.offer(postponed);
+        log.debug(
+            "Audit queue accepted new audit item `{}`: {}",
+            postponed.getAuditItem().getUid(),
+            wasAddedToQueue);
       }
     }
   }

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/AuditScheduler.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/AuditScheduler.java
@@ -76,10 +76,7 @@ public class AuditScheduler {
     } else {
       if (!delayed.contains(postponed)) {
         boolean wasAddedToQueue = delayed.offer(postponed);
-        log.debug(
-            "Audit queue accepted new audit item `{}`: {}",
-            postponed.getAuditItem().getUid(),
-            wasAddedToQueue);
+        log.debug("Audit queue accepted new audit item: {}", wasAddedToQueue);
       }
     }
   }


### PR DESCRIPTION
# Summary
## Issue
Sonar vulnerability [issue](https://sonarcloud.io/organizations/dhis2/rules?open=java%3AS899&rule_key=java%3AS899) highlights where an operation code is returned but never used, meaning nothing is done with it and it's not easily visible what has occurred.

## Fix (minimally invasive)
Log (debug) whether the item was added successfully to the queue or not.