### PR TITLE
fix: updateNoAcl should update lastUpdatedBy [DHIS2-15543]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
@@ -326,9 +326,23 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     return object;
   }
 
+  /**
+   * Method that updates a {@link BaseIdentifiableObject}, bypassing any ACL checks. It calls {@link
+   * #setFields(BaseIdentifiableObject, UserDetails)} which ensures that the following properties
+   * are set:
+   * <li>UID
+   * <li>created
+   * <li>createdBy
+   * <li>lastUpdated
+   * <li>lastUpdatedBy <br>
+   *     <br>
+   *     The current user is passed as the User to set for any relevant fields.
+   *
+   * @param object Object to update
+   */
   @Override
   public final void updateNoAcl(@Nonnull T object) {
-    object.setAutoFields();
+    setFields(object, CurrentUserUtil.getCurrentUserDetails());
     getSession().update(object);
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
@@ -329,7 +329,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
   /**
    * Method that updates a {@link BaseIdentifiableObject}, bypassing any ACL checks. It calls {@link
    * #setFields(BaseIdentifiableObject, UserDetails)} which ensures that the following properties
-   * are set:
+   * are set before updating:
    * <li>UID
    * <li>created
    * <li>createdBy

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SharingControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SharingControllerTest.java
@@ -176,7 +176,7 @@ class SharingControllerTest extends DhisControllerConvenienceTest {
     switchToSuperuser();
     PUT("/sharing?type=categoryOption&id=xYerKDKCef1", sharingPrivate()).content(HttpStatus.OK);
 
-    // then the lastUpdatedBy value should match the last user to update it
+    // then
     JsonCategoryOption catOption2 =
         GET("/categoryOptions/xYerKDKCef1").content(HttpStatus.OK).as(JsonCategoryOption.class);
     assertEquals(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SharingControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SharingControllerTest.java
@@ -34,9 +34,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.jsontree.JsonNode;
 import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.user.User;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.webapi.json.domain.JsonCategoryOption;
 import org.hisp.dhis.webapi.json.domain.JsonIdentifiableObject;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -152,5 +155,56 @@ class SharingControllerTest extends DhisControllerConvenienceTest {
     GET("/sharing?type=dataSet&id=" + dataSetId).content(HttpStatus.FORBIDDEN);
     switchToSuperuser();
     GET("/sharing?type=dataSet&id=" + dataSetId).content(HttpStatus.OK);
+  }
+
+  @Test
+  @DisplayName(
+      "Updating metadata sharing (which bypasses ACL checks) will update the lastUpdatedBy field to match the current user")
+  void updatingSharingWillUpdateTheLastUpdatedByField() {
+    // given a category option is created by a test user
+    User user = switchToNewUser("tester123", "ALL");
+    POST("/categoryOptions", catOption()).content(HttpStatus.CREATED);
+
+    JsonCategoryOption catOption =
+        GET("/categoryOptions/xYerKDKCef1").content(HttpStatus.OK).as(JsonCategoryOption.class);
+    assertEquals(
+        user.getUid(),
+        catOption.getLastUpdatedBy().getId(),
+        "The lastUpdatedBy value should match the user who just created the object");
+
+    // when a different user updates it
+    switchToSuperuser();
+    PUT("/sharing?type=categoryOption&id=xYerKDKCef1", sharingPrivate()).content(HttpStatus.OK);
+
+    // then the lastUpdatedBy value should match the last user to update it
+    JsonCategoryOption catOption2 =
+        GET("/categoryOptions/xYerKDKCef1").content(HttpStatus.OK).as(JsonCategoryOption.class);
+    assertEquals(
+        "M5zQapPyTZI",
+        catOption2.getLastUpdatedBy().getId(),
+        "The lastUpdatedBy value should match the user who last updated the object");
+  }
+
+  private String catOption() {
+    return """
+    {
+        "id": "xYerKDKCef1",
+        "displayName": "cat option 1",
+        "name": "test cat option",
+        "shortName": "test cat option"
+    }""";
+  }
+
+  private String sharingPrivate() {
+    return """
+    {
+         "object": {
+             "publicAccess": "--------",
+             "externalAccess": false,
+             "user": {},
+             "userAccesses": [],
+             "userGroupAccesses": []
+         }
+     }""";
   }
 }


### PR DESCRIPTION
# Issue
When the `updateNoAcl` method is used, the `lastUpdatedBy` value is not being updated.

# Fix
Instead of calling `setAutoFields` call `setFields` which includes a call to `setAutoFields` as well as updating the following fields:
- `createdBy` (if null)
- `lastUpdatedBy`

# Testing
## Automated
new web test added

## Manual
1. create metadata as user 1
`POST` `/api/categoryOptions` with body
```json
{
    "id": "xYerKDKCef1",
    "displayName": "cat test 1",
    "name": "cat test 1",
    "shortName": "cat test 1"
}
```

2. check the `lastUpdatedBy` value
`GET` `/api/categoryOptions/xYerKDKCef1`

3. update sharing of object with different user (superuser)
`POST` `/api/sharing?type=categoryOption&id=xYerKDKCef1` with body
```json
{
    "object": {
        "publicAccess": "r-------",
        "externalAccess": false,
        "user": {},
        "userAccesses": [],
        "userGroupAccesses": []
    }
}
```

4. check that the `lastUpdatedBy` value is the user who has updated it last (should be different to value at step 2)
`GET` `/api/categoryOptions/xYerKDKCef1`