### PR TITLE
fix: change email links to use new login app

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/RestoreType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/RestoreType.java
@@ -37,7 +37,8 @@ import java.util.Calendar;
 public enum RestoreType {
   RECOVER_PASSWORD(
       Calendar.DAY_OF_MONTH, 2, "restore_message", "email_restore_subject", "update-password"),
-  INVITE(Calendar.DAY_OF_YEAR, 7, "invite_message", "email_invite_subject", "complete-registration)");
+  INVITE(
+      Calendar.DAY_OF_YEAR, 7, "invite_message", "email_invite_subject", "complete-registration)");
 
   /** Type of Calendar interval before the restore expires. */
   private final int expiryIntervalType;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/RestoreType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/RestoreType.java
@@ -36,8 +36,8 @@ import java.util.Calendar;
  */
 public enum RestoreType {
   RECOVER_PASSWORD(
-      Calendar.DAY_OF_MONTH, 2, "restore_message", "email_restore_subject", "restore.action"),
-  INVITE(Calendar.DAY_OF_YEAR, 7, "invite_message", "email_invite_subject", "invite.action");
+      Calendar.DAY_OF_MONTH, 2, "restore_message", "email_restore_subject", "update-password"),
+  INVITE(Calendar.DAY_OF_YEAR, 7, "invite_message", "email_invite_subject", "complete-registration)");
 
   /** Type of Calendar interval before the restore expires. */
   private final int expiryIntervalType;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -58,7 +58,7 @@ public interface UserService {
 
   String TWO_FACTOR_AUTH_REQUIRED_RESTRICTION_NAME = "R_ENABLE_2FA";
 
-  String RESTORE_PATH = "/dhis-web-commons/security/";
+  String RESTORE_PATH = "/login-app/index.html#/";
 
   String TBD_NAME = "(TBD)";
 


### PR DESCRIPTION
## Summary
Change email links in password restore and invite message to link to the new login app endpoints instead of the old Struts bases ones.
## Manual test
1. Invoke password restore.
2. Click link in email and make sure it links to the password restore page.
3. Invite a new user.
4. Click link in email and observe you end up on the account form.
## Automatic test
n/a

### JIRA
[DHIS2-14617](https://dhis2.atlassian.net/browse/DHIS2-14617)
[DHIS2-14618](https://dhis2.atlassian.net/browse/DHIS2-14618)

[DHIS2-14617]: https://dhis2.atlassian.net/browse/DHIS2-14617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-14618]: https://dhis2.atlassian.net/browse/DHIS2-14618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ