### PR TITLE
chore: backport #36fe83e E6305 exception return when patch ADE

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/AggregateDataExchangeObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/AggregateDataExchangeObjectBundleHook.java
@@ -147,7 +147,7 @@ public class AggregateDataExchangeObjectBundleHook
           new ErrorReport(AggregateDataExchange.class, ErrorCode.E4000, "target.api.url"));
     }
 
-    if (api != null && !(api.isAccessTokenAuth() || api.isBasicAuth())) {
+    if (exchange.getId() == 0 && api != null && !(api.isAccessTokenAuth() || api.isBasicAuth())) {
       addReports.accept(new ErrorReport(AggregateDataExchange.class, ErrorCode.E6305));
     }
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
@@ -404,4 +404,64 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest {
     JsonResponse optionSet = GET("/optionSets/{uid}", "RHqFlB1Wm4d").content(HttpStatus.OK);
     assertTrue(optionSet.get("createdBy").exists());
   }
+
+  @Test
+  @DisplayName(
+      "Should return error in import report if deleting object is referenced by other object")
+  void testDeleteWithException() {
+    POST("{'optionSets':\n"
+            + "    [{'name': 'Device category','id': 'RHqFlB1Wm4d','version': 2,'valueType': 'TEXT'}]\n"
+            + ",'dataElements':\n"
+            + "[{'name':'test DataElement with OptionSet', 'shortName':'test DataElement', 'aggregationType':'SUM','domainType':'AGGREGATE','categoryCombo':{'id':'bjDvmb4bfuf'},'valueType':'NUMBER','optionSet':{'id':'RHqFlB1Wm4d'}\n"
+            + "}]}")
+        .content(HttpStatus.OK);
+    JsonImportSummary report =
+        POST(
+                "/metadata?importStrategy=DELETE",
+                "{'optionSets':"
+                    + "[{'name': 'Device category','id': 'RHqFlB1Wm4d','version': 2,'valueType': 'TEXT'}]}")
+            .content(HttpStatus.CONFLICT)
+            .get("response")
+            .as(JsonImportSummary.class);
+    assertEquals(0, report.getStats().getDeleted());
+    assertEquals(1, report.getStats().getIgnored());
+    assertEquals(
+        "Object could not be deleted because it is associated with another object: DataElement",
+        report
+            .find(
+                JsonErrorReport.class, errorReport -> errorReport.getErrorCode() == ErrorCode.E4030)
+            .getMessage());
+  }
+
+  @Test()
+  @DisplayName("Should not return error E6305 when PATCH any property of an AggregateDataExchange")
+  void testPatchAggregateDataExchange() {
+    POST("/metadata/", Body("metadata/aggregate_data_exchange.json")).content(HttpStatus.OK);
+    PATCH(
+            "/aggregateDataExchanges/PnWccbwCJLQ",
+            Body(
+                "[{'op': 'replace', 'path': '/name', 'value': 'External basic auth data exchange updated'}]"))
+        .content(HttpStatus.OK);
+
+    JsonObject object =
+        GET("/aggregateDataExchanges/PnWccbwCJLQ").content(HttpStatus.OK).as(JsonObject.class);
+    assertEquals("External basic auth data exchange updated", object.getString("name").string());
+  }
+
+  @Test
+  @DisplayName(
+      "Should return error E6305 if create a new AggregateDataExchange without authentication details")
+  void testCreateAggregateDataExchangeWithoutAuthentication() {
+    JsonImportSummary report =
+        POST("/metadata/", Body("metadata/aggregate_data_exchange_no_auth.json"))
+            .content(HttpStatus.CONFLICT)
+            .get("response")
+            .as(JsonImportSummary.class);
+    assertEquals(
+        "Aggregate data exchange target API must specify either access token or username and password",
+        report
+            .find(
+                JsonErrorReport.class, errorReport -> errorReport.getErrorCode() == ErrorCode.E6305)
+            .getMessage());
+  }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
@@ -405,34 +405,6 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest {
     assertTrue(optionSet.get("createdBy").exists());
   }
 
-  @Test
-  @DisplayName(
-      "Should return error in import report if deleting object is referenced by other object")
-  void testDeleteWithException() {
-    POST("{'optionSets':\n"
-            + "    [{'name': 'Device category','id': 'RHqFlB1Wm4d','version': 2,'valueType': 'TEXT'}]\n"
-            + ",'dataElements':\n"
-            + "[{'name':'test DataElement with OptionSet', 'shortName':'test DataElement', 'aggregationType':'SUM','domainType':'AGGREGATE','categoryCombo':{'id':'bjDvmb4bfuf'},'valueType':'NUMBER','optionSet':{'id':'RHqFlB1Wm4d'}\n"
-            + "}]}")
-        .content(HttpStatus.OK);
-    JsonImportSummary report =
-        POST(
-                "/metadata?importStrategy=DELETE",
-                "{'optionSets':"
-                    + "[{'name': 'Device category','id': 'RHqFlB1Wm4d','version': 2,'valueType': 'TEXT'}]}")
-            .content(HttpStatus.CONFLICT)
-            .get("response")
-            .as(JsonImportSummary.class);
-    assertEquals(0, report.getStats().getDeleted());
-    assertEquals(1, report.getStats().getIgnored());
-    assertEquals(
-        "Object could not be deleted because it is associated with another object: DataElement",
-        report
-            .find(
-                JsonErrorReport.class, errorReport -> errorReport.getErrorCode() == ErrorCode.E4030)
-            .getMessage());
-  }
-
   @Test()
   @DisplayName("Should not return error E6305 when PATCH any property of an AggregateDataExchange")
   void testPatchAggregateDataExchange() {

--- a/dhis-2/dhis-test-web-api/src/test/resources/metadata/aggregate_data_exchange.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/metadata/aggregate_data_exchange.json
@@ -1,0 +1,180 @@
+{
+  "dataElements": [
+    {
+      "id": "fbfJHSPpUQD",
+      "code": "DEA",
+      "name": "DEA",
+      "shortName": "DEA",
+      "aggregationType": "SUM",
+      "domainType": "AGGREGATE",
+      "valueType": "INTEGER"
+    },
+    {
+      "id": "cYeuwXTCPkU",
+      "code": "DEB",
+      "name": "DEB",
+      "shortName": "DEB",
+      "aggregationType": "SUM",
+      "domainType": "AGGREGATE",
+      "valueType": "INTEGER"
+    }
+  ],
+  "organisationUnits": [
+    {
+      "id": "ImspTQPwCqd",
+      "code": "OUA",
+      "name": "OUA",
+      "shortName": "OUA",
+      "openingDate": "2010-01-01"
+    }
+  ],
+  "aggregateDataExchanges": [
+    {
+      "id": "iFOyIpQciyk",
+      "name": "Internal data exchange",
+      "source": {
+        "params": {
+          "periodTypes": [
+            "MONTHLY",
+            "QUARTERLY"
+          ]
+        },
+        "requests": [
+          {
+            "name": "HIV",
+            "visualization": "kV2trY4bu9p",
+            "dx": [
+              "fbfJHSPpUQD",
+              "cYeuwXTCPkU"
+            ],
+            "pe": [
+              "LAST_12_MONTHS",
+              "202201"
+            ],
+            "ou": [
+              "ImspTQPwCqd"
+            ],
+            "inputIdScheme": "UID",
+            "outputDataElementIdScheme": "UID",
+            "outputOrgUnitIdScheme": "UID",
+            "outputDataItemIdScheme": "UID",
+            "outputIdScheme": "UID"
+          }
+        ]
+      },
+      "target": {
+        "type": "INTERNAL",
+        "request": {
+          "dataElementIdScheme": null,
+          "orgUnitIdScheme": null,
+          "categoryOptionComboIdScheme": null,
+          "idScheme": null,
+          "importStrategy": "CREATE_AND_UPDATE",
+          "skipAudit": false,
+          "dryRun": false
+        }
+      }
+    },
+    {
+      "id": "PnWccbwCJLQ",
+      "name": "External basic auth data exchange",
+      "source": {
+        "params": {
+          "periodTypes": [
+            "MONTHLY",
+            "QUARTERLY"
+          ]
+        },
+        "requests": [
+          {
+            "name": "TB",
+            "visualization": "BjQYD1mOQLb",
+            "dx": [
+              "fbfJHSPpUQD",
+              "cYeuwXTCPkU"
+            ],
+            "pe": [
+              "LAST_3_MONTHS",
+              "202202"
+            ],
+            "ou": [
+              "ImspTQPwCqd"
+            ],
+            "inputIdScheme": "UID",
+            "outputDataElementIdScheme": "UID",
+            "outputOrgUnitIdScheme": "UID",
+            "outputDataItemIdScheme": "UID",
+            "outputIdScheme": "UID"
+          }
+        ]
+      },
+      "target": {
+        "type": "EXTERNAL",
+        "api": {
+          "url": "https://play.dhis2.org/2.38.1",
+          "username": "admin",
+          "password": "district"
+        },
+        "request": {
+          "dataElementIdScheme": "UID",
+          "orgUnitIdScheme": "UID",
+          "categoryOptionComboIdScheme": "UID",
+          "idScheme": "UID",
+          "importStrategy": "CREATE_AND_UPDATE",
+          "skipAudit": false,
+          "dryRun": false
+        }
+      }
+    },
+    {
+      "id": "VpQ4qVEseyM",
+      "name": "External access token data exchange",
+      "source": {
+        "params": {
+          "periodTypes": [
+            "MONTHLY",
+            "QUARTERLY"
+          ]
+        },
+        "requests": [
+          {
+            "name": "Malaria",
+            "visualization": "DOL6ai1VCsL",
+            "dx": [
+              "fbfJHSPpUQD",
+              "cYeuwXTCPkU"
+            ],
+            "pe": [
+              "LAST_3_MONTHS",
+              "202202"
+            ],
+            "ou": [
+              "ImspTQPwCqd"
+            ],
+            "inputIdScheme": "UID",
+            "outputDataElementIdScheme": "UID",
+            "outputOrgUnitIdScheme": "UID",
+            "outputDataItemIdScheme": "UID",
+            "outputIdScheme": "UID"
+          }
+        ]
+      },
+      "target": {
+        "type": "EXTERNAL",
+        "api": {
+          "url": "https://play.dhis2.org/2.38.1",
+          "accessToken": "d2pat_fjx18dy0iB6nJybPxGSVsoagGtrXMAVn1162422598"
+        },
+        "request": {
+          "dataElementIdScheme": "UID",
+          "orgUnitIdScheme": "UID",
+          "categoryOptionComboIdScheme": "UID",
+          "idScheme": "UID",
+          "importStrategy": "CREATE_AND_UPDATE",
+          "skipAudit": false,
+          "dryRun": false
+        }
+      }
+    }
+  ]
+}

--- a/dhis-2/dhis-test-web-api/src/test/resources/metadata/aggregate_data_exchange_no_auth.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/metadata/aggregate_data_exchange_no_auth.json
@@ -1,0 +1,178 @@
+{
+  "dataElements": [
+    {
+      "id": "fbfJHSPpUQD",
+      "code": "DEA",
+      "name": "DEA",
+      "shortName": "DEA",
+      "aggregationType": "SUM",
+      "domainType": "AGGREGATE",
+      "valueType": "INTEGER"
+    },
+    {
+      "id": "cYeuwXTCPkU",
+      "code": "DEB",
+      "name": "DEB",
+      "shortName": "DEB",
+      "aggregationType": "SUM",
+      "domainType": "AGGREGATE",
+      "valueType": "INTEGER"
+    }
+  ],
+  "organisationUnits": [
+    {
+      "id": "ImspTQPwCqd",
+      "code": "OUA",
+      "name": "OUA",
+      "shortName": "OUA",
+      "openingDate": "2010-01-01"
+    }
+  ],
+  "aggregateDataExchanges": [
+    {
+      "id": "iFOyIpQciyk",
+      "name": "Internal data exchange",
+      "source": {
+        "params": {
+          "periodTypes": [
+            "MONTHLY",
+            "QUARTERLY"
+          ]
+        },
+        "requests": [
+          {
+            "name": "HIV",
+            "visualization": "kV2trY4bu9p",
+            "dx": [
+              "fbfJHSPpUQD",
+              "cYeuwXTCPkU"
+            ],
+            "pe": [
+              "LAST_12_MONTHS",
+              "202201"
+            ],
+            "ou": [
+              "ImspTQPwCqd"
+            ],
+            "inputIdScheme": "UID",
+            "outputDataElementIdScheme": "UID",
+            "outputOrgUnitIdScheme": "UID",
+            "outputDataItemIdScheme": "UID",
+            "outputIdScheme": "UID"
+          }
+        ]
+      },
+      "target": {
+        "type": "INTERNAL",
+        "request": {
+          "dataElementIdScheme": null,
+          "orgUnitIdScheme": null,
+          "categoryOptionComboIdScheme": null,
+          "idScheme": null,
+          "importStrategy": "CREATE_AND_UPDATE",
+          "skipAudit": false,
+          "dryRun": false
+        }
+      }
+    },
+    {
+      "id": "PnWccbwCJLQ",
+      "name": "External basic auth data exchange",
+      "source": {
+        "params": {
+          "periodTypes": [
+            "MONTHLY",
+            "QUARTERLY"
+          ]
+        },
+        "requests": [
+          {
+            "name": "TB",
+            "visualization": "BjQYD1mOQLb",
+            "dx": [
+              "fbfJHSPpUQD",
+              "cYeuwXTCPkU"
+            ],
+            "pe": [
+              "LAST_3_MONTHS",
+              "202202"
+            ],
+            "ou": [
+              "ImspTQPwCqd"
+            ],
+            "inputIdScheme": "UID",
+            "outputDataElementIdScheme": "UID",
+            "outputOrgUnitIdScheme": "UID",
+            "outputDataItemIdScheme": "UID",
+            "outputIdScheme": "UID"
+          }
+        ]
+      },
+      "target": {
+        "type": "EXTERNAL",
+        "api": {
+          "url": "https://play.dhis2.org/2.38.1"
+        },
+        "request": {
+          "dataElementIdScheme": "UID",
+          "orgUnitIdScheme": "UID",
+          "categoryOptionComboIdScheme": "UID",
+          "idScheme": "UID",
+          "importStrategy": "CREATE_AND_UPDATE",
+          "skipAudit": false,
+          "dryRun": false
+        }
+      }
+    },
+    {
+      "id": "VpQ4qVEseyM",
+      "name": "External access token data exchange",
+      "source": {
+        "params": {
+          "periodTypes": [
+            "MONTHLY",
+            "QUARTERLY"
+          ]
+        },
+        "requests": [
+          {
+            "name": "Malaria",
+            "visualization": "DOL6ai1VCsL",
+            "dx": [
+              "fbfJHSPpUQD",
+              "cYeuwXTCPkU"
+            ],
+            "pe": [
+              "LAST_3_MONTHS",
+              "202202"
+            ],
+            "ou": [
+              "ImspTQPwCqd"
+            ],
+            "inputIdScheme": "UID",
+            "outputDataElementIdScheme": "UID",
+            "outputOrgUnitIdScheme": "UID",
+            "outputDataItemIdScheme": "UID",
+            "outputIdScheme": "UID"
+          }
+        ]
+      },
+      "target": {
+        "type": "EXTERNAL",
+        "api": {
+          "url": "https://play.dhis2.org/2.38.1",
+          "accessToken": "d2pat_fjx18dy0iB6nJybPxGSVsoagGtrXMAVn1162422598"
+        },
+        "request": {
+          "dataElementIdScheme": "UID",
+          "orgUnitIdScheme": "UID",
+          "categoryOptionComboIdScheme": "UID",
+          "idScheme": "UID",
+          "importStrategy": "CREATE_AND_UPDATE",
+          "skipAudit": false,
+          "dryRun": false
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Backport fix which allows AggregateDataExchanges to be updated without re-inputting a password/token. 