### PR TITLE
fix: Improve performance of min max validation query [DHIS2-16750]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataanalysis/DataAnalysisService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataanalysis/DataAnalysisService.java
@@ -44,7 +44,7 @@ public interface DataAnalysisService {
   int MAX_OUTLIERS = 500;
 
   List<DeflatedDataValue> analyse(
-      Collection<OrganisationUnit> organisationUnits,
+      OrganisationUnit orgUnit,
       Collection<DataElement> dataElements,
       Collection<Period> periods,
       Double stdDevFactor,

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataanalysis/DataAnalysisStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataanalysis/DataAnalysisStore.java
@@ -55,7 +55,7 @@ public interface DataAnalysisStore {
   List<DataAnalysisMeasures> getDataAnalysisMeasures(
       DataElement dataElement,
       Collection<CategoryOptionCombo> categoryOptionCombos,
-      Collection<String> parentPaths,
+      OrganisationUnit orgUnit,
       Date from);
 
   /**
@@ -72,7 +72,7 @@ public interface DataAnalysisStore {
       Collection<DataElement> dataElements,
       Collection<CategoryOptionCombo> categoryOptionCombos,
       Collection<Period> periods,
-      Collection<OrganisationUnit> parents,
+      OrganisationUnit orgUnit,
       int limit);
 
   /**
@@ -107,6 +107,6 @@ public interface DataAnalysisStore {
       Collection<DataElement> dataElements,
       Collection<CategoryOptionCombo> categoryOptionCombos,
       Collection<Period> periods,
-      Collection<OrganisationUnit> parents,
+      OrganisationUnit orgUnit,
       int limit);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataanalysis/FollowupAnalysisService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataanalysis/FollowupAnalysisService.java
@@ -45,7 +45,7 @@ public interface FollowupAnalysisService {
    */
   @Deprecated
   List<DeflatedDataValue> getFollowupDataValues(
-      Collection<OrganisationUnit> parents,
+      OrganisationUnit orgUnit,
       Collection<DataElement> dataElements,
       Collection<Period> periods,
       int limit);

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/dataanalysis/DefaultFollowupAnalysisService.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/dataanalysis/DefaultFollowupAnalysisService.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.dataanalysis;
 
-import static java.util.Collections.emptyList;
 import static org.hisp.dhis.commons.collection.CollectionUtils.isEmpty;
 
 import java.util.Collection;
@@ -77,12 +76,12 @@ public class DefaultFollowupAnalysisService implements FollowupAnalysisService {
   @Override
   @Transactional(readOnly = true)
   public List<DeflatedDataValue> getFollowupDataValues(
-      Collection<OrganisationUnit> parents,
+      OrganisationUnit orgUnit,
       Collection<DataElement> dataElements,
       Collection<Period> periods,
       int limit) {
-    if (parents == null || parents.isEmpty() || limit < 1) {
-      return emptyList();
+    if (orgUnit == null || limit < 1) {
+      return List.of();
     }
 
     Set<DataElement> elements =
@@ -96,14 +95,10 @@ public class DefaultFollowupAnalysisService implements FollowupAnalysisService {
       categoryOptionCombos.addAll(dataElement.getCategoryOptionCombos());
     }
 
-    log.debug(
-        "Starting min-max analysis, no of data elements: "
-            + elements.size()
-            + ", no of parent org units: "
-            + parents.size());
+    log.debug("Starting min-max analysis, no of data elements: {}", elements.size());
 
     return dataAnalysisStore.getFollowupDataValues(
-        elements, categoryOptionCombos, periods, parents, limit);
+        elements, categoryOptionCombos, periods, orgUnit, limit);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/dataanalysis/StdDevOutlierAnalysisService.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/dataanalysis/StdDevOutlierAnalysisService.java
@@ -33,7 +33,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.category.CategoryOptionCombo;
@@ -60,34 +59,24 @@ public class StdDevOutlierAnalysisService implements DataAnalysisService {
 
   @Override
   public final List<DeflatedDataValue> analyse(
-      Collection<OrganisationUnit> parents,
+      OrganisationUnit orgUnit,
       Collection<DataElement> dataElements,
       Collection<Period> periods,
       Double stdDevFactor,
       Date from) {
-    log.info(
-        "Starting std dev analysis, no of org units: "
-            + parents.size()
-            + ", factor: "
-            + stdDevFactor
-            + ", from: "
-            + from);
+    log.info("Starting std dev analysis, factor: {}, from: {}", stdDevFactor, from);
 
     List<DeflatedDataValue> outlierCollection = new ArrayList<>();
 
-    List<String> parentsPaths =
-        parents.stream().map(OrganisationUnit::getPath).collect(Collectors.toList());
-
     loop:
     for (DataElement dataElement : dataElements) {
-      // TODO filter periods with data element period type
 
       if (dataElement.getValueType().isNumeric() && stdDevFactor != null) {
         Set<CategoryOptionCombo> categoryOptionCombos = dataElement.getCategoryOptionCombos();
 
         List<DataAnalysisMeasures> measuresList =
             dataAnalysisStore.getDataAnalysisMeasures(
-                dataElement, categoryOptionCombos, parentsPaths, from);
+                dataElement, categoryOptionCombos, orgUnit, from);
 
         MapMap<Long, Long, Integer> lowBoundMapMap = new MapMap<>();
         MapMap<Long, Long, Integer> highBoundMapMap = new MapMap<>();

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/dataanalysis/jdbc/JdbcDataAnalysisStore.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/dataanalysis/jdbc/JdbcDataAnalysisStore.java
@@ -86,7 +86,6 @@ public class JdbcDataAnalysisStore implements DataAnalysisStore {
             + "avg(cast(dv.value as double precision)) as average, "
             + "stddev_pop(cast(dv.value as double precision)) as standarddeviation "
             + "from datavalue dv "
-            + "inner join organisationunit ou on ou.organisationunitid = dv.sourceid "
             + "inner join period pe on dv.periodid = pe.periodid "
             + "where dv.dataelementid = "
             + dataElement.getId()

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/dataanalysis/jdbc/JdbcDataAnalysisStore.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/dataanalysis/jdbc/JdbcDataAnalysisStore.java
@@ -72,11 +72,11 @@ public class JdbcDataAnalysisStore implements DataAnalysisStore {
       Collection<CategoryOptionCombo> categoryOptionCombos,
       OrganisationUnit orgUnit,
       Date from) {
-    List<DataAnalysisMeasures> measures = new ArrayList<>();
-
-    if (categoryOptionCombos.isEmpty() || orgUnit == null) {
-      return measures;
+    if (categoryOptionCombos.isEmpty() || dataElement == null || orgUnit == null) {
+      return List.of();
     }
+
+    List<DataAnalysisMeasures> measures = new ArrayList<>();
 
     String catOptionComboIds =
         TextUtils.getCommaDelimitedString(getIdentifiers(categoryOptionCombos));
@@ -129,7 +129,7 @@ public class JdbcDataAnalysisStore implements DataAnalysisStore {
         || categoryOptionCombos.isEmpty()
         || periods.isEmpty()
         || orgUnit == null) {
-      return new ArrayList<>();
+      return List.of();
     }
 
     String dataElementIds = getCommaDelimitedString(getIdentifiers(dataElements));
@@ -181,7 +181,7 @@ public class JdbcDataAnalysisStore implements DataAnalysisStore {
       Map<Long, Integer> lowerBoundMap,
       Map<Long, Integer> upperBoundMap) {
     if (lowerBoundMap == null || lowerBoundMap.isEmpty() || periods.isEmpty()) {
-      return new ArrayList<>();
+      return List.of();
     }
 
     List<List<Long>> organisationUnitPages =
@@ -266,7 +266,7 @@ public class JdbcDataAnalysisStore implements DataAnalysisStore {
         || categoryOptionCombos.isEmpty()
         || periods.isEmpty()
         || orgUnit == null) {
-      return new ArrayList<>();
+      return List.of();
     }
 
     String dataElementIds = getCommaDelimitedString(getIdentifiers(dataElements));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataanalysis/DataAnalysisStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataanalysis/DataAnalysisStoreTest.java
@@ -156,10 +156,7 @@ class DataAnalysisStoreTest extends SingleSetupIntegrationTestBase {
         createDataValue(dataElementA, periodJ, organisationUnitA, "15", categoryOptionCombo));
     List<DataAnalysisMeasures> measures =
         dataAnalysisStore.getDataAnalysisMeasures(
-            dataElementA,
-            Lists.newArrayList(categoryOptionCombo),
-            Lists.newArrayList(organisationUnitA.getPath()),
-            from);
+            dataElementA, Lists.newArrayList(categoryOptionCombo), organisationUnitA, from);
     assertEquals(1, measures.size());
     assertEquals(measures.get(0).getAverage(), DELTA, 12.78);
     assertEquals(measures.get(0).getStandardDeviation(), DELTA, 15.26);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataanalysis/MinMaxOutlierAnalysisServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataanalysis/MinMaxOutlierAnalysisServiceTest.java
@@ -29,19 +29,14 @@ package org.hisp.dhis.dataanalysis;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
-import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.datavalue.DataValueService;
-import org.hisp.dhis.datavalue.DeflatedDataValue;
 import org.hisp.dhis.minmax.MinMaxDataElement;
 import org.hisp.dhis.minmax.MinMaxDataElementService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -74,15 +69,9 @@ class MinMaxOutlierAnalysisServiceTest extends IntegrationTestBase {
 
   private DataElement dataElementD;
 
-  private DataValue dataValueA;
+  private List<DataElement> dataElementsA;
 
-  private DataValue dataValueB;
-
-  private Set<DataElement> dataElementsA = new HashSet<>();
-
-  private Set<DataElement> dataElementsB = new HashSet<>();
-
-  private Set<DataElement> dataElementsC = new HashSet<>();
+  private List<DataElement> dataElementsB;
 
   private CategoryCombo categoryCombo;
 
@@ -112,8 +101,6 @@ class MinMaxOutlierAnalysisServiceTest extends IntegrationTestBase {
 
   private OrganisationUnit organisationUnitA;
 
-  private MinMaxDataElement minMaxDataElement;
-
   // ----------------------------------------------------------------------
   // Fixture
   // ----------------------------------------------------------------------
@@ -129,11 +116,10 @@ class MinMaxOutlierAnalysisServiceTest extends IntegrationTestBase {
     dataElementService.addDataElement(dataElementB);
     dataElementService.addDataElement(dataElementC);
     dataElementService.addDataElement(dataElementD);
-    dataElementsA.add(dataElementA);
-    dataElementsA.add(dataElementB);
-    dataElementsB.add(dataElementC);
-    dataElementsB.add(dataElementD);
-    dataElementsC.add(dataElementB);
+
+    dataElementsA = List.of(dataElementA, dataElementB);
+    dataElementsB = List.of(dataElementC, dataElementD);
+
     periodA = createPeriod(new MonthlyPeriodType(), getDate(2000, 3, 1), getDate(2000, 3, 31));
     periodB = createPeriod(new MonthlyPeriodType(), getDate(2000, 4, 1), getDate(2000, 4, 30));
     periodC = createPeriod(new MonthlyPeriodType(), getDate(2000, 5, 1), getDate(2000, 5, 30));
@@ -144,23 +130,17 @@ class MinMaxOutlierAnalysisServiceTest extends IntegrationTestBase {
     periodH = createPeriod(new MonthlyPeriodType(), getDate(2000, 10, 1), getDate(2000, 10, 30));
     periodI = createPeriod(new MonthlyPeriodType(), getDate(2000, 11, 1), getDate(2000, 11, 30));
     periodJ = createPeriod(new MonthlyPeriodType(), getDate(2000, 12, 1), getDate(2000, 12, 30));
+
     organisationUnitA = createOrganisationUnit('A');
     organisationUnitService.addOrganisationUnit(organisationUnitA);
   }
 
-  // ----------------------------------------------------------------------
-  // Business logic tests
-  // ----------------------------------------------------------------------
   @Test
   void testAnalyse() {
-    dataValueA =
-        createDataValue(dataElementA, periodI, organisationUnitA, "41", categoryOptionCombo);
-    dataValueB =
-        createDataValue(dataElementA, periodJ, organisationUnitA, "-41", categoryOptionCombo);
     dataValueService.addDataValue(
         createDataValue(dataElementA, periodA, organisationUnitA, "5", categoryOptionCombo));
     dataValueService.addDataValue(
-        createDataValue(dataElementA, periodB, organisationUnitA, "-5", categoryOptionCombo));
+        createDataValue(dataElementA, periodB, organisationUnitA, "-50", categoryOptionCombo));
     dataValueService.addDataValue(
         createDataValue(dataElementA, periodC, organisationUnitA, "5", categoryOptionCombo));
     dataValueService.addDataValue(
@@ -173,18 +153,38 @@ class MinMaxOutlierAnalysisServiceTest extends IntegrationTestBase {
         createDataValue(dataElementA, periodG, organisationUnitA, "13", categoryOptionCombo));
     dataValueService.addDataValue(
         createDataValue(dataElementA, periodH, organisationUnitA, "-13", categoryOptionCombo));
-    dataValueService.addDataValue(dataValueA);
-    dataValueService.addDataValue(dataValueB);
-    minMaxDataElement =
-        new MinMaxDataElement(dataElementA, organisationUnitA, categoryOptionCombo, -40, 40, false);
-    minMaxDataElementService.addMinMaxDataElement(minMaxDataElement);
-    List<Period> periods = new ArrayList<>();
-    periods.add(periodI);
-    periods.add(periodJ);
-    periods.add(periodA);
-    periods.add(periodE);
-    List<DeflatedDataValue> result =
-        minMaxOutlierAnalysisService.analyse(organisationUnitA, dataElementsA, periods, null, from);
-    assertEquals(2, result.size());
+    dataValueService.addDataValue(
+        createDataValue(dataElementA, periodI, organisationUnitA, "41", categoryOptionCombo));
+    dataValueService.addDataValue(
+        createDataValue(dataElementA, periodJ, organisationUnitA, "-41", categoryOptionCombo));
+
+    dataValueService.addDataValue(
+        createDataValue(dataElementC, periodA, organisationUnitA, "7", categoryOptionCombo));
+    dataValueService.addDataValue(
+        createDataValue(dataElementC, periodE, organisationUnitA, "15", categoryOptionCombo));
+    dataValueService.addDataValue(
+        createDataValue(dataElementC, periodI, organisationUnitA, "17", categoryOptionCombo));
+    dataValueService.addDataValue(
+        createDataValue(dataElementC, periodJ, organisationUnitA, "23", categoryOptionCombo));
+
+    minMaxDataElementService.addMinMaxDataElement(
+        new MinMaxDataElement(
+            dataElementA, organisationUnitA, categoryOptionCombo, -40, 40, false));
+
+    minMaxDataElementService.addMinMaxDataElement(
+        new MinMaxDataElement(dataElementC, organisationUnitA, categoryOptionCombo, 10, 20, false));
+
+    List<Period> periods = List.of(periodA, periodB, periodE, periodI, periodJ);
+
+    assertEquals(
+        3,
+        minMaxOutlierAnalysisService
+            .analyse(organisationUnitA, dataElementsA, periods, null, from)
+            .size());
+    assertEquals(
+        2,
+        minMaxOutlierAnalysisService
+            .analyse(organisationUnitA, dataElementsB, periods, null, from)
+            .size());
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataanalysis/MinMaxOutlierAnalysisServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataanalysis/MinMaxOutlierAnalysisServiceTest.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.dataanalysis;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
@@ -185,8 +184,7 @@ class MinMaxOutlierAnalysisServiceTest extends IntegrationTestBase {
     periods.add(periodA);
     periods.add(periodE);
     List<DeflatedDataValue> result =
-        minMaxOutlierAnalysisService.analyse(
-            Lists.newArrayList(organisationUnitA), dataElementsA, periods, null, from);
+        minMaxOutlierAnalysisService.analyse(organisationUnitA, dataElementsA, periods, null, from);
     assertEquals(2, result.size());
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataanalysis/MinMaxOutlierAnalysisServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataanalysis/MinMaxOutlierAnalysisServiceTest.java
@@ -37,6 +37,7 @@ import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.datavalue.DataValueService;
+import org.hisp.dhis.datavalue.DeflatedDataValue;
 import org.hisp.dhis.minmax.MinMaxDataElement;
 import org.hisp.dhis.minmax.MinMaxDataElementService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -97,6 +98,8 @@ class MinMaxOutlierAnalysisServiceTest extends IntegrationTestBase {
 
   private Period periodJ;
 
+  private List<Period> periodsA;
+
   private Date from = getDate(1998, 1, 1);
 
   private OrganisationUnit organisationUnitA;
@@ -130,6 +133,8 @@ class MinMaxOutlierAnalysisServiceTest extends IntegrationTestBase {
     periodH = createPeriod(new MonthlyPeriodType(), getDate(2000, 10, 1), getDate(2000, 10, 30));
     periodI = createPeriod(new MonthlyPeriodType(), getDate(2000, 11, 1), getDate(2000, 11, 30));
     periodJ = createPeriod(new MonthlyPeriodType(), getDate(2000, 12, 1), getDate(2000, 12, 30));
+
+    periodsA = List.of(periodA, periodB, periodE, periodI, periodJ);
 
     organisationUnitA = createOrganisationUnit('A');
     organisationUnitService.addOrganisationUnit(organisationUnitA);
@@ -174,17 +179,14 @@ class MinMaxOutlierAnalysisServiceTest extends IntegrationTestBase {
     minMaxDataElementService.addMinMaxDataElement(
         new MinMaxDataElement(dataElementC, organisationUnitA, categoryOptionCombo, 10, 20, false));
 
-    List<Period> periods = List.of(periodA, periodB, periodE, periodI, periodJ);
+    List<DeflatedDataValue> resultA =
+        minMaxOutlierAnalysisService.analyse(
+            organisationUnitA, dataElementsA, periodsA, null, from);
+    List<DeflatedDataValue> resultB =
+        minMaxOutlierAnalysisService.analyse(
+            organisationUnitA, dataElementsB, periodsA, null, from);
 
-    assertEquals(
-        3,
-        minMaxOutlierAnalysisService
-            .analyse(organisationUnitA, dataElementsA, periods, null, from)
-            .size());
-    assertEquals(
-        2,
-        minMaxOutlierAnalysisService
-            .analyse(organisationUnitA, dataElementsB, periods, null, from)
-            .size());
+    assertEquals(3, resultA.size());
+    assertEquals(2, resultB.size());
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataanalysis/StdDevOutlierAnalysisServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataanalysis/StdDevOutlierAnalysisServiceTest.java
@@ -31,7 +31,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
@@ -186,7 +185,7 @@ class StdDevOutlierAnalysisServiceTest extends SingleSetupIntegrationTestBase {
     periods.add(periodE);
     List<DeflatedDataValue> values =
         stdDevOutlierAnalysisService.analyse(
-            Lists.newArrayList(organisationUnitA), dataElementsA, periods, stdDevFactor, from);
+            organisationUnitA, dataElementsA, periods, stdDevFactor, from);
     DeflatedDataValue valueA = new DeflatedDataValue(dataValueA);
     DeflatedDataValue valueB = new DeflatedDataValue(dataValueB);
     assertEquals(1, values.size());

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataAnalysisController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataAnalysisController.java
@@ -33,7 +33,6 @@ import static org.hisp.dhis.system.util.CodecUtils.filenameEncode;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -290,7 +289,7 @@ public class DataAnalysisController {
     List<DeflatedDataValue> dataValues =
         new ArrayList<>(
             stdDevOutlierAnalysisService.analyse(
-                Sets.newHashSet(organisationUnit),
+                organisationUnit,
                 dataElements,
                 periods,
                 stdDevOutlierAnalysisParams.getStandardDeviation(),
@@ -345,7 +344,7 @@ public class DataAnalysisController {
     List<DeflatedDataValue> dataValues =
         new ArrayList<>(
             minMaxOutlierAnalysisService.analyse(
-                Sets.newHashSet(organisationUnit), dataElements, periods, null, from));
+                organisationUnit, dataElements, periods, null, from));
 
     session.setAttribute(KEY_ANALYSIS_DATA_VALUES, dataValues);
     session.setAttribute(KEY_ORG_UNIT, organisationUnit);
@@ -379,10 +378,7 @@ public class DataAnalysisController {
     List<DeflatedDataValue> dataValues =
         new ArrayList<>(
             followupAnalysisService.getFollowupDataValues(
-                Sets.newHashSet(organisationUnit),
-                dataElements,
-                periods,
-                DataAnalysisService.MAX_OUTLIERS + 1));
+                organisationUnit, dataElements, periods, DataAnalysisService.MAX_OUTLIERS + 1));
     // +1 to detect overflow
 
     session.setAttribute(KEY_ANALYSIS_DATA_VALUES, dataValues);

--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/java/org/hisp/dhis/de/action/ValidationAction.java
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/java/org/hisp/dhis/de/action/ValidationAction.java
@@ -27,10 +27,12 @@
  */
 package org.hisp.dhis.de.action;
 
-import com.google.common.collect.Sets;
-import com.opensymphony.xwork2.Action;
-import java.util.*;
-import lombok.extern.slf4j.Slf4j;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.dataanalysis.DataAnalysisService;
@@ -50,6 +52,9 @@ import org.hisp.dhis.validation.ValidationResult;
 import org.hisp.dhis.validation.ValidationService;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
+import com.google.common.collect.Sets;
+import com.opensymphony.xwork2.Action;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Margrethe Store
@@ -213,7 +218,7 @@ public class ValidationAction implements Action {
       List<DeflatedDataValue> values =
           new ArrayList<>(
               minMaxOutlierAnalysisService.analyse(
-                  Sets.newHashSet(organisationUnit),
+                  organisationUnit,
                   dataSet.getDataElements(),
                   Sets.newHashSet(period),
                   null,

--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/java/org/hisp/dhis/de/action/ValidationAction.java
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/java/org/hisp/dhis/de/action/ValidationAction.java
@@ -27,12 +27,15 @@
  */
 package org.hisp.dhis.de.action;
 
+import com.google.common.collect.Sets;
+import com.opensymphony.xwork2.Action;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.dataanalysis.DataAnalysisService;
@@ -52,9 +55,6 @@ import org.hisp.dhis.validation.ValidationResult;
 import org.hisp.dhis.validation.ValidationService;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
-import com.google.common.collect.Sets;
-import com.opensymphony.xwork2.Action;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Margrethe Store


### PR DESCRIPTION
This PR is about the min max value validation service used by the data entry app. The SQL query produced by the validation can be improved in terms of performance.

The query filters by the path column of organisation unit, which makes the query slow. The validation is always done for a single org unit, also not including the org unit sub-hierarchy. This means that the query can filter directly on the org unit ID, which is much faster.