### PR TITLE
feat: add recaptcha site to api/loginConfig

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/LoginConfigResponse.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/LoginConfigResponse.java
@@ -53,6 +53,7 @@ public class LoginConfigResponse {
   @JsonProperty private String uiLocale;
   @JsonProperty private String loginPageLogo;
   @JsonProperty private String loginPopup;
+  @JsonProperty private String recaptchaSite;
 
   @JsonProperty private boolean emailConfigured;
   @JsonProperty private boolean selfRegistrationEnabled;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/LoginConfigControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/LoginConfigControllerTest.java
@@ -34,6 +34,7 @@ import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.SystemService;
+import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerIntegrationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -125,5 +126,18 @@ class LoginConfigControllerTest extends DhisControllerIntegrationTest {
     assertEquals(
         systemService.getSystemInfo().getVersion(),
         responseDefaultLocale.getString("apiVersion").string());
+  }
+
+  @Test
+  void testRecaptchaSite() {
+    JsonObject response = GET("/loginConfig").content();
+    assertEquals(
+        SettingKey.RECAPTCHA_SITE.getDefaultValue(),
+        response.getString(SettingKey.RECAPTCHA_SITE.getName()).string());
+    POST("/systemSettings/" + SettingKey.RECAPTCHA_SITE.getName(), "test_recaptcha_stie")
+        .content(HttpStatus.OK);
+    response = GET("/loginConfig").content();
+    assertEquals(
+        "test_recaptcha_stie", response.getString(SettingKey.RECAPTCHA_SITE.getName()).string());
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/LoginConfigController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/LoginConfigController.java
@@ -72,7 +72,8 @@ public class LoginConfigController {
     LOGIN_POPUP(),
     SELF_REGISTRATION_NO_RECAPTCHA(),
     USE_CUSTOM_LOGO_FRONT(),
-    ACCOUNT_RECOVERY();
+    ACCOUNT_RECOVERY(),
+    RECAPTCHA_SITE();
 
     private final String defaultValue;
 
@@ -130,6 +131,7 @@ public class LoginConfigController {
         configurationService.getConfiguration().selfRegistrationAllowed());
 
     builder.apiVersion(systemService.getSystemInfo().getVersion());
+    builder.recaptchaSite(manager.getStringSetting(SettingKey.valueOf(KEYS.RECAPTCHA_SITE.name())));
 
     return builder.build();
   }


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-16943
- The recaptcha site and secret are configurable in SystemSettings App.
- This is to expose the site key to `api/loginConfig` so the new Login Page and display the recaptcha if it was enabled.