### PR TITLE
feat: added missing `stageOffset` in TEI cross program response headers [DHIS2-16742]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/GridHeader.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/GridHeader.java
@@ -33,6 +33,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.With;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.legend.LegendSet;
 import org.hisp.dhis.option.OptionSet;
@@ -40,6 +42,7 @@ import org.hisp.dhis.option.OptionSet;
 /**
  * @author Lars Helge Overland
  */
+@AllArgsConstructor
 public class GridHeader implements Serializable {
   private static final Set<String> NUMERIC_TYPES =
       Set.of(
@@ -70,7 +73,7 @@ public class GridHeader implements Serializable {
 
   private String displayColumn;
 
-  private transient RepeatableStageParams repeatableStageParams;
+  @With private transient RepeatableStageParams repeatableStageParams;
 
   // -------------------------------------------------------------------------
   // Constructors

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/RepeatableStageParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/RepeatableStageParams.java
@@ -28,13 +28,19 @@
 package org.hisp.dhis.common;
 
 import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /** Parameters for repeatable stage values. */
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @EqualsAndHashCode(of = {"startIndex", "count", "startDate", "endDate"})
 public class RepeatableStageParams {
   private int startIndex;
@@ -66,5 +72,9 @@ public class RepeatableStageParams {
   /** Indicates whether value type should be considered as a number. */
   public boolean simpleStageValueExpected() {
     return count == 1;
+  }
+
+  public static RepeatableStageParams ofStartIndex(int startIndex) {
+    return RepeatableStageParams.builder().startIndex(startIndex).build();
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TrackedEntityQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TrackedEntityQueryTest.java
@@ -3083,4 +3083,44 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
     validateRow(response, 0, List.of("John", "Kelly"));
     validateRow(response, 1, List.of("John", "Doe"));
   }
+
+  @Test
+  public void headerShouldContainOffsetIfPresent() {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("dimension=IpHINAT79UW.A03MvHHogjR[-1].bx6fsa0t90x")
+            .add("headers=IpHINAT79UW.A03MvHHogjR[-1].bx6fsa0t90x")
+            .add("pageSize=0");
+
+    // When
+    ApiResponse response = analyticsTeiActions.query().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers[0].name", equalTo("IpHINAT79UW.A03MvHHogjR[-1].bx6fsa0t90x"))
+        .body("headers[0].stageOffset", equalTo(-1));
+  }
+
+  @Test
+  public void headerShouldNotContainOffsetIfNotPresent() {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("dimension=IpHINAT79UW.A03MvHHogjR.bx6fsa0t90x")
+            .add("headers=IpHINAT79UW.A03MvHHogjR.bx6fsa0t90x")
+            .add("pageSize=0");
+
+    // When
+    ApiResponse response = analyticsTeiActions.query().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers[0].name", equalTo("IpHINAT79UW.A03MvHHogjR.bx6fsa0t90x"))
+        .body("headers[0]", not(hasKey("stageOffset")));
+  }
 }


### PR DESCRIPTION
This PR will add the missing "stageOffset" field to the response the Cross-Program Linelisting API provides in the Tei analytics. This field was present in other endpoints but was absent in the original response. With this addition, the API response now aligns consistently across endpoints.