### PR TITLE
Use file resource as Etag for tracker files/images DHIS2-16830

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerByIdTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerByIdTest.java
@@ -36,10 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.hash.HashCode;
-import com.google.common.hash.Hashing;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Date;
@@ -367,8 +364,8 @@ class EventsExportControllerByIdTest extends DhisControllerConvenienceTest {
             de.getUid());
 
     assertEquals(HttpStatus.OK, response.status());
-    assertEquals("\"" + file.getContentMd5() + "\"", response.header("Etag"));
-    assertEquals("max-age=0, must-revalidate, private", response.header("Cache-Control"));
+    assertEquals("\"" + file.getUid() + "\"", response.header("Etag"));
+    assertEquals("no-cache, private", response.header("Cache-Control"));
     assertEquals(Long.toString(file.getContentLength()), response.header("Content-Length"));
     assertEquals("filename=" + file.getName(), response.header("Content-Disposition"));
     assertEquals("file content", response.content("text/plain"));
@@ -390,8 +387,8 @@ class EventsExportControllerByIdTest extends DhisControllerConvenienceTest {
             de.getUid());
 
     assertEquals(HttpStatus.OK, response.status());
-    assertEquals("\"" + file.getContentMd5() + "\"", response.header("Etag"));
-    assertEquals("max-age=0, must-revalidate, private", response.header("Cache-Control"));
+    assertEquals("\"" + file.getUid() + "\"", response.header("Etag"));
+    assertEquals("no-cache, private", response.header("Cache-Control"));
     assertEquals("filename=" + file.getName(), response.header("Content-Disposition"));
     assertEquals(Long.toString(file.getContentLength()), response.header("Content-Length"));
     assertEquals("file content", response.content("image/png"));
@@ -411,11 +408,11 @@ class EventsExportControllerByIdTest extends DhisControllerConvenienceTest {
             "/tracker/events/{eventUid}/dataValues/{dataElementUid}/file",
             event.getUid(),
             de.getUid(),
-            Header("If-None-Match", "\"" + file.getContentMd5() + "\""));
+            Header("If-None-Match", "\"" + file.getUid() + "\""));
 
     assertEquals(HttpStatus.NOT_MODIFIED, response.status());
-    assertEquals("\"" + file.getContentMd5() + "\"", response.header("Etag"));
-    assertEquals("max-age=0, must-revalidate, private", response.header("Cache-Control"));
+    assertEquals("\"" + file.getUid() + "\"", response.header("Etag"));
+    assertEquals("no-cache, private", response.header("Cache-Control"));
     assertFalse(response.hasBody());
   }
 
@@ -561,8 +558,8 @@ class EventsExportControllerByIdTest extends DhisControllerConvenienceTest {
             de.getUid());
 
     assertEquals(HttpStatus.OK, response.status());
-    assertEquals("\"" + file.getContentMd5() + "\"", response.header("Etag"));
-    assertEquals("max-age=0, must-revalidate, private", response.header("Cache-Control"));
+    assertEquals("\"" + file.getUid() + "\"", response.header("Etag"));
+    assertEquals("no-cache, private", response.header("Cache-Control"));
     assertEquals("filename=" + file.getName(), response.header("Content-Disposition"));
     assertEquals(Long.toString(file.getContentLength()), response.header("Content-Length"));
     assertEquals("file content", response.content("image/png"));
@@ -595,9 +592,8 @@ class EventsExportControllerByIdTest extends DhisControllerConvenienceTest {
             de.getUid());
 
     assertEquals(HttpStatus.OK, response.status());
-    HashCode expectedHashCode = Hashing.md5().hashString(smallFileContent, StandardCharsets.UTF_8);
-    assertEquals("\"" + expectedHashCode + "\"", response.header("Etag"));
-    assertEquals("max-age=0, must-revalidate, private", response.header("Cache-Control"));
+    assertEquals("\"" + file.getUid() + "\"", response.header("Etag"));
+    assertEquals("no-cache, private", response.header("Cache-Control"));
     assertEquals("filename=" + file.getName(), response.header("Content-Disposition"));
     assertEquals(
         Long.toString(smallFileContent.getBytes().length), response.header("Content-Length"));

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -649,8 +649,8 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
             program.getUid());
 
     assertEquals(HttpStatus.OK, response.status());
-    assertEquals("\"" + file.getContentMd5() + "\"", response.header("Etag"));
-    assertEquals("max-age=0, must-revalidate, private", response.header("Cache-Control"));
+    assertEquals("\"" + file.getUid() + "\"", response.header("Etag"));
+    assertEquals("no-cache, private", response.header("Cache-Control"));
     assertEquals(Long.toString(file.getContentLength()), response.header("Content-Length"));
     assertEquals("filename=" + file.getName(), response.header("Content-Disposition"));
     assertEquals("file content", response.content("text/plain"));
@@ -674,8 +674,8 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
             tea.getUid());
 
     assertEquals(HttpStatus.OK, response.status());
-    assertEquals("\"" + file.getContentMd5() + "\"", response.header("Etag"));
-    assertEquals("max-age=0, must-revalidate, private", response.header("Cache-Control"));
+    assertEquals("\"" + file.getUid() + "\"", response.header("Etag"));
+    assertEquals("no-cache, private", response.header("Cache-Control"));
     assertEquals(Long.toString(file.getContentLength()), response.header("Content-Length"));
     assertEquals("filename=" + file.getName(), response.header("Content-Disposition"));
     assertEquals("file content", response.content("text/plain"));
@@ -928,8 +928,8 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
             program.getUid());
 
     assertEquals(HttpStatus.OK, response.status());
-    assertEquals("\"" + file.getContentMd5() + "\"", response.header("Etag"));
-    assertEquals("max-age=0, must-revalidate, private", response.header("Cache-Control"));
+    assertEquals("\"" + file.getUid() + "\"", response.header("Etag"));
+    assertEquals("no-cache, private", response.header("Cache-Control"));
     assertEquals("filename=" + file.getName(), response.header("Content-Disposition"));
     assertEquals(Long.toString(file.getContentLength()), response.header("Content-Length"));
     assertEquals("file content", response.content("image/png"));


### PR DESCRIPTION
- Use file resource as Etag for tracker files/images. This saves us from fetching and buffering the file if the client has a fresh copy of the data value/attribute i.e. it still points to the same file resource.
- Make `FileResourceStream` only use records instead of using `FileResource` and mutating its contentLength 
- Use `Cache-Control: no-cache, private` instead of the old `max-age=0, must-revalidate`. See jira issue for more details.