### PR TITLE
fix: Outliers detection, order by standard deviation

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/Order.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/Order.java
@@ -54,7 +54,7 @@ public enum Order {
   VALUE("value", "value"),
   MEDIAN(ColumnHeader.MEDIAN.getItem(), "middle_value"),
   MEAN(ColumnHeader.MEAN.getItem(), "middle_value"),
-  STD_DEV(STANDARD_DEVIATION.getName(), "std_dev"),
+  STD_DEV(STANDARD_DEVIATION.getItem(), "std_dev"),
   MEDIAN_ABS_DEV(MEDIAN_ABS_DEVIATION.getItem(), "mad"),
   ABS_DEV(ABSOLUTE_DEVIATION.getItem(), "middle_value_abs_dev"),
   LOWER_BOUND(LOWER_BOUNDARY.getItem(), "lower_bound"),

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection3AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection3AutoTest.java
@@ -1092,4 +1092,308 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "-505.334",
             "531.334"));
   }
+
+  @Test
+  public void queryQueryoutliertest11() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("endDate=2022-10-26")
+            .add("ou=ImspTQPwCqd")
+            .add("maxResults=5")
+            .add("outputIdScheme=uid")
+            .add("sortOrder=asc")
+            .add("orderBy=mean")
+            .add("startDate=2022-07-26")
+            .add("ds=BfMAe6Itzgt")
+            .add("algorithm=Z_SCORE");
+
+    // When
+    ApiResponse response = actions.query().get("", JSON, JSON, params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(18)))
+        .body("rows", hasSize(equalTo(3)))
+        .body("height", equalTo(3))
+        .body("width", equalTo(18))
+        .body("headerWidth", equalTo(18));
+
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"count\":3,\"orderBy\":\"MEAN\",\"threshold\":\"3.0\",\"maxResults\":5,\"algorithm\":\"Z_SCORE\"}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // Assert headers.
+    validateHeader(response, 0, "dx", "Data", "TEXT", "java.lang.String", false, false);
+    validateHeader(response, 1, "dxname", "Data name", "TEXT", "java.lang.String", false, false);
+    validateHeader(response, 2, "pe", "Period", "TEXT", "java.lang.String", false, false);
+    validateHeader(response, 3, "pename", "Period name", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response, 4, "ou", "Organisation unit", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response, 5, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response,
+        6,
+        "ounamehierarchy",
+        "Organisation unit name hierarchy",
+        "TEXT",
+        "java.lang.String",
+        false,
+        false);
+    validateHeader(
+        response, 7, "coc", "Category option combo", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response,
+        8,
+        "cocname",
+        "Category option combo name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        false);
+    validateHeader(
+        response, 9, "aoc", "Attribute option combo", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response,
+        10,
+        "aocname",
+        "Attribute option combo name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        false);
+    validateHeader(response, 11, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(response, 12, "mean", "Mean", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 13, "stddev", "Standard deviation", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 14, "absdev", "Absolute deviation", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(response, 15, "zscore", "zScore", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 16, "lowerbound", "Lower boundary", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 17, "upperbound", "Upper boundary", "NUMBER", "java.lang.Double", false, false);
+
+    // Assert rows.
+    validateRow(
+        response,
+        List.of(
+            "dU0GquGkGQr",
+            "Q_Early breastfeeding (within 1 hr after delivery) at BCG",
+            "202209",
+            "September 2022",
+            "Mi4dWRtfIOC",
+            "Sandaru CHC",
+            "/Sierra Leone/Kailahun/Penguia/Sandaru CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "105.0",
+            "18.26357",
+            "28.70554",
+            "86.73643",
+            "3.02159",
+            "-67.85306",
+            "104.38019"));
+    validateRow(
+        response,
+        List.of(
+            "s46m5MS0hxu",
+            "BCG doses given",
+            "202208",
+            "August 2022",
+            "CvBAqD6RzLZ",
+            "Ngalu CHC",
+            "/Sierra Leone/Bo/Bargbe/Ngalu CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "220.0",
+            "41.64407",
+            "57.44954",
+            "178.35593",
+            "3.10457",
+            "-130.70455",
+            "213.99269"));
+    validateRow(
+        response,
+        List.of(
+            "l6byfWFUGaP",
+            "Yellow Fever doses given",
+            "202209",
+            "September 2022",
+            "RhJbg8UD75Q",
+            "Yemoh Town CHC",
+            "/Sierra Leone/Bo/Kakua/Yemoh Town CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "466.0",
+            "48.18605",
+            "114.27966",
+            "417.81395",
+            "3.65607",
+            "-294.65294",
+            "391.02504"));
+  }
+
+  @Test
+  public void queryQueryoutliertest12() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("endDate=2022-10-26")
+            .add("ou=ImspTQPwCqd")
+            .add("maxResults=5")
+            .add("outputIdScheme=uid")
+            .add("sortOrder=asc")
+            .add("orderBy=stddev")
+            .add("startDate=2022-07-26")
+            .add("ds=BfMAe6Itzgt")
+            .add("algorithm=Z_SCORE");
+
+    // When
+    ApiResponse response = actions.query().get("", JSON, JSON, params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(18)))
+        .body("rows", hasSize(equalTo(3)))
+        .body("height", equalTo(3))
+        .body("width", equalTo(18))
+        .body("headerWidth", equalTo(18));
+
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"count\":3,\"orderBy\":\"STD_DEV\",\"threshold\":\"3.0\",\"maxResults\":5,\"algorithm\":\"Z_SCORE\"}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // Assert headers.
+    validateHeader(response, 0, "dx", "Data", "TEXT", "java.lang.String", false, false);
+    validateHeader(response, 1, "dxname", "Data name", "TEXT", "java.lang.String", false, false);
+    validateHeader(response, 2, "pe", "Period", "TEXT", "java.lang.String", false, false);
+    validateHeader(response, 3, "pename", "Period name", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response, 4, "ou", "Organisation unit", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response, 5, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response,
+        6,
+        "ounamehierarchy",
+        "Organisation unit name hierarchy",
+        "TEXT",
+        "java.lang.String",
+        false,
+        false);
+    validateHeader(
+        response, 7, "coc", "Category option combo", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response,
+        8,
+        "cocname",
+        "Category option combo name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        false);
+    validateHeader(
+        response, 9, "aoc", "Attribute option combo", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response,
+        10,
+        "aocname",
+        "Attribute option combo name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        false);
+    validateHeader(response, 11, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(response, 12, "mean", "Mean", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 13, "stddev", "Standard deviation", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 14, "absdev", "Absolute deviation", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(response, 15, "zscore", "zScore", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 16, "lowerbound", "Lower boundary", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 17, "upperbound", "Upper boundary", "NUMBER", "java.lang.Double", false, false);
+
+    // Assert rows.
+    validateRow(
+        response,
+        List.of(
+            "dU0GquGkGQr",
+            "Q_Early breastfeeding (within 1 hr after delivery) at BCG",
+            "202209",
+            "September 2022",
+            "Mi4dWRtfIOC",
+            "Sandaru CHC",
+            "/Sierra Leone/Kailahun/Penguia/Sandaru CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "105.0",
+            "18.26357",
+            "28.70554",
+            "86.73643",
+            "3.02159",
+            "-67.85306",
+            "104.38019"));
+    validateRow(
+        response,
+        List.of(
+            "s46m5MS0hxu",
+            "BCG doses given",
+            "202208",
+            "August 2022",
+            "CvBAqD6RzLZ",
+            "Ngalu CHC",
+            "/Sierra Leone/Bo/Bargbe/Ngalu CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "220.0",
+            "41.64407",
+            "57.44954",
+            "178.35593",
+            "3.10457",
+            "-130.70455",
+            "213.99269"));
+    validateRow(
+        response,
+        List.of(
+            "l6byfWFUGaP",
+            "Yellow Fever doses given",
+            "202209",
+            "September 2022",
+            "RhJbg8UD75Q",
+            "Yemoh Town CHC",
+            "/Sierra Leone/Bo/Kakua/Yemoh Town CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "466.0",
+            "48.18605",
+            "114.27966",
+            "417.81395",
+            "3.65607",
+            "-294.65294",
+            "391.02504"));
+  }
 }


### PR DESCRIPTION
Order by standard deviation must be supported but does not work properly. Request parser rejects the valid value for order by standard deviation.