### PR TITLE
feat: Implement configurable labels for certain DHIS2 terminology [Tracker] [More labels]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Program.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/Program.java
@@ -96,6 +96,10 @@ public class Program extends BaseNameableObject implements VersionedObject, Meta
 
   private String trackedEntityAttributeLabel;
 
+  private String programStageLabel;
+
+  private String eventLabel;
+
   private Set<OrganisationUnit> organisationUnits = new HashSet<>();
 
   private Set<ProgramStage> programStages = new HashSet<>();
@@ -563,6 +567,42 @@ public class Program extends BaseNameableObject implements VersionedObject, Meta
 
   @JsonProperty
   @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
+  @PropertyRange(min = 2)
+  public String getProgramStageLabel() {
+    return programStageLabel;
+  }
+
+  @JsonProperty
+  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
+  @Translatable(propertyName = "programStageLabel", key = "PROGRAM_STAGE_LABEL")
+  public String getDisplayProgramStageLabel() {
+    return getTranslation("PROGRAM_STAGE_LABEL", getProgramStageLabel());
+  }
+
+  public void setProgramStageLabel(String programStageLabel) {
+    this.programStageLabel = programStageLabel;
+  }
+
+  @JsonProperty
+  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
+  @PropertyRange(min = 2)
+  public String getEventLabel() {
+    return eventLabel;
+  }
+
+  @JsonProperty
+  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
+  @Translatable(propertyName = "eventLabel", key = "EVENT_LABEL")
+  public String getDisplayEventLabel() {
+    return getTranslation("EVENT_LABEL", getEventLabel());
+  }
+
+  public void setEventLabel(String eventLabel) {
+    this.eventLabel = eventLabel;
+  }
+
+  @JsonProperty
+  @JacksonXmlProperty(namespace = DxfNamespaces.DXF_2_0)
   public ProgramType getProgramType() {
     return programType;
   }
@@ -944,6 +984,8 @@ public class Program extends BaseNameableObject implements VersionedObject, Meta
     copy.setFollowUpLabel(original.getFollowUpLabel());
     copy.setOrgUnitLabel(original.getOrgUnitLabel());
     copy.setTrackedEntityAttributeLabel(original.getTrackedEntityAttributeLabel());
+    copy.setProgramStageLabel(original.getProgramStageLabel());
+    copy.setEventLabel(original.getEventLabel());
     copy.setRelationshipLabel(original.getRelationshipLabel());
   }
 

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/program/ProgramTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/program/ProgramTest.java
@@ -228,7 +228,7 @@ class ProgramTest {
   @Test
   void testExpectedFieldCount() {
     Field[] allClassFieldsIncludingInherited = getAllFields(Program.class);
-    assertEquals(61, allClassFieldsIncludingInherited.length);
+    assertEquals(63, allClassFieldsIncludingInherited.length);
   }
 
   public static boolean notEqualsOrBothNull(String original, String copy) {
@@ -283,6 +283,8 @@ class ProgramTest {
     p.setFollowUpLabel("Follow Up Label");
     p.setOrgUnitLabel("Org Unit Label");
     p.setTrackedEntityAttributeLabel("Tracked Entity Attribute Label");
+    p.setProgramStageLabel("Program Stage Label");
+    p.setEventLabel("Event Label");
     p.setRelationshipLabel("Relationship Label");
 
     return p;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Program.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Program.hbm.xml
@@ -41,7 +41,7 @@
 
         <property name="trackedEntityAttributeLabel" column="trackedentityattributelabel" type="text"/>
 
-        <property name="programStageLabel" column="programStageLabel" type="text"/>
+        <property name="programStageLabel" column="programstagelabel" type="text"/>
 
         <property name="eventLabel" column="eventLabel" type="text"/>
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Program.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Program.hbm.xml
@@ -43,7 +43,7 @@
 
         <property name="programStageLabel" column="programstagelabel" type="text"/>
 
-        <property name="eventLabel" column="eventLabel" type="text"/>
+        <property name="eventLabel" column="eventlabel" type="text"/>
 
         <set name="programStages" order-by="sortOrder">
             <key column="programid"/>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Program.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/Program.hbm.xml
@@ -41,6 +41,10 @@
 
         <property name="trackedEntityAttributeLabel" column="trackedentityattributelabel" type="text"/>
 
+        <property name="programStageLabel" column="programStageLabel" type="text"/>
+
+        <property name="eventLabel" column="eventLabel" type="text"/>
+
         <set name="programStages" order-by="sortOrder">
             <key column="programid"/>
             <one-to-many class="org.hisp.dhis.program.ProgramStage"/>

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_45__More_Configurable_label.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.41/V2_41_45__More_Configurable_label.sql
@@ -1,0 +1,5 @@
+-- https://dhis2.atlassian.net/browse/DHIS2-16236
+-- Implement configurable labels for a Program when there is no need to configure or relate to a program stage
+
+alter table program add column if not exists "programstagelabel" text;
+alter table program add column if not exists "eventlabel" text;

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonProgram.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonProgram.java
@@ -83,4 +83,12 @@ public interface JsonProgram extends JsonObject, JsonNameableObject {
   default JsonString getTrackedEntityAttributeLabel() {
     return getString("trackedEntityAttributeLabel");
   }
+
+  default JsonString getProgramStageLabel() {
+    return getString("programStageLabel");
+  }
+
+  default JsonString getEventLabel() {
+    return getString("eventLabel");
+  }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerTest.java
@@ -84,24 +84,25 @@ class ProgramControllerTest extends DhisControllerConvenienceTest {
     POST("/trackedEntityAttributes", jsonMapper.writeValueAsString(tea2))
         .content(HttpStatus.CREATED);
 
-    POST("/metadata", Body("program/create_program.json"))
-        .content(HttpStatus.OK)
-        .as(JsonWebMessage.class);
+    POST("/metadata", Body("program/create_program.json")).content(HttpStatus.OK);
   }
 
   @Test
   void shouldGetProgramLabels() {
 
     JsonProgram program =
-        GET("/programs/{id}", "PrZMWi7rBga").content(HttpStatus.OK).as(JsonProgram.class);
+        GET("/programs/{id}", PROGRAM_UID).content(HttpStatus.OK).as(JsonProgram.class);
 
-    assertEquals("enrollmetdatelabel", program.getEnrollmentDateLabel().string());
-    assertEquals("enrollmentlabel", program.getEnrollmentLabel().string());
-    assertEquals("followuplabel", program.getFollowUpLabel().string());
-    assertEquals("orgunitlabel", program.getOrUnitLabel().string());
-    assertEquals("relationshiplabel", program.getRelationshipLabel().string());
-    assertEquals("notelabel", program.getNoteLabel().string());
-    assertEquals("trackedentityattributelabel", program.getTrackedEntityAttributeLabel().string());
+    assertEquals("Label for Enrollment Date", program.getEnrollmentDateLabel().string());
+    assertEquals("Label for Enrollment", program.getEnrollmentLabel().string());
+    assertEquals("Label for Follow Up", program.getFollowUpLabel().string());
+    assertEquals("Label for Org Unit", program.getOrUnitLabel().string());
+    assertEquals("Label for Relationship", program.getRelationshipLabel().string());
+    assertEquals("Label for Note", program.getNoteLabel().string());
+    assertEquals(
+        "Label for Tracked Entity Attribute", program.getTrackedEntityAttributeLabel().string());
+    assertEquals("Label for Program Stage", program.getProgramStageLabel().string());
+    assertEquals("Label for Event", program.getEventLabel().string());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/resources/program/create_program.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/program/create_program.json
@@ -67,13 +67,15 @@
           }
         }
       ],
-      "enrollmentDateLabel": "enrollmetdatelabel",
-      "enrollmentLabel": "enrollmentlabel",
-      "followUpLabel": "followuplabel",
-      "orgUnitLabel": "orgunitlabel",
-      "relationshipLabel": "relationshiplabel",
-      "noteLabel": "notelabel",
-      "trackedEntityAttributeLabel": "trackedentityattributelabel"
+      "enrollmentDateLabel": "Label for Enrollment Date",
+      "enrollmentLabel": "Label for Enrollment",
+      "followUpLabel": "Label for Follow Up",
+      "orgUnitLabel": "Label for Org Unit",
+      "relationshipLabel": "Label for Relationship",
+      "noteLabel": "Label for Note",
+      "trackedEntityAttributeLabel": "Label for Tracked Entity Attribute",
+      "programStageLabel": "Label for Program Stage",
+      "eventLabel": "Label for Event"
     }
   ],
   "programStages": [


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-16326

Some labels have already been added, see https://github.com/dhis2/dhis2-core/pull/16288.

However, there is a new requirement for using labels in the program context during Android testing when we don't need to configure or refer to a specific program stage. Eventually, Android will use the label for the program stage only if it exists; otherwise, it will use the one in the program context.

### Note
Again, this is a temporary solution and is considered a technical debt. This feature will be removed in the future