### PR TITLE
chore: check if admin exists before creating in test

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -2877,16 +2877,22 @@ public abstract class DhisConvenienceTest {
   }
 
   protected User preCreateInjectAdminUser() {
-    User user = preCreateInjectAdminUserWithoutPersistence();
+    User adminTest = userService.getUserByUsername("admin_test");
 
-    userService.addUser(user);
+    if (adminTest == null) {
 
-    user.getUserRoles().forEach(userRole -> userService.addUserRole(userRole));
+      User user = preCreateInjectAdminUserWithoutPersistence();
 
-    userService.encodeAndSetPassword(user, user.getPassword());
-    userService.updateUser(user);
+      userService.addUser(user);
 
-    return user;
+      user.getUserRoles().forEach(userRole -> userService.addUserRole(userRole));
+
+      userService.encodeAndSetPassword(user, user.getPassword());
+      userService.updateUser(user);
+
+      return user;
+    }
+    return adminTest;
   }
 
   protected User preCreateInjectAdminUserWithoutPersistence() {


### PR DESCRIPTION
temporary fix to ensure no duplicate admins are created during tests.
Another solution would be to just append a random UID to `admin_test` + UID