### PR TITLE
fix: keep confidential generic SMS gateway paramaters values when empty [DHIS2-16695]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/config/GenericGatewayParameter.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/config/GenericGatewayParameter.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.sms.config;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serial;
 import java.io.Serializable;
 import lombok.EqualsAndHashCode;
@@ -45,9 +46,9 @@ public class GenericGatewayParameter implements Serializable {
 
   @Serial private static final long serialVersionUID = -863990758156009672L;
 
-  private String key;
-  private String value;
-  private boolean header;
-  private boolean encode;
-  private boolean confidential;
+  @JsonProperty private String key;
+  @JsonProperty private String value;
+  @JsonProperty private boolean header;
+  @JsonProperty private boolean encode;
+  @JsonProperty private boolean confidential;
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/DefaultGatewayAdministrationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/DefaultGatewayAdministrationService.java
@@ -262,9 +262,4 @@ public class DefaultGatewayAdministrationService implements GatewayAdministratio
 
     hasGateways.set(true);
   }
-
-  private boolean isPresent(
-      List<GenericGatewayParameter> parameters, GenericGatewayParameter parameter) {
-    return parameters.stream().anyMatch(p -> p.equals(parameter));
-  }
 }


### PR DESCRIPTION
### Summary
* allows to omit confidential parameter values to keep the old value
* adds missing `@JsonProperty` annotation on the `GenericGatewayParameter` fields
* fixes update logic of when to encode a confidential parameter value

### Automatic Testing
Added new test scenario to verify the update without parameter value does retain the current value

### Manual Testing
* create a generic SMS config with a confidential value
* update the config and record the PUT made
* redo a PUT but erase the `value` of the parameter object (either entirely or make it `null` or `""`) (might need a REST tool)
* check the value is still the old value