### PR TITLE
fix: fallback to name if translation is null for token search

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/TokenOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/TokenOperator.java
@@ -76,15 +76,18 @@ public class TokenOperator<T extends Comparable<? super T>> extends Operator<T> 
         || queryPath.getProperty().getTranslationKey() == null) {
       return defaultSearch;
     }
-    return builder.equal(
-        builder.function(
-            JsonbFunctions.SEARCH_TRANSLATION_TOKEN,
-            Boolean.class,
-            root.get("translations"),
-            builder.literal("{" + queryPath.getProperty().getTranslationKey() + "}"),
-            builder.literal(queryPath.getLocale().getLanguage()),
-            builder.literal(TokenUtils.createRegex(value).toString())),
-        true);
+
+    return builder.or(
+        builder.equal(
+            builder.function(
+                JsonbFunctions.SEARCH_TRANSLATION_TOKEN,
+                Boolean.class,
+                root.get("translations"),
+                builder.literal("{" + queryPath.getProperty().getTranslationKey() + "}"),
+                builder.literal(queryPath.getLocale().getLanguage()),
+                builder.literal(TokenUtils.createRegex(value).toString())),
+            true),
+        defaultSearch);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/DefaultQueryPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/DefaultQueryPlanner.java
@@ -31,7 +31,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Root;
 import lombok.RequiredArgsConstructor;
@@ -293,16 +292,20 @@ public class DefaultQueryPlanner implements QueryPlanner {
     return curProperty == null && CodeGenerator.isValidUid(propertyName);
   }
 
+  /**
+   * Set the current locale on the query path. The current locale is the user's selected database
+   * locale if available, otherwise the system setting DB_Locale. If neither is available, the
+   * {@link LocaleManager#DEFAULT_LOCALE} is used.
+   *
+   * @param restriction the {@link Restriction} which contains the query path.
+   */
   private void setQueryPathLocale(Restriction restriction) {
-    Locale systemLocale =
-        systemSettingManager.getSystemSetting(SettingKey.DB_LOCALE, LocaleManager.DEFAULT_LOCALE);
-    Locale currentUserLocale = CurrentUserUtil.getUserSetting(UserSettingKey.DB_LOCALE);
-    if (currentUserLocale != null && !currentUserLocale.equals(systemLocale)) {
-      // Use translations jsonb column for querying with the current user locale.
-      restriction.getQueryPath().setLocale(currentUserLocale);
-    } else {
-      // Use default properties for querying. Don't use the translations jsonb column.
-      restriction.getQueryPath().setLocale(null);
-    }
+    restriction
+        .getQueryPath()
+        .setLocale(
+            CurrentUserUtil.getUserSetting(
+                UserSettingKey.DB_LOCALE,
+                systemSettingManager.getSystemSetting(
+                    SettingKey.DB_LOCALE, LocaleManager.DEFAULT_LOCALE)));
   }
 }


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-17097

- Make the `token` api filter to fallback to `name` column if the translation value for current locale is not available.
### Test
- Can test by set UserSetting.DB_Locale to arabic, then in Maintenance app search for DataElement using English name.
- Expected behavior: the result should return DataElements which English name match the search token.