### PR TITLE
fix: make loginConfig public available if it includes API version

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -268,7 +268,7 @@ public class DhisWebApiWebSecurityConfig {
           .permitAll()
           .antMatchers("/oauth2/**")
           .permitAll()
-          .antMatchers(apiContextPath + "/loginConfig")
+          .antMatchers(apiContextPath + "/**/loginConfig")
           .permitAll()
           .antMatchers(apiContextPath + "/auth/login")
           .permitAll()


### PR DESCRIPTION
## Summary
Make **loginConfig** available without authentication, also when it includes the API version number in the URL like e.g. `/api/40/loginConfig`
Before this change, only `/api/loginConfig`, was publicly available.

### Manual testing
1. Open an incognito tab and go to: `http://localhost:8080/api/40/loginConfig`
2. Observe the endpoint is serving 200 OK and JSON content