### PR TITLE
chore: fix flaky GistFilterControllerTest#testFilter_ILike

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFilterControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFilterControllerTest.java
@@ -141,7 +141,8 @@ class GistFilterControllerTest extends AbstractGistControllerTest {
 
   @Test
   void testFilter_ILike() {
-    assertEquals(1, GET("/users/gist?filter=surname:ilike:Mi&headless=true").content().size());
+    List<User> allUsers = userService.getAllUsers();
+    assertEquals(1, GET("/users/gist?filter=surname:ilike:MIN&headless=true").content().size());
     assertEquals(
         0, GET("/users/gist?filter=surname:ilike:?headless&headless=true").content().size());
     assertEquals(3, GET("/users/gist?filter=surname:ilike:Sur*&headless=true").content().size());

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFilterControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFilterControllerTest.java
@@ -141,8 +141,7 @@ class GistFilterControllerTest extends AbstractGistControllerTest {
 
   @Test
   void testFilter_ILike() {
-    List<User> allUsers = userService.getAllUsers();
-    assertEquals(1, GET("/users/gist?filter=surname:ilike:MIN&headless=true").content().size());
+    assertEquals(1, GET("/users/gist?filter=surname:ilike:DMIN&headless=true").content().size());
     assertEquals(
         0, GET("/users/gist?filter=surname:ilike:?headless&headless=true").content().size());
     assertEquals(3, GET("/users/gist?filter=surname:ilike:Sur*&headless=true").content().size());


### PR DESCRIPTION
### Summary
Fixes a flaky test. It became flaky after the UserDetails refactoring, when we introduced a random part in the surname field of the user. The random part would sometime match the ilike testing value.