### PR TITLE
feat: expose build version in LoginConfigController

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/LoginConfigResponse.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/LoginConfigResponse.java
@@ -42,6 +42,8 @@ import lombok.NoArgsConstructor;
 @Builder
 public class LoginConfigResponse {
 
+  @JsonProperty private String apiVersion;
+
   @JsonProperty private String applicationTitle;
   @JsonProperty private String applicationDescription;
   @JsonProperty private String applicationNotification;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/LoginConfigControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/LoginConfigControllerTest.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
+import org.hisp.dhis.system.SystemService;
 import org.hisp.dhis.webapi.DhisControllerIntegrationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +44,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class LoginConfigControllerTest extends DhisControllerIntegrationTest {
 
   @Autowired SystemSettingManager systemSettingManager;
+  @Autowired SystemService systemService;
 
   @Test
   void shouldGetLoginConfig() {
@@ -108,5 +110,8 @@ class LoginConfigControllerTest extends DhisControllerIntegrationTest {
     assertFalse(responseDefaultLocale.getBoolean("selfRegistrationNoRecaptcha").booleanValue());
     assertFalse(responseDefaultLocale.getBoolean("selfRegistrationEnabled").booleanValue());
     assertFalse(responseDefaultLocale.getBoolean("emailConfigured").booleanValue());
+    assertEquals(
+        systemService.getSystemInfo().getVersion(),
+        responseDefaultLocale.getString("apiVersion").string());
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/LoginConfigController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/LoginConfigController.java
@@ -38,6 +38,7 @@ import org.hisp.dhis.security.LoginConfigResponse;
 import org.hisp.dhis.security.LoginConfigResponse.LoginConfigResponseBuilder;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
+import org.hisp.dhis.system.SystemService;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -56,6 +57,7 @@ public class LoginConfigController {
 
   private final SystemSettingManager manager;
   private final ConfigurationService configurationService;
+  private final SystemService systemService;
 
   @Getter
   private enum KEYS {
@@ -126,6 +128,8 @@ public class LoginConfigController {
 
     builder.selfRegistrationEnabled(
         configurationService.getConfiguration().selfRegistrationAllowed());
+
+    builder.apiVersion(systemService.getSystemInfo().getVersion());
 
     return builder.build();
   }


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-16945
- This is to expose the build version in `LoginConfigController` so the new login app can decide which api version it needs to use for sending request to server.
- The info return is the same as from `api/system/info` which is available on UI in `dhis-web-user-profile/#/aboutPage`