### PR TITLE
fix: Add variable support for job progress log messages

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
@@ -236,8 +236,8 @@ public interface JobProgress {
     startingStage(description, 0, onFailure);
   }
 
-  default void startingStage(String format, Object... args) {
-    startingStage(format(format, args), FailurePolicy.PARENT);
+  default void startingStage(String description, Object... args) {
+    startingStage(format(description, args), FailurePolicy.PARENT);
   }
 
   void completedStage(String summary, Object... args);

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
@@ -240,16 +240,16 @@ public interface JobProgress {
     startingStage(format(format, args), FailurePolicy.PARENT);
   }
 
-  void completedStage(String summary);
+  void completedStage(String summary, Object... args);
 
-  void failedStage(String error);
+  void failedStage(String error, Object... args);
 
   default void failedStage(Exception cause) {
     failedStage(getMessage(cause));
   }
 
-  default void startingWorkItem(String description) {
-    startingWorkItem(description, FailurePolicy.PARENT);
+  default void startingWorkItem(String description, Object... args) {
+    startingWorkItem(format(description, args), FailurePolicy.PARENT);
   }
 
   void startingWorkItem(String description, FailurePolicy onFailure);
@@ -258,7 +258,7 @@ public interface JobProgress {
     startingWorkItem("#" + (i + 1));
   }
 
-  void completedWorkItem(String summary);
+  void completedWorkItem(String summary, Object... args);
 
   void failedWorkItem(String error, Object... args);
 
@@ -317,7 +317,7 @@ public interface JobProgress {
         items,
         description,
         work,
-        (success, failed) -> format("%d successful and %d failed items", success, failed));
+        (success, failed) -> format("{} successful and {} failed items", success, failed));
   }
 
   /**
@@ -547,7 +547,7 @@ public interface JobProgress {
       } else {
         autoSkipStage(
             (s, f) ->
-                format("parallel processing aborted after %d successful and %d failed items", s, f),
+                format("parallel processing aborted after {} successful and {} failed items", s, f),
             success.get(),
             failed.get());
       }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.scheduling;
 
-import static java.lang.String.format;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -64,6 +63,7 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.tracker.imports.validation.ValidationCode;
+import org.slf4j.helpers.MessageFormatter;
 
 /**
  *
@@ -194,18 +194,18 @@ public interface JobProgress {
    * Tracking API:
    */
 
-  void startingProcess(String description);
+  void startingProcess(String description, Object... args);
 
   default void startingProcess() {
     startingProcess(null);
   }
 
-  void completedProcess(String summary);
+  void completedProcess(String summary, Object... args);
 
-  void failedProcess(String error);
+  void failedProcess(String error, Object... args);
 
   default void failedProcess(Exception cause) {
-    failedProcess("Process failed: " + getMessage(cause));
+    failedProcess("Process failed: {}", getMessage(cause));
   }
 
   default void endingProcess(boolean success) {
@@ -236,8 +236,8 @@ public interface JobProgress {
     startingStage(description, 0, onFailure);
   }
 
-  default void startingStage(String description) {
-    startingStage(description, FailurePolicy.PARENT);
+  default void startingStage(String format, Object... args) {
+    startingStage(format(format, args), FailurePolicy.PARENT);
   }
 
   void completedStage(String summary);
@@ -260,7 +260,7 @@ public interface JobProgress {
 
   void completedWorkItem(String summary);
 
-  void failedWorkItem(String error);
+  void failedWorkItem(String error, Object... args);
 
   default void failedWorkItem(Exception cause) {
     failedWorkItem(getMessage(cause));
@@ -559,6 +559,17 @@ public interface JobProgress {
     } finally {
       pool.shutdown();
     }
+  }
+
+  /**
+   * Returns a formatted string, or null if the given format is null.
+   *
+   * @param format the format string.
+   * @param args the format arguments.
+   * @return a formatted message string.
+   */
+  default String format(String format, Object... args) {
+    return format != null ? MessageFormatter.arrayFormat(format, args).getMessage() : null;
   }
 
   /*

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/NoopJobProgress.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/NoopJobProgress.java
@@ -62,12 +62,12 @@ public class NoopJobProgress implements JobProgress {
   }
 
   @Override
-  public void completedStage(String summary) {
+  public void completedStage(String summary, Object... args) {
     // as the name said we do nothing
   }
 
   @Override
-  public void failedStage(String error) {
+  public void failedStage(String error, Object... args) {
     // as the name said we do nothing
   }
 
@@ -77,7 +77,7 @@ public class NoopJobProgress implements JobProgress {
   }
 
   @Override
-  public void completedWorkItem(String summary) {
+  public void completedWorkItem(String summary, Object... args) {
     // as the name said we do nothing
   }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/NoopJobProgress.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/NoopJobProgress.java
@@ -42,17 +42,17 @@ public class NoopJobProgress implements JobProgress {
   }
 
   @Override
-  public void startingProcess(String description) {
+  public void startingProcess(String description, Object... args) {
     // as the name said we do nothing
   }
 
   @Override
-  public void completedProcess(String summary) {
+  public void completedProcess(String summary, Object... args) {
     // as the name said we do nothing
   }
 
   @Override
-  public void failedProcess(String error) {
+  public void failedProcess(String error, Object... args) {
     // as the name said we do nothing
   }
 
@@ -82,7 +82,7 @@ public class NoopJobProgress implements JobProgress {
   }
 
   @Override
-  public void failedWorkItem(String error) {
+  public void failedWorkItem(String error, Object... args) {
     // as the name said we do nothing
   }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobProgressTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobProgressTest.java
@@ -214,6 +214,13 @@ class JobProgressTest {
     runStageInParallel_Success(max(2, Runtime.getRuntime().availableProcessors() / 2));
   }
 
+  @Test
+  void testFormat() {
+    JobProgress progress = newMockJobProgress();
+    assertEquals(
+        "Found 2 items of type text", progress.format("Found {} items of type {}", 2, "text"));
+  }
+
   private static void runStageInParallel_Success(int parallelism) {
     AtomicInteger enterCount = new AtomicInteger();
     AtomicInteger exitCount = new AtomicInteger();

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobProgressTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobProgressTest.java
@@ -36,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
@@ -92,7 +93,7 @@ class JobProgressTest {
         Stream.of(1, 2, 3), String::valueOf, worked::add, JobProgressTest::printSummary);
     assertTrue(worked.isEmpty());
     verify(progress).failedStage(any(CancellationException.class));
-    verify(progress, never()).startingWorkItem(any());
+    verify(progress, never()).startingWorkItem(anyInt());
     verify(progress, never()).completedWorkItem(any());
   }
 
@@ -214,13 +215,6 @@ class JobProgressTest {
     runStageInParallel_Success(max(2, Runtime.getRuntime().availableProcessors() / 2));
   }
 
-  @Test
-  void testFormat() {
-    JobProgress progress = newMockJobProgress();
-    assertEquals(
-        "Found 2 items of type text", progress.format("Found {} items of type {}", 2, "text"));
-  }
-
   private static void runStageInParallel_Success(int parallelism) {
     AtomicInteger enterCount = new AtomicInteger();
     AtomicInteger exitCount = new AtomicInteger();
@@ -254,6 +248,13 @@ class JobProgressTest {
     verify(progress, never()).failedWorkItem(any(Exception.class));
     verify(progress, never()).failedStage(anyString());
     verify(progress, never()).failedStage(any(Exception.class));
+  }
+
+  @Test
+  void testFormat() {
+    JobProgress progress = newMockJobProgress();
+    assertEquals(
+        "Found 2 items of type text", progress.format("Found {} items of type {}", 2, "text"));
   }
 
   private static String printSummary(int success, int failed) {

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
@@ -741,7 +741,7 @@ public class DefaultDataIntegrityService implements DataIntegrityService {
       DataIntegrityCheckErrorHandler<T> createErrorReport) {
     try {
       running.addAll(checks);
-      progress.startingProcess("Data Integrity check");
+      progress.startingProcess("Data integrity check");
       progress.startingStage(stageDesc, checks.size(), SKIP_ITEM);
       progress.runStage(
           checks.stream()

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
@@ -93,7 +93,7 @@ public class DefaultAnalyticsTableGenerator implements AnalyticsTableGenerator {
         "Last successful analytics table update: '{}'", getLongDateString(lastSuccessfulUpdate));
 
     progress.startingProcess(
-        "Analytics table update process" + (params.isLatestUpdate() ? "(latest partition)" : ""));
+        "Analytics table update process{}", (params.isLatestUpdate() ? " (latest partition)" : ""));
 
     if (!params.isSkipResourceTables() && !params.isLatestUpdate()) {
       generateResourceTablesInternal(progress);
@@ -109,13 +109,13 @@ public class DefaultAnalyticsTableGenerator implements AnalyticsTableGenerator {
       }
     }
 
-    progress.startingStage("Updating settings");
+    progress.startingStage("Updating system settings");
     progress.runStage(() -> updateLastSuccessfulSystemSettings(params, clock));
 
     progress.startingStage("Invalidate analytics caches", SKIP_STAGE);
     progress.runStage(analyticsCache::invalidateAll);
     progress.runStage(outliersCache::invalidateAll);
-    progress.completedProcess("Analytics tables updated: " + clock.time());
+    progress.completedProcess("Analytics tables updated: {}", clock.time());
   }
 
   private void updateLastSuccessfulSystemSettings(AnalyticsTableUpdateParams params, Clock clock) {
@@ -141,9 +141,9 @@ public class DefaultAnalyticsTableGenerator implements AnalyticsTableGenerator {
     try {
       generateResourceTablesInternal(progress);
 
-      progress.completedProcess("Resource tables generated: " + clock.time());
+      progress.completedProcess("Resource tables generated: {}", clock.time());
     } catch (RuntimeException ex) {
-      progress.failedProcess("Resource tables generation: " + ex.getMessage());
+      progress.failedProcess("Resource tables generation: {}", ex.getMessage());
       throw ex;
     }
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
@@ -94,7 +94,7 @@ public class DefaultAnalyticsTableService implements AnalyticsTableService {
                     "Starting update of type: %s, table name: '%s', parallel jobs: %d",
                     tableType, tableType.getTableName(), parallelJobs));
 
-    progress.startingStage("Validating Analytics Table " + tableType);
+    progress.startingStage("Validating analytics table: {}", tableType);
     String validState = tableManager.validState();
     progress.completedStage(validState);
 
@@ -109,7 +109,7 @@ public class DefaultAnalyticsTableService implements AnalyticsTableService {
           String.format(
               "Table update aborted, no table or partitions to be updated: '%s'",
               tableType.getTableName()));
-      progress.startingStage("Table updates " + tableType);
+      progress.startingStage("Table updates: {}", tableType);
       progress.completedStage("Table updated aborted, no table or partitions to be updated");
       return;
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DefaultDataSetNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DefaultDataSetNotificationService.java
@@ -222,8 +222,7 @@ public class DefaultDataSetNotificationService implements DataSetNotificationSer
         msgText.setLength(0);
       }
     }
-    progress.completedStage(
-        format("%d summary dataset notifications created.", batch.dhisMessages.size()));
+    progress.completedStage("{} summary dataset notifications created.", batch.dhisMessages.size());
 
     return batch;
   }
@@ -341,9 +340,8 @@ public class DefaultDataSetNotificationService implements DataSetNotificationSer
     MessageBatch batch = createMessageBatch(createGroupedByMapper(singleTemplates));
 
     progress.completedStage(
-        format(
-            "Number of SINGLE notifications created: %d",
-            batch.programMessages.size() + batch.dhisMessages.size()));
+        "Number of SINGLE notifications created: {}",
+        batch.programMessages.size() + batch.dhisMessages.size());
     return batch;
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramTempOwnerStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramTempOwnerStore.java
@@ -65,6 +65,6 @@ public class HibernateProgramTempOwnerStore extends HibernateGenericStore<Progra
             + "where programid = ? and trackedentityid=? and userid=? "
             + "and extract(epoch from validtill)-extract (epoch from now()::timestamp) > 0";
     return jdbcTemplate.queryForObject(
-        sql, new Object[] {program.getId(), entityInstance.getId(), user.getId()}, Integer.class);
+        sql, Integer.class, new Object[] {program.getId(), entityInstance.getId(), user.getId()});
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramTempOwnerStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramTempOwnerStore.java
@@ -64,7 +64,7 @@ public class HibernateProgramTempOwnerStore extends HibernateGenericStore<Progra
         "select count(1) from programtempowner "
             + "where programid = ? and trackedentityid=? and userid=? "
             + "and extract(epoch from validtill)-extract (epoch from now()::timestamp) > 0";
-    return jdbcTemplate.queryForObject(
-        sql, Integer.class, new Object[] {program.getId(), entityInstance.getId(), user.getId()});
+    Object[] args = new Object[] {program.getId(), entityInstance.getId(), user.getId()};
+    return jdbcTemplate.queryForObject(sql, Integer.class, args);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationService.java
@@ -162,7 +162,7 @@ public class DefaultProgramNotificationService implements ProgramNotificationSer
         instancesWithTemplates.size(),
         SKIP_ITEM_OUTLIER);
     if (instancesWithTemplates.isEmpty()) {
-      progress.completedStage("No instances with templates found.");
+      progress.completedStage("No instances with templates found");
       return;
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
@@ -93,16 +93,16 @@ public class NotifierJobProgress implements JobProgress {
   }
 
   @Override
-  public void completedStage(String summary) {
+  public void completedStage(String summary, Object... args) {
     if (isNotEmpty(summary)) {
-      notifier.notify(jobId, summary);
+      notifier.notify(jobId, format(summary, args));
     }
   }
 
   @Override
-  public void failedStage(String error) {
+  public void failedStage(String error, Object... args) {
     if (isNotEmpty(error)) {
-      notifier.notify(jobId, NotificationLevel.ERROR, error, false);
+      notifier.notify(jobId, NotificationLevel.ERROR, format(error, args), false);
     }
   }
 
@@ -116,10 +116,10 @@ public class NotifierJobProgress implements JobProgress {
   }
 
   @Override
-  public void completedWorkItem(String summary) {
+  public void completedWorkItem(String summary, Object... args) {
     if (isNotEmpty(summary)) {
       String nOf = "[" + (stageItems > 0 ? stageItem + "/" + stageItems : "" + stageItem) + "] ";
-      notifier.notify(jobId, NotificationLevel.LOOP, nOf + summary, false);
+      notifier.notify(jobId, NotificationLevel.LOOP, nOf + format(summary, args), false);
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
@@ -56,9 +56,11 @@ public class NotifierJobProgress implements JobProgress {
   private int stageItem;
 
   @Override
-  public void startingProcess(String description) {
+  public void startingProcess(String description, Object... args) {
     String message =
-        isNotEmpty(description) ? description : jobId.getJobType() + " process started";
+        isNotEmpty(description)
+            ? format(description, args)
+            : jobId.getJobType() + " process started";
     if (hasCleared.compareAndSet(false, true)) {
       notifier.clear(jobId);
     }
@@ -72,13 +74,13 @@ public class NotifierJobProgress implements JobProgress {
   }
 
   @Override
-  public void completedProcess(String summary) {
-    notifier.notify(jobId, summary, true);
+  public void completedProcess(String summary, Object... args) {
+    notifier.notify(jobId, format(summary, args), true);
   }
 
   @Override
-  public void failedProcess(String error) {
-    notifier.notify(jobId, NotificationLevel.ERROR, error, true);
+  public void failedProcess(String error, Object... args) {
+    notifier.notify(jobId, NotificationLevel.ERROR, format(error, args), true);
   }
 
   @Override
@@ -122,9 +124,9 @@ public class NotifierJobProgress implements JobProgress {
   }
 
   @Override
-  public void failedWorkItem(String error) {
+  public void failedWorkItem(String error, Object... args) {
     if (isNotEmpty(error)) {
-      notifier.notify(jobId, NotificationLevel.ERROR, error, false);
+      notifier.notify(jobId, NotificationLevel.ERROR, format(error, args), false);
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/RecordingJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/RecordingJobProgress.java
@@ -252,24 +252,26 @@ public class RecordingJobProgress implements JobProgress {
   }
 
   @Override
-  public void completedStage(String summary) {
+  public void completedStage(String summary, Object... args) {
+    String message = format(summary, args);
     observer.run();
-    tracker.completedStage(summary);
+    tracker.completedStage(message);
     Stage stage = getOrAddLastIncompleteStage();
-    stage.complete(summary);
-    logInfo(stage, "completed", summary);
+    stage.complete(message);
+    logInfo(stage, "completed", message);
   }
 
   @Override
-  public void failedStage(String error) {
+  public void failedStage(String error, Object... args) {
+    String message = format(error, args);
     observer.run();
-    tracker.failedStage(error);
+    tracker.failedStage(message);
     Stage stage = getOrAddLastIncompleteStage();
-    stage.completeExceptionally(error, null);
+    stage.completeExceptionally(message, null);
     if (stage.getOnFailure() != FailurePolicy.SKIP_STAGE) {
-      automaticAbort(error, null);
+      automaticAbort(message, null);
     }
-    logError(stage, null, error);
+    logError(stage, null, message);
   }
 
   @Override
@@ -296,12 +298,13 @@ public class RecordingJobProgress implements JobProgress {
   }
 
   @Override
-  public void completedWorkItem(String summary) {
+  public void completedWorkItem(String summary, Object... args) {
+    String message = format(summary, args);
     observer.run();
-    tracker.completedWorkItem(summary);
+    tracker.completedWorkItem(message);
     Item item = getOrAddLastIncompleteItem();
-    item.complete(summary);
-    logDebug(item, "completed", summary);
+    item.complete(message);
+    logDebug(item, "completed", message);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeJob.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeJob.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.dataexchange.aggregate;
 
-import static java.lang.String.format;
-
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.IllegalQueryException;
@@ -69,7 +67,7 @@ public class AggregateDataExchangeJob implements Job {
 
     List<String> dataExchangeIds = params.getDataExchangeIds();
     progress.startingProcess(
-        format("Aggregate data exchange of %d exchange(s) started", dataExchangeIds.size()));
+        "Aggregate data exchange with {} exchange(s) started", dataExchangeIds.size());
     ImportSummaries allSummaries = new ImportSummaries();
     for (String dataExchangeId : dataExchangeIds) {
       AggregateDataExchange exchange;
@@ -88,7 +86,7 @@ public class AggregateDataExchangeJob implements Job {
     if (status == ImportStatus.ERROR) {
       progress.failedProcess("Aggregate data exchange completed with errors");
     } else {
-      progress.completedProcess("Aggregate data exchange completed with status " + status);
+      progress.completedProcess("Aggregate data exchange completed with status: {}", status);
     }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/dataset/tasks/ImportCompleteDataSetRegistrationsJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/dataset/tasks/ImportCompleteDataSetRegistrationsJob.java
@@ -72,7 +72,7 @@ public class ImportCompleteDataSetRegistrationsJob implements Job {
     try (InputStream input =
         progress.runStage(() -> fileResourceService.getFileResourceContent(data))) {
       String contentType = data.getContentType();
-      progress.startingStage("Importing data...");
+      progress.startingStage("Importing data");
       ImportSummary summary =
           switch (contentType) {
             case "application/json" ->
@@ -82,7 +82,7 @@ public class ImportCompleteDataSetRegistrationsJob implements Job {
                 progress.runStage(
                     () -> registrationService.saveCompleteDataSetRegistrationsXml(input, options));
             default -> {
-              progress.failedStage("Unknown format: " + contentType);
+              progress.failedStage("Unknown format: {}", contentType);
               yield null;
             }
           };
@@ -92,13 +92,12 @@ public class ImportCompleteDataSetRegistrationsJob implements Job {
       }
       ImportCount count = summary.getImportCount();
       progress.completedProcess(
-          "Import complete with status %s, %d created, %d updated, %d deleted, %d ignored"
-              .formatted(
-                  summary.getStatus(),
-                  count.getImported(),
-                  count.getUpdated(),
-                  count.getDeleted(),
-                  count.getIgnored()));
+          "Import complete with status {}, {} created, {} updated, {} deleted, {} ignored",
+          summary.getStatus(),
+          count.getImported(),
+          count.getUpdated(),
+          count.getDeleted(),
+          count.getIgnored());
       notifier.addJobSummary(jobConfig, summary, ImportSummary.class);
     } catch (IOException ex) {
       progress.failedProcess(ex);

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/tasks/DataValueSetImportJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/tasks/DataValueSetImportJob.java
@@ -89,7 +89,7 @@ public class DataValueSetImportJob implements Job {
                 progress.runStage(
                     () -> dataValueSetService.importDataValueSetXml(input, options, jobId));
             default -> {
-              progress.failedStage("Unknown format: " + contentType);
+              progress.failedStage("Unknown format: {}", contentType);
               yield null;
             }
           };
@@ -105,13 +105,12 @@ public class DataValueSetImportJob implements Job {
 
       ImportCount count = summary.getImportCount();
       progress.completedProcess(
-          "Import complete with status %s, %d created, %d updated, %d deleted, %d ignored"
-              .formatted(
-                  summary.getStatus(),
-                  count.getImported(),
-                  count.getUpdated(),
-                  count.getDeleted(),
-                  count.getIgnored()));
+          "Import complete with status {}, {} created, {} updated, {} deleted, {} ignored",
+          summary.getStatus(),
+          count.getImported(),
+          count.getUpdated(),
+          count.getDeleted(),
+          count.getIgnored());
     } catch (IOException ex) {
       progress.failedProcess(ex);
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/job/GeoJsonImportJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/job/GeoJsonImportJob.java
@@ -83,13 +83,12 @@ public class GeoJsonImportJob implements Job {
 
       ImportCount count = report.getImportCount();
       progress.completedProcess(
-          "GeoJSON import completed with status %s, %d created, %d updated, %d deleted, %d ignored"
-              .formatted(
-                  report.getStatus(),
-                  count.getImported(),
-                  count.getUpdated(),
-                  count.getDeleted(),
-                  count.getIgnored()));
+          "GeoJSON import completed with status {}, {} created, {} updated, {} deleted, {} ignored",
+          report.getStatus(),
+          count.getImported(),
+          count.getUpdated(),
+          count.getDeleted(),
+          count.getIgnored());
 
       notifier.addJobSummary(jobConfig, report, GeoJsonImportReport.class);
     } catch (IOException e) {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPreProcessor.java
@@ -123,7 +123,7 @@ public class MetadataSyncPreProcessor {
       List<MetadataVersion> versions = metadataVersionDelegate.getMetaDataDifference(version);
 
       if (isRemoteVersionEmpty(version, versions)) {
-        progress.completedStage("There are no metadata versions created in the remote instance.");
+        progress.completedStage("There are no metadata versions created in the remote instance");
         return versions;
       }
 
@@ -181,7 +181,7 @@ public class MetadataSyncPreProcessor {
 
     try {
       MetadataVersion version = metadataVersionService.getCurrentVersion();
-      progress.completedStage("Current Metadata Version of the system: " + version);
+      progress.completedStage("Current Metadata Version of the system: {}", version);
       return version;
     } catch (MetadataVersionServiceException ex) {
       context.updateRetryContext(MetadataSyncJob.GET_METADATAVERSION, ex.getMessage(), null, null);

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java
@@ -147,34 +147,29 @@ public class DefaultPushAnalysisService implements PushAnalysisService {
 
     if (pushAnalysis == null) {
       progress.failedStage(
-          "PushAnalysis with uid '" + uid + "' was not found. Terminating PushAnalysis");
+          "PushAnalysis with uid '{}' was not found. Terminating PushAnalysis.", uid);
       return;
     }
     if (pushAnalysis.getRecipientUserGroups().isEmpty()) {
       progress.failedStage(
-          "PushAnalysis with uid '"
-              + uid
-              + "' has no userGroups assigned. Terminating PushAnalysis.");
+          "PushAnalysis with uid '{}' has no userGroups assigned. Terminating PushAnalysis.", uid);
       return;
     }
 
     if (pushAnalysis.getDashboard() == null) {
       progress.failedStage(
-          "PushAnalysis with uid '"
-              + uid
-              + "' has no dashboard assigned. Terminating PushAnalysis.");
+          "PushAnalysis with uid '{}' has no dashboard assigned. Terminating PushAnalysis.", uid);
       return;
     }
 
     if (dhisConfigurationProvider.getServerBaseUrl() == null) {
       progress.failedStage(
-          "Missing configuration '"
-              + ConfigurationKey.SERVER_BASE_URL.getKey()
-              + "'. Terminating PushAnalysis.");
+          "Missing configuration '{}'. Terminating PushAnalysis.",
+          ConfigurationKey.SERVER_BASE_URL.getKey());
       return;
     }
 
-    progress.completedStage("pre-check completed successfully");
+    progress.completedStage("Pre-check completed successfully");
 
     // ----------------------------------------------------------------------
     // Compose list of users that can receive PushAnalysis
@@ -193,11 +188,9 @@ public class DefaultPushAnalysisService implements PushAnalysisService {
       }
     }
     progress.completedStage(
-        "List composed. "
-            + receivingUsers.size()
-            + " eligible users found."
-            + "Skipping users without valid email: "
-            + skippedUsers.stream().map(User::getUsername).collect(joining(",")));
+        "List composed. {} eligible users found. Skipping users without valid email: {}",
+        receivingUsers.size(),
+        skippedUsers.stream().map(User::getUsername).collect(joining(",")));
 
     // ----------------------------------------------------------------------
     // Generating reports


### PR DESCRIPTION
Adds Slf4j-style variable substitution support for `JobProgress` for more elegant logging and to avoid string concatenation.