### PR TITLE
fix: Analytics outliers: check why max value is lower than value (sometimes)[DHIS2-16953]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreSqlStatementProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreSqlStatementProcessor.java
@@ -212,7 +212,6 @@ public class AnalyticsZScoreSqlStatementProcessor implements OutlierSqlStatement
                 + " + (ax.std_dev * "
                 + thresholdParam
                 + ") as upper_bound ";
-    ;
     sql +=
         "from analytics ax "
             + "where "

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreSqlStatementProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreSqlStatementProcessor.java
@@ -195,15 +195,26 @@ public class AnalyticsZScoreSqlStatementProcessor implements OutlierSqlStatement
               + "       end) as z_score, ";
     }
     sql +=
-        middleValue
-            + " - (ax.std_dev * "
-            + thresholdParam
-            + ") as lower_bound, "
-            + middleValue
-            + " + (ax.std_dev * "
-            + thresholdParam
-            + ") as upper_bound "
-            + "from analytics ax "
+        modifiedZ
+            ? middleValue
+                + " - (ax.mad * "
+                + thresholdParam
+                + "/0.6745) as lower_bound, "
+                + middleValue
+                + " + (ax.mad * "
+                + thresholdParam
+                + "/0.6745) as upper_bound "
+            : middleValue
+                + " - (ax.std_dev * "
+                + thresholdParam
+                + ") as lower_bound, "
+                + middleValue
+                + " + (ax.std_dev * "
+                + thresholdParam
+                + ") as upper_bound ";
+    ;
+    sql +=
+        "from analytics ax "
             + "where "
             + getDataDimensionSql(withParams, request.getDataDimensions())
             + ouPathClause

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreSqlStatementProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreSqlStatementProcessor.java
@@ -163,6 +163,25 @@ public class AnalyticsZScoreSqlStatementProcessor implements OutlierSqlStatement
     String thresholdParam =
         withParams ? ":" + THRESHOLD.getKey() : Double.toString(request.getThreshold());
 
+    //  The constant 0.6745 in the formula for the modified z-score is derived from the standard
+    // normal distribution.
+    //  Specifically, it represents the approximate value of the standard deviation of the standard
+    // normal distribution
+    //  when calculated from the median absolute deviation (MAD).
+    //  In a standard normal distribution, approximately 75% of the data lies within one standard
+    // deviation of the mean.
+    //  Similarly, when using the median absolute deviation as a measure of dispersion,
+    // approximately 75% of the data points
+    //  lie within a certain range from the median. The constant 0.6745 is chosen to make the
+    // modified z-score calculation
+    //  consistent with this property.
+    //  It's important to note that 0.6745 is an approximation, and the exact value for the standard
+    // deviation of a standard
+    //  normal distribution is 1. However, in the context of the modified z-score calculation,
+    // 0.6745 is used to adjust
+    //  for the difference between the standard deviation and the median absolute deviation.
+    final double scoreScalingFactor = 0.6745;
+
     String sql =
         "select * from (select "
             + "ax.dx as de_uid, "
@@ -182,7 +201,9 @@ public class AnalyticsZScoreSqlStatementProcessor implements OutlierSqlStatement
     if (modifiedZ) {
       sql +=
           "(case when ax.mad = 0 then 0 "
-              + "      else 0.6745 * abs(ax.value::double precision - "
+              + "      else "
+              + scoreScalingFactor
+              + " * abs(ax.value::double precision - "
               + middleValue
               + " ) / ax.mad "
               + "       end) as z_score, ";
@@ -199,11 +220,15 @@ public class AnalyticsZScoreSqlStatementProcessor implements OutlierSqlStatement
             ? middleValue
                 + " - (ax.mad * "
                 + thresholdParam
-                + "/0.6745) as lower_bound, "
+                + "/"
+                + scoreScalingFactor
+                + ") as lower_bound, "
                 + middleValue
                 + " + (ax.mad * "
                 + thresholdParam
-                + "/0.6745) as upper_bound "
+                + "/"
+                + scoreScalingFactor
+                + ") as upper_bound "
             : middleValue
                 + " - (ax.std_dev * "
                 + thresholdParam

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection3AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection3AutoTest.java
@@ -48,530 +48,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
   private AnalyticsOutlierDetectionActions actions = new AnalyticsOutlierDetectionActions();
 
   @Test
-  public void queryQueryoutliertest9() throws JSONException {
-    // Given
-    QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("pe=THIS_YEAR")
-            .add("ou=ImspTQPwCqd")
-            .add("maxResults=20")
-            .add("orderBy=MODIFIEDZSCORE")
-            .add("threshold=2.5")
-            .add("ds=BfMAe6Itzgt")
-            .add("algorithm=MODIFIED_Z_SCORE")
-            .add("relativePeriodDate=2022-07-26");
-
-    // When
-    ApiResponse response = actions.query().get("", JSON, JSON, params);
-
-    // Then
-    response
-        .validate()
-        .statusCode(200)
-        .body("headers", hasSize(equalTo(18)))
-        .body("rows", hasSize(equalTo(20)))
-        .body("height", equalTo(20))
-        .body("width", equalTo(18))
-        .body("headerWidth", equalTo(18));
-
-    // Assert metaData.
-    String expectedMetaData =
-        "{\"count\":20,\"orderBy\":\"MODIFIED_Z_SCORE\",\"threshold\":\"2.5\",\"maxResults\":20,\"algorithm\":\"MODIFIED_Z_SCORE\"}";
-    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-
-    // Assert headers.
-    validateHeader(response, 0, "dx", "Data", "TEXT", "java.lang.String", false, false);
-    validateHeader(response, 1, "dxname", "Data name", "TEXT", "java.lang.String", false, false);
-    validateHeader(response, 2, "pe", "Period", "TEXT", "java.lang.String", false, false);
-    validateHeader(response, 3, "pename", "Period name", "TEXT", "java.lang.String", false, false);
-    validateHeader(
-        response, 4, "ou", "Organisation unit", "TEXT", "java.lang.String", false, false);
-    validateHeader(
-        response, 5, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, false);
-    validateHeader(
-        response,
-        6,
-        "ounamehierarchy",
-        "Organisation unit name hierarchy",
-        "TEXT",
-        "java.lang.String",
-        false,
-        false);
-    validateHeader(
-        response, 7, "coc", "Category option combo", "TEXT", "java.lang.String", false, false);
-    validateHeader(
-        response,
-        8,
-        "cocname",
-        "Category option combo name",
-        "TEXT",
-        "java.lang.String",
-        false,
-        false);
-    validateHeader(
-        response, 9, "aoc", "Attribute option combo", "TEXT", "java.lang.String", false, false);
-    validateHeader(
-        response,
-        10,
-        "aocname",
-        "Attribute option combo name",
-        "TEXT",
-        "java.lang.String",
-        false,
-        false);
-    validateHeader(response, 11, "value", "Value", "NUMBER", "java.lang.Double", false, false);
-    validateHeader(response, 12, "median", "Median", "NUMBER", "java.lang.Double", false, false);
-    validateHeader(
-        response,
-        13,
-        "medianabsdeviation",
-        "Median absolute deviation",
-        "NUMBER",
-        "java.lang.Double",
-        false,
-        false);
-    validateHeader(
-        response, 14, "absdev", "Absolute deviation", "NUMBER", "java.lang.Double", false, false);
-    validateHeader(
-        response,
-        15,
-        "modifiedzscore",
-        "Modified Z-score",
-        "NUMBER",
-        "java.lang.Double",
-        false,
-        false);
-    validateHeader(
-        response, 16, "lowerbound", "Lower boundary", "NUMBER", "java.lang.Double", false, false);
-    validateHeader(
-        response, 17, "upperbound", "Upper boundary", "NUMBER", "java.lang.Double", false, false);
-
-    // Assert rows.
-    validateRow(
-        response,
-        List.of(
-            "tU7GixyHhsv",
-            "Vitamin A given to < 5y",
-            "202206",
-            "202206",
-            "scc4QyxenJd",
-            "Makali CHC",
-            "Sierra Leone / Tonkolili / Kunike Barina / Makali CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "714.0",
-            "10.0",
-            "3.0",
-            "704.0",
-            "158.3",
-            "-559.9",
-            "579.9"));
-    validateRow(
-        response,
-        List.of(
-            "lVsbKXoF0zX",
-            "Weight for height below 70 percent",
-            "202206",
-            "202206",
-            "Qc9lf4VM9bD",
-            "Wellington Health Centre",
-            "Sierra Leone / Western Area / Freetown / Wellington Health Centre",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "1540.0",
-            "27.0",
-            "7.0",
-            "1513.0",
-            "145.8",
-            "-1075.7",
-            "1129.7"));
-    validateRow(
-        response,
-        List.of(
-            "bTcRDVjC66S",
-            "Weight for age below lower line (red)",
-            "202205",
-            "202205",
-            "OzjRQLn3G24",
-            "Koidu Govt. Hospital",
-            "Sierra Leone / Kono / Gbense / Koidu Govt. Hospital",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "400.0",
-            "11.0",
-            "2.0",
-            "389.0",
-            "131.2",
-            "-399.5",
-            "421.5"));
-    validateRow(
-        response,
-        List.of(
-            "O05mAByOgAv",
-            "OPV2 doses given",
-            "202208",
-            "202208",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "451.0",
-            "13.0",
-            "3.0",
-            "438.0",
-            "98.5",
-            "-474.5",
-            "500.5"));
-    validateRow(
-        response,
-        List.of(
-            "lVsbKXoF0zX",
-            "Weight for height below 70 percent",
-            "202205",
-            "202205",
-            "OzjRQLn3G24",
-            "Koidu Govt. Hospital",
-            "Sierra Leone / Kono / Gbense / Koidu Govt. Hospital",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "400.0",
-            "11.0",
-            "3.0",
-            "389.0",
-            "87.5",
-            "-416.7",
-            "438.7"));
-    validateRow(
-        response,
-        List.of(
-            "Y53Jcc9LBYh",
-            "Children supplied with food supplemements",
-            "202202",
-            "202202",
-            "oLuhRyYPxRO",
-            "Senehun CHC",
-            "Sierra Leone / Moyamba / Kamaje / Senehun CHC",
-            "psbwp3CQEhs",
-            "Fixed, >1y",
-            "HllvX50cXC0",
-            "default",
-            "130.0",
-            "11.0",
-            "1.0",
-            "119.0",
-            "80.3",
-            "-84.3",
-            "106.3"));
-    validateRow(
-        response,
-        List.of(
-            "vI2csg55S9C",
-            "OPV3 doses given",
-            "202208",
-            "202208",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "430.0",
-            "13.0",
-            "4.0",
-            "417.0",
-            "70.3",
-            "-505.3",
-            "531.3"));
-    validateRow(
-        response,
-        List.of(
-            "n6aMJNLdvep",
-            "Penta3 doses given",
-            "202208",
-            "202208",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "430.0",
-            "14.0",
-            "4.0",
-            "416.0",
-            "70.1",
-            "-463.2",
-            "491.2"));
-    validateRow(
-        response,
-        List.of(
-            "DUSpd8Jq3M7",
-            "Newborn protected at birth against tetanus (TT2+)",
-            "202207",
-            "202207",
-            "PQEpIeuSTCN",
-            "Tobanda CHC",
-            "Sierra Leone / Kenema / Small Bo / Tobanda CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "111.0",
-            "10.0",
-            "1.0",
-            "101.0",
-            "68.1",
-            "-63.4",
-            "83.4"));
-    validateRow(
-        response,
-        List.of(
-            "Y53Jcc9LBYh",
-            "Children supplied with food supplemements",
-            "202201",
-            "202201",
-            "agEKP19IUKI",
-            "Tambiama CHC",
-            "Sierra Leone / Bombali / Gbendembu Ngowahun / Tambiama CHC",
-            "psbwp3CQEhs",
-            "Fixed, >1y",
-            "HllvX50cXC0",
-            "default",
-            "113.0",
-            "14.0",
-            "1.0",
-            "99.0",
-            "66.8",
-            "-91.2",
-            "119.2"));
-    validateRow(
-        response,
-        List.of(
-            "Y53Jcc9LBYh",
-            "Children supplied with food supplemements",
-            "202202",
-            "202202",
-            "agEKP19IUKI",
-            "Tambiama CHC",
-            "Sierra Leone / Bombali / Gbendembu Ngowahun / Tambiama CHC",
-            "psbwp3CQEhs",
-            "Fixed, >1y",
-            "HllvX50cXC0",
-            "default",
-            "113.0",
-            "14.0",
-            "1.0",
-            "99.0",
-            "66.8",
-            "-91.2",
-            "119.2"));
-    validateRow(
-        response,
-        List.of(
-            "UOlfIjgN8X6",
-            "Fully Immunized child",
-            "202208",
-            "202208",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "455.0",
-            "12.0",
-            "5.0",
-            "443.0",
-            "59.8",
-            "-511.9",
-            "535.9"));
-    validateRow(
-        response,
-        List.of(
-            "I78gJm4KBo7",
-            "Penta2 doses given",
-            "202208",
-            "202208",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "451.0",
-            "14.0",
-            "5.0",
-            "437.0",
-            "59.0",
-            "-492.7",
-            "520.7"));
-    validateRow(
-        response,
-        List.of(
-            "l6byfWFUGaP",
-            "Yellow Fever doses given",
-            "202208",
-            "202208",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "457.0",
-            "11.5",
-            "5.5",
-            "445.5",
-            "54.6",
-            "-548.6",
-            "571.6"));
-    validateRow(
-        response,
-        List.of(
-            "fClA2Erf6IO",
-            "Penta1 doses given",
-            "202208",
-            "202208",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "489.0",
-            "20.0",
-            "6.0",
-            "469.0",
-            "52.7",
-            "-433.2",
-            "473.2"));
-    validateRow(
-        response,
-        List.of(
-            "l6byfWFUGaP",
-            "Yellow Fever doses given",
-            "202209",
-            "202209",
-            "RhJbg8UD75Q",
-            "Yemoh Town CHC",
-            "Sierra Leone / Bo / Kakua / Yemoh Town CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "466.0",
-            "14.0",
-            "6.0",
-            "452.0",
-            "50.8",
-            "-271.7",
-            "299.7"));
-    validateRow(
-        response,
-        List.of(
-            "YtbsuPPo010",
-            "Measles doses given",
-            "202209",
-            "202209",
-            "RhJbg8UD75Q",
-            "Yemoh Town CHC",
-            "Sierra Leone / Bo / Kakua / Yemoh Town CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "466.0",
-            "14.0",
-            "6.0",
-            "452.0",
-            "50.8",
-            "-345.7",
-            "373.7"));
-    validateRow(
-        response,
-        List.of(
-            "YtbsuPPo010",
-            "Measles doses given",
-            "202208",
-            "202208",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "457.0",
-            "12.5",
-            "6.0",
-            "444.5",
-            "50.0",
-            "-574.4",
-            "599.4"));
-    validateRow(
-        response,
-        List.of(
-            "Rmixc9wJl0G",
-            "Q_LLITN given at time of 2nd Vit A dose",
-            "202202",
-            "202202",
-            "EUUkKEDoNsf",
-            "Wilberforce CHC",
-            "Sierra Leone / Western Area / Freetown / Wilberforce CHC",
-            "hEFKSsPV5et",
-            "Outreach, >1y",
-            "HllvX50cXC0",
-            "default",
-            "40.0",
-            "5.5",
-            "0.5",
-            "34.5",
-            "46.5",
-            "-40.0",
-            "51.0"));
-    validateRow(
-        response,
-        List.of(
-            "Y53Jcc9LBYh",
-            "Children supplied with food supplemements",
-            "202201",
-            "202201",
-            "EXbPGmEUdnc",
-            "Mateboi CHC",
-            "Sierra Leone / Bombali / Sanda Tendaren / Mateboi CHC",
-            "psbwp3CQEhs",
-            "Fixed, >1y",
-            "HllvX50cXC0",
-            "default",
-            "80.0",
-            "11.0",
-            "1.0",
-            "69.0",
-            "46.5",
-            "-58.9",
-            "80.9"));
-  }
-
-  @Test
-  public void queryQueryoutliertest10() throws JSONException {
+  public void queryOutliertest10() throws JSONException {
     // Given
     QueryParamsBuilder params =
         new QueryParamsBuilder()
@@ -690,8 +167,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "3.0",
             "704.0",
             "158.3",
-            "-559.9",
-            "579.9"));
+            "-1.1",
+            "21.1"));
     validateRow(
         response,
         List.of(
@@ -711,8 +188,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "7.0",
             "1513.0",
             "145.8",
-            "-1075.7",
-            "1129.7"));
+            "1.1",
+            "52.9"));
     validateRow(
         response,
         List.of(
@@ -732,8 +209,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "3.0",
             "604.0",
             "135.8",
-            "-461.0",
-            "485.0"));
+            "0.9",
+            "23.1"));
     validateRow(
         response,
         List.of(
@@ -753,8 +230,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "3.0",
             "585.0",
             "131.5",
-            "-474.5",
-            "500.5"));
+            "1.9",
+            "24.1"));
     validateRow(
         response,
         List.of(
@@ -774,8 +251,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "2.0",
             "389.0",
             "131.2",
-            "-399.5",
-            "421.5"));
+            "3.6",
+            "18.4"));
     validateRow(
         response,
         List.of(
@@ -795,8 +272,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "4.0",
             "603.0",
             "101.7",
-            "-433.2",
-            "459.2"));
+            "-1.8",
+            "27.8"));
     validateRow(
         response,
         List.of(
@@ -816,8 +293,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "4.0",
             "587.0",
             "99.0",
-            "-505.3",
-            "531.3"));
+            "-1.8",
+            "27.8"));
     validateRow(
         response,
         List.of(
@@ -837,8 +314,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "4.0",
             "586.0",
             "98.8",
-            "-463.2",
-            "491.2"));
+            "-0.8",
+            "28.8"));
     validateRow(
         response,
         List.of(
@@ -858,8 +335,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "3.0",
             "438.0",
             "98.5",
-            "-474.5",
-            "500.5"));
+            "1.9",
+            "24.1"));
     validateRow(
         response,
         List.of(
@@ -879,8 +356,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "4.0",
             "561.0",
             "94.6",
-            "-466.1",
-            "504.1"));
+            "4.2",
+            "33.8"));
     validateRow(
         response,
         List.of(
@@ -900,8 +377,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "4.0",
             "535.0",
             "90.2",
-            "-381.8",
-            "405.8"));
+            "-2.8",
+            "26.8"));
     validateRow(
         response,
         List.of(
@@ -921,8 +398,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "3.0",
             "389.0",
             "87.5",
-            "-416.7",
-            "438.7"));
+            "-0.1",
+            "22.1"));
     validateRow(
         response,
         List.of(
@@ -942,8 +419,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "4.0",
             "518.0",
             "87.3",
-            "-341.4",
-            "365.4"));
+            "-2.8",
+            "26.8"));
     validateRow(
         response,
         List.of(
@@ -963,8 +440,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "4.0",
             "517.0",
             "87.2",
-            "-351.5",
-            "377.5"));
+            "-1.8",
+            "27.8"));
     validateRow(
         response,
         List.of(
@@ -984,8 +461,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "4.0",
             "490.0",
             "82.6",
-            "-318.8",
-            "358.8"));
+            "5.2",
+            "34.8"));
     validateRow(
         response,
         List.of(
@@ -1005,8 +482,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "1.0",
             "119.0",
             "80.3",
-            "-84.3",
-            "106.3"));
+            "7.3",
+            "14.7"));
     validateRow(
         response,
         List.of(
@@ -1026,8 +503,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "5.0",
             "584.0",
             "78.8",
-            "-492.7",
-            "520.7"));
+            "-4.5",
+            "32.5"));
     validateRow(
         response,
         List.of(
@@ -1047,8 +524,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "5.0",
             "582.0",
             "78.5",
-            "-511.9",
-            "535.9"));
+            "-6.5",
+            "30.5"));
     validateRow(
         response,
         List.of(
@@ -1068,8 +545,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "5.5",
             "584.5",
             "71.7",
-            "-548.6",
-            "571.6"));
+            "-8.9",
+            "31.9"));
     validateRow(
         response,
         List.of(
@@ -1089,8 +566,531 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "4.0",
             "417.0",
             "70.3",
-            "-505.3",
-            "531.3"));
+            "-1.8",
+            "27.8"));
+  }
+
+  @Test
+  public void queryOutliertest9() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("pe=THIS_YEAR")
+            .add("ou=ImspTQPwCqd")
+            .add("maxResults=20")
+            .add("orderBy=MODIFIEDZSCORE")
+            .add("threshold=2.5")
+            .add("ds=BfMAe6Itzgt")
+            .add("algorithm=MODIFIED_Z_SCORE")
+            .add("relativePeriodDate=2022-07-26");
+
+    // When
+    ApiResponse response = actions.query().get("", JSON, JSON, params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(18)))
+        .body("rows", hasSize(equalTo(20)))
+        .body("height", equalTo(20))
+        .body("width", equalTo(18))
+        .body("headerWidth", equalTo(18));
+
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"count\":20,\"orderBy\":\"MODIFIED_Z_SCORE\",\"threshold\":\"2.5\",\"maxResults\":20,\"algorithm\":\"MODIFIED_Z_SCORE\"}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // Assert headers.
+    validateHeader(response, 0, "dx", "Data", "TEXT", "java.lang.String", false, false);
+    validateHeader(response, 1, "dxname", "Data name", "TEXT", "java.lang.String", false, false);
+    validateHeader(response, 2, "pe", "Period", "TEXT", "java.lang.String", false, false);
+    validateHeader(response, 3, "pename", "Period name", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response, 4, "ou", "Organisation unit", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response, 5, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response,
+        6,
+        "ounamehierarchy",
+        "Organisation unit name hierarchy",
+        "TEXT",
+        "java.lang.String",
+        false,
+        false);
+    validateHeader(
+        response, 7, "coc", "Category option combo", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response,
+        8,
+        "cocname",
+        "Category option combo name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        false);
+    validateHeader(
+        response, 9, "aoc", "Attribute option combo", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response,
+        10,
+        "aocname",
+        "Attribute option combo name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        false);
+    validateHeader(response, 11, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(response, 12, "median", "Median", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response,
+        13,
+        "medianabsdeviation",
+        "Median absolute deviation",
+        "NUMBER",
+        "java.lang.Double",
+        false,
+        false);
+    validateHeader(
+        response, 14, "absdev", "Absolute deviation", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response,
+        15,
+        "modifiedzscore",
+        "Modified Z-score",
+        "NUMBER",
+        "java.lang.Double",
+        false,
+        false);
+    validateHeader(
+        response, 16, "lowerbound", "Lower boundary", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 17, "upperbound", "Upper boundary", "NUMBER", "java.lang.Double", false, false);
+
+    // Assert rows.
+    validateRow(
+        response,
+        List.of(
+            "tU7GixyHhsv",
+            "Vitamin A given to < 5y",
+            "202206",
+            "202206",
+            "scc4QyxenJd",
+            "Makali CHC",
+            "Sierra Leone / Tonkolili / Kunike Barina / Makali CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "714.0",
+            "10.0",
+            "3.0",
+            "704.0",
+            "158.3",
+            "-1.1",
+            "21.1"));
+    validateRow(
+        response,
+        List.of(
+            "lVsbKXoF0zX",
+            "Weight for height below 70 percent",
+            "202206",
+            "202206",
+            "Qc9lf4VM9bD",
+            "Wellington Health Centre",
+            "Sierra Leone / Western Area / Freetown / Wellington Health Centre",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "1540.0",
+            "27.0",
+            "7.0",
+            "1513.0",
+            "145.8",
+            "1.1",
+            "52.9"));
+    validateRow(
+        response,
+        List.of(
+            "bTcRDVjC66S",
+            "Weight for age below lower line (red)",
+            "202205",
+            "202205",
+            "OzjRQLn3G24",
+            "Koidu Govt. Hospital",
+            "Sierra Leone / Kono / Gbense / Koidu Govt. Hospital",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "400.0",
+            "11.0",
+            "2.0",
+            "389.0",
+            "131.2",
+            "3.6",
+            "18.4"));
+    validateRow(
+        response,
+        List.of(
+            "O05mAByOgAv",
+            "OPV2 doses given",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "451.0",
+            "13.0",
+            "3.0",
+            "438.0",
+            "98.5",
+            "1.9",
+            "24.1"));
+    validateRow(
+        response,
+        List.of(
+            "lVsbKXoF0zX",
+            "Weight for height below 70 percent",
+            "202205",
+            "202205",
+            "OzjRQLn3G24",
+            "Koidu Govt. Hospital",
+            "Sierra Leone / Kono / Gbense / Koidu Govt. Hospital",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "400.0",
+            "11.0",
+            "3.0",
+            "389.0",
+            "87.5",
+            "-0.1",
+            "22.1"));
+    validateRow(
+        response,
+        List.of(
+            "Y53Jcc9LBYh",
+            "Children supplied with food supplemements",
+            "202202",
+            "202202",
+            "oLuhRyYPxRO",
+            "Senehun CHC",
+            "Sierra Leone / Moyamba / Kamaje / Senehun CHC",
+            "psbwp3CQEhs",
+            "Fixed, >1y",
+            "HllvX50cXC0",
+            "default",
+            "130.0",
+            "11.0",
+            "1.0",
+            "119.0",
+            "80.3",
+            "7.3",
+            "14.7"));
+    validateRow(
+        response,
+        List.of(
+            "vI2csg55S9C",
+            "OPV3 doses given",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "430.0",
+            "13.0",
+            "4.0",
+            "417.0",
+            "70.3",
+            "-1.8",
+            "27.8"));
+    validateRow(
+        response,
+        List.of(
+            "n6aMJNLdvep",
+            "Penta3 doses given",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "430.0",
+            "14.0",
+            "4.0",
+            "416.0",
+            "70.1",
+            "-0.8",
+            "28.8"));
+    validateRow(
+        response,
+        List.of(
+            "DUSpd8Jq3M7",
+            "Newborn protected at birth against tetanus (TT2+)",
+            "202207",
+            "202207",
+            "PQEpIeuSTCN",
+            "Tobanda CHC",
+            "Sierra Leone / Kenema / Small Bo / Tobanda CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "111.0",
+            "10.0",
+            "1.0",
+            "101.0",
+            "68.1",
+            "6.3",
+            "13.7"));
+    validateRow(
+        response,
+        List.of(
+            "Y53Jcc9LBYh",
+            "Children supplied with food supplemements",
+            "202201",
+            "202201",
+            "agEKP19IUKI",
+            "Tambiama CHC",
+            "Sierra Leone / Bombali / Gbendembu Ngowahun / Tambiama CHC",
+            "psbwp3CQEhs",
+            "Fixed, >1y",
+            "HllvX50cXC0",
+            "default",
+            "113.0",
+            "14.0",
+            "1.0",
+            "99.0",
+            "66.8",
+            "10.3",
+            "17.7"));
+    validateRow(
+        response,
+        List.of(
+            "Y53Jcc9LBYh",
+            "Children supplied with food supplemements",
+            "202202",
+            "202202",
+            "agEKP19IUKI",
+            "Tambiama CHC",
+            "Sierra Leone / Bombali / Gbendembu Ngowahun / Tambiama CHC",
+            "psbwp3CQEhs",
+            "Fixed, >1y",
+            "HllvX50cXC0",
+            "default",
+            "113.0",
+            "14.0",
+            "1.0",
+            "99.0",
+            "66.8",
+            "10.3",
+            "17.7"));
+    validateRow(
+        response,
+        List.of(
+            "UOlfIjgN8X6",
+            "Fully Immunized child",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "455.0",
+            "12.0",
+            "5.0",
+            "443.0",
+            "59.8",
+            "-6.5",
+            "30.5"));
+    validateRow(
+        response,
+        List.of(
+            "I78gJm4KBo7",
+            "Penta2 doses given",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "451.0",
+            "14.0",
+            "5.0",
+            "437.0",
+            "59.0",
+            "-4.5",
+            "32.5"));
+    validateRow(
+        response,
+        List.of(
+            "l6byfWFUGaP",
+            "Yellow Fever doses given",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "457.0",
+            "11.5",
+            "5.5",
+            "445.5",
+            "54.6",
+            "-8.9",
+            "31.9"));
+    validateRow(
+        response,
+        List.of(
+            "fClA2Erf6IO",
+            "Penta1 doses given",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "489.0",
+            "20.0",
+            "6.0",
+            "469.0",
+            "52.7",
+            "-2.2",
+            "42.2"));
+    validateRow(
+        response,
+        List.of(
+            "l6byfWFUGaP",
+            "Yellow Fever doses given",
+            "202209",
+            "202209",
+            "RhJbg8UD75Q",
+            "Yemoh Town CHC",
+            "Sierra Leone / Bo / Kakua / Yemoh Town CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "466.0",
+            "14.0",
+            "6.0",
+            "452.0",
+            "50.8",
+            "-8.2",
+            "36.2"));
+    validateRow(
+        response,
+        List.of(
+            "YtbsuPPo010",
+            "Measles doses given",
+            "202209",
+            "202209",
+            "RhJbg8UD75Q",
+            "Yemoh Town CHC",
+            "Sierra Leone / Bo / Kakua / Yemoh Town CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "466.0",
+            "14.0",
+            "6.0",
+            "452.0",
+            "50.8",
+            "-8.2",
+            "36.2"));
+    validateRow(
+        response,
+        List.of(
+            "YtbsuPPo010",
+            "Measles doses given",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "457.0",
+            "12.5",
+            "6.0",
+            "444.5",
+            "50.0",
+            "-9.7",
+            "34.7"));
+    validateRow(
+        response,
+        List.of(
+            "Rmixc9wJl0G",
+            "Q_LLITN given at time of 2nd Vit A dose",
+            "202202",
+            "202202",
+            "EUUkKEDoNsf",
+            "Wilberforce CHC",
+            "Sierra Leone / Western Area / Freetown / Wilberforce CHC",
+            "hEFKSsPV5et",
+            "Outreach, >1y",
+            "HllvX50cXC0",
+            "default",
+            "40.0",
+            "5.5",
+            "0.5",
+            "34.5",
+            "46.5",
+            "3.6",
+            "7.4"));
+    validateRow(
+        response,
+        List.of(
+            "Y53Jcc9LBYh",
+            "Children supplied with food supplemements",
+            "202201",
+            "202201",
+            "EXbPGmEUdnc",
+            "Mateboi CHC",
+            "Sierra Leone / Bombali / Sanda Tendaren / Mateboi CHC",
+            "psbwp3CQEhs",
+            "Fixed, >1y",
+            "HllvX50cXC0",
+            "default",
+            "80.0",
+            "11.0",
+            "1.0",
+            "69.0",
+            "46.5",
+            "7.3",
+            "14.7"));
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection4AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection4AutoTest.java
@@ -170,8 +170,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "6.0",
             "1910.0",
             "214.7",
-            "-1568.6",
-            "1600.6"));
+            "-10.7",
+            "42.7"));
     validateRow(
         response,
         List.of(
@@ -191,8 +191,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "159.0",
             "920.0",
             "3.9",
-            "-290.9",
-            "1788.9"));
+            "41.8",
+            "1456.2"));
     validateRow(
         response,
         List.of(
@@ -212,8 +212,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "21.5",
             "853.5",
             "26.8",
-            "-651.3",
-            "772.3"));
+            "-35.1",
+            "156.1"));
     validateRow(
         response,
         List.of(
@@ -233,8 +233,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "1.0",
             "697.0",
             "470.1",
-            "-463.5",
-            "469.5"));
+            "-1.4",
+            "7.4"));
     validateRow(
         response,
         List.of(
@@ -254,8 +254,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "2.0",
             "653.0",
             "220.2",
-            "-432.3",
-            "440.3"));
+            "-4.9",
+            "12.9"));
     validateRow(
         response,
         List.of(
@@ -275,8 +275,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "47.0",
             "425.0",
             "6.1",
-            "-377.8",
-            "527.8"));
+            "-134.0",
+            "284.0"));
     validateRow(
         response,
         List.of(
@@ -296,8 +296,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "29.0",
             "280.5",
             "6.5",
-            "-120.8",
-            "447.8"));
+            "34.5",
+            "292.5"));
     validateRow(
         response,
         List.of(
@@ -317,8 +317,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "41.0",
             "260.5",
             "4.3",
-            "-163.1",
-            "344.1"));
+            "-91.9",
+            "272.9"));
     validateRow(
         response,
         List.of(
@@ -338,8 +338,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "29.5",
             "216.5",
             "5.0",
-            "-81.6",
-            "326.6"));
+            "-8.7",
+            "253.7"));
     validateRow(
         response,
         List.of(
@@ -359,8 +359,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "13.0",
             "260.5",
             "13.5",
-            "-285.0",
-            "410.0"));
+            "4.7",
+            "120.3"));
   }
 
   @Test
@@ -485,8 +485,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "47.0",
             "425.0",
             "6.1",
-            "-377.8",
-            "527.8"));
+            "-134.0",
+            "284.0"));
     validateRow(
         response,
         List.of(
@@ -506,8 +506,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "13.0",
             "260.5",
             "13.5",
-            "-285.0",
-            "410.0"));
+            "4.7",
+            "120.3"));
     validateRow(
         response,
         List.of(
@@ -527,8 +527,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "47.0",
             "221.0",
             "3.2",
-            "-377.8",
-            "527.8"));
+            "-134.0",
+            "284.0"));
     validateRow(
         response,
         List.of(
@@ -548,8 +548,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "11.0",
             "182.5",
             "11.2",
-            "-149.6",
-            "174.6"));
+            "-36.4",
+            "61.4"));
     validateRow(
         response,
         List.of(
@@ -569,8 +569,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "4.0",
             "124.0",
             "20.9",
-            "-123.7",
-            "135.7"));
+            "-11.8",
+            "23.8"));
   }
 
   @Test
@@ -695,8 +695,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "6.0",
             "1910.0",
             "214.7",
-            "-1568.6",
-            "1600.6"));
+            "-10.7",
+            "42.7"));
     validateRow(
         response,
         List.of(
@@ -716,8 +716,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "159.0",
             "920.0",
             "3.9",
-            "-290.9",
-            "1788.9"));
+            "41.8",
+            "1456.2"));
     validateRow(
         response,
         List.of(
@@ -737,8 +737,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "21.5",
             "853.5",
             "26.8",
-            "-651.3",
-            "772.3"));
+            "-35.1",
+            "156.1"));
     validateRow(
         response,
         List.of(
@@ -758,8 +758,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "1.0",
             "697.0",
             "470.1",
-            "-463.5",
-            "469.5"));
+            "-1.4",
+            "7.4"));
     validateRow(
         response,
         List.of(
@@ -779,8 +779,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "2.0",
             "653.0",
             "220.2",
-            "-432.3",
-            "440.3"));
+            "-4.9",
+            "12.9"));
     validateRow(
         response,
         List.of(
@@ -800,8 +800,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "29.0",
             "280.5",
             "6.5",
-            "-120.8",
-            "447.8"));
+            "34.5",
+            "292.5"));
     validateRow(
         response,
         List.of(
@@ -821,8 +821,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "41.0",
             "260.5",
             "4.3",
-            "-163.1",
-            "344.1"));
+            "-91.9",
+            "272.9"));
     validateRow(
         response,
         List.of(
@@ -842,8 +842,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "29.5",
             "216.5",
             "5.0",
-            "-81.6",
-            "326.6"));
+            "-8.7",
+            "253.7"));
     validateRow(
         response,
         List.of(
@@ -863,8 +863,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "24.5",
             "148.0",
             "4.1",
-            "16.6",
-            "323.4"));
+            "61.0",
+            "279.0"));
     validateRow(
         response,
         List.of(
@@ -884,8 +884,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "20.0",
             "124.0",
             "4.2",
-            "21.4",
-            "268.6"));
+            "56.0",
+            "234.0"));
   }
 
   @Test


### PR DESCRIPTION
The minimum and maximum values are defined as boundaries. Sample values that fall outside these boundaries are considered outliers. There was a bug in boundary calculation (min, max values) for modified z-score.