### PR TITLE
fix: set icon content type in DB to svg DHIS2-16872

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResource.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResource.java
@@ -33,7 +33,6 @@ import java.util.Optional;
 import java.util.Set;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
-import org.springframework.util.MimeType;
 import org.springframework.util.MimeTypeUtils;
 
 /**
@@ -47,9 +46,9 @@ public class FileResource extends BaseIdentifiableObject {
   public static final Set<String> IMAGE_CONTENT_TYPES =
       Set.of("image/jpg", "image/png", "image/jpeg");
 
-  public static FileResource ofKey(FileResourceDomain domain, String key, MimeType contentType) {
+  public static FileResource ofKey(FileResourceDomain domain, String key, String contentType) {
     return new FileResource(
-        key, domain.getContainerName() + "_" + key, contentType.toString(), 0, null, domain);
+        key, domain.getContainerName() + "_" + key, contentType, 0, null, domain);
   }
 
   /** MIME type. */

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceDomain.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceDomain.java
@@ -39,7 +39,7 @@ public enum FileResourceDomain {
   MESSAGE_ATTACHMENT("messageAttachment"),
   USER_AVATAR("userAvatar"),
   ORG_UNIT("organisationUnit"),
-  CUSTOM_ICON("customIcon"),
+  ICON("icon"),
   JOB_DATA("jobData");
 
   /** Container name to use when storing blobs of this FileResourceDomain */

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/DefaultFileResourceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/DefaultFileResourceService.java
@@ -172,9 +172,9 @@ public class DefaultFileResourceService implements FileResourceService {
                       new FileResourceOwner(
                           dv.de(), dv.ou(), periodService.getPeriod(dv.pe()).getIsoDate(), dv.co()))
               .toList();
-      case CUSTOM_ICON ->
+      case ICON ->
           fileResourceStore.findCustomIconByFileResource(uid).stream()
-              .map(key -> new FileResourceOwner(FileResourceDomain.CUSTOM_ICON, key))
+              .map(key -> new FileResourceOwner(FileResourceDomain.ICON, key))
               .toList();
       case JOB_DATA -> List.of(new FileResourceOwner(FileResourceDomain.JOB_DATA, uid));
     };

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/icon/DefaultIconService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/icon/DefaultIconService.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.icon;
 
-import static org.hisp.dhis.fileresource.FileResourceDomain.CUSTOM_ICON;
+import static org.hisp.dhis.fileresource.FileResourceDomain.ICON;
 
 import com.google.common.base.Strings;
 import java.io.IOException;
@@ -100,7 +100,7 @@ public class DefaultIconService implements IconService {
     String fileResourceId = CodeGenerator.generateUid();
     Resource resource = getDefaultIconResource(icon.getKey());
     try {
-      FileResource fileResource = FileResource.ofKey(CUSTOM_ICON, icon.getKey(), MEDIA_TYPE_SVG);
+      FileResource fileResource = FileResource.ofKey(ICON, icon.getKey(), MEDIA_TYPE_SVG);
       fileResource.setUid(fileResourceId);
       fileResource.setAssigned(true);
       try (InputStream image = resource.getInputStream()) {
@@ -249,7 +249,7 @@ public class DefaultIconService implements IconService {
     }
 
     Optional<FileResource> fileResource =
-        fileResourceService.getFileResource(fileResourceUid, CUSTOM_ICON);
+        fileResourceService.getFileResource(fileResourceUid, ICON);
     if (fileResource.isEmpty()) {
       throw new NotFoundException(String.format("FileResource %s does not exist", fileResourceUid));
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/icon/DefaultIconService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/icon/DefaultIconService.java
@@ -53,7 +53,6 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -69,6 +68,7 @@ public class DefaultIconService implements IconService {
   private static final Pattern pattern = Pattern.compile(CUSTOM_ICON_KEY_PATTERN);
 
   private static final String ICON_PATH = "SVGs";
+  private static final String MEDIA_TYPE_SVG = "image/svg+xml";
 
   private final IconStore iconStore;
   private final FileResourceService fileResourceService;
@@ -100,8 +100,7 @@ public class DefaultIconService implements IconService {
     String fileResourceId = CodeGenerator.generateUid();
     Resource resource = getDefaultIconResource(icon.getKey());
     try {
-      FileResource fileResource =
-          FileResource.ofKey(CUSTOM_ICON, icon.getKey(), MediaType.IMAGE_PNG);
+      FileResource fileResource = FileResource.ofKey(CUSTOM_ICON, icon.getKey(), MEDIA_TYPE_SVG);
       fileResource.setUid(fileResourceId);
       fileResource.setAssigned(true);
       try (InputStream image = resource.getInputStream()) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/JobCreationHelper.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/JobCreationHelper.java
@@ -61,7 +61,8 @@ public interface JobCreationHelper {
       throw new ConflictException(
           "Job must be of type %s to allow content data".formatted(SchedulingType.ONCE_ASAP));
     config.setAutoFields(); // ensure UID is set
-    FileResource fr = FileResource.ofKey(FileResourceDomain.JOB_DATA, config.getUid(), contentType);
+    FileResource fr =
+        FileResource.ofKey(FileResourceDomain.JOB_DATA, config.getUid(), contentType.toString());
     fr.setUid(config.getUid());
     fr.setAssigned(true);
     fileResourceService.syncSaveFileResource(fr, content);

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/icon/IconServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/icon/IconServiceTest.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.icon;
 
-import static org.hisp.dhis.fileresource.FileResourceDomain.CUSTOM_ICON;
+import static org.hisp.dhis.fileresource.FileResourceDomain.ICON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -73,7 +73,7 @@ class IconServiceTest extends DhisConvenienceTest {
     FileResource fileResource = createFileResource('A', "file".getBytes());
     fileResource.setUid(fileResourceUid);
     when(iconStore.getIconByKey(uniqueKey)).thenReturn(null);
-    when(fileResourceService.getFileResource(fileResourceUid, CUSTOM_ICON))
+    when(fileResourceService.getFileResource(fileResourceUid, ICON))
         .thenReturn(Optional.of(new FileResource()));
 
     User user = new User();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/icon/IconTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/icon/IconTest.java
@@ -258,11 +258,7 @@ class IconTest extends TrackerTest {
 
     FileResource fileResource =
         new FileResource(
-            filename,
-            contentType,
-            content.length,
-            contentMd5.toString(),
-            FileResourceDomain.CUSTOM_ICON);
+            filename, contentType, content.length, contentMd5.toString(), FileResourceDomain.ICON);
     fileResource.setAssigned(false);
     fileResource.setCreated(new Date());
     fileResource.setAutoFields();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/icon/IconControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/icon/IconControllerTest.java
@@ -253,7 +253,7 @@ class IconControllerTest extends DhisControllerIntegrationTest {
     InputStream in = getClass().getResourceAsStream("/icon/test-image.png");
     MockMultipartFile image = new MockMultipartFile("file", "test-image.png", "image/png", in);
 
-    HttpResponse response = POST_MULTIPART("/fileResources?domain=CUSTOM_ICON", image);
+    HttpResponse response = POST_MULTIPART("/fileResources?domain=ICON", image);
     JsonObject savedObject =
         response.content(HttpStatus.ACCEPTED).getObject("response").getObject("fileResource");
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/icon/IconMapperTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/icon/IconMapperTest.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.icon;
 
-import static org.hisp.dhis.fileresource.FileResourceDomain.CUSTOM_ICON;
+import static org.hisp.dhis.fileresource.FileResourceDomain.ICON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -76,7 +76,7 @@ class IconMapperTest {
   void shouldReturnCustomIconFromIconDto() throws BadRequestException {
     CustomIconRequest customIconRequest =
         new CustomIconRequest(KEY, DESCRIPTION, KEYWORDS, fileResource.getUid());
-    when(fileResourceService.getFileResource(fileResource.getUid(), CUSTOM_ICON))
+    when(fileResourceService.getFileResource(fileResource.getUid(), ICON))
         .thenReturn(Optional.of(fileResource));
 
     Icon icon = iconMapper.to(customIconRequest);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
@@ -168,7 +168,7 @@ public class FileResourceController extends AbstractFullReadOnlyController<FileR
       @RequestParam(required = false) String uid)
       throws WebMessageException, IOException {
     FileResource fileResource;
-    if (domain.equals(FileResourceDomain.CUSTOM_ICON)) {
+    if (domain.equals(FileResourceDomain.ICON)) {
       validateCustomIconFile(file);
       fileResource = fileResourceUtils.saveFileResource(uid, resizeToDefaultIconSize(file), domain);
     } else {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/icon/IconController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/icon/IconController.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.webapi.controller.icon;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.net.MediaType;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
@@ -198,9 +197,7 @@ public class IconController {
       throw new NotFoundException(FileResource.class, icon.getFileResource().getUid());
     }
 
-    response.setContentType(
-        icon.isCustom() ? fileResource.getContentType() : MediaType.SVG_UTF_8.toString());
-
+    response.setContentType(fileResource.getContentType());
     response.setHeader("Cache-Control", CacheControl.maxAge(TTL, TimeUnit.DAYS).getHeaderValue());
     response.setHeader(
         HttpHeaders.CONTENT_LENGTH,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/icon/IconMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/icon/IconMapper.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.icon;
 
-import static org.hisp.dhis.fileresource.FileResourceDomain.CUSTOM_ICON;
+import static org.hisp.dhis.fileresource.FileResourceDomain.ICON;
 
 import java.util.Optional;
 import lombok.AllArgsConstructor;
@@ -49,8 +49,7 @@ public class IconMapper {
       throw new BadRequestException("FileResource must be provided with Icon");
     }
 
-    fileResource =
-        fileResourceService.getFileResource(customIconRequest.getFileResourceId(), CUSTOM_ICON);
+    fileResource = fileResourceService.getFileResource(customIconRequest.getFileResourceId(), ICON);
     if (fileResource.isEmpty()) {
       throw new BadRequestException(
           String.format(
@@ -73,7 +72,7 @@ public class IconMapper {
 
     if (customIconRequest.getFileResourceId() != null) {
       fileResource =
-          fileResourceService.getFileResource(customIconRequest.getFileResourceId(), CUSTOM_ICON);
+          fileResourceService.getFileResource(customIconRequest.getFileResourceId(), ICON);
       if (fileResource.isEmpty()) {
         throw new BadRequestException(
             String.format(


### PR DESCRIPTION
* fix: set file resource content type of default icons to svg instead of png as [they are all svgs](https://github.com/dhis2/dhis2-core/tree/master/dhis-2/dhis-support/dhis-support-system/src/main/resources/SVGs)
https://github.com/dhis2/dhis2-core/commit/490df8f2e1d6d9009ff079afec3cef7241803698#diff-6bae3b8b6d4d426dd3eb33221c3a45713e53bc1647cba6d4133c35483a59e6faR85-R87

before

```sql
 select fr.contenttype, icon.iconkey  from fileresource fr join icon using(fileresourceid) where icon.iconkey='provider_fst_positive';
 contenttype |        iconkey
-------------+-----------------------
 image/png   | provider_fst_positive
```

* chore: remove redundant validations from controller as they are already done by the service

https://github.com/dhis2/dhis2-core/blob/945eb1222dee135f61048e53c519a6a8e081e31a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/icon/DefaultIconService.java#L134-L136

https://github.com/dhis2/dhis2-core/blob/945eb1222dee135f61048e53c519a6a8e081e31a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/icon/DefaultIconService.java#L181-L183

* chore: `getCustomIconReference` -> `getIconHref` as the reference is the same for default/custom icons

* fix: prefix file resource name of default icons with `icon` instead of `customIcon`

before they were named like `filename=customIcon_information_campaign_positive` due to

https://github.com/dhis2/dhis2-core/blob/945eb1222dee135f61048e53c519a6a8e081e31a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/icon/DefaultIconService.java#L104

The `FileResourceDomain` was introduced [in 2.41](https://github.com/dhis2/dhis2-core/commit/df3d184edafc38879a3f9a099daea580bcb477b0#diff-f037faa56d26351a604f363f3b3a33cb798366fc39241c0967e5399be5da8114R43) so it can be safely renamed.