### PR TITLE
feat: feat: add tracker endpoint to download attribute image DHIS2-16763

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/FileResourceStream.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/FileResourceStream.java
@@ -27,12 +27,22 @@
  */
 package org.hisp.dhis.tracker.export;
 
+import com.google.common.hash.Hashing;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.util.NoSuchElementException;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
+import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.fileresource.FileResource;
+import org.hisp.dhis.fileresource.FileResourceService;
+import org.hisp.dhis.fileresource.ImageFileDimension;
+import org.hisp.dhis.util.ObjectUtils;
 
 /**
  * FileResourceStream holds a file resource and a supplier to open an input stream to the file
@@ -43,5 +53,96 @@ import org.hisp.dhis.fileresource.FileResource;
 @RequiredArgsConstructor
 public class FileResourceStream {
   private final FileResource fileResource;
-  @Setter private FileResourceSupplier<InputStream> inputStreamSupplier;
+  private FileResourceSupplier<InputStream> inputStreamSupplier;
+
+  @Nonnull
+  public static FileResourceStream of(
+      FileResourceService fileResourceService, FileResource fileResource) {
+    return new FileResourceStream(
+        fileResource,
+        () -> {
+          try {
+            return fileResourceService.openContentStream(fileResource);
+          } catch (NoSuchElementException e) {
+            // Note: we are assuming that the file resource is not available yet. The same approach
+            // is taken in other file endpoints or code relying on the storageStatus = PENDING.
+            // All we know for sure is the file resource is in the DB but not in the store.
+            throw new ConflictException(
+                "The content is being processed and is not available yet. Try again later.");
+          } catch (IOException e) {
+            throw new ConflictException(
+                "Failed fetching the file from storage",
+                "There was an exception when trying to fetch the file from the storage backend. "
+                    + "Depending on the provider the root cause could be network or file system related.");
+          }
+        });
+  }
+
+  /**
+   * Creates a {@code FileResourceStream} of an image of the given dimension. Dimension defaults to
+   * the original dimensions if the given {@code dimension} is {@code null}.
+   *
+   * <p>Images have to be fetched and buffered in memory for image dimension other than the
+   * original. This is due to us currently only storing the originals content length and md5 hash in
+   * the DB. We thus need to read the image and compute its content length and md5 hash for them to
+   * be available for cache validation.
+   *
+   * @param dimension the dimension of the image to create a stream for
+   * @throws BadRequestException when the file resource is not an image, does not support multiple
+   *     dimensions or does not have multiple dimension files stored
+   */
+  @Nonnull
+  public static FileResourceStream ofImage(
+      FileResourceService fileResourceService,
+      FileResource fileResource,
+      @CheckForNull ImageFileDimension dimension)
+      throws BadRequestException, ConflictException {
+    // The FileResource only stores the storageKey, contentLength and md5Hash of the original image.
+    // At least for now we are losing the benefit of not fetching the file from storage if the
+    // client already has an up-to-date version of the image in the given dimension other than the
+    // original. We have to fetch and compute the length and hash of the image again.
+    ImageFileDimension imageDimension =
+        ObjectUtils.firstNonNull(dimension, ImageFileDimension.ORIGINAL);
+    FileResourceStream fileResourceStream = new FileResourceStream(fileResource);
+    if (imageDimension != ImageFileDimension.ORIGINAL) {
+      byte[] content;
+      try {
+        content = fileResourceService.copyImageContent(fileResource, imageDimension);
+        fileResourceStream.inputStreamSupplier = () -> new ByteArrayInputStream(content);
+      } catch (NoSuchElementException e) {
+        // Note: we are assuming that the file resource is not available yet. The same approach
+        // is taken in other file endpoints or code relying on the storageStatus = PENDING.
+        // All we know for sure is the file resource is in the DB but not in the store.
+        throw new ConflictException(
+            "The content is being processed and is not available yet. Try again later.");
+      } catch (IOException e) {
+        throw new ConflictException(
+            "Failed fetching the file from storage",
+            "There was an exception when trying to fetch the file from the storage backend. "
+                + "Depending on the provider the root cause could be network or file system related.");
+      }
+      fileResource.setContentLength(content.length);
+      fileResource.setContentMd5(Hashing.md5().hashBytes(content).toString());
+    } else {
+      fileResourceStream.inputStreamSupplier =
+          () -> {
+            try {
+              return fileResourceService.openContentStreamToImage(fileResource, dimension);
+            } catch (NoSuchElementException e) {
+              // Note: we are assuming that the file resource is not available yet. The same
+              // approach
+              // is taken in other file endpoints or code relying on the storageStatus = PENDING.
+              // All we know for sure is the file resource is in the DB but not in the store.
+              throw new ConflictException(
+                  "The content is being processed and is not available yet. Try again later.");
+            } catch (IOException e) {
+              throw new ConflictException(
+                  "Failed fetching the file from storage",
+                  "There was an exception when trying to fetch the file from the storage backend. "
+                      + "Depending on the provider the root cause could be network or file system related.");
+            }
+          };
+    }
+    return fileResourceStream;
+  }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -27,12 +27,8 @@
  */
 package org.hisp.dhis.tracker.export.event;
 
-import com.google.common.hash.Hashing;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
@@ -59,7 +55,6 @@ import org.hisp.dhis.tracker.export.PageParams;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
-import org.hisp.dhis.util.ObjectUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -90,25 +85,7 @@ class DefaultEventService implements EventService {
   public FileResourceStream getFileResource(UID eventUid, UID dataElementUid)
       throws NotFoundException {
     FileResource fileResource = getFileResourceMetadata(eventUid, dataElementUid);
-
-    return new FileResourceStream(
-        fileResource,
-        () -> {
-          try {
-            return fileResourceService.openContentStream(fileResource);
-          } catch (NoSuchElementException e) {
-            // Note: we are assuming that the file resource is not available yet. The same approach
-            // is taken in other file endpoints or code relying on the storageStatus = PENDING.
-            // All we know for sure is the file resource is in the DB but not in the store.
-            throw new ConflictException(
-                "The content is being processed and is not available yet. Try again later.");
-          } catch (IOException e) {
-            throw new ConflictException(
-                "Failed fetching the file from storage",
-                "There was an exception when trying to fetch the file from the storage backend. "
-                    + "Depending on the provider the root cause could be network or file system related.");
-          }
-        });
+    return FileResourceStream.of(fileResourceService, fileResource);
   }
 
   @Override
@@ -116,54 +93,7 @@ class DefaultEventService implements EventService {
       UID eventUid, UID dataElementUid, ImageFileDimension dimension)
       throws NotFoundException, ConflictException, BadRequestException {
     FileResource fileResource = getFileResourceMetadata(eventUid, dataElementUid);
-
-    // The FileResource only stores the storageKey, contentLength and md5Hash of the original image.
-    // At least for now we are losing the benefit of not fetching the file from storage if the
-    // client already has an up-to-date version of the image in the given dimension other than the
-    // original. We have to fetch and compute the length and hash of the image again.
-    ImageFileDimension imageDimension =
-        ObjectUtils.firstNonNull(dimension, ImageFileDimension.ORIGINAL);
-    FileResourceStream fileResourceStream = new FileResourceStream(fileResource);
-    if (imageDimension != ImageFileDimension.ORIGINAL) {
-      byte[] content;
-      try {
-        content = fileResourceService.copyImageContent(fileResource, imageDimension);
-        fileResourceStream.setInputStreamSupplier(() -> new ByteArrayInputStream(content));
-      } catch (NoSuchElementException e) {
-        // Note: we are assuming that the file resource is not available yet. The same approach
-        // is taken in other file endpoints or code relying on the storageStatus = PENDING.
-        // All we know for sure is the file resource is in the DB but not in the store.
-        throw new ConflictException(
-            "The content is being processed and is not available yet. Try again later.");
-      } catch (IOException e) {
-        throw new ConflictException(
-            "Failed fetching the file from storage",
-            "There was an exception when trying to fetch the file from the storage backend. "
-                + "Depending on the provider the root cause could be network or file system related.");
-      }
-      fileResource.setContentLength(content.length);
-      fileResource.setContentMd5(Hashing.md5().hashBytes(content).toString());
-    } else {
-      fileResourceStream.setInputStreamSupplier(
-          () -> {
-            try {
-              return fileResourceService.openContentStreamToImage(fileResource, dimension);
-            } catch (NoSuchElementException e) {
-              // Note: we are assuming that the file resource is not available yet. The same
-              // approach
-              // is taken in other file endpoints or code relying on the storageStatus = PENDING.
-              // All we know for sure is the file resource is in the DB but not in the store.
-              throw new ConflictException(
-                  "The content is being processed and is not available yet. Try again later.");
-            } catch (IOException e) {
-              throw new ConflictException(
-                  "Failed fetching the file from storage",
-                  "There was an exception when trying to fetch the file from the storage backend. "
-                      + "Depending on the provider the root cause could be network or file system related.");
-            }
-          });
-    }
-    return fileResourceStream;
+    return FileResourceStream.ofImage(fileResourceService, fileResource, dimension);
   }
 
   private FileResource getFileResourceMetadata(UID eventUid, UID dataElementUid)

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
@@ -31,8 +31,10 @@ import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
+import org.hisp.dhis.fileresource.ImageFileDimension;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.tracker.export.FileResourceStream;
 import org.hisp.dhis.tracker.export.Page;
@@ -43,6 +45,11 @@ public interface TrackedEntityService {
   /** Get a file for a tracked entities' attribute. */
   FileResourceStream getFileResource(UID trackedEntity, UID attribute, UID program)
       throws NotFoundException;
+
+  /** Get an image for a tracked entities' attribute in the given dimension. */
+  FileResourceStream getFileResourceImage(
+      UID trackedEntity, UID attribute, UID program, ImageFileDimension dimension)
+      throws NotFoundException, ConflictException, BadRequestException;
 
   TrackedEntity getTrackedEntity(String uid, TrackedEntityParams params, boolean includeDeleted)
       throws NotFoundException, ForbiddenException;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -56,6 +56,7 @@ import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fieldfiltering.FieldFilterParser;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
+import org.hisp.dhis.fileresource.ImageFileDimension;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.tracker.export.PageParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityOperationParams;
@@ -281,7 +282,7 @@ class TrackedEntitiesExportController {
   }
 
   @GetMapping("/{trackedEntity}/attributes/{attribute}/file")
-  ResponseEntity<InputStreamResource> getEventDataValueFile(
+  ResponseEntity<InputStreamResource> getAttributeValueFile(
       @OpenApi.Param({UID.class, TrackedEntity.class}) @PathVariable UID trackedEntity,
       @OpenApi.Param({UID.class, Attribute.class}) @PathVariable UID attribute,
       @OpenApi.Param({UID.class, Program.class}) @RequestParam(required = false) UID program,
@@ -289,5 +290,18 @@ class TrackedEntitiesExportController {
       throws NotFoundException, ConflictException, BadRequestException {
     return handleFileRequest(
         request, trackedEntityService.getFileResource(trackedEntity, attribute, program));
+  }
+
+  @GetMapping("/{trackedEntity}/attributes/{attribute}/image")
+  ResponseEntity<InputStreamResource> getAttributeValueImage(
+      @OpenApi.Param({UID.class, TrackedEntity.class}) @PathVariable UID trackedEntity,
+      @OpenApi.Param({UID.class, Attribute.class}) @PathVariable UID attribute,
+      @OpenApi.Param({UID.class, Program.class}) @RequestParam(required = false) UID program,
+      @RequestParam(required = false) ImageFileDimension dimension,
+      HttpServletRequest request)
+      throws NotFoundException, ConflictException, BadRequestException {
+    return handleFileRequest(
+        request,
+        trackedEntityService.getFileResourceImage(trackedEntity, attribute, program, dimension));
   }
 }


### PR DESCRIPTION
As for events https://github.com/dhis2/dhis2-core/pull/16473 add `GET "/tracker/trackedEntities/{trackedEntity}/attributes/{attribute}/image"`

* endpoint was already excluded from Springs shallow etag filter in https://github.com/dhis2/dhis2-core/pull/16487
* contain the ugliness of us having to re-compute small, medium and large image md5 hashes in the `FileResourceStream` class. This also allows us to hide the fact that we need to resort to mutation 😅  
