### PR TITLE
fix: can not update users after OpenID field is set

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
@@ -40,7 +40,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.adapter.BaseIdentifiableObject_;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
-import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
@@ -112,8 +111,9 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook<User> {
               .setErrorProperty(USERNAME));
     }
 
-    boolean openIdMappingExists = userService.getUserByOpenId(user.getOpenId()) != null;
-    if ((dhisConfig.isDisabled(ConfigurationKey.LINKED_ACCOUNTS_ENABLED) && openIdMappingExists)) {
+    User existingUserWithMatchingOpenID = userService.getUserByOpenId(user.getOpenId());
+    if (existingUserWithMatchingOpenID != null
+        && !existingUserWithMatchingOpenID.getUid().equals(user.getUid())) {
       addReports.accept(
           new ErrorReport(User.class, ErrorCode.E4054, "OIDC mapping value", user.getOpenId())
               .setErrorProperty(USERNAME));

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -81,6 +81,7 @@ import org.hisp.dhis.webapi.json.domain.JsonUserGroup;
 import org.hisp.dhis.webapi.json.domain.JsonWebMessage;
 import org.jboss.aerogear.security.otp.api.Base32;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.session.SessionRegistry;
@@ -217,6 +218,28 @@ class UserControllerTest extends DhisControllerConvenienceTest {
     User user = userService.getUser(peter.getUid());
     assertEquals("mapping value", user.getOpenId());
     assertEquals("mapping value", user.getUserCredentials().getOpenId());
+  }
+
+  @Test
+  @DisplayName(
+      "Make sure an update after first setting OpenID works, has special handling logic in UserObjectBundleHook.")
+  void testSetOpenIdThenUpdate() {
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/users/{id}",
+            peter.getUid() + "?importReportMode=ERRORS",
+            Body("[{'op': 'add', 'path': '/openId', 'value': 'mapping value'}]")));
+
+    User user = userService.getUser(peter.getUid());
+    assertEquals("mapping value", user.getOpenId());
+
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/users/{id}",
+            peter.getUid() + "?importReportMode=ERRORS",
+            Body("[{'op': 'add', 'path': '/openId', 'value': 'mapping value'}]")));
   }
 
   /**


### PR DESCRIPTION
## Summary
### Before:
When a user has set the OpenID field, a subsequent update action would fail on the (not in DB) OpenID uniqueness check.
### After:
Check if the existing OpenID belong to the user being updated. 
## Automatic test
UserControllerTest#testSetOpenIdThenUpdate
## Manual test
1. Create a user with the OpenID field set in the user app.
2. Update the user, just change e.g. the first name.
3. Observe user is updates and request returns 200 OK