### PR TITLE
feat: Add pagination on new change log endpoint [DHIS2-16856]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/Page.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/Page.java
@@ -28,40 +28,42 @@
 package org.hisp.dhis.tracker.export;
 
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 @ToString
 @EqualsAndHashCode
 public class Page<T> {
   private final List<T> items;
-  private final Integer page;
-  private final Integer pageSize;
+  private final int page;
+  private final int pageSize;
   private final Long total;
-  private final boolean prev;
-  private final boolean next;
+  private final Boolean prev;
+  private final Boolean next;
 
-  private Page(List<T> items, int page, int pageSize, long total, boolean prev, boolean next) {
-    this.items = items;
-    this.page = page;
-    this.pageSize = pageSize;
-    this.total = total;
-    this.prev = prev;
-    this.next = next;
+  /**
+   * Create a new page based on an existing one but with given {@code items}. Page related counts
+   * will not be changed so make sure the given {@code items} match the previous page size.
+   */
+  public <U> Page<U> withItems(List<U> items) {
+    return new Page<>(items, this.page, this.pageSize, this.total, this.prev, this.next);
   }
 
   public static <T> Page<T> withTotals(List<T> items, int page, int pageSize, long total) {
-    return new Page<>(items, page, pageSize, total, false, false);
+    return new Page<>(items, page, pageSize, total, null, null);
   }
 
   public static <T> Page<T> withoutTotals(List<T> items, int page, int pageSize) {
-    return new Page<>(items, page, pageSize, 0, false, false);
+    return new Page<>(items, page, pageSize, null, null, null);
   }
 
   public static <T> Page<T> withPrevAndNext(
       List<T> items, int page, int pageSize, boolean prev, boolean next) {
-    return new Page<>(items, page, pageSize, 0, prev, next);
+    return new Page<>(items, page, pageSize, null, prev, next);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/Page.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/Page.java
@@ -30,25 +30,38 @@ package org.hisp.dhis.tracker.export;
 import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
-import org.hisp.dhis.common.Pager;
 
-@RequiredArgsConstructor(staticName = "of")
 @Getter
 @ToString
 @EqualsAndHashCode
 public class Page<T> {
   private final List<T> items;
-  private final Pager pager;
+  private final Integer page;
+  private final Integer pageSize;
+  private final Long total;
+  private final boolean prev;
+  private final boolean next;
 
-  /**
-   * Indicates if the {@link #pager} contains the total number of items. The current {@link #pager}
-   * does not reveal that information as it was meant for metadata that does not allow disabling the
-   * return of totals.
-   */
-  private final boolean pageTotal;
+  private Page(List<T> items, int page, int pageSize, long total, boolean prev, boolean next) {
+    this.items = items;
+    this.page = page;
+    this.pageSize = pageSize;
+    this.total = total;
+    this.prev = prev;
+    this.next = next;
+  }
 
-  private final boolean hasPrevious;
-  private final boolean hasNext;
+  public static <T> Page<T> withTotals(List<T> items, int page, int pageSize, long total) {
+    return new Page<>(items, page, pageSize, total, false, false);
+  }
+
+  public static <T> Page<T> withoutTotals(List<T> items, int page, int pageSize) {
+    return new Page<>(items, page, pageSize, 0, false, false);
+  }
+
+  public static <T> Page<T> withPrevAndNext(
+      List<T> items, int page, int pageSize, boolean prev, boolean next) {
+    return new Page<>(items, page, pageSize, 0, prev, next);
+  }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/Page.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/Page.java
@@ -48,4 +48,7 @@ public class Page<T> {
    * return of totals.
    */
   private final boolean pageTotal;
+
+  private final boolean hasPrevious;
+  private final boolean hasNext;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -213,8 +213,13 @@ class DefaultEnrollmentService
             params.isIncludeDeleted(),
             queryParams.getOrganisationUnitMode());
 
-    return Page.of(
-        enrollments, enrollmentsPage.getPager(), enrollmentsPage.isPageTotal(), false, false);
+    return enrollmentsPage.getTotal() != null
+        ? Page.withTotals(
+            enrollments,
+            enrollmentsPage.getPage(),
+            enrollmentsPage.getPageSize(),
+            enrollmentsPage.getTotal())
+        : Page.withoutTotals(enrollments, enrollmentsPage.getPage(), enrollmentsPage.getPageSize());
   }
 
   private List<Enrollment> getEnrollments(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -213,7 +213,8 @@ class DefaultEnrollmentService
             params.isIncludeDeleted(),
             queryParams.getOrganisationUnitMode());
 
-    return Page.of(enrollments, enrollmentsPage.getPager(), enrollmentsPage.isPageTotal());
+    return Page.of(
+        enrollments, enrollmentsPage.getPager(), enrollmentsPage.isPageTotal(), false, false);
   }
 
   private List<Enrollment> getEnrollments(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -212,14 +212,7 @@ class DefaultEnrollmentService
             params.getEnrollmentParams(),
             params.isIncludeDeleted(),
             queryParams.getOrganisationUnitMode());
-
-    return enrollmentsPage.getTotal() != null
-        ? Page.withTotals(
-            enrollments,
-            enrollmentsPage.getPage(),
-            enrollmentsPage.getPageSize(),
-            enrollmentsPage.getTotal())
-        : Page.withoutTotals(enrollments, enrollmentsPage.getPage(), enrollmentsPage.getPageSize());
+    return enrollmentsPage.withItems(enrollments);
   }
 
   private List<Enrollment> getEnrollments(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentStore.java
@@ -43,7 +43,7 @@ interface EnrollmentStore extends IdentifiableObjectStore<Enrollment> {
    * @param params EnrollmentQueryParams to use
    * @return Count of matching enrollments
    */
-  int countEnrollments(EnrollmentQueryParams params);
+  long countEnrollments(EnrollmentQueryParams params);
 
   /** Get all enrollments matching given params. */
   List<Enrollment> getEnrollments(EnrollmentQueryParams params);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/HibernateEnrollmentStore.java
@@ -133,12 +133,12 @@ class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enrollment
     if (pageParams.isPageTotal()) {
       Pager pager =
           new Pager(pageParams.getPage(), enrollmentCount.getAsInt(), pageParams.getPageSize());
-      return Page.of(enrollments, pager, pageParams.isPageTotal());
+      return Page.of(enrollments, pager, pageParams.isPageTotal(), false, false);
     }
 
     Pager pager = new Pager(pageParams.getPage(), 0, pageParams.getPageSize());
     pager.force(pageParams.getPage(), pageParams.getPageSize());
-    return Page.of(enrollments, pager, pageParams.isPageTotal());
+    return Page.of(enrollments, pager, pageParams.isPageTotal(), false, false);
   }
 
   private QueryWithOrderBy buildEnrollmentHql(EnrollmentQueryParams params) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/HibernateEnrollmentStore.java
@@ -38,7 +38,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.function.Function;
-import java.util.function.IntSupplier;
+import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.persistence.EntityManager;
@@ -92,12 +92,12 @@ class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enrollment
   }
 
   @Override
-  public int countEnrollments(EnrollmentQueryParams params) {
+  public long countEnrollments(EnrollmentQueryParams params) {
     String hql = buildCountEnrollmentHql(params);
 
     Query<Long> query = getTypedQuery(hql);
 
-    return query.getSingleResult().intValue();
+    return query.getSingleResult().longValue();
   }
 
   private String buildCountEnrollmentHql(EnrollmentQueryParams params) {
@@ -123,15 +123,15 @@ class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enrollment
     query.setFirstResult((pageParams.getPage() - 1) * pageParams.getPageSize());
     query.setMaxResults(pageParams.getPageSize());
 
-    IntSupplier enrollmentCount = () -> countEnrollments(params);
+    LongSupplier enrollmentCount = () -> countEnrollments(params);
     return getPage(pageParams, query.list(), enrollmentCount);
   }
 
   private Page<Enrollment> getPage(
-      PageParams pageParams, List<Enrollment> enrollments, IntSupplier enrollmentCount) {
+      PageParams pageParams, List<Enrollment> enrollments, LongSupplier enrollmentCount) {
     if (pageParams.isPageTotal()) {
       return Page.withTotals(
-          enrollments, pageParams.getPage(), pageParams.getPageSize(), enrollmentCount.getAsInt());
+          enrollments, pageParams.getPage(), pageParams.getPageSize(), enrollmentCount.getAsLong());
     }
 
     return Page.withoutTotals(enrollments, pageParams.getPage(), pageParams.getPageSize());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/HibernateEnrollmentStore.java
@@ -50,7 +50,6 @@ import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.query.Query;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
-import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.hibernate.SoftDeleteHibernateObjectStore;
 import org.hisp.dhis.commons.util.SqlHelper;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -131,14 +130,11 @@ class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enrollment
   private Page<Enrollment> getPage(
       PageParams pageParams, List<Enrollment> enrollments, IntSupplier enrollmentCount) {
     if (pageParams.isPageTotal()) {
-      Pager pager =
-          new Pager(pageParams.getPage(), enrollmentCount.getAsInt(), pageParams.getPageSize());
-      return Page.of(enrollments, pager, pageParams.isPageTotal(), false, false);
+      return Page.withTotals(
+          enrollments, pageParams.getPage(), pageParams.getPageSize(), enrollmentCount.getAsInt());
     }
 
-    Pager pager = new Pager(pageParams.getPage(), 0, pageParams.getPageSize());
-    pager.force(pageParams.getPage(), pageParams.getPageSize());
-    return Page.of(enrollments, pager, pageParams.isPageTotal(), false, false);
+    return Page.withoutTotals(enrollments, pageParams.getPage(), pageParams.getPageSize());
   }
 
   private QueryWithOrderBy buildEnrollmentHql(EnrollmentQueryParams params) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventChangeLogService.java
@@ -33,6 +33,8 @@ import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
+import org.hisp.dhis.tracker.export.Page;
+import org.hisp.dhis.tracker.export.PageParams;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
@@ -53,7 +55,8 @@ public class DefaultEventChangeLogService implements EventChangeLogService {
   private final UserService userService;
 
   @Override
-  public List<EventChangeLog> getEventChangeLog(UID eventUid) throws NotFoundException {
+  public Page<EventChangeLog> getEventChangeLog(UID eventUid, PageParams pageParams)
+      throws NotFoundException {
     Event event = eventService.getEvent(eventUid.getValue());
     if (event == null) {
       throw new NotFoundException(Event.class, eventUid.getValue());
@@ -65,6 +68,6 @@ public class DefaultEventChangeLogService implements EventChangeLogService {
       throw new NotFoundException(Event.class, eventUid.getValue());
     }
 
-    return jdbcEventChangeLogStore.getEventChangeLog(eventUid.getValue());
+    return jdbcEventChangeLogStore.getEventChangeLog(eventUid.getValue(), pageParams);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventChangeLogService.java
@@ -68,6 +68,6 @@ public class DefaultEventChangeLogService implements EventChangeLogService {
       throw new NotFoundException(Event.class, eventUid.getValue());
     }
 
-    return jdbcEventChangeLogStore.getEventChangeLog(eventUid.getValue(), pageParams);
+    return jdbcEventChangeLogStore.getEventChangeLog(eventUid, pageParams);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLog.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLog.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.export.event;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Date;
 import org.hisp.dhis.program.UserInfoSnapshot;
@@ -40,6 +41,6 @@ public record EventChangeLog(
 
   public record DataValueChange(
       @JsonProperty String dataElement,
-      @JsonProperty String previousValue,
-      @JsonProperty String currentValue) {}
+      @JsonInclude @JsonProperty String previousValue,
+      @JsonInclude @JsonProperty String currentValue) {}
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLog.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLog.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.export.event;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Date;
 import org.hisp.dhis.program.UserInfoSnapshot;
@@ -41,6 +40,6 @@ public record EventChangeLog(
 
   public record DataValueChange(
       @JsonProperty String dataElement,
-      @JsonInclude @JsonProperty String previousValue,
-      @JsonInclude @JsonProperty String currentValue) {}
+      @JsonProperty String previousValue,
+      @JsonProperty String currentValue) {}
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLogService.java
@@ -37,7 +37,7 @@ public interface EventChangeLogService {
   /**
    * Retrieves the change log data for a particular event
    *
-   * @return paginated list of change logs of the supplied event, if any
+   * @return event change logs page
    */
   Page<EventChangeLog> getEventChangeLog(UID event, PageParams pageParams) throws NotFoundException;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventChangeLogStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventChangeLogStore.java
@@ -29,20 +29,21 @@ package org.hisp.dhis.tracker.export.event;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.hisp.dhis.common.Pager;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
 import org.hisp.dhis.tracker.export.event.EventChangeLog.Change;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 @Repository("org.hisp.dhis.tracker.export.event.ChangeLogStore")
 @RequiredArgsConstructor
 class JdbcEventChangeLogStore {
 
-  private final JdbcTemplate jdbcTemplate;
+  private final NamedParameterJdbcTemplate jdbcTemplate;
 
   private static final RowMapper<EventChangeLog> customEventChangeLogRowMapper =
       (rs, rowNum) -> {
@@ -62,7 +63,7 @@ class JdbcEventChangeLogStore {
                     rs.getString("currentValue"))));
       };
 
-  public Page<EventChangeLog> getEventChangeLog(String eventUid, PageParams pageParams) {
+  public Page<EventChangeLog> getEventChangeLog(UID event, PageParams pageParams) {
     final String sql =
         """
             select
@@ -86,21 +87,19 @@ class JdbcEventChangeLogStore {
               join dataelement d using (dataelementid)
               join userinfo u on u.username = t.modifiedby
               where t.audittype in ('CREATE', 'UPDATE', 'DELETE')
-              and e.uid = ?
+              and e.uid = :uid
               order by t.created desc) cl
-              limit ? offset ?
+              limit :limit offset :offset
             """;
 
-    List<EventChangeLog> changeLogs =
-        jdbcTemplate.query(
-            sql,
-            customEventChangeLogRowMapper,
-            eventUid,
-            pageParams.getPageSize() + 1,
-            (pageParams.getPage() - 1) * pageParams.getPageSize());
+    final MapSqlParameterSource parameters = new MapSqlParameterSource();
+    parameters.addValue("uid", event.getValue());
+    parameters.addValue("limit", pageParams.getPageSize() + 1);
+    parameters.addValue("offset", (pageParams.getPage() - 1) * pageParams.getPageSize());
 
-    Pager pager = new Pager();
-    pager.force(pageParams.getPage(), pageParams.getPageSize());
+    List<EventChangeLog> changeLogs =
+        jdbcTemplate.query(sql, parameters, customEventChangeLogRowMapper);
+
     if (changeLogs.size() > pageParams.getPageSize()) {
       return Page.withPrevAndNext(
           changeLogs.subList(0, pageParams.getPageSize()),
@@ -108,13 +107,13 @@ class JdbcEventChangeLogStore {
           pageParams.getPageSize(),
           pageParams.getPage() != 1,
           true);
-    } else {
-      return Page.withPrevAndNext(
-          changeLogs,
-          pageParams.getPage(),
-          pageParams.getPageSize(),
-          pageParams.getPage() != 1,
-          false);
     }
+
+    return Page.withPrevAndNext(
+        changeLogs,
+        pageParams.getPage(),
+        pageParams.getPageSize(),
+        pageParams.getPage() != 1,
+        false);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventChangeLogStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventChangeLogStore.java
@@ -102,14 +102,19 @@ class JdbcEventChangeLogStore {
     Pager pager = new Pager();
     pager.force(pageParams.getPage(), pageParams.getPageSize());
     if (changeLogs.size() > pageParams.getPageSize()) {
-      return Page.of(
+      return Page.withPrevAndNext(
           changeLogs.subList(0, pageParams.getPageSize()),
-          pager,
-          false,
+          pageParams.getPage(),
+          pageParams.getPageSize(),
           pageParams.getPage() != 1,
           true);
     } else {
-      return Page.of(changeLogs, pager, false, pageParams.getPage() != 1, false);
+      return Page.withPrevAndNext(
+          changeLogs,
+          pageParams.getPage(),
+          pageParams.getPageSize(),
+          pageParams.getPage() != 1,
+          false);
     }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -67,7 +67,6 @@ import org.hisp.dhis.common.AssignedUserSelectionMode;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdSchemes;
 import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.commons.collection.CollectionUtils;
@@ -434,14 +433,12 @@ class JdbcEventStore implements EventStore {
 
   private Page<Event> getPage(PageParams pageParams, List<Event> events, IntSupplier eventCount) {
     if (pageParams.isPageTotal()) {
-      Pager pager =
-          new Pager(pageParams.getPage(), eventCount.getAsInt(), pageParams.getPageSize());
-      return Page.of(events, pager, pageParams.isPageTotal(), false, false);
+      // TODO Why is total long if here we send an int?
+      return Page.withTotals(
+          events, pageParams.getPage(), pageParams.getPageSize(), eventCount.getAsInt());
     }
 
-    Pager pager = new Pager(pageParams.getPage(), 0, pageParams.getPageSize());
-    pager.force(pageParams.getPage(), pageParams.getPageSize());
-    return Page.of(events, pager, pageParams.isPageTotal(), false, false);
+    return Page.withoutTotals(events, pageParams.getPage(), pageParams.getPageSize());
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -436,12 +436,12 @@ class JdbcEventStore implements EventStore {
     if (pageParams.isPageTotal()) {
       Pager pager =
           new Pager(pageParams.getPage(), eventCount.getAsInt(), pageParams.getPageSize());
-      return Page.of(events, pager, pageParams.isPageTotal());
+      return Page.of(events, pager, pageParams.isPageTotal(), false, false);
     }
 
     Pager pager = new Pager(pageParams.getPage(), 0, pageParams.getPageSize());
     pager.force(pageParams.getPage(), pageParams.getPageSize());
-    return Page.of(events, pager, pageParams.isPageTotal());
+    return Page.of(events, pager, pageParams.isPageTotal(), false, false);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/JdbcEventStore.java
@@ -56,7 +56,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.IntSupplier;
+import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -242,7 +242,7 @@ class JdbcEventStore implements EventStore {
   @Override
   public Page<Event> getEvents(EventQueryParams queryParams, PageParams pageParams) {
     List<Event> events = fetchEvents(queryParams, pageParams);
-    IntSupplier eventCount = () -> getEventCount(queryParams);
+    LongSupplier eventCount = () -> getEventCount(queryParams);
     return getPage(pageParams, events, eventCount);
   }
 
@@ -431,11 +431,10 @@ class JdbcEventStore implements EventStore {
         });
   }
 
-  private Page<Event> getPage(PageParams pageParams, List<Event> events, IntSupplier eventCount) {
+  private Page<Event> getPage(PageParams pageParams, List<Event> events, LongSupplier eventCount) {
     if (pageParams.isPageTotal()) {
-      // TODO Why is total long if here we send an int?
       return Page.withTotals(
-          events, pageParams.getPage(), pageParams.getPageSize(), eventCount.getAsInt());
+          events, pageParams.getPage(), pageParams.getPageSize(), eventCount.getAsLong());
     }
 
     return Page.withoutTotals(events, pageParams.getPage(), pageParams.getPageSize());
@@ -529,7 +528,7 @@ class JdbcEventStore implements EventStore {
     return sqlBuilder.toString();
   }
 
-  private int getEventCount(EventQueryParams params) {
+  private long getEventCount(EventQueryParams params) {
     User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
     setAccessiblePrograms(currentUser, params);
 
@@ -545,7 +544,7 @@ class JdbcEventStore implements EventStore {
 
     sql = sql.replaceFirst("limit \\d+ offset \\d+", "");
 
-    return jdbcTemplate.queryForObject(sql, mapSqlParameterSource, Integer.class);
+    return jdbcTemplate.queryForObject(sql, mapSqlParameterSource, Long.class);
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -114,7 +114,7 @@ public class DefaultRelationshipService implements RelationshipService {
         relationshipPage.getItems().stream()
             .filter(r -> trackerAccessManager.canRead(currentUser, r).isEmpty())
             .toList();
-    return relationshipPage.withItems(relationships);
+    return relationshipPage.withItems(map(relationships));
   }
 
   public List<Relationship> getRelationshipsByEnrollment(
@@ -136,7 +136,7 @@ public class DefaultRelationshipService implements RelationshipService {
         relationshipPage.getItems().stream()
             .filter(r -> trackerAccessManager.canRead(currentUser, r).isEmpty())
             .toList();
-    return relationshipPage.withItems(relationships);
+    return relationshipPage.withItems(map(relationships));
   }
 
   public List<Relationship> getRelationshipsByEvent(
@@ -158,7 +158,7 @@ public class DefaultRelationshipService implements RelationshipService {
         relationshipPage.getItems().stream()
             .filter(r -> trackerAccessManager.canRead(currentUser, r).isEmpty())
             .toList();
-    return relationshipPage.withItems(relationships);
+    return relationshipPage.withItems(map(relationships));
   }
 
   private List<Relationship> getRelationships(RelationshipQueryParams queryParams) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -114,12 +114,14 @@ public class DefaultRelationshipService implements RelationshipService {
         relationshipPage.getItems().stream()
             .filter(r -> trackerAccessManager.canRead(currentUser, r).isEmpty())
             .toList();
-    return Page.of(
-        map(relationships),
-        relationshipPage.getPager(),
-        relationshipPage.isPageTotal(),
-        false,
-        false);
+
+    return relationshipPage.getTotal() != null
+        ? Page.withTotals(
+            relationships,
+            pageParams.getPage(),
+            pageParams.getPageSize(),
+            relationshipPage.getTotal())
+        : Page.withoutTotals(relationships, pageParams.getPage(), pageParams.getPageSize());
   }
 
   public List<Relationship> getRelationshipsByEnrollment(
@@ -141,12 +143,14 @@ public class DefaultRelationshipService implements RelationshipService {
         relationshipPage.getItems().stream()
             .filter(r -> trackerAccessManager.canRead(currentUser, r).isEmpty())
             .toList();
-    return Page.of(
-        map(relationships),
-        relationshipPage.getPager(),
-        relationshipPage.isPageTotal(),
-        false,
-        false);
+
+    return relationshipPage.getTotal() != null
+        ? Page.withTotals(
+            relationships,
+            pageParams.getPage(),
+            pageParams.getPageSize(),
+            relationshipPage.getTotal())
+        : Page.withoutTotals(relationships, pageParams.getPage(), pageParams.getPageSize());
   }
 
   public List<Relationship> getRelationshipsByEvent(
@@ -168,12 +172,14 @@ public class DefaultRelationshipService implements RelationshipService {
         relationshipPage.getItems().stream()
             .filter(r -> trackerAccessManager.canRead(currentUser, r).isEmpty())
             .toList();
-    return Page.of(
-        map(relationships),
-        relationshipPage.getPager(),
-        relationshipPage.isPageTotal(),
-        false,
-        false);
+
+    return relationshipPage.getTotal() != null
+        ? Page.withTotals(
+            relationships,
+            pageParams.getPage(),
+            pageParams.getPageSize(),
+            relationshipPage.getTotal())
+        : Page.withoutTotals(relationships, pageParams.getPage(), pageParams.getPageSize());
   }
 
   private List<Relationship> getRelationships(RelationshipQueryParams queryParams) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -114,7 +114,12 @@ public class DefaultRelationshipService implements RelationshipService {
         relationshipPage.getItems().stream()
             .filter(r -> trackerAccessManager.canRead(currentUser, r).isEmpty())
             .toList();
-    return Page.of(map(relationships), relationshipPage.getPager(), relationshipPage.isPageTotal());
+    return Page.of(
+        map(relationships),
+        relationshipPage.getPager(),
+        relationshipPage.isPageTotal(),
+        false,
+        false);
   }
 
   public List<Relationship> getRelationshipsByEnrollment(
@@ -136,7 +141,12 @@ public class DefaultRelationshipService implements RelationshipService {
         relationshipPage.getItems().stream()
             .filter(r -> trackerAccessManager.canRead(currentUser, r).isEmpty())
             .toList();
-    return Page.of(map(relationships), relationshipPage.getPager(), relationshipPage.isPageTotal());
+    return Page.of(
+        map(relationships),
+        relationshipPage.getPager(),
+        relationshipPage.isPageTotal(),
+        false,
+        false);
   }
 
   public List<Relationship> getRelationshipsByEvent(
@@ -158,7 +168,12 @@ public class DefaultRelationshipService implements RelationshipService {
         relationshipPage.getItems().stream()
             .filter(r -> trackerAccessManager.canRead(currentUser, r).isEmpty())
             .toList();
-    return Page.of(map(relationships), relationshipPage.getPager(), relationshipPage.isPageTotal());
+    return Page.of(
+        map(relationships),
+        relationshipPage.getPager(),
+        relationshipPage.isPageTotal(),
+        false,
+        false);
   }
 
   private List<Relationship> getRelationships(RelationshipQueryParams queryParams) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -114,14 +114,7 @@ public class DefaultRelationshipService implements RelationshipService {
         relationshipPage.getItems().stream()
             .filter(r -> trackerAccessManager.canRead(currentUser, r).isEmpty())
             .toList();
-
-    return relationshipPage.getTotal() != null
-        ? Page.withTotals(
-            relationships,
-            pageParams.getPage(),
-            pageParams.getPageSize(),
-            relationshipPage.getTotal())
-        : Page.withoutTotals(relationships, pageParams.getPage(), pageParams.getPageSize());
+    return relationshipPage.withItems(relationships);
   }
 
   public List<Relationship> getRelationshipsByEnrollment(
@@ -143,14 +136,7 @@ public class DefaultRelationshipService implements RelationshipService {
         relationshipPage.getItems().stream()
             .filter(r -> trackerAccessManager.canRead(currentUser, r).isEmpty())
             .toList();
-
-    return relationshipPage.getTotal() != null
-        ? Page.withTotals(
-            relationships,
-            pageParams.getPage(),
-            pageParams.getPageSize(),
-            relationshipPage.getTotal())
-        : Page.withoutTotals(relationships, pageParams.getPage(), pageParams.getPageSize());
+    return relationshipPage.withItems(relationships);
   }
 
   public List<Relationship> getRelationshipsByEvent(
@@ -172,14 +158,7 @@ public class DefaultRelationshipService implements RelationshipService {
         relationshipPage.getItems().stream()
             .filter(r -> trackerAccessManager.canRead(currentUser, r).isEmpty())
             .toList();
-
-    return relationshipPage.getTotal() != null
-        ? Page.withTotals(
-            relationships,
-            pageParams.getPage(),
-            pageParams.getPageSize(),
-            relationshipPage.getTotal())
-        : Page.withoutTotals(relationships, pageParams.getPage(), pageParams.getPageSize());
+    return relationshipPage.withItems(relationships);
   }
 
   private List<Relationship> getRelationships(RelationshipQueryParams queryParams) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
@@ -273,12 +273,12 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
     if (pageParams.isPageTotal()) {
       Pager pager =
           new Pager(pageParams.getPage(), relationshipsCount.getAsInt(), pageParams.getPageSize());
-      return Page.of(relationships, pager, pageParams.isPageTotal());
+      return Page.of(relationships, pager, pageParams.isPageTotal(), false, false);
     }
 
     Pager pager = new Pager(pageParams.getPage(), 0, pageParams.getPageSize());
     pager.force(pageParams.getPage(), pageParams.getPageSize());
-    return Page.of(relationships, pager, pageParams.isPageTotal());
+    return Page.of(relationships, pager, pageParams.isPageTotal(), false, false);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
@@ -42,7 +42,6 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Subquery;
 import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.SoftDeletableObject;
 import org.hisp.dhis.common.SortDirection;
 import org.hisp.dhis.common.hibernate.SoftDeleteHibernateObjectStore;
@@ -271,14 +270,14 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
       PageParams pageParams, List<Relationship> relationships, IntSupplier relationshipsCount) {
 
     if (pageParams.isPageTotal()) {
-      Pager pager =
-          new Pager(pageParams.getPage(), relationshipsCount.getAsInt(), pageParams.getPageSize());
-      return Page.of(relationships, pager, pageParams.isPageTotal(), false, false);
+      return Page.withTotals(
+          relationships,
+          pageParams.getPage(),
+          pageParams.getPageSize(),
+          relationshipsCount.getAsInt());
     }
 
-    Pager pager = new Pager(pageParams.getPage(), 0, pageParams.getPageSize());
-    pager.force(pageParams.getPage(), pageParams.getPageSize());
-    return Page.of(relationships, pager, pageParams.isPageTotal(), false, false);
+    return Page.withoutTotals(relationships, pageParams.getPage(), pageParams.getPageSize());
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.function.IntSupplier;
+import java.util.function.LongSupplier;
 import javax.annotation.Nonnull;
 import javax.persistence.EntityManager;
 import javax.persistence.TypedQuery;
@@ -161,7 +161,7 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
    * @return
    * @param <T> relationships count
    */
-  private <T extends SoftDeletableObject> int countRelationships(
+  private <T extends SoftDeletableObject> long countRelationships(
       T entity, RelationshipQueryParams queryParams) {
 
     CriteriaBuilder builder = getCriteriaBuilder();
@@ -175,7 +175,7 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
         whereConditionPredicates(
             entity, builder, criteriaQuery, root, queryParams.isIncludeDeleted()));
 
-    return getSession().createQuery(criteriaQuery).getSingleResult().intValue();
+    return getSession().createQuery(criteriaQuery).getSingleResult().longValue();
   }
 
   private <T extends SoftDeletableObject> CriteriaQuery<Relationship> criteriaQuery(
@@ -267,14 +267,13 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
   }
 
   private Page<Relationship> getPage(
-      PageParams pageParams, List<Relationship> relationships, IntSupplier relationshipsCount) {
-
+      PageParams pageParams, List<Relationship> relationships, LongSupplier relationshipsCount) {
     if (pageParams.isPageTotal()) {
       return Page.withTotals(
           relationships,
           pageParams.getPage(),
           pageParams.getPageSize(),
-          relationshipsCount.getAsInt());
+          relationshipsCount.getAsLong());
     }
 
     return Page.withoutTotals(relationships, pageParams.getPage(), pageParams.getPageSize());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -420,7 +420,9 @@ class DefaultTrackedEntityService implements TrackedEntityService {
 
     addSearchAudit(trackedEntities, queryParams.getUser());
 
-    return Page.of(trackedEntities, ids.getPager(), ids.isPageTotal(), false, false);
+    return ids.getTotal() != null
+        ? Page.withTotals(trackedEntities, ids.getPage(), ids.getPageSize(), ids.getTotal())
+        : Page.withoutTotals(trackedEntities, ids.getPage(), ids.getPageSize());
   }
 
   public List<Long> getTrackedEntityIds(TrackedEntityQueryParams params) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -420,7 +420,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
 
     addSearchAudit(trackedEntities, queryParams.getUser());
 
-    return Page.of(trackedEntities, ids.getPager(), ids.isPageTotal());
+    return Page.of(trackedEntities, ids.getPager(), ids.isPageTotal(), false, false);
   }
 
   public List<Long> getTrackedEntityIds(TrackedEntityQueryParams params) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -420,9 +420,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
 
     addSearchAudit(trackedEntities, queryParams.getUser());
 
-    return ids.getTotal() != null
-        ? Page.withTotals(trackedEntities, ids.getPage(), ids.getPageSize(), ids.getTotal())
-        : Page.withoutTotals(trackedEntities, ids.getPage(), ids.getPageSize());
+    return ids.withItems(trackedEntities);
   }
 
   public List<Long> getTrackedEntityIds(TrackedEntityQueryParams params) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -44,7 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.function.IntSupplier;
+import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
 import javax.persistence.criteria.CriteriaBuilder;
@@ -175,14 +175,15 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
       ids.add(rowSet.getLong("trackedentityid"));
     }
 
-    IntSupplier teCount = () -> getTrackedEntityCount(params);
+    LongSupplier teCount = () -> getTrackedEntityCount(params);
     return getPage(pageParams, ids, teCount);
   }
 
-  private Page<Long> getPage(PageParams pageParams, List<Long> teIds, IntSupplier enrollmentCount) {
+  private Page<Long> getPage(
+      PageParams pageParams, List<Long> teIds, LongSupplier enrollmentCount) {
     if (pageParams.isPageTotal()) {
       return Page.withTotals(
-          teIds, pageParams.getPage(), pageParams.getPageSize(), enrollmentCount.getAsInt());
+          teIds, pageParams.getPage(), pageParams.getPageSize(), enrollmentCount.getAsLong());
     }
 
     return Page.withoutTotals(teIds, pageParams.getPage(), pageParams.getPageSize());
@@ -208,9 +209,9 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
   }
 
   @Override
-  public int getTrackedEntityCount(TrackedEntityQueryParams params) {
+  public Long getTrackedEntityCount(TrackedEntityQueryParams params) {
     String sql = getCountQuery(params);
-    return jdbcTemplate.queryForObject(sql, Integer.class);
+    return jdbcTemplate.queryForObject(sql, Long.class);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -184,12 +184,12 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     if (pageParams.isPageTotal()) {
       Pager pager =
           new Pager(pageParams.getPage(), enrollmentCount.getAsInt(), pageParams.getPageSize());
-      return Page.of(teIds, pager, pageParams.isPageTotal());
+      return Page.of(teIds, pager, pageParams.isPageTotal(), false, false);
     }
 
     Pager pager = new Pager(pageParams.getPage(), 0, pageParams.getPageSize());
     pager.force(pageParams.getPage(), pageParams.getPageSize());
-    return Page.of(teIds, pager, pageParams.isPageTotal());
+    return Page.of(teIds, pager, pageParams.isPageTotal(), false, false);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -54,7 +54,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.AssignedUserSelectionMode;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
-import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.hibernate.SoftDeleteHibernateObjectStore;
 import org.hisp.dhis.commons.collection.CollectionUtils;
@@ -182,14 +181,11 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
 
   private Page<Long> getPage(PageParams pageParams, List<Long> teIds, IntSupplier enrollmentCount) {
     if (pageParams.isPageTotal()) {
-      Pager pager =
-          new Pager(pageParams.getPage(), enrollmentCount.getAsInt(), pageParams.getPageSize());
-      return Page.of(teIds, pager, pageParams.isPageTotal(), false, false);
+      return Page.withTotals(
+          teIds, pageParams.getPage(), pageParams.getPageSize(), enrollmentCount.getAsInt());
     }
 
-    Pager pager = new Pager(pageParams.getPage(), 0, pageParams.getPageSize());
-    pager.force(pageParams.getPage(), pageParams.getPageSize());
-    return Page.of(teIds, pager, pageParams.isPageTotal(), false, false);
+    return Page.withoutTotals(teIds, pageParams.getPage(), pageParams.getPageSize());
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityStore.java
@@ -51,7 +51,7 @@ interface TrackedEntityStore extends IdentifiableObjectStore<TrackedEntity> {
    */
   Set<String> getOrderableFields();
 
-  int getTrackedEntityCount(TrackedEntityQueryParams params);
+  Long getTrackedEntityCount(TrackedEntityQueryParams params);
 
   int getTrackedEntityCountWithMaxTrackedEntityLimit(TrackedEntityQueryParams params);
 }

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v41/V2_41_46__add_data_sharing_for_aggregate_data_exchange.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v41/V2_41_46__add_data_sharing_for_aggregate_data_exchange.java
@@ -40,8 +40,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * In table aggregatedataexchange, copy Metadata Write value to Data Write value in sharing.users and
- * sharing.userGroups in sharing column. Public access must not be changed.
+ * In table aggregatedataexchange, copy Metadata Write value to Data Write value in sharing.users
+ * and sharing.userGroups in sharing column. Public access must not be changed.
  *
  * @author Viet Nguyen
  */

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
@@ -48,7 +48,6 @@ import java.util.stream.Stream;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.SortDirection;
@@ -156,7 +155,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "first page",
-        () -> assertPager(1, 3, firstPage),
+        () -> assertPage(1, 3, firstPage),
         () ->
             assertEquals(
                 List.of("dUE514NMOlo", "mHWCacsGYYn", "QS6w44flWAf"), uids(firstPage.getItems())));
@@ -166,7 +165,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "second (last) page",
-        () -> assertPager(2, 3, secondPage),
+        () -> assertPage(2, 3, secondPage),
         () ->
             assertEquals(
                 List.of("QesgJkTyTCk", "woitxQbWYNq", "guVNoAerxWo"), uids(secondPage.getItems())));
@@ -192,7 +191,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "first page",
-        () -> assertPager(1, 3, 6, firstPage.getPager()),
+        () -> assertPage(1, 3, 6, firstPage),
         () ->
             assertEquals(
                 List.of("dUE514NMOlo", "mHWCacsGYYn", "QS6w44flWAf"), uids(firstPage.getItems())));
@@ -202,7 +201,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "second (last) page",
-        () -> assertPager(2, 3, 6, secondPage.getPager()),
+        () -> assertPage(2, 3, 6, secondPage),
         () ->
             assertEquals(
                 List.of("QesgJkTyTCk", "woitxQbWYNq", "guVNoAerxWo"), uids(secondPage.getItems())));
@@ -541,7 +540,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "first page",
-        () -> assertPager(1, 1, firstPage),
+        () -> assertPage(1, 1, firstPage),
         () -> assertEquals(List.of("nxP7UnKhomJ"), uids(firstPage.getItems())));
 
     Page<Enrollment> secondPage =
@@ -549,7 +548,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "second page is last page",
-        () -> assertPager(2, 1, secondPage),
+        () -> assertPage(2, 1, secondPage),
         () -> assertEquals(List.of("TvctPPhpD8z"), uids(secondPage.getItems())));
 
     Page<Enrollment> thirdPage =
@@ -573,7 +572,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "first page",
-        () -> assertPager(1, 1, 2, firstPage.getPager()),
+        () -> assertPage(1, 1, 2, firstPage),
         () -> assertEquals(List.of("nxP7UnKhomJ"), uids(firstPage.getItems())));
 
     Page<Enrollment> secondPage =
@@ -581,7 +580,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "second (last) page",
-        () -> assertPager(2, 1, 2, secondPage.getPager()),
+        () -> assertPage(2, 1, 2, secondPage),
         () -> assertEquals(List.of("TvctPPhpD8z"), uids(secondPage.getItems())));
 
     Page<Enrollment> thirdPage =
@@ -654,14 +653,14 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "first page",
-        () -> assertPager(1, 1, firstPage),
+        () -> assertPage(1, 1, firstPage),
         () -> assertEquals(List.of("D9PbzJY8bJM"), uids(firstPage)));
 
     Page<Event> secondPage = eventService.getEvents(operationParams, new PageParams(2, 1, false));
 
     assertAll(
         "second page is the last page",
-        () -> assertPager(2, 1, secondPage),
+        () -> assertPage(2, 1, secondPage),
         () -> assertEquals(List.of("pTzf9KYMk72"), uids(secondPage)));
 
     assertIsEmpty(getEvents(operationParams, new PageParams(3, 3, false)));
@@ -679,7 +678,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "page with total counts",
-        () -> assertPager(1, 2, 2, page),
+        () -> assertPage(1, 2, 2, page),
         () -> assertEquals(List.of("D9PbzJY8bJM", "pTzf9KYMk72"), uids(page)));
   }
 
@@ -700,14 +699,14 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "first page",
-        () -> assertPager(1, 3, firstPage),
+        () -> assertPage(1, 3, firstPage),
         () -> assertEquals(List.of("ck7DzdxqLqA", "OTmjvJDn0Fu", "kWjSezkXHVp"), uids(firstPage)));
 
     Page<Event> secondPage = eventService.getEvents(operationParams, new PageParams(2, 3, false));
 
     assertAll(
         "second page is the last page",
-        () -> assertPager(2, 3, secondPage),
+        () -> assertPage(2, 3, secondPage),
         () -> assertEquals(List.of("lumVtWwwy0O", "QRYjLTiJTrA", "cadc5eGj0j7"), uids(secondPage)));
 
     assertIsEmpty(getEvents(operationParams, new PageParams(3, 3, false)));
@@ -730,7 +729,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "page with total counts",
-        () -> assertPager(1, 2, 6, events),
+        () -> assertPage(1, 2, 6, events),
         () -> assertEquals(List.of("ck7DzdxqLqA", "OTmjvJDn0Fu"), uids(events)));
   }
 
@@ -894,14 +893,14 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "first page",
-        () -> assertPager(1, 1, firstPage),
+        () -> assertPage(1, 1, firstPage),
         () -> assertEquals(List.of("D9PbzJY8bJM"), uids(firstPage)));
 
     Page<Event> secondPage = eventService.getEvents(operationParams, new PageParams(2, 1, false));
 
     assertAll(
         "second (last) page",
-        () -> assertPager(2, 1, secondPage),
+        () -> assertPage(2, 1, secondPage),
         () -> assertEquals(List.of("pTzf9KYMk72"), uids(secondPage)));
 
     assertIsEmpty(getEvents(operationParams, new PageParams(3, 3, false)));
@@ -1328,7 +1327,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "first page",
-        () -> assertPager(1, 1, firstPage),
+        () -> assertPage(1, 1, firstPage),
         () -> assertEquals(List.of(expectedOnPage1), uids(firstPage)));
 
     Page<Relationship> secondPage =
@@ -1336,7 +1335,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "second (last) page",
-        () -> assertPager(2, 1, secondPage),
+        () -> assertPage(2, 1, secondPage),
         () -> assertEquals(List.of(expectedOnPage2), uids(secondPage)));
 
     Page<Relationship> thirdPage =
@@ -1373,7 +1372,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "first page",
-        () -> assertPager(1, 1, 2, firstPage),
+        () -> assertPage(1, 1, 2, firstPage),
         () -> assertEquals(List.of(expectedOnPage1), uids(firstPage)));
 
     Page<Relationship> secondPage =
@@ -1381,7 +1380,7 @@ class OrderAndPaginationExporterTest extends TrackerTest {
 
     assertAll(
         "second (last) page",
-        () -> assertPager(2, 1, 2, secondPage),
+        () -> assertPage(2, 1, 2, secondPage),
         () -> assertEquals(List.of(expectedOnPage2), uids(secondPage)));
 
     Page<Relationship> thirdPage =
@@ -1458,27 +1457,21 @@ class OrderAndPaginationExporterTest extends TrackerTest {
     return t;
   }
 
-  private static <T> void assertPager(int pageNumber, int pageSize, Page<T> page) {
-    Pager pager = page.getPager();
-    assertNotNull(pager, "pagintated results should have a pager");
+  private static <T> void assertPage(int pageNumber, int pageSize, Page<T> page) {
+    assertNotNull(page, "paginated results should have a page");
     assertAll(
         "pagination details",
-        () -> assertEquals(pageNumber, pager.getPage(), "number of current page"),
-        () -> assertEquals(pageSize, pager.getPageSize(), "page size"));
+        () -> assertEquals(pageNumber, page.getPage(), "number of current page"),
+        () -> assertEquals(pageSize, page.getPageSize(), "page size"));
   }
 
-  private static <T> void assertPager(int pageNumber, int pageSize, int totalCount, Page<T> page) {
-    Pager pager = page.getPager();
-    assertNotNull(pager, "pagintated results should have a pager");
-    assertPager(pageNumber, pageSize, totalCount, pager);
-  }
-
-  private static void assertPager(int pageNumber, int pageSize, int totalCount, Pager pager) {
+  private static <T> void assertPage(int pageNumber, int pageSize, int totalCount, Page<T> page) {
+    assertNotNull(page, "paginated results should have a page");
     assertAll(
         "pagination details",
-        () -> assertEquals(pageNumber, pager.getPage(), "number of current page"),
-        () -> assertEquals(pageSize, pager.getPageSize(), "page size"),
-        () -> assertEquals(totalCount, pager.getTotal(), "total count of items"));
+        () -> assertEquals(pageNumber, page.getPage(), "number of current page"),
+        () -> assertEquals(pageSize, page.getPageSize(), "page size"),
+        () -> assertEquals(totalCount, page.getTotal(), "total count of items"));
   }
 
   private List<String> getTrackedEntities(TrackedEntityOperationParams params)

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
@@ -41,6 +41,8 @@ import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.tracker.TrackerTest;
+import org.hisp.dhis.tracker.export.Page;
+import org.hisp.dhis.tracker.export.PageParams;
 import org.hisp.dhis.tracker.export.event.EventChangeLog.DataValueChange;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
@@ -64,6 +66,8 @@ class EventChangeLogServiceTest extends TrackerTest {
 
   private TrackerImportParams importParams;
 
+  private final PageParams defaultPageParams = new PageParams(null, null, false);
+
   @Override
   protected void initTest() throws IOException {
     userService = _userService;
@@ -79,7 +83,7 @@ class EventChangeLogServiceTest extends TrackerTest {
   void shouldFailWhenEventDoesNotExist() {
     assertThrows(
         NotFoundException.class,
-        () -> eventChangeLogService.getEventChangeLog(UID.of(CodeGenerator.generateUid())));
+        () -> eventChangeLogService.getEventChangeLog(UID.of(CodeGenerator.generateUid()), null));
   }
 
   @Test
@@ -88,7 +92,7 @@ class EventChangeLogServiceTest extends TrackerTest {
 
     assertThrows(
         NotFoundException.class,
-        () -> eventChangeLogService.getEventChangeLog(UID.of("D9PbzJY8bJM")));
+        () -> eventChangeLogService.getEventChangeLog(UID.of("D9PbzJY8bJM"), null));
   }
 
   @Test
@@ -97,7 +101,7 @@ class EventChangeLogServiceTest extends TrackerTest {
 
     assertThrows(
         NotFoundException.class,
-        () -> eventChangeLogService.getEventChangeLog(UID.of("G9PbzJY8bJG")));
+        () -> eventChangeLogService.getEventChangeLog(UID.of("G9PbzJY8bJG"), null));
   }
 
   @Test
@@ -106,7 +110,7 @@ class EventChangeLogServiceTest extends TrackerTest {
 
     assertThrows(
         NotFoundException.class,
-        () -> eventChangeLogService.getEventChangeLog(UID.of("H0PbzJY8bJG")));
+        () -> eventChangeLogService.getEventChangeLog(UID.of("H0PbzJY8bJG"), null));
   }
 
   @Test
@@ -115,7 +119,7 @@ class EventChangeLogServiceTest extends TrackerTest {
 
     assertThrows(
         NotFoundException.class,
-        () -> eventChangeLogService.getEventChangeLog(UID.of("G9PbzJY8bJG")));
+        () -> eventChangeLogService.getEventChangeLog(UID.of("G9PbzJY8bJG"), null));
   }
 
   @Test
@@ -124,13 +128,13 @@ class EventChangeLogServiceTest extends TrackerTest {
     Event event = getEvent("QRYjLTiJTrA");
     String dataElementUid = event.getEventDataValues().iterator().next().getDataElement();
 
-    List<EventChangeLog> changeLogs =
-        eventChangeLogService.getEventChangeLog(UID.of("QRYjLTiJTrA"));
+    Page<EventChangeLog> changeLogs =
+        eventChangeLogService.getEventChangeLog(UID.of("QRYjLTiJTrA"), defaultPageParams);
 
-    assertNumberOfChanges(1, changeLogs);
+    assertNumberOfChanges(1, changeLogs.getItems());
     assertAll(
-        () -> assertChange(dataElementUid, null, "15", changeLogs.get(0)),
-        () -> assertUser(importUser, changeLogs.get(0)));
+        () -> assertChange(dataElementUid, null, "15", changeLogs.getItems().get(0)),
+        () -> assertUser(importUser, changeLogs.getItems().get(0)));
   }
 
   @Test
@@ -144,15 +148,15 @@ class EventChangeLogServiceTest extends TrackerTest {
     updateDataValue(trackerObjects, event.getUid(), dataElementUid, "");
     assertNoErrors(trackerImportService.importTracker(importParams, trackerObjects));
 
-    List<EventChangeLog> changeLogs =
-        eventChangeLogService.getEventChangeLog(UID.of("QRYjLTiJTrA"));
-    assertNumberOfChanges(2, changeLogs);
+    Page<EventChangeLog> changeLogs =
+        eventChangeLogService.getEventChangeLog(UID.of("QRYjLTiJTrA"), defaultPageParams);
+    assertNumberOfChanges(2, changeLogs.getItems());
     assertAll(
-        () -> assertChange(dataElementUid, "15", null, changeLogs.get(0)),
-        () -> assertUser(importUser, changeLogs.get(0)));
+        () -> assertChange(dataElementUid, "15", null, changeLogs.getItems().get(0)),
+        () -> assertUser(importUser, changeLogs.getItems().get(0)));
     assertAll(
-        () -> assertChange(dataElementUid, null, "15", changeLogs.get(1)),
-        () -> assertUser(importUser, changeLogs.get(1)));
+        () -> assertChange(dataElementUid, null, "15", changeLogs.getItems().get(1)),
+        () -> assertUser(importUser, changeLogs.getItems().get(1)));
   }
 
   @Test
@@ -169,15 +173,15 @@ class EventChangeLogServiceTest extends TrackerTest {
     updateDataValue(trackerObjects, event.getUid(), dataElementUid, "");
     assertNoErrors(trackerImportService.importTracker(importParams, trackerObjects));
 
-    List<EventChangeLog> changeLogs =
-        eventChangeLogService.getEventChangeLog(UID.of("QRYjLTiJTrA"));
-    assertNumberOfChanges(2, changeLogs);
+    Page<EventChangeLog> changeLogs =
+        eventChangeLogService.getEventChangeLog(UID.of("QRYjLTiJTrA"), defaultPageParams);
+    assertNumberOfChanges(2, changeLogs.getItems());
     assertAll(
-        () -> assertChange(dataElementUid, "15", null, changeLogs.get(0)),
-        () -> assertUser(importUser, changeLogs.get(0)));
+        () -> assertChange(dataElementUid, "15", null, changeLogs.getItems().get(0)),
+        () -> assertUser(importUser, changeLogs.getItems().get(0)));
     assertAll(
-        () -> assertChange(dataElementUid, null, "15", changeLogs.get(1)),
-        () -> assertUser(importUser, changeLogs.get(1)));
+        () -> assertChange(dataElementUid, null, "15", changeLogs.getItems().get(1)),
+        () -> assertUser(importUser, changeLogs.getItems().get(1)));
   }
 
   @Test
@@ -191,15 +195,15 @@ class EventChangeLogServiceTest extends TrackerTest {
     updateDataValue(trackerObjects, event.getUid(), dataElementUid, "20");
     assertNoErrors(trackerImportService.importTracker(importParams, trackerObjects));
 
-    List<EventChangeLog> changeLogs =
-        eventChangeLogService.getEventChangeLog(UID.of("QRYjLTiJTrA"));
-    assertNumberOfChanges(2, changeLogs);
+    Page<EventChangeLog> changeLogs =
+        eventChangeLogService.getEventChangeLog(UID.of("QRYjLTiJTrA"), defaultPageParams);
+    assertNumberOfChanges(2, changeLogs.getItems());
     assertAll(
-        () -> assertChange(dataElementUid, "15", "20", changeLogs.get(0)),
-        () -> assertUser(importUser, changeLogs.get(0)));
+        () -> assertChange(dataElementUid, "15", "20", changeLogs.getItems().get(0)),
+        () -> assertUser(importUser, changeLogs.getItems().get(0)));
     assertAll(
-        () -> assertChange(dataElementUid, null, "15", changeLogs.get(1)),
-        () -> assertUser(importUser, changeLogs.get(1)));
+        () -> assertChange(dataElementUid, null, "15", changeLogs.getItems().get(1)),
+        () -> assertUser(importUser, changeLogs.getItems().get(1)));
   }
 
   @Test
@@ -216,18 +220,18 @@ class EventChangeLogServiceTest extends TrackerTest {
     updateDataValue(trackerObjects, event.getUid(), dataElementUid, "25");
     assertNoErrors(trackerImportService.importTracker(importParams, trackerObjects));
 
-    List<EventChangeLog> changeLogs =
-        eventChangeLogService.getEventChangeLog(UID.of("QRYjLTiJTrA"));
-    assertNumberOfChanges(3, changeLogs);
+    Page<EventChangeLog> changeLogs =
+        eventChangeLogService.getEventChangeLog(UID.of("QRYjLTiJTrA"), defaultPageParams);
+    assertNumberOfChanges(3, changeLogs.getItems());
     assertAll(
-        () -> assertChange(dataElementUid, "20", "25", changeLogs.get(0)),
-        () -> assertUser(importUser, changeLogs.get(0)));
+        () -> assertChange(dataElementUid, "20", "25", changeLogs.getItems().get(0)),
+        () -> assertUser(importUser, changeLogs.getItems().get(0)));
     assertAll(
-        () -> assertChange(dataElementUid, "15", "20", changeLogs.get(1)),
-        () -> assertUser(importUser, changeLogs.get(1)));
+        () -> assertChange(dataElementUid, "15", "20", changeLogs.getItems().get(1)),
+        () -> assertUser(importUser, changeLogs.getItems().get(1)));
     assertAll(
-        () -> assertChange(dataElementUid, null, "15", changeLogs.get(2)),
-        () -> assertUser(importUser, changeLogs.get(2)));
+        () -> assertChange(dataElementUid, null, "15", changeLogs.getItems().get(2)),
+        () -> assertUser(importUser, changeLogs.getItems().get(2)));
   }
 
   @Test
@@ -245,18 +249,18 @@ class EventChangeLogServiceTest extends TrackerTest {
     updateDataValue(trackerObjects, event.getUid(), dataElementUid, "");
     assertNoErrors(trackerImportService.importTracker(importParams, trackerObjects));
 
-    List<EventChangeLog> changeLogs =
-        eventChangeLogService.getEventChangeLog(UID.of("QRYjLTiJTrA"));
-    assertNumberOfChanges(3, changeLogs);
+    Page<EventChangeLog> changeLogs =
+        eventChangeLogService.getEventChangeLog(UID.of("QRYjLTiJTrA"), defaultPageParams);
+    assertNumberOfChanges(3, changeLogs.getItems());
     assertAll(
-        () -> assertChange(dataElementUid, "20", null, changeLogs.get(0)),
-        () -> assertUser(importUser, changeLogs.get(0)));
+        () -> assertChange(dataElementUid, "20", null, changeLogs.getItems().get(0)),
+        () -> assertUser(importUser, changeLogs.getItems().get(0)));
     assertAll(
-        () -> assertChange(dataElementUid, "15", "20", changeLogs.get(1)),
-        () -> assertUser(importUser, changeLogs.get(1)));
+        () -> assertChange(dataElementUid, "15", "20", changeLogs.getItems().get(1)),
+        () -> assertUser(importUser, changeLogs.getItems().get(1)));
     assertAll(
-        () -> assertChange(dataElementUid, null, "15", changeLogs.get(2)),
-        () -> assertUser(importUser, changeLogs.get(2)));
+        () -> assertChange(dataElementUid, null, "15", changeLogs.getItems().get(2)),
+        () -> assertUser(importUser, changeLogs.getItems().get(2)));
   }
 
   private void updateDataValue(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
@@ -145,7 +145,7 @@ class EventChangeLogServiceTest extends TrackerTest {
     String dataElementUid = event.getEventDataValues().iterator().next().getDataElement();
 
     TrackerObjects trackerObjects = fromJson("tracker/event_and_enrollment.json");
-    updateDataValue(trackerObjects, event.getUid(), dataElementUid, "");
+    updateDataValue(trackerObjects, event, dataElementUid, "");
     assertNoErrors(trackerImportService.importTracker(importParams, trackerObjects));
 
     Page<EventChangeLog> changeLogs =
@@ -168,9 +168,9 @@ class EventChangeLogServiceTest extends TrackerTest {
     String dataElementUid = event.getEventDataValues().iterator().next().getDataElement();
 
     TrackerObjects trackerObjects = fromJson("tracker/event_and_enrollment.json");
-    updateDataValue(trackerObjects, event.getUid(), dataElementUid, "");
+    updateDataValue(trackerObjects, event, dataElementUid, "");
     assertNoErrors(trackerImportService.importTracker(importParams, trackerObjects));
-    updateDataValue(trackerObjects, event.getUid(), dataElementUid, "");
+    updateDataValue(trackerObjects, event, dataElementUid, "");
     assertNoErrors(trackerImportService.importTracker(importParams, trackerObjects));
 
     Page<EventChangeLog> changeLogs =
@@ -192,7 +192,7 @@ class EventChangeLogServiceTest extends TrackerTest {
     String dataElementUid = event.getEventDataValues().iterator().next().getDataElement();
 
     TrackerObjects trackerObjects = fromJson("tracker/event_and_enrollment.json");
-    updateDataValue(trackerObjects, event.getUid(), dataElementUid, "20");
+    updateDataValue(trackerObjects, event, dataElementUid, "20");
     assertNoErrors(trackerImportService.importTracker(importParams, trackerObjects));
 
     Page<EventChangeLog> changeLogs =
@@ -215,9 +215,9 @@ class EventChangeLogServiceTest extends TrackerTest {
     String dataElementUid = event.getEventDataValues().iterator().next().getDataElement();
 
     TrackerObjects trackerObjects = fromJson("tracker/event_and_enrollment.json");
-    updateDataValue(trackerObjects, event.getUid(), dataElementUid, "20");
+    updateDataValue(trackerObjects, event, dataElementUid, "20");
     assertNoErrors(trackerImportService.importTracker(importParams, trackerObjects));
-    updateDataValue(trackerObjects, event.getUid(), dataElementUid, "25");
+    updateDataValue(trackerObjects, event, dataElementUid, "25");
     assertNoErrors(trackerImportService.importTracker(importParams, trackerObjects));
 
     Page<EventChangeLog> changeLogs =
@@ -243,10 +243,10 @@ class EventChangeLogServiceTest extends TrackerTest {
     String dataElementUid = event.getEventDataValues().iterator().next().getDataElement();
 
     TrackerObjects trackerObjects = fromJson("tracker/event_and_enrollment.json");
-    updateDataValue(trackerObjects, event.getUid(), dataElementUid, "20");
+    updateDataValue(trackerObjects, event, dataElementUid, "20");
     assertNoErrors(trackerImportService.importTracker(importParams, trackerObjects));
 
-    updateDataValue(trackerObjects, event.getUid(), dataElementUid, "");
+    updateDataValue(trackerObjects, event, dataElementUid, "");
     assertNoErrors(trackerImportService.importTracker(importParams, trackerObjects));
 
     Page<EventChangeLog> changeLogs =
@@ -264,9 +264,9 @@ class EventChangeLogServiceTest extends TrackerTest {
   }
 
   private void updateDataValue(
-      TrackerObjects trackerObjects, String eventUid, String dataElementUid, String newValue) {
+      TrackerObjects trackerObjects, Event event, String dataElementUid, String newValue) {
     trackerObjects.getEvents().stream()
-        .filter(e -> e.getEvent().equalsIgnoreCase(eventUid))
+        .filter(e -> e.getEvent().equalsIgnoreCase(event.getUid()))
         .findFirst()
         .flatMap(
             e ->

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationControllerTest.java
@@ -147,8 +147,8 @@ class DeduplicationControllerTest extends DhisControllerConvenienceTest {
     // assert deprecated fields
     assertEquals(2, page.getPage());
     assertEquals(1, page.getPageSize());
-    assertHasNoMember(page.getPager(), "total");
-    assertHasNoMember(page.getPager(), "pageCount");
+    assertHasNoMember(page, "total");
+    assertHasNoMember(page, "pageCount");
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerPostgresTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerPostgresTest.java
@@ -139,7 +139,7 @@ class EventsExportControllerPostgresTest extends DhisControllerIntegrationTest {
   @Test
   void shouldGetEventChangeLogWhenDataValueUpdatedAndThenDeleted() {
     JsonWebMessage changeLogResponse =
-        GET("/tracker/events/{id}/changeLog", event.getUid())
+        GET("/tracker/events/{id}/changeLogs", event.getUid())
             .content(HttpStatus.OK)
             .as(JsonWebMessage.class);
 
@@ -167,7 +167,7 @@ class EventsExportControllerPostgresTest extends DhisControllerIntegrationTest {
   void shouldGetChangeLogPagerWithNextElementWhenMultipleElementsImportedAndFirstPageRequested() {
     JsonWebMessage changeLogResponse =
         GET(
-                "/tracker/events/{id}/changeLog?page={page}&pageSize={pageSize}",
+                "/tracker/events/{id}/changeLogs?page={page}&pageSize={pageSize}",
                 event.getUid(),
                 "1",
                 "1")
@@ -184,7 +184,7 @@ class EventsExportControllerPostgresTest extends DhisControllerIntegrationTest {
                 pagerObject.getString("nextPage").string(),
                 2,
                 1,
-                String.format("http://localhost/tracker/events/%s/changeLog", event.getUid())));
+                String.format("http://localhost/tracker/events/%s/changeLogs", event.getUid())));
   }
 
   @Test
@@ -192,7 +192,7 @@ class EventsExportControllerPostgresTest extends DhisControllerIntegrationTest {
       shouldGetChangeLogPagerWithNextAndPreviousElementsWhenMultipleElementsImportedAndSecondPageRequested() {
     JsonWebMessage changeLogResponse =
         GET(
-                "/tracker/events/{id}/changeLog?page={page}&pageSize={pageSize}",
+                "/tracker/events/{id}/changeLogs?page={page}&pageSize={pageSize}",
                 event.getUid(),
                 "2",
                 "1")
@@ -208,13 +208,13 @@ class EventsExportControllerPostgresTest extends DhisControllerIntegrationTest {
                 pagerObject.getString("prevPage").string(),
                 1,
                 1,
-                String.format("http://localhost/tracker/events/%s/changeLog", event.getUid())),
+                String.format("http://localhost/tracker/events/%s/changeLogs", event.getUid())),
         () ->
             assertPagerLink(
                 pagerObject.getString("nextPage").string(),
                 3,
                 1,
-                String.format("http://localhost/tracker/events/%s/changeLog", event.getUid())));
+                String.format("http://localhost/tracker/events/%s/changeLogs", event.getUid())));
   }
 
   @Test
@@ -222,7 +222,7 @@ class EventsExportControllerPostgresTest extends DhisControllerIntegrationTest {
       shouldGetChangeLogPagerWithPreviousElementWhenMultipleElementsImportedAndLastPageRequested() {
     JsonWebMessage changeLogResponse =
         GET(
-                "/tracker/events/{id}/changeLog?page={page}&pageSize={pageSize}",
+                "/tracker/events/{id}/changeLogs?page={page}&pageSize={pageSize}",
                 event.getUid(),
                 "3",
                 "1")
@@ -238,7 +238,7 @@ class EventsExportControllerPostgresTest extends DhisControllerIntegrationTest {
               pagerObject.getString("prevPage").string(),
               2,
               1,
-              String.format("http://localhost/tracker/events/%s/changeLog", event.getUid()));
+              String.format("http://localhost/tracker/events/%s/changeLogs", event.getUid()));
           assertNull(pagerObject.getString("nextPage").string());
         });
   }
@@ -248,7 +248,7 @@ class EventsExportControllerPostgresTest extends DhisControllerIntegrationTest {
       shouldGetChangeLogPagerWithoutPreviousNorNextElementWhenMultipleElementsImportedAndAllElementsFitInOnePage() {
     JsonWebMessage changeLogResponse =
         GET(
-                "/tracker/events/{id}/changeLog?page={page}&pageSize={pageSize}",
+                "/tracker/events/{id}/changeLogs?page={page}&pageSize={pageSize}",
                 event.getUid(),
                 "1",
                 "3")

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerPostgresTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerPostgresTest.java
@@ -275,14 +275,14 @@ class EventsExportControllerPostgresTest extends DhisControllerIntegrationTest {
   }
 
   private TrackedEntityType trackedEntityTypeAccessible() {
-    TrackedEntityType type = trackedEntityType('A');
+    TrackedEntityType type = trackedEntityType();
     type.getSharing().addUserAccess(userAccess());
     manager.save(type, false);
     return type;
   }
 
-  private TrackedEntityType trackedEntityType(char uniqueChar) {
-    TrackedEntityType type = createTrackedEntityType(uniqueChar);
+  private TrackedEntityType trackedEntityType() {
+    TrackedEntityType type = createTrackedEntityType('A');
     type.getSharing().setOwner(owner);
     type.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
     return type;
@@ -313,8 +313,7 @@ class EventsExportControllerPostgresTest extends DhisControllerIntegrationTest {
   }
 
   private String createJson(Event event, String value) {
-    String response =
-        """
+    return """
       {
         "events": [
           {
@@ -348,16 +347,14 @@ class EventsExportControllerPostgresTest extends DhisControllerIntegrationTest {
         ]
       }}
         """
-            .formatted(
-                event.getUid(),
-                program.getUid(),
-                programStage.getUid(),
-                event.getEnrollment().getUid(),
-                event.getEnrollment().getTrackedEntity().getUid(),
-                event.getOrganisationUnit().getUid(),
-                event.getEventDataValues().iterator().next().getDataElement(),
-                value);
-
-    return response;
+        .formatted(
+            event.getUid(),
+            program.getUid(),
+            programStage.getUid(),
+            event.getEnrollment().getUid(),
+            event.getEnrollment().getTrackedEntity().getUid(),
+            event.getOrganisationUnit().getUid(),
+            event.getEventDataValues().iterator().next().getDataElement(),
+            value);
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationController.java
@@ -116,7 +116,7 @@ public class DeduplicationController {
       Pager pager = new Pager(criteria.getPageWithDefault(), 0, criteria.getPageSizeWithDefault());
       pager.force(criteria.getPageWithDefault(), criteria.getPageSizeWithDefault());
       org.hisp.dhis.tracker.export.Page<PotentialDuplicate> page =
-          org.hisp.dhis.tracker.export.Page.of(potentialDuplicates, pager, false);
+          org.hisp.dhis.tracker.export.Page.of(potentialDuplicates, pager, false, false, false);
       return Page.withPager("potentialDuplicates", objectNodes, page);
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationController.java
@@ -115,9 +115,11 @@ public class DeduplicationController {
     if (criteria.isPaged()) {
       Pager pager = new Pager(criteria.getPageWithDefault(), 0, criteria.getPageSizeWithDefault());
       pager.force(criteria.getPageWithDefault(), criteria.getPageSizeWithDefault());
+
       org.hisp.dhis.tracker.export.Page<PotentialDuplicate> page =
-          org.hisp.dhis.tracker.export.Page.of(potentialDuplicates, pager, false, false, false);
-      return Page.withPager("potentialDuplicates", objectNodes, page);
+          org.hisp.dhis.tracker.export.Page.withoutTotals(
+              potentialDuplicates, pager.getPage(), pager.getPageSize());
+      return Page.withPager("potentialDuplicates", objectNodes, page, null, null);
     }
 
     return Page.withoutPager("potentialDuplicates", objectNodes);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationController.java
@@ -37,7 +37,6 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.deduplication.DeduplicationMergeParams;
 import org.hisp.dhis.deduplication.DeduplicationService;
 import org.hisp.dhis.deduplication.DeduplicationStatus;
@@ -113,12 +112,11 @@ public class DeduplicationController {
     setNoStore(response);
 
     if (criteria.isPaged()) {
-      Pager pager = new Pager(criteria.getPageWithDefault(), 0, criteria.getPageSizeWithDefault());
-      pager.force(criteria.getPageWithDefault(), criteria.getPageSizeWithDefault());
-
       org.hisp.dhis.tracker.export.Page<PotentialDuplicate> page =
           org.hisp.dhis.tracker.export.Page.withoutTotals(
-              potentialDuplicates, pager.getPage(), pager.getPageSize());
+              potentialDuplicates,
+              criteria.getPageWithDefault(),
+              criteria.getPageSizeWithDefault());
       return Page.withPager("potentialDuplicates", page.withItems(objectNodes));
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationController.java
@@ -119,7 +119,7 @@ public class DeduplicationController {
       org.hisp.dhis.tracker.export.Page<PotentialDuplicate> page =
           org.hisp.dhis.tracker.export.Page.withoutTotals(
               potentialDuplicates, pager.getPage(), pager.getPageSize());
-      return Page.withPager("potentialDuplicates", objectNodes, page, null, null);
+      return Page.withPager("potentialDuplicates", page.withItems(objectNodes));
     }
 
     return Page.withoutPager("potentialDuplicates", objectNodes);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceController.java
@@ -126,7 +126,10 @@ public class ProgramNotificationInstanceController {
       return Page.withPager(
           ProgramNotificationInstanceSchemaDescriptor.PLURAL,
           instances,
-          org.hisp.dhis.tracker.export.Page.of(instances, pager, true, false, false));
+          org.hisp.dhis.tracker.export.Page.withTotals(
+              instances, pager.getPage(), pager.getPageSize(), (int) pager.getTotal()),
+          null,
+          null);
     }
 
     return Page.withoutPager(ProgramNotificationInstanceSchemaDescriptor.PLURAL, instances);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceController.java
@@ -126,7 +126,7 @@ public class ProgramNotificationInstanceController {
       return Page.withPager(
           ProgramNotificationInstanceSchemaDescriptor.PLURAL,
           instances,
-          org.hisp.dhis.tracker.export.Page.of(instances, pager, true));
+          org.hisp.dhis.tracker.export.Page.of(instances, pager, true, false, false));
     }
 
     return Page.withoutPager(ProgramNotificationInstanceSchemaDescriptor.PLURAL, instances);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceController.java
@@ -125,11 +125,8 @@ public class ProgramNotificationInstanceController {
       pager.force(page, pageSize);
       return Page.withPager(
           ProgramNotificationInstanceSchemaDescriptor.PLURAL,
-          instances,
           org.hisp.dhis.tracker.export.Page.withTotals(
-              instances, pager.getPage(), pager.getPageSize(), (int) pager.getTotal()),
-          null,
-          null);
+              instances, pager.getPage(), pager.getPageSize(), pager.getTotal()));
     }
 
     return Page.withoutPager(ProgramNotificationInstanceSchemaDescriptor.PLURAL, instances);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceController.java
@@ -33,7 +33,6 @@ import java.util.Date;
 import java.util.List;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.program.EnrollmentService;
@@ -120,13 +119,9 @@ public class ProgramNotificationInstanceController {
 
     if (isPaged) {
       long total = programNotificationInstanceService.countProgramNotificationInstances(params);
-
-      Pager pager = new Pager(page, total, pageSize);
-      pager.force(page, pageSize);
       return Page.withPager(
           ProgramNotificationInstanceSchemaDescriptor.PLURAL,
-          org.hisp.dhis.tracker.export.Page.withTotals(
-              instances, pager.getPage(), pager.getPageSize(), pager.getTotal()));
+          org.hisp.dhis.tracker.export.Page.withTotals(instances, page, pageSize, total));
     }
 
     return Page.withoutPager(ProgramNotificationInstanceSchemaDescriptor.PLURAL, instances);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationTemplateController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationTemplateController.java
@@ -118,7 +118,10 @@ public class ProgramNotificationTemplateController
       return Page.withPager(
           ProgramNotificationTemplateSchemaDescriptor.PLURAL,
           instances,
-          org.hisp.dhis.tracker.export.Page.of(instances, pager, true, false, false));
+          org.hisp.dhis.tracker.export.Page.withTotals(
+              instances, pager.getPage(), pager.getPageSize(), pager.getTotal()),
+          null,
+          null);
     }
 
     return Page.withoutPager(ProgramNotificationTemplateSchemaDescriptor.PLURAL, instances);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationTemplateController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationTemplateController.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.webapi.controller.event;
 import java.util.List;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
-import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStageService;
@@ -112,13 +111,9 @@ public class ProgramNotificationTemplateController
 
     if (isPaged) {
       long total = programNotificationTemplateService.countProgramNotificationTemplates(params);
-
-      Pager pager = new Pager(page, total, pageSize);
-      pager.force(page, pageSize);
       return Page.withPager(
           ProgramNotificationTemplateSchemaDescriptor.PLURAL,
-          org.hisp.dhis.tracker.export.Page.withTotals(
-              instances, pager.getPage(), pager.getPageSize(), pager.getTotal()));
+          org.hisp.dhis.tracker.export.Page.withTotals(instances, page, pageSize, total));
     }
 
     return Page.withoutPager(ProgramNotificationTemplateSchemaDescriptor.PLURAL, instances);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationTemplateController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationTemplateController.java
@@ -117,11 +117,8 @@ public class ProgramNotificationTemplateController
       pager.force(page, pageSize);
       return Page.withPager(
           ProgramNotificationTemplateSchemaDescriptor.PLURAL,
-          instances,
           org.hisp.dhis.tracker.export.Page.withTotals(
-              instances, pager.getPage(), pager.getPageSize(), pager.getTotal()),
-          null,
-          null);
+              instances, pager.getPage(), pager.getPageSize(), pager.getTotal()));
     }
 
     return Page.withoutPager(ProgramNotificationTemplateSchemaDescriptor.PLURAL, instances);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationTemplateController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationTemplateController.java
@@ -118,7 +118,7 @@ public class ProgramNotificationTemplateController
       return Page.withPager(
           ProgramNotificationTemplateSchemaDescriptor.PLURAL,
           instances,
-          org.hisp.dhis.tracker.export.Page.of(instances, pager, true));
+          org.hisp.dhis.tracker.export.Page.of(instances, pager, true, false, false));
     }
 
     return Page.withoutPager(ProgramNotificationTemplateSchemaDescriptor.PLURAL, instances);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
@@ -112,7 +112,7 @@ class EnrollmentsExportController {
               ENROLLMENT_MAPPER.fromCollection(enrollmentsPage.getItems()),
               requestParams.getFields());
 
-      return Page.withPager(ENROLLMENTS, objectNodes, enrollmentsPage, null, null);
+      return Page.withPager(ENROLLMENTS, enrollmentsPage.withItems(objectNodes));
     }
 
     Collection<org.hisp.dhis.program.Enrollment> enrollments =

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
@@ -112,7 +112,7 @@ class EnrollmentsExportController {
               ENROLLMENT_MAPPER.fromCollection(enrollmentsPage.getItems()),
               requestParams.getFields());
 
-      return Page.withPager(ENROLLMENTS, objectNodes, enrollmentsPage);
+      return Page.withPager(ENROLLMENTS, objectNodes, enrollmentsPage, null, null);
     }
 
     Collection<org.hisp.dhis.program.Enrollment> enrollments =

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/ChangeLogRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/ChangeLogRequestParams.java
@@ -25,19 +25,28 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker.export.event;
+package org.hisp.dhis.webapi.controller.tracker.export.event;
 
-import org.hisp.dhis.common.UID;
-import org.hisp.dhis.feedback.NotFoundException;
-import org.hisp.dhis.tracker.export.Page;
-import org.hisp.dhis.tracker.export.PageParams;
+import java.util.List;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.fieldfiltering.FieldFilterParser;
+import org.hisp.dhis.fieldfiltering.FieldPath;
 
-public interface EventChangeLogService {
+@OpenApi.Shared(name = "ChangeLogRequestParams")
+@OpenApi.Property
+@Data
+@NoArgsConstructor
+public class ChangeLogRequestParams {
 
-  /**
-   * Retrieves the change log data for a particular event
-   *
-   * @return paginated list of change logs of the supplied event, if any
-   */
-  Page<EventChangeLog> getEventChangeLog(UID event, PageParams pageParams) throws NotFoundException;
+  static final String DEFAULT_FIELDS_PARAM = "createdBy, change, createdAt";
+
+  @OpenApi.Property(defaultValue = "1")
+  private Integer page;
+
+  @OpenApi.Property(defaultValue = "50")
+  private Integer pageSize;
+
+  private List<FieldPath> fields = FieldFilterParser.parse(DEFAULT_FIELDS_PARAM);
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/ChangeLogRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/ChangeLogRequestParams.java
@@ -27,12 +27,14 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.event;
 
+import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.fieldfiltering.FieldFilterParser;
 import org.hisp.dhis.fieldfiltering.FieldPath;
+import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 
 @OpenApi.Shared(name = "ChangeLogRequestParams")
 @OpenApi.Property
@@ -40,13 +42,13 @@ import org.hisp.dhis.fieldfiltering.FieldPath;
 @NoArgsConstructor
 public class ChangeLogRequestParams {
 
-  static final String DEFAULT_FIELDS_PARAM = "createdBy, change, createdAt";
+  static final String DEFAULT_FIELDS_PARAM = "change,createdAt,createdBy";
 
-  @OpenApi.Property(defaultValue = "1")
-  private Integer page;
+  private int page = 1;
 
-  @OpenApi.Property(defaultValue = "50")
-  private Integer pageSize;
+  private int pageSize = 50;
 
   private List<FieldPath> fields = FieldFilterParser.parse(DEFAULT_FIELDS_PARAM);
+
+  private List<OrderCriteria> order = new ArrayList<>();
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/ChangeLogRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/ChangeLogRequestParams.java
@@ -27,14 +27,12 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.event;
 
-import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.fieldfiltering.FieldFilterParser;
 import org.hisp.dhis.fieldfiltering.FieldPath;
-import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 
 @OpenApi.Shared(name = "ChangeLogRequestParams")
 @OpenApi.Property
@@ -42,13 +40,11 @@ import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 @NoArgsConstructor
 public class ChangeLogRequestParams {
 
-  static final String DEFAULT_FIELDS_PARAM = "change,createdAt,createdBy";
+  private static final String DEFAULT_FIELDS_PARAM = "change,createdAt,createdBy";
 
   private int page = 1;
 
   private int pageSize = 50;
 
   private List<FieldPath> fields = FieldFilterParser.parse(DEFAULT_FIELDS_PARAM);
-
-  private List<OrderCriteria> order = new ArrayList<>();
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -295,7 +295,7 @@ class EventsExportController {
         request, eventService.getFileResourceImage(event, dataElement, dimension));
   }
 
-  @GetMapping("/{event}/changeLog")
+  @GetMapping("/{event}/changeLogs")
   Page<ObjectNode> getEventChangeLogByUid(
       @OpenApi.Param({UID.class, Event.class}) @PathVariable UID event,
       ChangeLogRequestParams requestParams,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -296,7 +296,7 @@ class EventsExportController {
   }
 
   @GetMapping("/{uid}/changeLog")
-  Page<ObjectNode> getEventByUid(
+  Page<ObjectNode> getEventChangeLogByUid(
       @OpenApi.Param({UID.class, Event.class}) @PathVariable UID uid,
       ChangeLogRequestParams requestParams,
       HttpServletRequest request)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -143,7 +143,7 @@ class EventsExportController {
           fieldFilterService.toObjectNodes(
               EVENTS_MAPPER.fromCollection(eventsPage.getItems()), requestParams.getFields());
 
-      return Page.withPager(EVENTS, objectNodes, eventsPage, null, null);
+      return Page.withPager(EVENTS, eventsPage.withItems(objectNodes));
     }
 
     List<org.hisp.dhis.program.Event> events = eventService.getEvents(eventOperationParams);
@@ -295,38 +295,19 @@ class EventsExportController {
         request, eventService.getFileResourceImage(event, dataElement, dimension));
   }
 
-  @GetMapping("/{uid}/changeLog")
+  @GetMapping("/{event}/changeLog")
   Page<ObjectNode> getEventChangeLogByUid(
-      @OpenApi.Param({UID.class, Event.class}) @PathVariable UID uid,
+      @OpenApi.Param({UID.class, Event.class}) @PathVariable UID event,
       ChangeLogRequestParams requestParams,
       HttpServletRequest request)
       throws NotFoundException {
-
     PageParams pageParams =
         new PageParams(requestParams.getPage(), requestParams.getPageSize(), false);
-
     org.hisp.dhis.tracker.export.Page<EventChangeLog> changeLogs =
-        eventChangeLogService.getEventChangeLog(uid, pageParams);
-
-    String nextPage = null;
-    if (changeLogs.isNext()) {
-      nextPage =
-          request.getRequestURI()
-              + String.format(
-                  "?page=%d&pageSize=%d", requestParams.getPage() + 1, requestParams.getPageSize());
-    }
-
-    String previousPage = null;
-    if (changeLogs.isPrev()) {
-      previousPage =
-          request.getRequestURI()
-              + String.format(
-                  "?page=%d&pageSize=%d", requestParams.getPage() - 1, requestParams.getPageSize());
-    }
+        eventChangeLogService.getEventChangeLog(event, pageParams);
 
     List<ObjectNode> objectNodes =
         fieldFilterService.toObjectNodes(changeLogs.getItems(), requestParams.getFields());
-
-    return Page.withPager("changeLogs", objectNodes, changeLogs, previousPage, nextPage);
+    return Page.withPager("changeLogs", changeLogs.withItems(objectNodes), request);
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -143,7 +143,7 @@ class EventsExportController {
           fieldFilterService.toObjectNodes(
               EVENTS_MAPPER.fromCollection(eventsPage.getItems()), requestParams.getFields());
 
-      return Page.withPager(EVENTS, objectNodes, eventsPage);
+      return Page.withPager(EVENTS, objectNodes, eventsPage, null, null);
     }
 
     List<org.hisp.dhis.program.Event> events = eventService.getEvents(eventOperationParams);
@@ -308,28 +308,25 @@ class EventsExportController {
     org.hisp.dhis.tracker.export.Page<EventChangeLog> changeLogs =
         eventChangeLogService.getEventChangeLog(uid, pageParams);
 
-    if (changeLogs.isHasNext()) {
-      changeLogs
-          .getPager()
-          .setNextPage(
-              request.getRequestURI()
-                  + String.format(
-                      "?page=%d&pageSize=%d",
-                      requestParams.getPage() + 1, requestParams.getPageSize()));
+    String nextPage = null;
+    if (changeLogs.isNext()) {
+      nextPage =
+          request.getRequestURI()
+              + String.format(
+                  "?page=%d&pageSize=%d", requestParams.getPage() + 1, requestParams.getPageSize());
     }
-    if (changeLogs.isHasPrevious()) {
-      changeLogs
-          .getPager()
-          .setPrevPage(
-              request.getRequestURI()
-                  + String.format(
-                      "?page=%d&pageSize=%d",
-                      requestParams.getPage() - 1, requestParams.getPageSize()));
+
+    String previousPage = null;
+    if (changeLogs.isPrev()) {
+      previousPage =
+          request.getRequestURI()
+              + String.format(
+                  "?page=%d&pageSize=%d", requestParams.getPage() - 1, requestParams.getPageSize());
     }
 
     List<ObjectNode> objectNodes =
         fieldFilterService.toObjectNodes(changeLogs.getItems(), requestParams.getFields());
 
-    return Page.withPager("changeLogs", objectNodes, changeLogs);
+    return Page.withPager("changeLogs", objectNodes, changeLogs, previousPage, nextPage);
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
@@ -111,7 +111,7 @@ class RelationshipsExportController {
               RELATIONSHIP_MAPPER.fromCollection(relationshipsPage.getItems()),
               requestParams.getFields());
 
-      return Page.withPager(RELATIONSHIPS, objectNodes, relationshipsPage, null, null);
+      return Page.withPager(RELATIONSHIPS, relationshipsPage.withItems(objectNodes));
     }
 
     List<org.hisp.dhis.relationship.Relationship> relationships =

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
@@ -111,7 +111,7 @@ class RelationshipsExportController {
               RELATIONSHIP_MAPPER.fromCollection(relationshipsPage.getItems()),
               requestParams.getFields());
 
-      return Page.withPager(RELATIONSHIPS, objectNodes, relationshipsPage);
+      return Page.withPager(RELATIONSHIPS, objectNodes, relationshipsPage, null, null);
     }
 
     List<org.hisp.dhis.relationship.Relationship> relationships =

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -152,7 +152,7 @@ class TrackedEntitiesExportController {
               TRACKED_ENTITY_MAPPER.fromCollection(trackedEntitiesPage.getItems()),
               requestParams.getFields());
 
-      return Page.withPager(TRACKED_ENTITIES, objectNodes, trackedEntitiesPage);
+      return Page.withPager(TRACKED_ENTITIES, objectNodes, trackedEntitiesPage, null, null);
     }
 
     List<org.hisp.dhis.trackedentity.TrackedEntity> trackedEntities =

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -152,7 +152,7 @@ class TrackedEntitiesExportController {
               TRACKED_ENTITY_MAPPER.fromCollection(trackedEntitiesPage.getItems()),
               requestParams.getFields());
 
-      return Page.withPager(TRACKED_ENTITIES, objectNodes, trackedEntitiesPage, null, null);
+      return Page.withPager(TRACKED_ENTITIES, trackedEntitiesPage.withItems(objectNodes));
     }
 
     List<org.hisp.dhis.trackedentity.TrackedEntity> trackedEntities =

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Page.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Page.java
@@ -88,6 +88,10 @@ public class Page<T> {
   @JsonProperty
   private final Integer pageCount;
 
+  /**
+   * Create a page without totals but prev and next page links. This page will also not include any
+   * of the deprecated flat pagination fields.
+   */
   private Page(
       String key, List<T> values, int page, int pageSize, String prevPage, String nextPage) {
     this.items.put(key, values);
@@ -99,40 +103,48 @@ public class Page<T> {
   }
 
   /**
+   * Returns a page which will only serialize the items into {@link #items} under given {@code key}.
+   * All other fields will be omitted from the JSON.
+   */
+  private Page(String key, List<T> values) {
+    this.items.put(key, values);
+    this.pager = null;
+    this.page = null;
+    this.pageSize = null;
+    this.total = null;
+    this.pageCount = null;
+  }
+
+  /**
+   * Create a page without totals.
+   *
    * @deprecated Only use if you need to serialize the deprecated flat pagination fields in addition
    *     to the standard pager object.
    */
   @Deprecated(since = "2.41")
-  private Page(
-      String key, List<T> values, org.hisp.dhis.common.Pager pager, boolean showPageTotal) {
+  private Page(String key, List<T> values, int page, int pageSize) {
     this.items.put(key, values);
-    if (pager == null) {
-      this.pager = null;
-      this.page = null;
-      this.pageSize = null;
-      this.total = null;
-      this.pageCount = null;
-      return;
-    }
+    this.page = page;
+    this.pageSize = pageSize;
+    this.total = null;
+    this.pageCount = null;
+    this.pager = new Pager(page, pageSize, null, null, null, null);
+  }
 
-    this.page = pager.getPage();
-    this.pageSize = pager.getPageSize();
-    if (showPageTotal) {
-      this.total = pager.getTotal();
-      this.pageCount = pager.getPageCount();
-      this.pager =
-          new Pager(
-              pager.getPage(),
-              pager.getPageSize(),
-              pager.getTotal(),
-              pager.getPageCount(),
-              null,
-              null);
-    } else {
-      this.total = null;
-      this.pageCount = null;
-      this.pager = new Pager(pager.getPage(), pager.getPageSize(), null, null, null, null);
-    }
+  /**
+   * Create a page with totals.
+   *
+   * @deprecated Only use if you need to serialize the deprecated flat pagination fields in addition
+   *     to the standard pager object.
+   */
+  @Deprecated(since = "2.41")
+  private Page(String key, List<T> values, int page, int pageSize, long total) {
+    this.items.put(key, values);
+    this.page = page;
+    this.pageSize = pageSize;
+    this.total = total;
+    this.pageCount = (int) Math.ceil(total / (double) pageSize);
+    this.pager = new Pager(page, pageSize, total, this.pageCount, null, null);
   }
 
   /**
@@ -146,16 +158,11 @@ public class Page<T> {
    */
   @Deprecated(since = "2.41")
   public static <T> Page<T> withPager(String key, org.hisp.dhis.tracker.export.Page<T> pager) {
-    org.hisp.dhis.common.Pager commonPager;
     if (pager.getTotal() != null) {
-      commonPager =
-          new org.hisp.dhis.common.Pager(pager.getPage(), pager.getTotal(), pager.getPageSize());
-      commonPager.force(pager.getPage(), pager.getPageSize());
-    } else {
-      commonPager = new org.hisp.dhis.common.Pager(pager.getPage(), 0, pager.getPageSize());
-      commonPager.force(pager.getPage(), pager.getPageSize());
+      return new Page<>(
+          key, pager.getItems(), pager.getPage(), pager.getPageSize(), pager.getTotal());
     }
-    return new Page<>(key, pager.getItems(), commonPager, pager.getTotal() != null);
+    return new Page<>(key, pager.getItems(), pager.getPage(), pager.getPageSize());
   }
 
   /**
@@ -178,7 +185,7 @@ public class Page<T> {
    * All other fields will be omitted from the JSON.
    */
   public static <T> Page<T> withoutPager(String key, List<T> items) {
-    return new Page<>(key, items, null, false);
+    return new Page<>(key, items);
   }
 
   @OpenApi.Shared(pattern = Pattern.TRACKER)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Page.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Page.java
@@ -87,52 +87,48 @@ public class Page<T> {
   private final Integer pageCount;
 
   private Page(
-      String key, List<T> values, org.hisp.dhis.common.Pager pager, boolean showPageTotal) {
+      String key,
+      List<T> values,
+      int page,
+      int pageSize,
+      Long total,
+      int pageCount,
+      String prev,
+      String next) {
     this.items.put(key, values);
-    if (pager == null) {
-      this.pager = null;
-      this.page = null;
-      this.pageSize = null;
-      this.total = null;
-      this.pageCount = null;
-      return;
-    }
 
-    this.page = pager.getPage();
-    this.pageSize = pager.getPageSize();
-    if (showPageTotal) {
-      this.total = pager.getTotal();
-      this.pageCount = pager.getPageCount();
-      this.pager =
-          new Pager(
-              pager.getPage(),
-              pager.getPageSize(),
-              pager.getTotal(),
-              pager.getPageCount(),
-              pager.getPrevPage(),
-              pager.getNextPage());
+    this.page = page;
+    this.pageSize = pageSize;
+    if (total != null) {
+      this.total = total;
+      this.pageCount = pageCount;
+      this.pager = new Pager(page, pageSize, total, pageCount, prev, next);
     } else {
       this.total = null;
       this.pageCount = null;
-      this.pager =
-          new Pager(
-              pager.getPage(),
-              pager.getPageSize(),
-              null,
-              null,
-              pager.getPrevPage(),
-              pager.getNextPage());
+      this.pager = new Pager(page, pageSize, null, null, prev, next);
     }
   }
 
   /**
    * Returns a page which will serialize the items into {@link #items} under given {@code key}.
-   * Pagination details will be serialized as well including totals only if {@link
-   * org.hisp.dhis.tracker.export.Page#isPageTotal()} is true.
+   * Pagination details will be serialized as well including totals only if showPageTotal is true.
    */
   public static <T, U> Page<T> withPager(
-      String key, List<T> items, org.hisp.dhis.tracker.export.Page<U> pager) {
-    return new Page<>(key, items, pager.getPager(), pager.isPageTotal());
+      String key,
+      List<T> items,
+      org.hisp.dhis.tracker.export.Page<U> pager,
+      String prev,
+      String next) {
+    return new Page<>(
+        key,
+        items,
+        pager.getPage(),
+        pager.getPageSize(),
+        pager.getTotal(),
+        (int) Math.ceil(pager.getTotal() / (double) pager.getPageSize()),
+        prev,
+        next);
   }
 
   /**
@@ -140,7 +136,7 @@ public class Page<T> {
    * All other fields will be omitted from the JSON.
    */
   public static <T> Page<T> withoutPager(String key, List<T> items) {
-    return new Page<>(key, items, null, false);
+    return new Page<>(key, items, 0, 0, null, 0, null, null);
   }
 
   @OpenApi.Shared(pattern = Pattern.TRACKER)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Page.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Page.java
@@ -104,11 +104,24 @@ public class Page<T> {
       this.total = pager.getTotal();
       this.pageCount = pager.getPageCount();
       this.pager =
-          new Pager(pager.getPage(), pager.getPageSize(), pager.getTotal(), pager.getPageCount());
+          new Pager(
+              pager.getPage(),
+              pager.getPageSize(),
+              pager.getTotal(),
+              pager.getPageCount(),
+              pager.getPrevPage(),
+              pager.getNextPage());
     } else {
       this.total = null;
       this.pageCount = null;
-      this.pager = new Pager(pager.getPage(), pager.getPageSize(), null, null);
+      this.pager =
+          new Pager(
+              pager.getPage(),
+              pager.getPageSize(),
+              null,
+              null,
+              pager.getPrevPage(),
+              pager.getNextPage());
     }
   }
 
@@ -139,5 +152,7 @@ public class Page<T> {
     @JsonProperty private Integer pageSize;
     @JsonProperty private Long total;
     @JsonProperty private Integer pageCount;
+    @JsonProperty private String prev;
+    @JsonProperty private String next;
   }
 }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/view/PageTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/view/PageTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.view;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class PageTest {
+
+  @Test
+  void shouldSetDeprecatedPagerWithoutTotals() {
+    List<String> fruits = List.of("apple", "banana", "cherry");
+    org.hisp.dhis.tracker.export.Page<String> exportPage =
+        org.hisp.dhis.tracker.export.Page.withoutTotals(fruits, 2, 3);
+
+    Page page = Page.withPager("fruits", exportPage);
+
+    // deprecated fields
+    assertEquals(2, page.getPage());
+    assertEquals(3, page.getPageSize());
+    assertNull(page.getTotal());
+    assertNull(page.getPageCount());
+
+    assertEquals(2, page.getPager().getPage());
+    assertEquals(3, page.getPager().getPageSize());
+    assertNull(page.getPager().getTotal());
+    assertNull(page.getPager().getPageCount());
+  }
+
+  @Test
+  void shouldSetDeprecatedPagerWithTotals() {
+    List<String> fruits = List.of("apple", "banana", "cherry");
+    org.hisp.dhis.tracker.export.Page<String> exportPage =
+        org.hisp.dhis.tracker.export.Page.withTotals(fruits, 2, 3, 17);
+
+    Page page = Page.withPager("fruits", exportPage);
+
+    // deprecated fields
+    assertEquals(2, page.getPage());
+    assertEquals(3, page.getPageSize());
+    assertEquals(17, page.getTotal());
+    assertEquals(6, page.getPageCount());
+
+    assertEquals(2, page.getPager().getPage());
+    assertEquals(3, page.getPager().getPageSize());
+    assertEquals(17, page.getPager().getTotal());
+    assertEquals(6, page.getPager().getPageCount());
+  }
+
+  @Test
+  void shouldSetPrevPage() {
+    // TODO write tests for all permutations
+    // build the url from the same page/pageSize values as the export page
+    List<String> fruits = List.of("apple", "banana", "cherry");
+    org.hisp.dhis.tracker.export.Page<String> exportPage =
+        org.hisp.dhis.tracker.export.Page.withPrevAndNext(fruits, 2, 3, true, false);
+
+    // TODO double check using debugger that this is how the request will look like in the
+    // controller
+    MockHttpServletRequest request =
+        new MockHttpServletRequest("GET", "https://dhis2.org/dev/api/organisationUnits");
+    request.setParameter("page", "2");
+    request.setParameter("pageSize", "3");
+    request.setParameter("fields", "displayName");
+
+    Page<String> page = Page.withPager("fruits", exportPage, request);
+
+    // deprecated fields should not be returned with this new factory!
+    assertNull(page.getTotal());
+    assertNull(page.getPageCount());
+    assertNull(page.getPage());
+    assertNull(page.getPageSize());
+
+    assertEquals(2, page.getPager().getPage());
+    assertEquals(3, page.getPager().getPageSize());
+    assertEquals(
+        "https://dhis2.org/dev/api/organisationUnits?page=1&pageSize=3&fields=displayName",
+        page.getPager().getPrevPage());
+    assertNull(page.getPager().getNextPage());
+  }
+}

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/view/PageTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/view/PageTest.java
@@ -29,7 +29,10 @@ package org.hisp.dhis.webapi.controller.tracker.view;
 
 import static org.hisp.dhis.utils.Assertions.assertContains;
 import static org.hisp.dhis.utils.Assertions.assertStartsWith;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -74,6 +77,30 @@ class PageTest {
     assertEquals(6, page.getPageCount());
 
     assertEquals(2, page.getPager().getPage());
+    assertEquals(3, page.getPager().getPageSize());
+    assertEquals(17, page.getPager().getTotal());
+    assertEquals(6, page.getPager().getPageCount());
+    assertNull(page.getPager().getPrevPage());
+    assertNull(page.getPager().getNextPage());
+  }
+
+  @Test
+  void shouldSetDeprecatedPagerWithTotalsAndKeepPageNumberEvenIfPastLastPage() {
+    // so we do not run into common.Pager bug https://dhis2.atlassian.net/browse/DHIS2-16849
+    List<String> fruits = List.of("apple", "banana", "cherry");
+    // page 10 is past last page of 6
+    org.hisp.dhis.tracker.export.Page<String> exportPage =
+        org.hisp.dhis.tracker.export.Page.withTotals(fruits, 10, 3, 17);
+
+    Page page = Page.withPager("fruits", exportPage);
+
+    // deprecated fields
+    assertEquals(10, page.getPage());
+    assertEquals(3, page.getPageSize());
+    assertEquals(17, page.getTotal());
+    assertEquals(6, page.getPageCount());
+
+    assertEquals(10, page.getPager().getPage());
     assertEquals(3, page.getPager().getPageSize());
     assertEquals(17, page.getPager().getTotal());
     assertEquals(6, page.getPager().getPageCount());


### PR DESCRIPTION
* inline fields from `common.Pager` into `org.hisp.dhis.tracker.export.Page` as there is no benefit for us in using `common.Pager` internally. The `common.Pager` does not support not returning totals which we have to.
* add `org.hisp.dhis.tracker.export.Page.with` instance method to copy a Page using a different list of items. This makes it easier in controllers to return the `fields` filtered list based on the same `Page` returned from a service
* use `LongSupplier` for counts as total is represented using a `long`
* return `prevPage` and `nextPage` in change log endpoint. The links are absolute as this is what we do for metadata.