### PR TITLE
chore: Remove Bing Maps API key [DHIS2-16881]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
@@ -187,12 +187,7 @@ public enum SettingKey {
   REMOTE_INSTANCE_USERNAME("keyRemoteInstanceUsername", "", String.class),
   REMOTE_INSTANCE_PASSWORD("keyRemoteInstancePassword", "", String.class, true, false),
   GOOGLE_MAPS_API_KEY("keyGoogleMapsApiKey", "", String.class, false, false),
-  BING_MAPS_API_KEY(
-      "keyBingMapsApiKey",
-      "",
-      String.class,
-      false,
-      false),
+  BING_MAPS_API_KEY("keyBingMapsApiKey", "", String.class, false, false),
   LAST_SUCCESSFUL_METADATA_SYNC("keyLastMetaDataSyncSuccess", Date.class),
   METADATAVERSION_ENABLED("keyVersionEnabled", Boolean.FALSE, Boolean.class),
   METADATA_FAILED_VERSION("keyMetadataFailedVersion", String.class),

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
@@ -189,7 +189,7 @@ public enum SettingKey {
   GOOGLE_MAPS_API_KEY("keyGoogleMapsApiKey", "", String.class, false, false),
   BING_MAPS_API_KEY(
       "keyBingMapsApiKey",
-      "AoifMs0zqvpAEuI6OX5Kk93rEM-oLrvQIJe_xdCv1BF4J3yquFnUozze-M7gEf0b",
+      "",
       String.class,
       false,
       false),


### PR DESCRIPTION
Remove Bing Maps API key from source code. Part of a[ larger effort](https://dhis2.atlassian.net/browse/DHIS2-16879) to remove keys.
Discussions and progress tracked in [this wiki](https://dhis2.atlassian.net/wiki/spaces/SOFTWARE/pages/253394946/DHIS2+Core+API+Keys).