### PR TITLE
fix: Getting internal server when trying to fetch a deleted enrollment [2.40]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportController.java
@@ -33,6 +33,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -113,6 +114,7 @@ public class TrackerEnrollmentsExportController {
           enrollmentIds != null
               ? enrollmentIds.stream()
                   .map(e -> enrollmentService.getEnrollment(e, enrollmentParams))
+                  .filter(Objects::nonNull)
                   .collect(Collectors.toList())
               : Collections.emptyList();
     }


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-16731

As discussed, for now, we only fix the null pointer exception thrown when we get a deleted enrollment in `/tracker/enrollments` by specifying the `enrollment` param. We'll discuss later whether to clarify the documentation for these cases or adapt with what is in 2.41.