### PR TITLE
fix: Tracked entity analytics row context returning invalid "not defined"[DHIS2-16886]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/RenderableDataValueIndicator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/RenderableDataValueIndicator.java
@@ -50,7 +50,8 @@ public class RenderableDataValueIndicator extends BaseRenderable {
                 List.of(
                     IsNotNullCondition.of(
                         () -> doubleQuote(dimensionIdentifier.getProgram().toString())),
-                    IsNotNullCondition.of(() -> doubleQuote(dimensionIdentifier.getPrefix())),
+                    IsNotNullCondition.of(
+                        () -> doubleQuote(dimensionIdentifier.getPrefix()) + "::varchar"),
                     Field.of(
                         doubleQuote(dimensionIdentifier.getPrefix()),
                         () -> "eventdatavalues",


### PR DESCRIPTION
There is an issue with handling JSON objects, particularly when testing for null values. It seems that the 'is not null' implementation might not cover all scenarios. For instance, in certain situations (details of which are unknown to me), checking if <<"IpHINAT79UW.A03MvHHogjR" is not null>> yields the same result as <<"IpHINAT79UW.A03MvHHogjR" is null>>.

A potential solution is to cast the JSONB object to varchar ("IpHINAT79UW.A03MvHHogjR"::varchar is not null).