### PR TITLE
Update wait time before generating analytics tables in test

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
@@ -576,7 +576,7 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
     enableDataSharing(userA, programB, AccessStringHelper.DATA_READ_WRITE);
     idObjectManager.update(userA);
 
-    // Wait for one second. This is needed because last updated time for
+    // Wait for three seconds. This is needed because last updated time for
     // the data we just created is stored to milliseconds, hh:mm:ss.SSS.
     // The queries to build analytics tables tests data last updated times
     // to be in the past but compares only to the second. So for example a
@@ -584,12 +584,12 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
     // future compared with 11:23:50. To compensate for this, we wait a
     // second until the time is 11:23:51. Then 11:23:50.123 will appear to
     // be in the past.
-    Date oneSecondFromNow =
+    Date threeSecondsFromNow =
         Date.from(LocalDateTime.now().plusSeconds(3).atZone(ZoneId.systemDefault()).toInstant());
 
     // Generate resource tables and analytics tables
     analyticsTableGenerator.generateTables(
-        AnalyticsTableUpdateParams.newBuilder().withStartTime(oneSecondFromNow).build(),
+        AnalyticsTableUpdateParams.newBuilder().withStartTime(threeSecondsFromNow).build(),
         NoopJobProgress.INSTANCE);
   }
 


### PR DESCRIPTION
This is a complete shot in the dark to see if it stops the flaky tests failing, until @jimgrace can have a look at why these tests are intermittently failing, quite often.

Increase the wait time before generating analytics tables, in case it's a race condition between getting data into the DB and then generating the Analytics tables.

If it fails, I'll revert.