### PR TITLE
fix: missing context path on default module redirect

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
@@ -168,7 +168,8 @@ public class AuthenticationController {
   }
 
   private String getRedirectUrl(HttpServletRequest request, HttpServletResponse response) {
-    String redirectUrl = "/" + settingManager.getStringSetting(SettingKey.START_MODULE);
+    String redirectUrl =
+        request.getContextPath() + "/" + settingManager.getStringSetting(SettingKey.START_MODULE);
 
     SavedRequest savedRequest = requestCache.getRequest(request, null);
     if (savedRequest != null) {


### PR DESCRIPTION
## Summary
Adds missing context path in the redirect URL when default module path is returned.