### PR TITLE
feat: support all HTTP methods when routing requests to upstream services [DHIS2-16921]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/RouteController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/RouteController.java
@@ -55,13 +55,11 @@ import org.springframework.web.bind.annotation.RestController;
 @OpenApi.Tags("integration")
 @RequiredArgsConstructor
 @RequestMapping(value = RouteSchemaDescriptor.API_ENDPOINT)
-@ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
+@ApiVersion({ DhisApiVersion.DEFAULT, DhisApiVersion.ALL })
 public class RouteController extends AbstractCrudController<Route> {
   private final RouteService routeService;
 
-  @RequestMapping(
-      value = "/{id}/run",
-      method = {RequestMethod.GET, RequestMethod.POST})
+  @RequestMapping(value = "/{id}/run")
   public ResponseEntity<String> run(
       @PathVariable("id") String id,
       @CurrentUser UserDetails currentUser,
@@ -70,9 +68,7 @@ public class RouteController extends AbstractCrudController<Route> {
     return runWithSubpath(id, currentUser, request);
   }
 
-  @RequestMapping(
-      value = "/{id}/run/**",
-      method = {RequestMethod.GET, RequestMethod.POST})
+  @RequestMapping(value = "/{id}/run/**")
   public ResponseEntity<String> runWithSubpath(
       @PathVariable("id") String id,
       @CurrentUser UserDetails currentUser,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/RouteController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/RouteController.java
@@ -45,7 +45,6 @@ import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -55,7 +54,7 @@ import org.springframework.web.bind.annotation.RestController;
 @OpenApi.Tags("integration")
 @RequiredArgsConstructor
 @RequestMapping(value = RouteSchemaDescriptor.API_ENDPOINT)
-@ApiVersion({ DhisApiVersion.DEFAULT, DhisApiVersion.ALL })
+@ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
 public class RouteController extends AbstractCrudController<Route> {
   private final RouteService routeService;
 


### PR DESCRIPTION
See [DHIS2-16921](https://dhis2.atlassian.net/browse/DHIS2-16921)

> In version 40 the route service was restricted to only GET and POST requests.  We should remove this restriction as it doesn’t provide any meaningful security benefit and can impede functionality of proxy routes.

[DHIS2-16921]: https://dhis2.atlassian.net/browse/DHIS2-16921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ