### PR TITLE
fix: ignore service worker requests but only one level

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -272,9 +272,9 @@ public class DhisWebApiWebSecurityConfig {
 
           // Temporary solution for Struts less login page, will be removed when apps are fully
           // migrated
-          .antMatchers("/**/service-worker.js.map")
+          .antMatchers("/*/service-worker.js.map")
           .permitAll()
-          .antMatchers("/**/service-worker.js")
+          .antMatchers("/*/service-worker.js")
           .permitAll()
           .antMatchers("/index.html")
           .permitAll()

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -272,6 +272,10 @@ public class DhisWebApiWebSecurityConfig {
 
           // Temporary solution for Struts less login page, will be removed when apps are fully
           // migrated
+          .antMatchers("/**/service-worker.js.map")
+          .permitAll()
+          .antMatchers("/**/service-worker.js")
+          .permitAll()
           .antMatchers("/index.html")
           .permitAll()
           .antMatchers("/external-static/**")

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
@@ -130,13 +130,20 @@ public class DhisWebCommonsWebSecurityConfig {
 
     @Override
     public void configure(WebSecurity web) {
-      web.ignoring().antMatchers("/api/ping");
+      web.ignoring()
+          .antMatchers("/api/ping")
+          .antMatchers("/**/service-worker.js.map")
+          .antMatchers("/**/service-worker.js");
     }
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
       http.authorizeRequests()
           .accessDecisionManager(accessDecisionManager())
+          .antMatchers("/**/service-worker.js.map")
+          .permitAll()
+          .antMatchers("/**/service-worker.js")
+          .permitAll()
           .antMatchers("/dhis-web-login/**")
           .permitAll()
           .requestMatchers(analyticsPluginResources())

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
@@ -132,17 +132,17 @@ public class DhisWebCommonsWebSecurityConfig {
     public void configure(WebSecurity web) {
       web.ignoring()
           .antMatchers("/api/ping")
-          .antMatchers("/**/service-worker.js.map")
-          .antMatchers("/**/service-worker.js");
+          .antMatchers("/*/service-worker.js.map")
+          .antMatchers("/*/service-worker.js");
     }
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
       http.authorizeRequests()
           .accessDecisionManager(accessDecisionManager())
-          .antMatchers("/**/service-worker.js.map")
+          .antMatchers("/*/service-worker.js.map")
           .permitAll()
-          .antMatchers("/**/service-worker.js")
+          .antMatchers("/*/service-worker.js")
           .permitAll()
           .antMatchers("/dhis-web-login/**")
           .permitAll()


### PR DESCRIPTION
## Summary
Adjust the public regexp for service-worker.js.map to only allow one level of parents.