### PR TITLE
fix(login-app): allow overriding the login app

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
@@ -60,6 +60,7 @@ public interface AppManager {
           "event-visualizer",
           "import-export",
           "interpretation",
+          "login",
           "maintenance",
           "maps",
           "menu-management",

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/appmanager/DefaultAppManager.java
@@ -379,8 +379,10 @@ public class DefaultAppManager implements AppManager {
 
   @Override
   public boolean isAccessible(App app) {
-    return CurrentUserUtil.hasAnyAuthority(
-        List.of("ALL", AppManager.WEB_MAINTENANCE_APPMANAGER_AUTHORITY, app.getSeeAppAuthority()));
+    return app.getKey().equals("login")
+        || CurrentUserUtil.hasAnyAuthority(
+            List.of(
+                "ALL", AppManager.WEB_MAINTENANCE_APPMANAGER_AUTHORITY, app.getSeeAppAuthority()));
   }
 
   @Override


### PR DESCRIPTION
This allows users to override the login app

## Changes
- "login" needed to be added in the list of bundled apps, to be considered core bundled (otherwise it won't allow overriding as the config for the project declares as "core" but not this list)
- we needed an exception to allow the login app to be displayed when the user has no authorities, otherwise the serving of the app reverts to the original bundled version.
  - I chose to do the exception by comparing the app name. It would have been cleaner to make the exception for the `app_type = login_app` in general, but that value is hardcoded now, and changing it seemed risky.
  - it's strange that the app serving reverts to the bundled version when the user has no authority, but that's a different story.
- Related to this is a change necessary in the login app itself since the name of the app has to match this list in dhis2 core for bundled apps. https://github.com/dhis2/login-app/pull/13

[login-override.webm](https://github.com/dhis2/dhis2-core/assets/1014725/a7fbbcce-f795-4937-a4c6-735f7aa8724c)


## Known issue
- Once the app is overridden, the first redirect in the login app fails - We will need to address this next, but these changes are needed in all cases.

![image](https://github.com/dhis2/dhis2-core/assets/1014725/ca3f2cab-1a70-43a3-8df6-d32dce12c2d7)
