### PR TITLE
fix: page incorrect /api/tracker/{trackedEntities,relationships} DHIS2-16715 [2.40]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingWrapper.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingWrapper.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import lombok.Builder;
 import lombok.Data;
@@ -53,6 +54,28 @@ public class PagingWrapper<T> {
 
   public PagingWrapper(String identifier) {
     this.identifier = identifier;
+  }
+
+  public static <T> PagingWrapper<T> withoutPager(Collection<T> elements) {
+    PagingWrapper<T> pagingWrapper = new PagingWrapper<>();
+    pagingWrapper.elements.put("instances", elements);
+    return pagingWrapper;
+  }
+
+  public static <T> PagingWrapper<T> withPager(
+      Collection<T> elements, int page, int pageSize, long total) {
+    PagingWrapper<T> pagingWrapper = new PagingWrapper<>();
+    pagingWrapper.elements.put("instances", elements);
+    org.hisp.dhis.common.Pager pager = new org.hisp.dhis.common.Pager(page, total, pageSize);
+    pagingWrapper.pager = Pager.fromLegacyWithTotals(pager);
+    return pagingWrapper;
+  }
+
+  public static <T> PagingWrapper<T> withPager(List<T> elements, int page, int pageSize) {
+    PagingWrapper<T> pagingWrapper = new PagingWrapper<>();
+    pagingWrapper.elements.put("instances", elements);
+    pagingWrapper.pager = Pager.builder().page(page).pageSize(pageSize).build();
+    return pagingWrapper;
   }
 
   public PagingWrapper<T> withPager(Pager pager) {
@@ -93,6 +116,17 @@ public class PagingWrapper<T> {
           .pageSize(pager.getPageSize())
           .pageCount(pagingCriteria.isTotalPages() ? pager.getPageCount() : null)
           .total(pagingCriteria.isTotalPages() ? pager.getTotal() : null)
+          .nextPage(pager.getNextPage())
+          .build();
+    }
+
+    private static Pager fromLegacyWithTotals(org.hisp.dhis.common.Pager pager) {
+      return Pager.builder()
+          .prevPage(pager.getPrevPage())
+          .page(pager.getPage())
+          .pageSize(pager.getPageSize())
+          .pageCount(pager.getPageCount())
+          .total(pager.getTotal())
           .nextPage(pager.getNextPage())
           .build();
     }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingWrapperTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingWrapperTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.event.webrequest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PagingWrapperTest {
+  @Test
+  void shouldCreateWrapperWithoutPager() {
+    List<String> elements = List.of("a", "b");
+
+    PagingWrapper<String> pagingWrapper = PagingWrapper.withoutPager(elements);
+
+    assertEquals("instances", pagingWrapper.getIdentifier());
+    assertEquals(elements, pagingWrapper.getElements().get("instances"));
+    assertNull(pagingWrapper.getPager());
+  }
+
+  @Test
+  void shouldCreateWrapperWithPagerButNoTotals() {
+    List<String> elements = List.of("a", "b");
+
+    PagingWrapper<String> pagingWrapper = PagingWrapper.withPager(elements, 2, 4);
+
+    assertEquals("instances", pagingWrapper.getIdentifier());
+    assertEquals(elements, pagingWrapper.getElements().get("instances"));
+    assertNotNull(pagingWrapper.getPager());
+    assertEquals(2, pagingWrapper.getPager().getPage());
+    assertEquals(4, pagingWrapper.getPager().getPageSize());
+    assertNull(pagingWrapper.getPager().getTotal());
+    assertNull(pagingWrapper.getPager().getPageCount());
+  }
+
+  @Test
+  void shouldCreateWrapperWithPagerAndTotals() {
+    List<String> elements = List.of("a", "b");
+
+    PagingWrapper<String> pagingWrapper = PagingWrapper.withPager(elements, 2, 4, 98);
+
+    assertEquals("instances", pagingWrapper.getIdentifier());
+    assertEquals(elements, pagingWrapper.getElements().get("instances"));
+    assertNotNull(pagingWrapper.getPager());
+    assertEquals(2, pagingWrapper.getPager().getPage());
+    assertEquals(4, pagingWrapper.getPager().getPageSize());
+    assertEquals(98, pagingWrapper.getPager().getTotal());
+    assertEquals(25, pagingWrapper.getPager().getPageCount());
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportController.java
@@ -49,7 +49,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.dxf2.events.relationship.RelationshipService;
 import org.hisp.dhis.dxf2.events.trackedentity.Relationship;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
@@ -141,12 +140,10 @@ public class TrackerRelationshipsExportController {
             criteria,
             criteria.isIncludeDeleted());
 
-    PagingWrapper<ObjectNode> pagingWrapper = new PagingWrapper<>();
     if (criteria.isPagingRequest()) {
-      long count = 0L;
-
+      List<ObjectNode> objectNodes = fieldFilterService.toObjectNodes(relationships, fields);
       if (criteria.isTotalPages()) {
-        count =
+        long count =
             tryGetRelationshipFrom(
                     identifier,
                     criteria.getIdentifierClass(),
@@ -154,16 +151,16 @@ public class TrackerRelationshipsExportController {
                     null,
                     criteria.isIncludeDeleted())
                 .size();
+        return PagingWrapper.withPager(
+            objectNodes, criteria.getPageWithDefault(), criteria.getPageSizeWithDefault(), count);
       }
 
-      Pager pager =
-          new Pager(criteria.getPageWithDefault(), count, criteria.getPageSizeWithDefault());
-
-      pagingWrapper = pagingWrapper.withPager(PagingWrapper.Pager.fromLegacy(criteria, pager));
+      return PagingWrapper.withPager(
+          objectNodes, criteria.getPageWithDefault(), criteria.getPageSizeWithDefault());
     }
 
     List<ObjectNode> objectNodes = fieldFilterService.toObjectNodes(relationships, fields);
-    return pagingWrapper.withInstances(objectNodes);
+    return PagingWrapper.withoutPager(objectNodes);
   }
 
   @GetMapping("{id}")


### PR DESCRIPTION
introduced in https://github.com/dhis2/dhis2-core/pull/13900

* `common.Pager` is not designed to support pagination without totals. Instantiating it with a total of `0` caused this bug.

The solution is either to avoid the `common.Pager` when not returning totals or to to call [Pager.force](https://github.com/dhis2/dhis2-core/blob/3af1a490cfae82b9a8907ba5e9801b5993e72b82/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Pager.java#L162).

Opted for not using `common.Pager` when not returning totals.

Note that tracker exporter does not use `PagingWrapper` from 2.41 on.