### PR TITLE
fix: assumes EQ if missing for dimensionalObjects [DHIS2-16749]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/DimensionParamItem.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/DimensionParamItem.java
@@ -42,10 +42,13 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.common.QueryOperator;
 
 @Getter
 @RequiredArgsConstructor(access = PRIVATE)
 public class DimensionParamItem {
+
+  private static final AnalyticsQueryOperator EQ = AnalyticsQueryOperator.of(QueryOperator.EQ);
 
   private final AnalyticsQueryOperator operator;
 
@@ -66,7 +69,7 @@ public class DimensionParamItem {
     if (isQueryItemFormat(items)) {
       return ofQueryItemFormat(items);
     } else {
-      return singletonList(new DimensionParamItem(null, items));
+      return singletonList(new DimensionParamItem(EQ, items));
     }
   }
 

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TrackedEntityQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TrackedEntityQueryTest.java
@@ -3163,4 +3163,24 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
         .body("headers[0].name", equalTo("IpHINAT79UW.A03MvHHogjR.a3kGcGDCuk6"))
         .body("headers[0].column", equalTo("MCH Apgar Score"));
   }
+
+  @Test
+  public void testOugs() {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("dimension=J5jldMd8OHv:CXw2yu5fodb")
+            .add("headers=J5jldMd8OHv")
+            .add("pageSize=0");
+
+    // When
+    ApiResponse response = analyticsTeiActions.query().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers[0].name", equalTo("J5jldMd8OHv"))
+        .body("headers[0].column", equalTo("Facility Type"));
+  }
 }


### PR DESCRIPTION
This PR assumes the operator to be EQ in case it is missing.
The operator is always missing in the request for Dimensional Objects (like OU for example).