### PR TITLE
fix(app): use correct authority for overidden bundled-apps

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
@@ -427,6 +427,10 @@ public class App implements Serializable {
   }
 
   public String getSeeAppAuthority() {
+    if (isBundled()) {
+      return SEE_APP_AUTHORITY_PREFIX + AppManager.BUNDLED_APP_PREFIX + getShortName();
+    }
+
     return SEE_APP_AUTHORITY_PREFIX
         + getShortName().trim().replaceAll("[^a-zA-Z0-9\\s]", "").replaceAll("\\s+", "_");
   }


### PR DESCRIPTION
Backport to 2.39.5 of #16488

2.39.5 is frozen. Waiting for RCB approval.
