### PR TITLE
feat: add new authority for adding external map layer

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/Authorities.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/Authorities.java
@@ -72,7 +72,8 @@ public enum Authorities {
   F_TRACKED_ENTITY_MERGE,
   F_DATAVALUE_ADD,
   F_IMPERSONATE_USER,
-  F_SYSTEM_SETTING;
+  F_SYSTEM_SETTING,
+  F_MAP_EXTERNAL_LAYER_ADD;
 
   public static Set<String> getAllAuthorities() {
     return Arrays.stream(Authorities.values()).map(Authorities::name).collect(Collectors.toSet());

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
@@ -442,6 +442,7 @@ F_ROUTE_PUBLIC_ADD=Add/Update Public Route
 F_ROUTE_PRIVATE_ADD=Add/Update Private Route
 F_ROUTE_PUBLIC_DELETE=Delete Route
 F_IMPERSONATE_USER=Impersonate user
+F_MAP_EXTERNAL_LAYER_ADD=Add external map layer
 #-- Common ---------------------------------------------------------------------#
 
 offline=Offline


### PR DESCRIPTION
## Summary
Adds a new authority `F_MAP_EXTERNAL_LAYER_ADD` for adding external map layers in the map app.

### JIRA:
[DHIS2-16960](https://dhis2.atlassian.net/browse/DHIS2-16960)