### PR TITLE
fix: handles multiple items for queryItems [DHIS2-16510]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/DimensionParamItem.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/DimensionParamItem.java
@@ -29,13 +29,15 @@ package org.hisp.dhis.analytics.common.params.dimension;
 
 import static java.util.Collections.singletonList;
 import static lombok.AccessLevel.PRIVATE;
+import static org.apache.commons.collections4.CollectionUtils.isEmpty;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.hisp.dhis.common.DimensionalObject.DIMENSION_NAME_SEP;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.ListUtils;
 
 @Getter
 @RequiredArgsConstructor(access = PRIVATE)
@@ -45,21 +47,60 @@ public class DimensionParamItem {
 
   private final List<String> values;
 
+  /**
+   * This method parses a list of strings into a list of DimensionParamItem. Items can be either a
+   * list in the form of [OP:VAL, OP2:VAL2, ...] (queryItem case) or a list of values in the form of
+   * [VAL, VAL2, ...] (values case - dimensionalObject).
+   *
+   * @param items List of strings to be parsed.
+   * @return List of DimensionParamItem.
+   */
   public static List<DimensionParamItem> ofStrings(List<String> items) {
-    if (items.isEmpty()) {
+    if (isEmpty(items)) {
       return Collections.emptyList();
     }
-    // If operator is specified, it's in the first element.
-    String firstElement = items.get(0);
-
-    if (firstElement.contains(DIMENSION_NAME_SEP)) { // Has operator.
-      String[] parts = firstElement.split(DIMENSION_NAME_SEP);
-      AnalyticsQueryOperator queryOperator = AnalyticsQueryOperator.ofString(parts[0].trim());
-      return singletonList(
-          new DimensionParamItem(
-              queryOperator, Stream.concat(Stream.of(parts[1]), items.stream().skip(1)).toList()));
+    if (isQueryItemFormat(items)) {
+      return ofQueryItemFormat(items);
     } else {
       return singletonList(new DimensionParamItem(null, items));
     }
+  }
+
+  /**
+   * This method checks if the list of strings is in the queryItem format, i.e. if the first item
+   * contains the dimension name separator. We assume that if the first item contains the separator,
+   * then the rest of the items are also in the queryItem format.
+   *
+   * @param items List of strings to be checked.
+   * @return True if the list is in the queryItem format, false otherwise.
+   */
+  private static boolean isQueryItemFormat(List<String> items) {
+    return isNotEmpty(items) && items.get(0).contains(DIMENSION_NAME_SEP);
+  }
+
+  /**
+   * This method parses a list of strings in the queryItem format into a list of DimensionParamItem.
+   *
+   * @param items List of strings to be parsed.
+   * @return List of DimensionParamItem.
+   */
+  private static List<DimensionParamItem> ofQueryItemFormat(List<String> items) {
+    return ListUtils.emptyIfNull(items).stream()
+        .map(DimensionParamItem::ofQueryItemFormat)
+        .toList();
+  }
+
+  /**
+   * This method parses a string in the queryItem format into a DimensionParamItem by simply
+   * splitting the string by the dimension name separator (:). The first part is the operator and
+   * the second part is the value.
+   *
+   * @param item String to be parsed.
+   * @return parsed DimensionParamItem.
+   */
+  private static DimensionParamItem ofQueryItemFormat(String item) {
+    String[] parts = item.split(DIMENSION_NAME_SEP);
+    AnalyticsQueryOperator queryOperator = AnalyticsQueryOperator.ofString(parts[0].trim());
+    return new DimensionParamItem(queryOperator, singletonList(parts[1]));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/query/AndCondition.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/query/AndCondition.java
@@ -34,7 +34,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(staticName = "of")
 public class AndCondition extends BaseRenderable {
-  private final List<Renderable> conditions;
+  private final List<? extends Renderable> conditions;
 
   @Override
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/TeiAttributeCondition.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/TeiAttributeCondition.java
@@ -34,10 +34,10 @@ import org.hisp.dhis.analytics.common.ValueTypeMapping;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifier;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionParam;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionParamItem;
+import org.hisp.dhis.analytics.common.query.AndCondition;
 import org.hisp.dhis.analytics.common.query.BaseRenderable;
 import org.hisp.dhis.analytics.common.query.BinaryConditionRenderer;
 import org.hisp.dhis.analytics.common.query.Field;
-import org.hisp.dhis.analytics.common.query.OrCondition;
 import org.hisp.dhis.analytics.tei.query.context.sql.QueryContext;
 
 @RequiredArgsConstructor(staticName = "of")
@@ -65,6 +65,6 @@ public class TeiAttributeCondition extends BaseRenderable {
       renderers.add(binaryConditionRenderer);
     }
 
-    return OrCondition.of(renderers).render();
+    return AndCondition.of(renderers).render();
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TeiQuery1AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TeiQuery1AutoTest.java
@@ -57,7 +57,8 @@ public class TeiQuery1AutoTest extends AnalyticsApiTest {
             .add("program=IpHINAT79UW")
             .add(
                 "dimension=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU,IpHINAT79UW.A03MvHHogjR.a3kGcGDCuk6")
-            .add("desc=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU,IpHINAT79UW.A03MvHHogjR.a3kGcGDCuk6");
+            .add(
+                "desc=IpHINAT79UW.A03MvHHogjR.UXz7xuGCEhU,IpHINAT79UW.A03MvHHogjR.a3kGcGDCuk6,lastupdated");
 
     // When
     ApiResponse response = actions.query().get("nEenWmSyUEp", JSON, JSON, params);
@@ -287,91 +288,6 @@ public class TeiQuery1AutoTest extends AnalyticsApiTest {
             "",
             "3999",
             "2"));
-    validateRow(
-        response,
-        List.of(
-            "UmDlYjOjnbW",
-            "2015-08-06 21:20:47.047",
-            "",
-            "2015-08-06 21:20:47.047",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "Rokai CHP",
-            "OU_211250",
-            "Sierra Leone / Kambia / Samu / Rokai CHP",
-            "Kathleen",
-            "Howard",
-            "Female",
-            "",
-            "3999",
-            "2"));
-    validateRow(
-        response,
-        List.of(
-            "W58QwQyTbdE",
-            "2015-08-07 15:47:21.024",
-            "",
-            "2015-08-07 15:47:21.023",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "Roktolon MCHP",
-            "OU_803066",
-            "Sierra Leone / Port Loko / Dibia / Roktolon MCHP",
-            "Randy",
-            "Chavez",
-            "Male",
-            "",
-            "3999",
-            "2"));
-    validateRow(
-        response,
-        List.of(
-            "XheNQ4xnHxp",
-            "2015-08-06 21:20:48.903",
-            "",
-            "2015-08-06 21:20:48.902",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "Gbo-Lambayama 1 MCHP",
-            "OU_222697",
-            "Sierra Leone / Kenema / Nongowa / Gbo-Lambayama 1 MCHP",
-            "Earl",
-            "Reid",
-            "Male",
-            "",
-            "3999",
-            "2"));
-    validateRow(
-        response,
-        9,
-        List.of(
-            "HmCXE7B3fiZ",
-            "2015-08-06 21:20:43.68",
-            "",
-            "2015-08-06 21:20:43.68",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "Follah MCHP",
-            "OU_204885",
-            "Sierra Leone / Kailahun / Njaluahun / Follah MCHP",
-            "Jacqueline",
-            "Ruiz",
-            "Female",
-            "",
-            "3999",
-            "1"));
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TrackedEntityQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TrackedEntityQueryTest.java
@@ -2989,6 +2989,27 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
   }
 
   @Test
+  public void multipleItemsForTrackedEntityAttributes() {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("dimension=w75KJ2mc4zz:NE:John:NE:Frank:LIKE:A")
+            .add("headers=w75KJ2mc4zz")
+            .add("lastUpdated=LAST_YEAR")
+            .add("desc=lastupdated")
+            .add("relativePeriodDate=2016-01-01")
+            .add("pageSize=1");
+
+    // When
+    ApiResponse response = analyticsTeiActions.query().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    response.validate().statusCode(200);
+
+    validateRow(response, 0, List.of("Alice"));
+  }
+
+  @Test
   public void multipleEnrollmentDateIsValidRequest() {
     // Given
     QueryParamsBuilder params =


### PR DESCRIPTION
This PR adds support in TEI analytics for properly parsing and executing query parameters like:

`dimension=TfdH5KvFmMy:ILIKE:A:!IEQ:Mark`

