### PR TITLE
test: cleanup admin user after HibernateQueryCacheTest

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -2877,12 +2877,6 @@ public abstract class DhisConvenienceTest {
   }
 
   protected User preCreateInjectAdminUser() {
-    User admin = userService.getUserByUsername(DEFAULT_USERNAME + "_test");
-    if (admin != null) {
-      injectSecurityContextUser(admin);
-      return admin;
-    }
-
     User user = preCreateInjectAdminUserWithoutPersistence();
 
     userService.addUser(user);

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/cache/HibernateCacheBaseTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/cache/HibernateCacheBaseTest.java
@@ -46,15 +46,6 @@ public class HibernateCacheBaseTest extends BaseSpringTest {
 
   @AfterEach
   public final void after() throws Exception {
-
-    clearSecurityContext();
-
-    tearDownTest();
-
-    try {
-      dbmsManager.clearSession();
-    } catch (Exception e) {
-      log.info("Failed to clear hibernate session, reason:" + e.getMessage());
-    }
+    nonTransactionalAfter();
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateQueryCacheTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateQueryCacheTest.java
@@ -41,14 +41,12 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.orm.jpa.EntityManagerHolder;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-@Disabled("are you the one ;)")
 class HibernateQueryCacheTest extends HibernateCacheBaseTest {
 
   private @Autowired EntityManagerFactory entityManagerFactory;
@@ -74,8 +72,7 @@ class HibernateQueryCacheTest extends HibernateCacheBaseTest {
   }
 
   @AfterEach
-  public final void afterEach() throws Exception {
-    unbindSession();
+  public final void afterEach() {
     entityManager.close();
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateQueryCacheTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateQueryCacheTest.java
@@ -41,12 +41,14 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.orm.jpa.EntityManagerHolder;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+@Disabled("are you the one ;)")
 class HibernateQueryCacheTest extends HibernateCacheBaseTest {
 
   private @Autowired EntityManagerFactory entityManagerFactory;


### PR DESCRIPTION
This reverts commit a69d3bf0c6d97880d1a7cbe942cc86cc6391ee01 which was a quick fix to unblock us.

```
Error:  Tests run: 5, Failures: 0, Errors: 1, Skipped: 1, Time elapsed: 0.601 s <<< FAILURE! -- in org.hisp.dhis.jdbc.batchhandler.CompleteDataSetRegistrationBatchHandlerTest
3497
Error:  org.hisp.dhis.jdbc.batchhandler.CompleteDataSetRegistrationBatchHandlerTest.testFindObject -- Time elapsed: 0.067 s <<< ERROR!
3498
org.springframework.dao.DataIntegrityViolationException: could not execute statement; SQL [n/a]; constraint [uk_userinfo_username]; nested exception is org.hibernate.exception.ConstraintViolationException: could not execute statement
3499
	at
```

was due to `HibernateQueryCacheTest` creating the admin user via `preCreateInjectAdminUser` but not cleaning it up. All base test classes or test classes calling `preCreateInjectAdminUser` where calling the `nonTransactionalAfter` that deletes table [userinfo](https://github.com/dhis2/dhis2-core/blob/8e2fa824454def89310ac87c18cc5a3d7d900501/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/dbms/HibernateDbmsManager.java#L333).
