### PR TITLE
fix: add jasperreports-fonts to fix pdf Arabic characters

### DIFF
--- a/dhis-2/dhis-services/dhis-service-reporting/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-reporting/pom.xml
@@ -167,6 +167,10 @@
       <artifactId>jasperreports</artifactId>
     </dependency>
     <dependency>
+      <groupId>net.sf.jasperreports</groupId>
+      <artifactId>jasperreports-fonts</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jfree</groupId>
       <artifactId>jfreechart</artifactId>
     </dependency>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1170,6 +1170,11 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>net.sf.jasperreports</groupId>
+        <artifactId>jasperreports-fonts</artifactId>
+        <version>${jasperreports.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.jfree</groupId>
         <artifactId>jfreechart</artifactId>
         <version>${jfreechart.version}</version>
@@ -2013,6 +2018,7 @@ jasperreports.version=${jasperreports.version}
             <ignoredUnusedDeclaredDependencies>
               <ignoredUnusedDeclaredDependency>org.junit.jupiter:junit-jupiter</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>net.sf.jasperreports:jasperreports</ignoredUnusedDeclaredDependency>
+              <ignoredUnusedDeclaredDependency>net.sf.jasperreports:jasperreports-fonts</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.mockito:mockito-inline</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>javax.servlet:javax.servlet-api</ignoredUnusedDeclaredDependency>


### PR DESCRIPTION
Continue on https://github.com/dhis2/dhis2-core/pull/16495
- When working on https://github.com/dhis2/dhis2-core/pull/16495 I added `jasperreports-fonts` dependency before downgrade Jasper Report to 6.20.0. Then I remove it and I thought the fix doesn't require this dependency but it turned out the test file on my local was cached. 
- Test again now on https://dev.im.dhis2.org/viet-test and and cleared the browser cache. 
<img width="1468" alt="Screen Shot 2024-02-14 at 2 57 51 PM" src="https://github.com/dhis2/dhis2-core/assets/766102/8d2ca841-dab3-4898-8401-00f431bde7a3">

