### PR TITLE
fix: return 200 on non unique email found

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -543,10 +543,9 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
     query.setParameter("email", email);
     List<User> list = query.getResultList();
     if (list.size() > 1) {
-      // TODO: MAS: We need to handle this case more gracefully, now it's only used be reset
       // password, but that should be changed when we have verified emails implemented.
       log.warn("Multiple users found with email: {}", email);
-      throw new IllegalStateException("Multiple users found with email: " + email);
+      return null;
     }
     return list.isEmpty() ? null : list.get(0);
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserAccountControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserAccountControllerTest.java
@@ -117,6 +117,23 @@ class UserAccountControllerTest extends DhisControllerConvenienceTest {
     assertTrue(allMessages.isEmpty());
   }
 
+  @Test
+  @DisplayName("Send non-unique email, should return OK to avoid username enumeration")
+  void testResetPasswordNonUniqueEmail() {
+    systemSettingManager.saveSystemSetting(SettingKey.ACCOUNT_RECOVERY, true);
+
+    switchContextToUser(superUser);
+    User userA = createUserWithAuth("userA");
+    userA.setEmail("same@email.no");
+    User userB = createUserWithAuth("userB");
+    userB.setEmail("same@email.no");
+
+    clearSecurityContext();
+    sendForgotPasswordRequest("wrong");
+    List<OutboundMessage> allMessages = ((FakeMessageSender) messageSender).getAllMessages();
+    assertTrue(allMessages.isEmpty());
+  }
+
   private void doAndCheckPasswordResetWithUser(User user) {
     String token = fetchTokenInSentEmail(user);
     String newPassword = "Abxf123###...";

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/UserAccountController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/UserAccountController.java
@@ -37,7 +37,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.DhisApiVersion;
-import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.auth.UserInviteParams;
 import org.hisp.dhis.common.auth.UserRegistrationParams;
@@ -107,7 +106,8 @@ public class UserAccountController {
 
     ErrorCode errorCode = userService.validateRestore(user);
     if (errorCode != null) {
-      throw new IllegalQueryException(errorCode);
+      log.warn("Validate email restore failed: {}", errorCode);
+      throw new HiddenNotFoundException("Validate failed: " + errorCode);
     }
 
     if (!userService.sendRestoreOrInviteMessage(


### PR DESCRIPTION
## Summary 
Return 200 instead of 409 on non-unique email found, to avoid email enumeration attacks.