### PR TITLE
chore: rename the job error search authority [DHIS2-16183]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobSchedulerService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobSchedulerService.java
@@ -124,7 +124,7 @@ public class DefaultJobSchedulerService implements JobSchedulerService {
     Progress progress = mapToProgress(json);
     if (progress == null) return null;
     UserDetails user = CurrentUserUtil.getCurrentUserDetails();
-    if (user == null || !(user.isSuper() || user.isAuthorized("F_SCHEDULING_ANALYSE")))
+    if (user == null || !(user.isSuper() || user.isAuthorized("F_JOB_LOG_READ")))
       progress.getErrors().clear();
     return progress;
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationRunErrorsControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationRunErrorsControllerTest.java
@@ -57,7 +57,7 @@ class JobConfigurationRunErrorsControllerTest extends DhisControllerIntegrationT
   @BeforeEach
   void setUp() throws InterruptedException {
     jobId = createAndRunImportWithErrors();
-    switchToNewUser("special-admin", "F_SCHEDULING_ANALYSE");
+    switchToNewUser("special-admin", "F_JOB_LOG_READ");
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -78,7 +78,7 @@ public class JobConfigurationController extends AbstractCrudController<JobConfig
   private final JobConfigurationService jobConfigurationService;
   private final JobSchedulerService jobSchedulerService;
 
-  @PreAuthorize("hasRole('ALL') or hasRole('F_SCHEDULING_ANALYSE')")
+  @PreAuthorize("hasRole('ALL') or hasRole('F_JOB_LOG_READ')")
   @GetMapping("/errors")
   public List<JsonObject> getJobRunErrors(JobRunErrorsParams params) {
     return jobConfigurationService.findJobRunErrors(params);
@@ -227,7 +227,7 @@ public class JobConfigurationController extends AbstractCrudController<JobConfig
         currentUser != null
             && (currentUser.isSuper()
                 || (!read && currentUser.isAuthorized("F_PERFORM_MAINTENANCE"))
-                || (read && currentUser.isAuthorized("F_SCHEDULING_ANALYSE"))
+                || (read && currentUser.isAuthorized("F_JOB_LOG_READ"))
                 || currentUser.getUid().equals(obj.getExecutedBy()));
     if (!isAuthorized) throw new ForbiddenException(JobConfiguration.class, obj.getUid());
   }


### PR DESCRIPTION
As discussed in slack `#logging-improvments` the authority that allows reading/searching job error logs is called `F_JOB_LOG_READ`.