### PR TITLE
fix: set CSP header with script-src in tracker file/image endpoints DHIS2-17154

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerByIdTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerByIdTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.event;
 
+import static org.hisp.dhis.utils.Assertions.assertContains;
 import static org.hisp.dhis.utils.Assertions.assertStartsWith;
 import static org.hisp.dhis.web.WebClient.Header;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasMember;
@@ -375,6 +376,7 @@ class EventsExportControllerByIdTest extends DhisControllerConvenienceTest {
     assertEquals("no-cache, private", response.header("Cache-Control"));
     assertEquals(Long.toString(file.getContentLength()), response.header("Content-Length"));
     assertEquals("filename=" + file.getName(), response.header("Content-Disposition"));
+    assertContains("script-src 'none';", response.header("Content-Security-Policy"));
     assertEquals("file content", response.content("text/plain"));
   }
 
@@ -420,6 +422,7 @@ class EventsExportControllerByIdTest extends DhisControllerConvenienceTest {
     assertEquals(HttpStatus.NOT_MODIFIED, response.status());
     assertEquals("\"" + file.getUid() + "\"", response.header("Etag"));
     assertEquals("no-cache, private", response.header("Cache-Control"));
+    assertContains("script-src 'none';", response.header("Content-Security-Policy"));
     assertFalse(response.hasBody());
   }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerUnitTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerUnitTest.java
@@ -67,7 +67,8 @@ class EventsExportControllerUnitTest {
         assertThrows(
             IllegalStateException.class,
             () ->
-                new EventsExportController(eventService, null, null, null, null, null, null, null));
+                new EventsExportController(
+                    eventService, null, null, null, null, null, null, null, null));
 
     assertAll(
         () -> assertStartsWith("event controller supports ordering by", exception.getMessage()),

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerUnitTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportControllerUnitTest.java
@@ -66,7 +66,7 @@ class TrackedEntitiesExportControllerUnitTest {
             IllegalStateException.class,
             () ->
                 new TrackedEntitiesExportController(
-                    trackedEntityService, null, null, null, null, null, null));
+                    trackedEntityService, null, null, null, null, null, null, null));
 
     assertAll(
         () ->

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -32,7 +32,6 @@ import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.RESOURCE
 import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.assertUserOrderableFieldsAreSupported;
 import static org.hisp.dhis.webapi.controller.tracker.export.CompressionUtil.writeGzip;
 import static org.hisp.dhis.webapi.controller.tracker.export.CompressionUtil.writeZip;
-import static org.hisp.dhis.webapi.controller.tracker.export.FileResourceRequestHandler.handleFileRequest;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validatePaginationParameters;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateUnsupportedParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.event.EventRequestParams.DEFAULT_FIELDS_PARAM;
@@ -70,6 +69,7 @@ import org.hisp.dhis.tracker.export.event.EventService;
 import org.hisp.dhis.webapi.controller.tracker.export.ChangeLogRequestParams;
 import org.hisp.dhis.webapi.controller.tracker.export.CsvService;
 import org.hisp.dhis.webapi.controller.tracker.export.FieldFilterRequestHandler;
+import org.hisp.dhis.webapi.controller.tracker.export.FileResourceRequestHandler;
 import org.hisp.dhis.webapi.controller.tracker.export.ResponseHeader;
 import org.hisp.dhis.webapi.controller.tracker.view.Event;
 import org.hisp.dhis.webapi.controller.tracker.view.Page;
@@ -117,6 +117,8 @@ class EventsExportController {
 
   private final FieldFilterRequestHandler fieldFilterRequestHandler;
 
+  private final FileResourceRequestHandler fileResourceRequestHandler;
+
   public EventsExportController(
       EventService eventService,
       EventRequestParamsMapper eventParamsMapper,
@@ -125,7 +127,8 @@ class EventsExportController {
       EventFieldsParamMapper eventsMapper,
       ObjectMapper objectMapper,
       EventChangeLogService eventChangeLogService,
-      FieldFilterRequestHandler fieldFilterRequestHandler) {
+      FieldFilterRequestHandler fieldFilterRequestHandler,
+      FileResourceRequestHandler fileResourceRequestHandler) {
     this.eventService = eventService;
     this.eventParamsMapper = eventParamsMapper;
     this.csvEventService = csvEventService;
@@ -134,6 +137,7 @@ class EventsExportController {
     this.objectMapper = objectMapper;
     this.eventChangeLogService = eventChangeLogService;
     this.fieldFilterRequestHandler = fieldFilterRequestHandler;
+    this.fileResourceRequestHandler = fileResourceRequestHandler;
 
     assertUserOrderableFieldsAreSupported(
         "event", EventMapper.ORDERABLE_FIELDS, eventService.getOrderableFields());
@@ -293,7 +297,8 @@ class EventsExportController {
         "dimension",
         "Request parameter 'dimension' is only supported for images by API /tracker/event/dataValues/{dataElement}/image");
 
-    return handleFileRequest(request, eventService.getFileResource(event, dataElement));
+    return fileResourceRequestHandler.handle(
+        request, eventService.getFileResource(event, dataElement));
   }
 
   @GetMapping("/{event}/dataValues/{dataElement}/image")
@@ -303,7 +308,7 @@ class EventsExportController {
       @RequestParam(required = false) ImageFileDimension dimension,
       HttpServletRequest request)
       throws NotFoundException, ConflictException, BadRequestException {
-    return handleFileRequest(
+    return fileResourceRequestHandler.handle(
         request, eventService.getFileResourceImage(event, dataElement, dimension));
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.webapi.controller.tracker.export.trackedentity;
 import static org.hisp.dhis.common.OpenApi.Response.Status;
 import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.RESOURCE_PATH;
 import static org.hisp.dhis.webapi.controller.tracker.ControllerSupport.assertUserOrderableFieldsAreSupported;
-import static org.hisp.dhis.webapi.controller.tracker.export.FileResourceRequestHandler.handleFileRequest;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validatePaginationParameters;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateUnsupportedParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.trackedentity.TrackedEntityRequestParams.DEFAULT_FIELDS_PARAM;
@@ -70,6 +69,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.tracker.export.ChangeLogRequestParams;
 import org.hisp.dhis.webapi.controller.tracker.export.CsvService;
 import org.hisp.dhis.webapi.controller.tracker.export.FieldFilterRequestHandler;
+import org.hisp.dhis.webapi.controller.tracker.export.FileResourceRequestHandler;
 import org.hisp.dhis.webapi.controller.tracker.export.ResponseHeader;
 import org.hisp.dhis.webapi.controller.tracker.view.Attribute;
 import org.hisp.dhis.webapi.controller.tracker.view.Page;
@@ -126,6 +126,7 @@ class TrackedEntitiesExportController {
   private final TrackedEntityChangeLogService trackedEntityChangeLogService;
 
   private final FieldFilterRequestHandler fieldFilterRequestHandler;
+  private final FileResourceRequestHandler fileResourceRequestHandler;
 
   public TrackedEntitiesExportController(
       TrackedEntityService trackedEntityService,
@@ -134,7 +135,8 @@ class TrackedEntitiesExportController {
       FieldFilterService fieldFilterService,
       TrackedEntityFieldsParamMapper fieldsMapper,
       TrackedEntityChangeLogService trackedEntityChangeLogService,
-      FieldFilterRequestHandler fieldFilterRequestHandler) {
+      FieldFilterRequestHandler fieldFilterRequestHandler,
+      FileResourceRequestHandler fileResourceRequestHandler) {
     this.trackedEntityService = trackedEntityService;
     this.paramsMapper = paramsMapper;
     this.entityCsvService = csvEventService;
@@ -142,6 +144,7 @@ class TrackedEntitiesExportController {
     this.fieldsMapper = fieldsMapper;
     this.trackedEntityChangeLogService = trackedEntityChangeLogService;
     this.fieldFilterRequestHandler = fieldFilterRequestHandler;
+    this.fileResourceRequestHandler = fileResourceRequestHandler;
 
     assertUserOrderableFieldsAreSupported(
         "tracked entity",
@@ -299,7 +302,7 @@ class TrackedEntitiesExportController {
         "dimension",
         "Request parameter 'dimension' is only supported for images by API /tracker/trackedEntities/attributes/{attribute}/image");
 
-    return handleFileRequest(
+    return fileResourceRequestHandler.handle(
         request, trackedEntityService.getFileResource(trackedEntity, attribute, program));
   }
 
@@ -311,7 +314,7 @@ class TrackedEntitiesExportController {
       @RequestParam(required = false) ImageFileDimension dimension,
       HttpServletRequest request)
       throws NotFoundException, ConflictException, BadRequestException {
-    return handleFileRequest(
+    return fileResourceRequestHandler.handle(
         request,
         trackedEntityService.getFileResourceImage(trackedEntity, attribute, program, dimension));
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/HeaderUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/HeaderUtils.java
@@ -30,9 +30,12 @@ package org.hisp.dhis.webapi.utils;
 import javax.servlet.http.HttpServletResponse;
 
 public class HeaderUtils {
+  public static final String X_CONTENT_TYPE_OPTIONS_VALUE = "nosniff";
+  public static final String X_XSS_PROTECTION_VALUE = "1; mode=block";
+
   public static void setSecurityHeaders(HttpServletResponse response, String cspHeaders) {
     response.setHeader("Content-Security-Policy", cspHeaders);
-    response.setHeader("X-Content-Type-Options", "nosniff");
-    response.setHeader("X-XSS-Protection", "1; mode=block");
+    response.setHeader("X-Content-Type-Options", X_CONTENT_TYPE_OPTIONS_VALUE);
+    response.setHeader("X-XSS-Protection", X_XSS_PROTECTION_VALUE);
   }
 }


### PR DESCRIPTION
Set headers as in https://github.com/dhis2/dhis2-core/blob/b759d3993995aa5456d7ac52ba261921909b20b5/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/HeaderUtils.java#L33 which file/image download endpoints do:

https://github.com/search?q=repo%3Adhis2%2Fdhis2-core%20%20%20%20%20%20%20%20%20response%2C%20dhisConfig.getProperty(ConfigurationKey.CSP_HEADER_VALUE))%3B&type=code

Ideally we would do this in a central place. So no one would ever forget. We plan a refactoring of file resource download code for version 42. We might be able to extract the repeated logic you can see in the above search to a central handler like `FileResourceRequestHandler`. `FileResourceRequestHandler` is currently used only inside of tracker but its logic is not tracker specific.