### PR TITLE
feat: contains and containsItems [DHIS2-16211]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ParserUtils.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ParserUtils.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.parser.expression;
 
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.AMPERSAND_2;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.AND;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.CONTAINS;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.CONTAINS_ITEMS;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.C_BRACE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.DIV;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.EQ;
@@ -66,6 +68,8 @@ import java.util.Date;
 import org.hisp.dhis.analytics.DataType;
 import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
 import org.hisp.dhis.parser.expression.dataitem.ItemConstant;
+import org.hisp.dhis.parser.expression.function.FunctionContains;
+import org.hisp.dhis.parser.expression.function.FunctionContainsItems;
 import org.hisp.dhis.parser.expression.function.FunctionFirstNonNull;
 import org.hisp.dhis.parser.expression.function.FunctionGreatest;
 import org.hisp.dhis.parser.expression.function.FunctionIf;
@@ -140,6 +144,8 @@ public class ParserUtils {
 
           // Functions (alphabetical)
 
+          .put(CONTAINS, new FunctionContains())
+          .put(CONTAINS_ITEMS, new FunctionContainsItems())
           .put(FIRST_NON_NULL, new FunctionFirstNonNull())
           .put(GREATEST, new FunctionGreatest())
           .put(IF, new FunctionIf())

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionContains.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionContains.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.parser.expression.function;
+
+import static java.util.stream.Collectors.toList;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.parser.expression.ExpressionItem;
+
+/**
+ * Function contains
+ *
+ * <p>returns true the first argument contains all other arguments as substrings.
+ *
+ * @author Jim Grace
+ */
+public class FunctionContains implements ExpressionItem {
+  @Override
+  public Object evaluate(ExprContext ctx, CommonExpressionVisitor visitor) {
+    String arg0 = visitor.castStringVisit(ctx.expr(0));
+    List<String> searches = getCodes(ctx, visitor);
+    return searches.stream().allMatch(s -> arg0.contains(s));
+  }
+
+  @Override
+  public Object getSql(ExprContext ctx, CommonExpressionVisitor visitor) {
+    String arg0 = visitor.castStringVisit(ctx.expr(0));
+    List<String> searches = getCodes(ctx, visitor);
+    String tests =
+        searches.stream()
+            .map(s -> "position(" + s + " in " + arg0 + ")>0")
+            .collect(Collectors.joining(" and "));
+    return "(" + tests + ")";
+  }
+
+  // -------------------------------------------------------------------------
+  // Supportive methods
+  // -------------------------------------------------------------------------
+
+  /** Gets the codes (second expr argument and following) as strings. */
+  private List<String> getCodes(ExprContext ctx, CommonExpressionVisitor visitor) {
+    return ctx.expr().stream().skip(1).map(visitor::castStringVisit).collect(toList());
+  }
+}

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionContains.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionContains.java
@@ -47,7 +47,7 @@ public class FunctionContains implements ExpressionItem {
   public Object evaluate(ExprContext ctx, CommonExpressionVisitor visitor) {
     String arg0 = visitor.castStringVisit(ctx.expr(0));
     List<String> searches = getCodes(ctx, visitor);
-    return searches.stream().allMatch(s -> arg0.contains(s));
+    return searches.stream().allMatch(arg0::contains);
   }
 
   @Override
@@ -67,6 +67,6 @@ public class FunctionContains implements ExpressionItem {
 
   /** Gets the codes (second expr argument and following) as strings. */
   private List<String> getCodes(ExprContext ctx, CommonExpressionVisitor visitor) {
-    return ctx.expr().stream().skip(1).map(visitor::castStringVisit).collect(toList());
+    return ctx.expr().stream().skip(1).map(visitor::castStringVisit).toList();
   }
 }

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionContains.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionContains.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.parser.expression.function;
 
-import static java.util.stream.Collectors.toList;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 
 import java.util.List;

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionContainsItems.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionContainsItems.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.parser.expression.function;
 
-import static java.util.stream.Collectors.toList;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 
 import java.util.List;

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionContainsItems.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionContainsItems.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.parser.expression.function;
+
+import static java.util.stream.Collectors.toList;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.parser.expression.ExpressionItem;
+
+/**
+ * Function containsItems
+ *
+ * <p>The first argument is split into tokens separated by the comma character ",". The function
+ * returns true if all subsequent arguments are an exact match for one of the tokens.
+ *
+ * @author Jim Grace
+ */
+public class FunctionContainsItems implements ExpressionItem {
+  @Override
+  public Object evaluate(ExprContext ctx, CommonExpressionVisitor visitor) {
+    Set<String> values = Set.of(visitor.castStringVisit(ctx.expr(0)).split(","));
+    List<String> searches = getCodes(ctx, visitor);
+    return values.containsAll(searches);
+  }
+
+  @Override
+  public Object getSql(ExprContext ctx, CommonExpressionVisitor visitor) {
+    String values = visitor.castStringVisit(ctx.expr(0));
+    String searches = getCodes(ctx, visitor).stream().collect(Collectors.joining(","));
+    return "(regexp_split_to_array(" + values + ",',') @> ARRAY[" + searches + "])";
+  }
+
+  // -------------------------------------------------------------------------
+  // Supportive methods
+  // -------------------------------------------------------------------------
+
+  /** Gets the codes (second expr argument and following) as strings. */
+  private List<String> getCodes(ExprContext ctx, CommonExpressionVisitor visitor) {
+    return ctx.expr().stream().skip(1).map(visitor::castStringVisit).collect(toList());
+  }
+}

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionContainsItems.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionContainsItems.java
@@ -65,6 +65,6 @@ public class FunctionContainsItems implements ExpressionItem {
 
   /** Gets the codes (second expr argument and following) as strings. */
   private List<String> getCodes(ExprContext ctx, CommonExpressionVisitor visitor) {
-    return ctx.expr().stream().skip(1).map(visitor::castStringVisit).collect(toList());
+    return ctx.expr().stream().skip(1).map(visitor::castStringVisit).toList();
   }
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -2340,6 +2340,16 @@ public abstract class DhisConvenienceTest {
     return option;
   }
 
+  public static Option createOption(String code) {
+    Option option = new Option();
+    option.setAutoFields();
+
+    option.setName("Option" + code);
+    option.setCode(code);
+
+    return option;
+  }
+
   public static void configureHierarchy(
       OrganisationUnit root,
       OrganisationUnit lvlOneLeft,

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
@@ -48,6 +48,7 @@ import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getList;
 import static org.hisp.dhis.common.ValueType.INTEGER;
+import static org.hisp.dhis.common.ValueType.MULTI_TEXT;
 import static org.hisp.dhis.common.ValueType.ORGANISATION_UNIT;
 import static org.hisp.dhis.common.ValueType.TEXT;
 import static org.hisp.dhis.period.PeriodType.getPeriodTypeByName;
@@ -91,10 +92,16 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.RequestTypeAware;
+import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dxf2.deprecated.tracker.event.EventStore;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
+import org.hisp.dhis.feedback.ConflictException;
+import org.hisp.dhis.option.Option;
+import org.hisp.dhis.option.OptionService;
+import org.hisp.dhis.option.OptionSet;
+import org.hisp.dhis.option.OptionStore;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitLevel;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
@@ -142,6 +149,10 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
   @Autowired private DataElementService dataElementService;
 
   @Autowired private OrganisationUnitService organisationUnitService;
+
+  @Autowired private OptionStore optionStore;
+
+  @Autowired private OptionService optionService;
 
   @Autowired private AnalyticsTableGenerator analyticsTableGenerator;
 
@@ -215,6 +226,8 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
 
   private DataElement deB;
 
+  private DataElement deM;
+
   private DataElement deU;
 
   private TrackedEntityAttribute atU;
@@ -247,7 +260,7 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
   }
 
   @Override
-  public void setUpTest() throws IOException, InterruptedException {
+  public void setUpTest() throws IOException, InterruptedException, ConflictException {
     userService = _userService;
 
     // Organisation Units
@@ -345,6 +358,19 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
     Date feb15Noon = new GregorianCalendar(2017, FEBRUARY, 15, 12, 0).getTime();
     Date mar15 = new GregorianCalendar(2017, MARCH, 15).getTime();
 
+    // Options and option Sets
+    Option oAbc = createOption("abc");
+    Option oDef = createOption("def");
+    Option oGhi = createOption("ghi");
+    Option oJkl = createOption("jkl");
+
+    OptionSet osA = createOptionSet('A', oAbc, oDef, oGhi, oJkl);
+    osA.setValueType(ValueType.MULTI_TEXT);
+
+    osA.getOptions().forEach(optionStore::save);
+
+    optionService.saveOptionSet(osA);
+
     // Data Elements
     deA = createDataElement('A', INTEGER, SUM);
     deA.setUid("deInteger0A");
@@ -353,6 +379,11 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
     deB = createDataElement('B', TEXT, NONE);
     deB.setUid("deText0000B");
     dataElementService.addDataElement(deB);
+
+    deM = createDataElement('M', MULTI_TEXT, NONE);
+    deM.setUid("deMultTextM");
+    deM.setOptionSet(osA);
+    dataElementService.addDataElement(deM);
 
     deU = createDataElement('U', ORGANISATION_UNIT, NONE);
     deU.setUid("deOrgUnit0U");
@@ -369,6 +400,7 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
     psB.setUid("progrStageB");
     psB.addDataElement(deA, 1);
     psB.addDataElement(deB, 2);
+    psB.addDataElement(deM, 3);
     idObjectManager.save(psB);
 
     // Programs
@@ -524,10 +556,17 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
         Set.of(new EventDataValue(deA.getUid(), "80"), new EventDataValue(deB.getUid(), "H")));
     eventB8.setAttributeOptionCombo(cocDefault);
 
+    Event eventM1 = createEvent(psB, piB, ouI);
+    eventM1.setScheduledDate(jan15);
+    eventM1.setOccurredDate(jan15);
+    eventM1.setUid("event0000M1");
+    eventM1.setEventDataValues(Set.of(new EventDataValue(deM.getUid(), "abc,def,ghi,jkl")));
+    eventM1.setAttributeOptionCombo(cocDefault);
+
     saveEvents(
         List.of(
             eventA1, eventA2, eventA3, eventB1, eventB2, eventB3, eventB4, eventB5, eventB6,
-            eventB7, eventB8));
+            eventB7, eventB8, eventM1));
 
     // Users
     userA = createUserWithAuth("A", "F_VIEW_EVENT_ANALYTICS");
@@ -1258,6 +1297,76 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
   }
 
   // -------------------------------------------------------------------------
+  // Test program indicators with contains()
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testProgramIndicatorContains() {
+    assertGridContains(
+        // Headers
+        List.of("pe", "ou", "value"),
+        // Grid
+        List.of(List.of("201701", "ouabcdefghA", "1.0"), List.of("201701", "ouabcdefghI", "1.0")),
+        getTestAggregatedGrid("if(contains(#{progrStageB.deMultTextM},'abc','ghi'),1,2)"));
+
+    assertGridContains(
+        // Headers
+        List.of("pe", "ou", "value"),
+        // Grid
+        List.of(List.of("201701", "ouabcdefghA", "2.0"), List.of("201701", "ouabcdefghI", "2.0")),
+        getTestAggregatedGrid("if(contains(#{progrStageB.deMultTextM},'xyz'),1,2)"));
+
+    assertGridContains(
+        // Headers
+        List.of("pe", "ou", "value"),
+        // Grid
+        List.of(List.of("201701", "ouabcdefghA", "1.0"), List.of("201701", "ouabcdefghI", "1.0")),
+        getTestAggregatedGrid("if(contains(#{progrStageB.deMultTextM},'ab'),1,2)"));
+
+    assertGridContains(
+        // Headers
+        List.of("pe", "ou", "value"),
+        // Grid
+        List.of(List.of("201701", "ouabcdefghA", "1.0"), List.of("201701", "ouabcdefghI", "1.0")),
+        getTestAggregatedGrid("if(contains(#{progrStageB.deMultTextM},'c,d'),1,2)"));
+  }
+
+  // -------------------------------------------------------------------------
+  // Test program indicators with containsItems()
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testProgramIndicatorContainsItems() {
+    assertGridContains(
+        // Headers
+        List.of("pe", "ou", "value"),
+        // Grid
+        List.of(List.of("201701", "ouabcdefghA", "1.0"), List.of("201701", "ouabcdefghI", "1.0")),
+        getTestAggregatedGrid("if(containsItems(#{progrStageB.deMultTextM},'abc','ghi'),1,2)"));
+
+    assertGridContains(
+        // Headers
+        List.of("pe", "ou", "value"),
+        // Grid
+        List.of(List.of("201701", "ouabcdefghA", "2.0"), List.of("201701", "ouabcdefghI", "2.0")),
+        getTestAggregatedGrid("if(containsItems(#{progrStageB.deMultTextM},'xyz'),1,2)"));
+
+    assertGridContains(
+        // Headers
+        List.of("pe", "ou", "value"),
+        // Grid
+        List.of(List.of("201701", "ouabcdefghA", "2.0"), List.of("201701", "ouabcdefghI", "2.0")),
+        getTestAggregatedGrid("if(containsItems(#{progrStageB.deMultTextM},'ab'),1,2)"));
+
+    assertGridContains(
+        // Headers
+        List.of("pe", "ou", "value"),
+        // Grid
+        List.of(List.of("201701", "ouabcdefghA", "2.0"), List.of("201701", "ouabcdefghI", "2.0")),
+        getTestAggregatedGrid("if(containsItems(#{progrStageB.deMultTextM},'c,d'),1,2)"));
+  }
+
+  // -------------------------------------------------------------------------
   // Supportive test methods
   // -------------------------------------------------------------------------
 
@@ -1301,12 +1410,17 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
         .addDimension(periodDimension);
   }
 
-  /** Gets a grid to test aggregation types */
+  /** Gets a grid for a PI specifying expression */
+  private Grid getTestAggregatedGrid(String expression) {
+    return getTestAggregatedGrid(expression, SUM);
+  }
+
+  /** Gets a grid for a PI specifying aggregation type */
   private Grid getTestAggregatedGrid(AggregationType aggregationType) {
     return getTestAggregatedGrid("#{progrStageB.deInteger0A}", aggregationType);
   }
 
-  /** Gets a grid to test aggregation types with a custom expression */
+  /** Gets a grid for a PI specifying expression and aggregation type */
   private Grid getTestAggregatedGrid(String expression, AggregationType aggregationType) {
     ProgramIndicator pi = createProgramIndicatorB(EVENT, expression, null, aggregationType);
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -1341,6 +1341,26 @@ class ExpressionServiceTest extends SingleSetupIntegrationTestBase {
   }
 
   @Test
+  void testContains() {
+    assertTrue(evalBoolean("contains('ab,cd,ef','ab')"));
+    assertTrue(evalBoolean("contains('ab,cd,ef','ef', 'cd', 'ab')"));
+    assertTrue(evalBoolean("contains('ab,cd,ef','b,c')"));
+    assertTrue(evalBoolean("contains('ab,cd,ef','a')"));
+    assertFalse(evalBoolean("contains('ab,cd,ef','ac')"));
+    assertFalse(evalBoolean("contains('ab,cd,ef','xy')"));
+  }
+
+  @Test
+  void testContainsItems() {
+    assertTrue(evalBoolean("containsItems('ab,cd,ef','ab')"));
+    assertTrue(evalBoolean("containsItems('ab,cd,ef','ef', 'cd', 'ab')"));
+    assertFalse(evalBoolean("containsItems('ab,cd,ef','b,c')"));
+    assertFalse(evalBoolean("containsItems('ab,cd,ef','a')"));
+    assertFalse(evalBoolean("containsItems('ab,cd,ef','ac')"));
+    assertFalse(evalBoolean("containsItems('ab,cd,ef','xy')"));
+  }
+
+  @Test
   void testGetExpressionDescription() {
     assertEquals("DeA", desc("#{dataElemenA}"));
     assertEquals(

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -236,7 +236,7 @@
     <spotless.version>2.43.0</spotless.version>
     <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
     <jrebel-x-maven-plugin.version>1.2.0</jrebel-x-maven-plugin.version>
-    <dhis-antlr-expression-parser.version>1.0.34</dhis-antlr-expression-parser.version>
+    <dhis-antlr-expression-parser.version>1.0.36</dhis-antlr-expression-parser.version>
     <jai-imageio.version>1.1.1</jai-imageio.version>
     <gson.version>2.8.9</gson.version>
     <semver4j.version>3.1.0</semver4j.version>


### PR DESCRIPTION
This PR adds two expression functions:

`contains(expr, ...)` returns true if the first expr contains each of the following expressions as a substring.

`containsItems(expr, ...)` returns true if the first expr is split into tokens separated by commas, and each of the following expressions exactly matches one of the tokens.

See [DHIS2-16211](https://dhis2.atlassian.net/browse/DHIS2-16211) for more details and examples.

[DHIS2-16211]: https://dhis2.atlassian.net/browse/DHIS2-16211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ