### PR TITLE
chore: use UserDetails for tracker access checks

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitService.java
@@ -349,13 +349,13 @@ public interface OrganisationUnitService extends OrganisationUnitDataIntegrityPr
    * @return true if the given organisation unit is part of the hierarchy.
    * @deprecated Use {@link org.hisp.dhis.user.UserDetails#isInUserHierarchy(String)} instead
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   boolean isInUserHierarchyCached(User user, OrganisationUnit organisationUnit);
 
   /**
    * @deprecated Use {@link org.hisp.dhis.user.UserDetails#isInUserHierarchy(String)} instead
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   boolean isInUserHierarchy(User user, OrganisationUnit organisationUnit);
 
   /**
@@ -367,7 +367,7 @@ public interface OrganisationUnitService extends OrganisationUnitDataIntegrityPr
    * @return true if the organisation unit with the given uid is part of the hierarchy.
    * @deprecated Use {@link org.hisp.dhis.user.UserDetails#isInUserHierarchy(String)} instead
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   boolean isInUserHierarchy(String uid, Set<OrganisationUnit> organisationUnits);
 
   /**
@@ -379,7 +379,7 @@ public interface OrganisationUnitService extends OrganisationUnitDataIntegrityPr
    * @return true if the given organisation unit is part of the data view hierarchy.
    * @deprecated Use {@link org.hisp.dhis.user.UserDetails#isInUserDataHierarchy(String)} instead
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   boolean isInUserDataViewHierarchy(User user, OrganisationUnit organisationUnit);
 
   /**
@@ -392,13 +392,13 @@ public interface OrganisationUnitService extends OrganisationUnitDataIntegrityPr
    * @return true if the given organisation unit is part of the hierarchy.
    * @deprecated Use {@link org.hisp.dhis.user.UserDetails#isInUserSearchHierarchy(String)} instead
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   boolean isInUserSearchHierarchyCached(User user, OrganisationUnit organisationUnit);
 
   /**
    * @deprecated Use {@link org.hisp.dhis.user.UserDetails#isInUserSearchHierarchy(String)} instead
    */
-  @Deprecated
+  @Deprecated(forRemoval = true)
   boolean isInUserSearchHierarchy(User user, OrganisationUnit organisationUnit);
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitService.java
@@ -347,9 +347,15 @@ public interface OrganisationUnitService extends OrganisationUnitDataIntegrityPr
    * @param user the user to check for.
    * @param organisationUnit the organisation unit.
    * @return true if the given organisation unit is part of the hierarchy.
+   * @deprecated Use {@link org.hisp.dhis.user.UserDetails#isInUserHierarchy(String)} instead
    */
+  @Deprecated
   boolean isInUserHierarchyCached(User user, OrganisationUnit organisationUnit);
 
+  /**
+   * @deprecated Use {@link org.hisp.dhis.user.UserDetails#isInUserHierarchy(String)} instead
+   */
+  @Deprecated
   boolean isInUserHierarchy(User user, OrganisationUnit organisationUnit);
 
   /**
@@ -359,7 +365,9 @@ public interface OrganisationUnitService extends OrganisationUnitDataIntegrityPr
    * @param uid the uid of the organisation unit.
    * @param organisationUnits the set of organisation units associated with a user.
    * @return true if the organisation unit with the given uid is part of the hierarchy.
+   * @deprecated Use {@link org.hisp.dhis.user.UserDetails#isInUserHierarchy(String)} instead
    */
+  @Deprecated
   boolean isInUserHierarchy(String uid, Set<OrganisationUnit> organisationUnits);
 
   /**
@@ -369,7 +377,9 @@ public interface OrganisationUnitService extends OrganisationUnitDataIntegrityPr
    * @param user the user to check for.
    * @param organisationUnit the organisation unit.
    * @return true if the given organisation unit is part of the data view hierarchy.
+   * @deprecated Use {@link org.hisp.dhis.user.UserDetails#isInUserDataHierarchy(String)} instead
    */
+  @Deprecated
   boolean isInUserDataViewHierarchy(User user, OrganisationUnit organisationUnit);
 
   /**
@@ -380,9 +390,15 @@ public interface OrganisationUnitService extends OrganisationUnitDataIntegrityPr
    * @param user the user to check for.
    * @param organisationUnit the organisation unit.
    * @return true if the given organisation unit is part of the hierarchy.
+   * @deprecated Use {@link org.hisp.dhis.user.UserDetails#isInUserSearchHierarchy(String)} instead
    */
+  @Deprecated
   boolean isInUserSearchHierarchyCached(User user, OrganisationUnit organisationUnit);
 
+  /**
+   * @deprecated Use {@link org.hisp.dhis.user.UserDetails#isInUserSearchHierarchy(String)} instead
+   */
+  @Deprecated
   boolean isInUserSearchHierarchy(User user, OrganisationUnit organisationUnit);
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
@@ -34,6 +34,7 @@ import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 
 /**
  * @author Abyot Asalefew
@@ -83,7 +84,7 @@ public interface EnrollmentService {
    * @param enrollment the Enrollment to update.
    * @param user the current user.
    */
-  void updateEnrollment(Enrollment enrollment, User user);
+  void updateEnrollment(Enrollment enrollment, UserDetails user);
 
   /**
    * Returns a {@link Enrollment}.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramTempOwnerService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramTempOwnerService.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.program;
 
 import org.hisp.dhis.trackedentity.TrackedEntity;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 
 /**
  * @author Ameen Mohamed <ameen@dhis2.org>
@@ -44,5 +44,5 @@ public interface ProgramTempOwnerService {
    */
   void addProgramTempOwner(ProgramTempOwner programTempOwner);
 
-  int getValidTempOwnerRecordCount(Program program, TrackedEntity entityInstance, User user);
+  int getValidTempOwnerRecordCount(Program program, TrackedEntity entityInstance, UserDetails user);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramTempOwnerStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramTempOwnerStore.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.program;
 
 import org.hisp.dhis.trackedentity.TrackedEntity;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 
 /**
  * @author Ameen Mohamed <ameen@dhis2.org>
@@ -44,5 +44,5 @@ public interface ProgramTempOwnerStore {
    */
   void addProgramTempOwner(ProgramTempOwner programTempOwner);
 
-  int getValidTempOwnerCount(Program program, TrackedEntity entityInstance, User user);
+  int getValidTempOwnerCount(Program program, TrackedEntity entityInstance, UserDetails user);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityService.java
@@ -33,7 +33,7 @@ import java.util.Set;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 
 /**
  * This interface is responsible for retrieving tracked entities (TE). The query methods accepts a
@@ -192,7 +192,7 @@ public interface TrackedEntityService {
    */
   void updateTrackedEntity(TrackedEntity trackedEntity);
 
-  void updateTrackedEntity(TrackedEntity trackedEntity, User user);
+  void updateTrackedEntity(TrackedEntity trackedEntity, UserDetails user);
 
   /**
    * Updates a last sync timestamp on specified TrackedEntity
@@ -234,7 +234,7 @@ public interface TrackedEntityService {
    * @param user User
    * @return the TrackedEntity with the given UID, or null if no match.
    */
-  TrackedEntity getTrackedEntity(String uid, User user);
+  TrackedEntity getTrackedEntity(String uid, UserDetails user);
 
   /**
    * Checks for the existence of a TE by UID. Deleted values are not taken into account.
@@ -270,5 +270,5 @@ public interface TrackedEntityService {
   long createTrackedEntity(
       TrackedEntity trackedEntity, Set<TrackedEntityAttributeValue> attributeValues);
 
-  List<TrackedEntity> getTrackedEntitiesByUid(List<String> uids, User user);
+  List<TrackedEntity> getTrackedEntitiesByUid(List<String> uids, UserDetails user);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityStore.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.hisp.dhis.common.IdentifiableObjectStore;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 
 /**
  * @author Abyot Asalefew Gizaw
@@ -99,5 +99,5 @@ public interface TrackedEntityStore extends IdentifiableObjectStore<TrackedEntit
   void updateTrackedEntityLastUpdated(
       Set<String> trackedEntityUIDs, Date lastUpdated, String userInfoSnapshot);
 
-  List<TrackedEntity> getTrackedEntityByUid(List<String> uids, User user);
+  List<TrackedEntity> getTrackedEntityByUid(List<String> uids, UserDetails user);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerAccessManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerAccessManager.java
@@ -35,41 +35,41 @@ import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.relationship.Relationship;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 public interface TrackerAccessManager {
-  List<String> canRead(User user, TrackedEntity trackedEntity);
+  List<String> canRead(UserDetails user, TrackedEntity trackedEntity);
 
-  List<String> canWrite(User user, TrackedEntity trackedEntity);
+  List<String> canWrite(UserDetails user, TrackedEntity trackedEntity);
 
   List<String> canRead(
-      User user, TrackedEntity trackedEntity, Program program, boolean skipOwnershipCheck);
+      UserDetails user, TrackedEntity trackedEntity, Program program, boolean skipOwnershipCheck);
 
   List<String> canWrite(
-      User user, TrackedEntity trackedEntity, Program program, boolean skipOwnershipCheck);
+      UserDetails user, TrackedEntity trackedEntity, Program program, boolean skipOwnershipCheck);
 
-  List<String> canRead(User user, Enrollment enrollment, boolean skipOwnershipCheck);
+  List<String> canRead(UserDetails user, Enrollment enrollment, boolean skipOwnershipCheck);
 
-  List<String> canCreate(User user, Enrollment enrollment, boolean skipOwnershipCheck);
+  List<String> canCreate(UserDetails user, Enrollment enrollment, boolean skipOwnershipCheck);
 
-  List<String> canUpdate(User user, Enrollment enrollment, boolean skipOwnershipCheck);
+  List<String> canUpdate(UserDetails user, Enrollment enrollment, boolean skipOwnershipCheck);
 
-  List<String> canDelete(User user, Enrollment enrollment, boolean skipOwnershipCheck);
+  List<String> canDelete(UserDetails user, Enrollment enrollment, boolean skipOwnershipCheck);
 
-  List<String> canRead(User user, Event event, boolean skipOwnershipCheck);
+  List<String> canRead(UserDetails user, Event event, boolean skipOwnershipCheck);
 
-  List<String> canCreate(User user, Event event, boolean skipOwnershipCheck);
+  List<String> canCreate(UserDetails user, Event event, boolean skipOwnershipCheck);
 
-  List<String> canUpdate(User user, Event event, boolean skipOwnershipCheck);
+  List<String> canUpdate(UserDetails user, Event event, boolean skipOwnershipCheck);
 
-  List<String> canDelete(User user, Event event, boolean skipOwnershipCheck);
+  List<String> canDelete(UserDetails user, Event event, boolean skipOwnershipCheck);
 
-  List<String> canRead(User user, Relationship relationship);
+  List<String> canRead(UserDetails user, Relationship relationship);
 
-  List<String> canWrite(User user, Relationship relationship);
+  List<String> canWrite(UserDetails user, Relationship relationship);
 
   /**
    * Checks the sharing read access to EventDataValue
@@ -79,7 +79,8 @@ public interface TrackerAccessManager {
    * @param dataElement DataElement of EventDataValue
    * @return Empty list if read access allowed, list of errors otherwise.
    */
-  List<String> canRead(User user, Event event, DataElement dataElement, boolean skipOwnershipCheck);
+  List<String> canRead(
+      UserDetails user, Event event, DataElement dataElement, boolean skipOwnershipCheck);
 
   /**
    * Checks the sharing write access to EventDataValue
@@ -90,11 +91,11 @@ public interface TrackerAccessManager {
    * @return Empty list if write access allowed, list of errors otherwise.
    */
   List<String> canWrite(
-      User user, Event event, DataElement dataElement, boolean skipOwnershipCheck);
+      UserDetails user, Event event, DataElement dataElement, boolean skipOwnershipCheck);
 
-  List<String> canRead(User user, CategoryOptionCombo categoryOptionCombo);
+  List<String> canRead(UserDetails user, CategoryOptionCombo categoryOptionCombo);
 
-  List<String> canWrite(User user, CategoryOptionCombo categoryOptionCombo);
+  List<String> canWrite(UserDetails user, CategoryOptionCombo categoryOptionCombo);
 
   /**
    * Checks if user has access to organisation unit under defined tracker program protection level
@@ -105,5 +106,5 @@ public interface TrackerAccessManager {
    * @return true if user has access to the org unit under the mentioned program context, otherwise
    *     return false
    */
-  boolean canAccess(User user, Program program, OrganisationUnit orgUnit);
+  boolean canAccess(UserDetails user, Program program, OrganisationUnit orgUnit);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerOwnershipManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerOwnershipManager.java
@@ -30,7 +30,7 @@ package org.hisp.dhis.trackedentity;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramType;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 
 /**
  * @author Ameen Mohamed
@@ -74,10 +74,10 @@ public interface TrackerOwnershipManager {
    * @param program The program.
    * @return true if the user has access, false otherwise.
    */
-  boolean hasAccess(User user, TrackedEntity entityInstance, Program program);
+  boolean hasAccess(UserDetails user, TrackedEntity entityInstance, Program program);
 
   boolean hasAccess(
-      User user, String entityInstance, OrganisationUnit organisationUnit, Program program);
+      UserDetails user, String entityInstance, OrganisationUnit organisationUnit, Program program);
 
   /**
    * Grant temporary ownership for a user for a specific te-program combination
@@ -88,7 +88,7 @@ public interface TrackerOwnershipManager {
    * @param reason The reason for requesting temporary ownership
    */
   void grantTemporaryOwnership(
-      TrackedEntity entityInstance, Program program, User user, String reason);
+      TrackedEntity entityInstance, Program program, UserDetails user, String reason);
 
   /**
    * Ownership check can be skipped if the user is super user or if the program type is without
@@ -98,7 +98,7 @@ public interface TrackerOwnershipManager {
    * @param program the {@link Program}.
    * @return true if ownership check can be skipped.
    */
-  boolean canSkipOwnershipCheck(User user, Program program);
+  boolean canSkipOwnershipCheck(UserDetails user, Program program);
 
   /**
    * Ownership check can be skipped if the user is super user or if the program type is without
@@ -108,5 +108,5 @@ public interface TrackerOwnershipManager {
    * @param programType the {@link ProgramType}.
    * @return true if ownership check can be skipped.
    */
-  boolean canSkipOwnershipCheck(User user, ProgramType programType);
+  boolean canSkipOwnershipCheck(UserDetails user, ProgramType programType);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentityattributevalue/TrackedEntityAttributeValueService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentityattributevalue/TrackedEntityAttributeValueService.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Map;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 
 /**
  * @author Abyot Asalefew
@@ -57,7 +57,8 @@ public interface TrackedEntityAttributeValueService {
    * @param attributeValue the TrackedEntityAttribute to update.
    * @param user User for audits
    */
-  void updateTrackedEntityAttributeValue(TrackedEntityAttributeValue attributeValue, User user);
+  void updateTrackedEntityAttributeValue(
+      TrackedEntityAttributeValue attributeValue, UserDetails user);
 
   /**
    * Deletes a {@link TrackedEntityAttribute}.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/SystemUser.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/SystemUser.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.security.Authorities;
 import org.springframework.security.core.GrantedAuthority;
@@ -41,11 +42,13 @@ import org.springframework.security.core.GrantedAuthority;
  */
 public class SystemUser implements UserDetails {
 
+  @Nonnull
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
     return List.of((GrantedAuthority) Authorities.ALL::name);
   }
 
+  @Nonnull
   @Override
   public Set<String> getAllAuthorities() {
     return Set.of(Authorities.ALL.name());
@@ -112,13 +115,27 @@ public class SystemUser implements UserDetails {
     return "user";
   }
 
+  @Nonnull
   @Override
   public Set<String> getUserGroupIds() {
     return Set.of();
   }
 
+  @Nonnull
   @Override
   public Set<String> getUserOrgUnitIds() {
+    return Set.of();
+  }
+
+  @Nonnull
+  @Override
+  public Set<String> getUserDataOrgUnitIds() {
+    return Set.of();
+  }
+
+  @Nonnull
+  @Override
+  public Set<String> getUserSearchOrgUnitIds() {
     return Set.of();
   }
 
@@ -132,11 +149,13 @@ public class SystemUser implements UserDetails {
     return false;
   }
 
+  @Nonnull
   @Override
   public Map<String, Serializable> getUserSettings() {
     return Map.of();
   }
 
+  @Nonnull
   @Override
   public Set<String> getUserRoleIds() {
     return Set.of();

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/User.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/User.java
@@ -1190,7 +1190,15 @@ public class User extends BaseIdentifiableObject implements MetadataObject {
     return username(user, "system-process");
   }
 
+  public static String username(UserDetails user) {
+    return username(user, "system-process");
+  }
+
   public static String username(User user, String defaultValue) {
+    return user != null ? user.getUsername() : defaultValue;
+  }
+
+  public static String username(UserDetails user, String defaultValue) {
     return user != null ? user.getUsername() : defaultValue;
   }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetails.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetails.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.user;
 
-import static java.util.Collections.unmodifiableMap;
-
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
@@ -86,7 +84,7 @@ public interface UserDetails extends org.springframework.security.core.userdetai
         .userOrgUnitIds(setOfIds(user.getOrganisationUnits()))
         .userSearchOrgUnitIds(setOfIds(user.getTeiSearchOrganisationUnitsWithFallback()))
         .userDataOrgUnitIds(setOfIds(user.getDataViewOrganisationUnitsWithFallback()))
-        .userSettings(settings == null ? Map.of() : unmodifiableMap(settings))
+        .userSettings(settings == null ? new HashMap<>() : new HashMap<>(settings))
         .build();
   }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetails.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetails.java
@@ -27,83 +27,70 @@
  */
 package org.hisp.dhis.user;
 
+import static java.util.Collections.unmodifiableMap;
+
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import org.hisp.dhis.common.BaseIdentifiableObject;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.springframework.security.core.GrantedAuthority;
 
 public interface UserDetails extends org.springframework.security.core.userdetails.UserDetails {
 
   // TODO MAS: This is a workaround and usually indicated a design flaw, and that we should refactor
   // to use UserDetails higher up in the layers.
-  static UserDetails fromUser(User user) {
-    if (user == null) {
-      return null;
-    }
-
+  @CheckForNull
+  static UserDetails fromUser(@CheckForNull User user) {
+    if (user == null) return null;
+    // TODO check in session if a UserDetails for the user already exists (if the user is the
+    // current user)
     return createUserDetails(
         user, user.isAccountNonLocked(), user.isCredentialsNonExpired(), new HashMap<>());
   }
 
+  @CheckForNull
   static UserDetails createUserDetails(
-      User user,
+      @CheckForNull User user,
       boolean accountNonLocked,
       boolean credentialsNonExpired,
-      Map<String, Serializable> settings) {
+      @CheckForNull Map<String, Serializable> settings) {
     if (user == null) {
       return null;
     }
 
-    UserDetailsImpl userDetails = new UserDetailsImpl();
-    userDetails.setId(user.getId());
-    userDetails.setUid(user.getUid());
-    userDetails.setUsername(user.getUsername());
-    userDetails.setPassword(user.getPassword());
-
-    userDetails.setExternalAuth(user.isExternalAuth());
-    userDetails.setTwoFactorEnabled(user.isTwoFactorEnabled());
-
-    userDetails.setCode(user.getCode());
-    userDetails.setFirstName(user.getFirstName());
-    userDetails.setSurname(user.getSurname());
-
-    userDetails.setEnabled(user.isEnabled());
-    userDetails.setAccountNonExpired(user.isAccountNonExpired());
-    userDetails.setAccountNonLocked(accountNonLocked);
-    userDetails.setCredentialsNonExpired(credentialsNonExpired);
-
-    userDetails.setAuthorities(user.getAuthorities());
-    userDetails.setAllAuthorities(
-        user.getAuthorities().stream()
-            .map(GrantedAuthority::getAuthority)
-            .collect(Collectors.toUnmodifiableSet()));
-    userDetails.setSuper(user.isSuper());
-
-    userDetails.setAllRestrictions(user.getAllRestrictions());
-
-    userDetails.setUserRoleIds(
-        user.getUserRoles().stream()
-            .map(BaseIdentifiableObject::getUid)
-            .collect(Collectors.toSet()));
-
-    Set<String> groupIds =
-        user.getGroups().stream().map(BaseIdentifiableObject::getUid).collect(Collectors.toSet());
-    userDetails.setUserGroupIds(user.getUid() == null ? Set.of() : groupIds);
-
-    userDetails.setUserOrgUnitIds(
-        user.getOrganisationUnits().stream()
-            .map(BaseIdentifiableObject::getUid)
-            .collect(Collectors.toSet()));
-
-    userDetails.setUserSettings(settings);
-
-    return userDetails;
+    return UserDetailsImpl.builder()
+        .id(user.getId())
+        .uid(user.getUid())
+        .username(user.getUsername())
+        .password(user.getPassword())
+        .externalAuth(user.isExternalAuth())
+        .isTwoFactorEnabled(user.isTwoFactorEnabled())
+        .code(user.getCode())
+        .firstName(user.getFirstName())
+        .surname(user.getSurname())
+        .enabled(user.isEnabled())
+        .accountNonExpired(user.isAccountNonExpired())
+        .accountNonLocked(accountNonLocked)
+        .credentialsNonExpired(credentialsNonExpired)
+        .authorities(user.getAuthorities())
+        .allAuthorities(
+            Set.copyOf(user.getAuthorities().stream().map(GrantedAuthority::getAuthority).toList()))
+        .isSuper(user.isSuper())
+        .allRestrictions(user.getAllRestrictions())
+        .userRoleIds(setOfIds(user.getUserRoles()))
+        .userGroupIds(user.getUid() == null ? Set.of() : setOfIds(user.getGroups()))
+        .userOrgUnitIds(setOfIds(user.getOrganisationUnits()))
+        .userSearchOrgUnitIds(setOfIds(user.getTeiSearchOrganisationUnitsWithFallback()))
+        .userDataOrgUnitIds(setOfIds(user.getDataViewOrganisationUnitsWithFallback()))
+        .userSettings(settings == null ? Map.of() : unmodifiableMap(settings))
+        .build();
   }
 
+  @Nonnull
   @Override
   Collection<? extends GrantedAuthority> getAuthorities();
 
@@ -137,18 +124,29 @@ public interface UserDetails extends org.springframework.security.core.userdetai
 
   String getSurname();
 
+  @Nonnull
   Set<String> getUserGroupIds();
 
+  @Nonnull
   Set<String> getAllAuthorities();
 
+  @Nonnull
   Set<String> getUserOrgUnitIds();
+
+  @Nonnull
+  Set<String> getUserSearchOrgUnitIds();
+
+  @Nonnull
+  Set<String> getUserDataOrgUnitIds();
 
   boolean hasAnyAuthority(Collection<String> auths);
 
   boolean isAuthorized(String auth);
 
+  @Nonnull
   Map<String, Serializable> getUserSettings();
 
+  @Nonnull
   Set<String> getUserRoleIds();
 
   boolean canModifyUser(User userToModify);
@@ -160,4 +158,30 @@ public interface UserDetails extends org.springframework.security.core.userdetai
   boolean hasAnyRestrictions(Collection<String> restrictions);
 
   void setId(Long id);
+
+  default boolean isInUserHierarchy(String orgUnitPath) {
+    return isInUserHierarchy(orgUnitPath, getUserOrgUnitIds());
+  }
+
+  default boolean isInUserSearchHierarchy(String orgUnitPath) {
+    return isInUserHierarchy(orgUnitPath, getUserSearchOrgUnitIds());
+  }
+
+  default boolean isInUserDataHierarchy(String orgUnitPath) {
+    return isInUserHierarchy(orgUnitPath, getUserDataOrgUnitIds());
+  }
+
+  private static boolean isInUserHierarchy(
+      @CheckForNull String orgUnitPath, @Nonnull Set<String> orgUnitIds) {
+    if (orgUnitPath == null) return false;
+    for (String uid : orgUnitPath.split("/")) if (orgUnitIds.contains(uid)) return true;
+    return false;
+  }
+
+  private static Set<String> setOfIds(
+      @CheckForNull Collection<? extends IdentifiableObject> objects) {
+    return objects == null || objects.isEmpty()
+        ? Set.of()
+        : Set.copyOf(objects.stream().map(IdentifiableObject::getUid).toList());
+  }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetailsImpl.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserDetailsImpl.java
@@ -29,9 +29,10 @@ package org.hisp.dhis.user;
 
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -39,32 +40,34 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
 
 @Getter
-@Setter
+@Builder
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Slf4j
 public class UserDetailsImpl implements UserDetails {
 
-  private String uid;
-  private Long id;
-  private String code;
-  @EqualsAndHashCode.Include private String username;
-  private String firstName;
-  private String surname;
-  private String password;
-  private boolean externalAuth;
-  private boolean isTwoFactorEnabled;
-  private boolean enabled;
-  private boolean accountNonExpired;
-  private boolean accountNonLocked;
-  private boolean credentialsNonExpired;
-  private Collection<GrantedAuthority> authorities;
-  private Set<String> allAuthorities;
-  private Set<String> allRestrictions;
-  private Map<String, Serializable> userSettings = new HashMap<>();
-  private Set<String> userGroupIds;
-  private Set<String> userOrgUnitIds;
-  private boolean isSuper;
-  private Set<String> userRoleIds;
+  private final String uid;
+  @Setter private Long id;
+  private final String code;
+  @EqualsAndHashCode.Include private final String username;
+  private final String firstName;
+  private final String surname;
+  private final String password;
+  private final boolean externalAuth;
+  private final boolean isTwoFactorEnabled;
+  private final boolean enabled;
+  private final boolean accountNonExpired;
+  private final boolean accountNonLocked;
+  private final boolean credentialsNonExpired;
+  @Nonnull private final Collection<GrantedAuthority> authorities;
+  @Nonnull private final Set<String> allAuthorities;
+  @Nonnull private final Set<String> allRestrictions;
+  @Nonnull private final Map<String, Serializable> userSettings;
+  @Nonnull private final Set<String> userGroupIds;
+  @Nonnull private final Set<String> userOrgUnitIds;
+  @Nonnull private final Set<String> userDataOrgUnitIds;
+  @Nonnull private final Set<String> userSearchOrgUnitIds;
+  private final boolean isSuper;
+  @Nonnull private final Set<String> userRoleIds;
 
   @Override
   public boolean canModifyUser(User other) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DimensionalObjectProducerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DimensionalObjectProducerTest.java
@@ -65,7 +65,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.hisp.dhis.analytics.AnalyticsFinancialYearStartKey;
-import org.hisp.dhis.analytics.AnalyticsSecurityManager;
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.common.BaseDimensionalItemObject;
@@ -92,8 +91,8 @@ import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.YearlyPeriodType;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.setting.SystemSettingManager;
+import org.hisp.dhis.user.SystemUser;
 import org.hisp.dhis.user.UserDetails;
-import org.hisp.dhis.user.UserDetailsImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -114,8 +113,6 @@ class DimensionalObjectProducerTest {
   @Mock private OrganisationUnitService organisationUnitService;
 
   @Mock private DimensionService dimensionService;
-
-  @Mock private AnalyticsSecurityManager securityManager;
 
   @Mock private SystemSettingManager systemSettingManager;
 
@@ -436,11 +433,7 @@ class DimensionalObjectProducerTest {
     List<String> items = List.of("ALL_ITEMS");
     category.setCategoryOptions(List.of(new CategoryOption()));
 
-    UserDetailsImpl currentUserDetails = new UserDetailsImpl();
-    currentUserDetails.setAllAuthorities(Set.of("ALL"));
-    currentUserDetails.setUsername("admin");
-    currentUserDetails.setSuper(true);
-    injectSecurityContext(currentUserDetails);
+    injectSecurityContext(new SystemUser());
 
     // when
     when(idObjectManager.get(DYNAMIC_DIM_CLASSES, UID, categoryUid)).thenReturn(category);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
@@ -161,8 +161,8 @@ public class DefaultEnrollmentService implements EnrollmentService {
 
   @Override
   @Transactional
-  public void updateEnrollment(Enrollment enrollment, User user) {
-    enrollmentStore.update(enrollment, UserDetails.fromUser(user));
+  public void updateEnrollment(Enrollment enrollment, UserDetails user) {
+    enrollmentStore.update(enrollment, user);
   }
 
   // TODO consider security

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramTempOwnerService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramTempOwnerService.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.program;
 
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.trackedentity.TrackedEntity;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,7 +54,7 @@ public class DefaultProgramTempOwnerService implements ProgramTempOwnerService {
   @Override
   @Transactional(readOnly = true)
   public int getValidTempOwnerRecordCount(
-      Program program, TrackedEntity entityInstance, User user) {
+      Program program, TrackedEntity entityInstance, UserDetails user) {
     return programTempOwnerStore.getValidTempOwnerCount(program, entityInstance, user);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramTempOwnerStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramTempOwnerStore.java
@@ -33,7 +33,7 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramTempOwner;
 import org.hisp.dhis.program.ProgramTempOwnerStore;
 import org.hisp.dhis.trackedentity.TrackedEntity;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -59,7 +59,8 @@ public class HibernateProgramTempOwnerStore extends HibernateGenericStore<Progra
   }
 
   @Override
-  public int getValidTempOwnerCount(Program program, TrackedEntity entityInstance, User user) {
+  public int getValidTempOwnerCount(
+      Program program, TrackedEntity entityInstance, UserDetails user) {
     final String sql =
         "select count(1) from programtempowner "
             + "where programid = ? and trackedentityid=? and userid=? "

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaQueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaQueryUtils.java
@@ -27,12 +27,11 @@
  */
 package org.hisp.dhis.query;
 
-import java.util.ArrayList;
+import static java.util.stream.Collectors.joining;
+
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.Expression;
@@ -243,7 +242,7 @@ public class JpaQueryUtils {
 
                   return sb.toString();
                 })
-            .collect(Collectors.joining(",")),
+            .collect(joining(",")),
         null);
   }
 
@@ -278,7 +277,7 @@ public class JpaQueryUtils {
 
                   return sb.toString();
                 })
-            .collect(Collectors.joining(",")),
+            .collect(joining(",")),
         null);
   }
 
@@ -317,18 +316,18 @@ public class JpaQueryUtils {
    * NULL if given Set of UserGroup is empty
    *
    * @param builder
-   * @param userGroupUids List of User Group Uids
+   * @param userGroupIds List of User Group Uids
    * @param access Access String
    * @return JPA Predicate
    */
   public static <T> Function<Root<T>, Predicate> checkUserGroupsAccess(
-      CriteriaBuilder builder, Set<String> userGroupUids, String access) {
+      CriteriaBuilder builder, Collection<String> userGroupIds, String access) {
     return root -> {
-      if (CollectionUtils.isEmpty(userGroupUids)) {
+      if (CollectionUtils.isEmpty(userGroupIds)) {
         return null;
       }
 
-      String groupUuIds = "{" + String.join(",", userGroupUids) + "}";
+      String groupUuIds = "{" + String.join(",", userGroupIds) + "}";
 
       return builder.and(
           builder.equal(
@@ -408,7 +407,7 @@ public class JpaQueryUtils {
   }
 
   public static String generateHqlQueryForSharingCheck(
-      String tableName, String access, String userId, List<String> userGroupIds) {
+      String tableName, String access, String userId, Collection<String> userGroupIds) {
     return "("
         + sqlToHql(
             tableName,
@@ -418,13 +417,13 @@ public class JpaQueryUtils {
   }
 
   private static String getGroupsIds(UserDetails user) {
-    return getGroupsIds(new ArrayList<>(user.getUserGroupIds()));
+    return getGroupsIds(user.getUserGroupIds());
   }
 
-  private static String getGroupsIds(List<String> userGroupIds) {
+  private static String getGroupsIds(Collection<String> userGroupIds) {
     return CollectionUtils.isEmpty(userGroupIds)
         ? null
-        : "{" + String.join(",", userGroupIds) + "}";
+        : "{" + userGroupIds.stream().sorted().collect(joining(",")) + "}";
   }
 
   private static String sqlToHql(String tableName, String sql) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUser.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUser.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
@@ -136,19 +137,34 @@ public class DhisOidcUser extends DefaultOAuth2User implements UserDetails, Oidc
     return user.getSurname();
   }
 
+  @Nonnull
   @Override
   public Set<String> getUserGroupIds() {
     return user.getUserGroupIds();
   }
 
+  @Nonnull
   @Override
   public Set<String> getAllAuthorities() {
     return user.getAllAuthorities();
   }
 
+  @Nonnull
   @Override
   public Set<String> getUserOrgUnitIds() {
     return user.getUserOrgUnitIds();
+  }
+
+  @Nonnull
+  @Override
+  public Set<String> getUserSearchOrgUnitIds() {
+    return user.getUserSearchOrgUnitIds();
+  }
+
+  @Nonnull
+  @Override
+  public Set<String> getUserDataOrgUnitIds() {
+    return user.getUserDataOrgUnitIds();
   }
 
   @Override
@@ -161,11 +177,13 @@ public class DhisOidcUser extends DefaultOAuth2User implements UserDetails, Oidc
     return false;
   }
 
+  @Nonnull
   @Override
   public Map<String, Serializable> getUserSettings() {
     return user.getUserSettings();
   }
 
+  @Nonnull
   @Override
   public Set<String> getUserRoleIds() {
     return user.getUserRoleIds();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityChangeLogService.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.user.CurrentUserUtil;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -73,7 +73,7 @@ public class DefaultTrackedEntityChangeLogService implements TrackedEntityChange
   @Transactional(readOnly = true)
   public List<TrackedEntityChangeLog> getTrackedEntityChangeLogs(
       TrackedEntityChangeLogQueryParams params) {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     return trackedEntityChangeLogStore.getTrackedEntityChangeLogs(params).stream()
         .filter(
             a ->

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityService.java
@@ -337,15 +337,17 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
 
     Set<String> tes = new HashSet<>();
 
+    User user = params.getUser();
+    UserDetails userDetails = UserDetails.fromUser(user);
     for (Map<String, String> entity : entities) {
-      if (params.getUser() != null
-          && !params.getUser().isSuper()
+      if (userDetails != null
+          && !userDetails.isSuper()
           && params.hasProgram()
           && (params.getProgram().getAccessLevel().equals(AccessLevel.PROTECTED)
               || params.getProgram().getAccessLevel().equals(AccessLevel.CLOSED))) {
         TrackedEntity te = trackedEntityStore.getByUid(entity.get(TRACKED_ENTITY_ID));
 
-        if (!trackerOwnershipAccessManager.hasAccess(params.getUser(), te, params.getProgram())) {
+        if (!trackerOwnershipAccessManager.hasAccess(userDetails, te, params.getProgram())) {
           continue;
         }
       }
@@ -751,7 +753,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
 
   @Override
   @Transactional(readOnly = true)
-  public List<TrackedEntity> getTrackedEntitiesByUid(List<String> uids, User user) {
+  public List<TrackedEntity> getTrackedEntitiesByUid(List<String> uids, UserDetails user) {
     if (uids == null || uids.isEmpty()) {
       return Collections.emptyList();
     }
@@ -766,8 +768,8 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
 
   @Override
   @Transactional
-  public void updateTrackedEntity(TrackedEntity trackedEntity, User user) {
-    trackedEntityStore.update(trackedEntity, UserDetails.fromUser(user));
+  public void updateTrackedEntity(TrackedEntity trackedEntity, UserDetails user) {
+    trackedEntityStore.update(trackedEntity, user);
   }
 
   @Override
@@ -812,7 +814,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
   }
 
   @Override
-  public TrackedEntity getTrackedEntity(String uid, User user) {
+  public TrackedEntity getTrackedEntity(String uid, UserDetails user) {
     TrackedEntity te = trackedEntityStore.getByUid(uid);
     addTrackedEntityAudit(te, User.username(user), ChangeLogType.READ);
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
@@ -67,10 +67,9 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
 
     OrganisationUnit ou = trackedEntity.getOrganisationUnit();
 
-    if (ou != null) { // ou should never be null, but needs to be checked for legacy reasons
-      if (!user.isInUserSearchHierarchy(ou.getPath())) {
-        errors.add("User has no read access to organisation unit: " + ou.getUid());
-      }
+    // ou should never be null, but needs to be checked for legacy reasons
+    if (ou != null && !user.isInUserSearchHierarchy(ou.getPath())) {
+      errors.add("User has no read access to organisation unit: " + ou.getUid());
     }
 
     TrackedEntityType trackedEntityType = trackedEntity.getTrackedEntityType();
@@ -94,10 +93,9 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
 
     OrganisationUnit ou = trackedEntity.getOrganisationUnit();
 
-    if (ou != null) { // ou should never be null, but needs to be checked for legacy reasons
-      if (!user.isInUserSearchHierarchy(ou.getPath())) {
-        errors.add("User has no write access to organisation unit: " + ou.getUid());
-      }
+    // ou should never be null, but needs to be checked for legacy reasons
+    if (ou != null && !user.isInUserSearchHierarchy(ou.getPath())) {
+      errors.add("User has no write access to organisation unit: " + ou.getUid());
     }
 
     TrackedEntityType trackedEntityType = trackedEntity.getTrackedEntityType();
@@ -214,10 +212,8 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
     Program program = enrollment.getProgram();
 
     OrganisationUnit ou = enrollment.getOrganisationUnit();
-    if (ou != null) {
-      if (!user.isInUserHierarchy(ou.getPath())) {
-        errors.add("User has no create access to organisation unit: " + ou.getUid());
-      }
+    if (ou != null && !user.isInUserHierarchy(ou.getPath())) {
+      errors.add("User has no create access to organisation unit: " + ou.getUid());
     }
 
     if (!aclService.canDataWrite(user, program)) {
@@ -272,10 +268,8 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
 
     } else {
       OrganisationUnit ou = enrollment.getOrganisationUnit();
-      if (ou != null) {
-        if (!user.isInUserHierarchy(ou.getPath())) {
-          errors.add("User has no write access to organisation unit: " + ou.getUid());
-        }
+      if (ou != null && !user.isInUserHierarchy(ou.getPath())) {
+        errors.add("User has no write access to organisation unit: " + ou.getUid());
       }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
@@ -443,10 +443,8 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
     List<String> errors = new ArrayList<>();
     if (program.isWithoutRegistration()) {
       OrganisationUnit ou = event.getOrganisationUnit();
-      if (ou != null) {
-        if (!user.isInUserDataHierarchy(ou.getPath())) {
-          errors.add("User has no delete access to organisation unit: " + ou.getUid());
-        }
+      if (ou != null && !user.isInUserDataHierarchy(ou.getPath())) {
+        errors.add("User has no delete access to organisation unit: " + ou.getUid());
       }
 
       if (!aclService.canDataWrite(user, program)) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
@@ -58,15 +58,13 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
 
   @Override
   public List<String> canRead(UserDetails user, TrackedEntity trackedEntity) {
-    List<String> errors = new ArrayList<>();
-
     // always allow if user == null (internal process) or user is superuser
     if (user == null || user.isSuper() || trackedEntity == null) {
-      return errors;
+      return List.of();
     }
 
     OrganisationUnit ou = trackedEntity.getOrganisationUnit();
-
+    List<String> errors = new ArrayList<>();
     // ou should never be null, but needs to be checked for legacy reasons
     if (ou != null && !user.isInUserSearchHierarchy(ou.getPath())) {
       errors.add("User has no read access to organisation unit: " + ou.getUid());
@@ -84,15 +82,14 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
 
   @Override
   public List<String> canWrite(UserDetails user, TrackedEntity trackedEntity) {
-    List<String> errors = new ArrayList<>();
-
     // always allow if user == null (internal process) or user is superuser
     if (user == null || user.isSuper() || trackedEntity == null) {
-      return errors;
+      return List.of();
     }
 
     OrganisationUnit ou = trackedEntity.getOrganisationUnit();
 
+    List<String> errors = new ArrayList<>();
     // ou should never be null, but needs to be checked for legacy reasons
     if (ou != null && !user.isInUserSearchHierarchy(ou.getPath())) {
       errors.add("User has no write access to organisation unit: " + ou.getUid());
@@ -110,13 +107,12 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
   @Override
   public List<String> canRead(
       UserDetails user, TrackedEntity trackedEntity, Program program, boolean skipOwnershipCheck) {
-    List<String> errors = new ArrayList<>();
-
     // always allow if user == null (internal process) or user is superuser
     if (user == null || user.isSuper() || trackedEntity == null) {
-      return errors;
+      return List.of();
     }
 
+    List<String> errors = new ArrayList<>();
     if (!aclService.canDataRead(user, program)) {
       errors.add("User has no data read access to program: " + program.getUid());
     }
@@ -137,13 +133,12 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
   @Override
   public List<String> canWrite(
       UserDetails user, TrackedEntity trackedEntity, Program program, boolean skipOwnershipCheck) {
-    List<String> errors = new ArrayList<>();
-
     // always allow if user == null (internal process) or user is superuser
     if (user == null || user.isSuper() || trackedEntity == null) {
-      return errors;
+      return List.of();
     }
 
+    List<String> errors = new ArrayList<>();
     if (!aclService.canDataWrite(user, program)) {
       errors.add("User has no data write access to program: " + program.getUid());
     }
@@ -163,15 +158,13 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
 
   @Override
   public List<String> canRead(UserDetails user, Enrollment enrollment, boolean skipOwnershipCheck) {
-    List<String> errors = new ArrayList<>();
-
     // always allow if user == null (internal process) or user is superuser
     if (user == null || user.isSuper() || enrollment == null) {
-      return errors;
+      return List.of();
     }
 
     Program program = enrollment.getProgram();
-
+    List<String> errors = new ArrayList<>();
     if (!aclService.canDataRead(user, program)) {
       errors.add("User has no data read access to program: " + program.getUid());
     }
@@ -202,15 +195,13 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
   @Override
   public List<String> canCreate(
       UserDetails user, Enrollment enrollment, boolean skipOwnershipCheck) {
-    List<String> errors = new ArrayList<>();
-
     // always allow if user == null (internal process) or user is superuser
     if (user == null || user.isSuper() || enrollment == null) {
-      return errors;
+      return List.of();
     }
 
     Program program = enrollment.getProgram();
-
+    List<String> errors = new ArrayList<>();
     OrganisationUnit ou = enrollment.getOrganisationUnit();
     if (ou != null && !user.isInUserHierarchy(ou.getPath())) {
       errors.add("User has no create access to organisation unit: " + ou.getUid());
@@ -241,15 +232,13 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
   @Override
   public List<String> canUpdate(
       UserDetails user, Enrollment enrollment, boolean skipOwnershipCheck) {
-    List<String> errors = new ArrayList<>();
-
     // always allow if user == null (internal process) or user is superuser
     if (user == null || user.isSuper() || enrollment == null) {
-      return errors;
+      return List.of();
     }
 
     Program program = enrollment.getProgram();
-
+    List<String> errors = new ArrayList<>();
     if (!aclService.canDataWrite(user, program)) {
       errors.add("User has no data write access to program: " + program.getUid());
     }
@@ -279,15 +268,13 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
   @Override
   public List<String> canDelete(
       UserDetails user, Enrollment enrollment, boolean skipOwnershipCheck) {
-    List<String> errors = new ArrayList<>();
-
     // always allow if user == null (internal process) or user is superuser
     if (user == null || user.isSuper() || enrollment == null) {
-      return errors;
+      return List.of();
     }
 
     Program program = enrollment.getProgram();
-
+    List<String> errors = new ArrayList<>();
     if (!aclService.canDataWrite(user, program)) {
       errors.add("User has no data write access to program: " + program.getUid());
     }
@@ -305,10 +292,8 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
       }
     } else {
       OrganisationUnit ou = enrollment.getOrganisationUnit();
-      if (ou != null) {
-        if (!user.isInUserHierarchy(ou.getPath())) {
-          errors.add("User has no delete access to organisation unit: " + ou.getUid());
-        }
+      if (ou != null && !user.isInUserHierarchy(ou.getPath())) {
+        errors.add("User has no delete access to organisation unit: " + ou.getUid());
       }
     }
 
@@ -317,21 +302,19 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
 
   @Override
   public List<String> canRead(UserDetails user, Event event, boolean skipOwnershipCheck) {
-    List<String> errors = new ArrayList<>();
-
     // always allow if user == null (internal process) or user is superuser
     if (user == null || user.isSuper() || event == null) {
-      return errors;
+      return List.of();
     }
 
     ProgramStage programStage = event.getProgramStage();
 
     if (isNull(programStage)) {
-      return errors;
+      return List.of();
     }
 
     Program program = programStage.getProgram();
-
+    List<String> errors = new ArrayList<>();
     if (!aclService.canDataRead(user, program)) {
       errors.add("User has no data read access to program: " + program.getUid());
     }
@@ -367,21 +350,19 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
 
   @Override
   public List<String> canCreate(UserDetails user, Event event, boolean skipOwnershipCheck) {
-    List<String> errors = new ArrayList<>();
-
     // always allow if user == null (internal process) or user is superuser
     if (user == null || user.isSuper() || event == null) {
-      return errors;
+      return List.of();
     }
 
     ProgramStage programStage = event.getProgramStage();
 
     if (isNull(programStage)) {
-      return errors;
+      return List.of();
     }
 
     Program program = programStage.getProgram();
-
+    List<String> errors = new ArrayList<>();
     OrganisationUnit ou = event.getOrganisationUnit();
     if (ou != null) {
       if (event.isCreatableInSearchScope()
@@ -396,25 +377,8 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
         errors.add("User has no data write access to program: " + program.getUid());
       }
     } else {
-      if (!aclService.canDataWrite(user, programStage)) {
-        errors.add("User has no data write access to program stage: " + programStage.getUid());
-      }
-
-      if (!aclService.canDataRead(user, program)) {
-        errors.add("User has no data read access to program: " + program.getUid());
-      }
-
-      if (!aclService.canDataRead(user, program.getTrackedEntityType())) {
-        errors.add(
-            "User has no data read access to tracked entity type: "
-                + program.getTrackedEntityType().getUid());
-      }
-
-      if (!skipOwnershipCheck
-          && !ownershipAccessManager.hasAccess(
-              user, event.getEnrollment().getTrackedEntity(), program)) {
-        errors.add(TrackerOwnershipManager.OWNERSHIP_ACCESS_DENIED);
-      }
+      canCreateOrDeleteWithRegistration(
+          errors, user, event, skipOwnershipCheck, programStage, program);
     }
 
     errors.addAll(canWrite(user, event.getAttributeOptionCombo()));
@@ -424,45 +388,29 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
 
   @Override
   public List<String> canUpdate(UserDetails user, Event event, boolean skipOwnershipCheck) {
-    List<String> errors = new ArrayList<>();
-
     // always allow if user == null (internal process) or user is superuser
     if (user == null || user.isSuper() || event == null) {
-      return errors;
+      return List.of();
     }
 
     ProgramStage programStage = event.getProgramStage();
 
     if (isNull(programStage)) {
-      return errors;
+      return List.of();
     }
 
     Program program = programStage.getProgram();
-
+    List<String> errors = new ArrayList<>();
     if (program.isWithoutRegistration()) {
       if (!aclService.canDataWrite(user, program)) {
         errors.add("User has no data write access to program: " + program.getUid());
       }
     } else {
-      if (!aclService.canDataWrite(user, programStage)) {
-        errors.add("User has no data write access to program stage: " + programStage.getUid());
-      }
-
-      if (!aclService.canDataRead(user, program)) {
-        errors.add("User has no data read access to program: " + program.getUid());
-      }
-
-      if (!aclService.canDataRead(user, program.getTrackedEntityType())) {
-        errors.add(
-            "User has no data read access to tracked entity type: "
-                + program.getTrackedEntityType().getUid());
-      }
+      canManageWithRegistration(errors, user, programStage, program);
 
       OrganisationUnit ou = event.getOrganisationUnit();
-      if (ou != null) {
-        if (!user.isInUserSearchHierarchy(ou.getPath())) {
-          errors.add("User has no update access to organisation unit: " + ou.getUid());
-        }
+      if (ou != null && !user.isInUserSearchHierarchy(ou.getPath())) {
+        errors.add("User has no update access to organisation unit: " + ou.getUid());
       }
 
       if (!skipOwnershipCheck
@@ -479,21 +427,20 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
 
   @Override
   public List<String> canDelete(UserDetails user, Event event, boolean skipOwnershipCheck) {
-    List<String> errors = new ArrayList<>();
-
     // always allow if user == null (internal process) or user is superuser
     if (user == null || user.isSuper() || event == null) {
-      return errors;
+      return List.of();
     }
 
     ProgramStage programStage = event.getProgramStage();
 
     if (isNull(programStage)) {
-      return errors;
+      return List.of();
     }
 
     Program program = programStage.getProgram();
 
+    List<String> errors = new ArrayList<>();
     if (program.isWithoutRegistration()) {
       OrganisationUnit ou = event.getOrganisationUnit();
       if (ou != null) {
@@ -506,25 +453,8 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
         errors.add("User has no data write access to program: " + program.getUid());
       }
     } else {
-      if (!aclService.canDataWrite(user, programStage)) {
-        errors.add("User has no data write access to program stage: " + programStage.getUid());
-      }
-
-      if (!aclService.canDataRead(user, program)) {
-        errors.add("User has no data read access to program: " + program.getUid());
-      }
-
-      if (!aclService.canDataRead(user, program.getTrackedEntityType())) {
-        errors.add(
-            "User has no data read access to tracked entity type: "
-                + program.getTrackedEntityType().getUid());
-      }
-
-      if (!skipOwnershipCheck
-          && !ownershipAccessManager.hasAccess(
-              user, event.getEnrollment().getTrackedEntity(), program)) {
-        errors.add(TrackerOwnershipManager.OWNERSHIP_ACCESS_DENIED);
-      }
+      canCreateOrDeleteWithRegistration(
+          errors, user, event, skipOwnershipCheck, programStage, program);
     }
 
     errors.addAll(canWrite(user, event.getAttributeOptionCombo()));
@@ -532,26 +462,54 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
     return errors;
   }
 
-  @Override
-  public List<String> canRead(UserDetails user, Relationship relationship) {
-    List<String> errors = new ArrayList<>();
-    RelationshipType relationshipType;
-    RelationshipItem from;
-    RelationshipItem to;
+  private void canCreateOrDeleteWithRegistration(
+      List<String> errors,
+      UserDetails user,
+      Event event,
+      boolean skipOwnershipCheck,
+      ProgramStage programStage,
+      Program program) {
+    canManageWithRegistration(errors, user, programStage, program);
 
-    // always allow if user == null (internal process) or user is superuser
-    if (user == null || user.isSuper() || relationship == null) {
-      return errors;
+    if (!skipOwnershipCheck
+        && !ownershipAccessManager.hasAccess(
+            user, event.getEnrollment().getTrackedEntity(), program)) {
+      errors.add(TrackerOwnershipManager.OWNERSHIP_ACCESS_DENIED);
+    }
+  }
+
+  private void canManageWithRegistration(
+      List<String> errors, UserDetails user, ProgramStage programStage, Program program) {
+    if (!aclService.canDataWrite(user, programStage)) {
+      errors.add("User has no data write access to program stage: " + programStage.getUid());
     }
 
-    relationshipType = relationship.getRelationshipType();
+    if (!aclService.canDataRead(user, program)) {
+      errors.add("User has no data read access to program: " + program.getUid());
+    }
 
+    if (!aclService.canDataRead(user, program.getTrackedEntityType())) {
+      errors.add(
+          "User has no data read access to tracked entity type: "
+              + program.getTrackedEntityType().getUid());
+    }
+  }
+
+  @Override
+  public List<String> canRead(UserDetails user, Relationship relationship) {
+    // always allow if user == null (internal process) or user is superuser
+    if (user == null || user.isSuper() || relationship == null) {
+      return List.of();
+    }
+
+    RelationshipType relationshipType = relationship.getRelationshipType();
+    List<String> errors = new ArrayList<>();
     if (!aclService.canDataRead(user, relationshipType)) {
       errors.add("User has no data read access to relationshipType: " + relationshipType.getUid());
     }
 
-    from = relationship.getFrom();
-    to = relationship.getTo();
+    RelationshipItem from = relationship.getFrom();
+    RelationshipItem to = relationship.getTo();
 
     errors.addAll(canRead(user, from.getTrackedEntity()));
     errors.addAll(canRead(user, from.getEnrollment(), false));
@@ -566,24 +524,20 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
 
   @Override
   public List<String> canWrite(UserDetails user, Relationship relationship) {
-    List<String> errors = new ArrayList<>();
-    RelationshipType relationshipType;
-    RelationshipItem from;
-    RelationshipItem to;
-
     // always allow if user == null (internal process) or user is superuser
     if (user == null || user.isSuper() || relationship == null) {
-      return errors;
+      return List.of();
     }
 
-    relationshipType = relationship.getRelationshipType();
+    RelationshipType relationshipType = relationship.getRelationshipType();
+    List<String> errors = new ArrayList<>();
 
     if (!aclService.canDataWrite(user, relationshipType)) {
       errors.add("User has no data write access to relationshipType: " + relationshipType.getUid());
     }
 
-    from = relationship.getFrom();
-    to = relationship.getTo();
+    RelationshipItem from = relationship.getFrom();
+    RelationshipItem to = relationship.getTo();
 
     errors.addAll(canWrite(user, from.getTrackedEntity()));
     errors.addAll(canUpdate(user, from.getEnrollment(), false));
@@ -599,12 +553,11 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
   @Override
   public List<String> canRead(
       UserDetails user, Event event, DataElement dataElement, boolean skipOwnershipCheck) {
-    List<String> errors = new ArrayList<>();
-
     if (user == null || user.isSuper()) {
-      return errors;
+      return List.of();
     }
 
+    List<String> errors = new ArrayList<>();
     errors.addAll(canRead(user, event, skipOwnershipCheck));
 
     if (!aclService.canRead(user, dataElement)) {
@@ -617,12 +570,11 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
   @Override
   public List<String> canWrite(
       UserDetails user, Event event, DataElement dataElement, boolean skipOwnershipCheck) {
-    List<String> errors = new ArrayList<>();
-
     if (user == null || user.isSuper()) {
-      return errors;
+      return List.of();
     }
 
+    List<String> errors = new ArrayList<>();
     errors.addAll(canUpdate(user, event, skipOwnershipCheck));
 
     if (!aclService.canRead(user, dataElement)) {
@@ -634,12 +586,11 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
 
   @Override
   public List<String> canRead(UserDetails user, CategoryOptionCombo categoryOptionCombo) {
-    List<String> errors = new ArrayList<>();
-
     if (user == null || user.isSuper() || categoryOptionCombo == null) {
-      return errors;
+      return List.of();
     }
 
+    List<String> errors = new ArrayList<>();
     for (CategoryOption categoryOption : categoryOptionCombo.getCategoryOptions()) {
       if (!aclService.canDataRead(user, categoryOption)) {
         errors.add("User has no read access to category option: " + categoryOption.getUid());
@@ -651,12 +602,11 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
 
   @Override
   public List<String> canWrite(UserDetails user, CategoryOptionCombo categoryOptionCombo) {
-    List<String> errors = new ArrayList<>();
-
     if (user == null || user.isSuper() || categoryOptionCombo == null) {
-      return errors;
+      return List.of();
     }
 
+    List<String> errors = new ArrayList<>();
     for (CategoryOption categoryOption : categoryOptionCombo.getCategoryOptions()) {
       if (!aclService.canDataWrite(user, categoryOption)) {
         errors.add("User has no write access to category option: " + categoryOption.getUid());

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
@@ -91,7 +91,7 @@ import org.hisp.dhis.system.util.SqlUtils;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityQueryParams;
 import org.hisp.dhis.trackedentity.TrackedEntityStore;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 import org.springframework.context.ApplicationEventPublisher;
@@ -1379,7 +1379,7 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
   }
 
   @Override
-  public List<TrackedEntity> getTrackedEntityByUid(List<String> uids, User user) {
+  public List<TrackedEntity> getTrackedEntityByUid(List<String> uids, UserDetails user) {
     List<List<String>> uidPartitions = Lists.partition(uids, 20000);
 
     List<TrackedEntity> instances = new ArrayList<>();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentityattributevalue/DefaultTrackedEntityAttributeValueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentityattributevalue/DefaultTrackedEntityAttributeValueService.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -164,14 +165,14 @@ public class DefaultTrackedEntityAttributeValueService
   @Override
   @Transactional
   public void updateTrackedEntityAttributeValue(TrackedEntityAttributeValue attributeValue) {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     updateTrackedEntityAttributeValue(attributeValue, currentUser);
   }
 
   @Override
   @Transactional
   public void updateTrackedEntityAttributeValue(
-      TrackedEntityAttributeValue attributeValue, User user) {
+      TrackedEntityAttributeValue attributeValue, UserDetails user) {
     if (attributeValue != null && StringUtils.isEmpty(attributeValue.getValue())) {
       deleteFileValue(attributeValue);
       attributeValueStore.delete(attributeValue);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitydatavalue/DefaultTrackedEntityDataValueChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitydatavalue/DefaultTrackedEntityDataValueChangeLogService.java
@@ -36,8 +36,7 @@ import org.hisp.dhis.program.Event;
 import org.hisp.dhis.trackedentity.TrackedEntityDataValueChangeLogQueryParams;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.user.CurrentUserUtil;
-import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,21 +46,19 @@ import org.springframework.transaction.annotation.Transactional;
 @Service("org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueChangeLogService")
 public class DefaultTrackedEntityDataValueChangeLogService
     implements TrackedEntityDataValueChangeLogService {
-  private final TrackedEntityDataValueChangeLogStore trackedEntityDataValueChangeLogStore;
 
+  private final TrackedEntityDataValueChangeLogStore trackedEntityDataValueChangeLogStore;
   private final Predicate<TrackedEntityDataValueChangeLog> aclFilter;
 
   public DefaultTrackedEntityDataValueChangeLogService(
       TrackedEntityDataValueChangeLogStore trackedEntityDataValueChangeLogStore,
-      TrackerAccessManager trackerAccessManager,
-      UserService userService) {
+      TrackerAccessManager trackerAccessManager) {
     checkNotNull(trackedEntityDataValueChangeLogStore);
     checkNotNull(trackerAccessManager);
-    checkNotNull(userService);
 
     this.trackedEntityDataValueChangeLogStore = trackedEntityDataValueChangeLogStore;
 
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
 
     aclFilter =
         changeLog ->

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManagerTest.java
@@ -32,22 +32,19 @@ import static org.hisp.dhis.common.AccessLevel.OPEN;
 import static org.hisp.dhis.common.AccessLevel.PROTECTED;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.when;
 
+import java.util.Set;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class DefaultTrackerAccessManagerTest {
-
-  @Mock private OrganisationUnitService organisationUnitService;
 
   @InjectMocks private DefaultTrackerAccessManager trackerAccessManager;
 
@@ -58,10 +55,10 @@ class DefaultTrackerAccessManagerTest {
     program.setAccessLevel(OPEN);
     OrganisationUnit orgUnit = new OrganisationUnit();
 
-    when(organisationUnitService.isInUserSearchHierarchy(user, orgUnit)).thenReturn(true);
+    user.setTeiSearchOrganisationUnits(Set.of(orgUnit));
 
     assertTrue(
-        trackerAccessManager.canAccess(user, program, orgUnit),
+        trackerAccessManager.canAccess(UserDetails.fromUser(user), program, orgUnit),
         "User should have access to open program");
   }
 
@@ -72,10 +69,8 @@ class DefaultTrackerAccessManagerTest {
     program.setAccessLevel(OPEN);
     OrganisationUnit orgUnit = new OrganisationUnit();
 
-    when(organisationUnitService.isInUserSearchHierarchy(user, orgUnit)).thenReturn(false);
-
     assertFalse(
-        trackerAccessManager.canAccess(user, program, orgUnit),
+        trackerAccessManager.canAccess(UserDetails.fromUser(user), program, orgUnit),
         "User should not have access to open program");
   }
 
@@ -84,10 +79,10 @@ class DefaultTrackerAccessManagerTest {
     User user = new User();
     OrganisationUnit orgUnit = new OrganisationUnit();
 
-    when(organisationUnitService.isInUserSearchHierarchy(user, orgUnit)).thenReturn(true);
+    user.setTeiSearchOrganisationUnits(Set.of(orgUnit));
 
     assertTrue(
-        trackerAccessManager.canAccess(user, null, orgUnit),
+        trackerAccessManager.canAccess(UserDetails.fromUser(user), null, orgUnit),
         "User should have access to unspecified program");
   }
 
@@ -96,10 +91,8 @@ class DefaultTrackerAccessManagerTest {
     User user = new User();
     OrganisationUnit orgUnit = new OrganisationUnit();
 
-    when(organisationUnitService.isInUserSearchHierarchy(user, orgUnit)).thenReturn(false);
-
     assertFalse(
-        trackerAccessManager.canAccess(user, null, orgUnit),
+        trackerAccessManager.canAccess(UserDetails.fromUser(user), null, orgUnit),
         "User should not have access to unspecified program");
   }
 
@@ -110,10 +103,10 @@ class DefaultTrackerAccessManagerTest {
     program.setAccessLevel(CLOSED);
     OrganisationUnit orgUnit = new OrganisationUnit();
 
-    when(organisationUnitService.isInUserHierarchy(user, orgUnit)).thenReturn(true);
+    user.setOrganisationUnits(Set.of(orgUnit));
 
     assertTrue(
-        trackerAccessManager.canAccess(user, program, orgUnit),
+        trackerAccessManager.canAccess(UserDetails.fromUser(user), program, orgUnit),
         "User should have access to closed program");
   }
 
@@ -124,10 +117,8 @@ class DefaultTrackerAccessManagerTest {
     program.setAccessLevel(CLOSED);
     OrganisationUnit orgUnit = new OrganisationUnit();
 
-    when(organisationUnitService.isInUserHierarchy(user, orgUnit)).thenReturn(false);
-
     assertFalse(
-        trackerAccessManager.canAccess(user, program, orgUnit),
+        trackerAccessManager.canAccess(UserDetails.fromUser(user), program, orgUnit),
         "User should not have access to closed program");
   }
 
@@ -138,10 +129,10 @@ class DefaultTrackerAccessManagerTest {
     program.setAccessLevel(PROTECTED);
     OrganisationUnit orgUnit = new OrganisationUnit();
 
-    when(organisationUnitService.isInUserHierarchy(user, orgUnit)).thenReturn(true);
+    user.setOrganisationUnits(Set.of(orgUnit));
 
     assertTrue(
-        trackerAccessManager.canAccess(user, program, orgUnit),
+        trackerAccessManager.canAccess(UserDetails.fromUser(user), program, orgUnit),
         "User should have access to protected program");
   }
 
@@ -152,10 +143,8 @@ class DefaultTrackerAccessManagerTest {
     program.setAccessLevel(PROTECTED);
     OrganisationUnit orgUnit = new OrganisationUnit();
 
-    when(organisationUnitService.isInUserHierarchy(user, orgUnit)).thenReturn(false);
-
     assertFalse(
-        trackerAccessManager.canAccess(user, program, orgUnit),
+        trackerAccessManager.canAccess(UserDetails.fromUser(user), program, orgUnit),
         "User should not have access to protected program");
   }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/enrollment/AbstractEnrollmentService.java
@@ -255,7 +255,7 @@ public abstract class AbstractEnrollmentService
       Iterable<Enrollment> programInstances) {
     List<org.hisp.dhis.dxf2.deprecated.tracker.enrollment.Enrollment> enrollments =
         new ArrayList<>();
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     for (Enrollment enrollment : programInstances) {
       if (enrollment != null
           && trackerOwnershipAccessManager.hasAccess(
@@ -277,13 +277,16 @@ public abstract class AbstractEnrollmentService
   @Override
   public org.hisp.dhis.dxf2.deprecated.tracker.enrollment.Enrollment getEnrollment(
       Enrollment enrollment, EnrollmentParams params) {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     return getEnrollment(currentUser, enrollment, params, false);
   }
 
   @Override
   public org.hisp.dhis.dxf2.deprecated.tracker.enrollment.Enrollment getEnrollment(
-      User user, Enrollment programInstance, EnrollmentParams params, boolean skipOwnershipCheck) {
+      UserDetails user,
+      Enrollment programInstance,
+      EnrollmentParams params,
+      boolean skipOwnershipCheck) {
     org.hisp.dhis.dxf2.deprecated.tracker.enrollment.Enrollment enrollment =
         new org.hisp.dhis.dxf2.deprecated.tracker.enrollment.Enrollment();
     enrollment.setEnrollment(programInstance.getUid());
@@ -360,7 +363,7 @@ public abstract class AbstractEnrollmentService
     if (params.isIncludeAttributes()) {
       Set<TrackedEntityAttribute> readableAttributes =
           trackedEntityAttributeService.getAllUserReadableTrackedEntityAttributes(
-              UserDetails.fromUser(user), List.of(programInstance.getProgram()), null);
+              user, List.of(programInstance.getProgram()), null);
 
       for (TrackedEntityAttributeValue trackedEntityAttributeValue :
           programInstance.getTrackedEntity().getTrackedEntityAttributeValues()) {
@@ -526,17 +529,17 @@ public abstract class AbstractEnrollmentService
       boolean handleEvents) {
     importOptions = updateImportOptions(importOptions);
 
+    UserDetails user = UserDetails.fromUser(importOptions.getUser());
+
     String storedBy =
         !StringUtils.isEmpty(enrollment.getStoredBy()) && enrollment.getStoredBy().length() < 31
             ? enrollment.getStoredBy()
-            : (importOptions.getUser() == null
-                    || StringUtils.isEmpty(importOptions.getUser().getUsername())
+            : (user == null || StringUtils.isEmpty(user.getUsername())
                 ? "system-process"
-                : importOptions.getUser().getUsername());
+                : user.getUsername());
 
     if (daoTrackedEntity == null) {
-      daoTrackedEntity =
-          getTrackedEntityInstance(enrollment.getTrackedEntityInstance(), importOptions.getUser());
+      daoTrackedEntity = getTrackedEntityInstance(enrollment.getTrackedEntityInstance(), user);
     }
 
     Program program = getProgram(importOptions.getIdSchemes(), enrollment.getProgram());
@@ -553,9 +556,7 @@ public abstract class AbstractEnrollmentService
 
     List<String> errors =
         trackerAccessManager.canCreate(
-            importOptions.getUser(),
-            new Enrollment(program, daoTrackedEntity, organisationUnit),
-            false);
+            user, new Enrollment(program, daoTrackedEntity, organisationUnit), false);
 
     if (!errors.isEmpty()) {
       return new ImportSummary(ImportStatus.ERROR, errors.toString()).incrementIgnored();
@@ -589,20 +590,19 @@ public abstract class AbstractEnrollmentService
         date = new Date();
       }
 
-      String user = enrollment.getCompletedBy();
+      String completedBy = enrollment.getCompletedBy();
 
-      if (user == null) {
-        user = importOptions.getUser().getUsername();
+      if (completedBy == null && user != null) {
+        completedBy = user.getUsername();
       }
 
-      programInstance.setCompletedBy(user);
+      programInstance.setCompletedBy(completedBy);
       programInstance.setCompletedDate(date);
     }
 
-    programInstance.setCreatedByUserInfo(
-        UserInfoSnapshot.from(UserDetails.fromUser(importOptions.getUser())));
-    programInstance.setLastUpdatedByUserInfo(
-        UserInfoSnapshot.from(UserDetails.fromUser(importOptions.getUser())));
+    UserInfoSnapshot snapshot = UserInfoSnapshot.from(user);
+    programInstance.setCreatedByUserInfo(snapshot);
+    programInstance.setLastUpdatedByUserInfo(snapshot);
 
     enrollmentService.addEnrollment(programInstance, importOptions.getUser());
 
@@ -629,10 +629,10 @@ public abstract class AbstractEnrollmentService
     programInstance.setFollowup(enrollment.getFollowup());
     programInstance.setStoredBy(storedBy);
 
-    enrollmentService.updateEnrollment(programInstance, importOptions.getUser());
+    enrollmentService.updateEnrollment(programInstance, user);
     trackerOwnershipAccessManager.assignOwnership(
         daoTrackedEntity, program, organisationUnit, true, true);
-    saveTrackedEntityComment(programInstance, enrollment, importOptions.getUser());
+    saveTrackedEntityComment(programInstance, enrollment, user);
 
     importSummary.setReference(programInstance.getUid());
     enrollment.setEnrollment(programInstance.getUid());
@@ -898,8 +898,8 @@ public abstract class AbstractEnrollmentService
     }
 
     Enrollment programInstance = enrollmentService.getEnrollment(enrollment.getEnrollment());
-    List<String> errors =
-        trackerAccessManager.canUpdate(importOptions.getUser(), programInstance, false);
+    UserDetails currentUser = UserDetails.fromUser(importOptions.getUser());
+    List<String> errors = trackerAccessManager.canUpdate(currentUser, programInstance, false);
 
     if (programInstance == null) {
       return new ImportSummary(
@@ -967,7 +967,7 @@ public abstract class AbstractEnrollmentService
       }
 
       if (user == null) {
-        user = importOptions.getUser().getUsername();
+        user = currentUser.getUsername();
       }
 
       if (EnrollmentStatus.CANCELLED == enrollment.getStatus()) {
@@ -993,13 +993,12 @@ public abstract class AbstractEnrollmentService
     updateAttributeValues(enrollment, importOptions);
     updateDateFields(enrollment, programInstance);
 
-    programInstance.setLastUpdatedByUserInfo(
-        UserInfoSnapshot.from(UserDetails.fromUser(importOptions.getUser())));
+    programInstance.setLastUpdatedByUserInfo(UserInfoSnapshot.from(currentUser));
 
-    enrollmentService.updateEnrollment(programInstance, importOptions.getUser());
-    teiService.updateTrackedEntity(programInstance.getTrackedEntity(), importOptions.getUser());
+    enrollmentService.updateEnrollment(programInstance, currentUser);
+    teiService.updateTrackedEntity(programInstance.getTrackedEntity(), currentUser);
 
-    saveTrackedEntityComment(programInstance, enrollment, importOptions.getUser());
+    saveTrackedEntityComment(programInstance, enrollment, currentUser);
 
     importSummary = new ImportSummary(enrollment.getEnrollment()).incrementUpdated();
     importSummary.setReference(enrollment.getEnrollment());
@@ -1034,7 +1033,7 @@ public abstract class AbstractEnrollmentService
           .incrementIgnored();
     }
 
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     saveTrackedEntityComment(programInstance, enrollment, currentUser);
 
     importSummary.setReference(enrollment.getEnrollment());
@@ -1060,6 +1059,8 @@ public abstract class AbstractEnrollmentService
     ImportSummary importSummary = new ImportSummary();
     importOptions = updateImportOptions(importOptions);
 
+    UserDetails user = UserDetails.fromUser(importOptions.getUser());
+
     boolean existsEnrollment = enrollmentService.enrollmentExists(uid);
 
     if (existsEnrollment) {
@@ -1070,8 +1071,8 @@ public abstract class AbstractEnrollmentService
         importSummary.setEvents(handleEvents(enrollment, programInstance, importOptions));
       }
 
-      if (importOptions.getUser() != null) {
-        isAllowedToDelete(importOptions.getUser(), programInstance, importSummary);
+      if (user != null) {
+        isAllowedToDelete(user, programInstance, importSummary);
 
         if (importSummary.hasConflicts()) {
           importSummary.setStatus(ImportStatus.ERROR);
@@ -1081,11 +1082,11 @@ public abstract class AbstractEnrollmentService
         }
       }
 
-      programInstance.setLastUpdatedByUserInfo(UserInfoSnapshot.from(importOptions.getUser()));
+      programInstance.setLastUpdatedByUserInfo(UserInfoSnapshot.from(user));
       enrollmentService.deleteEnrollment(programInstance);
 
       TrackedEntity entity = programInstance.getTrackedEntity();
-      entity.setLastUpdatedByUserInfo(UserInfoSnapshot.from(importOptions.getUser()));
+      entity.setLastUpdatedByUserInfo(UserInfoSnapshot.from(user));
 
       teiService.updateTrackedEntity(entity);
 
@@ -1341,7 +1342,8 @@ public abstract class AbstractEnrollmentService
       validateAttributeType(attribute, importOptions, importConflicts);
     }
 
-    List<String> errors = trackerAccessManager.canRead(importOptions.getUser(), trackedEntity);
+    UserDetails user = UserDetails.fromUser(importOptions.getUser());
+    List<String> errors = trackerAccessManager.canRead(user, trackedEntity);
 
     if (!errors.isEmpty()) {
       throw new IllegalQueryException(errors.toString());
@@ -1448,6 +1450,7 @@ public abstract class AbstractEnrollmentService
       attributeValueMap.put(attribute.getAttribute(), attribute);
     }
 
+    UserDetails user = UserDetails.fromUser(importOptions.getUser());
     trackedEntity.getTrackedEntityAttributeValues().stream()
         .filter(value -> attributeValueMap.containsKey(value.getAttribute().getUid()))
         .forEach(
@@ -1456,10 +1459,9 @@ public abstract class AbstractEnrollmentService
 
               String newValue = enrollmentAttribute.getValue();
               value.setValue(newValue);
-              value.setStoredBy(getStoredBy(enrollmentAttribute, importOptions.getUser()));
+              value.setStoredBy(getStoredBy(enrollmentAttribute, user));
 
-              trackedEntityAttributeValueService.updateTrackedEntityAttributeValue(
-                  value, importOptions.getUser());
+              trackedEntityAttributeValueService.updateTrackedEntityAttributeValue(value, user);
 
               attributeValueMap.remove(value.getAttribute().getUid());
             });
@@ -1474,7 +1476,7 @@ public abstract class AbstractEnrollmentService
 
         value.setValue(enrollmentAttribute.getValue());
         value.setAttribute(attribute);
-        value.setStoredBy(getStoredBy(enrollmentAttribute, importOptions.getUser()));
+        value.setStoredBy(getStoredBy(enrollmentAttribute, user));
 
         trackedEntityAttributeValueService.addTrackedEntityAttributeValue(value);
         trackedEntity.addAttributeValue(value);
@@ -1482,7 +1484,7 @@ public abstract class AbstractEnrollmentService
     }
   }
 
-  private String getStoredBy(Attribute attribute, User user) {
+  private String getStoredBy(Attribute attribute, UserDetails user) {
     if (!StringUtils.isEmpty(attribute.getStoredBy())) {
       return attribute.getStoredBy();
     }
@@ -1490,7 +1492,7 @@ public abstract class AbstractEnrollmentService
     return User.username(user, Constants.UNKNOWN);
   }
 
-  private TrackedEntity getTrackedEntityInstance(String teiUID, User user) {
+  private TrackedEntity getTrackedEntityInstance(String teiUID, UserDetails user) {
     TrackedEntity entityInstance = teiService.getTrackedEntity(teiUID, user);
 
     if (entityInstance == null) {
@@ -1521,7 +1523,7 @@ public abstract class AbstractEnrollmentService
   private void saveTrackedEntityComment(
       Enrollment programInstance,
       org.hisp.dhis.dxf2.deprecated.tracker.enrollment.Enrollment enrollment,
-      User user) {
+      UserDetails user) {
     for (Note note : enrollment.getNotes()) {
       String noteUid =
           CodeGenerator.isValidUid(note.getNote()) ? note.getNote() : CodeGenerator.generateUid();
@@ -1541,7 +1543,8 @@ public abstract class AbstractEnrollmentService
 
         comment.setCreated(created);
 
-        comment.setLastUpdatedBy(user);
+        // TODO is this needed here?
+        comment.setLastUpdatedBy(userService.getUser(user.getUid()));
         comment.setLastUpdated(new Date());
 
         commentService.addNote(comment);
@@ -1629,7 +1632,7 @@ public abstract class AbstractEnrollmentService
     importOptions.setUser(userService.getUser(importOptions.getUser().getUid()));
   }
 
-  private void isAllowedToDelete(User user, Enrollment pi, ImportConflicts importConflicts) {
+  private void isAllowedToDelete(UserDetails user, Enrollment pi, ImportConflicts importConflicts) {
 
     Set<Event> notDeletedEvents =
         pi.getEvents().stream().filter(psi -> !psi.isDeleted()).collect(Collectors.toSet());

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/enrollment/EnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/enrollment/EnrollmentService.java
@@ -37,7 +37,7 @@ import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.program.EnrollmentQueryParams;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.trackedentity.TrackedEntity;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -61,7 +61,7 @@ public interface EnrollmentService {
   Enrollment getEnrollment(org.hisp.dhis.program.Enrollment enrollment, EnrollmentParams params);
 
   Enrollment getEnrollment(
-      User user,
+      UserDetails user,
       org.hisp.dhis.program.Enrollment enrollment,
       EnrollmentParams params,
       boolean skipOwnershipCheck);

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/AbstractEventService.java
@@ -551,7 +551,7 @@ public abstract class AbstractEventService
                   () ->
                       organisationUnitService.getOrganisationUnit(trackedEntityOuInfo.orgUnitId()));
 
-      User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+      UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
       if (trackerOwnershipAccessManager.hasAccess(
           currentUser, trackedEntityOuInfo.trackedEntityUid(), ou, program)) {
         eventRows.getEventRows().add(eventRow);
@@ -615,7 +615,7 @@ public abstract class AbstractEventService
       event.setAssignedUserSurname(programStageInstance.getAssignedUser().getSurname());
     }
 
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     OrganisationUnit ou = programStageInstance.getOrganisationUnit();
 
     List<String> errors =
@@ -822,7 +822,7 @@ public abstract class AbstractEventService
       return;
     }
 
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     List<String> errors = trackerAccessManager.canUpdate(currentUser, programStageInstance, false);
 
     if (!errors.isEmpty()) {
@@ -877,7 +877,7 @@ public abstract class AbstractEventService
     if (existsEvent) {
       Event event = eventService.getEvent(uid);
 
-      User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+      UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
       List<String> errors = trackerAccessManager.canDelete(currentUser, event, false);
 
       if (!errors.isEmpty()) {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/delete/validation/DeleteProgramStageInstanceAclCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/delete/validation/DeleteProgramStageInstanceAclCheck.java
@@ -33,7 +33,7 @@ import java.util.List;
 import org.hisp.dhis.dxf2.deprecated.tracker.importer.shared.validation.BaseEventAclCheck;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 
 /**
@@ -42,7 +42,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class DeleteProgramStageInstanceAclCheck extends BaseEventAclCheck {
   @Override
-  public List<String> checkAcl(TrackerAccessManager trackerAccessManager, User user, Event event) {
+  public List<String> checkAcl(
+      TrackerAccessManager trackerAccessManager, UserDetails user, Event event) {
     if (event != null) {
       return trackerAccessManager.canDelete(user, event, true);
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/insert/validation/AttributeOptionComboAclCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/insert/validation/AttributeOptionComboAclCheck.java
@@ -36,6 +36,7 @@ import org.hisp.dhis.dxf2.deprecated.tracker.importer.shared.ImmutableEvent;
 import org.hisp.dhis.dxf2.importsummary.ImportStatus;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 
 /**
@@ -51,7 +52,8 @@ public class AttributeOptionComboAclCheck implements Checker {
     CategoryOptionCombo categoryOptionCombo = ctx.getCategoryOptionComboMap().get(event.getUid());
 
     List<String> errors =
-        trackerAccessManager.canWrite(importOptions.getUser(), categoryOptionCombo);
+        trackerAccessManager.canWrite(
+            UserDetails.fromUser(importOptions.getUser()), categoryOptionCombo);
 
     if (!errors.isEmpty()) {
       importSummary.setStatus(ImportStatus.ERROR);

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/insert/validation/DataValueAclCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/insert/validation/DataValueAclCheck.java
@@ -38,7 +38,7 @@ import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 
 /**
@@ -54,7 +54,7 @@ public class DataValueAclCheck implements Checker {
 
     Map<String, Set<EventDataValue>> eventDataValueMap = ctx.getEventDataValueMap();
 
-    final User user = ctx.getImportOptions().getUser();
+    final UserDetails user = UserDetails.fromUser(ctx.getImportOptions().getUser());
     final ImportSummary importSummary = new ImportSummary();
 
     // Note that here we are passing a Event, which during a

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/insert/validation/EventCreationAclCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/insert/validation/EventCreationAclCheck.java
@@ -31,7 +31,7 @@ import java.util.List;
 import org.hisp.dhis.dxf2.deprecated.tracker.importer.shared.validation.BaseEventAclCheck;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 
 /**
@@ -40,7 +40,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class EventCreationAclCheck extends BaseEventAclCheck {
   @Override
-  public List<String> checkAcl(TrackerAccessManager trackerAccessManager, User user, Event event) {
+  public List<String> checkAcl(
+      TrackerAccessManager trackerAccessManager, UserDetails user, Event event) {
     return trackerAccessManager.canCreate(user, event, false);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/shared/validation/BaseEventAclCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/shared/validation/BaseEventAclCheck.java
@@ -38,7 +38,7 @@ import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 
 /**
  * @author Luciano Fiandesio
@@ -49,11 +49,9 @@ public abstract class BaseEventAclCheck implements Checker {
 
     Event programStageInstance = prepareForAclValidation(ctx, event);
 
+    UserDetails user = UserDetails.fromUser(importOptions.getUser());
     List<String> errors =
-        checkAcl(
-            ctx.getServiceDelegator().getTrackerAccessManager(),
-            importOptions.getUser(),
-            programStageInstance);
+        checkAcl(ctx.getServiceDelegator().getTrackerAccessManager(), user, programStageInstance);
 
     final ImportSummary importSummary = new ImportSummary();
 
@@ -82,5 +80,5 @@ public abstract class BaseEventAclCheck implements Checker {
   }
 
   public abstract List<String> checkAcl(
-      TrackerAccessManager trackerAccessManager, User user, Event event);
+      TrackerAccessManager trackerAccessManager, UserDetails user, Event event);
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/update/validation/UpdateProgramStageInstanceAclCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/importer/update/validation/UpdateProgramStageInstanceAclCheck.java
@@ -31,7 +31,7 @@ import java.util.List;
 import org.hisp.dhis.dxf2.deprecated.tracker.importer.shared.validation.BaseEventAclCheck;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 
 /**
@@ -41,7 +41,7 @@ import org.springframework.stereotype.Component;
 public class UpdateProgramStageInstanceAclCheck extends BaseEventAclCheck {
   @Override
   public List<String> checkAcl(
-      final TrackerAccessManager trackerAccessManager, final User user, final Event event) {
+      final TrackerAccessManager trackerAccessManager, final UserDetails user, final Event event) {
     return trackerAccessManager.canUpdate(user, event, false);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/relationship/AbstractRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/relationship/AbstractRelationshipService.java
@@ -201,7 +201,7 @@ public abstract class AbstractRelationshipService implements RelationshipService
 
     importSummaries.addImportSummaries(addRelationships(create, importOptions));
     importSummaries.addImportSummaries(updateRelationships(update, importOptions));
-    importSummaries.addImportSummaries(deleteRelationships(delete, importOptions));
+    importSummaries.addImportSummaries(deleteRelationships(delete));
 
     if (ImportReportMode.ERRORS == importOptions.getReportMode()) {
       importSummaries.getImportSummaries().removeIf(is -> !is.hasConflicts());
@@ -407,22 +407,13 @@ public abstract class AbstractRelationshipService implements RelationshipService
 
   @Override
   @Transactional
-  public ImportSummary deleteRelationship(String uid) {
-    return deleteRelationship(uid, null);
-  }
-
-  @Override
-  @Transactional
-  public ImportSummaries deleteRelationships(
-      List<Relationship> relationships, ImportOptions importOptions) {
+  public ImportSummaries deleteRelationships(List<Relationship> relationships) {
     ImportSummaries importSummaries = new ImportSummaries();
-    importOptions = updateImportOptions(importOptions);
 
     int counter = 0;
 
     for (Relationship relationship : relationships) {
-      importSummaries.addImportSummary(
-          deleteRelationship(relationship.getRelationship(), importOptions));
+      importSummaries.addImportSummary(deleteRelationship(relationship.getRelationship()));
 
       if (counter % FLUSH_FREQUENCY == 0) {
         clearSession();
@@ -531,9 +522,10 @@ public abstract class AbstractRelationshipService implements RelationshipService
     return relationshipItem;
   }
 
-  private ImportSummary deleteRelationship(String uid, ImportOptions importOptions) {
+  @Override
+  @Transactional
+  public ImportSummary deleteRelationship(String uid) {
     ImportSummary importSummary = new ImportSummary();
-    importOptions = updateImportOptions(importOptions);
 
     if (uid.isEmpty()) {
       importSummary.setStatus(ImportStatus.WARNING);

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/relationship/AbstractRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/relationship/AbstractRelationshipService.java
@@ -119,7 +119,7 @@ public abstract class AbstractRelationshipService implements RelationshipService
       PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
       boolean skipAccessValidation,
       boolean includeDeleted) {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     return relationshipService
         .getRelationshipsByTrackedEntity(tei, pagingAndSortingCriteriaAdapter, includeDeleted)
         .stream()
@@ -138,7 +138,7 @@ public abstract class AbstractRelationshipService implements RelationshipService
       PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
       boolean skipAccessValidation,
       boolean includeDeleted) {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     return relationshipService
         .getRelationshipsByEnrollment(enrollment, pagingAndSortingCriteriaAdapter, includeDeleted)
         .stream()
@@ -157,7 +157,7 @@ public abstract class AbstractRelationshipService implements RelationshipService
       PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
       boolean skipAccessValidation,
       boolean includeDeleted) {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     return relationshipService
         .getRelationshipsByEvent(psi, pagingAndSortingCriteriaAdapter, includeDeleted)
         .stream()
@@ -219,9 +219,10 @@ public abstract class AbstractRelationshipService implements RelationshipService
 
     ImportSummaries importSummaries = new ImportSummaries();
 
+    UserDetails user = UserDetails.fromUser(importOptions.getUser());
     for (List<Relationship> _relationships : partitions) {
       reloadUser(importOptions);
-      prepareCaches(_relationships, importOptions.getUser());
+      prepareCaches(_relationships, user);
 
       for (Relationship relationship : _relationships) {
         importSummaries.addImportSummary(addRelationship(relationship, importOptions));
@@ -239,8 +240,9 @@ public abstract class AbstractRelationshipService implements RelationshipService
     importOptions = updateImportOptions(importOptions);
 
     // Set up cache if not set already
+    UserDetails user = UserDetails.fromUser(importOptions.getUser());
     if (!cacheExists()) {
-      prepareCaches(Lists.newArrayList(relationship), importOptions.getUser());
+      prepareCaches(Lists.newArrayList(relationship), user);
     }
 
     ImportSummary importSummary = new ImportSummary(relationship.getRelationship());
@@ -265,7 +267,7 @@ public abstract class AbstractRelationshipService implements RelationshipService
     }
 
     // Check access for both sides
-    List<String> errors = trackerAccessManager.canWrite(importOptions.getUser(), daoRelationship);
+    List<String> errors = trackerAccessManager.canWrite(user, daoRelationship);
 
     if (!errors.isEmpty()) {
       return new ImportSummary(ImportStatus.ERROR, errors.toString()).incrementIgnored();
@@ -287,9 +289,10 @@ public abstract class AbstractRelationshipService implements RelationshipService
     importOptions = updateImportOptions(importOptions);
     ImportSummaries importSummaries = new ImportSummaries();
 
+    UserDetails user = UserDetails.fromUser(importOptions.getUser());
     for (List<Relationship> _relationships : partitions) {
       reloadUser(importOptions);
-      prepareCaches(_relationships, importOptions.getUser());
+      prepareCaches(_relationships, user);
 
       for (Relationship relationship : _relationships) {
         importSummaries.addImportSummary(updateRelationship(relationship, importOptions));
@@ -306,8 +309,9 @@ public abstract class AbstractRelationshipService implements RelationshipService
     importOptions = updateImportOptions(importOptions);
 
     // Set up cache if not set already
+    UserDetails user = UserDetails.fromUser(importOptions.getUser());
     if (!cacheExists()) {
-      prepareCaches(Lists.newArrayList(relationship), importOptions.getUser());
+      prepareCaches(Lists.newArrayList(relationship), user);
     }
 
     org.hisp.dhis.relationship.Relationship daoRelationship =
@@ -333,7 +337,7 @@ public abstract class AbstractRelationshipService implements RelationshipService
           .incrementIgnored();
     }
 
-    List<String> errors = trackerAccessManager.canWrite(importOptions.getUser(), daoRelationship);
+    List<String> errors = trackerAccessManager.canWrite(user, daoRelationship);
 
     if (!errors.isEmpty() || importSummary.hasConflicts()) {
       importSummary.setStatus(ImportStatus.ERROR);
@@ -439,14 +443,14 @@ public abstract class AbstractRelationshipService implements RelationshipService
       return Optional.empty();
     }
 
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     return getRelationship(relationship, currentUser);
   }
 
   @Override
   @Transactional(readOnly = true)
   public Optional<Relationship> findRelationship(
-      org.hisp.dhis.relationship.Relationship dao, RelationshipParams params, User user) {
+      org.hisp.dhis.relationship.Relationship dao, RelationshipParams params, UserDetails user) {
     List<String> errors = trackerAccessManager.canRead(user, dao);
 
     if (!errors.isEmpty()) {
@@ -472,7 +476,7 @@ public abstract class AbstractRelationshipService implements RelationshipService
   }
 
   private Optional<Relationship> getRelationship(
-      org.hisp.dhis.relationship.Relationship dao, User user) {
+      org.hisp.dhis.relationship.Relationship dao, UserDetails user) {
     return findRelationship(dao, RelationshipParams.TRUE, user);
   }
 
@@ -543,7 +547,8 @@ public abstract class AbstractRelationshipService implements RelationshipService
     if (daoRelationship != null) {
       importSummary.setReference(uid);
 
-      List<String> errors = trackerAccessManager.canWrite(importOptions.getUser(), daoRelationship);
+      UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
+      List<String> errors = trackerAccessManager.canWrite(currentUser, daoRelationship);
 
       if (!errors.isEmpty()) {
         importSummary.setDescription(errors.toString());
@@ -753,7 +758,7 @@ public abstract class AbstractRelationshipService implements RelationshipService
     return !relationshipTypeCache.isEmpty();
   }
 
-  private void prepareCaches(List<Relationship> relationships, User user) {
+  private void prepareCaches(List<Relationship> relationships, UserDetails user) {
     Map<RelationshipEntity, List<String>> relationshipEntities = new HashMap<>();
     Map<String, List<Relationship>> relationshipTypeMap =
         relationships.stream().collect(Collectors.groupingBy(Relationship::getRelationshipType));
@@ -761,7 +766,7 @@ public abstract class AbstractRelationshipService implements RelationshipService
     // Find all the RelationshipTypes first, so we know what the uids refer
     // to
     Query query = Query.from(schemaService.getDynamicSchema(RelationshipType.class));
-    query.setCurrentUserDetails(UserDetails.fromUser(user));
+    query.setCurrentUserDetails(user);
     query.add(Restrictions.in("id", relationshipTypeMap.keySet()));
     queryService
         .query(query)
@@ -804,7 +809,7 @@ public abstract class AbstractRelationshipService implements RelationshipService
 
     if (relationshipEntities.get(PROGRAM_INSTANCE) != null) {
       Query piQuery = Query.from(schemaService.getDynamicSchema(Enrollment.class));
-      piQuery.setCurrentUserDetails(UserDetails.fromUser(user));
+      piQuery.setCurrentUserDetails(user);
       piQuery.add(Restrictions.in("id", relationshipEntities.get(PROGRAM_INSTANCE)));
       queryService
           .query(piQuery)
@@ -813,7 +818,7 @@ public abstract class AbstractRelationshipService implements RelationshipService
 
     if (relationshipEntities.get(PROGRAM_STAGE_INSTANCE) != null) {
       Query psiQuery = Query.from(schemaService.getDynamicSchema(Event.class));
-      psiQuery.setCurrentUserDetails(UserDetails.fromUser(user));
+      psiQuery.setCurrentUserDetails(user);
       psiQuery.add(Restrictions.in("id", relationshipEntities.get(PROGRAM_STAGE_INSTANCE)));
       queryService
           .query(psiQuery)

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/relationship/RelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/relationship/RelationshipService.java
@@ -109,8 +109,7 @@ public interface RelationshipService {
 
   ImportSummary deleteRelationship(String uid);
 
-  ImportSummaries deleteRelationships(
-      List<Relationship> relationships, ImportOptions importOptions);
+  ImportSummaries deleteRelationships(List<Relationship> relationships);
 
   Optional<Relationship> findRelationshipByUid(String id);
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/relationship/RelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/relationship/RelationshipService.java
@@ -39,7 +39,7 @@ import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.trackedentity.TrackedEntity;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
 
 /**
@@ -119,7 +119,7 @@ public interface RelationshipService {
   // -------------------------------------------------------------------------
 
   Optional<Relationship> findRelationship(
-      org.hisp.dhis.relationship.Relationship dao, RelationshipParams params, User user);
+      org.hisp.dhis.relationship.Relationship dao, RelationshipParams params, UserDetails user);
 
   ImportSummaries processRelationshipList(
       List<Relationship> relationships, ImportOptions importOptions);

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -266,14 +266,14 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
   @Transactional(readOnly = true)
   public TrackedEntityInstance getTrackedEntityInstance(
       TrackedEntity daoTrackedEntity, TrackedEntityInstanceParams params) {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     return getTrackedEntityInstance(daoTrackedEntity, params, currentUser);
   }
 
   @Override
   @Transactional(readOnly = true)
   public TrackedEntityInstance getTrackedEntityInstance(
-      TrackedEntity daoTrackedEntity, TrackedEntityInstanceParams params, User user) {
+      TrackedEntity daoTrackedEntity, TrackedEntityInstanceParams params, UserDetails user) {
     if (daoTrackedEntity == null) {
       return null;
     }
@@ -285,8 +285,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
     }
 
     Set<TrackedEntityAttribute> readableAttributes =
-        trackedEntityAttributeService.getAllUserReadableTrackedEntityAttributes(
-            user == null ? null : UserDetails.fromUser(user));
+        trackedEntityAttributeService.getAllUserReadableTrackedEntityAttributes(user);
 
     return getTei(daoTrackedEntity, readableAttributes, params, user);
   }
@@ -554,9 +553,10 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
 
     List<List<TrackedEntityInstance>> partitions = Lists.partition(validTeis, FLUSH_FREQUENCY);
 
+    UserDetails user = UserDetails.fromUser(importOptions.getUser());
     for (List<TrackedEntityInstance> _trackedEntityInstances : partitions) {
       reloadUser(importOptions);
-      prepareCaches(_trackedEntityInstances, importOptions.getUser());
+      prepareCaches(_trackedEntityInstances, user);
 
       for (TrackedEntityInstance trackedEntityInstance : _trackedEntityInstances) {
         ImportSummary importSummary =
@@ -671,7 +671,8 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
       return importSummary;
     }
 
-    List<String> errors = trackerAccessManager.canWrite(importOptions.getUser(), daoEntityInstance);
+    UserDetails user = UserDetails.fromUser(importOptions.getUser());
+    List<String> errors = trackerAccessManager.canWrite(user, daoEntityInstance);
 
     if (!errors.isEmpty()) {
       return new ImportSummary(ImportStatus.ERROR, errors.toString()).incrementIgnored();
@@ -679,7 +680,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
 
     teiService.addTrackedEntity(daoEntityInstance);
 
-    addAttributeValues(dtoEntityInstance, daoEntityInstance, importOptions.getUser());
+    addAttributeValues(dtoEntityInstance, daoEntityInstance, user);
 
     importSummary.setReference(daoEntityInstance.getUid());
     importSummary.getImportCount().incrementImported();
@@ -711,9 +712,10 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
     List<org.hisp.dhis.dxf2.deprecated.tracker.enrollment.Enrollment> enrollments =
         new ArrayList<>();
 
+    UserDetails user = UserDetails.fromUser(importOptions.getUser());
     for (List<TrackedEntityInstance> _trackedEntityInstances : partitions) {
       reloadUser(importOptions);
-      prepareCaches(_trackedEntityInstances, importOptions.getUser());
+      prepareCaches(_trackedEntityInstances, user);
 
       for (TrackedEntityInstance trackedEntityInstance : _trackedEntityInstances) {
         ImportSummary importSummary =
@@ -759,10 +761,10 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
 
     checkAttributes(dtoEntityInstance, importOptions, importSummary, true);
 
+    UserDetails user = UserDetails.fromUser(importOptions.getUser());
     TrackedEntity daoEntityInstance =
-        teiService.getTrackedEntity(
-            dtoEntityInstance.getTrackedEntityInstance(), importOptions.getUser());
-    List<String> errors = trackerAccessManager.canWrite(importOptions.getUser(), daoEntityInstance);
+        teiService.getTrackedEntity(dtoEntityInstance.getTrackedEntityInstance(), user);
+    List<String> errors = trackerAccessManager.canWrite(user, daoEntityInstance);
     OrganisationUnit organisationUnit =
         getOrganisationUnit(importOptions.getIdSchemes(), dtoEntityInstance.getOrgUnit());
     Program program = getProgram(importOptions.getIdSchemes(), programId);
@@ -794,8 +796,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
     daoEntityInstance.setOrganisationUnit(organisationUnit);
     daoEntityInstance.setInactive(dtoEntityInstance.isInactive());
     daoEntityInstance.setPotentialDuplicate(dtoEntityInstance.isPotentialDuplicate());
-    daoEntityInstance.setLastUpdatedByUserInfo(
-        UserInfoSnapshot.from(UserDetails.fromUser(importOptions.getUser())));
+    daoEntityInstance.setLastUpdatedByUserInfo(UserInfoSnapshot.from(user));
 
     if (dtoEntityInstance.getGeometry() != null) {
       FeatureType featureType = daoEntityInstance.getTrackedEntityType().getFeatureType();
@@ -829,7 +830,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
     }
 
     if (!importOptions.isIgnoreEmptyCollection() || !dtoEntityInstance.getAttributes().isEmpty()) {
-      updateAttributeValues(dtoEntityInstance, daoEntityInstance, program, importOptions.getUser());
+      updateAttributeValues(dtoEntityInstance, daoEntityInstance, program, user);
     }
 
     updateDateFields(dtoEntityInstance, daoEntityInstance);
@@ -893,8 +894,9 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
             handleEnrollments(dtoEntityInstance, daoEntityInstance, importOptions));
       }
 
-      if (importOptions.getUser() != null) {
-        isAllowedToDelete(importOptions.getUser(), daoEntityInstance, importSummary);
+      UserDetails user = UserDetails.fromUser(importOptions.getUser());
+      if (user != null) {
+        isAllowedToDelete(user, daoEntityInstance, importSummary);
 
         if (importSummary.hasConflicts()) {
           importSummary.setStatus(ImportStatus.ERROR);
@@ -904,7 +906,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
         }
       }
 
-      daoEntityInstance.setLastUpdatedByUserInfo(UserInfoSnapshot.from(importOptions.getUser()));
+      daoEntityInstance.setLastUpdatedByUserInfo(UserInfoSnapshot.from(user));
       teiService.deleteTrackedEntity(daoEntityInstance);
 
       importSummary.setStatus(ImportStatus.SUCCESS);
@@ -1016,14 +1018,14 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
             .map(Relationship::getRelationship)
             .collect(Collectors.toList());
 
+    UserDetails currentUser = UserDetails.fromUser(importOptions.getUser());
     List<Relationship> delete =
         daoEntityInstance.getRelationshipItems().stream()
             .map(RelationshipItem::getRelationship)
 
             // Remove items we cant write to
             .filter(
-                relationship ->
-                    trackerAccessManager.canWrite(importOptions.getUser(), relationship).isEmpty())
+                relationship -> trackerAccessManager.canWrite(currentUser, relationship).isEmpty())
             .filter(relationship -> isTeiPartOfRelationship(relationship, daoEntityInstance))
             .map(org.hisp.dhis.relationship.Relationship::getUid)
 
@@ -1153,7 +1155,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
     return importSummaries;
   }
 
-  private void prepareCaches(List<TrackedEntityInstance> trackedEntityInstances, User user) {
+  private void prepareCaches(List<TrackedEntityInstance> trackedEntityInstances, UserDetails user) {
     Collection<String> orgUnits =
         trackedEntityInstances.stream()
             .map(TrackedEntityInstance::getOrgUnit)
@@ -1161,7 +1163,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
 
     if (!orgUnits.isEmpty()) {
       Query query = Query.from(schemaService.getDynamicSchema(OrganisationUnit.class));
-      query.setCurrentUserDetails(UserDetails.fromUser(user));
+      query.setCurrentUserDetails(user);
       query.add(Restrictions.in("id", orgUnits));
       queryService
           .query(query)
@@ -1174,7 +1176,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
 
     if (!trackedEntityAttributes.isEmpty()) {
       Query query = Query.from(schemaService.getDynamicSchema(TrackedEntityAttribute.class));
-      query.setCurrentUserDetails(UserDetails.fromUser(user));
+      query.setCurrentUserDetails(user);
       query.add(Restrictions.in("id", trackedEntityAttributes));
       queryService
           .query(query)
@@ -1187,7 +1189,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
       TrackedEntityInstance dtoEntityInstance,
       TrackedEntity daoEntityInstance,
       Program program,
-      User user) {
+      UserDetails user) {
     Set<String> incomingAttributes = new HashSet<>();
     Map<String, TrackedEntityAttributeValue> teiAttributeToValueMap =
         getTeiAttributeValueMap(
@@ -1249,7 +1251,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
   }
 
   private void addAttributeValues(
-      TrackedEntityInstance dtoEntityInstance, TrackedEntity daoEntityInstance, User user) {
+      TrackedEntityInstance dtoEntityInstance, TrackedEntity daoEntityInstance, UserDetails user) {
     for (Attribute dtoAttribute : dtoEntityInstance.getAttributes()) {
       TrackedEntityAttribute daoEntityAttribute =
           trackedEntityAttributeService.getTrackedEntityAttribute(dtoAttribute.getAttribute());
@@ -1373,9 +1375,9 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
     TrackedEntity daoEntityInstance = null;
 
     if (teiExistsInDatabase) {
+      UserDetails user = UserDetails.fromUser(importOptions.getUser());
       daoEntityInstance =
-          teiService.getTrackedEntity(
-              dtoEntityInstance.getTrackedEntityInstance(), importOptions.getUser());
+          teiService.getTrackedEntity(dtoEntityInstance.getTrackedEntityInstance(), user);
 
       if (daoEntityInstance == null) {
         return;
@@ -1546,7 +1548,8 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
     importOptions.setUser(userService.getUser(importOptions.getUser().getUid()));
   }
 
-  private void isAllowedToDelete(User user, TrackedEntity tei, ImportConflicts importConflicts) {
+  private void isAllowedToDelete(
+      UserDetails user, TrackedEntity tei, ImportConflicts importConflicts) {
     Set<Enrollment> enrollments =
         tei.getEnrollments().stream().filter(pi -> !pi.isDeleted()).collect(Collectors.toSet());
 
@@ -1570,7 +1573,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
       TrackedEntity daoTrackedEntity,
       Set<TrackedEntityAttribute> readableAttributes,
       TrackedEntityInstanceParams params,
-      User user) {
+      UserDetails user) {
     if (daoTrackedEntity == null) {
       return null;
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -1078,8 +1078,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
     importSummaries.addImportSummaries(relationshipService.addRelationships(create, importOptions));
     importSummaries.addImportSummaries(
         relationshipService.updateRelationships(update, importOptions));
-    importSummaries.addImportSummaries(
-        relationshipService.deleteRelationships(delete, importOptions));
+    importSummaries.addImportSummaries(relationshipService.deleteRelationships(delete));
 
     return importSummaries;
   }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/trackedentity/TrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/trackedentity/TrackedEntityInstanceService.java
@@ -39,7 +39,7 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityQueryParams;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -91,7 +91,7 @@ public interface TrackedEntityInstanceService {
       TrackedEntity entityInstance, TrackedEntityInstanceParams params);
 
   TrackedEntityInstance getTrackedEntityInstance(
-      TrackedEntity entityInstance, TrackedEntityInstanceParams params, User user);
+      TrackedEntity entityInstance, TrackedEntityInstanceParams params, UserDetails user);
 
   List<TrackedEntityOuInfo> getTrackedEntityOuInfoByUid(List<String> uids);
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/TrackerCrudTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/TrackerCrudTest.java
@@ -140,7 +140,7 @@ class TrackerCrudTest {
     when(notifier.notify(any(JobConfiguration.class), anyString())).thenReturn(notifier);
     when(notifier.clear(any())).thenReturn(notifier);
 
-    when(defaultTrackedEntityInstanceService.getTrackedEntity(trackedEntityInstanceUid, user))
+    when(defaultTrackedEntityInstanceService.getTrackedEntity(trackedEntityInstanceUid, any()))
         .thenReturn(new TrackedEntity());
     when(defaultTrackedEntityInstanceService.getTrackedEntity(trackedEntityInstanceUid))
         .thenReturn(new TrackedEntity());
@@ -240,7 +240,7 @@ class TrackerCrudTest {
             .anyMatch(is -> is.isStatus(ImportStatus.ERROR)));
 
     verify(defaultTrackedEntityInstanceService, times(1))
-        .getTrackedEntity(trackedEntityInstanceUid, user);
+        .getTrackedEntity(trackedEntityInstanceUid, any());
     verify(defaultTrackedEntityInstanceService, times(1)).updateTrackedEntity(any());
   }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/TrackerCrudTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/TrackerCrudTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.dxf2.deprecated.tracker;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
@@ -140,7 +141,7 @@ class TrackerCrudTest {
     when(notifier.notify(any(JobConfiguration.class), anyString())).thenReturn(notifier);
     when(notifier.clear(any())).thenReturn(notifier);
 
-    when(defaultTrackedEntityInstanceService.getTrackedEntity(trackedEntityInstanceUid, any()))
+    when(defaultTrackedEntityInstanceService.getTrackedEntity(eq(trackedEntityInstanceUid), any()))
         .thenReturn(new TrackedEntity());
     when(defaultTrackedEntityInstanceService.getTrackedEntity(trackedEntityInstanceUid))
         .thenReturn(new TrackedEntity());
@@ -240,7 +241,7 @@ class TrackerCrudTest {
             .anyMatch(is -> is.isStatus(ImportStatus.ERROR)));
 
     verify(defaultTrackedEntityInstanceService, times(1))
-        .getTrackedEntity(trackedEntityInstanceUid, any());
+        .getTrackedEntity(eq(trackedEntityInstanceUid), any());
     verify(defaultTrackedEntityInstanceService, times(1)).updateTrackedEntity(any());
   }
 

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/SupplementaryDataProviderTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/SupplementaryDataProviderTest.java
@@ -37,7 +37,6 @@ import com.google.common.collect.Sets;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
@@ -96,7 +95,7 @@ class SupplementaryDataProviderTest extends DhisConvenienceTest {
     Map<String, List<String>> supplementaryData =
         providerToTest.getSupplementaryData(getProgramRules());
     assertFalse(supplementaryData.isEmpty());
-    assertEquals(getUserRoleUids(), supplementaryData.get("USER"));
+    assertEquals(getUserRoleUids(), Set.copyOf(supplementaryData.get("USER")));
     assertFalse(supplementaryData.get(ORG_UNIT_GROUP_UID).isEmpty());
     assertEquals(orgUnitA.getUid(), supplementaryData.get(ORG_UNIT_GROUP_UID).get(0));
     assertNull(supplementaryData.get(NOT_NEEDED_ORG_UNIT_GROUP_UID));
@@ -108,8 +107,8 @@ class SupplementaryDataProviderTest extends DhisConvenienceTest {
     return Lists.newArrayList(programRule);
   }
 
-  private List<String> getUserRoleUids() {
-    return getUserRoles().stream().map(UserRole::getUid).collect(Collectors.toList());
+  private Set<String> getUserRoleUids() {
+    return Set.copyOf(getUserRoles().stream().map(UserRole::getUid).toList());
   }
 
   private Set<UserRole> getUserRoles() {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -52,9 +52,7 @@ import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
 import org.hisp.dhis.user.CurrentUserUtil;
-import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
-import org.hisp.dhis.user.UserService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -69,8 +67,6 @@ class DefaultEnrollmentService
 
   private final TrackedEntityAttributeService trackedEntityAttributeService;
 
-  private final UserService userService;
-
   private final TrackerAccessManager trackerAccessManager;
 
   private final EnrollmentOperationParamsMapper paramsMapper;
@@ -84,7 +80,7 @@ class DefaultEnrollmentService
       throw new NotFoundException(Enrollment.class, uid);
     }
 
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     List<String> errors = trackerAccessManager.canRead(currentUser, enrollment, false);
 
     if (!errors.isEmpty()) {
@@ -99,7 +95,7 @@ class DefaultEnrollmentService
       @Nonnull Enrollment enrollment,
       EnrollmentParams params,
       boolean includeDeleted,
-      User currentUser) {
+      UserDetails currentUser) {
 
     Enrollment result = new Enrollment();
     result.setId(enrollment.getId());
@@ -138,13 +134,13 @@ class DefaultEnrollmentService
       result
           .getTrackedEntity()
           .setTrackedEntityAttributeValues(
-              getTrackedEntityAttributeValues(UserDetails.fromUser(currentUser), enrollment));
+              getTrackedEntityAttributeValues(currentUser, enrollment));
     }
 
     return result;
   }
 
-  private Set<Event> getEvents(User user, Enrollment enrollment, boolean includeDeleted) {
+  private Set<Event> getEvents(UserDetails user, Enrollment enrollment, boolean includeDeleted) {
     Set<Event> events = new HashSet<>();
 
     for (Event event : enrollment.getEvents()) {
@@ -157,7 +153,7 @@ class DefaultEnrollmentService
   }
 
   private Set<RelationshipItem> getRelationshipItems(
-      User user, Enrollment enrollment, boolean includeDeleted) {
+      UserDetails user, Enrollment enrollment, boolean includeDeleted) {
     Set<RelationshipItem> relationshipItems = new HashSet<>();
 
     for (RelationshipItem relationshipItem : enrollment.getRelationshipItems()) {
@@ -221,7 +217,7 @@ class DefaultEnrollmentService
       boolean includeDeleted,
       OrganisationUnitSelectionMode orgUnitMode) {
     List<Enrollment> enrollmentList = new ArrayList<>();
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
 
     for (Enrollment enrollment : enrollments) {
       if (enrollment != null

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
@@ -35,14 +35,14 @@ import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
-import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 
 public interface EnrollmentService {
   Enrollment getEnrollment(String uid, EnrollmentParams params, boolean includeDeleted)
       throws NotFoundException, ForbiddenException;
 
   Enrollment getEnrollment(
-      Enrollment enrollment, EnrollmentParams params, boolean includeDeleted, User user)
+      Enrollment enrollment, EnrollmentParams params, boolean includeDeleted, UserDetails user)
       throws ForbiddenException;
 
   /** Get all enrollments matching given params. */

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventChangeLogService.java
@@ -37,8 +37,7 @@ import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
 import org.hisp.dhis.user.CurrentUserUtil;
-import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,8 +52,6 @@ public class DefaultEventChangeLogService implements EventChangeLogService {
 
   private final TrackerAccessManager trackerAccessManager;
 
-  private final UserService userService;
-
   @Override
   public Page<EventChangeLog> getEventChangeLog(
       UID eventUid, EventChangeLogOperationParams operationParams, PageParams pageParams)
@@ -64,7 +61,7 @@ public class DefaultEventChangeLogService implements EventChangeLogService {
       throw new NotFoundException(Event.class, eventUid.getValue());
     }
 
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     List<String> errors = trackerAccessManager.canRead(currentUser, event, false);
     if (!errors.isEmpty()) {
       throw new NotFoundException(Event.class, eventUid.getValue());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -52,8 +52,7 @@ import org.hisp.dhis.tracker.export.FileResourceStream;
 import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
 import org.hisp.dhis.user.CurrentUserUtil;
-import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -65,8 +64,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 class DefaultEventService implements EventService {
-
-  private final UserService userService;
 
   private final EventStore eventStore;
 
@@ -111,7 +108,7 @@ class DefaultEventService implements EventService {
           "Data element " + dataElementUid.getValue() + " is not a file (or image).");
     }
 
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     List<String> errors = trackerAccessManager.canRead(currentUser, event, dataElement, false);
     if (!errors.isEmpty()) {
       throw new NotFoundException(DataElement.class, dataElementUid.getValue());
@@ -145,7 +142,7 @@ class DefaultEventService implements EventService {
   }
 
   public Event getEvent(@Nonnull Event event, EventParams eventParams) throws ForbiddenException {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     List<String> errors = trackerAccessManager.canRead(currentUser, event, false);
     if (!errors.isEmpty()) {
       throw new ForbiddenException(errors.toString());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -43,8 +43,7 @@ import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
 import org.hisp.dhis.user.CurrentUserUtil;
-import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,12 +52,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DefaultRelationshipService implements RelationshipService {
 
-  private final UserService userService;
-
   private final TrackerAccessManager trackerAccessManager;
-
   private final RelationshipStore relationshipStore;
-
   private final RelationshipOperationParamsMapper mapper;
 
   @Override
@@ -86,7 +81,7 @@ public class DefaultRelationshipService implements RelationshipService {
       throw new NotFoundException(Relationship.class, uid);
     }
 
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     List<String> errors = trackerAccessManager.canRead(currentUser, relationship);
     if (!errors.isEmpty()) {
       throw new ForbiddenException(errors.toString());
@@ -97,7 +92,7 @@ public class DefaultRelationshipService implements RelationshipService {
 
   public List<Relationship> getRelationshipsByTrackedEntity(
       TrackedEntity trackedEntity, RelationshipQueryParams queryParams) {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     List<Relationship> relationships =
         relationshipStore.getByTrackedEntity(trackedEntity, queryParams).stream()
             .filter(r -> trackerAccessManager.canRead(currentUser, r).isEmpty())
@@ -107,7 +102,7 @@ public class DefaultRelationshipService implements RelationshipService {
 
   public Page<Relationship> getRelationshipsByTrackedEntity(
       TrackedEntity trackedEntity, RelationshipQueryParams queryParams, PageParams pageParams) {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     Page<Relationship> relationshipPage =
         relationshipStore.getByTrackedEntity(trackedEntity, queryParams, pageParams);
     List<Relationship> relationships =
@@ -119,7 +114,7 @@ public class DefaultRelationshipService implements RelationshipService {
 
   public List<Relationship> getRelationshipsByEnrollment(
       Enrollment enrollment, RelationshipQueryParams queryParams) {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     List<Relationship> relationships =
         relationshipStore.getByEnrollment(enrollment, queryParams).stream()
             .filter(r -> trackerAccessManager.canRead(currentUser, r).isEmpty())
@@ -129,7 +124,7 @@ public class DefaultRelationshipService implements RelationshipService {
 
   public Page<Relationship> getRelationshipsByEnrollment(
       Enrollment enrollment, RelationshipQueryParams queryParams, PageParams pageParams) {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     Page<Relationship> relationshipPage =
         relationshipStore.getByEnrollment(enrollment, queryParams, pageParams);
     List<Relationship> relationships =
@@ -141,7 +136,7 @@ public class DefaultRelationshipService implements RelationshipService {
 
   public List<Relationship> getRelationshipsByEvent(
       Event event, RelationshipQueryParams queryParams) {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     List<Relationship> relationships =
         relationshipStore.getByEvent(event, queryParams).stream()
             .filter(r -> trackerAccessManager.canRead(currentUser, r).isEmpty())
@@ -151,7 +146,7 @@ public class DefaultRelationshipService implements RelationshipService {
 
   public Page<Relationship> getRelationshipsByEvent(
       Event event, RelationshipQueryParams queryParams, PageParams pageParams) {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     Page<Relationship> relationshipPage =
         relationshipStore.getByEvent(event, queryParams, pageParams);
     List<Relationship> relationships =

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapper.java
@@ -40,8 +40,7 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.user.CurrentUserUtil;
-import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,20 +53,15 @@ import org.springframework.transaction.annotation.Transactional;
 class RelationshipOperationParamsMapper {
 
   private final TrackedEntityService trackedEntityService;
-
   private final EnrollmentService enrollmentService;
-
   private final EventService eventService;
-
   private final TrackerAccessManager accessManager;
-
-  private final UserService userService;
 
   @Transactional(readOnly = true)
   public RelationshipQueryParams map(RelationshipOperationParams params)
       throws NotFoundException, ForbiddenException {
 
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
 
     IdentifiableObject entity =
         switch (params.getType()) {
@@ -84,7 +78,7 @@ class RelationshipOperationParamsMapper {
         .build();
   }
 
-  private TrackedEntity validateTrackedEntity(User user, String uid)
+  private TrackedEntity validateTrackedEntity(UserDetails user, String uid)
       throws NotFoundException, ForbiddenException {
     TrackedEntity trackedEntity = trackedEntityService.getTrackedEntity(uid);
     if (trackedEntity == null) {
@@ -99,7 +93,7 @@ class RelationshipOperationParamsMapper {
     return trackedEntity;
   }
 
-  private Enrollment validateEnrollment(User user, String uid)
+  private Enrollment validateEnrollment(UserDetails user, String uid)
       throws NotFoundException, ForbiddenException {
     Enrollment enrollment = enrollmentService.getEnrollment(uid);
     if (enrollment == null) {
@@ -114,7 +108,8 @@ class RelationshipOperationParamsMapper {
     return enrollment;
   }
 
-  private Event validateEvent(User user, String uid) throws NotFoundException, ForbiddenException {
+  private Event validateEvent(UserDetails user, String uid)
+      throws NotFoundException, ForbiddenException {
     Event event = eventService.getEvent(uid);
     if (event == null) {
       throw new NotFoundException(Event.class, uid);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityChangeLogService.java
@@ -39,14 +39,12 @@ import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
-import org.hisp.dhis.trackedentity.TrackedEntityProgramOwnerService;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
 import org.hisp.dhis.user.CurrentUserUtil;
-import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,13 +57,9 @@ public class DefaultTrackedEntityChangeLogService implements TrackedEntityChange
 
   private final ProgramService programService;
 
-  private final TrackedEntityProgramOwnerService trackedEntityProgramOwnerService;
-
   private final TrackedEntityAttributeService trackedEntityAttributeService;
 
   private final TrackerAccessManager trackerAccessManager;
-
-  private final UserService userService;
 
   private final JdbcTrackedEntityChangeLogStore jdbcTrackedEntityChangeLogStore;
 
@@ -82,7 +76,7 @@ public class DefaultTrackedEntityChangeLogService implements TrackedEntityChange
       throw new NotFoundException(TrackedEntity.class, trackedEntityUid.getValue());
     }
 
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     Set<String> trackedEntityAttributes = Collections.emptySet();
     if (programUid != null) {
       Program program = validateProgram(programUid.getValue());
@@ -114,7 +108,8 @@ public class DefaultTrackedEntityChangeLogService implements TrackedEntityChange
     return program;
   }
 
-  private void validateOwnership(User currentUser, TrackedEntity trackedEntity, Program program)
+  private void validateOwnership(
+      UserDetails currentUser, TrackedEntity trackedEntity, Program program)
       throws NotFoundException {
     if (!trackerAccessManager
         .canRead(currentUser, trackedEntity, program, currentUser.isSuper())
@@ -123,7 +118,7 @@ public class DefaultTrackedEntityChangeLogService implements TrackedEntityChange
     }
   }
 
-  private void validateTrackedEntity(User currentUser, TrackedEntity trackedEntity)
+  private void validateTrackedEntity(UserDetails currentUser, TrackedEntity trackedEntity)
       throws NotFoundException {
     if (!trackerAccessManager.canRead(currentUser, trackedEntity).isEmpty()) {
       throw new NotFoundException(TrackedEntity.class, trackedEntity.getUid());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -75,7 +75,7 @@ import org.hisp.dhis.tracker.export.event.EventService;
 import org.hisp.dhis.tracker.export.trackedentity.aggregates.TrackedEntityAggregate;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -105,8 +105,6 @@ class DefaultTrackedEntityService implements TrackedEntityService {
   private final FileResourceService fileResourceService;
 
   private final TrackedEntityOperationParamsMapper mapper;
-
-  private final UserService userService;
 
   @Override
   public FileResourceStream getFileResource(
@@ -165,7 +163,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
   private TrackedEntityAttribute getAttribute(
       UID attributeUid, TrackedEntity trackedEntity, @CheckForNull UID programUid)
       throws NotFoundException {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
 
     if (programUid != null) {
       Program program = programService.getProgram(programUid.getValue());
@@ -237,7 +235,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
 
     TrackedEntity trackedEntity = getTrackedEntity(uid, params, includeDeleted);
 
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
 
     if (program != null) {
       if (!trackerAccessManager.canRead(currentUser, trackedEntity, program, false).isEmpty()) {
@@ -277,7 +275,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
   public TrackedEntity getTrackedEntity(
       @Nonnull TrackedEntity trackedEntity, TrackedEntityParams params, boolean includeDeleted)
       throws ForbiddenException {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     List<String> errors = trackerAccessManager.canRead(currentUser, trackedEntity);
 
     if (!errors.isEmpty()) {
@@ -316,7 +314,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
   }
 
   private Set<RelationshipItem> getRelationshipItems(
-      TrackedEntity trackedEntity, User user, boolean includeDeleted) {
+      TrackedEntity trackedEntity, UserDetails user, boolean includeDeleted) {
     Set<RelationshipItem> items = new HashSet<>();
 
     for (RelationshipItem relationshipItem : trackedEntity.getRelationshipItems()) {
@@ -331,7 +329,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
   }
 
   private Set<Enrollment> getEnrollments(
-      TrackedEntity trackedEntity, User user, boolean includeDeleted) {
+      TrackedEntity trackedEntity, UserDetails user, boolean includeDeleted) {
     Set<Enrollment> enrollments = new HashSet<>();
 
     for (Enrollment enrollment : trackedEntity.getEnrollments()) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/MessageFormatter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/MessageFormatter.java
@@ -46,8 +46,8 @@ import org.hisp.dhis.tracker.imports.domain.Enrollment;
 import org.hisp.dhis.tracker.imports.domain.Event;
 import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.domain.TrackedEntity;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.util.DateUtils;
-import org.hisp.dhis.util.ObjectUtils;
 
 /**
  * @author Luciano Fiandesio
@@ -85,33 +85,37 @@ class MessageFormatter {
   }
 
   private static String formatArgument(TrackerIdSchemeParams idSchemes, Object argument) {
-    if (String.class.isAssignableFrom(ObjectUtils.firstNonNull(argument, "NULL").getClass())) {
-      return ObjectUtils.firstNonNull(argument, "NULL").toString();
-    } else if (MetadataIdentifier.class.isAssignableFrom(argument.getClass())) {
+    if (argument == null) return "NULL";
+    Class<?> type = argument.getClass();
+    if (String.class == type) {
+      return argument.toString();
+    } else if (MetadataIdentifier.class.isAssignableFrom(type)) {
       return ((MetadataIdentifier) argument).getIdentifierOrAttributeValue();
-    } else if (CategoryOptionCombo.class.isAssignableFrom(argument.getClass())) {
+    } else if (CategoryOptionCombo.class.isAssignableFrom(type)) {
       return getIdAndName(idSchemes.toMetadataIdentifier((CategoryOptionCombo) argument));
-    } else if (CategoryOption.class.isAssignableFrom(argument.getClass())) {
+    } else if (CategoryOption.class.isAssignableFrom(type)) {
       return getIdAndName(idSchemes.toMetadataIdentifier((CategoryOption) argument));
-    } else if (DataElement.class.isAssignableFrom(argument.getClass())) {
+    } else if (DataElement.class.isAssignableFrom(type)) {
       return getIdAndName(idSchemes.toMetadataIdentifier((DataElement) argument));
-    } else if (OrganisationUnit.class.isAssignableFrom(argument.getClass())) {
+    } else if (OrganisationUnit.class.isAssignableFrom(type)) {
       return getIdAndName(idSchemes.toMetadataIdentifier((OrganisationUnit) argument));
-    } else if (Program.class.isAssignableFrom(argument.getClass())) {
+    } else if (Program.class.isAssignableFrom(type)) {
       return getIdAndName(idSchemes.toMetadataIdentifier((Program) argument));
-    } else if (ProgramStage.class.isAssignableFrom(argument.getClass())) {
+    } else if (ProgramStage.class.isAssignableFrom(type)) {
       return getIdAndName(idSchemes.toMetadataIdentifier((ProgramStage) argument));
-    } else if (IdentifiableObject.class.isAssignableFrom(argument.getClass())) {
+    } else if (IdentifiableObject.class.isAssignableFrom(type)) {
       return getIdAndName(idSchemes.toMetadataIdentifier((IdentifiableObject) argument));
-    } else if (Date.class.isAssignableFrom(argument.getClass())) {
+    } else if (UserDetails.class.isAssignableFrom(type)) {
+      return ((UserDetails) argument).getUid();
+    } else if (Date.class.isAssignableFrom(type)) {
       return (DateFormat.getInstance().format(argument));
-    } else if (Instant.class.isAssignableFrom(argument.getClass())) {
+    } else if (Instant.class.isAssignableFrom(type)) {
       return DateUtils.toIso8601NoTz(DateUtils.fromInstant((Instant) argument));
-    } else if (Enrollment.class.isAssignableFrom(argument.getClass())) {
+    } else if (Enrollment.class.isAssignableFrom(type)) {
       return ((Enrollment) argument).getEnrollment();
-    } else if (Event.class.isAssignableFrom(argument.getClass())) {
+    } else if (Event.class.isAssignableFrom(type)) {
       return ((Event) argument).getEvent();
-    } else if (TrackedEntity.class.isAssignableFrom(argument.getClass())) {
+    } else if (TrackedEntity.class.isAssignableFrom(type)) {
       return ((TrackedEntity) argument).getTrackedEntity();
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/MessageFormatter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/MessageFormatter.java
@@ -33,7 +33,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.IdentifiableObject;
@@ -87,39 +86,32 @@ class MessageFormatter {
   private static String formatArgument(TrackerIdSchemeParams idSchemes, Object argument) {
     if (argument == null) return "NULL";
     Class<?> type = argument.getClass();
-    if (String.class == type) {
-      return argument.toString();
-    } else if (MetadataIdentifier.class.isAssignableFrom(type)) {
+    if (String.class == type) return argument.toString();
+    if (MetadataIdentifier.class.isAssignableFrom(type))
       return ((MetadataIdentifier) argument).getIdentifierOrAttributeValue();
-    } else if (CategoryOptionCombo.class.isAssignableFrom(type)) {
+    if (CategoryOptionCombo.class.isAssignableFrom(type))
       return getIdAndName(idSchemes.toMetadataIdentifier((CategoryOptionCombo) argument));
-    } else if (CategoryOption.class.isAssignableFrom(type)) {
+    if (CategoryOption.class.isAssignableFrom(type))
       return getIdAndName(idSchemes.toMetadataIdentifier((CategoryOption) argument));
-    } else if (DataElement.class.isAssignableFrom(type)) {
+    if (DataElement.class.isAssignableFrom(type))
       return getIdAndName(idSchemes.toMetadataIdentifier((DataElement) argument));
-    } else if (OrganisationUnit.class.isAssignableFrom(type)) {
+    if (OrganisationUnit.class.isAssignableFrom(type))
       return getIdAndName(idSchemes.toMetadataIdentifier((OrganisationUnit) argument));
-    } else if (Program.class.isAssignableFrom(type)) {
+    if (Program.class.isAssignableFrom(type))
       return getIdAndName(idSchemes.toMetadataIdentifier((Program) argument));
-    } else if (ProgramStage.class.isAssignableFrom(type)) {
+    if (ProgramStage.class.isAssignableFrom(type))
       return getIdAndName(idSchemes.toMetadataIdentifier((ProgramStage) argument));
-    } else if (IdentifiableObject.class.isAssignableFrom(type)) {
+    if (IdentifiableObject.class.isAssignableFrom(type))
       return getIdAndName(idSchemes.toMetadataIdentifier((IdentifiableObject) argument));
-    } else if (UserDetails.class.isAssignableFrom(type)) {
-      return ((UserDetails) argument).getUid();
-    } else if (Date.class.isAssignableFrom(type)) {
-      return (DateFormat.getInstance().format(argument));
-    } else if (Instant.class.isAssignableFrom(type)) {
+    if (UserDetails.class.isAssignableFrom(type)) return ((UserDetails) argument).getUid();
+    if (Date.class.isAssignableFrom(type)) return (DateFormat.getInstance().format(argument));
+    if (Instant.class.isAssignableFrom(type))
       return DateUtils.toIso8601NoTz(DateUtils.fromInstant((Instant) argument));
-    } else if (Enrollment.class.isAssignableFrom(type)) {
-      return ((Enrollment) argument).getEnrollment();
-    } else if (Event.class.isAssignableFrom(type)) {
-      return ((Event) argument).getEvent();
-    } else if (TrackedEntity.class.isAssignableFrom(type)) {
+    if (Enrollment.class.isAssignableFrom(type)) return ((Enrollment) argument).getEnrollment();
+    if (Event.class.isAssignableFrom(type)) return ((Event) argument).getEvent();
+    if (TrackedEntity.class.isAssignableFrom(type))
       return ((TrackedEntity) argument).getTrackedEntity();
-    }
-
-    return StringUtils.EMPTY;
+    return "";
   }
 
   private static String getIdAndName(MetadataIdentifier identifier) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/SecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/SecurityOwnershipValidator.java
@@ -157,12 +157,12 @@ class SecurityOwnershipValidator implements Validator<Enrollment> {
 
   private void checkOrgUnitInCaptureScope(
       Reporter reporter, TrackerBundle bundle, TrackerDto dto, OrganisationUnit orgUnit) {
-    User user = bundle.getUser();
+    UserDetails user = UserDetails.fromUser(bundle.getUser());
 
     checkNotNull(user, USER_CANT_BE_NULL);
     checkNotNull(orgUnit, ORGANISATION_UNIT_CANT_BE_NULL);
 
-    if (!UserDetails.fromUser(user).isInUserHierarchy(orgUnit.getPath())) {
+    if (!user.isInUserHierarchy(orgUnit.getPath())) {
       reporter.addError(dto, ValidationCode.E1000, user, orgUnit);
     }
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/SecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/SecurityOwnershipValidator.java
@@ -56,6 +56,7 @@ import org.hisp.dhis.tracker.imports.validation.Reporter;
 import org.hisp.dhis.tracker.imports.validation.ValidationCode;
 import org.hisp.dhis.tracker.imports.validation.Validator;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 
 /**
@@ -172,7 +173,7 @@ class SecurityOwnershipValidator implements Validator<Enrollment> {
   private void checkTeiTypeAndTeiProgramAccess(
       Reporter reporter,
       TrackerDto dto,
-      User user,
+      UserDetails user,
       String trackedEntity,
       OrganisationUnit ownerOrganisationUnit,
       Program program) {
@@ -216,7 +217,7 @@ class SecurityOwnershipValidator implements Validator<Enrollment> {
 
       checkNotNull(program.getTrackedEntityType(), TRACKED_ENTITY_TYPE_CANT_BE_NULL);
       checkTeiTypeAndTeiProgramAccess(
-          reporter, enrollment, user, trackedEntity, ownerOrgUnit, program);
+          reporter, enrollment, UserDetails.fromUser(user), trackedEntity, ownerOrgUnit, program);
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecurityOwnershipValidator.java
@@ -45,7 +45,6 @@ import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
@@ -74,11 +73,9 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 @Slf4j
 class SecurityOwnershipValidator implements Validator<org.hisp.dhis.tracker.imports.domain.Event> {
+
   @Nonnull private final AclService aclService;
-
   @Nonnull private final TrackerOwnershipManager ownershipAccessManager;
-
-  @Nonnull private final OrganisationUnitService organisationUnitService;
 
   private static final String ORG_UNIT_NO_USER_ASSIGNED =
       " has no organisation unit assigned, so we skip user validation";
@@ -255,12 +252,12 @@ class SecurityOwnershipValidator implements Validator<org.hisp.dhis.tracker.impo
 
   private void checkOrgUnitInCaptureScope(
       Reporter reporter, TrackerBundle bundle, TrackerDto dto, OrganisationUnit orgUnit) {
-    User user = bundle.getUser();
+    UserDetails user = UserDetails.fromUser(bundle.getUser());
 
     checkNotNull(user, USER_CANT_BE_NULL);
     checkNotNull(orgUnit, ORGANISATION_UNIT_CANT_BE_NULL);
 
-    if (!organisationUnitService.isInUserHierarchyCached(user, orgUnit)) {
+    if (!user.isInUserHierarchy(orgUnit.getPath())) {
       reporter.addError(dto, ValidationCode.E1000, user, orgUnit);
     }
   }
@@ -297,7 +294,7 @@ class SecurityOwnershipValidator implements Validator<org.hisp.dhis.tracker.impo
       CategoryOptionCombo categoryOptionCombo,
       String trackedEntity,
       boolean isCreatableInSearchScope) {
-    User user = bundle.getUser();
+    UserDetails user = UserDetails.fromUser(bundle.getUser());
 
     checkNotNull(user, USER_CANT_BE_NULL);
     checkNotNull(programStage, PROGRAM_STAGE_CANT_BE_NULL);
@@ -316,16 +313,11 @@ class SecurityOwnershipValidator implements Validator<org.hisp.dhis.tracker.impo
       checkProgramReadAccess(reporter, event, user, program);
 
       checkTeiTypeAndTeiProgramAccess(
-          reporter,
-          event,
-          UserDetails.fromUser(user),
-          trackedEntity,
-          ownerOrgUnit,
-          programStage.getProgram());
+          reporter, event, user, trackedEntity, ownerOrgUnit, programStage.getProgram());
     }
 
     if (categoryOptionCombo != null) {
-      checkWriteCategoryOptionComboAccess(reporter, bundle.getUser(), event, categoryOptionCombo);
+      checkWriteCategoryOptionComboAccess(reporter, user, event, categoryOptionCombo);
     }
   }
 
@@ -334,18 +326,18 @@ class SecurityOwnershipValidator implements Validator<org.hisp.dhis.tracker.impo
       org.hisp.dhis.tracker.imports.domain.Event event,
       OrganisationUnit eventOrgUnit,
       boolean isCreatableInSearchScope,
-      User user) {
+      UserDetails user) {
     if (eventOrgUnit == null) {
       log.warn("Event " + event.getUid() + ORG_UNIT_NO_USER_ASSIGNED);
     } else if (isCreatableInSearchScope
-        ? !organisationUnitService.isInUserSearchHierarchyCached(user, eventOrgUnit)
-        : !organisationUnitService.isInUserHierarchyCached(user, eventOrgUnit)) {
+        ? !user.isInUserSearchHierarchy(eventOrgUnit.getPath())
+        : !user.isInUserDataHierarchy(eventOrgUnit.getPath())) {
       reporter.addError(event, ValidationCode.E1000, user, eventOrgUnit);
     }
   }
 
   private void checkProgramReadAccess(
-      Reporter reporter, TrackerDto dto, User user, Program program) {
+      Reporter reporter, TrackerDto dto, UserDetails user, Program program) {
     checkNotNull(user, USER_CANT_BE_NULL);
     checkNotNull(program, PROGRAM_CANT_BE_NULL);
 
@@ -355,7 +347,7 @@ class SecurityOwnershipValidator implements Validator<org.hisp.dhis.tracker.impo
   }
 
   private void checkProgramStageWriteAccess(
-      Reporter reporter, TrackerDto dto, User user, ProgramStage programStage) {
+      Reporter reporter, TrackerDto dto, UserDetails user, ProgramStage programStage) {
     checkNotNull(user, USER_CANT_BE_NULL);
     checkNotNull(programStage, PROGRAM_STAGE_CANT_BE_NULL);
 
@@ -365,7 +357,7 @@ class SecurityOwnershipValidator implements Validator<org.hisp.dhis.tracker.impo
   }
 
   private void checkProgramWriteAccess(
-      Reporter reporter, TrackerDto dto, User user, Program program) {
+      Reporter reporter, TrackerDto dto, UserDetails user, Program program) {
     checkNotNull(user, USER_CANT_BE_NULL);
     checkNotNull(program, PROGRAM_CANT_BE_NULL);
 
@@ -375,7 +367,10 @@ class SecurityOwnershipValidator implements Validator<org.hisp.dhis.tracker.impo
   }
 
   public void checkWriteCategoryOptionComboAccess(
-      Reporter reporter, User user, TrackerDto dto, CategoryOptionCombo categoryOptionCombo) {
+      Reporter reporter,
+      UserDetails user,
+      TrackerDto dto,
+      CategoryOptionCombo categoryOptionCombo) {
     checkNotNull(user, USER_CANT_BE_NULL);
     checkNotNull(
         categoryOptionCombo, TrackerImporterAssertErrors.CATEGORY_OPTION_COMBO_CANT_BE_NULL);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecurityOwnershipValidator.java
@@ -63,6 +63,7 @@ import org.hisp.dhis.tracker.imports.validation.ValidationCode;
 import org.hisp.dhis.tracker.imports.validation.Validator;
 import org.hisp.dhis.tracker.imports.validation.validator.TrackerImporterAssertErrors;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 
 /**
@@ -267,7 +268,7 @@ class SecurityOwnershipValidator implements Validator<org.hisp.dhis.tracker.impo
   private void checkTeiTypeAndTeiProgramAccess(
       Reporter reporter,
       TrackerDto dto,
-      User user,
+      UserDetails user,
       String trackedEntity,
       OrganisationUnit ownerOrganisationUnit,
       Program program) {
@@ -315,7 +316,12 @@ class SecurityOwnershipValidator implements Validator<org.hisp.dhis.tracker.impo
       checkProgramReadAccess(reporter, event, user, program);
 
       checkTeiTypeAndTeiProgramAccess(
-          reporter, event, user, trackedEntity, ownerOrgUnit, programStage.getProgram());
+          reporter,
+          event,
+          UserDetails.fromUser(user),
+          trackedEntity,
+          ownerOrgUnit,
+          programStage.getProgram());
     }
 
     if (categoryOptionCombo != null) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapperTest.java
@@ -34,7 +34,6 @@ import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -110,7 +109,6 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
 
     user = UserDetails.fromUser(u);
     injectSecurityContext(user);
-    when(userService.getUserByUsername(anyString())).thenReturn(u);
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapperTest.java
@@ -90,7 +90,7 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
 
   private Event event;
 
-  private User user;
+  private UserDetails user;
 
   @BeforeEach
   public void setUp() {
@@ -105,11 +105,12 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
     event = createEvent(programStage, enrollment, organisationUnit);
     event.setUid(EV_UID);
 
-    user = new User();
-    user.setUsername("admin");
+    User u = new User();
+    u.setUsername("admin");
 
-    injectSecurityContext(UserDetails.fromUser(user));
-    when(userService.getUserByUsername(anyString())).thenReturn(user);
+    user = UserDetails.fromUser(u);
+    injectSecurityContext(user);
+    when(userService.getUserByUsername(anyString())).thenReturn(u);
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecurityOwnershipValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecurityOwnershipValidatorTest.java
@@ -32,13 +32,13 @@ import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1083;
 import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E1102;
 import static org.hisp.dhis.tracker.imports.validation.validator.AssertValidations.assertHasError;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.util.Collections;
+import java.util.Set;
+import java.util.function.Consumer;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.common.CodeGenerator;
@@ -63,6 +63,7 @@ import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.validation.Reporter;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -96,7 +97,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
 
   @Mock private OrganisationUnitService organisationUnitService;
 
-  private User user;
+  private UserDetails user;
 
   private Reporter reporter;
 
@@ -114,8 +115,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
   public void setUp() {
     when(bundle.getPreheat()).thenReturn(preheat);
 
-    user = makeUser("A");
-    when(bundle.getUser()).thenReturn(user);
+    setUpUser(user -> {});
 
     organisationUnit = createOrganisationUnit('A');
     organisationUnit.setUid(ORG_UNIT_ID);
@@ -135,6 +135,17 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
 
     validator =
         new SecurityOwnershipValidator(aclService, ownershipAccessManager, organisationUnitService);
+  }
+
+  private void setUpUser(Consumer<User> init) {
+    User u = makeUser("A");
+    init.accept(u);
+    user = UserDetails.fromUser(u);
+    when(bundle.getUser()).thenReturn(u);
+  }
+
+  private void setUpUserWithOrgUnit() {
+    setUpUser(user -> user.setOrganisationUnits(Set.of(organisationUnit)));
   }
 
   @Test
@@ -157,7 +168,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     when(preheat.getEvent(event.getEvent())).thenReturn(preheatEvent);
     when(preheat.getEnrollment(event.getEnrollment())).thenReturn(enrollment);
 
-    when(organisationUnitService.isInUserHierarchyCached(user, organisationUnit)).thenReturn(true);
+    setUpUserWithOrgUnit();
     when(aclService.canDataRead(user, program.getTrackedEntityType())).thenReturn(true);
     when(aclService.canDataRead(user, program)).thenReturn(true);
     when(aclService.canDataWrite(user, programStage)).thenReturn(true);
@@ -188,7 +199,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_ID))).thenReturn(program);
     when(preheat.getOrganisationUnit(MetadataIdentifier.ofUid(ORG_UNIT_ID)))
         .thenReturn(organisationUnit);
-    when(organisationUnitService.isInUserHierarchyCached(user, organisationUnit)).thenReturn(true);
+    setUpUserWithOrgUnit();
     when(aclService.canDataWrite(user, program)).thenReturn(true);
 
     validator.validate(reporter, bundle, event);
@@ -213,7 +224,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_ID))).thenReturn(program);
     when(preheat.getOrganisationUnit(MetadataIdentifier.ofUid(ORG_UNIT_ID)))
         .thenReturn(organisationUnit);
-    when(organisationUnitService.isInUserHierarchyCached(user, organisationUnit)).thenReturn(true);
+    setUpUserWithOrgUnit();
     when(aclService.canDataRead(user, program.getTrackedEntityType())).thenReturn(true);
     when(aclService.canDataRead(user, program)).thenReturn(true);
     when(aclService.canDataWrite(user, programStage)).thenReturn(true);
@@ -240,7 +251,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_ID))).thenReturn(program);
     when(preheat.getOrganisationUnit(MetadataIdentifier.ofUid(ORG_UNIT_ID)))
         .thenReturn(organisationUnit);
-    when(organisationUnitService.isInUserHierarchyCached(user, organisationUnit)).thenReturn(true);
+    setUpUserWithOrgUnit();
     when(aclService.canDataRead(user, program.getTrackedEntityType())).thenReturn(true);
     when(aclService.canDataRead(user, program)).thenReturn(true);
     when(aclService.canDataWrite(user, programStage)).thenReturn(true);
@@ -376,7 +387,6 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_ID))).thenReturn(program);
     when(preheat.getOrganisationUnit(MetadataIdentifier.ofUid(ORG_UNIT_ID)))
         .thenReturn(organisationUnit);
-    when(organisationUnitService.isInUserHierarchyCached(user, organisationUnit)).thenReturn(false);
     when(aclService.canDataRead(user, program.getTrackedEntityType())).thenReturn(true);
     when(aclService.canDataRead(user, program)).thenReturn(true);
     when(aclService.canDataWrite(user, programStage)).thenReturn(true);
@@ -406,8 +416,6 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_ID))).thenReturn(program);
     when(preheat.getOrganisationUnit(MetadataIdentifier.ofUid(ORG_UNIT_ID)))
         .thenReturn(organisationUnit);
-    when(organisationUnitService.isInUserSearchHierarchyCached(user, organisationUnit))
-        .thenReturn(false);
     when(aclService.canDataRead(user, program.getTrackedEntityType())).thenReturn(true);
     when(aclService.canDataRead(user, program)).thenReturn(true);
     when(aclService.canDataWrite(user, programStage)).thenReturn(true);
@@ -475,8 +483,6 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     when(aclService.canDataWrite(user, programStage)).thenReturn(true);
 
     validator.validate(reporter, bundle, event);
-
-    verify(organisationUnitService, times(0)).isInUserHierarchyCached(user, organisationUnit);
 
     assertIsEmpty(reporter.getErrors());
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecurityOwnershipValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecurityOwnershipValidatorTest.java
@@ -44,7 +44,6 @@ import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
@@ -95,8 +94,6 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
 
   @Mock private TrackerOwnershipManager ownershipAccessManager;
 
-  @Mock private OrganisationUnitService organisationUnitService;
-
   private UserDetails user;
 
   private Reporter reporter;
@@ -133,8 +130,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     idSchemes = TrackerIdSchemeParams.builder().build();
     reporter = new Reporter(idSchemes);
 
-    validator =
-        new SecurityOwnershipValidator(aclService, ownershipAccessManager, organisationUnitService);
+    validator = new SecurityOwnershipValidator(aclService, ownershipAccessManager);
   }
 
   private void setUpUser(Consumer<User> init) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/ProgramStageValidationStrategyTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/ProgramStageValidationStrategyTest.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Stream;
 import javax.persistence.EntityManager;
 import org.hamcrest.Matchers;
@@ -67,6 +68,7 @@ import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.user.sharing.UserAccess;
 import org.junit.jupiter.api.Test;
@@ -112,35 +114,42 @@ class ProgramStageValidationStrategyTest extends TransactionalIntegrationTest {
   protected void setUpTest() {
     final int testYear = Calendar.getInstance().get(Calendar.YEAR) - 1;
     userService = _userService;
-    createUserAndInjectSecurityContext(
-        false,
-        "F_TRACKED_ENTITY_DATAVALUE_ADD",
-        "F_TRACKED_ENTITY_DATAVALUE_DELETE",
-        "F_UNCOMPLETE_EVENT",
-        "F_PROGRAMSTAGE_ADD",
-        "F_PROGRAMSTAGE_DELETE",
-        "F_PROGRAM_PUBLIC_ADD",
-        "F_PROGRAM_PRIVATE_ADD",
-        "F_PROGRAM_DELETE",
-        "F_TRACKED_ENTITY_ADD",
-        "F_TRACKED_ENTITY_UPDATE",
-        "F_TRACKED_ENTITY_DELETE",
-        "F_DATAELEMENT_PUBLIC_ADD",
-        "F_DATAELEMENT_PRIVATE_ADD",
-        "F_DATAELEMENT_DELETE",
-        "F_CATEGORY_COMBO_PUBLIC_ADD",
-        "F_CATEGORY_COMBO_PRIVATE_ADD",
-        "F_CATEGORY_COMBO_DELETE");
-    User currentUser = getCurrentUser();
+
+    organisationUnitA = createOrganisationUnit('A');
+    manager.save(organisationUnitA, false);
+
+    User currentUser =
+        createUserAndInjectSecurityContext(
+            Set.of(organisationUnitA),
+            false,
+            "F_TRACKED_ENTITY_DATAVALUE_ADD",
+            "F_TRACKED_ENTITY_DATAVALUE_DELETE",
+            "F_UNCOMPLETE_EVENT",
+            "F_PROGRAMSTAGE_ADD",
+            "F_PROGRAMSTAGE_DELETE",
+            "F_PROGRAM_PUBLIC_ADD",
+            "F_PROGRAM_PRIVATE_ADD",
+            "F_PROGRAM_DELETE",
+            "F_TRACKED_ENTITY_ADD",
+            "F_TRACKED_ENTITY_UPDATE",
+            "F_TRACKED_ENTITY_DELETE",
+            "F_DATAELEMENT_PUBLIC_ADD",
+            "F_DATAELEMENT_PRIVATE_ADD",
+            "F_DATAELEMENT_DELETE",
+            "F_CATEGORY_COMBO_PUBLIC_ADD",
+            "F_CATEGORY_COMBO_PRIVATE_ADD",
+            "F_CATEGORY_COMBO_DELETE");
+    currentUser.getTeiSearchOrganisationUnits().add(organisationUnitA);
+    userService.updateUser(currentUser);
+    injectSecurityContext(UserDetails.fromUser(currentUser));
+
     UserAccess userAccess1 = new UserAccess(currentUser, "rwrw----");
     UserAccess userAccess2 = new UserAccess(currentUser, "rwrw----");
     UserAccess userAccess3 = new UserAccess(currentUser, "rwrw----");
-    organisationUnitA = createOrganisationUnit('A');
-    organisationUnitA.addUser(currentUser);
     organisationUnitA.getSharing().addUserAccess(userAccess1);
-    currentUser.getTeiSearchOrganisationUnits().add(organisationUnitA);
-    manager.save(organisationUnitA, false);
-    userService.updateUser(currentUser);
+
+    manager.update(organisationUnitA);
+
     TrackedEntityType trackedEntityType = createTrackedEntityType('A');
     trackedEntityType.getSharing().addUserAccess(userAccess1);
     manager.save(trackedEntityType, false);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/AuthenticationControllerTest.java
@@ -37,7 +37,7 @@ import java.util.Calendar;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserDetailsImpl;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisAuthenticationApiTest;
 import org.hisp.dhis.webapi.json.domain.JsonLoginResponse;
@@ -210,7 +210,7 @@ class AuthenticationControllerTest extends DhisAuthenticationApiTest {
     assertNotNull(response);
 
     assertEquals(1, sessionRegistry.getAllPrincipals().size());
-    UserDetailsImpl actual = (UserDetailsImpl) sessionRegistry.getAllPrincipals().get(0);
+    UserDetails actual = (UserDetails) sessionRegistry.getAllPrincipals().get(0);
 
     assertNotNull(actual);
     assertEquals("admin", actual.getUsername());

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationController.java
@@ -56,8 +56,7 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.user.CurrentUserUtil;
-import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.webapi.controller.tracker.view.Page;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.http.HttpStatus;
@@ -83,8 +82,6 @@ public class DeduplicationController {
   private final TrackedEntityService trackedEntityService;
 
   private final TrackerAccessManager trackerAccessManager;
-
-  private final UserService userService;
 
   private final FieldFilterService fieldFilterService;
 
@@ -268,7 +265,7 @@ public class DeduplicationController {
   }
 
   private void canReadTrackedEntity(TrackedEntity trackedEntity) throws ForbiddenException {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     if (!trackerAccessManager.canRead(currentUser, trackedEntity).isEmpty()) {
       throw new ForbiddenException(
           "You don't have read access to '" + trackedEntity.getUid() + "'.");

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/TrackedEntityInstanceController.java
@@ -93,8 +93,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.user.CurrentUserUtil;
-import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.webapi.controller.deprecated.tracker.imports.TrackedEntityInstanceStrategyHandler;
 import org.hisp.dhis.webapi.controller.deprecated.tracker.imports.request.TrackerEntityInstanceRequest;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -153,8 +152,6 @@ public class TrackedEntityInstanceController {
 
   private final TrackedEntityInstanceStrategyHandler trackedEntityInstanceStrategyHandler;
 
-  private final UserService userService;
-
   // -------------------------------------------------------------------------
   // READ
   // -------------------------------------------------------------------------
@@ -208,7 +205,7 @@ public class TrackedEntityInstanceController {
       @RequestParam(required = false) ImageFileDimension dimension,
       HttpServletResponse response)
       throws WebMessageException, ConflictException {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
 
     TrackedEntity trackedEntity = instanceService.getTrackedEntity(teiId);
 
@@ -280,7 +277,7 @@ public class TrackedEntityInstanceController {
       @PathVariable("attributeId") String attributeId,
       HttpServletResponse response)
       throws WebMessageException {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     TrackedEntity tei =
         Optional.ofNullable(instanceService.getTrackedEntity(teiId))
             .orElseThrow(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/TrackedEntityInstanceSupportService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deprecated/tracker/TrackedEntityInstanceSupportService.java
@@ -50,8 +50,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.trackedentity.TrackerOwnershipManager;
 import org.hisp.dhis.user.CurrentUserUtil;
-import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Service;
 
 /**
@@ -65,8 +64,6 @@ public class TrackedEntityInstanceSupportService {
 
   private final TrackedEntityInstanceService trackedEntityInstanceService;
 
-  private final UserService userService;
-
   private final ProgramService programService;
 
   private final TrackerAccessManager trackerAccessManager;
@@ -77,7 +74,7 @@ public class TrackedEntityInstanceSupportService {
 
   @SneakyThrows
   public TrackedEntityInstance getTrackedEntityInstance(String id, String pr, List<String> fields) {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     TrackedEntityInstanceParams trackedEntityInstanceParams =
         getTrackedEntityInstanceParams(fields);
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackerOwnershipController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackerOwnershipController.java
@@ -42,8 +42,7 @@ import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.trackedentity.TrackerOwnershipManager;
 import org.hisp.dhis.user.CurrentUserUtil;
-import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,8 +62,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
 public class TrackerOwnershipController {
   public static final String RESOURCE_PATH = "/tracker/ownership";
-
-  @Autowired private UserService userService;
 
   @Autowired private TrackerOwnershipManager trackerOwnershipAccessManager;
 
@@ -116,7 +113,7 @@ public class TrackerOwnershipController {
         validateMandatoryDeprecatedUidParameter(
             "trackedEntityInstance", trackedEntityInstance, "trackedEntity", trackedEntity);
 
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     trackerOwnershipAccessManager.grantTemporaryOwnership(
         trackedEntityService.getTrackedEntity(trackedEntityUid.getValue()),
         programService.getProgram(program),

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/CurrentUserHandlerMethodArgumentResolver.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/CurrentUserHandlerMethodArgumentResolver.java
@@ -32,7 +32,6 @@ import org.hisp.dhis.user.CurrentUser;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
-import org.hisp.dhis.user.UserDetailsImpl;
 import org.hisp.dhis.user.UserService;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
@@ -61,10 +60,7 @@ public class CurrentUserHandlerMethodArgumentResolver implements HandlerMethodAr
       return false;
     }
 
-    return type == String.class
-        || type == UserDetails.class
-        || type == UserDetailsImpl.class
-        || type == User.class;
+    return type == String.class || type == UserDetails.class || type == User.class;
   }
 
   @Override
@@ -82,10 +78,6 @@ public class CurrentUserHandlerMethodArgumentResolver implements HandlerMethodAr
     }
 
     if (type == UserDetails.class) {
-      return CurrentUserUtil.getCurrentUserDetails();
-    }
-
-    if (type == UserDetailsImpl.class) {
       return CurrentUserUtil.getCurrentUserDetails();
     }
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationMvcTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationMvcTest.java
@@ -59,8 +59,6 @@ import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
-import org.hisp.dhis.user.CurrentUserUtil;
-import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.webapi.controller.CrudControllerAdvice;
 import org.hisp.dhis.webapi.service.ContextService;
@@ -124,11 +122,9 @@ class DeduplicationMvcTest {
 
   @Test
   void shouldPostPotentialDuplicateWhenTeisExistAndUserHasAccess() throws Exception {
-    when(trackerAccessManager.canRead(any(User.class), any(TrackedEntity.class)))
+    when(trackerAccessManager.canRead(any(), any(TrackedEntity.class)))
         .thenReturn(Collections.emptyList());
 
-    User user = new User();
-    when(userService.getUserByUsername(CurrentUserUtil.getCurrentUsername())).thenReturn(user);
     when(trackedEntityService.getTrackedEntity(original)).thenReturn(trackedEntityA);
     when(trackedEntityService.getTrackedEntity(duplicate)).thenReturn(trackedEntityB);
 
@@ -146,11 +142,9 @@ class DeduplicationMvcTest {
 
   @Test
   void shouldThrowForbiddenExceptionExceptionWhenPostAndUserHasNoTeiAccess() throws Exception {
-    when(trackerAccessManager.canRead(any(User.class), any(TrackedEntity.class)))
+    when(trackerAccessManager.canRead(any(), any(TrackedEntity.class)))
         .thenReturn(List.of("error"));
 
-    User user = new User();
-    when(userService.getUserByUsername(CurrentUserUtil.getCurrentUsername())).thenReturn(user);
     when(trackedEntityService.getTrackedEntity(original)).thenReturn(trackedEntityA);
 
     PotentialDuplicate potentialDuplicate = new PotentialDuplicate(original, duplicate);

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deprecated/tracker/EventRequestToSearchParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deprecated/tracker/EventRequestToSearchParamsMapperTest.java
@@ -58,7 +58,6 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dxf2.deprecated.tracker.event.EventSearchParams;
 import org.hisp.dhis.dxf2.util.InputUtils;
-import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Program;
@@ -72,6 +71,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserRole;
 import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.Assertions;
@@ -229,22 +229,22 @@ class EventRequestToSearchParamsMapperTest {
   }
 
   @Test
-  void shouldMapRequestedOrgUnitAsSelectedWhenOrgUnitProvidedAndNoOrgUnitModeProvided()
-      throws ForbiddenException {
+  void shouldMapRequestedOrgUnitAsSelectedWhenOrgUnitProvidedAndNoOrgUnitModeProvided() {
     Program program = new Program();
     program.setUid(PROGRAM_UID);
     OrganisationUnit searchScopeOrgUnit = createOrgUnit("searchScopeOrgUnit", "uid4");
     User user = new User();
     user.setOrganisationUnits(Set.of(searchScopeOrgUnit));
+    user.setUsername("anyUser");
+    UserDetails userDetails = UserDetails.fromUser(user);
 
     when(programService.getProgram(PROGRAM_UID)).thenReturn(program);
     when(aclService.canDataRead(user, program)).thenReturn(true);
 
-    user.setUsername("anyUser");
     when(userService.getUserByUsername(CurrentUserUtil.getCurrentUsername())).thenReturn(user);
     //    when(getCurrentUser()).thenReturn(user.);
     when(organisationUnitService.getOrganisationUnit(orgUnit.getUid())).thenReturn(orgUnit);
-    when(trackerAccessManager.canAccess(user, program, orgUnit)).thenReturn(true);
+    when(trackerAccessManager.canAccess(userDetails, program, orgUnit)).thenReturn(true);
     when(organisationUnitService.isInUserHierarchy(
             orgUnit.getUid(), user.getTeiSearchOrganisationUnitsWithFallback()))
         .thenReturn(true);

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deprecated/tracker/TrackedEntityControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/deprecated/tracker/TrackedEntityControllerTest.java
@@ -94,8 +94,7 @@ class TrackedEntityControllerTest {
             null,
             null,
             new TrackedEntityInstanceStrategyImpl(
-                trackedEntityInstanceSyncStrategy, trackedEntityInstanceAsyncStrategy),
-            userService);
+                trackedEntityInstanceSyncStrategy, trackedEntityInstanceAsyncStrategy));
 
     mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
 


### PR DESCRIPTION
### Summary
2 main changes
* use `UserDetails` instead of `User` in the `TrackerAccessManager` API
* include "is in hierarchy" checks in `UserDetails` API (to be a feasible independent  replacement for `User`)

This entails smaller changes
* make `UserDetailsImpl` immutable build using a builder (except the `long` ID for now)

### Follow Up Work
Work identified while doing this PR
* replace `User` with `UserDetails` in `ImportOptions` (big PR on its own)
* `UserDetails.from(User)` is still called in many places and many times within the same request for some operations - we should not reconstruct the `UserDetails` each time but have it "in the session" when asked for the current session user
* replace usage of "is in hierarchy" methods in the `OrganisationUnitService` with methods in `UserDetails`
* user settings in `UserDetails` should be immutable but are set using `CurrentUserUtil#setUserSetting`
* hold spring level `UserDetails` as field in DHIS2 `UserDetails`
* `DefaultTrackerAccessManager` needs further duplicate code removal and avoiding creating not needed result `errors` lists