### PR TITLE
fix: adjust login config endpoint

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/LoginConfigResponse.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/LoginConfigResponse.java
@@ -48,6 +48,7 @@ public class LoginConfigResponse {
   @JsonProperty private String applicationDescription;
   @JsonProperty private String applicationNotification;
   @JsonProperty private String applicationLeftSideFooter;
+  @JsonProperty private String applicationRightSideFooter;
   @JsonProperty private String countryFlag;
   @JsonProperty private String uiLocale;
   @JsonProperty private String loginPageLogo;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/LoginConfigControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/LoginConfigControllerTest.java
@@ -60,6 +60,11 @@ class LoginConfigControllerTest extends DhisControllerIntegrationTest {
     systemSettingManager.saveSystemSettingTranslation(
         SettingKey.APPLICATION_FOOTER, "no", "Søknadsbunntekst");
 
+    systemSettingManager.saveSystemSetting(
+        SettingKey.APPLICATION_RIGHT_FOOTER, "APPLICATION_RIGHT_FOOTER");
+    systemSettingManager.saveSystemSettingTranslation(
+        SettingKey.APPLICATION_RIGHT_FOOTER, "no", "Høyre søknadsbunntekst");
+
     systemSettingManager.saveSystemSetting(SettingKey.APPLICATION_INTRO, "APPLICATION_INTRO");
     systemSettingManager.saveSystemSettingTranslation(
         SettingKey.APPLICATION_INTRO, "no", "Søknadsintroduksjon");
@@ -69,8 +74,8 @@ class LoginConfigControllerTest extends DhisControllerIntegrationTest {
     systemSettingManager.saveSystemSettingTranslation(
         SettingKey.APPLICATION_NOTIFICATION, "no", "Søknadsmelding");
 
-    systemSettingManager.saveSystemSetting(SettingKey.FLAG_IMAGE, "FLAG_IMAGE");
-    systemSettingManager.saveSystemSetting(SettingKey.CUSTOM_LOGIN_PAGE_LOGO, true);
+    systemSettingManager.saveSystemSetting(SettingKey.FLAG, "FLAG_IMAGE");
+    systemSettingManager.saveSystemSetting(SettingKey.USE_CUSTOM_LOGO_FRONT, true);
     systemSettingManager.saveSystemSetting(SettingKey.CUSTOM_TOP_MENU_LOGO, true);
 
     JsonObject responseDefaultLocale = GET("/loginConfig").content();
@@ -99,6 +104,13 @@ class LoginConfigControllerTest extends DhisControllerIntegrationTest {
     assertEquals(
         "Søknadsbunntekst",
         responseNorwegianLocale.getString("applicationLeftSideFooter").string());
+
+    assertEquals(
+        "APPLICATION_RIGHT_FOOTER",
+        responseDefaultLocale.getString("applicationRightSideFooter").string());
+    assertEquals(
+        "Høyre søknadsbunntekst",
+        responseNorwegianLocale.getString("applicationRightSideFooter").string());
 
     assertEquals("FLAG_IMAGE", responseDefaultLocale.getString("countryFlag").string());
     assertEquals("en", responseDefaultLocale.getString("uiLocale").string());

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/LoginConfigController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/LoginConfigController.java
@@ -61,29 +61,26 @@ public class LoginConfigController {
 
   @Getter
   private enum KEYS {
-    APPLICATION_TITLE("applicationTitle"),
-    APPLICATION_INTRO("applicationDescription"),
-    APPLICATION_NOTIFICATION("applicationNotification"),
-    APPLICATION_FOOTER("applicationLeftSideFooter"),
-    APPLICATION_RIGHT_FOOTER("applicationRightFooter"),
-    FLAG("countryFlag"),
-    CUSTOM_LOGIN_PAGE_LOGO("loginPageLogo", "/api/staticContent/logo_front.png"),
-    UI_LOCALE("uiLocale"),
-    LOGIN_POPUP("loginPopup"),
-    SELF_REGISTRATION_NO_RECAPTCHA("selfRegistrationNoRecaptcha"),
-    USE_CUSTOM_LOGO_FRONT("useCustomLogoFront"),
-    ACCOUNT_RECOVERY("allowAccountRecovery");
+    APPLICATION_TITLE(),
+    APPLICATION_INTRO(),
+    APPLICATION_NOTIFICATION(),
+    APPLICATION_FOOTER(),
+    APPLICATION_RIGHT_FOOTER(),
+    FLAG(),
+    CUSTOM_LOGIN_PAGE_LOGO("/api/staticContent/logo_front.png"),
+    UI_LOCALE(),
+    LOGIN_POPUP(),
+    SELF_REGISTRATION_NO_RECAPTCHA(),
+    USE_CUSTOM_LOGO_FRONT(),
+    ACCOUNT_RECOVERY();
 
-    private final String keyName;
     private final String defaultValue;
 
-    KEYS(String keyName) {
-      this.keyName = keyName;
+    KEYS() {
       this.defaultValue = null;
     }
 
-    KEYS(String keyName, String defaultValue) {
-      this.keyName = keyName;
+    KEYS(String defaultValue) {
       this.defaultValue = defaultValue;
     }
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/LoginConfigController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/LoginConfigController.java
@@ -65,7 +65,8 @@ public class LoginConfigController {
     APPLICATION_INTRO("applicationDescription"),
     APPLICATION_NOTIFICATION("applicationNotification"),
     APPLICATION_FOOTER("applicationLeftSideFooter"),
-    FLAG_IMAGE("countryFlag"),
+    APPLICATION_RIGHT_FOOTER("applicationRightFooter"),
+    FLAG("countryFlag"),
     CUSTOM_LOGIN_PAGE_LOGO("loginPageLogo", "/api/staticContent/logo_front.png"),
     UI_LOCALE("uiLocale"),
     LOGIN_POPUP("loginPopup"),
@@ -103,9 +104,11 @@ public class LoginConfigController {
     builder.applicationDescription(getTranslatableString(KEYS.APPLICATION_INTRO, locale));
     builder.applicationNotification(getTranslatableString(KEYS.APPLICATION_NOTIFICATION, locale));
     builder.applicationLeftSideFooter(getTranslatableString(KEYS.APPLICATION_FOOTER, locale));
+    builder.applicationRightSideFooter(
+        getTranslatableString(KEYS.APPLICATION_RIGHT_FOOTER, locale));
     builder.loginPopup(getTranslatableString(KEYS.LOGIN_POPUP, locale));
 
-    builder.countryFlag(manager.getStringSetting(SettingKey.valueOf(KEYS.FLAG_IMAGE.name())));
+    builder.countryFlag(manager.getStringSetting(SettingKey.valueOf(KEYS.FLAG.name())));
 
     builder.uiLocale(
         manager
@@ -113,7 +116,7 @@ public class LoginConfigController {
             .getLanguage());
 
     builder.loginPageLogo(
-        manager.getBoolSetting(SettingKey.valueOf(KEYS.CUSTOM_LOGIN_PAGE_LOGO.name()))
+        manager.getBoolSetting(SettingKey.valueOf(KEYS.USE_CUSTOM_LOGO_FRONT.name()))
             ? KEYS.CUSTOM_LOGIN_PAGE_LOGO.defaultValue
             : null);
 


### PR DESCRIPTION
## Summary
Makes four adjustment to the `loginConfig` endpoint.

- Change `countryFlag` settings source from `flagImage` to flag
- Added `applicationRightSideFooter`
- Change the boolean to trigger the showing of the logo path from: `CUSTOM_LOGIN_PAGE_LOGO` to: `USE_CUSTOM_LOGO_FRONT`
- Removes the `keyName` field, since it is not in use

### Automatic tests:
LoginConfigControllerTest