### PR TITLE
fix: data integrity summary uses continuous execution

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
@@ -234,7 +234,10 @@ public enum JobType {
    *     the ready jobs per type is attempted to start in a single loop cycle
    */
   public boolean isUsingContinuousExecution() {
-    return this == METADATA_IMPORT || this == TRACKER_IMPORT_JOB || this == DATA_INTEGRITY_DETAILS;
+    return this == METADATA_IMPORT
+        || this == TRACKER_IMPORT_JOB
+        || this == DATA_INTEGRITY
+        || this == DATA_INTEGRITY_DETAILS;
   }
 
   public boolean hasJobParameters() {


### PR DESCRIPTION
Makes data integrity summary execution "immediate" just to more convenient work process with the app. 