### PR TITLE
chore: reject dimension parameter on tracker file endpoints DHIS2-16786

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/ImageFileDimension.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/ImageFileDimension.java
@@ -28,10 +28,12 @@
 package org.hisp.dhis.fileresource;
 
 import java.util.Optional;
+import org.hisp.dhis.common.OpenApi;
 
 /**
  * @Author Zubair Asghar.
  */
+@OpenApi.Shared
 public enum ImageFileDimension {
   SMALL("small"),
   MEDIUM("medium"),

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerByIdTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerByIdTest.java
@@ -420,6 +420,18 @@ class EventsExportControllerByIdTest extends DhisControllerConvenienceTest {
   }
 
   @Test
+  void getDataValuesFileByDataElementIfGivenDimensionParameter() {
+    assertStartsWith(
+        "Request parameter 'dimension'",
+        GET(
+                "/tracker/events/{eventUid}/dataValues/{dataElementUid}/file?dimension=small",
+                CodeGenerator.generateUid(),
+                CodeGenerator.generateUid())
+            .error(HttpStatus.BAD_REQUEST)
+            .getMessage());
+  }
+
+  @Test
   void getDataValuesFileByDataElementIfDataElementIsNotFound() {
     Event event = event(enrollment(trackedEntity()));
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerByIdTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerByIdTest.java
@@ -370,7 +370,7 @@ class EventsExportControllerByIdTest extends DhisControllerConvenienceTest {
     assertEquals("\"" + file.getContentMd5() + "\"", response.header("Etag"));
     assertEquals("max-age=0, must-revalidate, private", response.header("Cache-Control"));
     assertEquals(Long.toString(file.getContentLength()), response.header("Content-Length"));
-    assertEquals("attachment; filename=" + file.getName(), response.header("Content-Disposition"));
+    assertEquals("filename=" + file.getName(), response.header("Content-Disposition"));
     assertEquals("file content", response.content("text/plain"));
   }
 
@@ -392,7 +392,7 @@ class EventsExportControllerByIdTest extends DhisControllerConvenienceTest {
     assertEquals(HttpStatus.OK, response.status());
     assertEquals("\"" + file.getContentMd5() + "\"", response.header("Etag"));
     assertEquals("max-age=0, must-revalidate, private", response.header("Cache-Control"));
-    assertEquals("attachment; filename=" + file.getName(), response.header("Content-Disposition"));
+    assertEquals("filename=" + file.getName(), response.header("Content-Disposition"));
     assertEquals(Long.toString(file.getContentLength()), response.header("Content-Length"));
     assertEquals("file content", response.content("image/png"));
   }
@@ -563,7 +563,7 @@ class EventsExportControllerByIdTest extends DhisControllerConvenienceTest {
     assertEquals(HttpStatus.OK, response.status());
     assertEquals("\"" + file.getContentMd5() + "\"", response.header("Etag"));
     assertEquals("max-age=0, must-revalidate, private", response.header("Cache-Control"));
-    assertEquals("attachment; filename=" + file.getName(), response.header("Content-Disposition"));
+    assertEquals("filename=" + file.getName(), response.header("Content-Disposition"));
     assertEquals(Long.toString(file.getContentLength()), response.header("Content-Length"));
     assertEquals("file content", response.content("image/png"));
   }
@@ -598,7 +598,7 @@ class EventsExportControllerByIdTest extends DhisControllerConvenienceTest {
     HashCode expectedHashCode = Hashing.md5().hashString(smallFileContent, StandardCharsets.UTF_8);
     assertEquals("\"" + expectedHashCode + "\"", response.header("Etag"));
     assertEquals("max-age=0, must-revalidate, private", response.header("Cache-Control"));
-    assertEquals("attachment; filename=" + file.getName(), response.header("Content-Disposition"));
+    assertEquals("filename=" + file.getName(), response.header("Content-Disposition"));
     assertEquals(
         Long.toString(smallFileContent.getBytes().length), response.header("Content-Length"));
     assertEquals(smallFileContent, response.content("image/png"));

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -652,7 +652,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
     assertEquals("\"" + file.getContentMd5() + "\"", response.header("Etag"));
     assertEquals("max-age=0, must-revalidate, private", response.header("Cache-Control"));
     assertEquals(Long.toString(file.getContentLength()), response.header("Content-Length"));
-    assertEquals("attachment; filename=" + file.getName(), response.header("Content-Disposition"));
+    assertEquals("filename=" + file.getName(), response.header("Content-Disposition"));
     assertEquals("file content", response.content("text/plain"));
   }
 
@@ -677,7 +677,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
     assertEquals("\"" + file.getContentMd5() + "\"", response.header("Etag"));
     assertEquals("max-age=0, must-revalidate, private", response.header("Cache-Control"));
     assertEquals(Long.toString(file.getContentLength()), response.header("Content-Length"));
-    assertEquals("attachment; filename=" + file.getName(), response.header("Content-Disposition"));
+    assertEquals("filename=" + file.getName(), response.header("Content-Disposition"));
     assertEquals("file content", response.content("text/plain"));
   }
 
@@ -930,7 +930,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
     assertEquals(HttpStatus.OK, response.status());
     assertEquals("\"" + file.getContentMd5() + "\"", response.header("Etag"));
     assertEquals("max-age=0, must-revalidate, private", response.header("Cache-Control"));
-    assertEquals("attachment; filename=" + file.getName(), response.header("Content-Disposition"));
+    assertEquals("filename=" + file.getName(), response.header("Content-Disposition"));
     assertEquals(Long.toString(file.getContentLength()), response.header("Content-Length"));
     assertEquals("file content", response.content("image/png"));
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -682,6 +682,18 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   }
 
   @Test
+  void getAttributeValuesFileByAttributeIfGivenParameterDimension() {
+    assertStartsWith(
+        "Request parameter 'dimension'",
+        GET(
+                "/tracker/trackedEntities/{trackedEntityUid}/attributes/{attributeUid}/file?dimension=small",
+                CodeGenerator.generateUid(),
+                CodeGenerator.generateUid())
+            .error(HttpStatus.BAD_REQUEST)
+            .getMessage());
+  }
+
+  @Test
   void getAttributeValuesFileByAttributeIfAttributeIsNotFound() throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
     TrackedEntityAttribute tea = attribute(ValueType.FILE_RESOURCE);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/FileResourceRequestHandler.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/FileResourceRequestHandler.java
@@ -75,7 +75,7 @@ public class FileResourceRequestHandler {
         .contentLength(fileResource.getContentLength())
         .header(
             HttpHeaders.CONTENT_DISPOSITION,
-            ResponseHeader.contentDispositionValue(fileResource.getName()))
+            ResponseHeader.contentDispositionInline(fileResource.getName()))
         .body(new InputStreamResource(file.getInputStreamSupplier().get()));
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamsValidator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamsValidator.java
@@ -46,6 +46,7 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
@@ -429,6 +430,13 @@ public class RequestParamsValidator {
 
   private static boolean lessThan(Integer a, int b) {
     return a != null && a < b;
+  }
+
+  public static void validateUnsupportedParameter(
+      HttpServletRequest request, String dimension, String message) throws BadRequestException {
+    if (StringUtils.isNotEmpty(request.getParameter(dimension))) {
+      throw new BadRequestException(message);
+    }
   }
 
   private static QueryFilter operatorValueQueryFilter(String operator, String value, String filter)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/ResponseHeader.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/ResponseHeader.java
@@ -37,12 +37,18 @@ public class ResponseHeader {
     throw new IllegalStateException("Utility class");
   }
 
-  public static void addContentDisposition(HttpServletResponse response, String filename) {
-    response.addHeader(ContextUtils.HEADER_CONTENT_DISPOSITION, contentDispositionValue(filename));
+  public static void addContentDispositionAttachment(
+      HttpServletResponse response, String filename) {
+    response.addHeader(
+        ContextUtils.HEADER_CONTENT_DISPOSITION, contentDispositionAttachment(filename));
   }
 
-  public static String contentDispositionValue(String filename) {
+  public static String contentDispositionAttachment(String filename) {
     return "attachment; filename=" + filename;
+  }
+
+  public static String contentDispositionInline(String filename) {
+    return "filename=" + filename;
   }
 
   public static void addContentTransferEncodingBinary(HttpServletResponse response) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -158,7 +158,7 @@ class EventsExportController {
     List<org.hisp.dhis.program.Event> events = eventService.getEvents(eventOperationParams);
 
     String attachment = getAttachmentOrDefault(eventRequestParams.getAttachment(), "json", "gz");
-    ResponseHeader.addContentDisposition(response, attachment);
+    ResponseHeader.addContentDispositionAttachment(response, attachment);
     ResponseHeader.addContentTransferEncodingBinary(response);
     response.setContentType(CONTENT_TYPE_JSON_GZIP);
 
@@ -176,7 +176,7 @@ class EventsExportController {
     List<org.hisp.dhis.program.Event> events = eventService.getEvents(eventOperationParams);
 
     String attachment = getAttachmentOrDefault(eventRequestParams.getAttachment(), "json", "zip");
-    ResponseHeader.addContentDisposition(response, attachment);
+    ResponseHeader.addContentDispositionAttachment(response, attachment);
     ResponseHeader.addContentTransferEncodingBinary(response);
     response.setContentType(CONTENT_TYPE_JSON_ZIP);
 
@@ -198,7 +198,7 @@ class EventsExportController {
     List<org.hisp.dhis.program.Event> events = eventService.getEvents(eventOperationParams);
 
     String attachment = getAttachmentOrDefault(eventRequestParams.getAttachment(), "csv");
-    ResponseHeader.addContentDisposition(response, attachment);
+    ResponseHeader.addContentDispositionAttachment(response, attachment);
     response.setContentType(CONTENT_TYPE_CSV);
 
     csvEventService.write(
@@ -216,7 +216,7 @@ class EventsExportController {
     List<org.hisp.dhis.program.Event> events = eventService.getEvents(eventOperationParams);
 
     String attachment = getAttachmentOrDefault(eventRequestParams.getAttachment(), "csv", "gz");
-    ResponseHeader.addContentDisposition(response, attachment);
+    ResponseHeader.addContentDispositionAttachment(response, attachment);
     ResponseHeader.addContentTransferEncodingBinary(response);
     response.setContentType(CONTENT_TYPE_CSV_GZIP);
 
@@ -235,7 +235,7 @@ class EventsExportController {
     List<org.hisp.dhis.program.Event> events = eventService.getEvents(eventOperationParams);
 
     String attachment = getAttachmentOrDefault(eventRequestParams.getAttachment(), "csv", "zip");
-    ResponseHeader.addContentDisposition(response, attachment);
+    ResponseHeader.addContentDispositionAttachment(response, attachment);
     ResponseHeader.addContentTransferEncodingBinary(response);
     response.setContentType(CONTENT_TYPE_CSV_ZIP);
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -84,7 +84,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping(value = RESOURCE_PATH + "/" + EventsExportController.EVENTS)
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
-@OpenApi.Ignore
 class EventsExportController {
   protected static final String EVENTS = "events";
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -34,6 +34,7 @@ import static org.hisp.dhis.webapi.controller.tracker.export.CompressionUtil.wri
 import static org.hisp.dhis.webapi.controller.tracker.export.CompressionUtil.writeZip;
 import static org.hisp.dhis.webapi.controller.tracker.export.FileResourceRequestHandler.handleFileRequest;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validatePaginationParameters;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateUnsupportedParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.event.EventRequestParams.DEFAULT_FIELDS_PARAM;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_CSV;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_CSV_GZIP;
@@ -270,6 +271,11 @@ class EventsExportController {
       @OpenApi.Param({UID.class, DataElement.class}) @PathVariable UID dataElement,
       HttpServletRequest request)
       throws NotFoundException, ConflictException, BadRequestException {
+    validateUnsupportedParameter(
+        request,
+        "dimension",
+        "Request parameter 'dimension' is only supported for images by API /tracker/event/dataValues/{dataElement}/image");
+
     return handleFileRequest(request, eventService.getFileResource(event, dataElement));
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -175,7 +175,7 @@ class TrackedEntitiesExportController {
         paramsMapper.map(trackedEntityRequestParams, user, CSV_FIELDS);
 
     String attachment = getAttachmentOrDefault(trackedEntityRequestParams.getAttachment(), "csv");
-    ResponseHeader.addContentDisposition(response, attachment);
+    ResponseHeader.addContentDispositionAttachment(response, attachment);
     ResponseHeader.addContentTransferEncodingBinary(response);
     response.setContentType(CONTENT_TYPE_CSV);
 
@@ -198,7 +198,7 @@ class TrackedEntitiesExportController {
 
     String attachment =
         getAttachmentOrDefault(trackedEntityRequestParams.getAttachment(), "csv", "zip");
-    ResponseHeader.addContentDisposition(response, attachment);
+    ResponseHeader.addContentDispositionAttachment(response, attachment);
     ResponseHeader.addContentTransferEncodingBinary(response);
     response.setContentType(CONTENT_TYPE_CSV_ZIP);
 
@@ -222,7 +222,7 @@ class TrackedEntitiesExportController {
 
     String attachment =
         getAttachmentOrDefault(trackedEntityRequestParams.getAttachment(), "csv", "gz");
-    ResponseHeader.addContentDisposition(response, attachment);
+    ResponseHeader.addContentDispositionAttachment(response, attachment);
     ResponseHeader.addContentTransferEncodingBinary(response);
     response.setContentType(CONTENT_TYPE_CSV_GZIP);
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.RESOURCE
 import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.assertUserOrderableFieldsAreSupported;
 import static org.hisp.dhis.webapi.controller.tracker.export.FileResourceRequestHandler.handleFileRequest;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validatePaginationParameters;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateUnsupportedParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.trackedentity.TrackedEntityRequestParams.DEFAULT_FIELDS_PARAM;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_CSV;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_CSV_GZIP;
@@ -288,6 +289,11 @@ class TrackedEntitiesExportController {
       @OpenApi.Param({UID.class, Program.class}) @RequestParam(required = false) UID program,
       HttpServletRequest request)
       throws NotFoundException, ConflictException, BadRequestException {
+    validateUnsupportedParameter(
+        request,
+        "dimension",
+        "Request parameter 'dimension' is only supported for images by API /tracker/trackedEntities/attributes/{attribute}/image");
+
     return handleFileRequest(
         request, trackedEntityService.getFileResource(trackedEntity, attribute, program));
   }

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/EventsExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/EventsExportController.md
@@ -24,6 +24,17 @@ for how to use it.
 
 NOTE: this query parameter has no effect on a response in CSV!
 
+### `getEventDataValueFile`
+
+Get an event data value file or image for given event and data element UID. Images are returned in
+their original dimension.
+
+### `getEventDataValueImage`
+
+Get an event data value image for given event and data element UID. Images are returned in their
+original dimension by default. This endpoint is only supported for data elements of value type
+image.
+
 ## Common for all endpoints
 
 ### `*.parameter.EventRequestParams.program`

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
@@ -33,7 +33,9 @@ attribute UID. Images are returned in their original dimension.
 
 ### `getAttributeValueFile.parameter.program`
 
-The program to be used for evaluating the users access to the file content. A program is required when requesting a program-specific tracked entity attributes. When no program is specified, access to the file content is evaluated based on the users access to the relevant tracked entity type.
+The program to be used for evaluating the users access to the file content. A program is required
+when requesting a program-specific tracked entity attribute. When no program is specified, access
+to the file content is evaluated based on the users access to the relevant tracked entity type.
 
 ### `getAttributeValueImage`
 
@@ -43,7 +45,9 @@ image.
 
 ### `getAttributeValueImage.parameter.program`
 
-The program to be used for evaluating the users access to the image. A program is required when requesting a program-specific tracked entity attributes. When no program is specified, access to the image is evaluated based on the users access to the relevant tracked entity type.
+The program to be used for evaluating the users access to the image. A program is required when
+requesting a program-specific tracked entity attribute. When no program is specified, access to the
+image is evaluated based on the users access to the relevant tracked entity type.
 
 ## Common for all endpoints
 
@@ -191,13 +195,17 @@ NOTE: this query parameter has no effect on a CSV response!
 
 `<filter1>[,<filter2>...]`
 
-Get tracked entities matching given filters on attributes. A filter is a colon separated attribute UID 
-with optional operator and value pairs. Example: `filter=H9IlTX2X6SL:sw:A` with operator starts with `sw` 
-followed by a value. Special characters like `+` need to be percent-encoded so `%2B` instead of `+`. 
-Characters such as `:` (colon) or `,` (comma), as part of the filter value, need to be escaped by `/` (slash).
-Likewise, `/` needs to be escaped. Multiple operator/value pairs for the same attribute 
-as `filter=AuPLng5hLbE:gt:438901703:lt:448901704` are allowed. Repeating the same attribute UID 
-is not allowed.  A user needs metadata read access to the attribute and data read access to the program 
+Get tracked entities matching given filters on attributes. A filter is a colon separated attribute
+UID
+with optional operator and value pairs. Example: `filter=H9IlTX2X6SL:sw:A` with operator starts
+with `sw`
+followed by a value. Special characters like `+` need to be percent-encoded so `%2B` instead of `+`.
+Characters such as `:` (colon) or `,` (comma), as part of the filter value, need to be escaped
+by `/` (slash).
+Likewise, `/` needs to be escaped. Multiple operator/value pairs for the same attribute
+as `filter=AuPLng5hLbE:gt:438901703:lt:448901704` are allowed. Repeating the same attribute UID
+is not allowed. A user needs metadata read access to the attribute and data read access to the
+program
 (if the program is without registration) or the program stage (if the program is with registration).
 
 Valid operators are:
@@ -221,5 +229,7 @@ Valid operators are:
 
 ### `*.parameter.TrackedEntityRequestParams.attachment`
 
-It allows you to specify the attachment file name when extracting in a binary format such as CSV, zip, or gzip.
-If not specified, it defaults to `trackedEntities.<type>.<compression>` (for example, `trackedEntities.csv.zip` for zip compression of a csv list)
+It allows you to specify the attachment file name when extracting in a binary format such as CSV,
+zip, or gzip.
+If not specified, it defaults to `trackedEntities.<type>.<compression>` (for
+example, `trackedEntities.csv.zip` for zip compression of a csv list)

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
@@ -33,7 +33,7 @@ attribute UID. Images are returned in their original dimension.
 
 ### `getAttributeValueFile.parameter.program`
 
-Provide a program UID for program attributes.
+The program to be used for evaluating the users access to the file content. A program is required when requesting a program-specific tracked entity attributes. When no program is specified, access to the file content is evaluated based on the users access to the relevant tracked entity type.
 
 ### `getAttributeValueImage`
 
@@ -43,7 +43,7 @@ image.
 
 ### `getAttributeValueImage.parameter.program`
 
-Provide a program UID for program attributes.
+The program to be used for evaluating the users access to the image. A program is required when requesting a program-specific tracked entity attributes. When no program is specified, access to the image is evaluated based on the users access to the relevant tracked entity type.
 
 ## Common for all endpoints
 

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
@@ -26,6 +26,25 @@ for how to use it.
 
 NOTE: this query parameter has no effect on a response in CSV!
 
+### `getAttributeValueFile`
+
+Get a tracked entity attribute value file or image for given tracked entity and tracked entity
+attribute UID. Images are returned in their original dimension.
+
+### `getAttributeValueFile.parameter.program`
+
+Provide a program UID for program attributes.
+
+### `getAttributeValueImage`
+
+Get an event data value image for given event and data element UID. Images are returned in their
+original dimension by default. This endpoint is only supported for data elements of value type
+image.
+
+### `getAttributeValueImage.parameter.program`
+
+Provide a program UID for program attributes.
+
 ## Common for all endpoints
 
 ### `*.parameter.TrackedEntityRequestParams.orgUnits`

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
@@ -196,17 +196,14 @@ NOTE: this query parameter has no effect on a CSV response!
 `<filter1>[,<filter2>...]`
 
 Get tracked entities matching given filters on attributes. A filter is a colon separated attribute
-UID
-with optional operator and value pairs. Example: `filter=H9IlTX2X6SL:sw:A` with operator starts
-with `sw`
-followed by a value. Special characters like `+` need to be percent-encoded so `%2B` instead of `+`.
-Characters such as `:` (colon) or `,` (comma), as part of the filter value, need to be escaped
-by `/` (slash).
-Likewise, `/` needs to be escaped. Multiple operator/value pairs for the same attribute
-as `filter=AuPLng5hLbE:gt:438901703:lt:448901704` are allowed. Repeating the same attribute UID
-is not allowed. A user needs metadata read access to the attribute and data read access to the
-program
-(if the program is without registration) or the program stage (if the program is with registration).
+UID with optional operator and value pairs. Example: `filter=H9IlTX2X6SL:sw:A` with operator starts
+with `sw` followed by a value. Special characters like `+` need to be percent-encoded so `%2B`
+instead of `+`. Characters such as `:` (colon) or `,` (comma), as part of the filter value, need to
+be escaped by `/` (slash). Likewise, `/` needs to be escaped. Multiple operator/value pairs for the
+same attribute as `filter=AuPLng5hLbE:gt:438901703:lt:448901704` are allowed. Repeating the same
+attribute UID is not allowed. A user needs metadata read access to the attribute and data read
+access to the program (if the program is without registration) or the program stage (if the program
+is with registration).
 
 Valid operators are:
 
@@ -230,6 +227,5 @@ Valid operators are:
 ### `*.parameter.TrackedEntityRequestParams.attachment`
 
 It allows you to specify the attachment file name when extracting in a binary format such as CSV,
-zip, or gzip.
-If not specified, it defaults to `trackedEntities.<type>.<compression>` (for
+zip, or gzip. If not specified, it defaults to `trackedEntities.<type>.<compression>` (for
 example, `trackedEntities.csv.zip` for zip compression of a csv list)


### PR DESCRIPTION
* improve OpenAPI spec (format file to be in width 100)
* unignore OpenAPI spec for tracker events which was ignored in https://github.com/dhis2/dhis2-core/pull/14888/files
* HTTP `content-disposition` inline files and images but keep the `filename` directive so browsers use it as a default when saving the file