### PR TITLE
fix: Make LDAP authentication work again [DHIS2-17036]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/ldap/authentication/CustomLdapAuthenticationProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/ldap/authentication/CustomLdapAuthenticationProvider.java
@@ -28,11 +28,19 @@
 package org.hisp.dhis.security.ldap.authentication;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.String.format;
 
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.ldap.authentication.LdapAuthenticationProvider;
 import org.springframework.security.ldap.authentication.LdapAuthenticator;
 import org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator;
+import org.springframework.security.ldap.userdetails.LdapUserDetailsImpl;
 import org.springframework.stereotype.Component;
 
 /**
@@ -42,14 +50,40 @@ import org.springframework.stereotype.Component;
 public class CustomLdapAuthenticationProvider extends LdapAuthenticationProvider {
   private final DhisConfigurationProvider configurationProvider;
 
+  private final UserDetailsService userDetailsService;
+
   public CustomLdapAuthenticationProvider(
       LdapAuthenticator authenticator,
+      UserDetailsService userDetailsService,
       LdapAuthoritiesPopulator authoritiesPopular,
       DhisConfigurationProvider configurationProvider) {
     super(authenticator, authoritiesPopular);
 
     checkNotNull(configurationProvider);
     this.configurationProvider = configurationProvider;
+    this.userDetailsService = userDetailsService;
+  }
+
+  @Override
+  public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+
+    Authentication authenticate = super.authenticate(authentication);
+
+    LdapUserDetailsImpl user = (LdapUserDetailsImpl) authenticate.getPrincipal();
+
+    UserDetails userDetails = userDetailsService.loadUserByUsername(user.getUsername());
+
+    if (userDetails == null) {
+      String msg = format("Could not find DHIS 2 user with username: '%s'", user.getUsername());
+      throw new UsernameNotFoundException(msg);
+    }
+
+    UsernamePasswordAuthenticationToken result =
+        UsernamePasswordAuthenticationToken.authenticated(
+            userDetails, user.getPassword(), userDetails.getAuthorities());
+    result.setDetails(authenticate.getDetails());
+
+    return result;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/ldap/authentication/DhisBindAuthenticator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/ldap/authentication/DhisBindAuthenticator.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.security.ldap.authentication;
 
+import static java.lang.String.format;
+
+import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +46,7 @@ import org.springframework.security.ldap.authentication.BindAuthenticator;
  *
  * @author Lars Helge Overland
  */
+@Slf4j
 public class DhisBindAuthenticator extends BindAuthenticator {
   @Autowired private UserService userService;
 
@@ -59,11 +63,23 @@ public class DhisBindAuthenticator extends BindAuthenticator {
     }
 
     if (user.hasLdapId()) {
+      log.debug(
+          "LDAP authentication attempt with username: '{}' and LDAP ID: '{}'",
+          user.getUsername(),
+          user.getLdapId());
       authentication =
           new UsernamePasswordAuthenticationToken(
               user.getLdapId(), authentication.getCredentials());
     }
 
     return super.authenticate(authentication);
+  }
+
+  @Override
+  public void handleBindException(String userDn, String username, Throwable cause) {
+    String message =
+        format("Failed to bind to LDAP host with DN: '%s' and username: '%s'", userDn, username);
+    log.warn(message, cause);
+    log.debug("LDAP user bind failed", cause);
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/AuthenticationProviderConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/AuthenticationProviderConfig.java
@@ -33,7 +33,6 @@ import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.security.AuthenticationLoggerListener;
 import org.hisp.dhis.security.ldap.authentication.CustomLdapAuthenticationProvider;
 import org.hisp.dhis.security.ldap.authentication.DhisBindAuthenticator;
-import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationProvider;
 import org.hisp.dhis.security.spring2fa.TwoFactorWebAuthenticationDetailsSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -61,8 +60,6 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 public class AuthenticationProviderConfig {
   @Autowired private DhisConfigurationProvider configurationProvider;
 
-  @Autowired TwoFactorAuthenticationProvider twoFactorAuthenticationProvider;
-
   @Autowired
   @Qualifier("ldapUserDetailsService")
   UserDetailsService ldapUserDetailsService;
@@ -76,6 +73,7 @@ public class AuthenticationProviderConfig {
   CustomLdapAuthenticationProvider customLdapAuthenticationProvider() {
     return new CustomLdapAuthenticationProvider(
         dhisBindAuthenticator(),
+        ldapUserDetailsService,
         userDetailsServiceLdapAuthoritiesPopulator(ldapUserDetailsService),
         configurationProvider);
   }


### PR DESCRIPTION
### Summary

Fixes broken LDAP authentication by converting `LdapUserDetails` to `CurrentUserDetails` in the `CustomLdapAuthenticationProvider` class.

### Manual tests

1. Set up an LDAP server like ApacheDS.
2. Configure DHIS2 to use the LDAP server for authentication.
3. Create a user in the LDAP server.  
4. Create a user in the DHIS2, and set the LDAP identifier to the LDAP user's ID.
5. Log in and observe it works.

### Automated tests

n/a 