### PR TITLE
fix: regression causing menu items to not be filtered on authorities

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/interceptor/ContextInterceptor.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/interceptor/ContextInterceptor.java
@@ -36,7 +36,6 @@ import java.util.Map;
 import lombok.AllArgsConstructor;
 import org.apache.struts2.ServletActionContext;
 import org.hisp.dhis.commons.util.TextUtils;
-import org.hisp.dhis.system.database.DatabaseInfoProvider;
 import org.springframework.stereotype.Component;
 
 /**
@@ -45,15 +44,11 @@ import org.springframework.stereotype.Component;
 @Component
 @AllArgsConstructor
 public class ContextInterceptor implements Interceptor {
-  private static final String KEY_IN_MEMORY_DATABASE = "inMemoryDatabase";
-
   private static final String KEY_TEXT_UTILS = "dhisTextUtils";
 
   private static final String KEY_CURRENT_PAGE = "keyCurrentPage";
 
   private static final String KEY_CURRENT_KEY = "keyCurrentKey";
-
-  private final DatabaseInfoProvider databaseInfoProvider;
 
   @Override
   public void destroy() {}
@@ -65,7 +60,6 @@ public class ContextInterceptor implements Interceptor {
   public String intercept(ActionInvocation invocation) throws Exception {
     Map<String, Object> map = new HashMap<>();
 
-    map.put(KEY_IN_MEMORY_DATABASE, databaseInfoProvider.isInMemory());
     map.put(KEY_TEXT_UTILS, TextUtils.INSTANCE);
     map.put(KEY_CURRENT_PAGE, getCookieValue(ServletActionContext.getRequest(), "currentPage"));
     map.put(KEY_CURRENT_KEY, getCookieValue(ServletActionContext.getRequest(), "currentKey"));

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/SpringSecurityActionAccessResolver.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/SpringSecurityActionAccessResolver.java
@@ -27,7 +27,19 @@
  */
 package org.hisp.dhis.security;
 
+import com.opensymphony.xwork2.config.Configuration;
+import com.opensymphony.xwork2.config.entities.ActionConfig;
+import com.opensymphony.xwork2.config.entities.PackageConfig;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.struts2.dispatcher.Dispatcher;
+import org.hisp.dhis.security.authority.RequiredAuthoritiesProvider;
+import org.springframework.security.access.AccessDecisionManager;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.SecurityMetadataSource;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * @author Torgeir Lorange Ostby
@@ -35,8 +47,80 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class SpringSecurityActionAccessResolver implements ActionAccessResolver {
+  // -------------------------------------------------------------------------
+  // Dependencies
+  // -------------------------------------------------------------------------
+
+  private RequiredAuthoritiesProvider requiredAuthoritiesProvider;
+
+  public void setRequiredAuthoritiesProvider(
+      RequiredAuthoritiesProvider requiredAuthoritiesProvider) {
+    this.requiredAuthoritiesProvider = requiredAuthoritiesProvider;
+  }
+
+  private AccessDecisionManager accessDecisionManager;
+
+  public void setAccessDecisionManager(AccessDecisionManager accessDecisionManager) {
+    this.accessDecisionManager = accessDecisionManager;
+  }
+
+  // -------------------------------------------------------------------------
+  // ActionAccessResolver implementation
+  // -------------------------------------------------------------------------
+
   @Override
   public boolean hasAccess(String module, String name) {
-    return true;
+    // ---------------------------------------------------------------------
+    // Get ObjectDefinitionSource
+    // ---------------------------------------------------------------------
+
+    Configuration config = Dispatcher.getInstance().getConfigurationManager().getConfiguration();
+
+    PackageConfig packageConfig = config.getPackageConfig(module);
+
+    if (packageConfig == null) {
+      throw new IllegalArgumentException("Module doesn't exist: '" + module + "'");
+    }
+
+    ActionConfig actionConfig = packageConfig.getActionConfigs().get(name);
+
+    if (actionConfig == null) {
+      throw new IllegalArgumentException(
+          "Module " + module + " doesn't have an action named: '" + name + "'");
+    }
+
+    SecurityMetadataSource securityMetadataSource =
+        requiredAuthoritiesProvider.createSecurityMetadataSource(actionConfig);
+
+    // ---------------------------------------------------------------------
+    // Test access
+    // ---------------------------------------------------------------------
+
+    SecurityContext securityContext = SecurityContextHolder.getContext();
+
+    Authentication authentication = securityContext.getAuthentication();
+
+    try {
+      if (securityMetadataSource.getAttributes(actionConfig) != null) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+          return false;
+        }
+
+        accessDecisionManager.decide(
+            authentication, actionConfig, securityMetadataSource.getAttributes(actionConfig));
+      }
+
+      log.debug("Access to [" + module + ", " + name + "]: TRUE");
+
+      return true;
+    } catch (AccessDeniedException e) {
+      log.debug("Access to [" + module + ", " + name + "]: FALSE (access denied)");
+
+      return false;
+    } catch (InsufficientAuthenticationException e) {
+      log.debug("Access to [" + module + ", " + name + "]: FALSE (insufficient authentication)");
+
+      return false;
+    }
   }
 }

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/AuthoritiesProviderConfig.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/AuthoritiesProviderConfig.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.security.config;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.appmanager.AppManager;
@@ -51,12 +50,8 @@ import org.hisp.dhis.security.authority.SimpleSystemAuthoritiesProvider;
 import org.hisp.dhis.security.intercept.LoginInterceptor;
 import org.hisp.dhis.security.intercept.XWorkSecurityInterceptor;
 import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationProvider;
-import org.hisp.dhis.security.vote.ActionAccessVoter;
-import org.hisp.dhis.security.vote.ModuleAccessVoter;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.webapi.security.ExternalAccessVoter;
-import org.hisp.dhis.webapi.security.vote.LogicalOrAccessDecisionManager;
-import org.hisp.dhis.webapi.security.vote.SimpleAccessVoter;
 import org.hisp.dhis.webportal.module.ModuleManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -65,10 +60,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.access.AccessDecisionManager;
-import org.springframework.security.access.vote.AuthenticatedVoter;
-import org.springframework.security.access.vote.UnanimousBased;
-import org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler;
-import org.springframework.security.web.access.expression.WebExpressionVoter;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
@@ -93,60 +84,9 @@ public class AuthoritiesProviderConfig {
 
   @Autowired private ExternalAccessVoter externalAccessVoter;
 
-  @Bean
-  public ActionAccessVoter actionAccessVoter() {
-    ActionAccessVoter voter = new ActionAccessVoter();
-    voter.setAttributePrefix("F_");
-    voter.setRequiredAuthoritiesKey("requiredAuthorities");
-    voter.setAnyAuthoritiesKey("anyAuthorities");
-    return voter;
-  }
-
-  @Bean
-  public ModuleAccessVoter moduleAccessVoter() {
-    ModuleAccessVoter voter = new ModuleAccessVoter();
-    voter.setAttributePrefix("M_");
-    voter.setAlwaysAccessible(
-        Set.of(
-            "dhis-web-commons-menu",
-            "dhis-web-commons-oust",
-            "dhis-web-commons-ouwt",
-            "dhis-web-commons-security",
-            "dhis-web-commons-i18n",
-            "dhis-web-commons-ajax",
-            "dhis-web-commons-ajax-json",
-            "dhis-web-commons-ajax-html",
-            "dhis-web-commons-stream",
-            "dhis-web-commons-help",
-            "dhis-web-commons-about",
-            "dhis-web-menu-management",
-            "dhis-web-apps",
-            "dhis-web-api-mobile",
-            "dhis-web-portal",
-            "dhis-web-uaa"));
-    return voter;
-  }
-
-  @Bean
-  public WebExpressionVoter webExpressionVoter() {
-    DefaultWebSecurityExpressionHandler h = new DefaultWebSecurityExpressionHandler();
-    h.setDefaultRolePrefix("");
-    WebExpressionVoter voter = new WebExpressionVoter();
-    voter.setExpressionHandler(h);
-    return voter;
-  }
-
-  @Bean("accessDecisionManager")
-  public LogicalOrAccessDecisionManager accessDecisionManager() {
-    List<AccessDecisionManager> decisionVoters =
-        Arrays.asList(
-            new UnanimousBased(List.of(new SimpleAccessVoter("ALL"))),
-            new UnanimousBased(List.of(actionAccessVoter(), moduleAccessVoter())),
-            new UnanimousBased(List.of(webExpressionVoter())),
-            new UnanimousBased(List.of(externalAccessVoter)),
-            new UnanimousBased(List.of(new AuthenticatedVoter())));
-    return new LogicalOrAccessDecisionManager(decisionVoters);
-  }
+  @Autowired
+  @Qualifier("accessDecisionManager")
+  public AccessDecisionManager accessDecisionManager;
 
   @Primary
   @Bean("org.hisp.dhis.security.SystemAuthoritiesProvider")
@@ -213,16 +153,14 @@ public class AuthoritiesProviderConfig {
 
   @Bean("org.hisp.dhis.security.intercept.XWorkSecurityInterceptor")
   public XWorkSecurityInterceptor xWorkSecurityInterceptor() throws Exception {
-    LogicalOrAccessDecisionManager accessDecisionManager = accessDecisionManager();
-
     DefaultRequiredAuthoritiesProvider provider = new DefaultRequiredAuthoritiesProvider();
     provider.setRequiredAuthoritiesKey("requiredAuthorities");
     provider.setAnyAuthoritiesKey("anyAuthorities");
     provider.setGlobalAttributes(Set.of("M_MODULE_ACCESS_VOTER_ENABLED"));
 
     SpringSecurityActionAccessResolver resolver = new SpringSecurityActionAccessResolver();
-    //    resolver.setRequiredAuthoritiesProvider(provider);
-    //    resolver.setAccessDecisionManager(accessDecisionManager);
+    resolver.setRequiredAuthoritiesProvider(provider);
+    resolver.setAccessDecisionManager(accessDecisionManager);
 
     XWorkSecurityInterceptor interceptor = new XWorkSecurityInterceptor();
     interceptor.setAccessDecisionManager(accessDecisionManager);

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/resources/META-INF/dhis/beans.xml
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/resources/META-INF/dhis/beans.xml
@@ -17,8 +17,8 @@
   </bean>
 
   <bean id="org.hisp.dhis.security.ActionAccessResolver" class="org.hisp.dhis.security.SpringSecurityActionAccessResolver">
-<!--    <property name="requiredAuthoritiesProvider" ref="org.hisp.dhis.security.authority.RequiredAuthoritiesProvider" />-->
-<!--    <property name="accessDecisionManager" ref="accessDecisionManager" />-->
+    <property name="requiredAuthoritiesProvider" ref="org.hisp.dhis.security.authority.RequiredAuthoritiesProvider" />
+    <property name="accessDecisionManager" ref="accessDecisionManager" />
   </bean>
 
   <bean id="org.hisp.dhis.webportal.module.ModuleManager" class="org.hisp.dhis.webportal.module.DefaultModuleManager">
@@ -459,6 +459,9 @@
   <bean id="org.hisp.dhis.interceptor.SystemSettingInterceptor" class="org.hisp.dhis.interceptor.SystemSettingInterceptor">
     <property name="systemSettingManager" ref="org.hisp.dhis.setting.SystemSettingManager" />
     <property name="configurationService" ref="org.hisp.dhis.configuration.ConfigurationService" />
+  </bean>
+
+  <bean id="org.hisp.dhis.interceptor.ContextInterceptor" class="org.hisp.dhis.interceptor.ContextInterceptor">
   </bean>
 
   <bean id="org.hisp.dhis.interceptor.CacheInterceptor" class="org.hisp.dhis.interceptor.CacheInterceptor" />


### PR DESCRIPTION
### Summary
Fixes regression introduced with the UserDetails refactoring, causing the menu items to skip filtering on permissions. 
This was done in order to migrate away from Struts, but was not added back when we reverted those changes.
As you can see, there is a very convoluted way of doing this filtering, most of it is legacy code also used for other related functionality in Struts world. This will to be completely rewritten when we remove Struts in 2.42.

## Manual test
1. Create a user with only access to the Dashboard app. and another app.
2. Log in with the new user and observe the app menu shows the app it was granted access to and nothing else. Note the "Menu management" app. is allowed by default.

## Automatic test
N/A
(We currently don't have any framework in place for testing Struts actions with unit tests. This functionality is only available by calling a Struts action. This might be a good candidate for a UI test with selenium, now available in the E2E test module)
