### PR TITLE
refactor: Separate method for partition clause [DHIS2-16705]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
@@ -316,9 +316,6 @@ public class JdbcAnalyticsTableManager extends AbstractJdbcTableManager {
     String approvalSelectExpression = getApprovalSelectExpression(partition.getYear());
     String approvalClause = getApprovalJoinClause(partition.getYear());
     String partitionClause = getPartitionClause(partition);
-        partition.isLatestPartition()
-            ? "and dv.lastupdated >= '" + toLongDate(partition.getStartDate()) + "' "
-            : "and ps.year = " + partition.getYear() + " ";
 
     String sql = "insert into " + tableName + " (";
 
@@ -669,7 +666,7 @@ public class JdbcAnalyticsTableManager extends AbstractJdbcTableManager {
         // standard deviation of the normal distribution
         + "stddev_pop(t3.value::double precision) as std_dev "
         // Table "t3" is the composition of the tables "t2" (median of xi) and "t3" (values xi).
-        // For Z-Score  the mean (avg_middle_value) and standard deviation (std_dev) is used ((xi -
+        // For Z-Score the mean (avg_middle_value) and standard deviation (std_dev) is used ((xi -
         // mean(x))/std_dev).
         // For modified Z-Score the median (percentile_middle_value) and the median of absolute
         // deviations (mad) is used (0.6745*(xi - median(x)/mad)).
@@ -702,7 +699,7 @@ public class JdbcAnalyticsTableManager extends AbstractJdbcTableManager {
         // Table "t2" is the complement of the t1 table. It contains all values belong to the
         // specific median (see t1).
         // To "group by" criteria is added the time dimension (periodid). This part of the query has
-        // to be verified (maybe add tei to aggregation criteria).
+        // to be verified (maybe add TEI to aggregation criteria).
         + "(select dv1.dataelementid as dataelementid, "
         + "dv1.sourceid as sourceid, "
         + "dv1.categoryoptioncomboid  as categoryoptioncomboid, "

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManager.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.analytics.table;
 
+import static java.lang.String.format;
 import static org.hisp.dhis.analytics.table.model.AnalyticsValueType.FACT;
 import static org.hisp.dhis.analytics.table.util.PartitionUtils.getLatestTablePartition;
 import static org.hisp.dhis.db.model.DataType.BOOLEAN;
@@ -43,6 +44,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+
 import org.hisp.dhis.analytics.AnalyticsTableHookService;
 import org.hisp.dhis.analytics.AnalyticsTableType;
 import org.hisp.dhis.analytics.AnalyticsTableUpdateParams;
@@ -192,10 +194,7 @@ public class JdbcCompletenessTableManager extends AbstractJdbcTableManager {
   protected void populateTable(
       AnalyticsTableUpdateParams params, AnalyticsTablePartition partition) {
     String tableName = partition.getName();
-    String partitionClause =
-        partition.isLatestPartition()
-            ? "and cdr.lastupdated >= '" + toLongDate(partition.getStartDate()) + "' "
-            : "and ps.year = " + partition.getYear() + " ";
+    String partitionClause = getPartitionClause(partition);
 
     String sql = "insert into " + tableName + " (";
 
@@ -238,6 +237,22 @@ public class JdbcCompletenessTableManager extends AbstractJdbcTableManager {
     invokeTimeAndLog(sql, String.format("Populate %s", tableName));
   }
 
+  /**
+   * Returns a partition SQL clause.
+   *
+   * @param partition the {@link AnalyticsTablePartition}.
+   * @return a partition SQL clause.
+   */
+  private String getPartitionClause(AnalyticsTablePartition partition) {
+    String latestFilter =
+        format("and cdr.lastupdated >= '%s' ", toLongDate(partition.getStartDate()));
+    String partitionFilter = format("and ps.year = %d ", partition.getYear());
+
+    return partition.isLatestPartition()
+        ? latestFilter
+        : partitionFilter;
+  }
+  
   private List<AnalyticsTableColumn> getColumns() {
     List<AnalyticsTableColumn> columns = new ArrayList<>();
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -46,6 +46,7 @@ import static org.hisp.dhis.period.PeriodDataProvider.DataSource.DATABASE;
 import static org.hisp.dhis.period.PeriodDataProvider.DataSource.SYSTEM_DEFINED;
 import static org.hisp.dhis.system.util.MathUtils.NUMERIC_LENIENT_REGEXP;
 import static org.hisp.dhis.util.DateUtils.toLongDate;
+import static org.hisp.dhis.util.DateUtils.toMediumDate;
 
 import java.time.Year;
 import java.util.ArrayList;
@@ -55,7 +56,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
+
 import org.hisp.dhis.analytics.AnalyticsTableHookService;
 import org.hisp.dhis.analytics.AnalyticsTableType;
 import org.hisp.dhis.analytics.AnalyticsTableUpdateParams;
@@ -93,6 +94,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Lars Helge Overland
@@ -430,23 +433,7 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
     Integer latestDataYear = availableDataYears.get(availableDataYears.size() - 1);
 
     Program program = partition.getMasterTable().getProgram();
-    String start = DateUtils.toLongDate(partition.getStartDate());
-    String end = DateUtils.toLongDate(partition.getEndDate());
-    String partitionClause =
-        partition.isLatestPartition()
-            ? "and psi.lastupdated >= '" + start + "' "
-            : "and "
-                + "("
-                + getDateLinkedToStatus()
-                + ") >= '"
-                + start
-                + "' "
-                + "and "
-                + "("
-                + getDateLinkedToStatus()
-                + ") < '"
-                + end
-                + "' ";
+    String partitionClause = getPartitionClause(partition);
 
     String fromClause =
         "from event psi "
@@ -494,6 +481,25 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
     populateTableInternal(partition, fromClause);
   }
 
+  /**
+   * Returns a partition SQL clause.
+   *
+   * @param partition the {@link AnalyticsTablePartition}.
+   * @return a partition SQL clause.
+   */
+  private String getPartitionClause(AnalyticsTablePartition partition) {
+    String start = toLongDate(partition.getStartDate());
+    String end = toLongDate(partition.getEndDate());
+    String statusDate = getDateLinkedToStatus();
+    String latestFilter = format("and psi.lastupdated >= '%s' ", start);
+    String partitionFilter =
+        format("and (%s) >= '%s' and (%s) < '%s' ", statusDate, start, statusDate, end);
+
+    return partition.isLatestPartition()
+        ? latestFilter
+        : partitionFilter;
+  }
+  
   /**
    * Returns dimensional analytics table columns.
    *
@@ -724,8 +730,7 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
   private String selectForInsert(
       TrackedEntityAttribute attribute, String fromType, String dataClause) {
     return format(
-        "(select %s"
-            + " from trackedentityattributevalue where trackedentityid=pi.trackedentityid "
+        "(select %s from trackedentityattributevalue where trackedentityid=pi.trackedentityid "
             + "and trackedentityattributeid="
             + attribute.getId()
             + dataClause
@@ -804,7 +809,7 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
           "and ("
               + getDateLinkedToStatus()
               + ") >= '"
-              + DateUtils.toMediumDate(params.getFromDate())
+              + toMediumDate(params.getFromDate())
               + "'";
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcValidationResultTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcValidationResultTableManager.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.analytics.table;
 
+import static java.lang.String.format;
 import static org.hisp.dhis.analytics.table.model.AnalyticsValueType.FACT;
 import static org.hisp.dhis.db.model.DataType.CHARACTER_11;
 import static org.hisp.dhis.db.model.DataType.DATE;
@@ -41,6 +42,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+
 import org.hisp.dhis.analytics.AnalyticsTableHookService;
 import org.hisp.dhis.analytics.AnalyticsTableType;
 import org.hisp.dhis.analytics.AnalyticsTableUpdateParams;
@@ -156,6 +158,7 @@ public class JdbcValidationResultTableManager extends AbstractJdbcTableManager {
   protected void populateTable(
       AnalyticsTableUpdateParams params, AnalyticsTablePartition partition) {
     String tableName = partition.getName();
+    String partitionClause = getPartitionClause(partition);
 
     String sql = "insert into " + tableName + " (";
 
@@ -186,13 +189,11 @@ public class JdbcValidationResultTableManager extends AbstractJdbcTableManager {
             + "and (cast(date_trunc('month', pe.startdate) as date)=ougs.startdate or ougs.startdate is null) "
             + "left join _orgunitstructure ous on vrs.organisationunitid=ous.organisationunitid "
             + "inner join _categorystructure acs on vrs.attributeoptioncomboid=acs.categoryoptioncomboid "
-            + "where ps.year = "
-            + partition.getYear()
-            + " "
-            + "and vrs.created < '"
+            + "where vrs.created < '"
             + toLongDate(params.getStartTime())
             + "' "
-            + "and vrs.created is not null";
+            + "and vrs.created is not null "
+            + partitionClause;
 
     invokeTimeAndLog(sql, String.format("Populate %s", tableName));
   }
@@ -212,6 +213,16 @@ public class JdbcValidationResultTableManager extends AbstractJdbcTableManager {
     }
 
     return jdbcTemplate.queryForList(sql, Integer.class);
+  }
+
+  /**
+   * Returns a partition SQL clause.
+   *
+   * @param partition the {@link AnalyticsTablePartition}.
+   * @return a partition SQL clause.
+   */
+  private String getPartitionClause(AnalyticsTablePartition partition) {
+    return format("and ps.year = %d ", partition.getYear());
   }
 
   private List<AnalyticsTableColumn> getColumns() {


### PR DESCRIPTION
Introduces a separate method for the "partition clause" for the populate analytics table statement. This logic has several branches and fits better as a separate method.

Adds integration tests for `PostgreSqlBuilder` focused on data types. 