### PR TITLE
fix: run in memory jobs on any node [DHIS2-16497]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
@@ -254,7 +254,9 @@ public abstract class AbstractSchedulingManager implements SchedulingManager {
       return false;
     }
     JobType type = configuration.getJobType();
-    if (configuration.isLeaderOnlyJob() && !leaderManager.isLeader()) {
+    if (!configuration.isInMemoryJob()
+        && configuration.isLeaderOnlyJob()
+        && !leaderManager.isLeader()) {
       whenLeaderOnlyOnNonLeader(configuration);
       return false;
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
@@ -266,7 +266,8 @@ public abstract class AbstractSchedulingManager implements SchedulingManager {
       whenAlreadyRunning(configuration);
       return false;
     }
-    if (!runningRemotely.putIfAbsent(type.name(), progress.getProcesses())) {
+    if (!type.isRunOnAllNodes()
+        && !runningRemotely.putIfAbsent(type.name(), progress.getProcesses())) {
       runningLocally.remove(type);
       whenAlreadyRunning(configuration);
       return false;
@@ -321,7 +322,7 @@ public abstract class AbstractSchedulingManager implements SchedulingManager {
       return false;
     } finally {
       completedLocally.put(type, runningLocally.remove(type));
-      runningRemotely.invalidate(type.name());
+      if (!type.isRunOnAllNodes()) runningRemotely.invalidate(type.name());
       whenRunIsDone(configuration, clock);
       MDC.remove("sessionId");
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
@@ -262,7 +262,7 @@ public abstract class AbstractSchedulingManager implements SchedulingManager {
     // OBS: we cannot use computeIfAbsent since we have no way of
     // atomically create and find out if there was a value before
     // so we need to pay the price of creating the progress up front
-    if (runningLocally.putIfAbsent(type, progress) != null) {
+    if (type != JobType.LEADER_ELECTION && runningLocally.putIfAbsent(type, progress) != null) {
       whenAlreadyRunning(configuration);
       return false;
     }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/leader/election/RedisLeaderManager.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/leader/election/RedisLeaderManager.java
@@ -38,7 +38,6 @@ import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.scheduling.SchedulingManager;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
@@ -64,8 +63,6 @@ public class RedisLeaderManager implements LeaderManager {
   private SchedulingManager schedulingManager;
 
   private final StringRedisTemplate redisTemplate;
-
-  private boolean electionDidRun = false;
 
   public RedisLeaderManager(
       Long timeToLiveMinutes,
@@ -105,7 +102,6 @@ public class RedisLeaderManager implements LeaderManager {
               .opsForValue()
               .setIfAbsent(NODE_ID_KEY, nodeId, timeToLiveSeconds, TimeUnit.SECONDS);
         });
-    electionDidRun = true;
     if (isLeader()) {
       renewLeader(progress);
 
@@ -124,7 +120,6 @@ public class RedisLeaderManager implements LeaderManager {
 
   @Override
   public boolean isLeader() {
-    if (!electionDidRun) electLeader(NoopJobProgress.INSTANCE);
     String leaderId = getLeaderNodeUuidFromRedis();
     return nodeUuid.equals(leaderId);
   }


### PR DESCRIPTION
The fix is twofold:

* always execute a "in-memory" job independent of leader status (a job submitted to a node for immediate execution that is not persisted)
* only synchronize the "runningRemotely" for job types that should only be run by the leader