### PR TITLE
feat: UNLOGGED by default + bug introduced recently [DHIS2-16809]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/model/AnalyticsTablePartition.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/model/AnalyticsTablePartition.java
@@ -31,7 +31,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import lombok.Getter;
-import org.hisp.dhis.db.model.Logged;
 import org.hisp.dhis.db.model.Table;
 
 /**
@@ -74,12 +73,31 @@ public class AnalyticsTablePartition extends Table {
         List.of(),
         List.of(),
         checks,
-        Logged.LOGGED,
+        masterTable.getLogged(),
         masterTable);
     this.masterTable = masterTable;
     this.year = year;
     this.startDate = startDate;
     this.endDate = endDate;
+  }
+
+  /**
+   * Constructor. Sets the name to represent a staging table partition.
+   *
+   * @param masterTable the master {@link Table} of this partition.
+   */
+  public AnalyticsTablePartition(AnalyticsTable masterTable) {
+    super(
+        toStaging(getTableName(masterTable.getMainName(), null)),
+        List.of(),
+        List.of(),
+        List.of(),
+        masterTable.getLogged(),
+        masterTable);
+    this.masterTable = masterTable;
+    this.year = null;
+    this.startDate = null;
+    this.endDate = null;
   }
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/setting/AnalyticsTableExportSettings.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/setting/AnalyticsTableExportSettings.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.analytics.table.setting;
 
+import static org.hisp.dhis.db.model.Logged.LOGGED;
+import static org.hisp.dhis.db.model.Logged.UNLOGGED;
 import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_TABLE_ORDERING;
 import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_TABLE_UNLOGGED;
 import static org.hisp.dhis.setting.SettingKey.ANALYTICS_MAX_PERIOD_YEARS_OFFSET;
@@ -58,10 +60,10 @@ public class AnalyticsTableExportSettings {
    */
   public Logged getTableLogged() {
     if (dhisConfigurationProvider.isEnabled(ANALYTICS_TABLE_UNLOGGED)) {
-      return Logged.UNLOGGED;
+      return UNLOGGED;
     }
 
-    return Logged.LOGGED;
+    return LOGGED;
   }
 
   public boolean isTableOrdering() {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/util/PartitionUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/util/PartitionUtils.java
@@ -215,7 +215,7 @@ public class PartitionUtils {
         partitions.addAll(table.getTablePartitions());
       } else {
         // Fake partition representing the master table
-        partitions.add(new AnalyticsTablePartition(table, List.of(), null, null, null));
+        partitions.add(new AnalyticsTablePartition(table));
       }
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/model/Table.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/model/Table.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.db.model;
 
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.hisp.dhis.db.model.Logged.UNLOGGED;
 import static org.hisp.dhis.util.ObjectUtils.notNull;
 
 import java.util.List;
@@ -76,12 +77,7 @@ public class Table {
    * @param primaryKey the primary key.
    */
   public Table(String name, List<Column> columns, List<String> primaryKey) {
-    this.name = name;
-    this.columns = columns;
-    this.primaryKey = primaryKey;
-    this.checks = List.of();
-    this.logged = Logged.LOGGED;
-    this.parent = null;
+    this(name, columns, primaryKey, List.of(), UNLOGGED, null);
     this.validate();
   }
 
@@ -94,12 +90,7 @@ public class Table {
    * @param logged the {@link Logged} parameter.
    */
   public Table(String name, List<Column> columns, List<String> primaryKey, Logged logged) {
-    this.name = name;
-    this.columns = columns;
-    this.primaryKey = primaryKey;
-    this.checks = List.of();
-    this.logged = logged;
-    this.parent = null;
+    this(name, columns, primaryKey, List.of(), logged, null);
     this.validate();
   }
 
@@ -118,12 +109,7 @@ public class Table {
       List<String> primaryKey,
       List<String> checks,
       Logged logged) {
-    this.name = name;
-    this.columns = columns;
-    this.primaryKey = primaryKey;
-    this.checks = checks;
-    this.logged = logged;
-    this.parent = null;
+    this(name, columns, primaryKey, checks, logged, null);
     this.validate();
   }
 
@@ -148,7 +134,7 @@ public class Table {
     this.columns = columns;
     this.primaryKey = primaryKey;
     this.checks = checks;
-    this.logged = logged;
+    this.logged = logged != null ? logged : UNLOGGED;
     this.parent = parent;
     this.validate();
   }
@@ -192,7 +178,7 @@ public class Table {
    * @return true if the table is unlogged.
    */
   public boolean isUnlogged() {
-    return Logged.UNLOGGED == logged;
+    return UNLOGGED == logged;
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/sql/PostgreSqlBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/sql/PostgreSqlBuilder.java
@@ -35,7 +35,6 @@ import java.util.stream.Collectors;
 import org.hisp.dhis.db.model.Collation;
 import org.hisp.dhis.db.model.Column;
 import org.hisp.dhis.db.model.Index;
-import org.hisp.dhis.db.model.Logged;
 import org.hisp.dhis.db.model.Table;
 import org.hisp.dhis.db.model.constraint.Nullable;
 import org.hisp.dhis.db.model.constraint.Unique;
@@ -220,7 +219,7 @@ public class PostgreSqlBuilder extends AbstractSqlBuilder {
 
   @Override
   public String createTable(Table table) {
-    String unlogged = table.getLogged() == Logged.UNLOGGED ? " unlogged" : "";
+    String unlogged = table.isUnlogged() ? " unlogged" : "";
 
     StringBuilder sql =
         new StringBuilder("create")

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManagerTest.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.analytics.table;
 
+import static org.hisp.dhis.db.model.Logged.LOGGED;
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -132,12 +134,54 @@ class JdbcAnalyticsTableManagerTest {
     assertNotNull(partitionA);
     assertNotNull(partitionA.getStartDate());
     assertNotNull(partitionA.getEndDate());
+    assertTrue(partitionA.isUnlogged());
     assertEquals(
         partitionA.getYear().intValue(), new DateTime(partitionA.getStartDate()).getYear());
 
     assertNotNull(partitionB);
     assertNotNull(partitionB.getStartDate());
     assertNotNull(partitionB.getEndDate());
+    assertTrue(partitionB.isUnlogged());
+    assertEquals(
+        partitionB.getYear().intValue(), new DateTime(partitionB.getStartDate()).getYear());
+  }
+
+  @Test
+  void testGetRegularAnalyticsTableLogged() {
+    Date startTime = new DateTime(2019, 3, 1, 10, 0).toDate();
+    List<Integer> dataYears = List.of(2018, 2019);
+
+    AnalyticsTableUpdateParams params =
+        AnalyticsTableUpdateParams.newBuilder().withStartTime(startTime).build();
+
+    when(analyticsExportSettings.getTableLogged()).thenReturn(LOGGED);
+    when(jdbcTemplate.queryForList(Mockito.anyString(), ArgumentMatchers.<Class<Integer>>any()))
+        .thenReturn(dataYears);
+
+    List<AnalyticsTable> tables = subject.getAnalyticsTables(params);
+
+    assertEquals(1, tables.size());
+
+    AnalyticsTable table = tables.get(0);
+
+    assertNotNull(table);
+    assertNotNull(table.getTablePartitions());
+    assertEquals(2, table.getTablePartitions().size());
+
+    AnalyticsTablePartition partitionA = table.getTablePartitions().get(0);
+    AnalyticsTablePartition partitionB = table.getTablePartitions().get(1);
+
+    assertNotNull(partitionA);
+    assertNotNull(partitionA.getStartDate());
+    assertNotNull(partitionA.getEndDate());
+    assertFalse(partitionA.isUnlogged());
+    assertEquals(
+        partitionA.getYear().intValue(), new DateTime(partitionA.getStartDate()).getYear());
+
+    assertNotNull(partitionB);
+    assertNotNull(partitionB.getStartDate());
+    assertNotNull(partitionB.getEndDate());
+    assertFalse(partitionB.isUnlogged());
     assertEquals(
         partitionB.getYear().intValue(), new DateTime(partitionB.getStartDate()).getYear());
   }
@@ -180,6 +224,7 @@ class JdbcAnalyticsTableManagerTest {
     assertTrue(partition.isLatestPartition());
     assertEquals(lastFullTableUpdate, partition.getStartDate());
     assertEquals(startTime, partition.getEndDate());
+    assertTrue(partition.isUnlogged());
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManagerTest.java
@@ -28,8 +28,8 @@
 package org.hisp.dhis.analytics.table;
 
 import static org.hisp.dhis.db.model.Logged.LOGGED;
-import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/db/sql/PostgreSqlBuilderTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/db/sql/PostgreSqlBuilderTest.java
@@ -58,7 +58,7 @@ class PostgreSqlBuilderTest {
 
     List<String> primaryKey = List.of("id");
 
-    return new Table("immunization", columns, primaryKey);
+    return new Table("immunization", columns, primaryKey, Logged.LOGGED);
   }
 
   private List<Index> getIndexesA() {

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -380,8 +380,8 @@ public enum ConfigurationKey {
 
   PROGRAM_TEMPORARY_OWNERSHIP_TIMEOUT("tracker.temporary.ownership.timeout", "3", false),
 
-  /** Use unlogged tables during analytics export. (default: off) */
-  ANALYTICS_TABLE_UNLOGGED("analytics.table.unlogged", Constants.OFF),
+  /** Use unlogged tables during analytics export. (default: ON) */
+  ANALYTICS_TABLE_UNLOGGED("analytics.table.unlogged", Constants.ON),
 
   /** Order analytics tables data on insert. */
   ANALYTICS_TABLE_ORDERING("analytics.table.ordering", Constants.OFF),


### PR DESCRIPTION
This PR enables `UNLOGGED` tables by default in the tables generated during the Analytics Export process.

During my tests, related to this change, I discovered that some recent changes had broken the logic to generate the `UNLOGGED` tables. The code was not considering partitions anymore, which increased the export time by around 30% (on my laptop).

I fixed this issue, and now the export respects the flag accordingly, including the partition tables.
Some tests and assertions were added to prevent this from happening again in the future.