### PR TITLE
fix: Improve logging for LDAP authentication

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/DefaultUserDetailsService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/DefaultUserDetailsService.java
@@ -54,7 +54,8 @@ public class DefaultUserDetailsService implements UserDetailsService {
 
     User user = userStore.getUserByUsername(username);
     if (user == null) {
-      throw new UsernameNotFoundException(String.format("Username '%s' not found.", username));
+      throw new UsernameNotFoundException(
+          String.format("User with username '%s' not found", username));
     }
 
     return userService.createUserDetails(user);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/ldap/authentication/DhisBindAuthenticator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/ldap/authentication/DhisBindAuthenticator.java
@@ -71,4 +71,13 @@ public class DhisBindAuthenticator extends BindAuthenticator {
 
     return super.authenticate(authentication);
   }
+
+  @Override
+  public void handleBindException(String userDn, String username, Throwable cause) {
+    log.warn(
+        String.format(
+            "Failed to bind to LDAP host with DN: '%s' for username: '%s'", userDn, username),
+        cause);
+    log.debug("LDAP user bind failed", cause);
+  }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/ldap/authentication/DhisBindAuthenticator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/ldap/authentication/DhisBindAuthenticator.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.security.ldap.authentication;
 
+import static java.lang.String.format;
+
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserStore;
@@ -63,7 +65,9 @@ public class DhisBindAuthenticator extends BindAuthenticator {
 
     if (user.hasLdapId()) {
       log.debug(
-          "Attemping username/password LDAP authentication for user: '{}'", user.getUsername());
+          "LDAP authentication attempt with username: '{}' and LDAP ID: '{}'",
+          user.getUsername(),
+          user.getLdapId());
       authentication =
           new UsernamePasswordAuthenticationToken(
               user.getLdapId(), authentication.getCredentials());
@@ -74,10 +78,9 @@ public class DhisBindAuthenticator extends BindAuthenticator {
 
   @Override
   public void handleBindException(String userDn, String username, Throwable cause) {
-    log.warn(
-        String.format(
-            "Failed to bind to LDAP host with DN: '%s' for username: '%s'", userDn, username),
-        cause);
+    String message =
+        format("Failed to bind to LDAP host with DN: '%s' and username: '%s'", userDn, username);
+    log.warn(message, cause);
     log.debug("LDAP user bind failed", cause);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/GenericOidcProviderConfigParser.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/GenericOidcProviderConfigParser.java
@@ -310,11 +310,10 @@ public final class GenericOidcProviderConfigParser {
       checkAndLogInvalidKeyNames(providerName, differences);
 
       log.error(
-          String.format(
-              "OpenID Connect (OIDC) configuration for provider: '%s' contains one or more invalid properties. "
-                  + "Failed to configure the provider successfully! "
-                  + "See previous errors for more information on what property that triggered this error!",
-              providerName));
+          "OpenID Connect (OIDC) configuration for provider: '{}' contains one or more invalid properties. "
+              + "Failed to configure the provider successfully! "
+              + "See previous errors for more information on what property that triggered this error!",
+          providerName);
 
       return false;
     }
@@ -342,13 +341,13 @@ public final class GenericOidcProviderConfigParser {
       wrongKeyAndMinDist = getLevenshteinDistances(wrongKeyName, wrongKeyAndMinDist);
 
       String msg =
-          "OpenID Connect (OIDC) configuration for provider: '%s' contains an invalid property: '%s'";
+          "OpenID Connect (OIDC) configuration for provider: '{}' contains an invalid property: '{}'";
 
       if (wrongKeyAndMinDist.getRight() < maxLevenshteinDistance) {
-        msg += ", did you mean: '%s' ?";
-        log.error(String.format(msg, providerName, wrongKeyName, wrongKeyAndMinDist.getLeft()));
+        msg += ", did you mean: '{}' ?";
+        log.error(msg, providerName, wrongKeyName, wrongKeyAndMinDist.getLeft());
       } else {
-        log.error(String.format(msg, providerName, wrongKeyName));
+        log.error(msg, providerName, wrongKeyName);
       }
     }
   }
@@ -400,10 +399,10 @@ public final class GenericOidcProviderConfigParser {
 
       if (isRequired && Strings.isNullOrEmpty(value)) {
         log.error(
-            String.format(
-                "OpenId Connect (OIDC) configuration for provider: '%s' is missing a required property: '%s'. "
-                    + "Failed to configure the provider successfully!",
-                providerId, key));
+            "OpenId Connect (OIDC) configuration for provider: '{}' is missing a required property: '{}'. "
+                + "Failed to configure the provider successfully!",
+            providerId,
+            key);
 
         return false;
       }
@@ -411,10 +410,11 @@ public final class GenericOidcProviderConfigParser {
       UrlValidator urlValidator = new UrlValidator(UrlValidator.ALLOW_LOCAL_URLS);
       if (value != null && key.endsWith("uri") && !urlValidator.isValid(value)) {
         log.error(
-            String.format(
-                "OpenId Connect (OIDC) configuration for provider: '%s' has a URI property: '%s', "
-                    + "with a malformed value: '%s'. Failed to configure the provider successfully!",
-                providerId, key, value));
+            "OpenId Connect (OIDC) configuration for provider: '{}' has a URI property: '{}', "
+                + "with a malformed value: '{}'. Failed to configure the provider successfully!",
+            providerId,
+            key,
+            value);
 
         return false;
       }


### PR DESCRIPTION
This PR is about logging and LDAP authentication (bind). Currently, DHIS 2 is completely silent about LDAP authentication. This PR adds a statement at the warn level on LDAP authentication error, and logs the exception at debug level, to allow admins to debug potential LDAP related errors.