### PR TITLE
feat: Analytics outliers: round to two decimal digits, instead of only one[DHIS2-16954]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreOutlierDetector.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/outlier/service/AnalyticsZScoreOutlierDetector.java
@@ -147,7 +147,7 @@ public class AnalyticsZScoreOutlierDetector {
    */
   private void addZScoreBasedParamsToOutlier(
       Outlier outlier, ResultSet rs, boolean modifiedZ, boolean skipRounding) throws SQLException {
-    final int scale = skipRounding ? 10 : 1;
+    final int scale = skipRounding ? 10 : 2;
     if (modifiedZ) {
       outlier.setMedian(round(rs.getDouble("middle_value"), scale));
       outlier.setStdDev(round(rs.getDouble("mad"), scale));

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventQueryTest.java
@@ -676,16 +676,17 @@ public class EventQueryTest extends AnalyticsApiTest {
     // Given
     QueryParamsBuilder params =
         new QueryParamsBuilder()
-            .add("dimension=edqlbukwRfQ.vANAXwtLwcT,ou:ImspTQPwCqd")
+            .add("dimension=edqlbukwRfQ.vANAXwtLwcT,ou:ImspTQPwCqd, pe:THIS_YEAR")
             .add("headers=ou,ounamehierarchy,edqlbukwRfQ.vANAXwtLwcT")
             .add("stage=edqlbukwRfQ")
             .add("displayProperty=NAME")
             .add("outputType=EVENT")
-            .add("desc=incidentdate")
+            .add("desc=incidentdate,edqlbukwRfQ.vANAXwtLwcT")
             .add("totalPages=false")
-            .add("pageSize=100")
+            .add("pageSize=2")
             .add("page=1")
-            .add("rowContext=true");
+            .add("rowContext=true")
+            .add("relativePeriodDate=2022-09-22");
 
     // When
     ApiResponse response = analyticsEventActions.query().get("WSGAb5XwJ3Y", JSON, JSON, params);
@@ -693,7 +694,7 @@ public class EventQueryTest extends AnalyticsApiTest {
         .validate()
         .statusCode(200)
         .body("headers", hasSize(equalTo(3)))
-        .body("rows", hasSize(equalTo(100)));
+        .body("rows", hasSize(equalTo(2)));
 
     validateHeader(response, 0, "ou", "Organisation unit", "TEXT", "java.lang.String", false, true);
     validateHeader(
@@ -717,11 +718,15 @@ public class EventQueryTest extends AnalyticsApiTest {
 
     validateRow(
         response,
+        0,
         List.of(
-            "NjyJYiIuKIG", "Sierra Leone / Bombali / Sella Limba / Kathanta Yimbor CHC", "14.0"));
+            "zQpYVEyAM2t",
+            "Sierra Leone / Western Area / Rural Western Area / Hastings Health Centre",
+            "10.0"));
     validateRow(
         response,
-        List.of("xATvj8pdYoT", "Sierra Leone / Kailahun / Peje Bongre / Grima Jou MCHP", "24.0"));
+        1,
+        List.of("lyONqUkY1Bq", "Sierra Leone / Tonkolili / Kunike / Matholey MCHP", "17.0"));
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection1AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection1AutoTest.java
@@ -136,6 +136,7 @@ public class OutliersDetection1AutoTest extends AnalyticsApiTest {
     // Assert rows.
     validateRow(
         response,
+        0,
         List.of(
             "n6aMJNLdvep",
             "Penta3 doses given",
@@ -157,6 +158,7 @@ public class OutliersDetection1AutoTest extends AnalyticsApiTest {
             "22.99"));
     validateRow(
         response,
+        1,
         List.of(
             "s46m5MS0hxu",
             "BCG doses given",
@@ -178,6 +180,7 @@ public class OutliersDetection1AutoTest extends AnalyticsApiTest {
             "213.99"));
     validateRow(
         response,
+        2,
         List.of(
             "x3Do5e7g4Qo",
             "OPV0 doses given",
@@ -199,6 +202,7 @@ public class OutliersDetection1AutoTest extends AnalyticsApiTest {
             "236.88"));
     validateRow(
         response,
+        3,
         List.of(
             "pnL2VG8Bn7N",
             "Weight for height 70-79 percent",
@@ -220,6 +224,7 @@ public class OutliersDetection1AutoTest extends AnalyticsApiTest {
             "115.57"));
     validateRow(
         response,
+        4,
         List.of(
             "l6byfWFUGaP",
             "Yellow Fever doses given",

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection1AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection1AutoTest.java
@@ -136,7 +136,6 @@ public class OutliersDetection1AutoTest extends AnalyticsApiTest {
     // Assert rows.
     validateRow(
         response,
-        0,
         List.of(
             "n6aMJNLdvep",
             "Penta3 doses given",
@@ -150,15 +149,14 @@ public class OutliersDetection1AutoTest extends AnalyticsApiTest {
             "HllvX50cXC0",
             "default",
             "23.0",
-            "7.5",
-            "5.1",
-            "15.5",
+            "7.55",
+            "5.15",
+            "15.45",
             "3.0",
             "-7.9",
-            "23.0"));
+            "22.99"));
     validateRow(
         response,
-        1,
         List.of(
             "s46m5MS0hxu",
             "BCG doses given",
@@ -172,15 +170,14 @@ public class OutliersDetection1AutoTest extends AnalyticsApiTest {
             "HllvX50cXC0",
             "default",
             "220.0",
-            "41.6",
-            "57.4",
-            "178.4",
+            "41.64",
+            "57.45",
+            "178.36",
             "3.1",
             "-130.7",
-            "214.0"));
+            "213.99"));
     validateRow(
         response,
-        2,
         List.of(
             "x3Do5e7g4Qo",
             "OPV0 doses given",
@@ -194,15 +191,14 @@ public class OutliersDetection1AutoTest extends AnalyticsApiTest {
             "HllvX50cXC0",
             "default",
             "245.0",
-            "43.0",
-            "64.6",
-            "202.0",
-            "3.1",
-            "-150.8",
-            "236.9"));
+            "43.02",
+            "64.62",
+            "201.98",
+            "3.13",
+            "-150.84",
+            "236.88"));
     validateRow(
         response,
-        3,
         List.of(
             "pnL2VG8Bn7N",
             "Weight for height 70-79 percent",
@@ -216,15 +212,14 @@ public class OutliersDetection1AutoTest extends AnalyticsApiTest {
             "HllvX50cXC0",
             "default",
             "120.0",
-            "29.0",
-            "28.9",
-            "91.0",
-            "3.2",
-            "-57.6",
-            "115.6"));
+            "28.96",
+            "28.87",
+            "91.04",
+            "3.15",
+            "-57.64",
+            "115.57"));
     validateRow(
         response,
-        4,
         List.of(
             "l6byfWFUGaP",
             "Yellow Fever doses given",
@@ -238,12 +233,12 @@ public class OutliersDetection1AutoTest extends AnalyticsApiTest {
             "HllvX50cXC0",
             "default",
             "466.0",
-            "48.2",
-            "114.3",
-            "417.8",
-            "3.7",
-            "-294.7",
-            "391.0"));
+            "48.19",
+            "114.28",
+            "417.81",
+            "3.66",
+            "-294.65",
+            "391.03"));
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection2AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection2AutoTest.java
@@ -179,6 +179,7 @@ public class OutliersDetection2AutoTest extends AnalyticsApiTest {
     // Assert rows.
     validateRow(
         response,
+        0,
         List.of(
             "l6byfWFUGaP",
             "Yellow Fever doses given",
@@ -200,6 +201,7 @@ public class OutliersDetection2AutoTest extends AnalyticsApiTest {
             "391.03"));
     validateRow(
         response,
+        1,
         List.of(
             "s46m5MS0hxu",
             "BCG doses given",
@@ -221,6 +223,7 @@ public class OutliersDetection2AutoTest extends AnalyticsApiTest {
             "213.99"));
     validateRow(
         response,
+        2,
         List.of(
             "dU0GquGkGQr",
             "Q_Early breastfeeding (within 1 hr after delivery) at BCG",
@@ -290,11 +293,11 @@ public class OutliersDetection2AutoTest extends AnalyticsApiTest {
         false);
 
     // Assert rows.
-    validateRow(response, List.of("O05mAByOgAv", "OPV2 doses given", "98.48"));
-    validateRow(response, List.of("vI2csg55S9C", "OPV3 doses given", "70.32"));
-    validateRow(response, List.of("n6aMJNLdvep", "Penta3 doses given", "70.15"));
-    validateRow(response, List.of("UOlfIjgN8X6", "Fully Immunized child", "59.76"));
-    validateRow(response, List.of("I78gJm4KBo7", "Penta2 doses given", "58.95"));
+    validateRow(response, 0, List.of("O05mAByOgAv", "OPV2 doses given", "98.48"));
+    validateRow(response, 1, List.of("vI2csg55S9C", "OPV3 doses given", "70.32"));
+    validateRow(response, 2, List.of("n6aMJNLdvep", "Penta3 doses given", "70.15"));
+    validateRow(response, 3, List.of("UOlfIjgN8X6", "Fully Immunized child", "59.76"));
+    validateRow(response, 4, List.of("I78gJm4KBo7", "Penta2 doses given", "58.95"));
   }
 
   @Test
@@ -337,8 +340,8 @@ public class OutliersDetection2AutoTest extends AnalyticsApiTest {
     validateHeader(response, 2, "zscore", "Z-score", "NUMBER", "java.lang.Double", false, false);
 
     // Assert rows.
-    validateRow(response, List.of("l6byfWFUGaP", "Yellow Fever doses given", "3.66"));
-    validateRow(response, List.of("s46m5MS0hxu", "BCG doses given", "3.1"));
+    validateRow(response, 0, List.of("l6byfWFUGaP", "Yellow Fever doses given", "3.66"));
+    validateRow(response, 1, List.of("s46m5MS0hxu", "BCG doses given", "3.1"));
     validateRow(
         response,
         List.of(

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection2AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection2AutoTest.java
@@ -344,6 +344,7 @@ public class OutliersDetection2AutoTest extends AnalyticsApiTest {
     validateRow(response, 1, List.of("s46m5MS0hxu", "BCG doses given", "3.1"));
     validateRow(
         response,
+        2,
         List.of(
             "dU0GquGkGQr", "Q_Early breastfeeding (within 1 hr after delivery) at BCG", "3.02"));
   }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection2AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection2AutoTest.java
@@ -179,7 +179,6 @@ public class OutliersDetection2AutoTest extends AnalyticsApiTest {
     // Assert rows.
     validateRow(
         response,
-        0,
         List.of(
             "l6byfWFUGaP",
             "Yellow Fever doses given",
@@ -193,15 +192,14 @@ public class OutliersDetection2AutoTest extends AnalyticsApiTest {
             "HllvX50cXC0",
             "default",
             "466.0",
-            "48.2",
-            "114.3",
-            "417.8",
-            "3.7",
-            "-294.7",
-            "391.0"));
+            "48.19",
+            "114.28",
+            "417.81",
+            "3.66",
+            "-294.65",
+            "391.03"));
     validateRow(
         response,
-        1,
         List.of(
             "s46m5MS0hxu",
             "BCG doses given",
@@ -215,15 +213,14 @@ public class OutliersDetection2AutoTest extends AnalyticsApiTest {
             "HllvX50cXC0",
             "default",
             "220.0",
-            "41.6",
-            "57.4",
-            "178.4",
+            "41.64",
+            "57.45",
+            "178.36",
             "3.1",
             "-130.7",
-            "214.0"));
+            "213.99"));
     validateRow(
         response,
-        2,
         List.of(
             "dU0GquGkGQr",
             "Q_Early breastfeeding (within 1 hr after delivery) at BCG",
@@ -237,12 +234,12 @@ public class OutliersDetection2AutoTest extends AnalyticsApiTest {
             "HllvX50cXC0",
             "default",
             "105.0",
-            "18.3",
-            "28.7",
-            "86.7",
-            "3.0",
-            "-67.9",
-            "104.4"));
+            "18.26",
+            "28.71",
+            "86.74",
+            "3.02",
+            "-67.85",
+            "104.38"));
   }
 
   @Test
@@ -293,11 +290,11 @@ public class OutliersDetection2AutoTest extends AnalyticsApiTest {
         false);
 
     // Assert rows.
-    validateRow(response, 0, List.of("O05mAByOgAv", "OPV2 doses given", "98.5"));
-    validateRow(response, 1, List.of("vI2csg55S9C", "OPV3 doses given", "70.3"));
-    validateRow(response, 2, List.of("n6aMJNLdvep", "Penta3 doses given", "70.1"));
-    validateRow(response, 3, List.of("UOlfIjgN8X6", "Fully Immunized child", "59.8"));
-    validateRow(response, 4, List.of("I78gJm4KBo7", "Penta2 doses given", "59.0"));
+    validateRow(response, List.of("O05mAByOgAv", "OPV2 doses given", "98.48"));
+    validateRow(response, List.of("vI2csg55S9C", "OPV3 doses given", "70.32"));
+    validateRow(response, List.of("n6aMJNLdvep", "Penta3 doses given", "70.15"));
+    validateRow(response, List.of("UOlfIjgN8X6", "Fully Immunized child", "59.76"));
+    validateRow(response, List.of("I78gJm4KBo7", "Penta2 doses given", "58.95"));
   }
 
   @Test
@@ -340,11 +337,11 @@ public class OutliersDetection2AutoTest extends AnalyticsApiTest {
     validateHeader(response, 2, "zscore", "Z-score", "NUMBER", "java.lang.Double", false, false);
 
     // Assert rows.
-    validateRow(response, 0, List.of("l6byfWFUGaP", "Yellow Fever doses given", "3.7"));
-    validateRow(response, 1, List.of("s46m5MS0hxu", "BCG doses given", "3.1"));
+    validateRow(response, List.of("l6byfWFUGaP", "Yellow Fever doses given", "3.66"));
+    validateRow(response, List.of("s46m5MS0hxu", "BCG doses given", "3.1"));
     validateRow(
         response,
-        2,
-        List.of("dU0GquGkGQr", "Q_Early breastfeeding (within 1 hr after delivery) at BCG", "3.0"));
+        List.of(
+            "dU0GquGkGQr", "Q_Early breastfeeding (within 1 hr after delivery) at BCG", "3.02"));
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection3AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection3AutoTest.java
@@ -54,7 +54,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
         new QueryParamsBuilder()
             .add("pe=THIS_YEAR")
             .add("ou=ImspTQPwCqd")
-            .add("maxResults=20")
+            .add("maxResults=10")
             .add("orderBy=MODIFIEDZSCORE")
             .add("threshold=2.5")
             .add("ds=BfMAe6Itzgt")
@@ -69,14 +69,14 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
         .validate()
         .statusCode(200)
         .body("headers", hasSize(equalTo(18)))
-        .body("rows", hasSize(equalTo(20)))
-        .body("height", equalTo(20))
+        .body("rows", hasSize(equalTo(10)))
+        .body("height", equalTo(10))
         .body("width", equalTo(18))
         .body("headerWidth", equalTo(18));
 
     // Assert metaData.
     String expectedMetaData =
-        "{\"count\":20,\"orderBy\":\"MODIFIED_Z_SCORE\",\"threshold\":\"2.5\",\"maxResults\":20,\"algorithm\":\"MODIFIED_Z_SCORE\"}";
+        "{\"count\":10,\"orderBy\":\"MODIFIED_Z_SCORE\",\"threshold\":\"2.5\",\"maxResults\":10,\"algorithm\":\"MODIFIED_Z_SCORE\"}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
@@ -346,248 +346,6 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "68.12",
             "6.29",
             "13.71"));
-    validateRow(
-        response,
-        9,
-        List.of(
-            "Y53Jcc9LBYh",
-            "Children supplied with food supplemements",
-            "202201",
-            "202201",
-            "agEKP19IUKI",
-            "Tambiama CHC",
-            "Sierra Leone / Bombali / Gbendembu Ngowahun / Tambiama CHC",
-            "psbwp3CQEhs",
-            "Fixed, >1y",
-            "HllvX50cXC0",
-            "default",
-            "113.0",
-            "14.0",
-            "1.0",
-            "99.0",
-            "66.78",
-            "10.29",
-            "17.71"));
-    validateRow(
-        response,
-        10,
-        List.of(
-            "Y53Jcc9LBYh",
-            "Children supplied with food supplemements",
-            "202202",
-            "202202",
-            "agEKP19IUKI",
-            "Tambiama CHC",
-            "Sierra Leone / Bombali / Gbendembu Ngowahun / Tambiama CHC",
-            "psbwp3CQEhs",
-            "Fixed, >1y",
-            "HllvX50cXC0",
-            "default",
-            "113.0",
-            "14.0",
-            "1.0",
-            "99.0",
-            "66.78",
-            "10.29",
-            "17.71"));
-    validateRow(
-        response,
-        11,
-        List.of(
-            "UOlfIjgN8X6",
-            "Fully Immunized child",
-            "202208",
-            "202208",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "455.0",
-            "12.0",
-            "5.0",
-            "443.0",
-            "59.76",
-            "-6.53",
-            "30.53"));
-    validateRow(
-        response,
-        12,
-        List.of(
-            "I78gJm4KBo7",
-            "Penta2 doses given",
-            "202208",
-            "202208",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "451.0",
-            "14.0",
-            "5.0",
-            "437.0",
-            "58.95",
-            "-4.53",
-            "32.53"));
-    validateRow(
-        response,
-        13,
-        List.of(
-            "l6byfWFUGaP",
-            "Yellow Fever doses given",
-            "202208",
-            "202208",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "457.0",
-            "11.5",
-            "5.5",
-            "445.5",
-            "54.63",
-            "-8.89",
-            "31.89"));
-    validateRow(
-        response,
-        14,
-        List.of(
-            "fClA2Erf6IO",
-            "Penta1 doses given",
-            "202208",
-            "202208",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "489.0",
-            "20.0",
-            "6.0",
-            "469.0",
-            "52.72",
-            "-2.24",
-            "42.24"));
-    validateRow(
-        response,
-        15,
-        List.of(
-            "l6byfWFUGaP",
-            "Yellow Fever doses given",
-            "202209",
-            "202209",
-            "RhJbg8UD75Q",
-            "Yemoh Town CHC",
-            "Sierra Leone / Bo / Kakua / Yemoh Town CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "466.0",
-            "14.0",
-            "6.0",
-            "452.0",
-            "50.81",
-            "-8.24",
-            "36.24"));
-    validateRow(
-        response,
-        16,
-        List.of(
-            "YtbsuPPo010",
-            "Measles doses given",
-            "202209",
-            "202209",
-            "RhJbg8UD75Q",
-            "Yemoh Town CHC",
-            "Sierra Leone / Bo / Kakua / Yemoh Town CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "466.0",
-            "14.0",
-            "6.0",
-            "452.0",
-            "50.81",
-            "-8.24",
-            "36.24"));
-    validateRow(
-        response,
-        17,
-        List.of(
-            "YtbsuPPo010",
-            "Measles doses given",
-            "202208",
-            "202208",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "457.0",
-            "12.5",
-            "6.0",
-            "444.5",
-            "49.97",
-            "-9.74",
-            "34.74"));
-    validateRow(
-        response,
-        18,
-        List.of(
-            "Rmixc9wJl0G",
-            "Q_LLITN given at time of 2nd Vit A dose",
-            "202202",
-            "202202",
-            "EUUkKEDoNsf",
-            "Wilberforce CHC",
-            "Sierra Leone / Western Area / Freetown / Wilberforce CHC",
-            "hEFKSsPV5et",
-            "Outreach, >1y",
-            "HllvX50cXC0",
-            "default",
-            "40.0",
-            "5.5",
-            "0.5",
-            "34.5",
-            "46.54",
-            "3.65",
-            "7.35"));
-    validateRow(
-        response,
-        19,
-        List.of(
-            "Y53Jcc9LBYh",
-            "Children supplied with food supplemements",
-            "202201",
-            "202201",
-            "EXbPGmEUdnc",
-            "Mateboi CHC",
-            "Sierra Leone / Bombali / Sanda Tendaren / Mateboi CHC",
-            "psbwp3CQEhs",
-            "Fixed, >1y",
-            "HllvX50cXC0",
-            "default",
-            "80.0",
-            "11.0",
-            "1.0",
-            "69.0",
-            "46.54",
-            "7.29",
-            "14.71"));
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection3AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection3AutoTest.java
@@ -48,530 +48,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
   private AnalyticsOutlierDetectionActions actions = new AnalyticsOutlierDetectionActions();
 
   @Test
-  public void queryQueryoutliertest9() throws JSONException {
-    // Given
-    QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("pe=THIS_YEAR")
-            .add("ou=ImspTQPwCqd")
-            .add("maxResults=20")
-            .add("orderBy=MODIFIEDZSCORE")
-            .add("threshold=2.5")
-            .add("ds=BfMAe6Itzgt")
-            .add("algorithm=MODIFIED_Z_SCORE")
-            .add("relativePeriodDate=2022-07-26");
-
-    // When
-    ApiResponse response = actions.query().get("", JSON, JSON, params);
-
-    // Then
-    response
-        .validate()
-        .statusCode(200)
-        .body("headers", hasSize(equalTo(18)))
-        .body("rows", hasSize(equalTo(20)))
-        .body("height", equalTo(20))
-        .body("width", equalTo(18))
-        .body("headerWidth", equalTo(18));
-
-    // Assert metaData.
-    String expectedMetaData =
-        "{\"count\":20,\"orderBy\":\"MODIFIED_Z_SCORE\",\"threshold\":\"2.5\",\"maxResults\":20,\"algorithm\":\"MODIFIED_Z_SCORE\"}";
-    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-
-    // Assert headers.
-    validateHeader(response, 0, "dx", "Data", "TEXT", "java.lang.String", false, false);
-    validateHeader(response, 1, "dxname", "Data name", "TEXT", "java.lang.String", false, false);
-    validateHeader(response, 2, "pe", "Period", "TEXT", "java.lang.String", false, false);
-    validateHeader(response, 3, "pename", "Period name", "TEXT", "java.lang.String", false, false);
-    validateHeader(
-        response, 4, "ou", "Organisation unit", "TEXT", "java.lang.String", false, false);
-    validateHeader(
-        response, 5, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, false);
-    validateHeader(
-        response,
-        6,
-        "ounamehierarchy",
-        "Organisation unit name hierarchy",
-        "TEXT",
-        "java.lang.String",
-        false,
-        false);
-    validateHeader(
-        response, 7, "coc", "Category option combo", "TEXT", "java.lang.String", false, false);
-    validateHeader(
-        response,
-        8,
-        "cocname",
-        "Category option combo name",
-        "TEXT",
-        "java.lang.String",
-        false,
-        false);
-    validateHeader(
-        response, 9, "aoc", "Attribute option combo", "TEXT", "java.lang.String", false, false);
-    validateHeader(
-        response,
-        10,
-        "aocname",
-        "Attribute option combo name",
-        "TEXT",
-        "java.lang.String",
-        false,
-        false);
-    validateHeader(response, 11, "value", "Value", "NUMBER", "java.lang.Double", false, false);
-    validateHeader(response, 12, "median", "Median", "NUMBER", "java.lang.Double", false, false);
-    validateHeader(
-        response,
-        13,
-        "medianabsdeviation",
-        "Median absolute deviation",
-        "NUMBER",
-        "java.lang.Double",
-        false,
-        false);
-    validateHeader(
-        response, 14, "absdev", "Absolute deviation", "NUMBER", "java.lang.Double", false, false);
-    validateHeader(
-        response,
-        15,
-        "modifiedzscore",
-        "Modified Z-score",
-        "NUMBER",
-        "java.lang.Double",
-        false,
-        false);
-    validateHeader(
-        response, 16, "lowerbound", "Lower boundary", "NUMBER", "java.lang.Double", false, false);
-    validateHeader(
-        response, 17, "upperbound", "Upper boundary", "NUMBER", "java.lang.Double", false, false);
-
-    // Assert rows.
-    validateRow(
-        response,
-        List.of(
-            "tU7GixyHhsv",
-            "Vitamin A given to < 5y",
-            "202206",
-            "202206",
-            "scc4QyxenJd",
-            "Makali CHC",
-            "Sierra Leone / Tonkolili / Kunike Barina / Makali CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "714.0",
-            "10.0",
-            "3.0",
-            "704.0",
-            "158.3",
-            "-559.9",
-            "579.9"));
-    validateRow(
-        response,
-        List.of(
-            "lVsbKXoF0zX",
-            "Weight for height below 70 percent",
-            "202206",
-            "202206",
-            "Qc9lf4VM9bD",
-            "Wellington Health Centre",
-            "Sierra Leone / Western Area / Freetown / Wellington Health Centre",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "1540.0",
-            "27.0",
-            "7.0",
-            "1513.0",
-            "145.8",
-            "-1075.7",
-            "1129.7"));
-    validateRow(
-        response,
-        List.of(
-            "bTcRDVjC66S",
-            "Weight for age below lower line (red)",
-            "202205",
-            "202205",
-            "OzjRQLn3G24",
-            "Koidu Govt. Hospital",
-            "Sierra Leone / Kono / Gbense / Koidu Govt. Hospital",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "400.0",
-            "11.0",
-            "2.0",
-            "389.0",
-            "131.2",
-            "-399.5",
-            "421.5"));
-    validateRow(
-        response,
-        List.of(
-            "O05mAByOgAv",
-            "OPV2 doses given",
-            "202208",
-            "202208",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "451.0",
-            "13.0",
-            "3.0",
-            "438.0",
-            "98.5",
-            "-474.5",
-            "500.5"));
-    validateRow(
-        response,
-        List.of(
-            "lVsbKXoF0zX",
-            "Weight for height below 70 percent",
-            "202205",
-            "202205",
-            "OzjRQLn3G24",
-            "Koidu Govt. Hospital",
-            "Sierra Leone / Kono / Gbense / Koidu Govt. Hospital",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "400.0",
-            "11.0",
-            "3.0",
-            "389.0",
-            "87.5",
-            "-416.7",
-            "438.7"));
-    validateRow(
-        response,
-        List.of(
-            "Y53Jcc9LBYh",
-            "Children supplied with food supplemements",
-            "202202",
-            "202202",
-            "oLuhRyYPxRO",
-            "Senehun CHC",
-            "Sierra Leone / Moyamba / Kamaje / Senehun CHC",
-            "psbwp3CQEhs",
-            "Fixed, >1y",
-            "HllvX50cXC0",
-            "default",
-            "130.0",
-            "11.0",
-            "1.0",
-            "119.0",
-            "80.3",
-            "-84.3",
-            "106.3"));
-    validateRow(
-        response,
-        List.of(
-            "vI2csg55S9C",
-            "OPV3 doses given",
-            "202208",
-            "202208",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "430.0",
-            "13.0",
-            "4.0",
-            "417.0",
-            "70.3",
-            "-505.3",
-            "531.3"));
-    validateRow(
-        response,
-        List.of(
-            "n6aMJNLdvep",
-            "Penta3 doses given",
-            "202208",
-            "202208",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "430.0",
-            "14.0",
-            "4.0",
-            "416.0",
-            "70.1",
-            "-463.2",
-            "491.2"));
-    validateRow(
-        response,
-        List.of(
-            "DUSpd8Jq3M7",
-            "Newborn protected at birth against tetanus (TT2+)",
-            "202207",
-            "202207",
-            "PQEpIeuSTCN",
-            "Tobanda CHC",
-            "Sierra Leone / Kenema / Small Bo / Tobanda CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "111.0",
-            "10.0",
-            "1.0",
-            "101.0",
-            "68.1",
-            "-63.4",
-            "83.4"));
-    validateRow(
-        response,
-        List.of(
-            "Y53Jcc9LBYh",
-            "Children supplied with food supplemements",
-            "202201",
-            "202201",
-            "agEKP19IUKI",
-            "Tambiama CHC",
-            "Sierra Leone / Bombali / Gbendembu Ngowahun / Tambiama CHC",
-            "psbwp3CQEhs",
-            "Fixed, >1y",
-            "HllvX50cXC0",
-            "default",
-            "113.0",
-            "14.0",
-            "1.0",
-            "99.0",
-            "66.8",
-            "-91.2",
-            "119.2"));
-    validateRow(
-        response,
-        List.of(
-            "Y53Jcc9LBYh",
-            "Children supplied with food supplemements",
-            "202202",
-            "202202",
-            "agEKP19IUKI",
-            "Tambiama CHC",
-            "Sierra Leone / Bombali / Gbendembu Ngowahun / Tambiama CHC",
-            "psbwp3CQEhs",
-            "Fixed, >1y",
-            "HllvX50cXC0",
-            "default",
-            "113.0",
-            "14.0",
-            "1.0",
-            "99.0",
-            "66.8",
-            "-91.2",
-            "119.2"));
-    validateRow(
-        response,
-        List.of(
-            "UOlfIjgN8X6",
-            "Fully Immunized child",
-            "202208",
-            "202208",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "455.0",
-            "12.0",
-            "5.0",
-            "443.0",
-            "59.8",
-            "-511.9",
-            "535.9"));
-    validateRow(
-        response,
-        List.of(
-            "I78gJm4KBo7",
-            "Penta2 doses given",
-            "202208",
-            "202208",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "451.0",
-            "14.0",
-            "5.0",
-            "437.0",
-            "59.0",
-            "-492.7",
-            "520.7"));
-    validateRow(
-        response,
-        List.of(
-            "l6byfWFUGaP",
-            "Yellow Fever doses given",
-            "202208",
-            "202208",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "457.0",
-            "11.5",
-            "5.5",
-            "445.5",
-            "54.6",
-            "-548.6",
-            "571.6"));
-    validateRow(
-        response,
-        List.of(
-            "fClA2Erf6IO",
-            "Penta1 doses given",
-            "202208",
-            "202208",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "489.0",
-            "20.0",
-            "6.0",
-            "469.0",
-            "52.7",
-            "-433.2",
-            "473.2"));
-    validateRow(
-        response,
-        List.of(
-            "l6byfWFUGaP",
-            "Yellow Fever doses given",
-            "202209",
-            "202209",
-            "RhJbg8UD75Q",
-            "Yemoh Town CHC",
-            "Sierra Leone / Bo / Kakua / Yemoh Town CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "466.0",
-            "14.0",
-            "6.0",
-            "452.0",
-            "50.8",
-            "-271.7",
-            "299.7"));
-    validateRow(
-        response,
-        List.of(
-            "YtbsuPPo010",
-            "Measles doses given",
-            "202209",
-            "202209",
-            "RhJbg8UD75Q",
-            "Yemoh Town CHC",
-            "Sierra Leone / Bo / Kakua / Yemoh Town CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "466.0",
-            "14.0",
-            "6.0",
-            "452.0",
-            "50.8",
-            "-345.7",
-            "373.7"));
-    validateRow(
-        response,
-        List.of(
-            "YtbsuPPo010",
-            "Measles doses given",
-            "202208",
-            "202208",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "457.0",
-            "12.5",
-            "6.0",
-            "444.5",
-            "50.0",
-            "-574.4",
-            "599.4"));
-    validateRow(
-        response,
-        List.of(
-            "Rmixc9wJl0G",
-            "Q_LLITN given at time of 2nd Vit A dose",
-            "202202",
-            "202202",
-            "EUUkKEDoNsf",
-            "Wilberforce CHC",
-            "Sierra Leone / Western Area / Freetown / Wilberforce CHC",
-            "hEFKSsPV5et",
-            "Outreach, >1y",
-            "HllvX50cXC0",
-            "default",
-            "40.0",
-            "5.5",
-            "0.5",
-            "34.5",
-            "46.5",
-            "-40.0",
-            "51.0"));
-    validateRow(
-        response,
-        List.of(
-            "Y53Jcc9LBYh",
-            "Children supplied with food supplemements",
-            "202201",
-            "202201",
-            "EXbPGmEUdnc",
-            "Mateboi CHC",
-            "Sierra Leone / Bombali / Sanda Tendaren / Mateboi CHC",
-            "psbwp3CQEhs",
-            "Fixed, >1y",
-            "HllvX50cXC0",
-            "default",
-            "80.0",
-            "11.0",
-            "1.0",
-            "69.0",
-            "46.5",
-            "-58.9",
-            "80.9"));
-  }
-
-  @Test
-  public void queryQueryoutliertest10() throws JSONException {
+  public void queryOutliertest10() throws JSONException {
     // Given
     QueryParamsBuilder params =
         new QueryParamsBuilder()
@@ -690,8 +167,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "3.0",
             "704.0",
             "158.3",
-            "-559.9",
-            "579.9"));
+            "-1.1",
+            "21.1"));
     validateRow(
         response,
         List.of(
@@ -711,8 +188,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "7.0",
             "1513.0",
             "145.8",
-            "-1075.7",
-            "1129.7"));
+            "1.1",
+            "52.9"));
     validateRow(
         response,
         List.of(
@@ -732,8 +209,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "3.0",
             "604.0",
             "135.8",
-            "-461.0",
-            "485.0"));
+            "0.9",
+            "23.1"));
     validateRow(
         response,
         List.of(
@@ -753,8 +230,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "3.0",
             "585.0",
             "131.5",
-            "-474.5",
-            "500.5"));
+            "1.9",
+            "24.1"));
     validateRow(
         response,
         List.of(
@@ -774,8 +251,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "2.0",
             "389.0",
             "131.2",
-            "-399.5",
-            "421.5"));
+            "3.6",
+            "18.4"));
     validateRow(
         response,
         List.of(
@@ -795,8 +272,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "4.0",
             "603.0",
             "101.7",
-            "-433.2",
-            "459.2"));
+            "-1.8",
+            "27.8"));
     validateRow(
         response,
         List.of(
@@ -816,8 +293,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "4.0",
             "587.0",
             "99.0",
-            "-505.3",
-            "531.3"));
+            "-1.8",
+            "27.8"));
     validateRow(
         response,
         List.of(
@@ -837,8 +314,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "4.0",
             "586.0",
             "98.8",
-            "-463.2",
-            "491.2"));
+            "-0.8",
+            "28.8"));
     validateRow(
         response,
         List.of(
@@ -858,8 +335,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "3.0",
             "438.0",
             "98.5",
-            "-474.5",
-            "500.5"));
+            "1.9",
+            "24.1"));
     validateRow(
         response,
         List.of(
@@ -879,8 +356,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "4.0",
             "561.0",
             "94.6",
-            "-466.1",
-            "504.1"));
+            "4.2",
+            "33.8"));
     validateRow(
         response,
         List.of(
@@ -900,8 +377,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "4.0",
             "535.0",
             "90.2",
-            "-381.8",
-            "405.8"));
+            "-2.8",
+            "26.8"));
     validateRow(
         response,
         List.of(
@@ -921,8 +398,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "3.0",
             "389.0",
             "87.5",
-            "-416.7",
-            "438.7"));
+            "-0.1",
+            "22.1"));
     validateRow(
         response,
         List.of(
@@ -942,8 +419,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "4.0",
             "518.0",
             "87.3",
-            "-341.4",
-            "365.4"));
+            "-2.8",
+            "26.8"));
     validateRow(
         response,
         List.of(
@@ -963,8 +440,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "4.0",
             "517.0",
             "87.2",
-            "-351.5",
-            "377.5"));
+            "-1.8",
+            "27.8"));
     validateRow(
         response,
         List.of(
@@ -984,8 +461,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "4.0",
             "490.0",
             "82.6",
-            "-318.8",
-            "358.8"));
+            "5.2",
+            "34.8"));
     validateRow(
         response,
         List.of(
@@ -1005,8 +482,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "1.0",
             "119.0",
             "80.3",
-            "-84.3",
-            "106.3"));
+            "7.3",
+            "14.7"));
     validateRow(
         response,
         List.of(
@@ -1026,8 +503,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "5.0",
             "584.0",
             "78.8",
-            "-492.7",
-            "520.7"));
+            "-4.5",
+            "32.5"));
     validateRow(
         response,
         List.of(
@@ -1047,8 +524,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "5.0",
             "582.0",
             "78.5",
-            "-511.9",
-            "535.9"));
+            "-6.5",
+            "30.5"));
     validateRow(
         response,
         List.of(
@@ -1068,8 +545,8 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "5.5",
             "584.5",
             "71.7",
-            "-548.6",
-            "571.6"));
+            "-8.9",
+            "31.9"));
     validateRow(
         response,
         List.of(
@@ -1089,8 +566,531 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "4.0",
             "417.0",
             "70.3",
-            "-505.3",
-            "531.3"));
+            "-1.8",
+            "27.8"));
+  }
+
+  @Test
+  public void queryOutliertest9() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("pe=THIS_YEAR")
+            .add("ou=ImspTQPwCqd")
+            .add("maxResults=20")
+            .add("orderBy=MODIFIEDZSCORE")
+            .add("threshold=2.5")
+            .add("ds=BfMAe6Itzgt")
+            .add("algorithm=MODIFIED_Z_SCORE")
+            .add("relativePeriodDate=2022-07-26");
+
+    // When
+    ApiResponse response = actions.query().get("", JSON, JSON, params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(18)))
+        .body("rows", hasSize(equalTo(20)))
+        .body("height", equalTo(20))
+        .body("width", equalTo(18))
+        .body("headerWidth", equalTo(18));
+
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"count\":20,\"orderBy\":\"MODIFIED_Z_SCORE\",\"threshold\":\"2.5\",\"maxResults\":20,\"algorithm\":\"MODIFIED_Z_SCORE\"}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // Assert headers.
+    validateHeader(response, 0, "dx", "Data", "TEXT", "java.lang.String", false, false);
+    validateHeader(response, 1, "dxname", "Data name", "TEXT", "java.lang.String", false, false);
+    validateHeader(response, 2, "pe", "Period", "TEXT", "java.lang.String", false, false);
+    validateHeader(response, 3, "pename", "Period name", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response, 4, "ou", "Organisation unit", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response, 5, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response,
+        6,
+        "ounamehierarchy",
+        "Organisation unit name hierarchy",
+        "TEXT",
+        "java.lang.String",
+        false,
+        false);
+    validateHeader(
+        response, 7, "coc", "Category option combo", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response,
+        8,
+        "cocname",
+        "Category option combo name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        false);
+    validateHeader(
+        response, 9, "aoc", "Attribute option combo", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response,
+        10,
+        "aocname",
+        "Attribute option combo name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        false);
+    validateHeader(response, 11, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(response, 12, "median", "Median", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response,
+        13,
+        "medianabsdeviation",
+        "Median absolute deviation",
+        "NUMBER",
+        "java.lang.Double",
+        false,
+        false);
+    validateHeader(
+        response, 14, "absdev", "Absolute deviation", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response,
+        15,
+        "modifiedzscore",
+        "Modified Z-score",
+        "NUMBER",
+        "java.lang.Double",
+        false,
+        false);
+    validateHeader(
+        response, 16, "lowerbound", "Lower boundary", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 17, "upperbound", "Upper boundary", "NUMBER", "java.lang.Double", false, false);
+
+    // Assert rows.
+    validateRow(
+        response,
+        List.of(
+            "tU7GixyHhsv",
+            "Vitamin A given to < 5y",
+            "202206",
+            "202206",
+            "scc4QyxenJd",
+            "Makali CHC",
+            "Sierra Leone / Tonkolili / Kunike Barina / Makali CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "714.0",
+            "10.0",
+            "3.0",
+            "704.0",
+            "158.3",
+            "-1.1",
+            "21.1"));
+    validateRow(
+        response,
+        List.of(
+            "lVsbKXoF0zX",
+            "Weight for height below 70 percent",
+            "202206",
+            "202206",
+            "Qc9lf4VM9bD",
+            "Wellington Health Centre",
+            "Sierra Leone / Western Area / Freetown / Wellington Health Centre",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "1540.0",
+            "27.0",
+            "7.0",
+            "1513.0",
+            "145.8",
+            "1.1",
+            "52.9"));
+    validateRow(
+        response,
+        List.of(
+            "bTcRDVjC66S",
+            "Weight for age below lower line (red)",
+            "202205",
+            "202205",
+            "OzjRQLn3G24",
+            "Koidu Govt. Hospital",
+            "Sierra Leone / Kono / Gbense / Koidu Govt. Hospital",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "400.0",
+            "11.0",
+            "2.0",
+            "389.0",
+            "131.2",
+            "3.6",
+            "18.4"));
+    validateRow(
+        response,
+        List.of(
+            "O05mAByOgAv",
+            "OPV2 doses given",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "451.0",
+            "13.0",
+            "3.0",
+            "438.0",
+            "98.5",
+            "1.9",
+            "24.1"));
+    validateRow(
+        response,
+        List.of(
+            "lVsbKXoF0zX",
+            "Weight for height below 70 percent",
+            "202205",
+            "202205",
+            "OzjRQLn3G24",
+            "Koidu Govt. Hospital",
+            "Sierra Leone / Kono / Gbense / Koidu Govt. Hospital",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "400.0",
+            "11.0",
+            "3.0",
+            "389.0",
+            "87.5",
+            "-0.1",
+            "22.1"));
+    validateRow(
+        response,
+        List.of(
+            "Y53Jcc9LBYh",
+            "Children supplied with food supplemements",
+            "202202",
+            "202202",
+            "oLuhRyYPxRO",
+            "Senehun CHC",
+            "Sierra Leone / Moyamba / Kamaje / Senehun CHC",
+            "psbwp3CQEhs",
+            "Fixed, >1y",
+            "HllvX50cXC0",
+            "default",
+            "130.0",
+            "11.0",
+            "1.0",
+            "119.0",
+            "80.3",
+            "7.3",
+            "14.7"));
+    validateRow(
+        response,
+        List.of(
+            "vI2csg55S9C",
+            "OPV3 doses given",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "430.0",
+            "13.0",
+            "4.0",
+            "417.0",
+            "70.3",
+            "-1.8",
+            "27.8"));
+    validateRow(
+        response,
+        List.of(
+            "n6aMJNLdvep",
+            "Penta3 doses given",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "430.0",
+            "14.0",
+            "4.0",
+            "416.0",
+            "70.1",
+            "-0.8",
+            "28.8"));
+    validateRow(
+        response,
+        List.of(
+            "DUSpd8Jq3M7",
+            "Newborn protected at birth against tetanus (TT2+)",
+            "202207",
+            "202207",
+            "PQEpIeuSTCN",
+            "Tobanda CHC",
+            "Sierra Leone / Kenema / Small Bo / Tobanda CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "111.0",
+            "10.0",
+            "1.0",
+            "101.0",
+            "68.1",
+            "6.3",
+            "13.7"));
+    validateRow(
+        response,
+        List.of(
+            "Y53Jcc9LBYh",
+            "Children supplied with food supplemements",
+            "202201",
+            "202201",
+            "agEKP19IUKI",
+            "Tambiama CHC",
+            "Sierra Leone / Bombali / Gbendembu Ngowahun / Tambiama CHC",
+            "psbwp3CQEhs",
+            "Fixed, >1y",
+            "HllvX50cXC0",
+            "default",
+            "113.0",
+            "14.0",
+            "1.0",
+            "99.0",
+            "66.8",
+            "10.3",
+            "17.7"));
+    validateRow(
+        response,
+        List.of(
+            "Y53Jcc9LBYh",
+            "Children supplied with food supplemements",
+            "202202",
+            "202202",
+            "agEKP19IUKI",
+            "Tambiama CHC",
+            "Sierra Leone / Bombali / Gbendembu Ngowahun / Tambiama CHC",
+            "psbwp3CQEhs",
+            "Fixed, >1y",
+            "HllvX50cXC0",
+            "default",
+            "113.0",
+            "14.0",
+            "1.0",
+            "99.0",
+            "66.8",
+            "10.3",
+            "17.7"));
+    validateRow(
+        response,
+        List.of(
+            "UOlfIjgN8X6",
+            "Fully Immunized child",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "455.0",
+            "12.0",
+            "5.0",
+            "443.0",
+            "59.8",
+            "-6.5",
+            "30.5"));
+    validateRow(
+        response,
+        List.of(
+            "I78gJm4KBo7",
+            "Penta2 doses given",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "451.0",
+            "14.0",
+            "5.0",
+            "437.0",
+            "59.0",
+            "-4.5",
+            "32.5"));
+    validateRow(
+        response,
+        List.of(
+            "l6byfWFUGaP",
+            "Yellow Fever doses given",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "457.0",
+            "11.5",
+            "5.5",
+            "445.5",
+            "54.6",
+            "-8.9",
+            "31.9"));
+    validateRow(
+        response,
+        List.of(
+            "fClA2Erf6IO",
+            "Penta1 doses given",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "489.0",
+            "20.0",
+            "6.0",
+            "469.0",
+            "52.7",
+            "-2.2",
+            "42.2"));
+    validateRow(
+        response,
+        List.of(
+            "l6byfWFUGaP",
+            "Yellow Fever doses given",
+            "202209",
+            "202209",
+            "RhJbg8UD75Q",
+            "Yemoh Town CHC",
+            "Sierra Leone / Bo / Kakua / Yemoh Town CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "466.0",
+            "14.0",
+            "6.0",
+            "452.0",
+            "50.8",
+            "-8.2",
+            "36.2"));
+    validateRow(
+        response,
+        List.of(
+            "YtbsuPPo010",
+            "Measles doses given",
+            "202209",
+            "202209",
+            "RhJbg8UD75Q",
+            "Yemoh Town CHC",
+            "Sierra Leone / Bo / Kakua / Yemoh Town CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "466.0",
+            "14.0",
+            "6.0",
+            "452.0",
+            "50.8",
+            "-8.2",
+            "36.2"));
+    validateRow(
+        response,
+        List.of(
+            "YtbsuPPo010",
+            "Measles doses given",
+            "202208",
+            "202208",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "457.0",
+            "12.5",
+            "6.0",
+            "444.5",
+            "50.0",
+            "-9.7",
+            "34.7"));
+    validateRow(
+        response,
+        List.of(
+            "Rmixc9wJl0G",
+            "Q_LLITN given at time of 2nd Vit A dose",
+            "202202",
+            "202202",
+            "EUUkKEDoNsf",
+            "Wilberforce CHC",
+            "Sierra Leone / Western Area / Freetown / Wilberforce CHC",
+            "hEFKSsPV5et",
+            "Outreach, >1y",
+            "HllvX50cXC0",
+            "default",
+            "40.0",
+            "5.5",
+            "0.5",
+            "34.5",
+            "46.5",
+            "3.6",
+            "7.4"));
+    validateRow(
+        response,
+        List.of(
+            "Y53Jcc9LBYh",
+            "Children supplied with food supplemements",
+            "202201",
+            "202201",
+            "EXbPGmEUdnc",
+            "Mateboi CHC",
+            "Sierra Leone / Bombali / Sanda Tendaren / Mateboi CHC",
+            "psbwp3CQEhs",
+            "Fixed, >1y",
+            "HllvX50cXC0",
+            "default",
+            "80.0",
+            "11.0",
+            "1.0",
+            "69.0",
+            "46.5",
+            "7.3",
+            "14.7"));
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection3AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection3AutoTest.java
@@ -150,6 +150,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
     // Assert rows.
     validateRow(
         response,
+        0,
         List.of(
             "tU7GixyHhsv",
             "Vitamin A given to < 5y",
@@ -171,6 +172,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "21.12"));
     validateRow(
         response,
+        1,
         List.of(
             "lVsbKXoF0zX",
             "Weight for height below 70 percent",
@@ -192,6 +194,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "52.95"));
     validateRow(
         response,
+        2,
         List.of(
             "bTcRDVjC66S",
             "Weight for age below lower line (red)",
@@ -213,6 +216,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "18.41"));
     validateRow(
         response,
+        3,
         List.of(
             "O05mAByOgAv",
             "OPV2 doses given",
@@ -234,6 +238,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "24.12"));
     validateRow(
         response,
+        4,
         List.of(
             "lVsbKXoF0zX",
             "Weight for height below 70 percent",
@@ -255,6 +260,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "22.12"));
     validateRow(
         response,
+        5,
         List.of(
             "Y53Jcc9LBYh",
             "Children supplied with food supplemements",
@@ -276,6 +282,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "14.71"));
     validateRow(
         response,
+        6,
         List.of(
             "vI2csg55S9C",
             "OPV3 doses given",
@@ -297,6 +304,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "27.83"));
     validateRow(
         response,
+        7,
         List.of(
             "n6aMJNLdvep",
             "Penta3 doses given",
@@ -318,6 +326,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "28.83"));
     validateRow(
         response,
+        8,
         List.of(
             "DUSpd8Jq3M7",
             "Newborn protected at birth against tetanus (TT2+)",
@@ -339,6 +348,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "13.71"));
     validateRow(
         response,
+        9,
         List.of(
             "Y53Jcc9LBYh",
             "Children supplied with food supplemements",
@@ -360,6 +370,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "17.71"));
     validateRow(
         response,
+        10,
         List.of(
             "Y53Jcc9LBYh",
             "Children supplied with food supplemements",
@@ -381,6 +392,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "17.71"));
     validateRow(
         response,
+        11,
         List.of(
             "UOlfIjgN8X6",
             "Fully Immunized child",
@@ -402,6 +414,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "30.53"));
     validateRow(
         response,
+        12,
         List.of(
             "I78gJm4KBo7",
             "Penta2 doses given",
@@ -423,6 +436,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "32.53"));
     validateRow(
         response,
+        13,
         List.of(
             "l6byfWFUGaP",
             "Yellow Fever doses given",
@@ -444,6 +458,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "31.89"));
     validateRow(
         response,
+        14,
         List.of(
             "fClA2Erf6IO",
             "Penta1 doses given",
@@ -465,6 +480,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "42.24"));
     validateRow(
         response,
+        15,
         List.of(
             "l6byfWFUGaP",
             "Yellow Fever doses given",
@@ -486,6 +502,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "36.24"));
     validateRow(
         response,
+        16,
         List.of(
             "YtbsuPPo010",
             "Measles doses given",
@@ -507,6 +524,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "36.24"));
     validateRow(
         response,
+        17,
         List.of(
             "YtbsuPPo010",
             "Measles doses given",
@@ -528,6 +546,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "34.74"));
     validateRow(
         response,
+        18,
         List.of(
             "Rmixc9wJl0G",
             "Q_LLITN given at time of 2nd Vit A dose",
@@ -549,6 +568,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "7.35"));
     validateRow(
         response,
+        19,
         List.of(
             "Y53Jcc9LBYh",
             "Children supplied with food supplemements",
@@ -673,6 +693,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
     // Assert rows.
     validateRow(
         response,
+        0,
         List.of(
             "tU7GixyHhsv",
             "Vitamin A given to < 5y",
@@ -694,6 +715,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "21.12"));
     validateRow(
         response,
+        1,
         List.of(
             "lVsbKXoF0zX",
             "Weight for height below 70 percent",
@@ -715,6 +737,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "52.95"));
     validateRow(
         response,
+        2,
         List.of(
             "l6byfWFUGaP",
             "Yellow Fever doses given",
@@ -736,6 +759,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "23.12"));
     validateRow(
         response,
+        3,
         List.of(
             "O05mAByOgAv",
             "OPV2 doses given",
@@ -757,6 +781,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "24.12"));
     validateRow(
         response,
+        4,
         List.of(
             "bTcRDVjC66S",
             "Weight for age below lower line (red)",
@@ -778,6 +803,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "18.41"));
     validateRow(
         response,
+        5,
         List.of(
             "YtbsuPPo010",
             "Measles doses given",
@@ -799,6 +825,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "27.83"));
     validateRow(
         response,
+        6,
         List.of(
             "vI2csg55S9C",
             "OPV3 doses given",
@@ -820,6 +847,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "27.83"));
     validateRow(
         response,
+        7,
         List.of(
             "n6aMJNLdvep",
             "Penta3 doses given",
@@ -841,6 +869,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "28.83"));
     validateRow(
         response,
+        8,
         List.of(
             "O05mAByOgAv",
             "OPV2 doses given",
@@ -862,6 +891,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "24.12"));
     validateRow(
         response,
+        9,
         List.of(
             "I78gJm4KBo7",
             "Penta2 doses given",
@@ -883,6 +913,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "33.83"));
     validateRow(
         response,
+        10,
         List.of(
             "UOlfIjgN8X6",
             "Fully Immunized child",
@@ -904,6 +935,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "26.83"));
     validateRow(
         response,
+        11,
         List.of(
             "lVsbKXoF0zX",
             "Weight for height below 70 percent",
@@ -925,6 +957,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "22.12"));
     validateRow(
         response,
+        12,
         List.of(
             "vI2csg55S9C",
             "OPV3 doses given",
@@ -946,6 +979,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "26.83"));
     validateRow(
         response,
+        13,
         List.of(
             "n6aMJNLdvep",
             "Penta3 doses given",
@@ -967,6 +1001,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "27.83"));
     validateRow(
         response,
+        14,
         List.of(
             "x3Do5e7g4Qo",
             "OPV0 doses given",
@@ -988,6 +1023,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "34.83"));
     validateRow(
         response,
+        15,
         List.of(
             "Y53Jcc9LBYh",
             "Children supplied with food supplemements",
@@ -1009,6 +1045,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "14.71"));
     validateRow(
         response,
+        16,
         List.of(
             "I78gJm4KBo7",
             "Penta2 doses given",
@@ -1030,6 +1067,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "32.53"));
     validateRow(
         response,
+        17,
         List.of(
             "UOlfIjgN8X6",
             "Fully Immunized child",
@@ -1051,6 +1089,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "30.53"));
     validateRow(
         response,
+        18,
         List.of(
             "l6byfWFUGaP",
             "Yellow Fever doses given",
@@ -1072,6 +1111,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "31.89"));
     validateRow(
         response,
+        19,
         List.of(
             "vI2csg55S9C",
             "OPV3 doses given",
@@ -1182,6 +1222,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
     // Assert rows.
     validateRow(
         response,
+        0,
         List.of(
             "dU0GquGkGQr",
             "Q_Early breastfeeding (within 1 hr after delivery) at BCG",
@@ -1203,6 +1244,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "104.38"));
     validateRow(
         response,
+        1,
         List.of(
             "s46m5MS0hxu",
             "BCG doses given",
@@ -1224,6 +1266,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "213.99"));
     validateRow(
         response,
+        2,
         List.of(
             "l6byfWFUGaP",
             "Yellow Fever doses given",
@@ -1334,6 +1377,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
     // Assert rows.
     validateRow(
         response,
+        0,
         List.of(
             "dU0GquGkGQr",
             "Q_Early breastfeeding (within 1 hr after delivery) at BCG",
@@ -1355,6 +1399,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "104.38"));
     validateRow(
         response,
+        1,
         List.of(
             "s46m5MS0hxu",
             "BCG doses given",
@@ -1376,6 +1421,7 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "213.99"));
     validateRow(
         response,
+        2,
         List.of(
             "l6byfWFUGaP",
             "Yellow Fever doses given",

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection3AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection3AutoTest.java
@@ -48,529 +48,6 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
   private AnalyticsOutlierDetectionActions actions = new AnalyticsOutlierDetectionActions();
 
   @Test
-  public void queryOutliertest10() throws JSONException {
-    // Given
-    QueryParamsBuilder params =
-        new QueryParamsBuilder()
-            .add("pe=LAST_YEAR")
-            .add("ou=ImspTQPwCqd")
-            .add("maxResults=20")
-            .add("orderBy=MODIFIEDZSCORE")
-            .add("threshold=2.5")
-            .add("ds=BfMAe6Itzgt")
-            .add("algorithm=MODIFIED_Z_SCORE")
-            .add("relativePeriodDate=2022-07-26");
-
-    // When
-    ApiResponse response = actions.query().get("", JSON, JSON, params);
-
-    // Then
-    response
-        .validate()
-        .statusCode(200)
-        .body("headers", hasSize(equalTo(18)))
-        .body("rows", hasSize(equalTo(20)))
-        .body("height", equalTo(20))
-        .body("width", equalTo(18))
-        .body("headerWidth", equalTo(18));
-
-    // Assert metaData.
-    String expectedMetaData =
-        "{\"count\":20,\"orderBy\":\"MODIFIED_Z_SCORE\",\"threshold\":\"2.5\",\"maxResults\":20,\"algorithm\":\"MODIFIED_Z_SCORE\"}";
-    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
-    assertEquals(expectedMetaData, actualMetaData, false);
-
-    // Assert headers.
-    validateHeader(response, 0, "dx", "Data", "TEXT", "java.lang.String", false, false);
-    validateHeader(response, 1, "dxname", "Data name", "TEXT", "java.lang.String", false, false);
-    validateHeader(response, 2, "pe", "Period", "TEXT", "java.lang.String", false, false);
-    validateHeader(response, 3, "pename", "Period name", "TEXT", "java.lang.String", false, false);
-    validateHeader(
-        response, 4, "ou", "Organisation unit", "TEXT", "java.lang.String", false, false);
-    validateHeader(
-        response, 5, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, false);
-    validateHeader(
-        response,
-        6,
-        "ounamehierarchy",
-        "Organisation unit name hierarchy",
-        "TEXT",
-        "java.lang.String",
-        false,
-        false);
-    validateHeader(
-        response, 7, "coc", "Category option combo", "TEXT", "java.lang.String", false, false);
-    validateHeader(
-        response,
-        8,
-        "cocname",
-        "Category option combo name",
-        "TEXT",
-        "java.lang.String",
-        false,
-        false);
-    validateHeader(
-        response, 9, "aoc", "Attribute option combo", "TEXT", "java.lang.String", false, false);
-    validateHeader(
-        response,
-        10,
-        "aocname",
-        "Attribute option combo name",
-        "TEXT",
-        "java.lang.String",
-        false,
-        false);
-    validateHeader(response, 11, "value", "Value", "NUMBER", "java.lang.Double", false, false);
-    validateHeader(response, 12, "median", "Median", "NUMBER", "java.lang.Double", false, false);
-    validateHeader(
-        response,
-        13,
-        "medianabsdeviation",
-        "Median absolute deviation",
-        "NUMBER",
-        "java.lang.Double",
-        false,
-        false);
-    validateHeader(
-        response, 14, "absdev", "Absolute deviation", "NUMBER", "java.lang.Double", false, false);
-    validateHeader(
-        response,
-        15,
-        "modifiedzscore",
-        "Modified Z-score",
-        "NUMBER",
-        "java.lang.Double",
-        false,
-        false);
-    validateHeader(
-        response, 16, "lowerbound", "Lower boundary", "NUMBER", "java.lang.Double", false, false);
-    validateHeader(
-        response, 17, "upperbound", "Upper boundary", "NUMBER", "java.lang.Double", false, false);
-
-    // Assert rows.
-    validateRow(
-        response,
-        List.of(
-            "tU7GixyHhsv",
-            "Vitamin A given to < 5y",
-            "202106",
-            "202106",
-            "scc4QyxenJd",
-            "Makali CHC",
-            "Sierra Leone / Tonkolili / Kunike Barina / Makali CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "714.0",
-            "10.0",
-            "3.0",
-            "704.0",
-            "158.3",
-            "-1.1",
-            "21.1"));
-    validateRow(
-        response,
-        List.of(
-            "lVsbKXoF0zX",
-            "Weight for height below 70 percent",
-            "202106",
-            "202106",
-            "Qc9lf4VM9bD",
-            "Wellington Health Centre",
-            "Sierra Leone / Western Area / Freetown / Wellington Health Centre",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "1540.0",
-            "27.0",
-            "7.0",
-            "1513.0",
-            "145.8",
-            "1.1",
-            "52.9"));
-    validateRow(
-        response,
-        List.of(
-            "l6byfWFUGaP",
-            "Yellow Fever doses given",
-            "202111",
-            "202111",
-            "mzsOsz0NwNY",
-            "New Police Barracks CHC",
-            "Sierra Leone / Bo / Kakua / New Police Barracks CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "616.0",
-            "12.0",
-            "3.0",
-            "604.0",
-            "135.8",
-            "0.9",
-            "23.1"));
-    validateRow(
-        response,
-        List.of(
-            "O05mAByOgAv",
-            "OPV2 doses given",
-            "202110",
-            "202110",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "598.0",
-            "13.0",
-            "3.0",
-            "585.0",
-            "131.5",
-            "1.9",
-            "24.1"));
-    validateRow(
-        response,
-        List.of(
-            "bTcRDVjC66S",
-            "Weight for age below lower line (red)",
-            "202105",
-            "202105",
-            "OzjRQLn3G24",
-            "Koidu Govt. Hospital",
-            "Sierra Leone / Kono / Gbense / Koidu Govt. Hospital",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "400.0",
-            "11.0",
-            "2.0",
-            "389.0",
-            "131.2",
-            "3.6",
-            "18.4"));
-    validateRow(
-        response,
-        List.of(
-            "YtbsuPPo010",
-            "Measles doses given",
-            "202111",
-            "202111",
-            "mzsOsz0NwNY",
-            "New Police Barracks CHC",
-            "Sierra Leone / Bo / Kakua / New Police Barracks CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "616.0",
-            "13.0",
-            "4.0",
-            "603.0",
-            "101.7",
-            "-1.8",
-            "27.8"));
-    validateRow(
-        response,
-        List.of(
-            "vI2csg55S9C",
-            "OPV3 doses given",
-            "202110",
-            "202110",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "600.0",
-            "13.0",
-            "4.0",
-            "587.0",
-            "99.0",
-            "-1.8",
-            "27.8"));
-    validateRow(
-        response,
-        List.of(
-            "n6aMJNLdvep",
-            "Penta3 doses given",
-            "202110",
-            "202110",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "600.0",
-            "14.0",
-            "4.0",
-            "586.0",
-            "98.8",
-            "-0.8",
-            "28.8"));
-    validateRow(
-        response,
-        List.of(
-            "O05mAByOgAv",
-            "OPV2 doses given",
-            "202108",
-            "202108",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "451.0",
-            "13.0",
-            "3.0",
-            "438.0",
-            "98.5",
-            "1.9",
-            "24.1"));
-    validateRow(
-        response,
-        List.of(
-            "I78gJm4KBo7",
-            "Penta2 doses given",
-            "202111",
-            "202111",
-            "mzsOsz0NwNY",
-            "New Police Barracks CHC",
-            "Sierra Leone / Bo / Kakua / New Police Barracks CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "580.0",
-            "19.0",
-            "4.0",
-            "561.0",
-            "94.6",
-            "4.2",
-            "33.8"));
-    validateRow(
-        response,
-        List.of(
-            "UOlfIjgN8X6",
-            "Fully Immunized child",
-            "202111",
-            "202111",
-            "mzsOsz0NwNY",
-            "New Police Barracks CHC",
-            "Sierra Leone / Bo / Kakua / New Police Barracks CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "547.0",
-            "12.0",
-            "4.0",
-            "535.0",
-            "90.2",
-            "-2.8",
-            "26.8"));
-    validateRow(
-        response,
-        List.of(
-            "lVsbKXoF0zX",
-            "Weight for height below 70 percent",
-            "202105",
-            "202105",
-            "OzjRQLn3G24",
-            "Koidu Govt. Hospital",
-            "Sierra Leone / Kono / Gbense / Koidu Govt. Hospital",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "400.0",
-            "11.0",
-            "3.0",
-            "389.0",
-            "87.5",
-            "-0.1",
-            "22.1"));
-    validateRow(
-        response,
-        List.of(
-            "vI2csg55S9C",
-            "OPV3 doses given",
-            "202111",
-            "202111",
-            "mzsOsz0NwNY",
-            "New Police Barracks CHC",
-            "Sierra Leone / Bo / Kakua / New Police Barracks CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "530.0",
-            "12.0",
-            "4.0",
-            "518.0",
-            "87.3",
-            "-2.8",
-            "26.8"));
-    validateRow(
-        response,
-        List.of(
-            "n6aMJNLdvep",
-            "Penta3 doses given",
-            "202111",
-            "202111",
-            "mzsOsz0NwNY",
-            "New Police Barracks CHC",
-            "Sierra Leone / Bo / Kakua / New Police Barracks CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "530.0",
-            "13.0",
-            "4.0",
-            "517.0",
-            "87.2",
-            "-1.8",
-            "27.8"));
-    validateRow(
-        response,
-        List.of(
-            "x3Do5e7g4Qo",
-            "OPV0 doses given",
-            "202112",
-            "202112",
-            "ui12Hyvn6jR",
-            "Wilberforce Military Hospital",
-            "Sierra Leone / Western Area / Freetown / Wilberforce Military Hospital",
-            "V6L425pT3A0",
-            "Outreach, <1y",
-            "HllvX50cXC0",
-            "default",
-            "510.0",
-            "20.0",
-            "4.0",
-            "490.0",
-            "82.6",
-            "5.2",
-            "34.8"));
-    validateRow(
-        response,
-        List.of(
-            "Y53Jcc9LBYh",
-            "Children supplied with food supplemements",
-            "202102",
-            "202102",
-            "oLuhRyYPxRO",
-            "Senehun CHC",
-            "Sierra Leone / Moyamba / Kamaje / Senehun CHC",
-            "psbwp3CQEhs",
-            "Fixed, >1y",
-            "HllvX50cXC0",
-            "default",
-            "130.0",
-            "11.0",
-            "1.0",
-            "119.0",
-            "80.3",
-            "7.3",
-            "14.7"));
-    validateRow(
-        response,
-        List.of(
-            "I78gJm4KBo7",
-            "Penta2 doses given",
-            "202110",
-            "202110",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "598.0",
-            "14.0",
-            "5.0",
-            "584.0",
-            "78.8",
-            "-4.5",
-            "32.5"));
-    validateRow(
-        response,
-        List.of(
-            "UOlfIjgN8X6",
-            "Fully Immunized child",
-            "202110",
-            "202110",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "594.0",
-            "12.0",
-            "5.0",
-            "582.0",
-            "78.5",
-            "-6.5",
-            "30.5"));
-    validateRow(
-        response,
-        List.of(
-            "l6byfWFUGaP",
-            "Yellow Fever doses given",
-            "202110",
-            "202110",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "596.0",
-            "11.5",
-            "5.5",
-            "584.5",
-            "71.7",
-            "-8.9",
-            "31.9"));
-    validateRow(
-        response,
-        List.of(
-            "vI2csg55S9C",
-            "OPV3 doses given",
-            "202108",
-            "202108",
-            "tSBcgrTDdB8",
-            "Paramedical CHC",
-            "Sierra Leone / Bo / Kakua / Paramedical CHC",
-            "Prlt0C1RF0s",
-            "Fixed, <1y",
-            "HllvX50cXC0",
-            "default",
-            "430.0",
-            "13.0",
-            "4.0",
-            "417.0",
-            "70.3",
-            "-1.8",
-            "27.8"));
-  }
-
-  @Test
   public void queryOutliertest9() throws JSONException {
     // Given
     QueryParamsBuilder params =
@@ -689,9 +166,9 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "10.0",
             "3.0",
             "704.0",
-            "158.3",
-            "-1.1",
-            "21.1"));
+            "158.28",
+            "-1.12",
+            "21.12"));
     validateRow(
         response,
         List.of(
@@ -710,9 +187,9 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "27.0",
             "7.0",
             "1513.0",
-            "145.8",
-            "1.1",
-            "52.9"));
+            "145.79",
+            "1.05",
+            "52.95"));
     validateRow(
         response,
         List.of(
@@ -731,9 +208,9 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "11.0",
             "2.0",
             "389.0",
-            "131.2",
-            "3.6",
-            "18.4"));
+            "131.19",
+            "3.59",
+            "18.41"));
     validateRow(
         response,
         List.of(
@@ -752,9 +229,9 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "13.0",
             "3.0",
             "438.0",
-            "98.5",
-            "1.9",
-            "24.1"));
+            "98.48",
+            "1.88",
+            "24.12"));
     validateRow(
         response,
         List.of(
@@ -773,9 +250,9 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "11.0",
             "3.0",
             "389.0",
-            "87.5",
-            "-0.1",
-            "22.1"));
+            "87.46",
+            "-0.12",
+            "22.12"));
     validateRow(
         response,
         List.of(
@@ -794,9 +271,9 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "11.0",
             "1.0",
             "119.0",
-            "80.3",
-            "7.3",
-            "14.7"));
+            "80.27",
+            "7.29",
+            "14.71"));
     validateRow(
         response,
         List.of(
@@ -815,9 +292,9 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "13.0",
             "4.0",
             "417.0",
-            "70.3",
-            "-1.8",
-            "27.8"));
+            "70.32",
+            "-1.83",
+            "27.83"));
     validateRow(
         response,
         List.of(
@@ -836,9 +313,9 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "14.0",
             "4.0",
             "416.0",
-            "70.1",
-            "-0.8",
-            "28.8"));
+            "70.15",
+            "-0.83",
+            "28.83"));
     validateRow(
         response,
         List.of(
@@ -857,9 +334,9 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "10.0",
             "1.0",
             "101.0",
-            "68.1",
-            "6.3",
-            "13.7"));
+            "68.12",
+            "6.29",
+            "13.71"));
     validateRow(
         response,
         List.of(
@@ -878,9 +355,9 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "14.0",
             "1.0",
             "99.0",
-            "66.8",
-            "10.3",
-            "17.7"));
+            "66.78",
+            "10.29",
+            "17.71"));
     validateRow(
         response,
         List.of(
@@ -899,9 +376,9 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "14.0",
             "1.0",
             "99.0",
-            "66.8",
-            "10.3",
-            "17.7"));
+            "66.78",
+            "10.29",
+            "17.71"));
     validateRow(
         response,
         List.of(
@@ -920,9 +397,9 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "12.0",
             "5.0",
             "443.0",
-            "59.8",
-            "-6.5",
-            "30.5"));
+            "59.76",
+            "-6.53",
+            "30.53"));
     validateRow(
         response,
         List.of(
@@ -941,9 +418,9 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "14.0",
             "5.0",
             "437.0",
-            "59.0",
-            "-4.5",
-            "32.5"));
+            "58.95",
+            "-4.53",
+            "32.53"));
     validateRow(
         response,
         List.of(
@@ -962,9 +439,9 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "11.5",
             "5.5",
             "445.5",
-            "54.6",
-            "-8.9",
-            "31.9"));
+            "54.63",
+            "-8.89",
+            "31.89"));
     validateRow(
         response,
         List.of(
@@ -983,9 +460,9 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "20.0",
             "6.0",
             "469.0",
-            "52.7",
-            "-2.2",
-            "42.2"));
+            "52.72",
+            "-2.24",
+            "42.24"));
     validateRow(
         response,
         List.of(
@@ -1004,9 +481,9 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "14.0",
             "6.0",
             "452.0",
-            "50.8",
-            "-8.2",
-            "36.2"));
+            "50.81",
+            "-8.24",
+            "36.24"));
     validateRow(
         response,
         List.of(
@@ -1025,9 +502,9 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "14.0",
             "6.0",
             "452.0",
-            "50.8",
-            "-8.2",
-            "36.2"));
+            "50.81",
+            "-8.24",
+            "36.24"));
     validateRow(
         response,
         List.of(
@@ -1046,9 +523,9 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "12.5",
             "6.0",
             "444.5",
-            "50.0",
-            "-9.7",
-            "34.7"));
+            "49.97",
+            "-9.74",
+            "34.74"));
     validateRow(
         response,
         List.of(
@@ -1067,9 +544,9 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "5.5",
             "0.5",
             "34.5",
-            "46.5",
-            "3.6",
-            "7.4"));
+            "46.54",
+            "3.65",
+            "7.35"));
     validateRow(
         response,
         List.of(
@@ -1088,13 +565,536 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "11.0",
             "1.0",
             "69.0",
-            "46.5",
-            "7.3",
-            "14.7"));
+            "46.54",
+            "7.29",
+            "14.71"));
   }
 
   @Test
-  public void queryQueryoutliertest11() throws JSONException {
+  public void queryOutliertest10() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("pe=LAST_YEAR")
+            .add("ou=ImspTQPwCqd")
+            .add("maxResults=20")
+            .add("orderBy=MODIFIEDZSCORE")
+            .add("threshold=2.5")
+            .add("ds=BfMAe6Itzgt")
+            .add("algorithm=MODIFIED_Z_SCORE")
+            .add("relativePeriodDate=2022-07-26");
+
+    // When
+    ApiResponse response = actions.query().get("", JSON, JSON, params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(18)))
+        .body("rows", hasSize(equalTo(20)))
+        .body("height", equalTo(20))
+        .body("width", equalTo(18))
+        .body("headerWidth", equalTo(18));
+
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"count\":20,\"orderBy\":\"MODIFIED_Z_SCORE\",\"threshold\":\"2.5\",\"maxResults\":20,\"algorithm\":\"MODIFIED_Z_SCORE\"}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // Assert headers.
+    validateHeader(response, 0, "dx", "Data", "TEXT", "java.lang.String", false, false);
+    validateHeader(response, 1, "dxname", "Data name", "TEXT", "java.lang.String", false, false);
+    validateHeader(response, 2, "pe", "Period", "TEXT", "java.lang.String", false, false);
+    validateHeader(response, 3, "pename", "Period name", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response, 4, "ou", "Organisation unit", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response, 5, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response,
+        6,
+        "ounamehierarchy",
+        "Organisation unit name hierarchy",
+        "TEXT",
+        "java.lang.String",
+        false,
+        false);
+    validateHeader(
+        response, 7, "coc", "Category option combo", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response,
+        8,
+        "cocname",
+        "Category option combo name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        false);
+    validateHeader(
+        response, 9, "aoc", "Attribute option combo", "TEXT", "java.lang.String", false, false);
+    validateHeader(
+        response,
+        10,
+        "aocname",
+        "Attribute option combo name",
+        "TEXT",
+        "java.lang.String",
+        false,
+        false);
+    validateHeader(response, 11, "value", "Value", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(response, 12, "median", "Median", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response,
+        13,
+        "medianabsdeviation",
+        "Median absolute deviation",
+        "NUMBER",
+        "java.lang.Double",
+        false,
+        false);
+    validateHeader(
+        response, 14, "absdev", "Absolute deviation", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response,
+        15,
+        "modifiedzscore",
+        "Modified Z-score",
+        "NUMBER",
+        "java.lang.Double",
+        false,
+        false);
+    validateHeader(
+        response, 16, "lowerbound", "Lower boundary", "NUMBER", "java.lang.Double", false, false);
+    validateHeader(
+        response, 17, "upperbound", "Upper boundary", "NUMBER", "java.lang.Double", false, false);
+
+    // Assert rows.
+    validateRow(
+        response,
+        List.of(
+            "tU7GixyHhsv",
+            "Vitamin A given to < 5y",
+            "202106",
+            "202106",
+            "scc4QyxenJd",
+            "Makali CHC",
+            "Sierra Leone / Tonkolili / Kunike Barina / Makali CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "714.0",
+            "10.0",
+            "3.0",
+            "704.0",
+            "158.28",
+            "-1.12",
+            "21.12"));
+    validateRow(
+        response,
+        List.of(
+            "lVsbKXoF0zX",
+            "Weight for height below 70 percent",
+            "202106",
+            "202106",
+            "Qc9lf4VM9bD",
+            "Wellington Health Centre",
+            "Sierra Leone / Western Area / Freetown / Wellington Health Centre",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "1540.0",
+            "27.0",
+            "7.0",
+            "1513.0",
+            "145.79",
+            "1.05",
+            "52.95"));
+    validateRow(
+        response,
+        List.of(
+            "l6byfWFUGaP",
+            "Yellow Fever doses given",
+            "202111",
+            "202111",
+            "mzsOsz0NwNY",
+            "New Police Barracks CHC",
+            "Sierra Leone / Bo / Kakua / New Police Barracks CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "616.0",
+            "12.0",
+            "3.0",
+            "604.0",
+            "135.8",
+            "0.88",
+            "23.12"));
+    validateRow(
+        response,
+        List.of(
+            "O05mAByOgAv",
+            "OPV2 doses given",
+            "202110",
+            "202110",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "598.0",
+            "13.0",
+            "3.0",
+            "585.0",
+            "131.53",
+            "1.88",
+            "24.12"));
+    validateRow(
+        response,
+        List.of(
+            "bTcRDVjC66S",
+            "Weight for age below lower line (red)",
+            "202105",
+            "202105",
+            "OzjRQLn3G24",
+            "Koidu Govt. Hospital",
+            "Sierra Leone / Kono / Gbense / Koidu Govt. Hospital",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "400.0",
+            "11.0",
+            "2.0",
+            "389.0",
+            "131.19",
+            "3.59",
+            "18.41"));
+    validateRow(
+        response,
+        List.of(
+            "YtbsuPPo010",
+            "Measles doses given",
+            "202111",
+            "202111",
+            "mzsOsz0NwNY",
+            "New Police Barracks CHC",
+            "Sierra Leone / Bo / Kakua / New Police Barracks CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "616.0",
+            "13.0",
+            "4.0",
+            "603.0",
+            "101.68",
+            "-1.83",
+            "27.83"));
+    validateRow(
+        response,
+        List.of(
+            "vI2csg55S9C",
+            "OPV3 doses given",
+            "202110",
+            "202110",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "600.0",
+            "13.0",
+            "4.0",
+            "587.0",
+            "98.98",
+            "-1.83",
+            "27.83"));
+    validateRow(
+        response,
+        List.of(
+            "n6aMJNLdvep",
+            "Penta3 doses given",
+            "202110",
+            "202110",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "600.0",
+            "14.0",
+            "4.0",
+            "586.0",
+            "98.81",
+            "-0.83",
+            "28.83"));
+    validateRow(
+        response,
+        List.of(
+            "O05mAByOgAv",
+            "OPV2 doses given",
+            "202108",
+            "202108",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "451.0",
+            "13.0",
+            "3.0",
+            "438.0",
+            "98.48",
+            "1.88",
+            "24.12"));
+    validateRow(
+        response,
+        List.of(
+            "I78gJm4KBo7",
+            "Penta2 doses given",
+            "202111",
+            "202111",
+            "mzsOsz0NwNY",
+            "New Police Barracks CHC",
+            "Sierra Leone / Bo / Kakua / New Police Barracks CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "580.0",
+            "19.0",
+            "4.0",
+            "561.0",
+            "94.6",
+            "4.17",
+            "33.83"));
+    validateRow(
+        response,
+        List.of(
+            "UOlfIjgN8X6",
+            "Fully Immunized child",
+            "202111",
+            "202111",
+            "mzsOsz0NwNY",
+            "New Police Barracks CHC",
+            "Sierra Leone / Bo / Kakua / New Police Barracks CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "547.0",
+            "12.0",
+            "4.0",
+            "535.0",
+            "90.21",
+            "-2.83",
+            "26.83"));
+    validateRow(
+        response,
+        List.of(
+            "lVsbKXoF0zX",
+            "Weight for height below 70 percent",
+            "202105",
+            "202105",
+            "OzjRQLn3G24",
+            "Koidu Govt. Hospital",
+            "Sierra Leone / Kono / Gbense / Koidu Govt. Hospital",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "400.0",
+            "11.0",
+            "3.0",
+            "389.0",
+            "87.46",
+            "-0.12",
+            "22.12"));
+    validateRow(
+        response,
+        List.of(
+            "vI2csg55S9C",
+            "OPV3 doses given",
+            "202111",
+            "202111",
+            "mzsOsz0NwNY",
+            "New Police Barracks CHC",
+            "Sierra Leone / Bo / Kakua / New Police Barracks CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "530.0",
+            "12.0",
+            "4.0",
+            "518.0",
+            "87.35",
+            "-2.83",
+            "26.83"));
+    validateRow(
+        response,
+        List.of(
+            "n6aMJNLdvep",
+            "Penta3 doses given",
+            "202111",
+            "202111",
+            "mzsOsz0NwNY",
+            "New Police Barracks CHC",
+            "Sierra Leone / Bo / Kakua / New Police Barracks CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "530.0",
+            "13.0",
+            "4.0",
+            "517.0",
+            "87.18",
+            "-1.83",
+            "27.83"));
+    validateRow(
+        response,
+        List.of(
+            "x3Do5e7g4Qo",
+            "OPV0 doses given",
+            "202112",
+            "202112",
+            "ui12Hyvn6jR",
+            "Wilberforce Military Hospital",
+            "Sierra Leone / Western Area / Freetown / Wilberforce Military Hospital",
+            "V6L425pT3A0",
+            "Outreach, <1y",
+            "HllvX50cXC0",
+            "default",
+            "510.0",
+            "20.0",
+            "4.0",
+            "490.0",
+            "82.63",
+            "5.17",
+            "34.83"));
+    validateRow(
+        response,
+        List.of(
+            "Y53Jcc9LBYh",
+            "Children supplied with food supplemements",
+            "202102",
+            "202102",
+            "oLuhRyYPxRO",
+            "Senehun CHC",
+            "Sierra Leone / Moyamba / Kamaje / Senehun CHC",
+            "psbwp3CQEhs",
+            "Fixed, >1y",
+            "HllvX50cXC0",
+            "default",
+            "130.0",
+            "11.0",
+            "1.0",
+            "119.0",
+            "80.27",
+            "7.29",
+            "14.71"));
+    validateRow(
+        response,
+        List.of(
+            "I78gJm4KBo7",
+            "Penta2 doses given",
+            "202110",
+            "202110",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "598.0",
+            "14.0",
+            "5.0",
+            "584.0",
+            "78.78",
+            "-4.53",
+            "32.53"));
+    validateRow(
+        response,
+        List.of(
+            "UOlfIjgN8X6",
+            "Fully Immunized child",
+            "202110",
+            "202110",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "594.0",
+            "12.0",
+            "5.0",
+            "582.0",
+            "78.51",
+            "-6.53",
+            "30.53"));
+    validateRow(
+        response,
+        List.of(
+            "l6byfWFUGaP",
+            "Yellow Fever doses given",
+            "202110",
+            "202110",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "596.0",
+            "11.5",
+            "5.5",
+            "584.5",
+            "71.68",
+            "-8.89",
+            "31.89"));
+    validateRow(
+        response,
+        List.of(
+            "vI2csg55S9C",
+            "OPV3 doses given",
+            "202108",
+            "202108",
+            "tSBcgrTDdB8",
+            "Paramedical CHC",
+            "Sierra Leone / Bo / Kakua / Paramedical CHC",
+            "Prlt0C1RF0s",
+            "Fixed, <1y",
+            "HllvX50cXC0",
+            "default",
+            "430.0",
+            "13.0",
+            "4.0",
+            "417.0",
+            "70.32",
+            "-1.83",
+            "27.83"));
+  }
+
+  @Test
+  public void queryOutliertest11() throws JSONException {
     // Given
     QueryParamsBuilder params =
         new QueryParamsBuilder()
@@ -1195,12 +1195,12 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "HllvX50cXC0",
             "default",
             "105.0",
-            "18.3",
-            "28.7",
-            "86.7",
-            "3.0",
-            "-67.9",
-            "104.4"));
+            "18.26",
+            "28.71",
+            "86.74",
+            "3.02",
+            "-67.85",
+            "104.38"));
     validateRow(
         response,
         List.of(
@@ -1216,12 +1216,12 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "HllvX50cXC0",
             "default",
             "220.0",
-            "41.6",
-            "57.4",
-            "178.4",
+            "41.64",
+            "57.45",
+            "178.36",
             "3.1",
             "-130.7",
-            "214.0"));
+            "213.99"));
     validateRow(
         response,
         List.of(
@@ -1237,16 +1237,16 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "HllvX50cXC0",
             "default",
             "466.0",
-            "48.2",
-            "114.3",
-            "417.8",
-            "3.7",
-            "-294.7",
-            "391.0"));
+            "48.19",
+            "114.28",
+            "417.81",
+            "3.66",
+            "-294.65",
+            "391.03"));
   }
 
   @Test
-  public void queryQueryoutliertest12() throws JSONException {
+  public void queryOutliertest12() throws JSONException {
     // Given
     QueryParamsBuilder params =
         new QueryParamsBuilder()
@@ -1347,12 +1347,12 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "HllvX50cXC0",
             "default",
             "105.0",
-            "18.3",
-            "28.7",
-            "86.7",
-            "3.0",
-            "-67.9",
-            "104.4"));
+            "18.26",
+            "28.71",
+            "86.74",
+            "3.02",
+            "-67.85",
+            "104.38"));
     validateRow(
         response,
         List.of(
@@ -1368,12 +1368,12 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "HllvX50cXC0",
             "default",
             "220.0",
-            "41.6",
-            "57.4",
-            "178.4",
+            "41.64",
+            "57.45",
+            "178.36",
             "3.1",
             "-130.7",
-            "214.0"));
+            "213.99"));
     validateRow(
         response,
         List.of(
@@ -1389,11 +1389,11 @@ public class OutliersDetection3AutoTest extends AnalyticsApiTest {
             "HllvX50cXC0",
             "default",
             "466.0",
-            "48.2",
-            "114.3",
-            "417.8",
-            "3.7",
-            "-294.7",
-            "391.0"));
+            "48.19",
+            "114.28",
+            "417.81",
+            "3.66",
+            "-294.65",
+            "391.03"));
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection4AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection4AutoTest.java
@@ -153,6 +153,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
     // Assert rows.
     validateRow(
         response,
+        0,
         List.of(
             "Jtf34kNZhzP",
             "ANC 3rd visit",
@@ -174,6 +175,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "42.69"));
     validateRow(
         response,
+        1,
         List.of(
             "cYeuwXTCPkU",
             "ANC 2nd visit",
@@ -195,6 +197,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "1456.19"));
     validateRow(
         response,
+        2,
         List.of(
             "cYeuwXTCPkU",
             "ANC 2nd visit",
@@ -216,6 +219,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "156.13"));
     validateRow(
         response,
+        3,
         List.of(
             "fbfJHSPpUQD",
             "ANC 1st visit",
@@ -237,6 +241,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "7.45"));
     validateRow(
         response,
+        4,
         List.of(
             "cYeuwXTCPkU",
             "ANC 2nd visit",
@@ -258,6 +263,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "12.9"));
     validateRow(
         response,
+        5,
         List.of(
             "FHD3wiSM7Sn",
             "ARI treated with antibiotics (pneumonia) follow-up",
@@ -279,6 +285,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "284.04"));
     validateRow(
         response,
+        6,
         List.of(
             "fbfJHSPpUQD",
             "ANC 1st visit",
@@ -300,6 +307,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "292.48"));
     validateRow(
         response,
+        7,
         List.of(
             "cYeuwXTCPkU",
             "ANC 2nd visit",
@@ -321,6 +329,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "272.86"));
     validateRow(
         response,
+        8,
         List.of(
             "fbfJHSPpUQD",
             "ANC 1st visit",
@@ -342,6 +351,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "253.71"));
     validateRow(
         response,
+        9,
         List.of(
             "FHD3wiSM7Sn",
             "ARI treated with antibiotics (pneumonia) follow-up",
@@ -468,6 +478,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
     // Assert rows.
     validateRow(
         response,
+        0,
         List.of(
             "FHD3wiSM7Sn",
             "ARI treated with antibiotics (pneumonia) follow-up",
@@ -489,6 +500,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "284.04"));
     validateRow(
         response,
+        1,
         List.of(
             "FHD3wiSM7Sn",
             "ARI treated with antibiotics (pneumonia) follow-up",
@@ -510,6 +522,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "120.32"));
     validateRow(
         response,
+        2,
         List.of(
             "FHD3wiSM7Sn",
             "ARI treated with antibiotics (pneumonia) follow-up",
@@ -531,6 +544,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "284.04"));
     validateRow(
         response,
+        3,
         List.of(
             "FHD3wiSM7Sn",
             "ARI treated with antibiotics (pneumonia) follow-up",
@@ -552,6 +566,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "61.43"));
     validateRow(
         response,
+        4,
         List.of(
             "FHD3wiSM7Sn",
             "ARI treated with antibiotics (pneumonia) follow-up",
@@ -678,6 +693,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
     // Assert rows.
     validateRow(
         response,
+        0,
         List.of(
             "Jtf34kNZhzP",
             "ANC 3rd visit",
@@ -699,6 +715,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "42.69"));
     validateRow(
         response,
+        1,
         List.of(
             "cYeuwXTCPkU",
             "ANC 2nd visit",
@@ -720,6 +737,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "1456.19"));
     validateRow(
         response,
+        2,
         List.of(
             "cYeuwXTCPkU",
             "ANC 2nd visit",
@@ -741,6 +759,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "156.13"));
     validateRow(
         response,
+        3,
         List.of(
             "fbfJHSPpUQD",
             "ANC 1st visit",
@@ -762,6 +781,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "7.45"));
     validateRow(
         response,
+        4,
         List.of(
             "cYeuwXTCPkU",
             "ANC 2nd visit",
@@ -783,6 +803,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "12.9"));
     validateRow(
         response,
+        5,
         List.of(
             "fbfJHSPpUQD",
             "ANC 1st visit",
@@ -804,6 +825,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "292.48"));
     validateRow(
         response,
+        6,
         List.of(
             "cYeuwXTCPkU",
             "ANC 2nd visit",
@@ -825,6 +847,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "272.86"));
     validateRow(
         response,
+        7,
         List.of(
             "fbfJHSPpUQD",
             "ANC 1st visit",
@@ -846,6 +869,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "253.71"));
     validateRow(
         response,
+        8,
         List.of(
             "fbfJHSPpUQD",
             "ANC 1st visit",
@@ -867,6 +891,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "278.97"));
     validateRow(
         response,
+        9,
         List.of(
             "fbfJHSPpUQD",
             "ANC 1st visit",
@@ -936,6 +961,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
     // Assert rows.
     validateRow(
         response,
+        0,
         List.of(
             "dU0GquGkGQr",
             "Q_Early breastfeeding (within 1 hr after delivery) at BCG",
@@ -945,6 +971,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "-67.8530554519"));
     validateRow(
         response,
+        1,
         List.of(
             "s46m5MS0hxu",
             "BCG doses given",
@@ -954,6 +981,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "-130.7045505648"));
     validateRow(
         response,
+        2,
         List.of(
             "l6byfWFUGaP",
             "Yellow Fever doses given",

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection4AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection4AutoTest.java
@@ -169,9 +169,9 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "16.0",
             "6.0",
             "1910.0",
-            "214.7",
-            "-10.7",
-            "42.7"));
+            "214.72",
+            "-10.69",
+            "42.69"));
     validateRow(
         response,
         List.of(
@@ -191,8 +191,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "159.0",
             "920.0",
             "3.9",
-            "41.8",
-            "1456.2"));
+            "41.81",
+            "1456.19"));
     validateRow(
         response,
         List.of(
@@ -211,9 +211,9 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "60.5",
             "21.5",
             "853.5",
-            "26.8",
-            "-35.1",
-            "156.1"));
+            "26.78",
+            "-35.13",
+            "156.13"));
     validateRow(
         response,
         List.of(
@@ -232,9 +232,9 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "3.0",
             "1.0",
             "697.0",
-            "470.1",
-            "-1.4",
-            "7.4"));
+            "470.13",
+            "-1.45",
+            "7.45"));
     validateRow(
         response,
         List.of(
@@ -253,7 +253,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "4.0",
             "2.0",
             "653.0",
-            "220.2",
+            "220.22",
             "-4.9",
             "12.9"));
     validateRow(
@@ -275,8 +275,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "47.0",
             "425.0",
             "6.1",
-            "-134.0",
-            "284.0"));
+            "-134.04",
+            "284.04"));
     validateRow(
         response,
         List.of(
@@ -295,9 +295,9 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "163.5",
             "29.0",
             "280.5",
-            "6.5",
-            "34.5",
-            "292.5"));
+            "6.52",
+            "34.52",
+            "292.48"));
     validateRow(
         response,
         List.of(
@@ -316,9 +316,9 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "90.5",
             "41.0",
             "260.5",
-            "4.3",
-            "-91.9",
-            "272.9"));
+            "4.29",
+            "-91.86",
+            "272.86"));
     validateRow(
         response,
         List.of(
@@ -337,9 +337,9 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "122.5",
             "29.5",
             "216.5",
-            "5.0",
-            "-8.7",
-            "253.7"));
+            "4.95",
+            "-8.71",
+            "253.71"));
     validateRow(
         response,
         List.of(
@@ -358,9 +358,9 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "62.5",
             "13.0",
             "260.5",
-            "13.5",
-            "4.7",
-            "120.3"));
+            "13.52",
+            "4.68",
+            "120.32"));
   }
 
   @Test
@@ -485,8 +485,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "47.0",
             "425.0",
             "6.1",
-            "-134.0",
-            "284.0"));
+            "-134.04",
+            "284.04"));
     validateRow(
         response,
         List.of(
@@ -505,9 +505,9 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "62.5",
             "13.0",
             "260.5",
-            "13.5",
-            "4.7",
-            "120.3"));
+            "13.52",
+            "4.68",
+            "120.32"));
     validateRow(
         response,
         List.of(
@@ -526,9 +526,9 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "75.0",
             "47.0",
             "221.0",
-            "3.2",
-            "-134.0",
-            "284.0"));
+            "3.17",
+            "-134.04",
+            "284.04"));
     validateRow(
         response,
         List.of(
@@ -547,9 +547,9 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "12.5",
             "11.0",
             "182.5",
-            "11.2",
-            "-36.4",
-            "61.4"));
+            "11.19",
+            "-36.43",
+            "61.43"));
     validateRow(
         response,
         List.of(
@@ -568,9 +568,9 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "6.0",
             "4.0",
             "124.0",
-            "20.9",
-            "-11.8",
-            "23.8"));
+            "20.91",
+            "-11.79",
+            "23.79"));
   }
 
   @Test
@@ -694,9 +694,9 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "16.0",
             "6.0",
             "1910.0",
-            "214.7",
-            "-10.7",
-            "42.7"));
+            "214.72",
+            "-10.69",
+            "42.69"));
     validateRow(
         response,
         List.of(
@@ -716,8 +716,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "159.0",
             "920.0",
             "3.9",
-            "41.8",
-            "1456.2"));
+            "41.81",
+            "1456.19"));
     validateRow(
         response,
         List.of(
@@ -736,9 +736,9 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "60.5",
             "21.5",
             "853.5",
-            "26.8",
-            "-35.1",
-            "156.1"));
+            "26.78",
+            "-35.13",
+            "156.13"));
     validateRow(
         response,
         List.of(
@@ -757,9 +757,9 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "3.0",
             "1.0",
             "697.0",
-            "470.1",
-            "-1.4",
-            "7.4"));
+            "470.13",
+            "-1.45",
+            "7.45"));
     validateRow(
         response,
         List.of(
@@ -778,7 +778,7 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "4.0",
             "2.0",
             "653.0",
-            "220.2",
+            "220.22",
             "-4.9",
             "12.9"));
     validateRow(
@@ -799,9 +799,9 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "163.5",
             "29.0",
             "280.5",
-            "6.5",
-            "34.5",
-            "292.5"));
+            "6.52",
+            "34.52",
+            "292.48"));
     validateRow(
         response,
         List.of(
@@ -820,9 +820,9 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "90.5",
             "41.0",
             "260.5",
-            "4.3",
-            "-91.9",
-            "272.9"));
+            "4.29",
+            "-91.86",
+            "272.86"));
     validateRow(
         response,
         List.of(
@@ -841,9 +841,9 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "122.5",
             "29.5",
             "216.5",
-            "5.0",
-            "-8.7",
-            "253.7"));
+            "4.95",
+            "-8.71",
+            "253.71"));
     validateRow(
         response,
         List.of(
@@ -862,9 +862,9 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "170.0",
             "24.5",
             "148.0",
-            "4.1",
-            "61.0",
-            "279.0"));
+            "4.07",
+            "61.03",
+            "278.97"));
     validateRow(
         response,
         List.of(
@@ -883,9 +883,9 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "145.0",
             "20.0",
             "124.0",
-            "4.2",
-            "56.0",
-            "234.0"));
+            "4.18",
+            "56.05",
+            "233.95"));
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection4AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection4AutoTest.java
@@ -170,8 +170,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "6.0",
             "1910.0",
             "214.7",
-            "-1568.6",
-            "1600.6"));
+            "-10.7",
+            "42.7"));
     validateRow(
         response,
         List.of(
@@ -191,8 +191,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "159.0",
             "920.0",
             "3.9",
-            "-290.9",
-            "1788.9"));
+            "41.8",
+            "1456.2"));
     validateRow(
         response,
         List.of(
@@ -212,8 +212,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "21.5",
             "853.5",
             "26.8",
-            "-651.3",
-            "772.3"));
+            "-35.1",
+            "156.1"));
     validateRow(
         response,
         List.of(
@@ -233,8 +233,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "1.0",
             "697.0",
             "470.1",
-            "-463.5",
-            "469.5"));
+            "-1.4",
+            "7.4"));
     validateRow(
         response,
         List.of(
@@ -254,8 +254,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "2.0",
             "653.0",
             "220.2",
-            "-432.3",
-            "440.3"));
+            "-4.9",
+            "12.9"));
     validateRow(
         response,
         List.of(
@@ -275,8 +275,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "47.0",
             "425.0",
             "6.1",
-            "-377.8",
-            "527.8"));
+            "-134.0",
+            "284.0"));
     validateRow(
         response,
         List.of(
@@ -296,8 +296,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "29.0",
             "280.5",
             "6.5",
-            "-120.8",
-            "447.8"));
+            "34.5",
+            "292.5"));
     validateRow(
         response,
         List.of(
@@ -317,8 +317,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "41.0",
             "260.5",
             "4.3",
-            "-163.1",
-            "344.1"));
+            "-91.9",
+            "272.9"));
     validateRow(
         response,
         List.of(
@@ -338,8 +338,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "29.5",
             "216.5",
             "5.0",
-            "-81.6",
-            "326.6"));
+            "-8.7",
+            "253.7"));
     validateRow(
         response,
         List.of(
@@ -359,8 +359,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "13.0",
             "260.5",
             "13.5",
-            "-285.0",
-            "410.0"));
+            "4.7",
+            "120.3"));
   }
 
   @Test
@@ -485,8 +485,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "47.0",
             "425.0",
             "6.1",
-            "-377.8",
-            "527.8"));
+            "-134.0",
+            "284.0"));
     validateRow(
         response,
         List.of(
@@ -506,8 +506,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "13.0",
             "260.5",
             "13.5",
-            "-285.0",
-            "410.0"));
+            "4.7",
+            "120.3"));
     validateRow(
         response,
         List.of(
@@ -527,8 +527,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "47.0",
             "221.0",
             "3.2",
-            "-377.8",
-            "527.8"));
+            "-134.0",
+            "284.0"));
     validateRow(
         response,
         List.of(
@@ -548,8 +548,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "11.0",
             "182.5",
             "11.2",
-            "-149.6",
-            "174.6"));
+            "-36.4",
+            "61.4"));
     validateRow(
         response,
         List.of(
@@ -569,8 +569,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "4.0",
             "124.0",
             "20.9",
-            "-123.7",
-            "135.7"));
+            "-11.8",
+            "23.8"));
   }
 
   @Test
@@ -695,8 +695,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "6.0",
             "1910.0",
             "214.7",
-            "-1568.6",
-            "1600.6"));
+            "-10.7",
+            "42.7"));
     validateRow(
         response,
         List.of(
@@ -716,8 +716,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "159.0",
             "920.0",
             "3.9",
-            "-290.9",
-            "1788.9"));
+            "41.8",
+            "1456.2"));
     validateRow(
         response,
         List.of(
@@ -737,8 +737,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "21.5",
             "853.5",
             "26.8",
-            "-651.3",
-            "772.3"));
+            "-35.1",
+            "156.1"));
     validateRow(
         response,
         List.of(
@@ -758,8 +758,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "1.0",
             "697.0",
             "470.1",
-            "-463.5",
-            "469.5"));
+            "-1.4",
+            "7.4"));
     validateRow(
         response,
         List.of(
@@ -779,8 +779,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "2.0",
             "653.0",
             "220.2",
-            "-432.3",
-            "440.3"));
+            "-4.9",
+            "12.9"));
     validateRow(
         response,
         List.of(
@@ -800,8 +800,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "29.0",
             "280.5",
             "6.5",
-            "-120.8",
-            "447.8"));
+            "34.5",
+            "292.5"));
     validateRow(
         response,
         List.of(
@@ -821,8 +821,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "41.0",
             "260.5",
             "4.3",
-            "-163.1",
-            "344.1"));
+            "-91.9",
+            "272.9"));
     validateRow(
         response,
         List.of(
@@ -842,8 +842,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "29.5",
             "216.5",
             "5.0",
-            "-81.6",
-            "326.6"));
+            "-8.7",
+            "253.7"));
     validateRow(
         response,
         List.of(
@@ -863,8 +863,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "24.5",
             "148.0",
             "4.1",
-            "16.6",
-            "323.4"));
+            "61.0",
+            "279.0"));
     validateRow(
         response,
         List.of(
@@ -884,8 +884,8 @@ public class OutliersDetection4AutoTest extends AnalyticsApiTest {
             "20.0",
             "124.0",
             "4.2",
-            "21.4",
-            "268.6"));
+            "56.0",
+            "234.0"));
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection5AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection5AutoTest.java
@@ -269,11 +269,11 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "202210",
             "Kasse MCHP",
             "1926.0",
-            "174.3",
-            "3.3",
-            "528.2",
-            "-1410.2",
-            "1758.9"));
+            "174.33",
+            "3.32",
+            "528.19",
+            "-1410.23",
+            "1758.89"));
     validateRow(
         response,
         List.of(
@@ -282,11 +282,11 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "202111",
             "Kasse MCHP",
             "1926.0",
-            "174.3",
-            "3.3",
-            "528.2",
-            "-1410.2",
-            "1758.9"));
+            "174.33",
+            "3.32",
+            "528.19",
+            "-1410.23",
+            "1758.89"));
     validateRow(
         response,
         List.of(
@@ -295,11 +295,11 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "202111",
             "Ngelehun CHC",
             "700.0",
-            "40.4",
-            "4.2",
+            "40.37",
+            "4.24",
             "155.5",
-            "-426.1",
-            "506.9"));
+            "-426.12",
+            "506.85"));
     validateRow(
         response,
         List.of(
@@ -308,11 +308,11 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "202111",
             "Ngelehun CHC",
             "234.0",
-            "24.3",
-            "3.8",
-            "55.5",
-            "-142.3",
-            "190.8"));
+            "24.25",
+            "3.78",
+            "55.51",
+            "-142.29",
+            "190.79"));
     validateRow(
         response,
         List.of(
@@ -321,11 +321,11 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "202205",
             "Ross Road Health Centre",
             "188.0",
-            "72.7",
+            "72.67",
             "3.1",
-            "37.3",
+            "37.26",
             "-39.1",
-            "184.4"));
+            "184.44"));
   }
 
   @Test
@@ -397,11 +397,11 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "202201",
             "St Anthony clinic",
             "145.0",
-            "52.3",
-            "3.0",
-            "30.4",
-            "-39.0",
-            "143.6"));
+            "52.33",
+            "3.05",
+            "30.43",
+            "-38.96",
+            "143.63"));
     validateRow(
         response,
         List.of(
@@ -410,11 +410,11 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "202203",
             "Maforay (B. Sebora) MCHP",
             "92.0",
-            "17.8",
-            "3.1",
+            "17.82",
+            "3.14",
             "23.6",
-            "-53.0",
-            "88.6"));
+            "-52.98",
+            "88.61"));
     validateRow(
         response,
         List.of(
@@ -423,11 +423,11 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "202203",
             "Maforay (B. Sebora) MCHP",
             "64.0",
-            "11.3",
-            "3.2",
-            "16.7",
-            "-38.8",
-            "61.4"));
+            "11.27",
+            "3.16",
+            "16.71",
+            "-38.85",
+            "61.39"));
     validateRow(
         response,
         List.of(
@@ -436,11 +436,11 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "202201",
             "Tikonko (gaura) MCHP",
             "58.0",
-            "12.8",
-            "3.2",
-            "14.0",
-            "-29.3",
-            "54.8"));
+            "12.75",
+            "3.23",
+            "14.03",
+            "-29.34",
+            "54.84"));
     validateRow(
         response,
         List.of(
@@ -451,9 +451,9 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "45.0",
             "10.8",
             "3.6",
-            "9.5",
-            "-17.7",
-            "39.3"));
+            "9.51",
+            "-17.73",
+            "39.33"));
   }
 
   @Test
@@ -525,11 +525,11 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "202205",
             "Ross Road Health Centre",
             "188.0",
-            "72.7",
+            "72.67",
             "3.1",
-            "37.3",
+            "37.26",
             "-39.1",
-            "184.4"));
+            "184.44"));
     validateRow(
         response,
         List.of(
@@ -538,11 +538,11 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "202204",
             "Lyn Maternity MCHP",
             "121.0",
-            "29.3",
-            "3.1",
-            "29.2",
-            "-58.3",
-            "117.0"));
+            "29.33",
+            "3.14",
+            "29.21",
+            "-58.29",
+            "116.95"));
     validateRow(
         response,
         List.of(
@@ -551,11 +551,11 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "202206",
             "Mondema CHC",
             "90.0",
-            "14.8",
-            "3.1",
+            "14.82",
+            "3.13",
             "24.0",
-            "-57.2",
-            "86.8"));
+            "-57.19",
+            "86.83"));
     validateRow(
         response,
         List.of(
@@ -564,11 +564,11 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "202204",
             "Fogbo (WAR) MCHP",
             "84.0",
-            "25.6",
-            "3.2",
-            "18.0",
-            "-28.4",
-            "79.5"));
+            "25.58",
+            "3.25",
+            "17.98",
+            "-28.35",
+            "79.52"));
     validateRow(
         response,
         List.of(
@@ -578,9 +578,9 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "Gbanja Town MCHP",
             "35.0",
             "14.0",
-            "3.1",
-            "6.7",
-            "-6.0",
-            "34.0"));
+            "3.15",
+            "6.67",
+            "-6.01",
+            "34.01"));
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection5AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/outlier/OutliersDetection5AutoTest.java
@@ -137,6 +137,7 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
     // Assert rows.
     validateRow(
         response,
+        0,
         List.of(
             "dU0GquGkGQr",
             "Q_Early breastfeeding (within 1 hr after delivery) at BCG",
@@ -158,6 +159,7 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "104.3801872349"));
     validateRow(
         response,
+        1,
         List.of(
             "s46m5MS0hxu",
             "BCG doses given",
@@ -179,6 +181,7 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "213.992686158"));
     validateRow(
         response,
+        2,
         List.of(
             "l6byfWFUGaP",
             "Yellow Fever doses given",
@@ -263,6 +266,7 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
     // Assert rows.
     validateRow(
         response,
+        0,
         List.of(
             "ANC 3rd visit",
             "Outreach",
@@ -276,6 +280,7 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "1758.89"));
     validateRow(
         response,
+        1,
         List.of(
             "ANC 3rd visit",
             "Outreach",
@@ -289,6 +294,7 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "1758.89"));
     validateRow(
         response,
+        2,
         List.of(
             "ANC 1st visit",
             "Outreach",
@@ -302,6 +308,7 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "506.85"));
     validateRow(
         response,
+        3,
         List.of(
             "ANC 3rd visit",
             "Outreach",
@@ -315,6 +322,7 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "190.79"));
     validateRow(
         response,
+        4,
         List.of(
             "ANC 1st visit",
             "Fixed",
@@ -391,6 +399,7 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
     // Assert rows.
     validateRow(
         response,
+        0,
         List.of(
             "ANC 3rd visit",
             "Fixed",
@@ -404,6 +413,7 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "143.63"));
     validateRow(
         response,
+        1,
         List.of(
             "ANC 1st visit",
             "Fixed",
@@ -417,6 +427,7 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "88.61"));
     validateRow(
         response,
+        2,
         List.of(
             "ANC 3rd visit",
             "Fixed",
@@ -430,6 +441,7 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "61.39"));
     validateRow(
         response,
+        3,
         List.of(
             "ANC 1st visit",
             "Outreach",
@@ -443,6 +455,7 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "54.84"));
     validateRow(
         response,
+        4,
         List.of(
             "ANC 1st visit",
             "Outreach",
@@ -519,6 +532,7 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
     // Assert rows.
     validateRow(
         response,
+        0,
         List.of(
             "ANC 1st visit",
             "Fixed",
@@ -532,6 +546,7 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "184.44"));
     validateRow(
         response,
+        1,
         List.of(
             "ANC 1st visit",
             "Fixed",
@@ -545,6 +560,7 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "116.95"));
     validateRow(
         response,
+        2,
         List.of(
             "ANC 3rd visit",
             "Outreach",
@@ -558,6 +574,7 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "86.83"));
     validateRow(
         response,
+        3,
         List.of(
             "ANC 1st visit",
             "Fixed",
@@ -571,6 +588,7 @@ public class OutliersDetection5AutoTest extends AnalyticsApiTest {
             "79.52"));
     validateRow(
         response,
+        4,
         List.of(
             "ANC 1st visit",
             "Fixed",


### PR DESCRIPTION
All decimal numbers are now rounded to two decimal places. The default rounding scale remains unchanged and is set to 10 decimals.