### PR TITLE
feat: add email as valid input to password reset

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/HiddenNotFoundException.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/HiddenNotFoundException.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.feedback;
+
+import static org.hisp.dhis.common.OpenApi.Response.Status.OK;
+
+import java.text.MessageFormat;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.webmessage.WebMessageResponse;
+
+@Getter
+@Accessors(chain = true)
+@OpenApi.Response(status = OK, value = WebMessageResponse.class)
+public final class HiddenNotFoundException extends Exception implements Error {
+  public static <E extends RuntimeException, V> V on(Class<E> type, Supplier<V> operation)
+      throws HiddenNotFoundException {
+    return Error.rethrow(type, HiddenNotFoundException::new, operation);
+  }
+
+  public static <E extends RuntimeException, V> V on(
+      Class<E> type, Function<E, HiddenNotFoundException> map, Supplier<V> operation)
+      throws HiddenNotFoundException {
+    return Error.rethrowMapped(type, map, operation);
+  }
+
+  private final ErrorCode code;
+
+  public HiddenNotFoundException(Class<?> type, String uid) {
+    this(type.getSimpleName() + " with id " + uid + " could not be found.");
+  }
+
+  public HiddenNotFoundException(String message) {
+    super(message);
+    this.code = ErrorCode.E1005;
+  }
+
+  public HiddenNotFoundException(ErrorCode code, Object... args) {
+    super(MessageFormat.format(code.getMessage(), args));
+    this.code = code;
+  }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/CredentialsInfo.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/CredentialsInfo.java
@@ -27,43 +27,21 @@
  */
 package org.hisp.dhis.user;
 
-/** Created by zubair on 17.03.17. */
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author Morten Svanæs <msvanaes@dhis2.org>
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
 public class CredentialsInfo {
   private String username;
-
   private String password;
-
   private String email;
-
   private boolean newUser;
-
-  protected CredentialsInfo() {}
-
-  public CredentialsInfo(String username, String password, String email, boolean newUser) {
-    this.username = username;
-    this.password = password;
-    this.email = email;
-    this.newUser = newUser;
-  }
-
-  public CredentialsInfo(String password, boolean newUser) {
-    this.password = password;
-    this.newUser = newUser;
-  }
-
-  public String getUsername() {
-    return username;
-  }
-
-  public String getPassword() {
-    return password;
-  }
-
-  public String getEmail() {
-    return email;
-  }
-
-  public boolean isNewUser() {
-    return newUser;
-  }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -156,6 +156,14 @@ public interface UserService {
   User getUserByIdentifier(String id);
 
   /**
+   * Retrieves the User with the given email.
+   *
+   * @param email the email of the User to retrieve.
+   * @return the User.
+   */
+  User getUserByEmail(String email);
+
+  /**
    * Retrieves a collection of User with the given unique identifiers.
    *
    * @param uids the identifiers of the collection of Users to retrieve.
@@ -471,9 +479,9 @@ public interface UserService {
    * Use this method instead of {@link #createUserDetails(User)} if no {@link User} instance is
    * available or if the one available is not fully loaded or connected to a session.
    *
-   * @see #createUserDetails(User)
    * @param userUid UID of the {@link UserDetails} to create
    * @return the implementation object
+   * @see #createUserDetails(User)
    */
   UserDetails createUserDetails(String userUid) throws NotFoundException;
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
@@ -191,6 +191,14 @@ public interface UserStore extends IdentifiableObjectStore<User> {
    */
   User getUserByUuid(UUID uuid);
 
+  /**
+   * Retrieves the User associated with the User with the given email.
+   *
+   * @param email email.
+   * @return the User.
+   */
+  User getUserByEmail(String email);
+
   List<User> getHasAuthority(String authority);
 
   List<User> getLinkedUserAccounts(User currentUser);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -920,6 +920,12 @@ public class DefaultUserService implements UserService {
 
   @Override
   @Transactional(readOnly = true)
+  public User getUserByEmail(String email) {
+    return userStore.getUserByEmail(email);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
   public boolean canCurrentUserCanModify(
       User currentUser, User userToModify, Consumer<ErrorReport> errors) {
     if (!aclService.canUpdate(currentUser, userToModify)) {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/webmessage/WebMessageUtils.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/webmessage/WebMessageUtils.java
@@ -58,6 +58,11 @@ import org.springframework.http.HttpStatus;
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 public final class WebMessageUtils {
+
+  public static WebMessage createWebMessage(Status status, HttpStatus httpStatus) {
+    return new WebMessage(status, httpStatus);
+  }
+
   public static WebMessage createWebMessage(String message, Status status, HttpStatus httpStatus) {
     return new WebMessage(status, httpStatus).setMessage(message);
   }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/message/FakeMessageSender.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/message/FakeMessageSender.java
@@ -62,6 +62,14 @@ public class FakeMessageSender implements MessageSender {
     return unmodifiableList(sendMessagesByRecipient.getOrDefault(recipient, emptyList()));
   }
 
+  public void clearMessages() {
+    sendMessagesByRecipient.clear();
+  }
+
+  public List<OutboundMessage> getAllMessages() {
+    return sendMessagesByRecipient.values().stream().flatMap(List::stream).toList();
+  }
+
   @Override
   public OutboundMessageResponse sendMessage(
       String subject,

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/DhisControllerConvenienceTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/DhisControllerConvenienceTest.java
@@ -78,7 +78,7 @@ public abstract class DhisControllerConvenienceTest extends DhisControllerTestBa
   private User adminUser;
 
   @BeforeEach
-  final void setup() throws Exception {
+  public final void setup() throws Exception {
     userService = _userService;
     renderService = _renderService;
     clearSecurityContext();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserAccountControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserAccountControllerTest.java
@@ -49,6 +49,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.webapi.json.domain.JsonUser;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -69,23 +70,34 @@ class UserAccountControllerTest extends DhisControllerConvenienceTest {
   private String superUserRoleUid;
 
   @Test
-  void testResetPasswordOk() {
+  @DisplayName("Happy path for forgot password with username as input")
+  void testResetPasswordOkUsername() {
     systemSettingManager.saveSystemSetting(SettingKey.ACCOUNT_RECOVERY, true);
-
-    User test = switchToNewUser("test");
-
+    User user = switchToNewUser("test");
     clearSecurityContext();
-    String token = sendForgotPasswordRequest(test);
+    sendForgotPasswordRequest(user.getUsername());
+    doAndCheckPasswordResetWithUser(user);
+  }
 
+  @Test
+  @DisplayName("Happy path for forgot password with email as input")
+  void testResetPasswordOkEmail() {
+    systemSettingManager.saveSystemSetting(SettingKey.ACCOUNT_RECOVERY, true);
+    User user = switchToNewUser("test");
+    clearSecurityContext();
+    sendForgotPasswordRequest(user.getEmail());
+    doAndCheckPasswordResetWithUser(user);
+  }
+
+  private void doAndCheckPasswordResetWithUser(User user) {
+    String token = fetchTokenInSentEmail(user);
     String newPassword = "Abxf123###...";
-
     POST(
             "/auth/passwordReset",
             "{'newPassword':'%s', 'resetToken':'%s'}".formatted(newPassword, token))
         .content(HttpStatus.OK);
 
-    User updatedUser = userService.getUserByUsername(test.getUsername());
-
+    User updatedUser = userService.getUserByUsername(user.getUsername());
     boolean passwordMatch = passwordEncoder.matches(newPassword, updatedUser.getPassword());
 
     assertTrue(passwordMatch);
@@ -410,19 +422,20 @@ class UserAccountControllerTest extends DhisControllerConvenienceTest {
         arguments("sAdmin1@", "Password must not have any generic word"));
   }
 
-  private String sendForgotPasswordRequest(User test) {
-    POST("/auth/forgotPassword", "{'username':'%s'}".formatted(test.getUsername()))
+  private void sendForgotPasswordRequest(String emailOrUsername) {
+    POST("/auth/forgotPassword", "{'emailOrUsername':'%s'}".formatted(emailOrUsername))
         .content(HttpStatus.OK);
+  }
 
-    OutboundMessage message = assertMessageSendTo(test.getEmail());
-
+  @NotNull
+  private String fetchTokenInSentEmail(User user) {
+    OutboundMessage message = assertMessageSendTo(user.getEmail());
     Pattern pattern = Pattern.compile("\\?token=(.*?)\\n");
     Matcher matcher = pattern.matcher(message.getText());
     String token = "";
     if (matcher.find()) {
       token = matcher.group(1);
     }
-
     assertFalse(token.isEmpty());
     return token;
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserAccountControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserAccountControllerTest.java
@@ -88,6 +88,24 @@ class UserAccountControllerTest extends DhisControllerConvenienceTest {
     doAndCheckPasswordResetWithUser(user);
   }
 
+  @Test
+  @DisplayName("Send wrong/non-existent email, should return OK to avoid email enumeration")
+  void testResetPasswordWrongEmail() {
+    systemSettingManager.saveSystemSetting(SettingKey.ACCOUNT_RECOVERY, true);
+    clearSecurityContext();
+    sendForgotPasswordRequest("wrong@email.com");
+    assertTrue(((FakeMessageSender) messageSender).getAllMessages().isEmpty());
+  }
+
+  @Test
+  @DisplayName("Send wrong/non-existent username, should return OK to avoid username enumeration")
+  void testResetPasswordWrongUsername() {
+    systemSettingManager.saveSystemSetting(SettingKey.ACCOUNT_RECOVERY, true);
+    clearSecurityContext();
+    sendForgotPasswordRequest("wrong");
+    assertTrue(((FakeMessageSender) messageSender).getAllMessages().isEmpty());
+  }
+
   private void doAndCheckPasswordResetWithUser(User user) {
     String token = fetchTokenInSentEmail(user);
     String newPassword = "Abxf123###...";

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserAccountControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserAccountControllerTest.java
@@ -49,7 +49,6 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.webapi.json.domain.JsonUser;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -427,7 +426,6 @@ class UserAccountControllerTest extends DhisControllerConvenienceTest {
         .content(HttpStatus.OK);
   }
 
-  @NotNull
   private String fetchTokenInSentEmail(User user) {
     OutboundMessage message = assertMessageSendTo(user.getEmail());
     Pattern pattern = Pattern.compile("\\?token=(.*?)\\n");

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserAccountControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserAccountControllerTest.java
@@ -53,6 +53,7 @@ import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.webapi.json.domain.JsonUser;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -71,6 +72,11 @@ class UserAccountControllerTest extends DhisControllerConvenienceTest {
   @Autowired private PasswordManager passwordEncoder;
 
   private String superUserRoleUid;
+
+  @BeforeEach
+  final void setupHere() throws Exception {
+    ((FakeMessageSender) messageSender).clearMessages();
+  }
 
   @Test
   @DisplayName("Happy path for forgot password with username as input")
@@ -107,7 +113,8 @@ class UserAccountControllerTest extends DhisControllerConvenienceTest {
     systemSettingManager.saveSystemSetting(SettingKey.ACCOUNT_RECOVERY, true);
     clearSecurityContext();
     sendForgotPasswordRequest("wrong");
-    assertTrue(((FakeMessageSender) messageSender).getAllMessages().isEmpty());
+    List<OutboundMessage> allMessages = ((FakeMessageSender) messageSender).getAllMessages();
+    assertTrue(allMessages.isEmpty());
   }
 
   private void doAndCheckPasswordResetWithUser(User user) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
@@ -552,7 +552,8 @@ public class AccountController {
   }
 
   private Map<String, String> validatePassword(String password) {
-    CredentialsInfo credentialsInfo = new CredentialsInfo(password, true);
+    CredentialsInfo credentialsInfo =
+        CredentialsInfo.builder().password(password).newUser(true).build();
 
     PasswordValidationResult passwordValidationResult =
         passwordValidationService.validate(credentialsInfo);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -199,6 +199,12 @@ public class CrudControllerAdvice {
     return createWebMessage(ex.getMessage(), Status.ERROR, HttpStatus.NOT_FOUND, ex.getCode());
   }
 
+  @ExceptionHandler(org.hisp.dhis.feedback.HiddenNotFoundException.class)
+  @ResponseBody
+  public WebMessage hiddenNotFoundException(org.hisp.dhis.feedback.HiddenNotFoundException ex) {
+    return createWebMessage(Status.OK, HttpStatus.OK);
+  }
+
   @ExceptionHandler(RestClientException.class)
   @ResponseBody
   public WebMessage restClientExceptionHandler(RestClientException ex) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ForgotPasswordRequest.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ForgotPasswordRequest.java
@@ -41,5 +41,5 @@ import lombok.NoArgsConstructor;
 @Getter
 @Builder
 public class ForgotPasswordRequest {
-  @JsonProperty private String username;
+  @JsonProperty private String emailOrUsername;
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/UserAccountController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/UserAccountController.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.setting.SystemSettingManager;
+import org.hisp.dhis.system.util.ValidationUtils;
 import org.hisp.dhis.user.CredentialsInfo;
 import org.hisp.dhis.user.PasswordValidationResult;
 import org.hisp.dhis.user.PasswordValidationService;
@@ -94,27 +95,15 @@ public class UserAccountController {
       HttpServletRequest request, @RequestBody ForgotPasswordRequest forgotPasswordRequest)
       throws NotFoundException, ConflictException, ForbiddenException {
 
-    String username = forgotPasswordRequest.getUsername();
-
-    if (userService.isRecoveryLocked(username)) {
-      throw new ForbiddenException(
-          "The account recovery operation for the given user is temporarily locked due to too "
-              + "many calls to this endpoint in the last '"
-              + RECOVERY_LOCKOUT_MINS
-              + "' minutes. Username:"
-              + username);
-    } else {
-      userService.registerRecoveryAttempt(username);
+    if (!systemSettingManager.accountRecoveryEnabled()) {
+      throw new ConflictException("Account recovery is not enabled");
     }
 
-    User user = userService.getUserByUsername(username);
+    User user = getUser(forgotPasswordRequest.getEmailOrUsername());
 
-    if (user == null) {
-      throw new NotFoundException("User does not exist: " + username);
-    }
+    checkRecoveryLock(user.getUsername());
 
     ErrorCode errorCode = userService.validateRestore(user);
-
     if (errorCode != null) {
       throw new IllegalQueryException(errorCode);
     }
@@ -126,13 +115,17 @@ public class UserAccountController {
       throw new ConflictException("Account could not be recovered");
     }
 
-    log.info("Recovery message sent for user: {}", username);
+    log.info("Forgot email was sent to user: {}", user.getUsername());
   }
 
   @PostMapping("/passwordReset")
   @ResponseStatus(HttpStatus.OK)
   public void resetPassword(@RequestBody ResetPasswordRequest resetRequest)
       throws ConflictException, BadRequestException {
+
+    if (!systemSettingManager.accountRecoveryEnabled()) {
+      throw new ConflictException("Account recovery is not enabled");
+    }
 
     String token = resetRequest.getResetToken();
     String newPassword = resetRequest.getNewPassword();
@@ -144,34 +137,32 @@ public class UserAccountController {
     if (user == null || idAndRestoreToken.length < 2) {
       throw new ConflictException("Account recovery failed");
     }
-    String restoreToken = idAndRestoreToken[1];
 
-    if (!systemSettingManager.accountRecoveryEnabled()) {
-      throw new ConflictException("Account recovery is not enabled");
-    }
+    String restoreToken = idAndRestoreToken[1];
 
     if (newPassword.trim().equals(user.getUsername())) {
       throw new BadRequestException("Password cannot be equal to username");
     }
 
     CredentialsInfo credentialsInfo =
-        new CredentialsInfo(
-            user.getUsername(), newPassword, StringUtils.trimToEmpty(user.getEmail()), false);
+        CredentialsInfo.builder()
+            .username(user.getUsername())
+            .password(newPassword)
+            .email(StringUtils.trimToEmpty(user.getEmail()))
+            .newUser(false)
+            .build();
 
     PasswordValidationResult result = passwordValidationService.validate(credentialsInfo);
-
     if (!result.isValid()) {
       throw new BadRequestException(result.getErrorMessage());
     }
 
-    boolean restoreSuccess =
-        userService.restore(user, restoreToken, newPassword, RestoreType.RECOVER_PASSWORD);
-
-    if (!restoreSuccess) {
-      throw new BadRequestException("Account could not be restored");
+    if (!userService.restore(user, restoreToken, newPassword, RestoreType.RECOVER_PASSWORD)) {
+      throw new BadRequestException(
+          "Account could not be restored for user: " + user.getUsername());
     }
 
-    log.info("Account restored for user: {}", user.getUsername());
+    log.info("Password was reset for user: {}", user.getUsername());
   }
 
   @PostMapping("/register")
@@ -183,5 +174,33 @@ public class UserAccountController {
     userAccountService.createAndAddSelfRegisteredUser(selfRegForm, request);
     log.info("Self registration successful");
     return ok("Account created");
+  }
+
+  private void checkRecoveryLock(String username) throws ForbiddenException {
+    if (userService.isRecoveryLocked(username)) {
+      throw new ForbiddenException(
+          "The account recovery operation for the given user is temporarily locked due to too "
+              + "many calls to this endpoint in the last '"
+              + RECOVERY_LOCKOUT_MINS
+              + "' minutes. Username:"
+              + username);
+    } else {
+      userService.registerRecoveryAttempt(username);
+    }
+  }
+
+  private User getUser(String emailOrUsername) throws NotFoundException {
+    User user;
+
+    if (ValidationUtils.emailIsValid(emailOrUsername)) {
+      user = userService.getUserByEmail(emailOrUsername);
+    } else {
+      user = userService.getUserByUsername(emailOrUsername);
+    }
+    if (user == null) {
+      throw new NotFoundException("User does not exist: " + emailOrUsername);
+    }
+
+    return user;
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/UserAccountController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/UserAccountController.java
@@ -43,7 +43,7 @@ import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ForbiddenException;
-import org.hisp.dhis.feedback.NotFoundException;
+import org.hisp.dhis.feedback.HiddenNotFoundException;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.util.ValidationUtils;
 import org.hisp.dhis.user.CredentialsInfo;
@@ -93,7 +93,7 @@ public class UserAccountController {
   @ResponseStatus(HttpStatus.OK)
   public void forgotPassword(
       HttpServletRequest request, @RequestBody ForgotPasswordRequest forgotPasswordRequest)
-      throws NotFoundException, ConflictException, ForbiddenException {
+      throws HiddenNotFoundException, ConflictException, ForbiddenException {
 
     if (!systemSettingManager.accountRecoveryEnabled()) {
       throw new ConflictException("Account recovery is not enabled");
@@ -189,7 +189,7 @@ public class UserAccountController {
     }
   }
 
-  private User getUser(String emailOrUsername) throws NotFoundException {
+  private User getUser(String emailOrUsername) throws HiddenNotFoundException {
     User user;
 
     if (ValidationUtils.emailIsValid(emailOrUsername)) {
@@ -198,7 +198,7 @@ public class UserAccountController {
       user = userService.getUserByUsername(emailOrUsername);
     }
     if (user == null) {
-      throw new NotFoundException("User does not exist: " + emailOrUsername);
+      throw new HiddenNotFoundException("User does not exist: " + emailOrUsername);
     }
 
     return user;


### PR DESCRIPTION
### Summary
* Adds email as possible password reset input, this however will not work when there are duplicate emails in the system.
Since we don't have unique email support, look up on an email that has multiple entries, will now throw an exception.
* Make sure a username or email reset request don't return 404 when the user doesn't exist, this is to prevent username and email enumeration attacks.
* Minor refactorings.
### Automatic tests
UserAccountControllerTest
