### PR TITLE
fix: SQL view update job parameters mapping [DHIS2-14718]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
@@ -305,7 +305,9 @@ public class JobConfiguration extends BaseIdentifiableObject implements Secondar
         @JsonSubTypes.Type(
             value = AggregateDataExchangeJobParameters.class,
             name = "AGGREGATE_DATA_EXCHANGE"),
-        @JsonSubTypes.Type(value = SqlViewUpdateParameters.class, name = "SQL_VIEW_UPDATE"),
+        @JsonSubTypes.Type(
+            value = SqlViewUpdateParameters.class,
+            name = "MATERIALIZED_SQL_VIEW_UPDATE"),
         @JsonSubTypes.Type(
             value = LockExceptionCleanupJobParameters.class,
             name = "LOCK_EXCEPTION_CLEANUP"),

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationControllerTest.java
@@ -162,6 +162,18 @@ class JobConfigurationControllerTest extends DhisControllerConvenienceTest {
   }
 
   @Test
+  void testMATERIALIZED_SQL_VIEW_UPDATE() {
+    // language=JSON
+    String json =
+        """
+                {"name":"test","jobType":"MATERIALIZED_SQL_VIEW_UPDATE","cronExpression":"0 0 12 ? * MON-FRI",
+                "jobParameters":{"sqlViews":["u0123456789"]}}""";
+    String jobId = assertStatus(HttpStatus.CREATED, POST("/jobConfigurations", json));
+    JsonObject parameters = assertJobConfigurationExists(jobId, "MATERIALIZED_SQL_VIEW_UPDATE");
+    assertEquals("u0123456789", parameters.getArray("sqlViews").getString(0).string());
+  }
+
+  @Test
   void testHTML_PUSH_ANALYTICS() {
     // language=JSON
     String json =


### PR DESCRIPTION
In the original PR the enum was renamed from `SQL_VIEW_UPDATE` to `MATERIALIZED_SQL_VIEW_UPDATE` but the mapping in `JobConfiguration` got overlooked and there was no test ;(

I added a test now.