### PR TITLE
fix: Event analytics test temp fix [DHIS2-17041]

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
@@ -493,8 +493,8 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
     eventA3.setAttributeOptionCombo(cocDefault);
 
     Event eventB1 = createEvent(psB, piB, ouI);
-    eventB1.setScheduledDate(jan15);
-    eventB1.setOccurredDate(jan15);
+    eventB1.setScheduledDate(jan1);
+    eventB1.setOccurredDate(jan1);
     eventB1.setUid("event0000B1");
     eventB1.setEventDataValues(
         Set.of(new EventDataValue(deA.getUid(), "10"), new EventDataValue(deB.getUid(), "A")));
@@ -509,8 +509,8 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
     eventB2.setAttributeOptionCombo(cocDefault);
 
     Event eventB3 = createEvent(psB, piB, ouJ);
-    eventB3.setScheduledDate(jan15);
-    eventB3.setOccurredDate(jan15);
+    eventB3.setScheduledDate(jan1);
+    eventB3.setOccurredDate(jan1);
     eventB3.setUid("event0000B3");
     eventB3.setEventDataValues(
         Set.of(new EventDataValue(deA.getUid(), "30"), new EventDataValue(deB.getUid(), "C")));


### PR DESCRIPTION
See [DHIS2-17041](https://dhis2.atlassian.net/browse/DHIS2-17041).

This is a temporary fix to `EventAnalyticsServiceTest` to prevent Jenkins builds from failing until the real fix for the problem can be implemented. (The ticket for that is [DHIS2-17076](https://dhis2.atlassian.net/browse/DHIS2-17076).)


[DHIS2-17041]: https://dhis2.atlassian.net/browse/DHIS2-17041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-17076]: https://dhis2.atlassian.net/browse/DHIS2-17076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ