### PR TITLE
chore(deps): bump jclouds.version from 2.5.0 to 2.6.0

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/TwoFactorController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/TwoFactorController.java
@@ -27,11 +27,11 @@
  */
 package org.hisp.dhis.webapi.controller.security;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.unauthorized;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM_VALUE;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -96,7 +96,7 @@ public class TwoFactorController {
     return Map.of("url", "url");
   }
 
-  @GetMapping(value = "/qrCode", produces = APPLICATION_OCTET_STREAM)
+  @GetMapping(value = "/qrCode", produces = APPLICATION_OCTET_STREAM_VALUE)
   @ResponseStatus(HttpStatus.ACCEPTED)
   public void generateQRCode(@CurrentUser User currentUser, HttpServletResponse response)
       throws IOException, WebMessageException {

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -142,7 +142,7 @@
     <xercesImpl.version>2.12.2</xercesImpl.version>
 
     <!--- Apache jclouds -->
-    <jclouds.version>2.5.0</jclouds.version>
+    <jclouds.version>2.6.0</jclouds.version>
 
     <!-- Reporting -->
     <jasperreports.version>6.20.0</jasperreports.version>
@@ -238,7 +238,7 @@
     <jrebel-x-maven-plugin.version>1.2.0</jrebel-x-maven-plugin.version>
     <dhis-antlr-expression-parser.version>1.0.36</dhis-antlr-expression-parser.version>
     <jai-imageio.version>1.1.1</jai-imageio.version>
-    <gson.version>2.8.9</gson.version>
+    <gson.version>2.10.1</gson.version>
     <semver4j.version>3.1.0</semver4j.version>
     <opentelemetry.version>2.1.0</opentelemetry.version>
   </properties>


### PR DESCRIPTION
https://github.com/apache/jclouds-site/blob/master/releasenotes/2.6.0.md sounds safe and sensible to update.

Side benefit is we can now upgrade gson due to their fix https://issues.apache.org/jira/browse/JCLOUDS-1620. We [were stuck before](https://github.com/dhis2/dhis2-core/pull/12209#issuecomment-1318179623) this.

## Fixes

1. Exchange

https://docs.oracle.com/javaee%2F7%2Fapi%2F%2F/javax/ws/rs/core/MediaType.html#APPLICATION_OCTET_STREAM

for

https://github.com/spring-projects/spring-framework/blob/7d197972e010b9e1e42606fce942a1016b4617a0/spring-web/src/main/java/org/springframework/http/MediaType.java#L171

as the former seems to be unavailable after the update. We already relied on Springs MediaType in this class.

2. upgrade https://mvnrepository.com/artifact/com.google.code.gson/gson 