### PR TITLE
fix: Use appropriate JDBC template with read replicas [DHIS2-17062]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/TransactionMode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/TransactionMode.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.common;
 
-public enum TransactionType {
+public enum TransactionMode {
   READ,
   WRITE
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/TransactionType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/TransactionType.java
@@ -1,0 +1,6 @@
+package org.hisp.dhis.common;
+
+public enum TransactionType {
+  READ,
+  WRITE
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/TransactionType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/TransactionType.java
@@ -1,3 +1,30 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.common;
 
 public enum TransactionType {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sqlview/SqlViewStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sqlview/SqlViewStore.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.sqlview;
 
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.IdentifiableObjectStore;
-import org.hisp.dhis.common.TransactionType;
+import org.hisp.dhis.common.TransactionMode;
 
 /**
  * @author Dang Duy Hieu
@@ -43,15 +43,15 @@ public interface SqlViewStore extends IdentifiableObjectStore<SqlView> {
 
   /**
    * This method will use the appropriate jdbcTemplate depending how DHIS2 has been setup.<br>
-   * <br>
-   * If DHIS2 has been set up using Postgres read replica, then the readOnlyJdbcTemplate will be
+   *
+   * <p>If DHIS2 has been set up using Postgres read replica, then the readOnlyJdbcTemplate will be
    * used for the reads, otherwise the normal jdbcTemplate will be used for all reads/writes.
    *
-   * @param grid grid
-   * @param sql sql
-   * @param transType type of transaction read or write
+   * @param grid the {@link Grid} to populate with the results of the sql query.
+   * @param sql the sql query to execute.
+   * @param transactionMode the {@link TransactionMode} to use for the query.
    */
-  void populateSqlViewGrid(Grid grid, String sql, TransactionType transType);
+  void populateSqlViewGrid(Grid grid, String sql, TransactionMode transactionMode);
 
   boolean refreshMaterializedView(SqlView sqlView);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sqlview/SqlViewStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sqlview/SqlViewStore.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.sqlview;
 
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.IdentifiableObjectStore;
+import org.hisp.dhis.common.TransactionType;
 
 /**
  * @author Dang Duy Hieu
@@ -40,7 +41,17 @@ public interface SqlViewStore extends IdentifiableObjectStore<SqlView> {
 
   void dropViewTable(SqlView sqlView);
 
-  void populateSqlViewGrid(Grid grid, String sql);
+  /**
+   * This method will use the appropriate jdbcTemplate depending how DHIS2 has been setup.<br>
+   * <br>
+   * If DHIS2 has been set up using Postgres read replica, then the readOnlyJdbcTemplate will be
+   * used for the reads, otherwise the normal jdbcTemplate will be used for all reads/writes.
+   *
+   * @param grid grid
+   * @param sql sql
+   * @param transType type of transaction read or write
+   */
+  void populateSqlViewGrid(Grid grid, String sql, TransactionType transType);
 
   boolean refreshMaterializedView(SqlView sqlView);
 }

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
@@ -43,6 +43,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.common.TransactionType;
 import org.hisp.dhis.commons.util.SqlHelper;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
@@ -160,7 +161,7 @@ public class DefaultSqlViewService implements SqlViewService {
       Map<String, String> variables,
       List<String> filters,
       List<String> fields) {
-    return getGridData(sqlView, criteria, variables, filters, fields);
+    return getGridData(sqlView, criteria, variables, filters, fields, TransactionType.READ);
   }
 
   @Override
@@ -171,7 +172,7 @@ public class DefaultSqlViewService implements SqlViewService {
       Map<String, String> variables,
       List<String> filters,
       List<String> fields) {
-    return getGridData(sqlView, criteria, variables, filters, fields);
+    return getGridData(sqlView, criteria, variables, filters, fields, TransactionType.WRITE);
   }
 
   private Grid getGridData(
@@ -179,7 +180,8 @@ public class DefaultSqlViewService implements SqlViewService {
       Map<String, String> criteria,
       Map<String, String> variables,
       List<String> filters,
-      List<String> fields) {
+      List<String> fields,
+      TransactionType transType) {
     canAccess(sqlView);
     validateSqlView(sqlView, criteria, variables);
 
@@ -194,7 +196,7 @@ public class DefaultSqlViewService implements SqlViewService {
             ? getSqlForQuery(sqlView, criteria, variables, filters, fields)
             : getSqlForView(sqlView, criteria, filters, fields);
 
-    sqlViewStore.populateSqlViewGrid(grid, sql);
+    sqlViewStore.populateSqlViewGrid(grid, sql, transType);
     return grid;
   }
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java
@@ -43,7 +43,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.IllegalQueryException;
-import org.hisp.dhis.common.TransactionType;
+import org.hisp.dhis.common.TransactionMode;
 import org.hisp.dhis.commons.util.SqlHelper;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
@@ -161,7 +161,7 @@ public class DefaultSqlViewService implements SqlViewService {
       Map<String, String> variables,
       List<String> filters,
       List<String> fields) {
-    return getGridData(sqlView, criteria, variables, filters, fields, TransactionType.READ);
+    return getGridData(sqlView, criteria, variables, filters, fields, TransactionMode.READ);
   }
 
   @Override
@@ -172,7 +172,7 @@ public class DefaultSqlViewService implements SqlViewService {
       Map<String, String> variables,
       List<String> filters,
       List<String> fields) {
-    return getGridData(sqlView, criteria, variables, filters, fields, TransactionType.WRITE);
+    return getGridData(sqlView, criteria, variables, filters, fields, TransactionMode.WRITE);
   }
 
   private Grid getGridData(
@@ -181,7 +181,7 @@ public class DefaultSqlViewService implements SqlViewService {
       Map<String, String> variables,
       List<String> filters,
       List<String> fields,
-      TransactionType transType) {
+      TransactionMode transactionMode) {
     canAccess(sqlView);
     validateSqlView(sqlView, criteria, variables);
 
@@ -196,7 +196,7 @@ public class DefaultSqlViewService implements SqlViewService {
             ? getSqlForQuery(sqlView, criteria, variables, filters, fields)
             : getSqlForView(sqlView, criteria, filters, fields);
 
-    sqlViewStore.populateSqlViewGrid(grid, sql, transType);
+    sqlViewStore.populateSqlViewGrid(grid, sql, transactionMode);
     return grid;
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sqlview/hibernate/HibernateSqlViewStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sqlview/hibernate/HibernateSqlViewStore.java
@@ -33,7 +33,7 @@ import static java.lang.String.format;
 import javax.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.Grid;
-import org.hisp.dhis.common.TransactionType;
+import org.hisp.dhis.common.TransactionMode;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.setting.SettingKey;
@@ -119,9 +119,9 @@ public class HibernateSqlViewStore extends HibernateIdentifiableObjectStore<SqlV
   }
 
   @Override
-  public void populateSqlViewGrid(Grid grid, String sql, TransactionType transType) {
+  public void populateSqlViewGrid(Grid grid, String sql, TransactionMode transactionMode) {
     SqlRowSet rs =
-        switch (transType) {
+        switch (transactionMode) {
           case READ -> readOnlyJdbcTemplate.queryForRowSet(sql);
           case WRITE -> jdbcTemplate.queryForRowSet(sql);
         };

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sqlview/hibernate/HibernateSqlViewStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sqlview/hibernate/HibernateSqlViewStore.java
@@ -33,6 +33,7 @@ import static java.lang.String.format;
 import javax.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.TransactionType;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.setting.SettingKey;
@@ -118,8 +119,12 @@ public class HibernateSqlViewStore extends HibernateIdentifiableObjectStore<SqlV
   }
 
   @Override
-  public void populateSqlViewGrid(Grid grid, String sql) {
-    SqlRowSet rs = readOnlyJdbcTemplate.queryForRowSet(sql);
+  public void populateSqlViewGrid(Grid grid, String sql, TransactionType transType) {
+    SqlRowSet rs =
+        switch (transType) {
+          case READ -> readOnlyJdbcTemplate.queryForRowSet(sql);
+          case WRITE -> jdbcTemplate.queryForRowSet(sql);
+        };
 
     int maxLimit = systemSettingManager.getIntSetting(SettingKey.SQL_VIEW_MAX_LIMIT);
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sqlview/hibernate/HibernateSqlViewStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sqlview/hibernate/HibernateSqlViewStoreTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.sqlview.hibernate;
+
+import static org.hisp.dhis.common.TransactionType.READ;
+import static org.hisp.dhis.common.TransactionType.WRITE;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import javax.persistence.EntityManager;
+import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.setting.SystemSettingManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class HibernateSqlViewStoreTest {
+
+  @Mock EntityManager entityManager;
+  @Mock JdbcTemplate jdbcTemplate;
+  @Mock JdbcTemplate readOnlyJdbcTemplate;
+  @Mock ApplicationEventPublisher publisher;
+  @Mock AclService aclService;
+  @Mock SystemSettingManager systemSettingManager;
+  @Mock Grid grid;
+  HibernateSqlViewStore store;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    store =
+        new HibernateSqlViewStore(
+            entityManager,
+            jdbcTemplate,
+            publisher,
+            aclService,
+            readOnlyJdbcTemplate,
+            systemSettingManager);
+  }
+
+  @Test
+  @DisplayName("ensure the correct jdbc template is used for an SQL view with writes")
+  void sqlViewJdbcTemplateWriteTest() {
+    // when
+    store.populateSqlViewGrid(grid, "sql", WRITE);
+
+    // then
+    verify(readOnlyJdbcTemplate, times(0)).queryForRowSet(anyString());
+    verify(jdbcTemplate, times(1)).queryForRowSet(anyString());
+  }
+
+  @Test
+  @DisplayName("ensure the correct jdbc template is used for an SQL view with reads")
+  void sqlViewReadOnlyJdbcTemplateReadTest() {
+    // when
+    store.populateSqlViewGrid(grid, "sql", READ);
+
+    // then
+    verify(readOnlyJdbcTemplate, times(1)).queryForRowSet(anyString());
+    verify(jdbcTemplate, times(0)).queryForRowSet(anyString());
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sqlview/hibernate/HibernateSqlViewStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sqlview/hibernate/HibernateSqlViewStoreTest.java
@@ -27,8 +27,8 @@
  */
 package org.hisp.dhis.sqlview.hibernate;
 
-import static org.hisp.dhis.common.TransactionType.READ;
-import static org.hisp.dhis.common.TransactionType.WRITE;
+import static org.hisp.dhis.common.TransactionMode.READ;
+import static org.hisp.dhis.common.TransactionMode.WRITE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
# Issue
When DHIS2 is set up using a Postgres read replica DB, any SQL view (which has an underlying write) will be retrieved using the `readOnlyJdbcTemplate`, which causes an error `cannot execute ... in a read-only transaction`.

# Cause
The method `HibernateSqlViewStore#populateSqlViewGrid` always only ever used the `readOnlyJdbcTemplate`. This never causes any issues when DHIS2 is set up to only use a primary Postgres DB (no read replica DBs) as the `readOnlyJdbcTemplate` falls back to using the normal `jdbcTemplate` when no read replica DBs are found at startup.
If a read replica DB is detected at startup, then the `readOnlyJdbcTemplate` would be used and would target the read replica DB, wherever it is used in the code.

This is only an issue when sql views perform writes underneath (e.g. a select query that calls a DB function, which in turn creates a temp table).

This issue would only ever be seen when the following config is in place:
- using read only replicas
- using sql views that perform writes (`system.sql_view_write_enabled=on`)

# Fix
In order to use the correct jdbc template, when we know the SQL view has an underlying write, then we pass the enum `TransactionType.WRITE` to the store so the normal `jdbcTemplate` can perform the operation.
When we know the SQL view is read only, then we pass the enum `TransactionType.READ` so the `readOnlyJdbcTemplate` is used.

# Testing
Because of the complicated set up involving a read replica DB, this is extremely difficult to test automatically. It suits a manual test, preferably by the reporter of the issue.

## Automated
Simple mock test added to ensure the correct template is used based on the enum value passed in.

## Manual
Set up DHIS2 to use a read replica DB - [see guide](https://github.com/dhis2/wow-backend/blob/master/guides/postgres/postgres_read_replica.md)
Then follow the steps in the Jira to check if issue has been resolved.