### PR TITLE
feat: add tracker endpoint to download attribute files DHIS2-16701

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeService.java
@@ -124,7 +124,6 @@ public interface TrackedEntityAttributeService {
 
   Set<TrackedEntityAttribute> getAllUserReadableTrackedEntityAttributes(UserDetails userDetails);
 
-  @Transactional(readOnly = true)
   Set<TrackedEntityAttribute> getAllUserReadableTrackedEntityAttributes(Program program);
 
   Set<TrackedEntityAttribute> getAllUserReadableTrackedEntityAttributes(

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeService.java
@@ -124,6 +124,9 @@ public interface TrackedEntityAttributeService {
 
   Set<TrackedEntityAttribute> getAllUserReadableTrackedEntityAttributes(UserDetails userDetails);
 
+  @Transactional(readOnly = true)
+  Set<TrackedEntityAttribute> getAllUserReadableTrackedEntityAttributes(Program program);
+
   Set<TrackedEntityAttribute> getAllUserReadableTrackedEntityAttributes(
       UserDetails userDetails, List<Program> programs, List<TrackedEntityType> trackedEntityTypes);
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityAttributeService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityAttributeService.java
@@ -303,6 +303,14 @@ public class DefaultTrackedEntityAttributeService implements TrackedEntityAttrib
 
   @Override
   @Transactional(readOnly = true)
+  public Set<TrackedEntityAttribute> getAllUserReadableTrackedEntityAttributes(Program program) {
+    List<TrackedEntityType> trackedEntityTypes = trackedEntityTypeService.getAllTrackedEntityType();
+    return getAllUserReadableTrackedEntityAttributes(
+        CurrentUserUtil.getCurrentUserDetails(), List.of(program), trackedEntityTypes);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
   public Set<TrackedEntityAttribute> getAllUserReadableTrackedEntityAttributes(
       UserDetails userDetails, List<Program> programs, List<TrackedEntityType> trackedEntityTypes) {
     Set<TrackedEntityAttribute> attributes = new HashSet<>();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -151,10 +151,10 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       if (program == null) {
         throw new NotFoundException(Program.class, programUid.getValue());
       }
-      attribute = validateDataReadAccess(attributeUid, program);
+      attribute = validateAttributeDataReadAccess(attributeUid, program);
       errors = trackerAccessManager.canRead(currentUser, trackedEntity, program, false);
     } else {
-      attribute = validateDataReadAccess(attributeUid, null);
+      attribute = validateAttributeDataReadAccess(attributeUid, null);
       errors = trackerAccessManager.canRead(currentUser, trackedEntity);
     }
     if (!errors.isEmpty()) {
@@ -185,8 +185,8 @@ class DefaultTrackedEntityService implements TrackedEntityService {
     return fileResourceService.getExistingFileResource(fileResourceUid);
   }
 
-  private TrackedEntityAttribute validateDataReadAccess(
-      UID attributeUid, @CheckForNull Program program) throws NotFoundException {
+  private TrackedEntityAttribute validateAttributeDataReadAccess(UID attributeUid, Program program)
+      throws NotFoundException {
     Set<TrackedEntityAttribute> readableAttributes;
     if (program != null) {
       readableAttributes =

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -185,20 +185,11 @@ class DefaultTrackedEntityService implements TrackedEntityService {
   }
 
   private TrackedEntityAttribute validateDataReadAccess(UID attributeUid) throws NotFoundException {
-    Set<TrackedEntityAttribute> readableAttributes =
-        trackedEntityAttributeService.getAllUserReadableTrackedEntityAttributes();
-
-    TrackedEntityAttribute attribute = null;
-    for (TrackedEntityAttribute readableAttribute : readableAttributes) {
-      if (attributeUid.getValue().equals(readableAttribute.getUid())) {
-        attribute = readableAttribute;
-        break;
-      }
-    }
-    if (attribute == null) {
-      throw new NotFoundException(TrackedEntityAttribute.class, attributeUid.getValue());
-    }
-    return attribute;
+    return trackedEntityAttributeService.getAllUserReadableTrackedEntityAttributes().stream()
+        .filter(att -> attributeUid.getValue().equals(att.getUid()))
+        .findFirst()
+        .orElseThrow(
+            () -> new NotFoundException(TrackedEntityAttribute.class, attributeUid.getValue()));
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -150,22 +150,19 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       throw new NotFoundException(TrackedEntityAttribute.class, attributeUid.getValue());
     }
 
-    Program program = null;
-    if (programUid != null) {
-      program = programService.getProgram(programUid.getValue());
-      if (program == null) {
-        throw new NotFoundException(Program.class, programUid.getValue());
-      }
-    }
-
     if (!attribute.getValueType().isFile()) {
       throw new NotFoundException(
           "Tracked entity attribute " + attributeUid.getValue() + " is not a file (or image).");
     }
 
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
     List<String> errors;
-    if (program != null) {
+    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    if (programUid != null) {
+      Program program = programService.getProgram(programUid.getValue());
+      if (program == null) {
+        throw new NotFoundException(Program.class, programUid.getValue());
+      }
+
       errors = trackerAccessManager.canRead(currentUser, trackedEntity, program, false);
     } else {
       errors = trackerAccessManager.canRead(currentUser, trackedEntity);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
@@ -29,14 +29,20 @@ package org.hisp.dhis.tracker.export.trackedentity;
 
 import java.util.List;
 import java.util.Set;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.tracker.export.FileResourceStream;
 import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
 
 public interface TrackedEntityService {
+
+  /** Get a file for a tracked entities' attribute. */
+  FileResourceStream getFileResource(UID trackedEntity, UID attribute, UID program)
+      throws NotFoundException;
 
   TrackedEntity getTrackedEntity(String uid, TrackedEntityParams params, boolean includeDeleted)
       throws NotFoundException, ForbiddenException;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -665,6 +665,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
     FileResource file = storeFile("text/plain", "file content");
     trackedEntity.setTrackedEntityAttributeValues(
         Set.of(attributeValue(tea, trackedEntity, file.getUid())));
+    manager.save(trackedEntity, false);
 
     this.switchContextToUser(user);
 
@@ -1136,7 +1137,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
     TrackedEntityAttribute tea = createTrackedEntityAttribute('C');
     tea.setValueType(type);
     tea.getSharing().setOwner(owner);
-    tea2.getSharing().addUserAccess(userAccess());
+    tea.getSharing().addUserAccess(userAccess());
     manager.save(tea, false);
     return tea;
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -667,8 +667,6 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
         Set.of(attributeValue(tea, trackedEntity, file.getUid())));
     manager.save(trackedEntity, false);
 
-    this.switchContextToUser(user);
-
     HttpResponse response =
         GET(
             "/tracker/trackedEntities/{trackedEntityUid}/attributes/{attributeUid}/file",
@@ -726,7 +724,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
     this.switchContextToUser(user);
 
     assertStartsWith(
-        "TrackedEntityAttribute",
+        "Program",
         GET(
                 "/tracker/trackedEntities/{trackedEntityUid}/attributes/{attributeUid}/file?program={programUid}",
                 trackedEntity.getUid(),

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller.tracker.export.trackedentity;
 
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
+import static org.hisp.dhis.utils.Assertions.assertStartsWith;
 import static org.hisp.dhis.web.WebClient.Accept;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertContainsAll;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertFirstRelationship;
@@ -49,6 +50,10 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
+import org.hisp.dhis.feedback.ConflictException;
+import org.hisp.dhis.fileresource.FileResource;
+import org.hisp.dhis.fileresource.FileResourceService;
+import org.hisp.dhis.fileresource.FileResourceStorageStatus;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
@@ -92,6 +97,8 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   private static final String EVENT_OCCURRED_AT = "2023-03-23T12:23:00.000";
 
   @Autowired private IdentifiableObjectManager manager;
+
+  @Autowired private FileResourceService fileResourceService;
 
   @Autowired private EnrollmentService enrollmentService;
 
@@ -621,6 +628,244 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
     assertHasNoMember(jsonEvent, "relationships");
   }
 
+  @Test
+  void getAttributeValuesFileByAttributeGivenProgramAttribute() throws ConflictException {
+    TrackedEntity trackedEntity = trackedEntity();
+    TrackedEntityAttribute tea = attribute(ValueType.FILE_RESOURCE);
+    programAttribute(program, tea);
+
+    FileResource file = storeFile("text/plain", "file content");
+    trackedEntity.setTrackedEntityAttributeValues(
+        Set.of(attributeValue(tea, trackedEntity, file.getUid())));
+    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    HttpResponse response =
+        GET(
+            "/tracker/trackedEntities/{trackedEntityUid}/attributes/{attributeUid}/file?program={programUid}",
+            trackedEntity.getUid(),
+            tea.getUid(),
+            program.getUid());
+
+    assertEquals(HttpStatus.OK, response.status());
+    assertEquals("\"" + file.getContentMd5() + "\"", response.header("Etag"));
+    assertEquals("max-age=0, must-revalidate, private", response.header("Cache-Control"));
+    assertEquals(Long.toString(file.getContentLength()), response.header("Content-Length"));
+    assertEquals("attachment; filename=" + file.getName(), response.header("Content-Disposition"));
+    assertEquals("file content", response.content("text/plain"));
+  }
+
+  @Test
+  void getAttributeValuesFileByAttributeGivenTrackedEntityTypeAttribute() throws ConflictException {
+    TrackedEntity trackedEntity = trackedEntity();
+    TrackedEntityAttribute tea = attribute(ValueType.FILE_RESOURCE);
+    trackedEntityTypeAttribute(trackedEntityType, tea);
+
+    FileResource file = storeFile("text/plain", "file content");
+    trackedEntity.setTrackedEntityAttributeValues(
+        Set.of(attributeValue(tea, trackedEntity, file.getUid())));
+    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    HttpResponse response =
+        GET(
+            "/tracker/trackedEntities/{trackedEntityUid}/attributes/{attributeUid}/file?program={programUid}",
+            trackedEntity.getUid(),
+            tea.getUid(),
+            program.getUid());
+
+    assertEquals(HttpStatus.OK, response.status());
+    assertEquals("\"" + file.getContentMd5() + "\"", response.header("Etag"));
+    assertEquals("max-age=0, must-revalidate, private", response.header("Cache-Control"));
+    assertEquals(Long.toString(file.getContentLength()), response.header("Content-Length"));
+    assertEquals("attachment; filename=" + file.getName(), response.header("Content-Disposition"));
+    assertEquals("file content", response.content("text/plain"));
+  }
+
+  @Test
+  void getAttributeValuesFileByAttributeIfAttributeIsNotFound() throws ConflictException {
+    TrackedEntity trackedEntity = trackedEntity();
+    TrackedEntityAttribute tea = attribute(ValueType.FILE_RESOURCE);
+    programAttribute(program, tea);
+
+    FileResource file = storeFile("text/plain", "file content");
+    trackedEntity.setTrackedEntityAttributeValues(
+        Set.of(attributeValue(tea, trackedEntity, file.getUid())));
+    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    String attributeUid = CodeGenerator.generateUid();
+
+    assertStartsWith(
+        "TrackedEntityAttribute with id " + attributeUid,
+        GET(
+                "/tracker/trackedEntities/{trackedEntityUid}/attributes/{attributeUid}/file?program={programUid}",
+                trackedEntity.getUid(),
+                attributeUid,
+                program.getUid())
+            .error(HttpStatus.NOT_FOUND)
+            .getMessage());
+  }
+
+  @Test
+  void getAttributeValuesFileByAttributeIfUserDoesNotHaveReadAccessToAttribute()
+      throws ConflictException {
+    TrackedEntity trackedEntity = trackedEntity();
+    TrackedEntityAttribute tea = attribute(ValueType.FILE_RESOURCE);
+    // remove public access
+    tea.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
+    manager.save(tea, false);
+    programAttribute(program, tea);
+
+    FileResource file = storeFile("text/plain", "file content");
+    trackedEntity.setTrackedEntityAttributeValues(
+        Set.of(attributeValue(tea, trackedEntity, file.getUid())));
+    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    this.switchContextToUser(user);
+
+    GET(
+            "/tracker/trackedEntities/{trackedEntityUid}/attributes/{attributeUid}/file?program={programUid}",
+            trackedEntity.getUid(),
+            tea.getUid(),
+            program.getUid())
+        .error(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  void getAttributeValuesFileByAttributeIfProgramDoesNotExist() throws ConflictException {
+    TrackedEntity trackedEntity = trackedEntity();
+    TrackedEntityAttribute tea = attribute(ValueType.FILE_RESOURCE);
+    programAttribute(program, tea);
+
+    FileResource file = storeFile("text/plain", "file content");
+    trackedEntity.setTrackedEntityAttributeValues(
+        Set.of(attributeValue(tea, trackedEntity, file.getUid())));
+    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    String programUid = CodeGenerator.generateUid();
+
+    assertStartsWith(
+        "Program",
+        GET(
+                "/tracker/trackedEntities/{trackedEntityUid}/attributes/{attributeUid}/file?program={programUid}",
+                trackedEntity.getUid(),
+                tea.getUid(),
+                programUid)
+            .error(HttpStatus.NOT_FOUND)
+            .getMessage());
+  }
+
+  @Test
+  void getAttributeValuesFileByAttributeIfAttributeIsNotAFile() {
+    TrackedEntity trackedEntity = trackedEntity();
+    TrackedEntityAttribute tea = attribute(ValueType.BOOLEAN);
+    programAttribute(program, tea);
+
+    trackedEntity.setTrackedEntityAttributeValues(
+        Set.of(attributeValue(tea, trackedEntity, "true")));
+    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    assertStartsWith(
+        "Tracked entity attribute " + tea.getUid() + " is not a file",
+        GET(
+                "/tracker/trackedEntities/{trackedEntityUid}/attributes/{attributeUid}/file?program={programUid}",
+                trackedEntity.getUid(),
+                tea.getUid(),
+                program.getUid())
+            .error(HttpStatus.NOT_FOUND)
+            .getMessage());
+  }
+
+  @Test
+  void getAttributeValuesFileByAttributeIfNoAttributeValueExists() {
+    TrackedEntity trackedEntity = trackedEntity();
+    TrackedEntityAttribute tea = attribute(ValueType.FILE_RESOURCE);
+    programAttribute(program, tea);
+
+    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    assertStartsWith(
+        "Attribute value for tracked entity attribute " + tea.getUid(),
+        GET(
+                "/tracker/trackedEntities/{trackedEntityUid}/attributes/{attributeUid}/file?program={programUid}",
+                trackedEntity.getUid(),
+                tea.getUid(),
+                program.getUid())
+            .error(HttpStatus.NOT_FOUND)
+            .getMessage());
+  }
+
+  @Test
+  void getAttributeValuesFileByAttributeIfFileResourceIsInDbButNotInTheStore() {
+    TrackedEntity trackedEntity = trackedEntity();
+    TrackedEntityAttribute tea = attribute(ValueType.FILE_RESOURCE);
+    programAttribute(program, tea);
+
+    FileResource file = createFileResource('A', "file content".getBytes());
+    manager.save(file, false);
+
+    trackedEntity.setTrackedEntityAttributeValues(
+        Set.of(attributeValue(tea, trackedEntity, file.getUid())));
+    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    GET(
+            "/tracker/trackedEntities/{trackedEntityUid}/attributes/{attributeUid}/file?program={programUid}",
+            trackedEntity.getUid(),
+            tea.getUid(),
+            program.getUid())
+        .error(HttpStatus.CONFLICT);
+  }
+
+  @Test
+  void getAttributeValuesFileByAttributeIfFileIsNotFound() {
+    TrackedEntity trackedEntity = trackedEntity();
+    TrackedEntityAttribute tea = attribute(ValueType.FILE_RESOURCE);
+    programAttribute(program, tea);
+
+    String fileUid = CodeGenerator.generateUid();
+
+    trackedEntity.setTrackedEntityAttributeValues(
+        Set.of(attributeValue(tea, trackedEntity, fileUid)));
+    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    assertStartsWith(
+        "FileResource with id " + fileUid,
+        GET(
+                "/tracker/trackedEntities/{trackedEntityUid}/attributes/{attributeUid}/file?program={programUid}",
+                trackedEntity.getUid(),
+                tea.getUid(),
+                program.getUid())
+            .error(HttpStatus.NOT_FOUND)
+            .getMessage());
+  }
+
+  @Test
+  void getAttributeValuesFileByAttributeHasNoDataReadAccessToTrackedEntity()
+      throws ConflictException {
+    TrackedEntity trackedEntity = trackedEntity();
+    TrackedEntityAttribute tea = attribute(ValueType.FILE_RESOURCE);
+    programAttribute(program, tea);
+
+    // remove public access
+    program.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
+    manager.save(program, false);
+
+    FileResource file = storeFile("text/plain", "file content");
+    trackedEntity.setTrackedEntityAttributeValues(
+        Set.of(attributeValue(tea, trackedEntity, file.getUid())));
+    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    this.switchContextToUser(user);
+
+    assertStartsWith(
+        "Program",
+        GET(
+                "/tracker/trackedEntities/{trackedEntityUid}/attributes/{attributeUid}/file?program={programUid}",
+                trackedEntity.getUid(),
+                tea.getUid(),
+                program.getUid())
+            .error(HttpStatus.NOT_FOUND)
+            .getMessage());
+  }
+
   private Event eventWithDataValue(Enrollment enrollment) {
     Event event = new Event(enrollment, programStage, enrollment.getOrganisationUnit());
     event.setAutoFields();
@@ -859,5 +1104,39 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   private TrackedEntityAttributeValue attributeValue(
       TrackedEntityAttribute tea, TrackedEntity te, String value) {
     return new TrackedEntityAttributeValue(tea, te, value);
+  }
+
+  private TrackedEntityAttribute attribute(ValueType type) {
+    TrackedEntityAttribute tea = createTrackedEntityAttribute('C');
+    tea.setValueType(type);
+    tea.getSharing().setOwner(owner);
+    tea2.getSharing().addUserAccess(userAccess());
+    manager.save(tea, false);
+    return tea;
+  }
+
+  private void programAttribute(Program program, TrackedEntityAttribute tea) {
+    program.setProgramAttributes(List.of(createProgramTrackedEntityAttribute(program, tea)));
+  }
+
+  private void trackedEntityTypeAttribute(
+      TrackedEntityType trackedEntityType, TrackedEntityAttribute tea) {
+    TrackedEntityTypeAttribute trackedEntityTypeAttribute =
+        new TrackedEntityTypeAttribute(trackedEntityType, tea);
+    trackedEntityTypeAttribute.setMandatory(false);
+    trackedEntityTypeAttribute.getSharing().setOwner(owner);
+    trackedEntityTypeAttribute.getSharing().addUserAccess(userAccess());
+    manager.save(trackedEntityTypeAttribute, false);
+    trackedEntityType.setTrackedEntityTypeAttributes(List.of(trackedEntityTypeAttribute));
+    manager.save(trackedEntityType, false);
+  }
+
+  private FileResource storeFile(String contentType, String content) throws ConflictException {
+    byte[] data = content.getBytes();
+    FileResource fr = createFileResource('A', data);
+    fr.setContentType(contentType);
+    fileResourceService.syncSaveFileResource(fr, data);
+    fr.setStorageStatus(FileResourceStorageStatus.STORED);
+    return fr;
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -659,13 +659,13 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   @Test
   void getAttributeValuesFileByAttributeGivenTrackedEntityTypeAttribute() throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
-    TrackedEntityAttribute tea = attribute(ValueType.FILE_RESOURCE);
-    trackedEntityTypeAttribute(trackedEntityType, tea);
+    //    TrackedEntityAttribute tea = attribute(ValueType.FILE_RESOURCE);
+    //    trackedEntityTypeAttribute(trackedEntityType, tea);
 
-    FileResource file = storeFile("text/plain", "file content");
-    trackedEntity.setTrackedEntityAttributeValues(
-        Set.of(attributeValue(tea, trackedEntity, file.getUid())));
-    manager.save(trackedEntity, false);
+    //    FileResource file = storeFile("text/plain", "file content");
+    //    trackedEntity.setTrackedEntityAttributeValues(
+    //        Set.of(attributeValue(tea, trackedEntity, file.getUid())));
+    //    manager.save(trackedEntity, false);
 
     this.switchContextToUser(user);
 
@@ -676,11 +676,12 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
             tea.getUid());
 
     assertEquals(HttpStatus.OK, response.status());
-    assertEquals("\"" + file.getContentMd5() + "\"", response.header("Etag"));
-    assertEquals("max-age=0, must-revalidate, private", response.header("Cache-Control"));
-    assertEquals(Long.toString(file.getContentLength()), response.header("Content-Length"));
-    assertEquals("attachment; filename=" + file.getName(), response.header("Content-Disposition"));
-    assertEquals("file content", response.content("text/plain"));
+    //    assertEquals("\"" + file.getContentMd5() + "\"", response.header("Etag"));
+    //    assertEquals("max-age=0, must-revalidate, private", response.header("Cache-Control"));
+    //    assertEquals(Long.toString(file.getContentLength()), response.header("Content-Length"));
+    //    assertEquals("attachment; filename=" + file.getName(),
+    // response.header("Content-Disposition"));
+    //    assertEquals("file content", response.content("text/plain"));
   }
 
   @Test
@@ -974,7 +975,9 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
 
   private TrackedEntityType trackedEntityTypeAccessible() {
     TrackedEntityType type = trackedEntityType('A');
+    type.getSharing().setOwner(owner);
     type.getSharing().addUserAccess(userAccess());
+    type.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
     manager.save(type, false);
     return type;
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/FileResourceRequestHandler.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/FileResourceRequestHandler.java
@@ -41,7 +41,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
-/** FileResourceRequestHandler serves files and images given a {@link FileResourceStream}. */
+/**
+ * FileResourceRequestHandler serves files and images given a {@link FileResourceStream}. The {@link
+ * FileResourceStream#getInputStreamSupplier()} will not be called if the client has an up-to-date
+ * file according to its {@link FileResource#getContentMd5()} value.
+ */
 public class FileResourceRequestHandler {
 
   private static final CacheControl MUST_REVALIDATE =

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/FileResourceRequestHandler.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/FileResourceRequestHandler.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.export;
+
+import java.util.concurrent.TimeUnit;
+import javax.servlet.http.HttpServletRequest;
+import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ConflictException;
+import org.hisp.dhis.fileresource.FileResource;
+import org.hisp.dhis.tracker.export.FileResourceStream;
+import org.hisp.dhis.webapi.utils.ResponseEntityUtils;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+/** FileResourceRequestHandler serves files and images given a {@link FileResourceStream}. */
+public class FileResourceRequestHandler {
+
+  private static final CacheControl MUST_REVALIDATE =
+      CacheControl.maxAge(0, TimeUnit.SECONDS).cachePrivate().mustRevalidate();
+
+  private FileResourceRequestHandler() {
+    throw new IllegalStateException("Utility class");
+  }
+
+  public static ResponseEntity<InputStreamResource> handleFileRequest(
+      HttpServletRequest request, FileResourceStream file)
+      throws ConflictException, BadRequestException {
+    FileResource fileResource = file.getFileResource();
+
+    final String etag = fileResource.getContentMd5();
+    if (ResponseEntityUtils.checkNotModified(etag, request)) {
+      return ResponseEntity.status(HttpStatus.NOT_MODIFIED)
+          .cacheControl(MUST_REVALIDATE)
+          .eTag(etag)
+          .build();
+    }
+
+    return ResponseEntity.ok()
+        .cacheControl(MUST_REVALIDATE)
+        .eTag(etag)
+        .contentType(MediaType.valueOf(fileResource.getContentType()))
+        .contentLength(fileResource.getContentLength())
+        .header(
+            HttpHeaders.CONTENT_DISPOSITION,
+            ResponseHeader.contentDispositionValue(fileResource.getName()))
+        .body(new InputStreamResource(file.getInputStreamSupplier().get()));
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/ResponseHeader.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/ResponseHeader.java
@@ -44,4 +44,10 @@ public class ResponseHeader {
   public static String contentDispositionValue(String filename) {
     return "attachment; filename=" + filename;
   }
+
+  public static void addContentTransferEncodingBinary(HttpServletResponse response) {
+    response.addHeader(
+        ContextUtils.HEADER_CONTENT_TRANSFER_ENCODING,
+        ContextUtils.BINARY_HEADER_CONTENT_TRANSFER_ENCODING);
+  }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/ResponseHeader.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/ResponseHeader.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.export;
+
+import javax.servlet.http.HttpServletResponse;
+import org.hisp.dhis.webapi.utils.ContextUtils;
+
+/** ResponseHeader sets HTTP headers common in tracker export endpoints. */
+public class ResponseHeader {
+
+  private ResponseHeader() {
+    throw new IllegalStateException("Utility class");
+  }
+
+  public static void addContentDisposition(HttpServletResponse response, String filename) {
+    response.addHeader(ContextUtils.HEADER_CONTENT_DISPOSITION, contentDispositionValue(filename));
+  }
+
+  public static String contentDispositionValue(String filename) {
+    return "attachment; filename=" + filename;
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -71,7 +71,6 @@ import org.hisp.dhis.webapi.controller.tracker.export.ResponseHeader;
 import org.hisp.dhis.webapi.controller.tracker.view.Event;
 import org.hisp.dhis.webapi.controller.tracker.view.Page;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
-import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.hisp.dhis.webapi.utils.ResponseEntityUtils;
 import org.mapstruct.factory.Mappers;
 import org.springframework.core.io.InputStreamResource;
@@ -167,9 +166,7 @@ class EventsExportController {
 
     String attachment = getAttachmentOrDefault(eventRequestParams.getAttachment(), "json", "gz");
     ResponseHeader.addContentDisposition(response, attachment);
-    response.addHeader(
-        ContextUtils.HEADER_CONTENT_TRANSFER_ENCODING,
-        ContextUtils.BINARY_HEADER_CONTENT_TRANSFER_ENCODING);
+    ResponseHeader.addContentTransferEncodingBinary(response);
     response.setContentType(CONTENT_TYPE_JSON_GZIP);
 
     writeGzip(
@@ -187,9 +184,7 @@ class EventsExportController {
 
     String attachment = getAttachmentOrDefault(eventRequestParams.getAttachment(), "json", "zip");
     ResponseHeader.addContentDisposition(response, attachment);
-    response.addHeader(
-        ContextUtils.HEADER_CONTENT_TRANSFER_ENCODING,
-        ContextUtils.BINARY_HEADER_CONTENT_TRANSFER_ENCODING);
+    ResponseHeader.addContentTransferEncodingBinary(response);
     response.setContentType(CONTENT_TYPE_JSON_ZIP);
 
     writeZip(
@@ -229,9 +224,7 @@ class EventsExportController {
 
     String attachment = getAttachmentOrDefault(eventRequestParams.getAttachment(), "csv", "gz");
     ResponseHeader.addContentDisposition(response, attachment);
-    response.addHeader(
-        ContextUtils.HEADER_CONTENT_TRANSFER_ENCODING,
-        ContextUtils.BINARY_HEADER_CONTENT_TRANSFER_ENCODING);
+    ResponseHeader.addContentTransferEncodingBinary(response);
     response.setContentType(CONTENT_TYPE_CSV_GZIP);
 
     csvEventService.writeGzip(
@@ -250,9 +243,7 @@ class EventsExportController {
 
     String attachment = getAttachmentOrDefault(eventRequestParams.getAttachment(), "csv", "zip");
     ResponseHeader.addContentDisposition(response, attachment);
-    response.addHeader(
-        ContextUtils.HEADER_CONTENT_TRANSFER_ENCODING,
-        ContextUtils.BINARY_HEADER_CONTENT_TRANSFER_ENCODING);
+    ResponseHeader.addContentTransferEncodingBinary(response);
     response.setContentType(CONTENT_TYPE_CSV_ZIP);
 
     csvEventService.writeZip(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -284,7 +284,7 @@ class TrackedEntitiesExportController {
   ResponseEntity<InputStreamResource> getEventDataValueFile(
       @OpenApi.Param({UID.class, TrackedEntity.class}) @PathVariable UID trackedEntity,
       @OpenApi.Param({UID.class, Attribute.class}) @PathVariable UID attribute,
-      @OpenApi.Param({UID.class, Program.class}) @RequestParam UID program,
+      @OpenApi.Param({UID.class, Program.class}) @RequestParam(required = false) UID program,
       HttpServletRequest request)
       throws NotFoundException, ConflictException, BadRequestException {
     return handleFileRequest(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/ExcludableShallowEtagHeaderFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/ExcludableShallowEtagHeaderFilter.java
@@ -84,6 +84,11 @@ public class ExcludableShallowEtagHeaderFilter extends ShallowEtagHeaderFilter {
           + UID_REGEXP
           + "/dataValues/"
           + UID_REGEXP
+          + "/(file|image)|"
+          + "/api/(\\d{2}/)?tracker/trackedEntities/"
+          + UID_REGEXP
+          + "/attributes/"
+          + UID_REGEXP
           + "/(file|image)";
 
   private Pattern pattern = null;

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/filter/ExcludableShallowEtagHeaderFilterTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/filter/ExcludableShallowEtagHeaderFilterTest.java
@@ -68,6 +68,8 @@ class ExcludableShallowEtagHeaderFilterTest {
         "/api/41/tracker/events/RkV9CZzmV2E/dataValues/q33Wv8jNvFA/file",
         "/api/tracker/events/RkV9CZzmV2E/dataValues/q33Wv8jNvFA/image",
         "/api/41/tracker/events/RkV9CZzmV2E/dataValues/q33Wv8jNvFA/image",
+        "/api/tracker/trackedEntities/vOxUH373fy5/attributes/nDlikr3TUS6/file",
+        "/api/41/tracker/trackedEntities/vOxUH373fy5/attributes/nDlikr3TUS6/file"
       })
   void shouldNotAddEtagHeader(String URI) throws Exception {
     final MockHttpServletRequest request = new MockHttpServletRequest("GET", URI);

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/filter/ExcludableShallowEtagHeaderFilterTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/filter/ExcludableShallowEtagHeaderFilterTest.java
@@ -69,7 +69,9 @@ class ExcludableShallowEtagHeaderFilterTest {
         "/api/tracker/events/RkV9CZzmV2E/dataValues/q33Wv8jNvFA/image",
         "/api/41/tracker/events/RkV9CZzmV2E/dataValues/q33Wv8jNvFA/image",
         "/api/tracker/trackedEntities/vOxUH373fy5/attributes/nDlikr3TUS6/file",
-        "/api/41/tracker/trackedEntities/vOxUH373fy5/attributes/nDlikr3TUS6/file"
+        "/api/41/tracker/trackedEntities/vOxUH373fy5/attributes/nDlikr3TUS6/file",
+        "/api/tracker/trackedEntities/vOxUH373fy5/attributes/nDlikr3TUS6/image",
+        "/api/41/tracker/trackedEntities/vOxUH373fy5/attributes/nDlikr3TUS6/image"
       })
   void shouldNotAddEtagHeader(String URI) throws Exception {
     final MockHttpServletRequest request = new MockHttpServletRequest("GET", URI);


### PR DESCRIPTION
As for events https://github.com/dhis2/dhis2-core/pull/16446 add `GET "/tracker/trackedEntities/{trackedEntity}/attributes/{attribute}/file"`.

* extract serving of files from event controller into `FileResourceRequestHandler` for reuse in tracked entity controller
* implement finding file resource and its stream analogous to the implementation for events https://github.com/dhis2/dhis2-core/pull/16446
