### PR TITLE
fix: get TEA via program attributes else TET attributes DHIS2-16859

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeService.java
@@ -124,7 +124,17 @@ public interface TrackedEntityAttributeService {
 
   Set<TrackedEntityAttribute> getAllUserReadableTrackedEntityAttributes(UserDetails userDetails);
 
-  Set<TrackedEntityAttribute> getAllUserReadableTrackedEntityAttributes(Program program);
+  /**
+   * Get the tracked entity attributes for given program i.e. program attributes to which the
+   * current user must have data read access.
+   */
+  Set<TrackedEntityAttribute> getProgramAttributes(Program program);
+
+  /**
+   * Get the tracked entity attributes for given tracked entity type i.e. tracked entity type
+   * attributes to which the current user must have data read access.
+   */
+  Set<TrackedEntityAttribute> getTrackedEntityTypeAttributes(TrackedEntityType trackedEntityType);
 
   Set<TrackedEntityAttribute> getAllUserReadableTrackedEntityAttributes(
       UserDetails userDetails, List<Program> programs, List<TrackedEntityType> trackedEntityTypes);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityAttributeService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityAttributeService.java
@@ -303,10 +303,17 @@ public class DefaultTrackedEntityAttributeService implements TrackedEntityAttrib
 
   @Override
   @Transactional(readOnly = true)
-  public Set<TrackedEntityAttribute> getAllUserReadableTrackedEntityAttributes(Program program) {
-    List<TrackedEntityType> trackedEntityTypes = trackedEntityTypeService.getAllTrackedEntityType();
+  public Set<TrackedEntityAttribute> getProgramAttributes(Program program) {
     return getAllUserReadableTrackedEntityAttributes(
-        CurrentUserUtil.getCurrentUserDetails(), List.of(program), trackedEntityTypes);
+        CurrentUserUtil.getCurrentUserDetails(), List.of(program), List.of());
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Set<TrackedEntityAttribute> getTrackedEntityTypeAttributes(
+      TrackedEntityType trackedEntityType) {
+    return getAllUserReadableTrackedEntityAttributes(
+        CurrentUserUtil.getCurrentUserDetails(), List.of(), List.of(trackedEntityType));
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -38,7 +38,6 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.feedback.BadRequestException;
-import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fileresource.FileResource;
@@ -90,8 +89,7 @@ class DefaultEventService implements EventService {
 
   @Override
   public FileResourceStream getFileResourceImage(
-      UID eventUid, UID dataElementUid, ImageFileDimension dimension)
-      throws NotFoundException, ConflictException, BadRequestException {
+      UID eventUid, UID dataElementUid, ImageFileDimension dimension) throws NotFoundException {
     FileResource fileResource = getFileResourceMetadata(eventUid, dataElementUid);
     return FileResourceStream.ofImage(fileResourceService, fileResource, dimension);
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
-import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fileresource.ImageFileDimension;
@@ -49,7 +48,7 @@ public interface EventService {
 
   /** Get an image for an events' data element in the given dimension. */
   FileResourceStream getFileResourceImage(UID event, UID dataElement, ImageFileDimension dimension)
-      throws NotFoundException, ConflictException, BadRequestException;
+      throws NotFoundException;
 
   /** Get event matching given {@code UID} and params. */
   Event getEvent(String uid, EventParams eventParams) throws NotFoundException, ForbiddenException;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -131,24 +131,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       throw new NotFoundException(TrackedEntity.class, trackedEntityUid.getValue());
     }
 
-    TrackedEntityAttribute attribute;
-    List<String> errors;
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
-    if (programUid != null) {
-      Program program = programService.getProgram(programUid.getValue());
-      if (program == null) {
-        throw new NotFoundException(Program.class, programUid.getValue());
-      }
-      attribute = validateAttributeDataReadAccess(attributeUid, program);
-      errors = trackerAccessManager.canRead(currentUser, trackedEntity, program, false);
-    } else {
-      attribute = validateAttributeDataReadAccess(attributeUid, null);
-      errors = trackerAccessManager.canRead(currentUser, trackedEntity);
-    }
-    if (!errors.isEmpty()) {
-      throw new NotFoundException(TrackedEntityAttribute.class, attributeUid.getValue());
-    }
-
+    TrackedEntityAttribute attribute = getAttribute(attributeUid, trackedEntity, programUid);
     if (!attribute.getValueType().isFile()) {
       throw new NotFoundException(
           "Tracked entity attribute " + attributeUid.getValue() + " is not a file (or image).");
@@ -173,22 +156,56 @@ class DefaultTrackedEntityService implements TrackedEntityService {
     return fileResourceService.getExistingFileResource(fileResourceUid);
   }
 
-  private TrackedEntityAttribute validateAttributeDataReadAccess(UID attributeUid, Program program)
+  /**
+   * Tracked entity attributes are fetched from the program if supplied, otherwise from the tracked
+   * entity. Access is determined through the program sharing and ownership if present. If no
+   * program is supplied, we fall back to tracked entity type ownership and the registering org unit
+   * of the tracked entity.
+   */
+  private TrackedEntityAttribute getAttribute(
+      UID attributeUid, TrackedEntity trackedEntity, @CheckForNull UID programUid)
       throws NotFoundException {
-    Set<TrackedEntityAttribute> readableAttributes;
-    if (program != null) {
-      readableAttributes =
-          trackedEntityAttributeService.getAllUserReadableTrackedEntityAttributes(program);
-    } else {
-      readableAttributes =
-          trackedEntityAttributeService.getAllUserReadableTrackedEntityAttributes();
+    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+
+    if (programUid != null) {
+      Program program = programService.getProgram(programUid.getValue());
+      if (program == null) {
+        throw new NotFoundException(Program.class, programUid.getValue());
+      }
+
+      if (!trackerAccessManager.canRead(currentUser, trackedEntity, program, false).isEmpty()) {
+        throw new NotFoundException(TrackedEntity.class, trackedEntity.getUid());
+      }
+      return getAttribute(attributeUid, program);
     }
 
-    return readableAttributes.stream()
-        .filter(att -> attributeUid.getValue().equals(att.getUid()))
+    if (!trackerAccessManager.canRead(currentUser, trackedEntity).isEmpty()) {
+      throw new NotFoundException(TrackedEntity.class, trackedEntity.getUid());
+    }
+    return getAttribute(attributeUid, trackedEntity.getTrackedEntityType());
+  }
+
+  private TrackedEntityAttribute getAttribute(UID attribute, Program program)
+      throws NotFoundException {
+    Set<TrackedEntityAttribute> attributes =
+        trackedEntityAttributeService.getProgramAttributes(program);
+    return getAttribute(attributes, attribute);
+  }
+
+  private TrackedEntityAttribute getAttribute(UID attribute, TrackedEntityType trackedEntityType)
+      throws NotFoundException {
+    Set<TrackedEntityAttribute> attributes =
+        trackedEntityAttributeService.getTrackedEntityTypeAttributes(trackedEntityType);
+    return getAttribute(attributes, attribute);
+  }
+
+  private static TrackedEntityAttribute getAttribute(
+      Set<TrackedEntityAttribute> attributes, UID attribute) throws NotFoundException {
+    return attributes.stream()
+        .filter(att -> attribute.getValue().equals(att.getUid()))
         .findFirst()
         .orElseThrow(
-            () -> new NotFoundException(TrackedEntityAttribute.class, attributeUid.getValue()));
+            () -> new NotFoundException(TrackedEntityAttribute.class, attribute.getValue()));
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -158,7 +158,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
 
   /**
    * Tracked entity attributes are fetched from the program if supplied, otherwise from the tracked
-   * entity. Access is determined through the program sharing and ownership if present. If no
+   * entities type. Access is determined through the program sharing and ownership if present. If no
    * program is supplied, we fall back to tracked entity type ownership and the registering org unit
    * of the tracked entity.
    */

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -43,7 +43,6 @@ import org.hisp.dhis.common.AccessLevel;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
-import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fileresource.FileResource;
@@ -119,7 +118,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
   @Override
   public FileResourceStream getFileResourceImage(
       UID trackedEntity, UID attribute, @CheckForNull UID program, ImageFileDimension dimension)
-      throws NotFoundException, ConflictException, BadRequestException {
+      throws NotFoundException {
     FileResource fileResource = getFileResourceMetadata(trackedEntity, attribute, program);
     return FileResourceStream.ofImage(fileResourceService, fileResource, dimension);
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityService.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
-import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fileresource.ImageFileDimension;
@@ -49,7 +48,7 @@ public interface TrackedEntityService {
   /** Get an image for a tracked entities' attribute in the given dimension. */
   FileResourceStream getFileResourceImage(
       UID trackedEntity, UID attribute, UID program, ImageFileDimension dimension)
-      throws NotFoundException, ConflictException, BadRequestException;
+      throws NotFoundException;
 
   TrackedEntity getTrackedEntity(String uid, TrackedEntityParams params, boolean includeDeleted)
       throws NotFoundException, ForbiddenException;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -730,7 +730,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   }
 
   @Test
-  void getAttributeValuesFileByAttributeAndProgramIfUserDoesNotHaveReadAccessToProgram()
+  void getAttributeValuesFileByAttributeAndProgramIfUserDoesNotHaveDataReadAccessToProgram()
       throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
     enroll(trackedEntity, program, orgUnit);
@@ -799,8 +799,9 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   }
 
   @Test
-  void getAttributeValuesFileByAttributeAndProgramIfUserDoesNotHaveReadAccessToTrackedEntityType()
-      throws ConflictException {
+  void
+      getAttributeValuesFileByAttributeAndProgramIfUserDoesNotHaveDataReadAccessToTrackedEntityType()
+          throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
     enroll(trackedEntity, program, orgUnit);
 
@@ -815,16 +816,19 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
 
     this.switchContextToUser(user);
 
-    GET(
-            "/tracker/trackedEntities/{trackedEntityUid}/attributes/{attributeUid}/file?program={programUid}",
-            trackedEntity.getUid(),
-            tea.getUid(),
-            program.getUid())
-        .error(HttpStatus.NOT_FOUND);
+    assertStartsWith(
+        "TrackedEntity ",
+        GET(
+                "/tracker/trackedEntities/{trackedEntityUid}/attributes/{attributeUid}/file?program={programUid}",
+                trackedEntity.getUid(),
+                tea.getUid(),
+                program.getUid())
+            .error(HttpStatus.NOT_FOUND)
+            .getMessage());
   }
 
   @Test
-  void getAttributeValuesFileByAttributeIfUserDoesNotHaveReadAccessToTrackedEntityType()
+  void getAttributeValuesFileByAttributeIfUserDoesNotHaveDataReadAccessToTrackedEntityType()
       throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
     enroll(trackedEntity, program, orgUnit);
@@ -840,11 +844,14 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
 
     this.switchContextToUser(user);
 
-    GET(
-            "/tracker/trackedEntities/{trackedEntityUid}/attributes/{attributeUid}/file",
-            trackedEntity.getUid(),
-            tea.getUid())
-        .error(HttpStatus.NOT_FOUND);
+    assertStartsWith(
+        "TrackedEntity ",
+        GET(
+                "/tracker/trackedEntities/{trackedEntityUid}/attributes/{attributeUid}/file",
+                trackedEntity.getUid(),
+                tea.getUid())
+            .error(HttpStatus.NOT_FOUND)
+            .getMessage());
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -119,7 +119,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   private TrackedEntity softDeletedTrackedEntity;
 
   // Used to generate unique chars for creating TEA in test setup
-  private int uniqueAttributeCharCounter = 1;
+  private int uniqueAttributeCharCounter = 0;
 
   @BeforeEach
   void setUp() {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -235,8 +235,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   @Test
   void getTrackedEntityByIdWithAttributesReturnsTrackedEntityTypeAttributesOnly() {
     TrackedEntity trackedEntity = trackedEntity();
-    // TODO write enrollTrackedEntity(trackedEntity, program, orgUnit);
-    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+    enroll(trackedEntity, program, orgUnit);
 
     TrackedEntityAttribute tea =
         addTrackedEntityTypeAttributeValue(trackedEntity, ValueType.NUMBER, "12");
@@ -263,7 +262,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   @Test
   void getTrackedEntityByIdWithAttributesReturnsAllAttributes() {
     TrackedEntity trackedEntity = trackedEntity();
-    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+    enroll(trackedEntity, program, orgUnit);
 
     TrackedEntityAttribute tea =
         addTrackedEntityTypeAttributeValue(trackedEntity, ValueType.NUMBER, "12");
@@ -498,9 +497,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   @Test
   void shouldGetEnrollmentWhenFieldsHasEnrollments() {
     TrackedEntity trackedEntity = trackedEntity();
-    Enrollment enrollment =
-        enrollmentService.enrollTrackedEntity(
-            trackedEntity, program, new Date(), new Date(), orgUnit);
+    Enrollment enrollment = enroll(trackedEntity, program, orgUnit);
 
     JsonList<JsonEnrollment> json =
         GET("/tracker/trackedEntities/{id}?fields=enrollments", trackedEntity.getUid())
@@ -518,9 +515,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   void shouldGetNoEventRelationshipsWhenEventsHasNoRelationshipsAndFieldsIncludeAll() {
     TrackedEntity trackedEntity = trackedEntity();
 
-    Enrollment enrollment =
-        enrollmentService.enrollTrackedEntity(
-            trackedEntity, program, new Date(), new Date(), orgUnit);
+    Enrollment enrollment = enroll(trackedEntity, program, orgUnit);
 
     Event event = eventWithDataValue(enrollment);
 
@@ -545,9 +540,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   void shouldGetEventRelationshipsWhenEventHasRelationshipsAndFieldsIncludeEventRelationships() {
     TrackedEntity trackedEntity = trackedEntity();
 
-    Enrollment enrollment =
-        enrollmentService.enrollTrackedEntity(
-            trackedEntity, program, new Date(), new Date(), orgUnit);
+    Enrollment enrollment = enroll(trackedEntity, program, orgUnit);
 
     Event event = eventWithDataValue(enrollment);
     enrollment.getEvents().add(event);
@@ -578,9 +571,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   void shouldGetNoEventRelationshipsWhenEventHasRelationshipsAndFieldsExcludeEventRelationships() {
     TrackedEntity trackedEntity = trackedEntity();
 
-    Enrollment enrollment =
-        enrollmentService.enrollTrackedEntity(
-            trackedEntity, program, new Date(), new Date(), orgUnit);
+    Enrollment enrollment = enroll(trackedEntity, program, orgUnit);
 
     Event event = eventWithDataValue(enrollment);
 
@@ -608,7 +599,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   @Test
   void getAttributeValuesFileByAttributeAndProgramGivenProgramAttribute() throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
-    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+    enroll(trackedEntity, program, orgUnit);
 
     FileResource file = storeFile("text/plain", "file content");
     TrackedEntityAttribute tea =
@@ -659,15 +650,14 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   void getAttributeValuesFileByAttributeAndProgramGivenTrackedEntityTypeAttribute()
       throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
-    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+    enroll(trackedEntity, program, orgUnit);
 
     FileResource file1 = storeFile("text/plain", "file content");
     TrackedEntityAttribute tetTea =
         addTrackedEntityTypeAttributeValue(trackedEntity, ValueType.FILE_RESOURCE, file1.getUid());
 
     FileResource file2 = storeFile("text/plain", "file content", 'B');
-    TrackedEntityAttribute programTea =
-        addProgramAttributeValue(trackedEntity, program, ValueType.FILE_RESOURCE, file2.getUid());
+    addProgramAttributeValue(trackedEntity, program, ValueType.FILE_RESOURCE, file2.getUid());
 
     this.switchContextToUser(user);
 
@@ -685,7 +675,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   @Test
   void getAttributeValuesFileByAttributeGivenProgramAttribute() throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
-    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+    enroll(trackedEntity, program, orgUnit);
 
     FileResource file1 = storeFile("text/plain", "file content");
     addTrackedEntityTypeAttributeValue(trackedEntity, ValueType.FILE_RESOURCE, file1.getUid());
@@ -721,7 +711,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   @Test
   void getAttributeValuesFileByAttributeAndProgramIfAttributeIsNotFound() throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
-    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+    enroll(trackedEntity, program, orgUnit);
 
     FileResource file = storeFile("text/plain", "file content");
     addProgramAttributeValue(trackedEntity, program, ValueType.FILE_RESOURCE, file.getUid());
@@ -743,7 +733,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   void getAttributeValuesFileByAttributeAndProgramIfUserDoesNotHaveReadAccessToProgram()
       throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
-    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+    enroll(trackedEntity, program, orgUnit);
 
     FileResource file = storeFile("text/plain", "file content");
     TrackedEntityAttribute tea =
@@ -770,7 +760,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   @Test
   void getAttributeValuesFileByAttributeAndProgramIfAttributeIsNotAFile() {
     TrackedEntity trackedEntity = trackedEntity();
-    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+    enroll(trackedEntity, program, orgUnit);
 
     TrackedEntityAttribute tea =
         addProgramAttributeValue(trackedEntity, program, ValueType.BOOLEAN, "true");
@@ -789,7 +779,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   @Test
   void getAttributeValuesFileByAttributeAndProgramIfProgramDoesNotExist() throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
-    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+    enroll(trackedEntity, program, orgUnit);
 
     FileResource file = storeFile("text/plain", "file content");
     TrackedEntityAttribute tea =
@@ -812,7 +802,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   void getAttributeValuesFileByAttributeAndProgramIfUserDoesNotHaveReadAccessToTrackedEntityType()
       throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
-    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+    enroll(trackedEntity, program, orgUnit);
 
     FileResource file = storeFile("text/plain", "file content");
     TrackedEntityAttribute tea =
@@ -837,7 +827,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   void getAttributeValuesFileByAttributeIfUserDoesNotHaveReadAccessToTrackedEntityType()
       throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
-    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+    enroll(trackedEntity, program, orgUnit);
 
     FileResource file = storeFile("text/plain", "file content");
     TrackedEntityAttribute tea =
@@ -863,7 +853,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
 
     TrackedEntityAttribute tea = programAttribute(program, ValueType.FILE_RESOURCE);
 
-    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+    enroll(trackedEntity, program, orgUnit);
 
     assertStartsWith(
         "Attribute value for tracked entity attribute " + tea.getUid(),
@@ -879,7 +869,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   @Test
   void getAttributeValuesFileByAttributeAndProgramIfFileResourceIsInDbButNotInTheStore() {
     TrackedEntity trackedEntity = trackedEntity();
-    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+    enroll(trackedEntity, program, orgUnit);
 
     FileResource file = createFileResource('A', "file content".getBytes());
     manager.save(file, false);
@@ -897,7 +887,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   @Test
   void getAttributeValuesFileByAttributeAndProgramIfFileIsNotFound() {
     TrackedEntity trackedEntity = trackedEntity();
-    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+    enroll(trackedEntity, program, orgUnit);
 
     String fileUid = CodeGenerator.generateUid();
     TrackedEntityAttribute tea =
@@ -917,7 +907,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   @Test
   void getAttributeValuesImageByProgramAttribute() throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
-    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+    enroll(trackedEntity, program, orgUnit);
 
     FileResource file = storeFile("image/png", "file content");
     TrackedEntityAttribute tea =
@@ -1072,6 +1062,12 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
     return te;
   }
 
+  private Enrollment enroll(
+      TrackedEntity trackedEntity, Program program, OrganisationUnit orgUnit) {
+    return enrollmentService.enrollTrackedEntity(
+        trackedEntity, program, new Date(), new Date(), orgUnit);
+  }
+
   private UserAccess userAccess() {
     UserAccess a = new UserAccess();
     a.setUser(user);
@@ -1192,12 +1188,6 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
     trackedEntity.addAttributeValue(attributeValue(tea, trackedEntity, value));
     manager.save(trackedEntity, false);
     return tea;
-  }
-
-  private void addAttributeValue(
-      TrackedEntity trackedEntity, TrackedEntityAttribute tea, String value) {
-    trackedEntity.addAttributeValue(attributeValue(tea, trackedEntity, value));
-    manager.save(trackedEntity, false);
   }
 
   private TrackedEntityAttributeValue attributeValue(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerTest.java
@@ -235,12 +235,12 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   @Test
   void getTrackedEntityByIdWithAttributesReturnsTrackedEntityTypeAttributesOnly() {
     TrackedEntity trackedEntity = trackedEntity();
-    TrackedEntityAttribute tea =
-        trackedEntityTypeAttribute(trackedEntity.getTrackedEntityType(), ValueType.NUMBER);
-    addAttributeValue(trackedEntity, tea, "12");
-    TrackedEntityAttribute tea2 = programAttribute(program, ValueType.NUMBER);
-    addAttributeValue(trackedEntity, tea2, "24");
+    // TODO write enrollTrackedEntity(trackedEntity, program, orgUnit);
     enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    TrackedEntityAttribute tea =
+        addTrackedEntityTypeAttributeValue(trackedEntity, ValueType.NUMBER, "12");
+    addProgramAttributeValue(trackedEntity, program, ValueType.NUMBER, "24");
 
     JsonList<JsonAttribute> attributes =
         GET(
@@ -263,13 +263,12 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   @Test
   void getTrackedEntityByIdWithAttributesReturnsAllAttributes() {
     TrackedEntity trackedEntity = trackedEntity();
-    TrackedEntityAttribute tea =
-        trackedEntityTypeAttribute(trackedEntity.getTrackedEntityType(), ValueType.NUMBER);
-    addAttributeValue(trackedEntity, tea, "12");
-    TrackedEntityAttribute tea2 = programAttribute(program, ValueType.NUMBER);
-    addAttributeValue(trackedEntity, tea2, "24");
-
     enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    TrackedEntityAttribute tea =
+        addTrackedEntityTypeAttributeValue(trackedEntity, ValueType.NUMBER, "12");
+    TrackedEntityAttribute tea2 =
+        addProgramAttributeValue(trackedEntity, program, ValueType.NUMBER, "24");
 
     JsonList<JsonAttribute> attributes =
         GET(
@@ -609,11 +608,11 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   @Test
   void getAttributeValuesFileByAttributeAndProgramGivenProgramAttribute() throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
-
-    TrackedEntityAttribute tea = programAttribute(program, ValueType.FILE_RESOURCE);
-    FileResource file = storeFile("text/plain", "file content");
-    addAttributeValue(trackedEntity, tea, file.getUid());
     enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    FileResource file = storeFile("text/plain", "file content");
+    TrackedEntityAttribute tea =
+        addProgramAttributeValue(trackedEntity, program, ValueType.FILE_RESOURCE, file.getUid());
 
     this.switchContextToUser(user);
 
@@ -636,10 +635,9 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   void getAttributeValuesFileByAttributeGivenTrackedEntityTypeAttribute() throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
 
-    TrackedEntityAttribute tea =
-        trackedEntityTypeAttribute(trackedEntityType, ValueType.FILE_RESOURCE);
     FileResource file = storeFile("text/plain", "file content");
-    addAttributeValue(trackedEntity, tea, file.getUid());
+    TrackedEntityAttribute tea =
+        addTrackedEntityTypeAttributeValue(trackedEntity, ValueType.FILE_RESOURCE, file.getUid());
 
     this.switchContextToUser(user);
 
@@ -661,17 +659,15 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   void getAttributeValuesFileByAttributeAndProgramGivenTrackedEntityTypeAttribute()
       throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
-
-    TrackedEntityAttribute tetTea =
-        trackedEntityTypeAttribute(trackedEntityType, ValueType.FILE_RESOURCE);
-    FileResource file1 = storeFile("text/plain", "file content");
-    addAttributeValue(trackedEntity, tetTea, file1.getUid());
-
-    TrackedEntityAttribute programTea = programAttribute(program, ValueType.FILE_RESOURCE);
-    FileResource file2 = storeFile("text/plain", "file content", 'B');
-    addAttributeValue(trackedEntity, programTea, file2.getUid());
-
     enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    FileResource file1 = storeFile("text/plain", "file content");
+    TrackedEntityAttribute tetTea =
+        addTrackedEntityTypeAttributeValue(trackedEntity, ValueType.FILE_RESOURCE, file1.getUid());
+
+    FileResource file2 = storeFile("text/plain", "file content", 'B');
+    TrackedEntityAttribute programTea =
+        addProgramAttributeValue(trackedEntity, program, ValueType.FILE_RESOURCE, file2.getUid());
 
     this.switchContextToUser(user);
 
@@ -689,17 +685,14 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   @Test
   void getAttributeValuesFileByAttributeGivenProgramAttribute() throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
-
-    TrackedEntityAttribute tetTea =
-        trackedEntityTypeAttribute(trackedEntityType, ValueType.FILE_RESOURCE);
-    FileResource file1 = storeFile("text/plain", "file content");
-    addAttributeValue(trackedEntity, tetTea, file1.getUid());
-
-    TrackedEntityAttribute programTea = programAttribute(program, ValueType.FILE_RESOURCE);
-    FileResource file2 = storeFile("text/plain", "file content", 'B');
-    addAttributeValue(trackedEntity, programTea, file2.getUid());
-
     enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    FileResource file1 = storeFile("text/plain", "file content");
+    addTrackedEntityTypeAttributeValue(trackedEntity, ValueType.FILE_RESOURCE, file1.getUid());
+
+    FileResource file2 = storeFile("text/plain", "file content", 'B');
+    TrackedEntityAttribute programTea =
+        addProgramAttributeValue(trackedEntity, program, ValueType.FILE_RESOURCE, file2.getUid());
 
     this.switchContextToUser(user);
 
@@ -728,12 +721,10 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   @Test
   void getAttributeValuesFileByAttributeAndProgramIfAttributeIsNotFound() throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
-
-    TrackedEntityAttribute tea = programAttribute(program, ValueType.FILE_RESOURCE);
-    FileResource file = storeFile("text/plain", "file content");
-    addAttributeValue(trackedEntity, tea, file.getUid());
-
     enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    FileResource file = storeFile("text/plain", "file content");
+    addProgramAttributeValue(trackedEntity, program, ValueType.FILE_RESOURCE, file.getUid());
 
     String attributeUid = CodeGenerator.generateUid();
 
@@ -752,17 +743,16 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   void getAttributeValuesFileByAttributeAndProgramIfUserDoesNotHaveReadAccessToProgram()
       throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
+    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    FileResource file = storeFile("text/plain", "file content");
+    TrackedEntityAttribute tea =
+        addProgramAttributeValue(trackedEntity, program, ValueType.FILE_RESOURCE, file.getUid());
 
     // remove access
     program.getSharing().setUserAccesses(Set.of());
     program.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
     manager.save(program, false);
-
-    TrackedEntityAttribute tea = programAttribute(program, ValueType.FILE_RESOURCE);
-    FileResource file = storeFile("text/plain", "file content");
-    addAttributeValue(trackedEntity, tea, file.getUid());
-
-    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
 
     this.switchContextToUser(user);
 
@@ -780,11 +770,10 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   @Test
   void getAttributeValuesFileByAttributeAndProgramIfAttributeIsNotAFile() {
     TrackedEntity trackedEntity = trackedEntity();
-
-    TrackedEntityAttribute tea = programAttribute(program, ValueType.BOOLEAN);
-    addAttributeValue(trackedEntity, tea, "true");
-
     enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    TrackedEntityAttribute tea =
+        addProgramAttributeValue(trackedEntity, program, ValueType.BOOLEAN, "true");
 
     assertStartsWith(
         "Tracked entity attribute " + tea.getUid() + " is not a file",
@@ -800,12 +789,11 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   @Test
   void getAttributeValuesFileByAttributeAndProgramIfProgramDoesNotExist() throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
-
-    TrackedEntityAttribute tea = programAttribute(program, ValueType.FILE_RESOURCE);
-    FileResource file = storeFile("text/plain", "file content");
-    addAttributeValue(trackedEntity, tea, file.getUid());
-
     enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    FileResource file = storeFile("text/plain", "file content");
+    TrackedEntityAttribute tea =
+        addProgramAttributeValue(trackedEntity, program, ValueType.FILE_RESOURCE, file.getUid());
 
     String programUid = CodeGenerator.generateUid();
 
@@ -824,17 +812,16 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   void getAttributeValuesFileByAttributeAndProgramIfUserDoesNotHaveReadAccessToTrackedEntityType()
       throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
+    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    FileResource file = storeFile("text/plain", "file content");
+    TrackedEntityAttribute tea =
+        addProgramAttributeValue(trackedEntity, program, ValueType.FILE_RESOURCE, file.getUid());
 
     // remove public access
     trackedEntityType.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
     trackedEntityType.getSharing().setUserAccesses(Set.of());
     manager.save(trackedEntityType, false);
-
-    TrackedEntityAttribute tea = programAttribute(program, ValueType.FILE_RESOURCE);
-    FileResource file = storeFile("text/plain", "file content");
-    addAttributeValue(trackedEntity, tea, file.getUid());
-
-    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
 
     this.switchContextToUser(user);
 
@@ -850,18 +837,16 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   void getAttributeValuesFileByAttributeIfUserDoesNotHaveReadAccessToTrackedEntityType()
       throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
+    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    FileResource file = storeFile("text/plain", "file content");
+    TrackedEntityAttribute tea =
+        addTrackedEntityTypeAttributeValue(trackedEntity, ValueType.FILE_RESOURCE, file.getUid());
 
     // remove public access
     trackedEntityType.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
     trackedEntityType.getSharing().setUserAccesses(Set.of());
     manager.save(trackedEntityType, false);
-
-    TrackedEntityAttribute tea =
-        trackedEntityTypeAttribute(trackedEntityType, ValueType.FILE_RESOURCE);
-    FileResource file = storeFile("text/plain", "file content");
-    addAttributeValue(trackedEntity, tea, file.getUid());
-
-    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
 
     this.switchContextToUser(user);
 
@@ -894,13 +879,12 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   @Test
   void getAttributeValuesFileByAttributeAndProgramIfFileResourceIsInDbButNotInTheStore() {
     TrackedEntity trackedEntity = trackedEntity();
+    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
 
-    TrackedEntityAttribute tea = programAttribute(program, ValueType.FILE_RESOURCE);
     FileResource file = createFileResource('A', "file content".getBytes());
     manager.save(file, false);
-    addAttributeValue(trackedEntity, tea, file.getUid());
-
-    enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+    TrackedEntityAttribute tea =
+        addProgramAttributeValue(trackedEntity, program, ValueType.FILE_RESOURCE, file.getUid());
 
     GET(
             "/tracker/trackedEntities/{trackedEntityUid}/attributes/{attributeUid}/file?program={programUid}",
@@ -913,12 +897,11 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   @Test
   void getAttributeValuesFileByAttributeAndProgramIfFileIsNotFound() {
     TrackedEntity trackedEntity = trackedEntity();
-
-    TrackedEntityAttribute tea = programAttribute(program, ValueType.FILE_RESOURCE);
-    String fileUid = CodeGenerator.generateUid();
-    addAttributeValue(trackedEntity, tea, fileUid);
-
     enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    String fileUid = CodeGenerator.generateUid();
+    TrackedEntityAttribute tea =
+        addProgramAttributeValue(trackedEntity, program, ValueType.FILE_RESOURCE, fileUid);
 
     assertStartsWith(
         "FileResource with id " + fileUid,
@@ -934,12 +917,11 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
   @Test
   void getAttributeValuesImageByProgramAttribute() throws ConflictException {
     TrackedEntity trackedEntity = trackedEntity();
-
-    TrackedEntityAttribute tea = programAttribute(program, ValueType.IMAGE);
-    FileResource file = storeFile("image/png", "file content");
-    addAttributeValue(trackedEntity, tea, file.getUid());
-
     enrollmentService.enrollTrackedEntity(trackedEntity, program, new Date(), new Date(), orgUnit);
+
+    FileResource file = storeFile("image/png", "file content");
+    TrackedEntityAttribute tea =
+        addProgramAttributeValue(trackedEntity, program, ValueType.IMAGE, file.getUid());
 
     this.switchContextToUser(user);
 
@@ -1090,12 +1072,6 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
     return te;
   }
 
-  private void addAttributeValue(
-      TrackedEntity trackedEntity, TrackedEntityAttribute tea, String value) {
-    trackedEntity.addAttributeValue(attributeValue(tea, trackedEntity, value));
-    manager.save(trackedEntity, false);
-  }
-
   private UserAccess userAccess() {
     UserAccess a = new UserAccess();
     a.setUser(user);
@@ -1201,6 +1177,29 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
     assertTrue(jsonTe.getArray("attributes").isEmpty());
   }
 
+  private TrackedEntityAttribute addTrackedEntityTypeAttributeValue(
+      TrackedEntity trackedEntity, ValueType type, String value) {
+    TrackedEntityAttribute tea =
+        trackedEntityTypeAttribute(trackedEntity.getTrackedEntityType(), type);
+    trackedEntity.addAttributeValue(attributeValue(tea, trackedEntity, value));
+    manager.save(trackedEntity, false);
+    return tea;
+  }
+
+  private TrackedEntityAttribute addProgramAttributeValue(
+      TrackedEntity trackedEntity, Program program, ValueType type, String value) {
+    TrackedEntityAttribute tea = programAttribute(program, type);
+    trackedEntity.addAttributeValue(attributeValue(tea, trackedEntity, value));
+    manager.save(trackedEntity, false);
+    return tea;
+  }
+
+  private void addAttributeValue(
+      TrackedEntity trackedEntity, TrackedEntityAttribute tea, String value) {
+    trackedEntity.addAttributeValue(attributeValue(tea, trackedEntity, value));
+    manager.save(trackedEntity, false);
+  }
+
   private TrackedEntityAttributeValue attributeValue(
       TrackedEntityAttribute tea, TrackedEntity te, String value) {
     return new TrackedEntityAttributeValue(tea, te, value);
@@ -1218,7 +1217,7 @@ class TrackedEntitiesExportControllerTest extends DhisControllerConvenienceTest 
     TrackedEntityAttribute tea = trackedEntityAttribute(type);
     TrackedEntityTypeAttribute teta = new TrackedEntityTypeAttribute(trackedEntityType, tea);
     manager.save(teta, false);
-    trackedEntityType.setTrackedEntityTypeAttributes(List.of(teta));
+    trackedEntityType.getTrackedEntityTypeAttributes().add(teta);
     manager.save(trackedEntityType, false);
     return tea;
   }


### PR DESCRIPTION
* `/api/tracker/trackedEntities/vOxUH373fy5/attributes/nDlikr3TUS6/image?program={programUid}`: validate ACL against TE and program + find attribute in program attributes
* `/api/tracker/trackedEntities/vOxUH373fy5/attributes/nDlikr3TUS6/image`: validate ACL against TE + find attributes in tracked entity type attributes of the TE

* simplify creating attributes and values (tracked entity attribute value -> tracked entity type attribute|program attribute -> tracked entity attribute)