### PR TITLE
feat: add tracker endpoint to download data element image DHIS2-16696

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
@@ -131,6 +131,9 @@ public interface FileResourceService {
   byte[] copyFileResourceContent(FileResource fileResource)
       throws IOException, NoSuchElementException;
 
+  /** Copy file content of file stored under given storage {@code key} to a byte array. */
+  byte[] copyFileResourceContent(String key) throws IOException, NoSuchElementException;
+
   /** Opens a stream to the file resource content. */
   InputStream openContentStream(FileResource fileResource)
       throws IOException, NoSuchElementException;
@@ -142,7 +145,7 @@ public interface FileResourceService {
    * @param dimension the dimension of the image to open
    * @return the stream to the image
    * @throws BadRequestException when the file resource is not an image, does not support multiple
-   *     dimensions or does not have multiple dimensions files stored
+   *     dimensions or does not have multiple dimension files stored
    */
   InputStream openContentStreamToImage(FileResource fileResource, ImageFileDimension dimension)
       throws IOException, NoSuchElementException, BadRequestException;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
@@ -131,8 +131,17 @@ public interface FileResourceService {
   byte[] copyFileResourceContent(FileResource fileResource)
       throws IOException, NoSuchElementException;
 
-  /** Copy file content of file stored under given storage {@code key} to a byte array. */
-  byte[] copyFileResourceContent(String key) throws IOException, NoSuchElementException;
+  /**
+   * Copies the file resource content of an image of the given dimension. Copies the image in its
+   * original dimensions if the given {@code dimension} is {@code null}.
+   *
+   * @param dimension the dimension of the image to copy
+   * @return image bytes
+   * @throws BadRequestException when the file resource is not an image, does not support multiple
+   *     dimensions or does not have multiple dimension files stored
+   */
+  byte[] copyImageContent(FileResource fileResource, ImageFileDimension dimension)
+      throws BadRequestException, IOException;
 
   /** Opens a stream to the file resource content. */
   InputStream openContentStream(FileResource fileResource)

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
@@ -37,6 +37,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.NotFoundException;
 
@@ -133,6 +134,18 @@ public interface FileResourceService {
   /** Opens a stream to the file resource content. */
   InputStream openContentStream(FileResource fileResource)
       throws IOException, NoSuchElementException;
+
+  /**
+   * Opens a stream to the file resource content of an image of the given dimension. Returns the
+   * image in its original dimensions if the given {@code dimension} is {@code null}.
+   *
+   * @param dimension the dimension of the image to open
+   * @return the stream to the image
+   * @throws BadRequestException when the file resource is not an image, does not support multiple
+   *     dimensions or does not have multiple dimensions files stored
+   */
+  InputStream openContentStreamToImage(FileResource fileResource, ImageFileDimension dimension)
+      throws IOException, NoSuchElementException, BadRequestException;
 
   boolean fileResourceExists(String uid);
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/DefaultFileResourceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/DefaultFileResourceService.java
@@ -42,7 +42,9 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.NotFoundException;
@@ -52,6 +54,7 @@ import org.hisp.dhis.fileresource.events.FileSavedEvent;
 import org.hisp.dhis.fileresource.events.ImageFileSavedEvent;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.user.CurrentUserUtil;
+import org.hisp.dhis.util.ObjectUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.Hours;
@@ -183,8 +186,7 @@ public class DefaultFileResourceService implements FileResourceService {
     fileResourceStore.save(fileResource);
     entityManager.flush();
 
-    if (FileResource.isImage(fileResource.getContentType())
-        && FileResourceDomain.isDomainForMultipleImages(fileResource.getDomain())) {
+    if (hasMultiDimensionImageSupport(fileResource)) {
       Map<ImageFileDimension, File> imageFiles =
           imageProcessingService.createImages(fileResource, file);
 
@@ -293,6 +295,31 @@ public class DefaultFileResourceService implements FileResourceService {
   public InputStream openContentStream(FileResource fileResource)
       throws IOException, NoSuchElementException {
     return fileResourceContentStore.openStream(fileResource.getStorageKey());
+  }
+
+  @Override
+  public InputStream openContentStreamToImage(
+      FileResource fileResource, ImageFileDimension dimension)
+      throws IOException, NoSuchElementException, BadRequestException {
+    if (!hasMultiDimensionImageSupport(fileResource)) {
+      throw new BadRequestException(
+          "File is not an image or does not have support for multiple dimensions");
+    }
+
+    ImageFileDimension imageDimension =
+        ObjectUtils.firstNonNull(dimension, ImageFileDimension.ORIGINAL);
+    if (imageDimension != ImageFileDimension.ORIGINAL
+        && !fileResource.isHasMultipleStorageFiles()) {
+      throw new BadRequestException("Image is not stored using multiple dimensions");
+    }
+
+    String key = StringUtils.join(fileResource.getStorageKey(), imageDimension.getDimension());
+    return fileResourceContentStore.openStream(key);
+  }
+
+  private static boolean hasMultiDimensionImageSupport(FileResource fileResource) {
+    return FileResource.isImage(fileResource.getContentType())
+        && FileResourceDomain.isDomainForMultipleImages(fileResource.getDomain());
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/DefaultFileResourceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/DefaultFileResourceService.java
@@ -288,7 +288,12 @@ public class DefaultFileResourceService implements FileResourceService {
   @Override
   public byte[] copyFileResourceContent(FileResource fileResource)
       throws IOException, NoSuchElementException {
-    return fileResourceContentStore.copyContent(fileResource.getStorageKey());
+    return this.copyFileResourceContent(fileResource.getStorageKey());
+  }
+
+  @Override
+  public byte[] copyFileResourceContent(String key) throws IOException, NoSuchElementException {
+    return fileResourceContentStore.copyContent(key);
   }
 
   @Override
@@ -301,13 +306,17 @@ public class DefaultFileResourceService implements FileResourceService {
   public InputStream openContentStreamToImage(
       FileResource fileResource, ImageFileDimension dimension)
       throws IOException, NoSuchElementException, BadRequestException {
-    if (!hasMultiDimensionImageSupport(fileResource)) {
-      throw new BadRequestException(
-          "File is not an image or does not have support for multiple dimensions");
+    if (!FileResource.isImage(fileResource.getContentType())) {
+      throw new BadRequestException("File is not an image");
     }
 
     ImageFileDimension imageDimension =
         ObjectUtils.firstNonNull(dimension, ImageFileDimension.ORIGINAL);
+    if (imageDimension != ImageFileDimension.ORIGINAL
+        && !hasMultiDimensionImageSupport(fileResource)) {
+      throw new BadRequestException("Image does not have support for multiple dimensions");
+    }
+
     if (imageDimension != ImageFileDimension.ORIGINAL
         && !fileResource.isHasMultipleStorageFiles()) {
       throw new BadRequestException("Image is not stored using multiple dimensions");

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/FileResourceStream.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/FileResourceStream.java
@@ -29,11 +29,10 @@ package org.hisp.dhis.tracker.export;
 
 import java.io.InputStream;
 import org.hisp.dhis.fileresource.FileResource;
-import org.hisp.dhis.util.ConflictExceptionSupplier;
 
 /**
  * FileResourceStream holds a file resource and a supplier to open an input stream to the file
  * resource content if needed.
  */
 public record FileResourceStream(
-    FileResource fileResource, ConflictExceptionSupplier<InputStream> inputStream) {}
+    FileResource fileResource, FileResourceSupplier<InputStream> inputStream) {}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/FileResourceStream.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/FileResourceStream.java
@@ -28,11 +28,20 @@
 package org.hisp.dhis.tracker.export;
 
 import java.io.InputStream;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.hisp.dhis.fileresource.FileResource;
 
 /**
  * FileResourceStream holds a file resource and a supplier to open an input stream to the file
  * resource content if needed.
  */
-public record FileResourceStream(
-    FileResource fileResource, FileResourceSupplier<InputStream> inputStream) {}
+@Getter
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class FileResourceStream {
+  private final FileResource fileResource;
+  @Setter private FileResourceSupplier<InputStream> inputStreamSupplier;
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/FileResourceSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/FileResourceSupplier.java
@@ -30,10 +30,6 @@ package org.hisp.dhis.tracker.export;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ConflictException;
 
-/**
- * Use instead of {@link java.util.function.Supplier} when you need to throw a {@link
- * ConflictException} as checked exceptions cannot be thrown from lambdas.
- */
 @FunctionalInterface
 public interface FileResourceSupplier<T> {
   T get() throws ConflictException, BadRequestException;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/FileResourceSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/FileResourceSupplier.java
@@ -25,8 +25,9 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.util;
+package org.hisp.dhis.tracker.export;
 
+import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ConflictException;
 
 /**
@@ -34,6 +35,6 @@ import org.hisp.dhis.feedback.ConflictException;
  * ConflictException} as checked exceptions cannot be thrown from lambdas.
  */
 @FunctionalInterface
-public interface ConflictExceptionSupplier<T> {
-  T get() throws ConflictException;
+public interface FileResourceSupplier<T> {
+  T get() throws ConflictException, BadRequestException;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.export.event;
 
+import com.google.common.hash.Hashing;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
@@ -35,6 +36,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
@@ -57,6 +59,7 @@ import org.hisp.dhis.tracker.export.PageParams;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.util.ObjectUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -110,8 +113,37 @@ class DefaultEventService implements EventService {
 
   @Override
   public FileResourceStream getFileResourceImage(
-      UID eventUid, UID dataElementUid, ImageFileDimension dimension) throws NotFoundException {
+      UID eventUid, UID dataElementUid, ImageFileDimension dimension)
+      throws NotFoundException, ConflictException {
     FileResource fileResource = getFileResourceMetadata(eventUid, dataElementUid);
+
+    ImageFileDimension imageDimension =
+        ObjectUtils.firstNonNull(dimension, ImageFileDimension.ORIGINAL);
+
+    // The FileResource only stores the storageKey, contentLength and md5Hash of the original image.
+    // At least for now we are losing the benefit of not fetching the file from storage if the
+    // client already has an up-to-date version of the image in the given dimension other than the
+    // original. We have to fetch and compute the length and hash of the image again.
+    if (imageDimension != ImageFileDimension.ORIGINAL) {
+      byte[] content;
+      try {
+        String key = StringUtils.join(fileResource.getStorageKey(), imageDimension.getDimension());
+        content = fileResourceService.copyFileResourceContent(key);
+      } catch (NoSuchElementException e) {
+        // Note: we are assuming that the file resource is not available yet. The same approach
+        // is taken in other file endpoints or code relying on the storageStatus = PENDING.
+        // All we know for sure is the file resource is in the DB but not in the store.
+        throw new ConflictException(
+            "The content is being processed and is not available yet. Try again later.");
+      } catch (IOException e) {
+        throw new ConflictException(
+            "Failed fetching the file from storage",
+            "There was an exception when trying to fetch the file from the storage backend. "
+                + "Depending on the provider the root cause could be network or file system related.");
+      }
+      fileResource.setContentLength(content.length);
+      fileResource.setContentMd5(Hashing.md5().hashBytes(content).toString());
+    }
 
     return new FileResourceStream(
         fileResource,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fileresource.ImageFileDimension;
@@ -48,7 +49,7 @@ public interface EventService {
 
   /** Get an image for an events' data element in the given dimension. */
   FileResourceStream getFileResourceImage(UID event, UID dataElement, ImageFileDimension dimension)
-      throws NotFoundException;
+      throws NotFoundException, ConflictException;
 
   /** Get event matching given {@code UID} and params. */
   Event getEvent(String uid, EventParams eventParams) throws NotFoundException, ForbiddenException;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
@@ -49,7 +49,7 @@ public interface EventService {
 
   /** Get an image for an events' data element in the given dimension. */
   FileResourceStream getFileResourceImage(UID event, UID dataElement, ImageFileDimension dimension)
-      throws NotFoundException, ConflictException;
+      throws NotFoundException, ConflictException, BadRequestException;
 
   /** Get event matching given {@code UID} and params. */
   Event getEvent(String uid, EventParams eventParams) throws NotFoundException, ForbiddenException;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
@@ -31,9 +31,9 @@ import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
-import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
+import org.hisp.dhis.fileresource.ImageFileDimension;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.tracker.export.FileResourceStream;
 import org.hisp.dhis.tracker.export.Page;
@@ -44,8 +44,11 @@ import org.hisp.dhis.tracker.export.PageParams;
  */
 public interface EventService {
   /** Get a file for an events' data element. */
-  FileResourceStream getFileResource(UID event, UID dataElement)
-      throws NotFoundException, ConflictException;
+  FileResourceStream getFileResource(UID event, UID dataElement) throws NotFoundException;
+
+  /** Get an image for an events' data element in the given dimension. */
+  FileResourceStream getFileResourceImage(UID event, UID dataElement, ImageFileDimension dimension)
+      throws NotFoundException;
 
   /** Get event matching given {@code UID} and params. */
   Event getEvent(String uid, EventParams eventParams) throws NotFoundException, ForbiddenException;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerByIdTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerByIdTest.java
@@ -36,8 +36,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.common.hash.HashCode;
+import com.google.common.hash.Hashing;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -46,8 +53,10 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.fileresource.FileResource;
+import org.hisp.dhis.fileresource.FileResourceContentStore;
 import org.hisp.dhis.fileresource.FileResourceService;
 import org.hisp.dhis.fileresource.FileResourceStorageStatus;
+import org.hisp.dhis.fileresource.ImageFileDimension;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.note.Note;
@@ -76,6 +85,7 @@ import org.hisp.dhis.webapi.controller.tracker.JsonRelationship;
 import org.hisp.dhis.webapi.controller.tracker.JsonRelationshipItem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class EventsExportControllerByIdTest extends DhisControllerConvenienceTest {
@@ -84,6 +94,8 @@ class EventsExportControllerByIdTest extends DhisControllerConvenienceTest {
   @Autowired private IdentifiableObjectManager manager;
 
   @Autowired private FileResourceService fileResourceService;
+
+  @Autowired private FileResourceContentStore fileResourceContentStore;
 
   private OrganisationUnit orgUnit;
 
@@ -536,13 +548,68 @@ class EventsExportControllerByIdTest extends DhisControllerConvenienceTest {
             event.getUid(),
             de.getUid());
 
-    // TODO check original dimension
     assertEquals(HttpStatus.OK, response.status());
     assertEquals("\"" + file.getContentMd5() + "\"", response.header("Etag"));
     assertEquals("max-age=0, must-revalidate, private", response.header("Cache-Control"));
     assertEquals("attachment; filename=" + file.getName(), response.header("Content-Disposition"));
     assertEquals(Long.toString(file.getContentLength()), response.header("Content-Length"));
     assertEquals("file content", response.content("image/png"));
+  }
+
+  @Test
+  void getDataValuesImageByDataElementUsingAnotherDimension(@TempDir Path tempDir)
+      throws ConflictException, IOException {
+    Event event = event(enrollment(trackedEntity()));
+    DataElement de = dataElement(ValueType.IMAGE);
+    // simulating the work of the ImageResizingJob
+    // original "image"
+    FileResource file = storeFile("image/png", "original image");
+    file.setHasMultipleStorageFiles(true);
+    manager.update(file);
+    // small "image"
+    Path smallImage = tempDir.resolve("small.png");
+    String smallFileContent = "small file";
+    Files.writeString(smallImage, smallFileContent);
+    fileResourceContentStore.saveFileResourceContent(
+        file, Map.of(ImageFileDimension.SMALL, smallImage.toFile()));
+
+    event.getEventDataValues().add(dataValue(de, file.getUid()));
+    manager.update(event);
+
+    HttpResponse response =
+        GET(
+            "/tracker/events/{eventUid}/dataValues/{dataElementUid}/image?dimension=small",
+            event.getUid(),
+            de.getUid());
+
+    assertEquals(HttpStatus.OK, response.status());
+    HashCode expectedHashCode = Hashing.md5().hashString(smallFileContent, StandardCharsets.UTF_8);
+    assertEquals("\"" + expectedHashCode + "\"", response.header("Etag"));
+    assertEquals("max-age=0, must-revalidate, private", response.header("Cache-Control"));
+    assertEquals("attachment; filename=" + file.getName(), response.header("Content-Disposition"));
+    assertEquals(
+        Long.toString(smallFileContent.getBytes().length), response.header("Content-Length"));
+    assertEquals(smallFileContent, response.content("image/png"));
+  }
+
+  @Test
+  void getDataValuesImageByDataElementWithInvalidDimension() throws ConflictException {
+    Event event = event(enrollment(trackedEntity()));
+    DataElement de = dataElement(ValueType.IMAGE);
+    FileResource file = storeFile("image/png", "file content");
+
+    event.getEventDataValues().add(dataValue(de, file.getUid()));
+    manager.update(event);
+
+    String message =
+        GET(
+                "/tracker/events/{eventUid}/dataValues/{dataElementUid}/image?dimension=tiny",
+                event.getUid(),
+                de.getUid())
+            .error(HttpStatus.BAD_REQUEST)
+            .getMessage();
+
+    assertStartsWith("Value 'tiny' is not valid", message);
   }
 
   @Test
@@ -554,8 +621,46 @@ class EventsExportControllerByIdTest extends DhisControllerConvenienceTest {
     event.getEventDataValues().add(dataValue(de, file.getUid()));
     manager.update(event);
 
-    GET("/tracker/events/{eventUid}/dataValues/{dataElementUid}/image", event.getUid(), de.getUid())
-        .error(HttpStatus.BAD_REQUEST);
+    String message =
+        GET(
+                "/tracker/events/{eventUid}/dataValues/{dataElementUid}/image",
+                event.getUid(),
+                de.getUid())
+            .error(HttpStatus.BAD_REQUEST)
+            .getMessage();
+
+    assertStartsWith("File is not an image", message);
+  }
+
+  @Test
+  void getDataValuesImageByDataElementUsingAnotherDimensionIfDoesNotHaveMultipleStoredFiles(
+      @TempDir Path tempDir) throws ConflictException, IOException {
+    Event event = event(enrollment(trackedEntity()));
+    DataElement de = dataElement(ValueType.IMAGE);
+    // simulating the work of the ImageResizingJob
+    // original "image"
+    FileResource file = storeFile("image/png", "original image");
+    file.setHasMultipleStorageFiles(false);
+    manager.update(file);
+    // small "image"
+    Path smallImage = tempDir.resolve("small.png");
+    String smallFileContent = "small file";
+    Files.writeString(smallImage, smallFileContent);
+    fileResourceContentStore.saveFileResourceContent(
+        file, Map.of(ImageFileDimension.SMALL, smallImage.toFile()));
+
+    event.getEventDataValues().add(dataValue(de, file.getUid()));
+    manager.update(event);
+
+    String message =
+        GET(
+                "/tracker/events/{eventUid}/dataValues/{dataElementUid}/image?dimension=small",
+                event.getUid(),
+                de.getUid())
+            .error(HttpStatus.BAD_REQUEST)
+            .getMessage();
+
+    assertStartsWith("Image is not stored using multiple dimensions", message);
   }
 
   private FileResource storeFile(String contentType, String content) throws ConflictException {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -61,6 +61,7 @@ import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.fileresource.FileResource;
+import org.hisp.dhis.fileresource.ImageFileDimension;
 import org.hisp.dhis.tracker.export.FileResourceStream;
 import org.hisp.dhis.tracker.export.PageParams;
 import org.hisp.dhis.tracker.export.event.EventOperationParams;
@@ -294,8 +295,25 @@ class EventsExportController {
       @OpenApi.Param({UID.class, Event.class}) @PathVariable UID event,
       @OpenApi.Param({UID.class, DataElement.class}) @PathVariable UID dataElement,
       HttpServletRequest request)
-      throws NotFoundException, ConflictException {
-    FileResourceStream file = eventService.getFileResource(event, dataElement);
+      throws NotFoundException, ConflictException, BadRequestException {
+    return handleFileRequest(request, eventService.getFileResource(event, dataElement));
+  }
+
+  // TODO set / document the default dimension
+  @GetMapping("/{event}/dataValues/{dataElement}/image")
+  ResponseEntity<InputStreamResource> getEventDataValueImage(
+      @OpenApi.Param({UID.class, Event.class}) @PathVariable UID event,
+      @OpenApi.Param({UID.class, DataElement.class}) @PathVariable UID dataElement,
+      @RequestParam(required = false) ImageFileDimension dimension,
+      HttpServletRequest request)
+      throws NotFoundException, ConflictException, BadRequestException {
+    return handleFileRequest(
+        request, eventService.getFileResourceImage(event, dataElement, dimension));
+  }
+
+  private static ResponseEntity<InputStreamResource> handleFileRequest(
+      HttpServletRequest request, FileResourceStream file)
+      throws ConflictException, BadRequestException {
     FileResource fileResource = file.fileResource();
 
     final String etag = fileResource.getContentMd5();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -313,7 +313,7 @@ class EventsExportController {
   private static ResponseEntity<InputStreamResource> handleFileRequest(
       HttpServletRequest request, FileResourceStream file)
       throws ConflictException, BadRequestException {
-    FileResource fileResource = file.fileResource();
+    FileResource fileResource = file.getFileResource();
 
     final String etag = fileResource.getContentMd5();
     if (ResponseEntityUtils.checkNotModified(etag, request)) {
@@ -331,7 +331,7 @@ class EventsExportController {
         .header(
             HttpHeaders.CONTENT_DISPOSITION,
             getContentDispositionHeaderValue(fileResource.getName()))
-        .body(new InputStreamResource(file.inputStream().get()));
+        .body(new InputStreamResource(file.getInputStreamSupplier().get()));
   }
 
   private static String getContentDispositionHeaderValue(String filename) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -299,7 +299,6 @@ class EventsExportController {
     return handleFileRequest(request, eventService.getFileResource(event, dataElement));
   }
 
-  // TODO set / document the default dimension
   @GetMapping("/{event}/dataValues/{dataElement}/image")
   ResponseEntity<InputStreamResource> getEventDataValueImage(
       @OpenApi.Param({UID.class, Event.class}) @PathVariable UID event,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/ExcludableShallowEtagHeaderFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/ExcludableShallowEtagHeaderFilter.java
@@ -84,7 +84,7 @@ public class ExcludableShallowEtagHeaderFilter extends ShallowEtagHeaderFilter {
           + UID_REGEXP
           + "/dataValues/"
           + UID_REGEXP
-          + "/file";
+          + "/(file|image)";
 
   private Pattern pattern = null;
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/filter/ExcludableShallowEtagHeaderFilterTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/filter/ExcludableShallowEtagHeaderFilterTest.java
@@ -66,6 +66,8 @@ class ExcludableShallowEtagHeaderFilterTest {
         "/api/41/dataValues",
         "/api/tracker/events/RkV9CZzmV2E/dataValues/q33Wv8jNvFA/file",
         "/api/41/tracker/events/RkV9CZzmV2E/dataValues/q33Wv8jNvFA/file",
+        "/api/tracker/events/RkV9CZzmV2E/dataValues/q33Wv8jNvFA/image",
+        "/api/41/tracker/events/RkV9CZzmV2E/dataValues/q33Wv8jNvFA/image",
       })
   void shouldNotAddEtagHeader(String URI) throws Exception {
     final MockHttpServletRequest request = new MockHttpServletRequest("GET", URI);


### PR DESCRIPTION
Add `GET "/{event}/dataValues/{dataElement}/image"`

Building on https://github.com/dhis2/dhis2-core/pull/16446.

Other image controller methods use [FileResourceUtils.setImageFileDimensions](https://github.com/dhis2/dhis2-core/blob/4506e935a5b5414b0ec79cd7f27c09da682a9d45/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FileResourceUtils.java#L139-L148) to support image download given a dimension.

It works by
* validating the file resource supports multiple dimensions without letting the user know it does not
* mutating the `FileResource.storageKey` to point to the file of the given dimension (`storageKey` of original image +`dimension`)

Created an image specific method in the `FileResourceService` to support the above. Differences are
* validate and throw instead of returning the file in the original dimension. We should always fail early and not pretend the request could be fulfilled while assuming the user is ok with us returning the original in this case
* compute the correct storage key without mutating the actual `FileResource`
* method is null-safe in that null leads to the original being returned

## Future Improvements

**One caveat** is that we only store the original files contentLength and md5 hash. This means we have to fetch the image for requests with a `dimension` other than original. Even if the client has an up-to-date image in its cache.

We are planning improvements to the way we serve files. We should include improvements to handling images of different dimensions.

## Github Code Smells

Github mentions md5 being deprecated which is correct. We have to still use it as it's used to store a hash of files/images in `FileResource`.