### PR TITLE
fix: programStatus/enrollmentStatus/eventStatus parameters can now be used without specifying a value [DHIS2-16800]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/context/querybuilder/StatusQueryBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/context/querybuilder/StatusQueryBuilder.java
@@ -51,6 +51,7 @@ import org.hisp.dhis.analytics.tei.query.StatusCondition;
 import org.hisp.dhis.analytics.tei.query.context.sql.QueryContext;
 import org.hisp.dhis.analytics.tei.query.context.sql.RenderableSqlQuery;
 import org.hisp.dhis.analytics.tei.query.context.sql.SqlQueryBuilderAdaptor;
+import org.hisp.dhis.analytics.tei.query.context.sql.SqlQueryBuilders;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -99,6 +100,7 @@ public class StatusQueryBuilder extends SqlQueryBuilderAdaptor {
         .forEach(builder::selectField);
 
     acceptedDimensions.stream()
+        .filter(SqlQueryBuilders::hasRestrictions)
         .map(
             dimensionIdentifier ->
                 GroupableCondition.of(

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TrackedEntityQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TrackedEntityQueryTest.java
@@ -3183,4 +3183,23 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
         .body("headers[0].name", equalTo("J5jldMd8OHv"))
         .body("headers[0].column", equalTo("Facility Type"));
   }
+
+  @Test
+  public void testProgramStatusAsDimensionNoValue() {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("programStatus=IpHINAT79UW")
+            .add("headers=IpHINAT79UW.programstatus")
+            .add("pageSize=0");
+
+    // When
+    ApiResponse response = analyticsTeiActions.query().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers[0].column", equalTo("Program Status, Child Programme"));
+  }
 }


### PR DESCRIPTION
This PR is to allow parameter like:

- `programStatus=IpHINAT79UW`

to be a valid dimensionIdentifier