### PR TITLE
fix: add search parameter to icons

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/icon/IconOperationParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/icon/IconOperationParams.java
@@ -32,7 +32,6 @@ import java.util.Date;
 import java.util.List;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.Pager;
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/icon/IconOperationParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/icon/IconOperationParams.java
@@ -32,6 +32,8 @@ import java.util.Date;
 import java.util.List;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.Pager;
 
 /**
@@ -50,6 +52,7 @@ public class IconOperationParams {
   private Date lastUpdatedStartDate;
   private Date lastUpdatedEndDate;
   private Boolean custom = null;
+  private String search;
   private boolean paging = true;
   private Pager pager = new Pager();
 
@@ -79,5 +82,9 @@ public class IconOperationParams {
 
   public boolean hasCustom() {
     return custom != null;
+  }
+
+  public boolean hasSearch() {
+    return StringUtils.isNotEmpty(search);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/icon/JdbcIconStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/icon/JdbcIconStore.java
@@ -29,6 +29,11 @@ package org.hisp.dhis.icon;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.apache.commons.lang3.StringUtils.wrap;
+import static org.hisp.dhis.commons.util.TextUtils.doubleQuote;
+import static org.hisp.dhis.dataitem.query.shared.StatementUtil.addIlikeReplacingCharacters;
+
 import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -208,6 +213,15 @@ public class JdbcIconStore implements IconStore {
       sql += hlp.whereAnd() + " c.iconkey IN (:keys )";
 
       parameterSource.addValue("keys", params.getKeys());
+    }
+
+    if (params.hasSearch()) {
+      String searchValue = params.getSearch();
+
+      sql += hlp.whereAnd() + " c.iconkey ilike :search";
+      sql += " OR jsonb_path_exists(keywords, '$[*] ? (@ like_regex " + doubleQuote(searchValue) + ")')";
+
+      parameterSource.addValue("search", wrap(addIlikeReplacingCharacters(searchValue), '%'));
     }
 
     return sql;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/icon/JdbcIconStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/icon/JdbcIconStore.java
@@ -27,13 +27,12 @@
  */
 package org.hisp.dhis.icon;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import static org.apache.commons.lang3.StringUtils.wrap;
 import static org.hisp.dhis.commons.util.TextUtils.doubleQuote;
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.addIlikeReplacingCharacters;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -219,7 +218,10 @@ public class JdbcIconStore implements IconStore {
       String searchValue = params.getSearch();
 
       sql += hlp.whereAnd() + " c.iconkey ilike :search";
-      sql += " OR jsonb_path_exists(keywords, '$[*] ? (@ like_regex " + doubleQuote(searchValue) + ")')";
+      sql +=
+          " OR jsonb_path_exists(keywords, '$[*] ? (@ like_regex "
+              + doubleQuote(searchValue)
+              + ")')";
 
       parameterSource.addValue("search", wrap(addIlikeReplacingCharacters(searchValue), '%'));
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/icon/JdbcIconStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/icon/JdbcIconStore.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.icon;
 
 import static org.apache.commons.lang3.StringUtils.wrap;
-import static org.hisp.dhis.commons.util.TextUtils.doubleQuote;
 import static org.hisp.dhis.dataitem.query.shared.StatementUtil.addIlikeReplacingCharacters;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -218,11 +217,8 @@ public class JdbcIconStore implements IconStore {
       String searchValue = params.getSearch();
 
       sql += hlp.whereAnd() + " c.iconkey ilike :search";
-      sql +=
-          " OR jsonb_path_exists(keywords, '$[*] ? (@ like_regex "
-              + doubleQuote(searchValue)
-              + ")')";
-
+      sql += " OR jsonb_path_exists(keywords, '$[*] ? (@ like_regex \":keywordsSearch\")')";
+      parameterSource.addValue("keywordsSearch", searchValue);
       parameterSource.addValue("search", wrap(addIlikeReplacingCharacters(searchValue), '%'));
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/icon/IconRequestParamMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/icon/IconRequestParamMapper.java
@@ -65,6 +65,7 @@ public class IconRequestParamMapper {
     operationParams.setLastUpdatedEndDate(iconRequestParams.getLastUpdatedEndDate());
     operationParams.setPaging(iconRequestParams.isPaging());
     operationParams.setCustom(TYPE_MAPPER.getOrDefault(iconRequestParams.getType(), null));
+    operationParams.setSearch(iconRequestParams.getSearch());
 
     return operationParams;
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/icon/IconRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/icon/IconRequestParams.java
@@ -53,6 +53,7 @@ public class IconRequestParams {
   private Date lastUpdatedStartDate;
   private Date lastUpdatedEndDate;
   private IconTypeFilter type = IconTypeFilter.ALL;
+  private String search;
   private boolean paging = true;
   private int pageSize = Pager.DEFAULT_PAGE_SIZE;
   private int page = 1;


### PR DESCRIPTION
Adds `search`-param to `/icons` API.

This allows searching for a part of the `iconkey`, or partial matches in any keyword.