### PR TITLE
chore: Bump flyway version and upgrade Postgres version to 13

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -141,6 +141,9 @@ updates:
       - dependency-name: "org.hisp.dhis.rules:*" # Rule engine must be upgraded manually due to circular dependency with ANTLR parser
         versions:
           - ">= 2.0"
+      - dependency-name: "org.flywaydb:flyway-core" # It requires Postgres version to be >= 11
+        versions:
+          - "> 9.22.3"
       - dependency-name: "org.slf4j:slf4j-api" # will update in https://dhis2.atlassian.net/browse/DHIS2-16504
         versions:
           - ">= 2.0"

--- a/dhis-2/dhis-support/dhis-support-db-migration/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-db-migration/pom.xml
@@ -20,7 +20,7 @@
     <!-- Flyway -->
     <dependency>
       <groupId>org.flywaydb</groupId>
-      <artifactId>flyway-core</artifactId>
+      <artifactId>flyway-database-postgresql</artifactId>
     </dependency>
 
     <dependency>

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/config/TestContainerPostgresConfig.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/config/TestContainerPostgresConfig.java
@@ -41,10 +41,10 @@ import org.testcontainers.utility.DockerImageName;
 @Configuration
 public class TestContainerPostgresConfig {
   /**
-   * Refers to the {@code postgis/postgis:10-2.5-alpine} image which contains PostgreSQL 10 and
-   * PostGIS 2.5.
+   * Refers to the {@code postgis/postgis:16-3.4-alpine} image which contains PostgreSQL 16 and
+   * PostGIS 3.4.2.
    */
-  private static final String POSTGRES_POSTGIS_VERSION = "10-2.5-alpine";
+  private static final String POSTGRES_POSTGIS_VERSION = "16-3.4-alpine";
 
   private static final DockerImageName POSTGIS_IMAGE_NAME =
       DockerImageName.parse("postgis/postgis").asCompatibleSubstituteFor("postgres");

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/config/TestContainerPostgresConfig.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/config/TestContainerPostgresConfig.java
@@ -41,10 +41,10 @@ import org.testcontainers.utility.DockerImageName;
 @Configuration
 public class TestContainerPostgresConfig {
   /**
-   * Refers to the {@code postgis/postgis:16-3.4-alpine} image which contains PostgreSQL 16 and
+   * Refers to the {@code postgis/postgis:13-3.4-alpine} image which contains PostgreSQL 16 and
    * PostGIS 3.4.2.
    */
-  private static final String POSTGRES_POSTGIS_VERSION = "16-3.4-alpine";
+  private static final String POSTGRES_POSTGIS_VERSION = "13-3.4-alpine";
 
   private static final DockerImageName POSTGIS_IMAGE_NAME =
       DockerImageName.parse("postgis/postgis").asCompatibleSubstituteFor("postgres");

--- a/dhis-2/dhis-test-e2e/docker-compose.yml
+++ b/dhis-2/dhis-test-e2e/docker-compose.yml
@@ -18,7 +18,7 @@ services:
         condition: service_started
 
   db:
-    image: postgis/postgis:16-3.4-alpine
+    image: postgis/postgis:13-3.4-alpine
     command: postgres -c max_locks_per_transaction=100
     restart: unless-stopped
     environment:

--- a/dhis-2/dhis-test-e2e/docker-compose.yml
+++ b/dhis-2/dhis-test-e2e/docker-compose.yml
@@ -18,7 +18,7 @@ services:
         condition: service_started
 
   db:
-    image: postgis/postgis:10-2.5-alpine
+    image: postgis/postgis:16-3.4-alpine
     command: postgres -c max_locks_per_transaction=100
     restart: unless-stopped
     environment:

--- a/dhis-2/dhis-web-embedded-jetty/src/test/java/org/hisp/dhis/auth/AuthTest.java
+++ b/dhis-2/dhis-web-embedded-jetty/src/test/java/org/hisp/dhis/auth/AuthTest.java
@@ -59,7 +59,7 @@ import org.testcontainers.utility.DockerImageName;
  */
 @Slf4j
 class AuthTest {
-  private static final String POSTGRES_POSTGIS_VERSION = "10-2.5-alpine";
+  private static final String POSTGRES_POSTGIS_VERSION = "16-3.4-alpine";
   private static final DockerImageName POSTGIS_IMAGE_NAME =
       DockerImageName.parse("postgis/postgis").asCompatibleSubstituteFor("postgres");
   private static final String POSTGRES_DATABASE_NAME = "dhis";

--- a/dhis-2/dhis-web-embedded-jetty/src/test/java/org/hisp/dhis/auth/AuthTest.java
+++ b/dhis-2/dhis-web-embedded-jetty/src/test/java/org/hisp/dhis/auth/AuthTest.java
@@ -59,7 +59,7 @@ import org.testcontainers.utility.DockerImageName;
  */
 @Slf4j
 class AuthTest {
-  private static final String POSTGRES_POSTGIS_VERSION = "16-3.4-alpine";
+  private static final String POSTGRES_POSTGIS_VERSION = "13-3.4-alpine";
   private static final DockerImageName POSTGIS_IMAGE_NAME =
       DockerImageName.parse("postgis/postgis").asCompatibleSubstituteFor("postgres");
   private static final String POSTGRES_DATABASE_NAME = "dhis";

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -111,7 +111,7 @@
     <lettuce.version>6.3.1.RELEASE</lettuce.version>
 
     <!--DBMS -->
-    <flyway-core.version>9.22.3</flyway-core.version>
+    <flyway-database-postgresql.version>10.10.0</flyway-database-postgresql.version>
     <hibernate.version>5.6.15.Final</hibernate.version>
     <hibernate-types.version>2.21.1</hibernate-types.version>
     <!-- Data sources,db pools and db drivers -->
@@ -1067,8 +1067,8 @@
       <!-- Flyway -->
       <dependency>
         <groupId>org.flywaydb</groupId>
-        <artifactId>flyway-core</artifactId>
-        <version>${flyway-core.version}</version>
+        <artifactId>flyway-database-postgresql</artifactId>
+        <version>${flyway-database-postgresql.version}</version>
       </dependency>
 
       <!-- Google gson -->
@@ -2016,6 +2016,7 @@ jasperreports.version=${jasperreports.version}
           <configuration>
             <failOnWarning>true</failOnWarning>
             <ignoredUnusedDeclaredDependencies>
+              <ignoredUnusedDeclaredDependency>org.flywaydb:flyway-database-postgresql</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.junit.jupiter:junit-jupiter</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>net.sf.jasperreports:jasperreports</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>net.sf.jasperreports:jasperreports-fonts</ignoredUnusedDeclaredDependency>
@@ -2058,6 +2059,7 @@ jasperreports.version=${jasperreports.version}
               <ignoredUnusedDeclaredDependency>org.hisp.dhis:dhis-web-apps</ignoredUnusedDeclaredDependency>
             </ignoredUnusedDeclaredDependencies>
             <ignoredUsedUndeclaredDependencies>
+              <ignoredUsedUndeclaredDependency>org.flywaydb:flyway-core</ignoredUsedUndeclaredDependency>
               <ignoredUsedUndeclaredDependency>org.antlr:antlr4-runtime</ignoredUsedUndeclaredDependency>
               <ignoredUsedUndeclaredDependency>org.junit.jupiter:junit-jupiter-api</ignoredUsedUndeclaredDependency>
               <ignoredUsedUndeclaredDependency>io.micrometer:micrometer-core</ignoredUsedUndeclaredDependency>


### PR DESCRIPTION
- Ignoring flyway upgrades for version 2.41
- Import of `flyway-database-postgresql` dependency is needed instead of `flyway-core` but as the former is not directly used in our code and the latter is, we need to update the list of `usedUndeclared` and `unusedDeclared` dependencies in the `pom.xml` file
- Upgrade Postgres version to 13 (minimum version suggested) used by TestContainers for integration tests and in Docker image used by e2e tests