### PR TITLE
fix(DHIS2-16132): fix hibernate mapping for displayOptions jsonb field

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataset/hibernate/Section.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/dataset/hibernate/Section.hbm.xml
@@ -54,7 +54,7 @@
 
     <property name="showColumnTotals" />
     
-    <property name="displayOptions" type="jbPlainString" column="displayoptions" />
+    <property name="displayOptions" type="jbPlainString" column="displayoptions" length="50000" />
 
     <property name="disableDataElementAutoGroup" column="disabledataelementautogroup" />
 


### PR DESCRIPTION
The length property was not set for the `displayOptions` jsonb field. This meant it defaults to 256 characters which is not enough for our use case, now that we're using the JSON field to store all styling related options.

This PR sets it to 50K characters (which is inline with other fields like DataStore value)