### PR TITLE
chore(deps): bump org.springframework.security:spring-security-core [2.41]

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -90,7 +90,7 @@
     <dhis-json-tree.version>1.0</dhis-json-tree.version>
 
     <!-- Security -->
-    <spring-security.version>5.8.10</spring-security.version>
+    <spring-security.version>5.8.11</spring-security.version>
     <spring-security-oauth2.version>2.5.2.RELEASE</spring-security-oauth2.version>
     <spring-security-jwt.version>1.1.1.RELEASE</spring-security-jwt.version>
     <bcprov-jdk15on.version>1.70</bcprov-jdk15on.version>


### PR DESCRIPTION
backport of https://github.com/dhis2/dhis2-core/pull/16813

to close https://github.com/dhis2/dhis2-core/security/dependabot/37 in 2.41 as well