### PR TITLE
fix: SQL error in enrollment request when using E2E - Coordinate and E2E - Organisation Unit [2.41.0-backport] [DHIS2-17139]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -401,7 +401,8 @@ public abstract class AbstractJdbcEventAnalyticsManager {
         String columnForExists = " exists (" + columnAndAlias.column + ")";
         String aliasForExists = columnAndAlias.alias + ".exists";
         columns.add((new ColumnAndAlias(columnForExists, aliasForExists)).asSql());
-        String columnForStatus = replaceStringBetween(columnAndAlias.column, "select", "from"," psistatus ");
+        String columnForStatus =
+            replaceStringBetween(columnAndAlias.column, "select", "from", " psistatus ");
         String aliasForStatus = columnAndAlias.alias + ".status";
         columns.add((new ColumnAndAlias(columnForStatus, aliasForStatus)).asSql());
       }
@@ -453,11 +454,11 @@ public abstract class AbstractJdbcEventAnalyticsManager {
           .anyMatch(f -> queryItem.getItem().getUid().equals(f))) {
         return getCoordinateColumn(queryItem, OU_GEOMETRY_COL_SUFFIX);
       } else {
-        return rowContextAllowedAndNeeded(params, queryItem) ?
-                ColumnAndAlias.ofColumnAndAlias(
-            getColumn(queryItem, OU_NAME_COL_SUFFIX),
-            getAlias(queryItem).orElse(queryItem.getItemName())):
-                ColumnAndAlias.ofColumn(getColumn(queryItem, OU_NAME_COL_SUFFIX));
+        return rowContextAllowedAndNeeded(params, queryItem)
+            ? ColumnAndAlias.ofColumnAndAlias(
+                getColumn(queryItem, OU_NAME_COL_SUFFIX),
+                getAlias(queryItem).orElse(queryItem.getItemName()))
+            : ColumnAndAlias.ofColumn(getColumn(queryItem, OU_NAME_COL_SUFFIX));
       }
     } else if (queryItem.getValueType() == ValueType.NUMBER && !isGroupByClause) {
       ColumnAndAlias columnAndAlias =

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
@@ -59,6 +59,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -1144,5 +1145,17 @@ public class AnalyticsUtils {
     }
 
     return Optional.empty();
+  }
+
+  /**
+   * Retrieves the sql string with content replacement between select and from
+   *
+   * @param original original sql string
+   * @param replacement the content of replacement
+   */
+  public static String replaceStringBetween(String original, String startToken, String endToken, String replacement) {
+    Pattern pattern =  Pattern.compile(Pattern.quote(startToken) + "(.*?)" + Pattern.quote(endToken));
+    Matcher matcher = pattern.matcher(original);
+    return matcher.replaceAll(startToken + replacement + endToken);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
@@ -1148,10 +1148,10 @@ public class AnalyticsUtils {
   }
 
   /**
-   * Retrieves the sql string with content replacement between select and from
+   * Retrieves the sql string with content replacement between for example select and from
    *
    * @param original original sql string
-   * @param replacement the content of replacement
+   * @param replacement the replacement content
    */
   public static String replaceStringBetween(String original, String startToken, String endToken, String replacement) {
     Pattern pattern =  Pattern.compile(Pattern.quote(startToken) + "(.*?)" + Pattern.quote(endToken));

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
@@ -1153,8 +1153,10 @@ public class AnalyticsUtils {
    * @param original original sql string
    * @param replacement the replacement content
    */
-  public static String replaceStringBetween(String original, String startToken, String endToken, String replacement) {
-    Pattern pattern =  Pattern.compile(Pattern.quote(startToken) + "(.*?)" + Pattern.quote(endToken));
+  public static String replaceStringBetween(
+      String original, String startToken, String endToken, String replacement) {
+    Pattern pattern =
+        Pattern.compile(Pattern.quote(startToken) + "(.*?)" + Pattern.quote(endToken));
     Matcher matcher = pattern.matcher(original);
     return matcher.replaceAll(startToken + replacement + endToken);
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -284,7 +284,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + "[-1]."
             + dataElementUid
             + ".exists\""
-            + ", ((select \"psistatus\" "
+            + ",(select psistatus "
             + "from analytics_event_"
             + programUid
             + " where analytics_event_"
@@ -293,7 +293,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + programUid
             + ".pi = ax.pi and ps = '"
             + programStageUid
-            + "' order by occurreddate desc, created desc offset 1 limit 1 )) "
+            + "' order by occurreddate desc, created desc offset 1 limit 1 ) "
             + "as \""
             + programStageUid
             + "[-1]."

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TrackedEntityQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TrackedEntityQueryTest.java
@@ -2888,7 +2888,7 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
         "IpHINAT79UW.incidentdate",
         "Date of birth, Child Programme",
         "DATE",
-        "java.time.LocalDateTime",
+        "java.time.LocalDate",
         false,
         true);
 


### PR DESCRIPTION
**[NEEDS RCB APPROVAL]**

BACKPORT: The handling of repeatable stages, data type organization unit coordinate, and organization unit contains a bug. The row context handler is generating invalid SQL statements.