### PR TITLE
fix: FollowUp is not persisted in programStageWorkingListFilters

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programstageworkinglist/ProgramStageQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programstageworkinglist/ProgramStageQueryCriteria.java
@@ -102,5 +102,5 @@ public class ProgramStageQueryCriteria implements Serializable {
   private List<AttributeValueFilter> attributeValueFilters = Collections.emptyList();
 
   /** Property to filter events based on {@link org.hisp.dhis.program.Enrollment#followup property */
-  @JsonProperty private boolean followup;
+  @JsonProperty private boolean followUp;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programstageworkinglist/ProgramStageQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programstageworkinglist/ProgramStageQueryCriteria.java
@@ -100,4 +100,7 @@ public class ProgramStageQueryCriteria implements Serializable {
   /** Property to filter tracked entity instances based on tracked entity attribute values */
   @JsonProperty @Builder.Default
   private List<AttributeValueFilter> attributeValueFilters = Collections.emptyList();
+
+  /** Property to filter events based on {@link org.hisp.dhis.program.Enrollment#followup property */
+  @JsonProperty private boolean followup;
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/JsonDatePeriod.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/JsonDatePeriod.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.programstageworkinglist;
+
+import org.hisp.dhis.jsontree.JsonObject;
+
+/** Representation of {@link org.hisp.dhis.programstageworkinglist.ProgramStageWorkingList}. */
+public interface JsonDatePeriod extends JsonObject {
+
+  default String getType() {
+    return getString("type").string();
+  }
+
+  default String getPeriod() {
+    return getString("period").string();
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/JsonProgramStageQueryCriteria.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/JsonProgramStageQueryCriteria.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.programstageworkinglist;
+
+import org.hisp.dhis.jsontree.JsonArray;
+import org.hisp.dhis.jsontree.JsonObject;
+
+/** Representation of {@link org.hisp.dhis.programstageworkinglist.ProgramStageQueryCriteria}. */
+public interface JsonProgramStageQueryCriteria extends JsonObject {
+
+  default String getEnrollmentStatus() {
+    return getString("enrollmentStatus").string();
+  }
+
+  default String getOrder() {
+    return getString("order").string();
+  }
+
+  default JsonArray getDisplayColumnOrder() {
+    return getArray("displayColumnOrder");
+  }
+
+  default JsonDatePeriod getEventOccurredAt() {
+    return get("eventOccurredAt").as(JsonDatePeriod.class);
+  }
+
+  default boolean getFollowUp() {
+    return getBoolean("followup").booleanValue();
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/JsonProgramStageQueryCriteria.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/JsonProgramStageQueryCriteria.java
@@ -50,6 +50,6 @@ public interface JsonProgramStageQueryCriteria extends JsonObject {
   }
 
   default boolean getFollowUp() {
-    return getBoolean("followup").booleanValue();
+    return getBoolean("followUp").booleanValue();
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/JsonWorkingList.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/JsonWorkingList.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.programstageworkinglist;
+
+import org.hisp.dhis.jsontree.JsonObject;
+
+/** Representation of {@link org.hisp.dhis.programstageworkinglist.ProgramStageWorkingList}. */
+public interface JsonWorkingList extends JsonObject {
+  default String getProgram() {
+    return get("program").asObject().getString("id").string();
+  }
+
+  default String getProgramStage() {
+    return get("programStage").asObject().getString("id").string();
+  }
+
+  default JsonProgramStageQueryCriteria getProgramStageQueryCriteria() {
+    return get("programStageQueryCriteria").as(JsonProgramStageQueryCriteria.class);
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/ProgramStageWorkingListControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/ProgramStageWorkingListControllerTest.java
@@ -263,33 +263,32 @@ class ProgramStageWorkingListControllerTest extends DhisControllerConvenienceTes
 
   @Test
   void shouldCreateWorkingListWithProgramStageQueryCriteria() {
-
     String workingListJson =
         assertStatus(
             HttpStatus.CREATED,
             POST(
                 "/programStageWorkingLists",
                 """
-         {
-         'program': {'id': '%s'},
-         'programStage': {'id': '%s'},
-         'name':'workingListName',
-         'programStageQueryCriteria': {
-           "displayColumnOrder": [
-             "w75KJ2mc4zz",
-             "zDhUuAYrxNC",
-             "APtutTb0nOY"
-           ],
-           'order': 'createdAt:desc',
-           'enrollmentStatus': 'ACTIVE',
-           'followup': 'true',
-           'eventOccurredAt': {
-             'type': 'RELATIVE',
-             'period': 'TODAY'
-           }
-         }
-        }
-        """
+               {
+               'program': {'id': '%s'},
+               'programStage': {'id': '%s'},
+               'name':'workingListName',
+               'programStageQueryCriteria': {
+                 "displayColumnOrder": [
+                   "w75KJ2mc4zz",
+                   "zDhUuAYrxNC",
+                   "APtutTb0nOY"
+                 ],
+                 'order': 'createdAt:desc',
+                 'enrollmentStatus': 'ACTIVE',
+                 'followUp': 'true',
+                 'eventOccurredAt': {
+                   'type': 'RELATIVE',
+                   'period': 'TODAY'
+                 }
+               }
+              }
+              """
                     .formatted(programId, programStageId)));
 
     JsonWorkingList workingList =

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/ProgramStageWorkingListControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/ProgramStageWorkingListControllerTest.java
@@ -292,16 +292,16 @@ class ProgramStageWorkingListControllerTest extends DhisControllerConvenienceTes
         """
                     .formatted(programId, programStageId)));
 
-    JsonWorkingList response =
+    JsonWorkingList workingList =
         GET("/programStageWorkingLists/{id}", workingListJson).content().as(JsonWorkingList.class);
 
-    assertFalse(response.isEmpty());
+    assertFalse(workingList.isEmpty());
 
-    assertEquals(programId, response.getProgram());
-    assertEquals(programStageId, response.getProgramStage());
+    assertEquals(programId, workingList.getProgram());
+    assertEquals(programStageId, workingList.getProgramStage());
 
     JsonProgramStageQueryCriteria programStageQueryCriteria =
-        response.getProgramStageQueryCriteria();
+        workingList.getProgramStageQueryCriteria();
 
     assertFalse(programStageQueryCriteria.isEmpty());
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/ProgramStageWorkingListControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/programstageworkinglist/ProgramStageWorkingListControllerTest.java
@@ -270,24 +270,24 @@ class ProgramStageWorkingListControllerTest extends DhisControllerConvenienceTes
                 "/programStageWorkingLists",
                 """
                {
-               'program': {'id': '%s'},
-               'programStage': {'id': '%s'},
-               'name':'workingListName',
-               'programStageQueryCriteria': {
-                 "displayColumnOrder": [
-                   "w75KJ2mc4zz",
-                   "zDhUuAYrxNC",
-                   "APtutTb0nOY"
-                 ],
-                 'order': 'createdAt:desc',
-                 'enrollmentStatus': 'ACTIVE',
-                 'followUp': 'true',
-                 'eventOccurredAt': {
-                   'type': 'RELATIVE',
-                   'period': 'TODAY'
-                 }
-               }
-              }
+                 'program': {'id': '%s'},
+                 'programStage': {'id': '%s'},
+                 'name':'workingListName',
+                 'programStageQueryCriteria': {
+                   "displayColumnOrder": [
+                     "w75KJ2mc4zz",
+                     "zDhUuAYrxNC",
+                     "APtutTb0nOY"
+                   ],
+                   'order': 'createdAt:desc',
+                   'enrollmentStatus': 'ACTIVE',
+                   'followUp': 'true',
+                   'eventOccurredAt': {
+                     'type': 'RELATIVE',
+                     'period': 'TODAY'
+                    }
+                  }
+                }
               """
                     .formatted(programId, programStageId)));
 
@@ -326,9 +326,9 @@ class ProgramStageWorkingListControllerTest extends DhisControllerConvenienceTes
             "/programStageWorkingLists",
             """
                 {
-                'program': {'id': '%s'},
-                'programStage': {'id': '%s'},
-                'name':'%s'
+                  'program': {'id': '%s'},
+                  'programStage': {'id': '%s'},
+                  'name':'%s'
                 }
               """
                 .formatted(programId, programStageId, workingListName)));


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-16738

With program stage working list we can define a `programStageQueryCriteria`, for example;
```
{
  "name": "test",
  "program": {
    "id": "IpHINAT79UW"
  },
  "programStage": {
    "id": "A03MvHHogjR"
  },
  "programStageQueryCriteria": {
    "displayColumnOrder": [
      "w75KJ2mc4zz",
      "zDhUuAYrxNC",
      "APtutTb0nOY"
    ],
    "order": "createdAt:desc",
    "enrollmentStatus": "ACTIVE",
    "followUp": "true",
    "eventOccurredAt": {
      "type": "RELATIVE",
      "period": "TODAY"
    },
    "attributeValueFilters": [],
    "dataFilters": []
  }
}
```
In the capture app, we can then convert the `programStageQueryCriteria` filters to an API call to filter, for example, a tracked entity list.
The `followUp` filter is currently missing, and we have fixed it with this PR. This is the API parameter for the [request](https://github.com/dhis2/dhis2-core/blob/cf8a3809d42893f9bcdca782c92acbb818ed254a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParams.java#L136), although does not reflect the class [property](https://github.com/dhis2/dhis2-core/blob/cf8a3809d42893f9bcdca782c92acbb818ed254a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Enrollment.java#L90) 
