### PR TITLE
fix: Do not swallow stack trace from JDK exceptions

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
@@ -1433,7 +1433,7 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
     if (isSet(deprecatedTeiMaxLimit)
         && isSet(newTeiMaxLimit)
         && deprecatedTeiMaxLimit != newTeiMaxLimit) {
-      throw new IllegalStateException(
+      throw new IllegalQueryException(
           String.format(
               "Only one parameter of '%s' and '%s' must be specified. Prefer '%s' as '%s' will be removed.",
               SettingKey.TRACKED_ENTITY_MAX_LIMIT.getName(),

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
@@ -361,7 +361,7 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
    */
   private String getQuery(TrackedEntityQueryParams params, boolean isGridQuery) {
     if (params.isOrQuery() && params.getAttributesAndFilters().isEmpty()) {
-      throw new IllegalArgumentException(
+      throw new IllegalQueryException(
           "A query parameter is used in the request but there aren't filterable attributes");
     }
 

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/deprecated/tracker/TrackedEntityInstanceQueryTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/deprecated/tracker/TrackedEntityInstanceQueryTests.java
@@ -34,8 +34,6 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hisp.dhis.helpers.matchers.CustomMatchers.hasToStringContaining;
 import static org.hisp.dhis.helpers.matchers.MatchesJson.matchesJSON;
-
-import com.google.gson.JsonObject;
 import java.io.File;
 import java.util.Arrays;
 import java.util.stream.Stream;
@@ -56,6 +54,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import com.google.gson.JsonObject;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -153,9 +152,9 @@ class TrackedEntityInstanceQueryTests extends DeprecatedTrackerApiTest {
     trackedEntityInstanceQueryActions
         .get("?ouMode=ACCESSIBLE&query=LIKE:value&program=jDnjGYZFkA2")
         .validate()
-        .statusCode(400)
-        .body("status", equalTo("ERROR"))
-        .body("httpStatusCode", equalTo(400));
+        .statusCode(409)
+        .body("status", equalTo("CONFLICT"))
+        .body("httpStatusCode", equalTo(409));
   }
 
   private String createTei() {

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/deprecated/tracker/TrackedEntityInstanceQueryTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/deprecated/tracker/TrackedEntityInstanceQueryTests.java
@@ -34,6 +34,8 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hisp.dhis.helpers.matchers.CustomMatchers.hasToStringContaining;
 import static org.hisp.dhis.helpers.matchers.MatchesJson.matchesJSON;
+
+import com.google.gson.JsonObject;
 import java.io.File;
 import java.util.Arrays;
 import java.util.stream.Stream;
@@ -54,7 +56,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import com.google.gson.JsonObject;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/deprecated/tracker/TrackedEntityInstanceQueryTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/deprecated/tracker/TrackedEntityInstanceQueryTests.java
@@ -153,7 +153,7 @@ class TrackedEntityInstanceQueryTests extends DeprecatedTrackerApiTest {
         .get("?ouMode=ACCESSIBLE&query=LIKE:value&program=jDnjGYZFkA2")
         .validate()
         .statusCode(409)
-        .body("status", equalTo("CONFLICT"))
+        .body("status", equalTo("ERROR"))
         .body("httpStatusCode", equalTo(409));
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityQueryLimitTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityQueryLimitTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
@@ -152,7 +153,7 @@ class TrackedEntityQueryLimitTest extends SingleSetupIntegrationTestBase {
     params.setSkipPaging(true);
 
     assertThrows(
-        IllegalStateException.class,
+        IllegalQueryException.class,
         () -> trackedEntityService.getTrackedEntityIds(params, false, false),
         String.format(
             "Only one parameter of '%s' and '%s' must be specified. Prefer '%s' as '%s' will be removed.",

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityServiceTest.java
@@ -40,6 +40,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryOperator;
@@ -306,7 +307,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     params.setQuery(new QueryFilter(QueryOperator.LIKE, ATTRIBUTE_VALUE));
 
     assertThrows(
-        IllegalArgumentException.class, () -> entityInstanceService.getTrackedEntitiesGrid(params));
+        IllegalQueryException.class, () -> entityInstanceService.getTrackedEntitiesGrid(params));
   }
 
   @Test
@@ -322,7 +323,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     params.setQuery(new QueryFilter(QueryOperator.LIKE, ATTRIBUTE_VALUE));
 
     assertThrows(
-        IllegalArgumentException.class, () -> entityInstanceService.getTrackedEntitiesGrid(params));
+        IllegalQueryException.class, () -> entityInstanceService.getTrackedEntitiesGrid(params));
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -361,7 +361,7 @@ public class CrudControllerAdvice {
 
   @ExceptionHandler(Dhis2ClientException.class)
   @ResponseBody
-  public WebMessage dhis2ClientException(Dhis2ClientException ex) {
+  public WebMessage dhis2ClientExceptionHandler(Dhis2ClientException ex) {
     return conflict(ex.getMessage(), ex.getErrorCode());
   }
 
@@ -496,16 +496,27 @@ public class CrudControllerAdvice {
   }
 
   /**
-   * Handles {@link IllegalArgumentException} and {@link IllegalStateException} and prints the stack
-   * trace to standard error. These JDK exceptions are used in application code for validation
-   * logic, and also used by the JDK and various frameworks to indicate programming errors, which
-   * means the stack trace must be printed and not swallowed.
+   * Handles {@link IllegalArgumentException} and prints the stack trace to standard error. {@link
+   * IllegalArgumentException} is used in DHIS 2 application code but also by various frameworks to
+   * indicate programming errors, so stack trace must be printed and not swallowed.
    */
-  @ExceptionHandler({IllegalArgumentException.class, IllegalStateException.class})
+  @ExceptionHandler(IllegalArgumentException.class)
   @ResponseBody
-  public WebMessage handleBadRequestWithLogging(Exception ex) {
+  public WebMessage illegalArgumentExceptionHandler(IllegalArgumentException ex) {
     ex.printStackTrace();
     return badRequest(ex.getMessage());
+  }
+
+  /**
+   * Handles {@link IllegalStateException} and prints the stack trace to standard error. {@link
+   * IllegalArgumentException} is used in DHIS 2 application code but also by various frameworks to
+   * indicate programming errors, so stack trace must be printed and not swallowed.
+   */
+  @ExceptionHandler(IllegalStateException.class)
+  @ResponseBody
+  public WebMessage illegalArgumentExceptionHandler(IllegalStateException ex) {
+    ex.printStackTrace();
+    return conflict(ex.getMessage());
   }
 
   @ExceptionHandler(MetadataVersionException.class)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -496,12 +496,12 @@ public class CrudControllerAdvice {
   }
 
   /**
-   * Handles {@link IllegalArgumentException} and prints the stack trace to standard error. {@link
-   * IllegalArgumentException} is used in application code for validation logic, and also used by
-   * the JDK and various frameworks to indicate programming errors, which means the stack trace must
-   * be printed and not swallowed.
+   * Handles {@link IllegalArgumentException} and {@link IllegalStateException} and prints the stack
+   * trace to standard error. These JDK exceptions are used in application code for validation
+   * logic, and also used by the JDK and various frameworks to indicate programming errors, which
+   * means the stack trace must be printed and not swallowed.
    */
-  @ExceptionHandler(IllegalArgumentException.class)
+  @ExceptionHandler({IllegalArgumentException.class, IllegalStateException.class})
   @ResponseBody
   public WebMessage handleBadRequestWithLogging(Exception ex) {
     ex.printStackTrace();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -36,8 +36,6 @@ import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.mergeReport;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.objectReport;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.unauthorized;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import io.github.classgraph.ClassGraph;
 import java.beans.PropertyEditorSupport;
 import java.text.MessageFormat;
 import java.util.Arrays;
@@ -47,8 +45,10 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
 import javax.persistence.PersistenceException;
 import javax.servlet.ServletException;
+
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.exception.ConstraintViolationException;
@@ -117,6 +117,10 @@ import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import com.fasterxml.jackson.core.JsonParseException;
+
+import io.github.classgraph.ClassGraph;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -384,7 +388,7 @@ public class CrudControllerAdvice {
     return conflict(ex.getMessage());
   }
 
-  @ExceptionHandler({DataApprovalException.class, AdxException.class, IllegalStateException.class})
+  @ExceptionHandler({DataApprovalException.class, AdxException.class})
   @ResponseBody
   public WebMessage dataApprovalExceptionHandler(Exception ex) {
     return conflict(ex.getMessage());
@@ -490,7 +494,6 @@ public class CrudControllerAdvice {
   }
 
   @ExceptionHandler({
-    IllegalArgumentException.class,
     SchemaPathException.class,
     JsonPatchException.class
   })
@@ -660,7 +663,7 @@ public class CrudControllerAdvice {
     }
 
     @Override
-    public void setAsText(String text) throws IllegalArgumentException {
+    public void setAsText(String text) {
       setValue(fromText.apply(text));
     }
   }
@@ -673,7 +676,7 @@ public class CrudControllerAdvice {
     }
 
     @Override
-    public void setAsText(String text) throws IllegalArgumentException {
+    public void setAsText(String text) {
       Enum<T> enumValue = EnumUtils.getEnumIgnoreCase(enumClass, text);
 
       if (enumValue == null) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -491,8 +491,21 @@ public class CrudControllerAdvice {
 
   @ExceptionHandler({SchemaPathException.class, JsonPatchException.class})
   @ResponseBody
-  public WebMessage handleBadRequest(Exception exception) {
-    return badRequest(exception.getMessage());
+  public WebMessage handleBadRequest(Exception ex) {
+    return badRequest(ex.getMessage());
+  }
+
+  /**
+   * Handles {@link IllegalArgumentException} and prints the stack trace to standard error. {@link
+   * IllegalArgumentException} is used in application code for validation logic, and also used by
+   * the JDK and various frameworks to indicate programming errors, which means the stack trace must
+   * be printed and not swallowed.
+   */
+  @ExceptionHandler(IllegalArgumentException.class)
+  @ResponseBody
+  public WebMessage handleBadRequestWithLogging(Exception ex) {
+    ex.printStackTrace();
+    return badRequest(ex.getMessage());
   }
 
   @ExceptionHandler(MetadataVersionException.class)
@@ -504,8 +517,8 @@ public class CrudControllerAdvice {
 
   @ExceptionHandler(MetadataSyncException.class)
   @ResponseBody
-  public WebMessage handleMetaDataSyncException(MetadataSyncException metadataSyncException) {
-    return error(metadataSyncException.getMessage());
+  public WebMessage handleMetaDataSyncException(MetadataSyncException ex) {
+    return error(ex.getMessage());
   }
 
   @ExceptionHandler(DhisVersionMismatchException.class)
@@ -517,12 +530,11 @@ public class CrudControllerAdvice {
 
   @ExceptionHandler(MetadataImportConflictException.class)
   @ResponseBody
-  public WebMessage handleMetadataImportConflictException(
-      MetadataImportConflictException conflictException) {
-    if (conflictException.getMetadataSyncSummary() == null) {
-      return conflict(conflictException.getMessage());
+  public WebMessage handleMetadataImportConflictException(MetadataImportConflictException ex) {
+    if (ex.getMetadataSyncSummary() == null) {
+      return conflict(ex.getMessage());
     }
-    return conflict(null).setResponse(conflictException.getMetadataSyncSummary());
+    return conflict(null).setResponse(ex.getMetadataSyncSummary());
   }
 
   @ExceptionHandler(OAuth2AuthenticationException.class)
@@ -564,14 +576,14 @@ public class CrudControllerAdvice {
 
   @ExceptionHandler({PotentialDuplicateConflictException.class})
   @ResponseBody
-  public WebMessage handlePotentialDuplicateConflictRequest(Exception exception) {
-    return conflict(exception.getMessage());
+  public WebMessage handlePotentialDuplicateConflictRequest(Exception ex) {
+    return conflict(ex.getMessage());
   }
 
   @ExceptionHandler({PotentialDuplicateForbiddenException.class})
   @ResponseBody
-  public WebMessage handlePotentialDuplicateForbiddenRequest(Exception exception) {
-    return forbidden(exception.getMessage());
+  public WebMessage handlePotentialDuplicateForbiddenRequest(Exception ex) {
+    return forbidden(ex.getMessage());
   }
 
   /**

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -49,6 +49,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.persistence.PersistenceException;
 import javax.servlet.ServletException;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.exception.ConstraintViolationException;
@@ -121,6 +122,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@Slf4j
 @ControllerAdvice
 public class CrudControllerAdvice {
   // Add sensitive exceptions into this array
@@ -496,26 +498,26 @@ public class CrudControllerAdvice {
   }
 
   /**
-   * Handles {@link IllegalArgumentException} and prints the stack trace to standard error. {@link
+   * Handles {@link IllegalArgumentException} and logs the stack trace to standard error. {@link
    * IllegalArgumentException} is used in DHIS 2 application code but also by various frameworks to
    * indicate programming errors, so stack trace must be printed and not swallowed.
    */
   @ExceptionHandler(IllegalArgumentException.class)
   @ResponseBody
   public WebMessage illegalArgumentExceptionHandler(IllegalArgumentException ex) {
-    ex.printStackTrace();
+    log.error(IllegalArgumentException.class.getName(), ex);
     return badRequest(ex.getMessage());
   }
 
   /**
-   * Handles {@link IllegalStateException} and prints the stack trace to standard error. {@link
+   * Handles {@link IllegalStateException} and logs the stack trace to standard error. {@link
    * IllegalArgumentException} is used in DHIS 2 application code but also by various frameworks to
    * indicate programming errors, so stack trace must be printed and not swallowed.
    */
   @ExceptionHandler(IllegalStateException.class)
   @ResponseBody
   public WebMessage illegalArgumentExceptionHandler(IllegalStateException ex) {
-    ex.printStackTrace();
+    log.error(IllegalStateException.class.getName(), ex);
     return conflict(ex.getMessage());
   }
 
@@ -604,7 +606,7 @@ public class CrudControllerAdvice {
   @ResponseBody
   @ExceptionHandler(Exception.class)
   public WebMessage defaultExceptionHandler(Exception ex) {
-    ex.printStackTrace();
+    log.error(Exception.class.getName(), ex);
     return error(getExceptionMessage(ex));
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -36,6 +36,8 @@ import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.mergeReport;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.objectReport;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.unauthorized;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import io.github.classgraph.ClassGraph;
 import java.beans.PropertyEditorSupport;
 import java.text.MessageFormat;
 import java.util.Arrays;
@@ -45,10 +47,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 import javax.persistence.PersistenceException;
 import javax.servlet.ServletException;
-
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.exception.ConstraintViolationException;
@@ -117,10 +117,6 @@ import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
-
-import com.fasterxml.jackson.core.JsonParseException;
-
-import io.github.classgraph.ClassGraph;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -493,10 +489,7 @@ public class CrudControllerAdvice {
     throw ex;
   }
 
-  @ExceptionHandler({
-    SchemaPathException.class,
-    JsonPatchException.class
-  })
+  @ExceptionHandler({SchemaPathException.class, JsonPatchException.class})
   @ResponseBody
   public WebMessage handleBadRequest(Exception exception) {
     return badRequest(exception.getMessage());


### PR DESCRIPTION
This PR is about exception handling. Currently in `CrudControllerAdvice`, general JDK exceptions such as `java.lang.IllegalStateException` and `java.lang.IllegalArgumentException` are caught and returned with a generic "error occurred" message. 

This is not ideal since it will swallow exceptions coming from the JDK or external frameworks, potentially from programming errors, and there is no way to distinguish the two.

For DHIS 2, it is typically better to rely on DHIS 2-specific exceptions to indicate validation failing, etc.

This fix adds stack trace printing for `java.lang.IllegalStateException` and `java.lang.IllegalArgumentException`.

The alternative is to refactor and replace use of these exceptions in DHIS 2, but that will be a huge undertaking.

Replaces use of `IllegalArgumentException` to `IllegalQueryException` in tracked entity service query, which is more appropriate since they signal application level validation error.

Renames variables `exception` to `ex` for consistency.