### PR TITLE
fix: meta.items.name doesn't contains info on program and program stage [DHIS2-16807]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/DimensionIdentifierHelper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/DimensionIdentifierHelper.java
@@ -198,29 +198,40 @@ public class DimensionIdentifierHelper {
   }
 
   public static String getCustomLabelOrHeaderColumnName(
-      DimensionIdentifier<DimensionParam> dimensionIdentifier, boolean useOffset) {
-    return getCustomLabel(dimensionIdentifier, StaticDimension::getHeaderColumnName, useOffset);
+      DimensionIdentifier<DimensionParam> dimensionIdentifier,
+      boolean useOffset,
+      boolean skipSuffixes) {
+    return getCustomLabel(
+        dimensionIdentifier, StaticDimension::getHeaderColumnName, useOffset, skipSuffixes);
   }
 
   public static String getCustomLabelOrFullName(
-      DimensionIdentifier<DimensionParam> dimensionIdentifier, boolean useOffset) {
-    return getCustomLabel(dimensionIdentifier, StaticDimension::getFullName, useOffset);
+      DimensionIdentifier<DimensionParam> dimensionIdentifier,
+      boolean useOffset,
+      boolean skipSuffixes) {
+    return getCustomLabel(
+        dimensionIdentifier, StaticDimension::getFullName, useOffset, skipSuffixes);
   }
 
   private static String getCustomLabel(
       DimensionIdentifier<DimensionParam> dimensionIdentifier,
       Function<StaticDimension, String> defaultLabelMapper,
-      boolean useOffset) {
-    return joinedWithPrefixesIfNeeded(
-        dimensionIdentifier,
+      boolean useOffset,
+      boolean skipSuffixes) {
+    String label =
         Optional.of(dimensionIdentifier)
             .filter(DimensionIdentifierHelper::supportsCustomLabel)
             .map(DimensionIdentifierHelper::getStaticDimensionDisplayName)
             .orElseGet(
                 () ->
                     defaultLabelMapper.apply(
-                        dimensionIdentifier.getDimension().getStaticDimension())),
-        useOffset);
+                        dimensionIdentifier.getDimension().getStaticDimension()));
+
+    if (skipSuffixes) {
+      return label;
+    }
+
+    return joinedWithPrefixesIfNeeded(dimensionIdentifier, label, useOffset);
   }
 
   public static String joinedWithPrefixesIfNeeded(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/processing/MetadataParamsHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/processing/MetadataParamsHandler.java
@@ -35,7 +35,6 @@ import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ORG_UNIT_HIERARCHY;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ORG_UNIT_NAME_HIERARCHY;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.PAGER;
 import static org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifierHelper.getCustomLabelOrHeaderColumnName;
-import static org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifierHelper.joinedWithPrefixesIfNeeded;
 import static org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifierHelper.supportsCustomLabel;
 import static org.hisp.dhis.analytics.orgunit.OrgUnitHelper.getActiveOrganisationUnits;
 import static org.hisp.dhis.analytics.util.AnalyticsOrganisationUnitUtils.getUserOrganisationUnitItems;
@@ -173,7 +172,7 @@ public class MetadataParamsHandler {
   private MetadataItem getMetadataWithCustomLabel(
       DimensionIdentifier<DimensionParam> dimensionIdentifier) {
 
-    String customLabel = getCustomLabelOrHeaderColumnName(dimensionIdentifier, false);
+    String customLabel = getCustomLabelOrHeaderColumnName(dimensionIdentifier, false, true);
 
     MetadataItem metadataItem = new MetadataItem(customLabel);
     metadataItem.setDimensionType(
@@ -184,14 +183,6 @@ public class MetadataParamsHandler {
 
   private static Entry<String, Object> asEntryWithFullPrefix(
       DimensionIdentifier<DimensionParam> dimensionIdentifier, Entry<String, Object> entry) {
-    if (entry.getValue() instanceof MetadataItem metadataItem) {
-      MetadataItem clone =
-          new MetadataItem(
-              joinedWithPrefixesIfNeeded(dimensionIdentifier, metadataItem.getName(), false));
-      clone.setDimensionType(metadataItem.getDimensionType());
-      clone.setValueType(metadataItem.getValueType());
-      return Map.entry(dimensionIdentifier.getKeyNoOffset(), clone);
-    }
     return Map.entry(dimensionIdentifier.getKeyNoOffset(), entry.getValue());
   }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/TeiFields.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/TeiFields.java
@@ -292,9 +292,9 @@ public class TeiFields {
       DimensionIdentifier<DimensionParam> dimId) {
     if (dimId.isEventDimension() || dimId.isEnrollmentDimension()) {
       return getGridHeader(
-          dimensionId -> getCustomLabelOrHeaderColumnName(dimensionId, true), dimId);
+          dimensionId -> getCustomLabelOrHeaderColumnName(dimensionId, true, false), dimId);
     }
-    return getGridHeader(dimensionId -> getCustomLabelOrFullName(dimensionId, false), dimId);
+    return getGridHeader(dimensionId -> getCustomLabelOrFullName(dimensionId, false, false), dimId);
   }
 
   private static GridHeader getGridHeader(

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TrackedEntityQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TrackedEntityQueryTest.java
@@ -1724,7 +1724,7 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
         .body("metaData.items.GQY2lXrypjO.name", equalTo("MCH Infant Weight  (g)"))
         .body(
             "metaData.items[\"IpHINAT79UW.ZzYYXq4fJie.GQY2lXrypjO\"].name",
-            equalTo("MCH Infant Weight  (g), Child Programme, Baby Postnatal"))
+            equalTo("MCH Infant Weight  (g)"))
         .body("height", equalTo(1))
         .body("width", equalTo(17))
         .body("headerWidth", equalTo(17));
@@ -1818,7 +1818,7 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
 
     // Assert metaData.
     String expectedMetaData =
-        "{\"pager\":{\"page\":1,\"pageSize\":50,\"isLastPage\":false},\"items\":{\"zDhUuAYrxNC\":{\"name\":\"Last name\"},\"pe\":{\"name\":\"Period\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"IpHINAT79UW.pe\":{\"name\":\"Period, Child Programme\"},\"w75KJ2mc4zz\":{\"name\":\"First name\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"2022\":{\"name\":\"2022\"},\"LAST_YEAR\":{\"name\":\"Last year\"}},\"dimensions\":{\"lZGmxYbs97q\":[],\"zDhUuAYrxNC\":[],\"pe\":[\"2022\"],\"w75KJ2mc4zz\":[],\"cejWyOfXge6\":[\"rBvjJYbMCVx\",\"Mnp3oXrpAbK\"]}}";
+        "{\"pager\":{\"page\":1,\"pageSize\":50,\"isLastPage\":false},\"items\":{\"zDhUuAYrxNC\":{\"name\":\"Last name\"},\"pe\":{\"name\":\"Period\"},\"IpHINAT79UW\":{\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"name\":\"Baby Postnatal\"},\"IpHINAT79UW.pe\":{\"name\":\"Period\"},\"w75KJ2mc4zz\":{\"name\":\"First name\"},\"A03MvHHogjR\":{\"name\":\"Birth\"},\"2022\":{\"name\":\"2022\"},\"LAST_YEAR\":{\"name\":\"Last year\"}},\"dimensions\":{\"lZGmxYbs97q\":[],\"zDhUuAYrxNC\":[],\"pe\":[\"2022\"],\"w75KJ2mc4zz\":[],\"cejWyOfXge6\":[\"rBvjJYbMCVx\",\"Mnp3oXrpAbK\"]}}";
     String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
@@ -2967,13 +2967,11 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
     response
         .validate()
         .statusCode(200)
-        .body(
-            "metaData.items['IpHINAT79UW.enrollmentdate'].name",
-            equalTo("Date of enrollment, Child Programme"))
+        .body("metaData.items['IpHINAT79UW.enrollmentdate'].name", equalTo("Date of enrollment"))
         .body("headers[1].column", equalTo("Date of enrollment, Child Programme"))
         .body(
             "metaData.items['IpHINAT79UW.ZzYYXq4fJie.cYGaxwK615G'].name",
-            equalTo("MCH Infant HIV Test Result, Child Programme, Baby Postnatal"));
+            equalTo("MCH Infant HIV Test Result"));
   }
 
   @Test
@@ -3226,18 +3224,18 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
   @Test
   public void metaItemsContainsCustomLabels() {
 
-    Map<String, String> headersCustomLabels =
+    Map<String, String> metaCustomLabels =
         Map.of(
             "IpHINAT79UW.enrollmentdate",
-            "Date of enrollment, Child Programme",
+            "Date of enrollment",
             "IpHINAT79UW.incidentdate",
-            "Date of birth, Child Programme",
+            "Date of birth",
             "IpHINAT79UW.A03MvHHogjR.occurreddate",
-            "Report date, Child Programme, Birth",
+            "Report date",
             "IpHINAT79UW.ouname",
-            "Organisation Unit Name, Child Programme");
+            "Organisation Unit Name");
 
-    headersCustomLabels.forEach(this::testMetaCustomLabel);
+    metaCustomLabels.forEach(this::testMetaCustomLabel);
   }
 
   private void testMetaCustomLabel(String header, String expected) {


### PR DESCRIPTION
This PR removes information on program and programStage in meta.items for the fully prefixed dimensions.