### PR TITLE
chore: make embedded jetty use new login app

### DIFF
--- a/dhis-2/dhis-web-embedded-jetty/pom.xml
+++ b/dhis-2/dhis-web-embedded-jetty/pom.xml
@@ -135,8 +135,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
   </dependencies>
 

--- a/dhis-2/dhis-web-embedded-jetty/src/main/java/org/hisp/dhis/web/embeddedjetty/EmbeddedJettyBase.java
+++ b/dhis-2/dhis-web-embedded-jetty/src/main/java/org/hisp/dhis/web/embeddedjetty/EmbeddedJettyBase.java
@@ -81,7 +81,7 @@ public abstract class EmbeddedJettyBase {
     rewrite.setHandler(resourceHandler);
     RedirectPatternRule rewritePatternRule = new RedirectPatternRule();
     rewritePatternRule.setPattern("");
-    rewritePatternRule.setLocation("/index.html");
+    rewritePatternRule.setLocation("/dhis-web-login");
     rewrite.addRule(rewritePatternRule);
 
     HandlerList handlers = new HandlerList();

--- a/dhis-2/dhis-web-embedded-jetty/src/main/java/org/hisp/dhis/web/embeddedjetty/LogoutServlet.java
+++ b/dhis-2/dhis-web-embedded-jetty/src/main/java/org/hisp/dhis/web/embeddedjetty/LogoutServlet.java
@@ -52,7 +52,7 @@ public class LogoutServlet extends HttpServlet {
 
       String referer = (String) req.getAttribute("origin");
       req.setAttribute("origin", referer);
-      resp.sendRedirect("/index.html");
+      resp.sendRedirect("/dhis-web-login");
     } else {
       resp.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
     }

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -2075,6 +2075,7 @@ jasperreports.version=${jasperreports.version}
               <ignoredNonTestScopedDependency>org.springframework:spring-beans</ignoredNonTestScopedDependency>
               <ignoredNonTestScopedDependency>io.debezium:debezium-connector-postgres</ignoredNonTestScopedDependency>
               <ignoredNonTestScopedDependency>org.springframework.security:spring-security-core</ignoredNonTestScopedDependency>
+              <ignoredNonTestScopedDependency>com.fasterxml.jackson.core:jackson-databind</ignoredNonTestScopedDependency>
             </ignoredNonTestScopedDependencies>
           </configuration>
         </plugin>


### PR DESCRIPTION
## Summary
Switches the embedded Jetty functionality to use the new login app, and fixes a Maven dependency issue in the same module.

### Manual test

1. Start the embedded Jetty server from the `JettyEmbeddedCoreWeb.java#main()` class.
2. Go to [http://localhost:9090](http://localhost:9090)
3. Observe you get redirected to [http://localhost:9090/dhis-web-login/index.html](http://localhost:9090/dhis-web-login/index.html)
4. Make sure you can log in. 