### PR TITLE
fix: Remove sorting restriction on column [DHIS2-16542]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualization.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualization.java
@@ -28,8 +28,6 @@
 package org.hisp.dhis.eventvisualization;
 
 import static java.util.stream.Collectors.toList;
-import static org.apache.commons.lang3.ArrayUtils.contains;
-import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.join;
 import static org.hisp.dhis.common.AnalyticsType.EVENT;
 import static org.hisp.dhis.common.DimensionalObjectUtils.TITLE_ITEM_SEP;
@@ -636,21 +634,6 @@ public class EventVisualization extends BaseAnalyticalObject
     setDimensionItemsForFilters(object, dataItemGrid, true);
 
     return object != null ? object.getItems() : null;
-  }
-
-  /** Validates the state of the current list of {@link Sorting} objects (if one is defined). */
-  public void validateSortingState() {
-    List<String> columns = getColumnDimensions();
-    List<Sorting> sortingList = getSorting().stream().collect(toList());
-
-    sortingList.forEach(
-        s -> {
-          if (isBlank(s.getDimension()) || s.getDirection() == null) {
-            throw new IllegalArgumentException("Sorting is not valid");
-          } else if (columns.stream().noneMatch(c -> contains(s.getDimension().split("\\."), c))) {
-            throw new IllegalStateException(s.getDimension());
-          }
-        });
   }
 
   public AnalyticsType getAnalyticsType() {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/EventVisualizationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/EventVisualizationControllerTest.java
@@ -31,7 +31,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hisp.dhis.web.HttpStatus.BAD_REQUEST;
-import static org.hisp.dhis.web.HttpStatus.CONFLICT;
 import static org.hisp.dhis.web.HttpStatus.CREATED;
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -430,68 +429,5 @@ class EventVisualizationControllerTest extends DhisControllerConvenienceTest {
     assertThat(response.get("sorting").toString(), containsString("pe"));
     assertThat(response.get("sorting").toString(), containsString("ASC"));
     assertThat(response.get("sorting").toString(), not(containsString("DESC")));
-  }
-
-  @Test
-  void testPostInvalidSortingObject() {
-    // Given
-    String invalidDimension = "invalidOne";
-    String sorting = "'sorting': [{'dimension': '" + invalidDimension + "', 'direction':'ASC'}]";
-    String body =
-        "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
-            + mockProgram.getUid()
-            + "'}, 'columns': [{'dimension': 'pe'}],"
-            + sorting
-            + "}";
-
-    // When
-    HttpResponse response = POST("/eventVisualizations/", body);
-
-    // Then
-    assertEquals(
-        "Sorting dimension ‘" + invalidDimension + "’ is not a column",
-        response.error(CONFLICT).getMessage());
-  }
-
-  @Test
-  void testPostBlankSortingObject() {
-    // Given
-    String blankDimension = " ";
-    String sorting = "'sorting': [{'dimension': '" + blankDimension + "', 'direction':'ASC'}]";
-    String body =
-        "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
-            + mockProgram.getUid()
-            + "'}, 'columns': [{'dimension': 'pe'}],"
-            + sorting
-            + "}";
-
-    // When
-    HttpResponse response = POST("/eventVisualizations/", body);
-
-    // Then
-    assertEquals(
-        "Sorting must have a valid dimension and a direction",
-        response.error(CONFLICT).getMessage());
-  }
-
-  @Test
-  void testPostNullSortingObject() {
-    // Given
-    String blankDimension = " ";
-    String sorting = "'sorting': [{'dimension': '" + blankDimension + "', 'direction':'ASC'}]";
-    String body =
-        "{'name': 'Name Test', 'type': 'STACKED_COLUMN', 'program': {'id':'"
-            + mockProgram.getUid()
-            + "'}, 'columns': [{'dimension': 'pe'}],"
-            + sorting
-            + "}";
-
-    // When
-    HttpResponse response = POST("/eventVisualizations/", body);
-
-    // Then
-    assertEquals(
-        "Sorting must have a valid dimension and a direction",
-        response.error(CONFLICT).getMessage());
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventVisualizationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventVisualizationController.java
@@ -34,8 +34,6 @@ import static org.hisp.dhis.common.cache.CacheStrategy.RESPECT_SYSTEM_SETTING;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.eventvisualization.EventVisualizationType.LINE_LIST;
 import static org.hisp.dhis.eventvisualization.EventVisualizationType.PIVOT_TABLE;
-import static org.hisp.dhis.feedback.ErrorCode.E7237;
-import static org.hisp.dhis.feedback.ErrorCode.E7238;
 import static org.hisp.dhis.schema.descriptors.EventVisualizationSchemaDescriptor.API_ENDPOINT;
 import static org.hisp.dhis.system.util.CodecUtils.filenameEncode;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_PNG;
@@ -49,11 +47,9 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import org.hisp.dhis.common.DimensionService;
-import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.eventvisualization.EventVisualization;
 import org.hisp.dhis.eventvisualization.EventVisualizationService;
-import org.hisp.dhis.feedback.ErrorMessage;
 import org.hisp.dhis.i18n.I18nFormat;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.legend.LegendSetService;
@@ -64,7 +60,6 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.visualization.ChartService;
 import org.hisp.dhis.visualization.PlotData;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
-import org.hisp.dhis.webapi.controller.exception.ConflictException;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
@@ -189,8 +184,6 @@ public class EventVisualizationController extends AbstractCrudController<EventVi
      * become a non-legacy EventVisualization.
      */
     forceNonLegacy(newEventVisualization);
-
-    validateSorting(newEventVisualization);
   }
 
   @Override
@@ -201,31 +194,6 @@ public class EventVisualizationController extends AbstractCrudController<EventVi
      * become a non-legacy EventVisualization.
      */
     forceNonLegacy(newEventVisualization);
-
-    validateSorting(newEventVisualization);
-  }
-
-  @Override
-  protected void prePatchEntity(
-      EventVisualization eventVisualization, EventVisualization newEventVisualization) {
-    validateSorting(newEventVisualization);
-  }
-
-  /**
-   * Simply validates the state of the {@link Sorting} attribute in the given {@link
-   * EventVisualization} object.
-   *
-   * @param eventVisualization the {@link EventVisualization}.
-   * @throws ConflictException if the {@link Sorting} attribute is not valid.
-   */
-  private void validateSorting(EventVisualization eventVisualization) {
-    try {
-      eventVisualization.validateSortingState();
-    } catch (IllegalArgumentException e) {
-      throw new IllegalQueryException(new ErrorMessage(E7237));
-    } catch (IllegalStateException e) {
-      throw new IllegalQueryException(new ErrorMessage(E7238, e.getMessage()));
-    }
   }
 
   private void forceNonLegacy(final EventVisualization eventVisualization) {


### PR DESCRIPTION
**[Backport from master/2.41]** (#16298)

Currently, there is a validation in the “sorting” object:
```
    "sorting": [
    {
        "dimension": "IpHINAT79UW.pe",
        "direction": "ASC"
    }
```

It requires a “dimension” that is also defined in “columns”, otherwise it fails. This restriction has to be removed.
This PR removes the validation from it in two places where it happens. Users should also be able to set it back to null. This change will also allow it.