### PR TITLE
feat(DHIS2-16132): add ability to customise the display of a section form

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/Section.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/Section.java
@@ -33,10 +33,8 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.common.BaseIdentifiableObject;
@@ -67,11 +65,7 @@ public class Section extends BaseIdentifiableObject implements MetadataObject {
 
   private boolean disableDataElementAutoGroup;
 
-  private String textBeforeSection;
-
-  private String textAfterSection;
-
-  private Map<String, String> displayOptions = new HashMap<>();
+  private String displayOptions;
 
   // -------------------------------------------------------------------------
   // Constructors
@@ -224,31 +218,11 @@ public class Section extends BaseIdentifiableObject implements MetadataObject {
 
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
-  public String getTextBeforeSection() {
-    return textBeforeSection;
-  }
-
-  public void setTextBeforeSection(String textBeforeSection) {
-    this.textBeforeSection = textBeforeSection;
-  }
-
-  @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
-  public String getTextAfterSection() {
-    return textAfterSection;
-  }
-
-  public void setTextAfterSection(String textAfterSection) {
-    this.textAfterSection = textAfterSection;
-  }
-
-  @JsonProperty
-  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
-  public Map<String, String> getDisplayOptions() {
+  public String getDisplayOptions() {
     return displayOptions;
   }
 
-  public void setDisplayOptions(Map<String, String> displayOptions) {
+  public void setDisplayOptions(String displayOptions) {
     this.displayOptions = displayOptions;
   }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/Section.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/Section.java
@@ -33,8 +33,10 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.common.BaseIdentifiableObject;
@@ -64,6 +66,12 @@ public class Section extends BaseIdentifiableObject implements MetadataObject {
   private boolean showColumnTotals;
 
   private boolean disableDataElementAutoGroup;
+
+  private String textBeforeSection;
+
+  private String textAfterSection;
+
+  private Map<String, String> displayOptions = new HashMap<>();
 
   // -------------------------------------------------------------------------
   // Constructors
@@ -212,6 +220,36 @@ public class Section extends BaseIdentifiableObject implements MetadataObject {
 
   public void setShowColumnTotals(boolean showColumnTotals) {
     this.showColumnTotals = showColumnTotals;
+  }
+
+  @JsonProperty
+  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
+  public String getTextBeforeSection() {
+    return textBeforeSection;
+  }
+
+  public void setTextBeforeSection(String textBeforeSection) {
+    this.textBeforeSection = textBeforeSection;
+  }
+
+  @JsonProperty
+  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
+  public String getTextAfterSection() {
+    return textAfterSection;
+  }
+
+  public void setTextAfterSection(String textAfterSection) {
+    this.textAfterSection = textAfterSection;
+  }
+
+  @JsonProperty
+  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
+  public Map<String, String> getDisplayOptions() {
+    return displayOptions;
+  }
+
+  public void setDisplayOptions(Map<String, String> displayOptions) {
+    this.displayOptions = displayOptions;
   }
 
   @JsonProperty

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataset/hibernate/Section.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataset/hibernate/Section.hbm.xml
@@ -54,11 +54,7 @@
 
     <property name="showColumnTotals" />
     
-    <property name="displayOptions" type="jbObject" column="displayoptions" />
-
-    <property name="textBeforeSection" column="textbeforesection" />
-
-    <property name="textAfterSection" column="textaftersection" />
+    <property name="displayOptions" type="jbPlainString" column="displayoptions" />
 
     <property name="disableDataElementAutoGroup" column="disabledataelementautogroup" />
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataset/hibernate/Section.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataset/hibernate/Section.hbm.xml
@@ -53,6 +53,12 @@
     <property name="showRowTotals" />
 
     <property name="showColumnTotals" />
+    
+    <property name="displayOptions" type="jbObject" column="displayoptions" />
+
+    <property name="textBeforeSection" column="textbeforesection" />
+
+    <property name="textAfterSection" column="textaftersection" />
 
     <property name="disableDataElementAutoGroup" column="disabledataelementautogroup" />
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
@@ -57,6 +57,7 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetElement;
 import org.hisp.dhis.dataset.DataSetService;
+import org.hisp.dhis.dataset.Section;
 import org.hisp.dhis.expression.ExpressionService;
 import org.hisp.dhis.fieldfiltering.FieldFilterParams;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
@@ -84,6 +85,7 @@ public class DefaultDataSetMetadataExportService implements DataSetMetadataExpor
   private static final List<Class<? extends IdentifiableObject>> METADATA_TYPES =
       List.of(
           DataSet.class,
+          Section.class,
           DataElement.class,
           Indicator.class,
           CategoryCombo.class,
@@ -100,7 +102,7 @@ public class DefaultDataSetMetadataExportService implements DataSetMetadataExpor
           + "dataInputPeriods[period,openingDate,closingDate],"
           + "indicators~pluck[id],"
           + "compulsoryDataElementOperands[dataElement[id],categoryOptionCombo[id]],"
-          + "sections[:simple,dataElements~pluck[id],indicators~pluck[id],"
+          + "sections[:simple,displayOptions,dataElements~pluck[id],indicators~pluck[id],"
           + "greyedFields[dataElement[id],categoryOptionCombo[id]]]";
 
   private static final String FIELDS_DATA_SET_ELEMENTS = "dataElement[id],categoryCombo[id]";

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_46__add_section_config_fields.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_46__add_section_config_fields.sql
@@ -1,0 +1,4 @@
+ALTER TABLE section ADD COLUMN IF NOT EXISTS textbeforesection text;
+ALTER TABLE section ADD COLUMN IF NOT EXISTS textaftersection text;
+ALTER TABLE section ADD COLUMN IF NOT EXISTS displayoptions jsonb default '{}'::jsonb;
+

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_46__add_section_config_fields.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_46__add_section_config_fields.sql
@@ -1,4 +1,2 @@
-ALTER TABLE section ADD COLUMN IF NOT EXISTS textbeforesection text;
-ALTER TABLE section ADD COLUMN IF NOT EXISTS textaftersection text;
 ALTER TABLE section ADD COLUMN IF NOT EXISTS displayoptions jsonb default '{}'::jsonb;
 


### PR DESCRIPTION
This PR adds configuration option to the Section metadata in order to be able to display a form transposed, and grouped by data elements in the data entry app. Implements [DHIS2-16132 ](https://dhis2.atlassian.net/browse/DHIS2-16132).

## Implementation details

- The `displayOptions` was added as a JSON type to allow us flexibility to add more options without updating the backend. See discussion here.
  - The JSON object only supports these properties: `pivotMode` and `pivotedCategory` (this is a FE concern though, irrelevant to this PR) 
- [This line](https://github.com/dhis2/dhis2-core/pull/16562/files#diff-3f4dd79ed04bd98558f59e7b97ec192556f92cbe19bbae558a60e6516696cbeaR88) was added to  `DefaultDataSetMetadataExportService` as otherwise the `dataEntry/metadata` eTag is not updated when a section is updated and the new configuration is not shown to the user (unless the server is restarted?)
- The change includes a migration to create the new columns (applied in v41)

![image](https://github.com/dhis2/dhis2-core/assets/1014725/f8a94832-e937-4072-855b-08460fd3a300)

## Background

We are aiming to add more form configuration options as part of an initiative to provide configurations natively to data entry forms to reduce the necessity for custom forms. Users are currently building custom forms as a workaround for shortcomings of the configuration options (ability to transpose, or customise a cell design) or implementation (such to avoid issues with RTL issues).

This is [an RFC](https://dhis2.atlassian.net/wiki/spaces/SOFTWARE/pages/121995265/Form+configuration+RFC) that describes the approach and the priorities for form configuration options. This is based on a [thorough investigation](https://docs.google.com/presentation/d/1pSeFoF91HDYNeL88GghKLvj3wpYf0qUCdhkKXklB2MY/edit#slide=id.g2462c2dd6c9_0_53) by the functional design team for custom form use cases in real-life implementations. Based on that investigation, the ability to transpose forms and adding free-text descriptions were one of the main reasons people choose to go the custom forms route so we're tackling these first.

### UI

[form-config-4.webm](https://github.com/dhis2/dhis2-core/assets/1014725/2774b230-52a3-4f20-bfde-63ec544c35e4)

## Related PRs:

- [Maintenance app](https://github.com/dhis2/maintenance-app/pull/2802)
- [Data entry app (beta)](https://github.com/dhis2/aggregate-data-entry-app/pull/367)
- [Backend](https://github.com/dhis2/dhis2-core/pull/16562)