### PR TITLE
fix: SMS gateway update - only allow one config of each type [DHIS2-16695] (2.41)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/DefaultGatewayAdministrationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/DefaultGatewayAdministrationService.java
@@ -96,6 +96,8 @@ public class DefaultGatewayAdministrationService implements GatewayAdministratio
     config.setUid(CodeGenerator.generateCode(10));
 
     SmsConfiguration smsConfiguration = getSmsConfiguration();
+    if (smsConfiguration.getGateways().stream().anyMatch(c -> c.getClass() == config.getClass()))
+      return false;
 
     config.setDefault(smsConfiguration.getGateways().isEmpty());
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/config/GatewayAdministrationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/config/GatewayAdministrationServiceTest.java
@@ -143,7 +143,7 @@ class GatewayAdministrationServiceTest {
     subject.addGateway(bulkConfig);
 
     // bulksms gateway already exist so it will not be added.
-    assertGateways(3);
+    assertGateways(2);
   }
 
   @Test


### PR DESCRIPTION
cherry-pick backport of #16766