### PR TITLE
clean: enrollment with no tracked entity tests

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentImportValidationTest.java
@@ -255,9 +255,8 @@ class EnrollmentImportValidationTest extends TrackerTest {
   }
 
   @Test
-  void shouldNotImportEnrollmentWhenTeIsMissingTe() {
+  void shouldNotImportEnrollmentWhenTeIsMissing() {
     Enrollment enrollment = new Enrollment();
-
     enrollment.setEnrollment("MNWZ6hnuhSw");
     enrollment.setProgram(MetadataIdentifier.ofUid("E8o1E9tAppy"));
     enrollment.setOrgUnit(MetadataIdentifier.ofUid("QfUVllTs6cS"));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentImportValidationTest.java
@@ -37,6 +37,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.TrackerType;
@@ -44,6 +47,8 @@ import org.hisp.dhis.tracker.imports.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
+import org.hisp.dhis.tracker.imports.domain.Enrollment;
+import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheatService;
@@ -247,5 +252,23 @@ class EnrollmentImportValidationTest extends TrackerTest {
         trackerImportService.importTracker(new TrackerImportParams(), trackerObjects);
 
     assertNoErrors(importReport);
+  }
+
+  @Test
+  void shouldNotImportEnrollmentWhenTeIsMissingTe() {
+    Enrollment enrollment = new Enrollment();
+
+    enrollment.setEnrollment("MNWZ6hnuhSw");
+    enrollment.setProgram(MetadataIdentifier.ofUid("E8o1E9tAppy"));
+    enrollment.setOrgUnit(MetadataIdentifier.ofUid("QfUVllTs6cS"));
+    enrollment.setEnrolledAt(Instant.now().minus(1, ChronoUnit.DAYS));
+    enrollment.setOccurredAt(Instant.now().minus(1, ChronoUnit.DAYS));
+
+    TrackerObjects trackerObjects =
+        TrackerObjects.builder().enrollments(List.of(enrollment)).build();
+    ImportReport importReport =
+        trackerImportService.importTracker(new TrackerImportParams(), trackerObjects);
+
+    assertHasOnlyErrors(importReport.getValidationReport(), ValidationCode.E1122);
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TrackedEntityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TrackedEntityImportValidationTest.java
@@ -38,18 +38,12 @@ import static org.hisp.dhis.tracker.imports.validation.Users.USER_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.imports.AtomicMode;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
-import org.hisp.dhis.tracker.imports.domain.Enrollment;
-import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
-import org.hisp.dhis.tracker.imports.domain.TrackedEntity;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.user.User;
@@ -243,34 +237,6 @@ class TrackedEntityImportValidationTest extends TrackerTest {
         trackerImportService.importTracker(params, deleteTrackerObjects);
     assertNoErrors(importReportDelete);
     assertEquals(1, importReportDelete.getStats().getDeleted());
-  }
-
-  @Test
-  void shouldNotImportTeWhenEnrollmentIsMissingTe() {
-
-    TrackedEntity trackedEntity = new TrackedEntity();
-    trackedEntity.setTrackedEntity("Kj6vYde4LHh");
-    trackedEntity.setTrackedEntityType(MetadataIdentifier.ofUid("bPJ0FMtcnEh"));
-    trackedEntity.setOrgUnit(MetadataIdentifier.ofUid("QfUVllTs6cS"));
-
-    Enrollment enrollment = new Enrollment();
-    enrollment.setEnrollment("MNWZ6hnuhSQ");
-    enrollment.setProgram(MetadataIdentifier.ofUid("E8o1E9tAppy"));
-    enrollment.setOrgUnit(MetadataIdentifier.ofUid("QfUVllTs6cS"));
-    enrollment.setEnrolledAt(Instant.now().minus(1, ChronoUnit.DAYS));
-    enrollment.setOccurredAt(Instant.now().minus(1, ChronoUnit.DAYS));
-
-    trackedEntity.setEnrollments(List.of(enrollment));
-
-    TrackerObjects trackerObjects =
-        TrackerObjects.builder()
-            .trackedEntities(List.of(trackedEntity))
-            .enrollments(List.of(enrollment))
-            .build();
-    ImportReport importReport =
-        trackerImportService.importTracker(new TrackerImportParams(), trackerObjects);
-
-    assertHasOnlyErrors(importReport.getValidationReport(), ValidationCode.E1122);
   }
 
   protected void importEnrollments() throws IOException {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TrackedEntityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TrackedEntityImportValidationTest.java
@@ -38,12 +38,18 @@ import static org.hisp.dhis.tracker.imports.validation.Users.USER_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.imports.AtomicMode;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
+import org.hisp.dhis.tracker.imports.domain.Enrollment;
+import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackedEntity;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 import org.hisp.dhis.user.User;
@@ -237,6 +243,34 @@ class TrackedEntityImportValidationTest extends TrackerTest {
         trackerImportService.importTracker(params, deleteTrackerObjects);
     assertNoErrors(importReportDelete);
     assertEquals(1, importReportDelete.getStats().getDeleted());
+  }
+
+  @Test
+  void shouldNotImportTeWhenEnrollmentIsMissingTe() {
+
+    TrackedEntity trackedEntity = new TrackedEntity();
+    trackedEntity.setTrackedEntity("Kj6vYde4LHh");
+    trackedEntity.setTrackedEntityType(MetadataIdentifier.ofUid("bPJ0FMtcnEh"));
+    trackedEntity.setOrgUnit(MetadataIdentifier.ofUid("QfUVllTs6cS"));
+
+    Enrollment enrollment = new Enrollment();
+    enrollment.setEnrollment("MNWZ6hnuhSQ");
+    enrollment.setProgram(MetadataIdentifier.ofUid("E8o1E9tAppy"));
+    enrollment.setOrgUnit(MetadataIdentifier.ofUid("QfUVllTs6cS"));
+    enrollment.setEnrolledAt(Instant.now().minus(1, ChronoUnit.DAYS));
+    enrollment.setOccurredAt(Instant.now().minus(1, ChronoUnit.DAYS));
+
+    trackedEntity.setEnrollments(List.of(enrollment));
+
+    TrackerObjects trackerObjects =
+        TrackerObjects.builder()
+            .trackedEntities(List.of(trackedEntity))
+            .enrollments(List.of(enrollment))
+            .build();
+    ImportReport importReport =
+        trackerImportService.importTracker(new TrackerImportParams(), trackerObjects);
+
+    assertHasOnlyErrors(importReport.getValidationReport(), ValidationCode.E1122);
   }
 
   protected void importEnrollments() throws IOException {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/BodyConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/BodyConverter.java
@@ -269,7 +269,6 @@ class BodyConverter extends StdConverter<Body, Body> {
   private Event updateEventReferences(Event event, String enrollment) {
     event.setEvent(updateReference(event.getEvent()));
     event.setEnrollment(StringUtils.isEmpty(enrollment) ? null : enrollment);
-    event.setEnrollment(StringUtils.isEmpty(enrollment) ? null : enrollment);
     return event;
   }
 


### PR DESCRIPTION
- Add integration tests to show we do not allow the creation of enrollments without a tracked entity. 
- For nested payloads, such as enrollment inside a tracked entity, we allow an empty reference because it is set during the Body [serialization](https://github.com/dhis2/dhis2-core/blob/e89badf997775011223ba8e21a261cb38b12cd9d/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/BodyConverter.java#L229). However, there are no unit tests for BodyConverer so, we add an e2e test for enrollment import.
- At a service level, nesting is no longer relevant.