### PR TITLE
feat: data sharing for AggregateDataExchange

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/sharing/Sharing.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/sharing/Sharing.java
@@ -189,6 +189,35 @@ public class Sharing implements Serializable {
         .build();
   }
 
+  /**
+   * Returns a new {@link Sharing} instance where Users and UserGroups access strings have been
+   * transformed. Public access will not be changed.
+   *
+   * @param accessTransformation A transformation for access strings that is applied to all access
+   *     strings of this {@link Sharing} to produce the access strings used in the newly created
+   *     {@link Sharing} object returned.
+   * @return A new {@link Sharing} instance where the access strings of public access, user and
+   *     group access have been transformed by the provided transformation. This {@link Sharing} is
+   *     kept unchanged.
+   */
+  public Sharing withUserAndUserGroupAccess(UnaryOperator<String> accessTransformation) {
+    return builder()
+        .external(external)
+        .publicAccess(publicAccess)
+        .owner(owner)
+        .users(
+            mapValues(
+                users,
+                user -> new UserAccess(accessTransformation.apply(user.getAccess()), user.getId())))
+        .userGroups(
+            mapValues(
+                userGroups,
+                group ->
+                    new UserGroupAccess(
+                        accessTransformation.apply(group.getAccess()), group.getId())))
+        .build();
+  }
+
   private static <K, V> Map<K, V> mapValues(Map<K, V> map, UnaryOperator<V> mapper) {
     if (map == null) {
       return null;
@@ -230,20 +259,20 @@ public class Sharing implements Serializable {
   }
 
   /**
-   * Copy Metadata Read value to Data Read
+   * Copy Metadata Write value to Data Write value
    *
    * <pre>
-   * r------- => r-r-----
-   * rw------ => rwr-----
+   * -w------ => ---w----
+   * rw------ => rw-w----
    * </pre>
    *
    * @param access an access string which is expected to be either null or 8 characters long
    * @return the update access string with Data Read value copied from Metadata Read
    */
-  public static String copySharingRead(String access) {
+  public static String copyDataWrite(String access) {
     if (access == null) {
       return null;
     }
-    return access.substring(0, 2) + access.substring(0, 1) + access.substring(3);
+    return access.substring(0, 3) + access.substring(1, 2) + access.substring(4);
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/sharing/Sharing.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/sharing/Sharing.java
@@ -233,18 +233,17 @@ public class Sharing implements Serializable {
    * Copy Metadata Read value to Data Read
    *
    * <pre>
-   * r------- -> r-r----- rw------ -> rwr-----
+   * r------- => r-r-----
+   * rw------ => rwr-----
    * </pre>
    *
-   * @param access a access string which is expected to be either null or 8 characters long
+   * @param access an access string which is expected to be either null or 8 characters long
    * @return the update access string with Data Read value copied from Metadata Read
    */
   public static String copySharingRead(String access) {
     if (access == null) {
       return null;
     }
-    String metadataRead = access.substring(0, 1);
-    String metadata = access.substring(0, 2);
-    return metadata + metadataRead + access.substring(3);
+    return access.substring(0, 2) + access.substring(0, 1) + access.substring(3);
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/sharing/Sharing.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/sharing/Sharing.java
@@ -228,4 +228,23 @@ public class Sharing implements Serializable {
     String metadata = access.substring(0, 2);
     return metadata + metadata + access.substring(4);
   }
+
+  /**
+   * Copy Metadata Read value to Data Read
+   *
+   * <pre>
+   * r------- -> r-r----- rw------ -> rwr-----
+   * </pre>
+   *
+   * @param access a access string which is expected to be either null or 8 characters long
+   * @return the update access string with Data Read value copied from Metadata Read
+   */
+  public static String copySharingRead(String access) {
+    if (access == null) {
+      return null;
+    }
+    String metadataRead = access.substring(0, 1);
+    String metadata = access.substring(0, 2);
+    return metadata + metadataRead + access.substring(3);
+  }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/SharingUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/SharingUtils.java
@@ -58,6 +58,13 @@ public class SharingUtils {
     return FROM_AND_TO_JSON.writeValueAsString(value.withAccess(accessTransformation));
   }
 
+  public static String withUserAndUserGroupAccess(
+      String jsonb, UnaryOperator<String> accessTransformation) throws JsonProcessingException {
+    Sharing value = FROM_AND_TO_JSON.readValue(jsonb, Sharing.class);
+    return FROM_AND_TO_JSON.writeValueAsString(
+        value.withUserAndUserGroupAccess(accessTransformation));
+  }
+
   public static boolean isLegacySharingProperty(Property property) {
     return LEGACY_SHARING_PROPERTIES.contains(property.getFieldName());
   }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/sharing/SharingTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/sharing/SharingTest.java
@@ -128,4 +128,23 @@ class SharingTest {
     actual.addUserGroupAccess(new UserGroupAccess("rw------", "uid"));
     assertEquals(1, actual.getUserGroups().size());
   }
+
+  @Test
+  void testCopySharingRead() {
+    String source = "r-------";
+    String result = Sharing.copySharingRead(source);
+    assertEquals("r-r-----", result);
+
+    source = "rw------";
+    result = Sharing.copySharingRead(source);
+    assertEquals("rwr-----", result);
+
+    source = "rw-w----";
+    result = Sharing.copySharingRead(source);
+    assertEquals("rwrw----", result);
+
+    source = "r-r-----";
+    result = Sharing.copySharingRead(source);
+    assertEquals("r-r-----", result);
+  }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/sharing/SharingTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/sharing/SharingTest.java
@@ -37,6 +37,7 @@ import java.util.function.UnaryOperator;
 import org.hisp.dhis.user.sharing.Sharing;
 import org.hisp.dhis.user.sharing.UserAccess;
 import org.hisp.dhis.user.sharing.UserGroupAccess;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -132,19 +133,35 @@ class SharingTest {
   @Test
   void testCopySharingRead() {
     String source = "r-------";
-    String result = Sharing.copySharingRead(source);
-    assertEquals("r-r-----", result);
+    String result = Sharing.copyDataWrite(source);
+    assertEquals("r-------", result);
 
     source = "rw------";
-    result = Sharing.copySharingRead(source);
-    assertEquals("rwr-----", result);
+    result = Sharing.copyDataWrite(source);
+    assertEquals("rw-w----", result);
 
     source = "rw-w----";
-    result = Sharing.copySharingRead(source);
-    assertEquals("rwrw----", result);
+    result = Sharing.copyDataWrite(source);
+    assertEquals("rw-w----", result);
 
-    source = "r-r-----";
-    result = Sharing.copySharingRead(source);
-    assertEquals("r-r-----", result);
+    source = "rwr-----";
+    result = Sharing.copyDataWrite(source);
+    assertEquals("rwrw----", result);
+  }
+
+  @Test
+  @DisplayName(
+      "Users and UserGroups access string should be transformed using Sharing.withUserAndUserGroupAccess, public access must not be changed.")
+  void testCopyWithAccessForSharingRead() {
+    Sharing original = new Sharing();
+    original.setPublicAccess("rw------");
+    original.setUserAccesses(singleton(new UserAccess("rw------", "id")));
+    original.setUserGroupAccess(singleton(new UserGroupAccess("r-------", "uid")));
+    Sharing actual = original.withUserAndUserGroupAccess(Sharing::copyDataWrite);
+    UserAccess userAccess = actual.getUsers().values().iterator().next();
+    assertEquals("rw-w----", userAccess.getAccess());
+    UserGroupAccess userGroupAccess = actual.getUserGroups().values().iterator().next();
+    assertEquals("r-------", userGroupAccess.getAccess());
+    assertEquals("rw------", actual.getPublicAccess());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-data-exchange/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/pom.xml
@@ -39,6 +39,10 @@
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-support-system</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.hisp.dhis</groupId>
+      <artifactId>dhis-service-acl</artifactId>
+    </dependency>
 
     <!-- Application -->
     <dependency>

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeJob.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeJob.java
@@ -40,6 +40,8 @@ import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.parameters.AggregateDataExchangeJobParameters;
 import org.hisp.dhis.system.notification.NotificationLevel;
 import org.hisp.dhis.system.notification.Notifier;
+import org.hisp.dhis.user.UserDetails;
+import org.hisp.dhis.user.UserService;
 import org.springframework.stereotype.Component;
 
 /**
@@ -53,6 +55,7 @@ public class AggregateDataExchangeJob implements Job {
   private final AggregateDataExchangeService dataExchangeService;
 
   private final Notifier notifier;
+  private final UserService userService;
 
   @Override
   public JobType getJobType() {
@@ -79,7 +82,11 @@ public class AggregateDataExchangeJob implements Job {
         allSummaries.addImportSummary(new ImportSummary(ImportStatus.ERROR, ex.getMessage()));
         continue;
       }
-      allSummaries.addImportSummaries(dataExchangeService.exchangeData(exchange, progress));
+      allSummaries.addImportSummaries(
+          dataExchangeService.exchangeData(
+              UserDetails.fromUser(userService.getUser(config.getExecutedBy())),
+              exchange,
+              progress));
     }
     notifier.addJobSummary(config, NotificationLevel.INFO, allSummaries, ImportSummaries.class);
     ImportStatus status = allSummaries.getStatus();

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeJob.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeJob.java
@@ -41,8 +41,6 @@ import org.hisp.dhis.scheduling.parameters.AggregateDataExchangeJobParameters;
 import org.hisp.dhis.system.notification.NotificationLevel;
 import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.user.CurrentUserUtil;
-import org.hisp.dhis.user.UserDetails;
-import org.hisp.dhis.user.UserService;
 import org.springframework.stereotype.Component;
 
 /**
@@ -56,7 +54,6 @@ public class AggregateDataExchangeJob implements Job {
   private final AggregateDataExchangeService dataExchangeService;
 
   private final Notifier notifier;
-  private final UserService userService;
 
   @Override
   public JobType getJobType() {
@@ -68,11 +65,6 @@ public class AggregateDataExchangeJob implements Job {
     notifier.clear(config);
     AggregateDataExchangeJobParameters params =
         (AggregateDataExchangeJobParameters) config.getJobParameters();
-
-    UserDetails currentUser =
-        config.getExecutedBy() != null
-            ? UserDetails.fromUser(userService.getUser(config.getExecutedBy()))
-            : CurrentUserUtil.getCurrentUserDetails();
 
     List<String> dataExchangeIds = params.getDataExchangeIds();
     progress.startingProcess(
@@ -89,7 +81,8 @@ public class AggregateDataExchangeJob implements Job {
         continue;
       }
       allSummaries.addImportSummaries(
-          dataExchangeService.exchangeData(currentUser, exchange, progress));
+          dataExchangeService.exchangeData(
+              CurrentUserUtil.getCurrentUserDetails(), exchange, progress));
     }
     notifier.addJobSummary(config, NotificationLevel.INFO, allSummaries, ImportSummaries.class);
     ImportStatus status = allSummaries.getStatus();

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeService.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeService.java
@@ -139,6 +139,7 @@ public class AggregateDataExchangeService {
               String.format(
                   "User has no data write access for AggregateDataExchange: %s",
                   exchange.getDisplayName())));
+      return summaries;
     }
 
     progress.startingStage(toStageDescription(exchange), FailurePolicy.SKIP_ITEM);

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/AggregateDataExchangeSchemaDescriptor.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/AggregateDataExchangeSchemaDescriptor.java
@@ -47,6 +47,7 @@ public class AggregateDataExchangeSchemaDescriptor implements SchemaDescriptor {
     Schema schema = new Schema(AggregateDataExchange.class, SINGULAR, PLURAL);
     schema.setRelativeApiEndpoint(API_ENDPOINT);
     schema.setOrder(1900);
+    schema.setDataShareable(true);
 
     schema.add(
         new Authority(

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v41/V2_41_46__add_data_sharing_for_aggregate_data_exchange.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v41/V2_41_46__add_data_sharing_for_aggregate_data_exchange.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.db.migration.v41;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.hisp.dhis.user.sharing.Sharing;
+import org.hisp.dhis.util.SharingUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class V2_41_46__add_data_sharing_for_aggregate_data_exchange extends BaseJavaMigration {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(V2_41_46__add_data_sharing_for_aggregate_data_exchange.class);
+
+  @Override
+  public void migrate(Context context) throws Exception {
+    try (Statement statement = context.getConnection().createStatement()) {
+      ResultSet results =
+          statement.executeQuery(
+              "select aggregatedataexchangeid, sharing from aggregatedataexchange;");
+      while (results.next()) {
+        updateRow(context, results.getLong(1), results.getString(2));
+      }
+    }
+  }
+
+  private void updateRow(Context context, long id, String sharing)
+      throws SQLException, JsonProcessingException {
+    String updatedSharing = SharingUtils.withAccess(sharing, Sharing::copySharingRead);
+    try (PreparedStatement statement =
+        context
+            .getConnection()
+            .prepareStatement(
+                "update aggregatedataexchange set sharing = ?::json where aggregatedataexchangeid = ?")) {
+      statement.setLong(2, id);
+      statement.setString(1, updatedSharing);
+
+      log.info("Executing sharing migration query: [" + statement + "]");
+      statement.executeUpdate();
+    } catch (SQLException e) {
+      log.error(e.getMessage());
+      throw e;
+    }
+  }
+}

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v41/V2_41_46__add_data_sharing_for_aggregate_data_exchange.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v41/V2_41_46__add_data_sharing_for_aggregate_data_exchange.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * In table aggregatedataexchange, copy Metadata Read value to Data Read value in sharing.users and
- * sharing.userGroups in sharing column.
+ * sharing.userGroups in sharing column. Public access must not be changed.
  *
  * @author Viet Nguyen
  */
@@ -64,7 +64,8 @@ public class V2_41_46__add_data_sharing_for_aggregate_data_exchange extends Base
 
   private void updateRow(Context context, long id, String sharing)
       throws SQLException, JsonProcessingException {
-    String updatedSharing = SharingUtils.withAccess(sharing, Sharing::copySharingRead);
+    String updatedSharing =
+        SharingUtils.withUserAndUserGroupAccess(sharing, Sharing::copyDataWrite);
     try (PreparedStatement statement =
         context
             .getConnection()

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v41/V2_41_46__add_data_sharing_for_aggregate_data_exchange.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v41/V2_41_46__add_data_sharing_for_aggregate_data_exchange.java
@@ -67,11 +67,8 @@ public class V2_41_46__add_data_sharing_for_aggregate_data_exchange extends Base
       statement.setLong(2, id);
       statement.setString(1, updatedSharing);
 
-      log.info("Executing sharing migration query: [" + statement + "]");
+      log.info("Executing sharing migration query: {}", statement);
       statement.executeUpdate();
-    } catch (SQLException e) {
-      log.error(e.getMessage());
-      throw e;
     }
   }
 }

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v41/V2_41_46__add_data_sharing_for_aggregate_data_exchange.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v41/V2_41_46__add_data_sharing_for_aggregate_data_exchange.java
@@ -39,6 +39,12 @@ import org.hisp.dhis.util.SharingUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * In table aggregatedataexchange, copy Metadata Read value to Data Read value in sharing.users and
+ * sharing.userGroups in sharing column.
+ *
+ * @author Viet Nguyen
+ */
 public class V2_41_46__add_data_sharing_for_aggregate_data_exchange extends BaseJavaMigration {
 
   private static final Logger log =

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v41/V2_41_46__add_data_sharing_for_aggregate_data_exchange.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v41/V2_41_46__add_data_sharing_for_aggregate_data_exchange.java
@@ -40,7 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * In table aggregatedataexchange, copy Metadata Read value to Data Read value in sharing.users and
+ * In table aggregatedataexchange, copy Metadata Write value to Data Write value in sharing.users and
  * sharing.userGroups in sharing column. Public access must not be changed.
  *
  * @author Viet Nguyen

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
@@ -535,4 +535,22 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest {
                 JsonErrorReport.class, errorReport -> errorReport.getErrorCode() == ErrorCode.E6305)
             .getMessage());
   }
+
+  @Test
+  @DisplayName(
+      "Should return error E6305 if create a new AggregateDataExchange without authentication details")
+  void testUpdateAggregateDataExchangeWithoutAuthentication() {
+    POST("/metadata/", Body("metadata/aggregate_data_exchange.json")).content(HttpStatus.OK);
+    JsonImportSummary report =
+        POST("/metadata/", Body("metadata/aggregate_data_exchange_no_auth.json"))
+            .content(HttpStatus.CONFLICT)
+            .get("response")
+            .as(JsonImportSummary.class);
+    assertEquals(
+        "Aggregate data exchange target API must specify either access token or username and password",
+        report
+            .find(
+                JsonErrorReport.class, errorReport -> errorReport.getErrorCode() == ErrorCode.E6305)
+            .getMessage());
+  }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
@@ -535,22 +535,4 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest {
                 JsonErrorReport.class, errorReport -> errorReport.getErrorCode() == ErrorCode.E6305)
             .getMessage());
   }
-
-  @Test
-  @DisplayName(
-      "Should return error E6305 if create a new AggregateDataExchange without authentication details")
-  void testUpdateAggregateDataExchangeWithoutAuthentication() {
-    POST("/metadata/", Body("metadata/aggregate_data_exchange.json")).content(HttpStatus.OK);
-    JsonImportSummary report =
-        POST("/metadata/", Body("metadata/aggregate_data_exchange_no_auth.json"))
-            .content(HttpStatus.CONFLICT)
-            .get("response")
-            .as(JsonImportSummary.class);
-    assertEquals(
-        "Aggregate data exchange target API must specify either access token or username and password",
-        report
-            .find(
-                JsonErrorReport.class, errorReport -> errorReport.getErrorCode() == ErrorCode.E6305)
-            .getMessage());
-  }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
@@ -535,4 +535,21 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest {
                 JsonErrorReport.class, errorReport -> errorReport.getErrorCode() == ErrorCode.E6305)
             .getMessage());
   }
+
+  @Test
+  @DisplayName(
+      "Should return error E6305 if create a new AggregateDataExchange without authentication details")
+  void testDataWriteAggregateDataExchangeWithoutAuthentication() {
+    JsonImportSummary report =
+        POST("/metadata/", Body("metadata/aggregate_data_exchange_no_auth.json"))
+            .content(HttpStatus.CONFLICT)
+            .get("response")
+            .as(JsonImportSummary.class);
+    assertEquals(
+        "Aggregate data exchange target API must specify either access token or username and password",
+        report
+            .find(
+                JsonErrorReport.class, errorReport -> errorReport.getErrorCode() == ErrorCode.E6305)
+            .getMessage());
+  }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AggregateDataExchangeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AggregateDataExchangeController.java
@@ -36,7 +36,8 @@ import org.hisp.dhis.dataexchange.aggregate.AggregateDataExchange;
 import org.hisp.dhis.dataexchange.aggregate.AggregateDataExchangeService;
 import org.hisp.dhis.dataexchange.aggregate.SourceDataQueryParams;
 import org.hisp.dhis.dxf2.datavalueset.DataValueSet;
-import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
+import org.hisp.dhis.dxf2.webmessage.WebMessage;
+import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.schema.descriptors.AggregateDataExchangeSchemaDescriptor;
 import org.hisp.dhis.user.CurrentUser;
@@ -64,16 +65,18 @@ public class AggregateDataExchangeController extends AbstractCrudController<Aggr
 
   @PostMapping("/exchange")
   @ResponseStatus(value = HttpStatus.OK)
-  public ImportSummaries runDataExchange(
+  public WebMessage runDataExchange(
       @RequestBody AggregateDataExchange exchange, @CurrentUser UserDetails userDetails) {
-    return service.exchangeData(userDetails, exchange, NoopJobProgress.INSTANCE);
+    return WebMessageUtils.importSummaries(
+        service.exchangeData(userDetails, exchange, NoopJobProgress.INSTANCE));
   }
 
   @PostMapping("/{uid}/exchange")
   @ResponseStatus(value = HttpStatus.OK)
-  public ImportSummaries runDataExchangeByUid(
+  public WebMessage runDataExchangeByUid(
       @PathVariable String uid, @CurrentUser UserDetails userDetails) {
-    return service.exchangeData(userDetails, uid, NoopJobProgress.INSTANCE);
+    return WebMessageUtils.importSummaries(
+        service.exchangeData(userDetails, uid, NoopJobProgress.INSTANCE));
   }
 
   @GetMapping("/{uid}/sourceData")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AggregateDataExchangeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AggregateDataExchangeController.java
@@ -39,6 +39,8 @@ import org.hisp.dhis.dxf2.datavalueset.DataValueSet;
 import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
 import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.schema.descriptors.AggregateDataExchangeSchemaDescriptor;
+import org.hisp.dhis.user.CurrentUser;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -62,14 +64,16 @@ public class AggregateDataExchangeController extends AbstractCrudController<Aggr
 
   @PostMapping("/exchange")
   @ResponseStatus(value = HttpStatus.OK)
-  public ImportSummaries runDataExchange(@RequestBody AggregateDataExchange exchange) {
-    return service.exchangeData(exchange, NoopJobProgress.INSTANCE);
+  public ImportSummaries runDataExchange(
+      @RequestBody AggregateDataExchange exchange, @CurrentUser UserDetails userDetails) {
+    return service.exchangeData(userDetails, exchange, NoopJobProgress.INSTANCE);
   }
 
   @PostMapping("/{uid}/exchange")
   @ResponseStatus(value = HttpStatus.OK)
-  public ImportSummaries runDataExchangeByUid(@PathVariable String uid) {
-    return service.exchangeData(uid, NoopJobProgress.INSTANCE);
+  public ImportSummaries runDataExchangeByUid(
+      @PathVariable String uid, @CurrentUser UserDetails userDetails) {
+    return service.exchangeData(userDetails, uid, NoopJobProgress.INSTANCE);
   }
 
   @GetMapping("/{uid}/sourceData")


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-16814
### Summary
- Enable data sharing for AggregateDataExchange.
- In endpoint `aggregateDataExchanges/{uid}/exchange` validate if user has data write permission for specified AggregateDataExchange object.
- Add flyway script to enable data sharing for existing records in database. This is done by copying Metadata Write to Data Write value.
- Add tests to verify all utils methods used in the migration script.