### PR TITLE
fix: Analytics enrollment endpoint: remove the use of default period for empty enrollment/incident date[2.41-DHIS2-17103-backport]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/PeriodCriteriaUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/PeriodCriteriaUtils.java
@@ -72,7 +72,7 @@ public class PeriodCriteriaUtils {
    * @return true if the criteria contains a period dimension, (start and end date) or event date.
    *     False, otherwise.
    */
-  private static boolean hasPeriod(EventsAnalyticsQueryCriteria criteria) {
+  public static boolean hasPeriod(EventsAnalyticsQueryCriteria criteria) {
     return criteria.getDimension().stream().anyMatch(d -> d.startsWith(PERIOD_DIM_ID))
         || (criteria.getFilter() != null
             && criteria.getFilter().stream().anyMatch(d -> d.startsWith(PERIOD_DIM_ID)))
@@ -92,7 +92,7 @@ public class PeriodCriteriaUtils {
    * @return true if the criteria contains a period dimension, (start and end date) or enrollment
    *     date. False, otherwise.
    */
-  private static boolean hasPeriod(EnrollmentAnalyticsQueryCriteria criteria) {
+  public static boolean hasPeriod(EnrollmentAnalyticsQueryCriteria criteria) {
     return criteria.getDimension().stream().anyMatch(d -> d.startsWith(PERIOD_DIM_ID))
         || !isBlank(criteria.getEnrollmentDate())
         || (criteria.getStartDate() != null && criteria.getEndDate() != null)

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsPeriodCriteriaUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsPeriodCriteriaUtils.java
@@ -32,6 +32,8 @@ import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.hisp.dhis.common.EnrollmentAnalyticsQueryCriteria;
 import org.hisp.dhis.common.EventsAnalyticsQueryCriteria;
 import org.hisp.dhis.period.PeriodDataProvider;
@@ -40,6 +42,7 @@ import org.hisp.dhis.util.PeriodCriteriaUtils;
 /**
  * Helper class that provides supportive methods to deal with analytics query criteria and periods.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class AnalyticsPeriodCriteriaUtils {
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsPeriodCriteriaUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsPeriodCriteriaUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.util;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import org.hisp.dhis.common.EnrollmentAnalyticsQueryCriteria;
+import org.hisp.dhis.common.EventsAnalyticsQueryCriteria;
+import org.hisp.dhis.period.PeriodDataProvider;
+import org.hisp.dhis.util.PeriodCriteriaUtils;
+
+/**
+ * Helper class that provides supportive methods to deal with analytics query criteria and periods.
+ */
+public final class AnalyticsPeriodCriteriaUtils {
+
+  /**
+   * Defines a default period for the given criteria, if none is present.
+   *
+   * @param criteria {@link EventsAnalyticsQueryCriteria} query criteria.
+   * @param periodDataProvider {@link EventsAnalyticsQueryCriteria} period data provider.
+   * @param dataSource {@link PeriodDataProvider.DataSource} source of data.
+   */
+  public static void defineDefaultPeriodForCriteria(
+      EnrollmentAnalyticsQueryCriteria criteria,
+      PeriodDataProvider periodDataProvider,
+      PeriodDataProvider.DataSource dataSource) {
+    List<Integer> availableYears = periodDataProvider.getAvailableYears(dataSource);
+
+    if (PeriodCriteriaUtils.hasPeriod(criteria)) {
+      return;
+    }
+
+    Date startDate =
+        Date.from(
+            LocalDate.of(Collections.min(availableYears), 1, 1)
+                .atStartOfDay(ZoneId.systemDefault())
+                .toInstant());
+
+    Date endDate =
+        Date.from(
+            LocalDate.of(Collections.max(availableYears), 12, 31)
+                .atStartOfDay(ZoneId.systemDefault())
+                .toInstant());
+
+    criteria.setStartDate(startDate);
+    criteria.setEndDate(endDate);
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsPeriodCriteriaUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsPeriodCriteriaUtilsTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.util;
+
+import static java.time.LocalDate.now;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.ZoneId;
+import java.util.Set;
+import org.hisp.dhis.common.EnrollmentAnalyticsQueryCriteria;
+import org.hisp.dhis.period.PeriodDataProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class AnalyticsPeriodCriteriaUtilsTest {
+  @Test
+  void testDefineDefaultPeriodForCriteria_without_period() {
+    // given
+    EnrollmentAnalyticsQueryCriteria criteria = new EnrollmentAnalyticsQueryCriteria();
+    criteria.setDimension(Set.of("dimension"));
+    PeriodDataProvider periodDataProvider = new PeriodDataProvider(new JdbcTemplate());
+
+    // when
+    AnalyticsPeriodCriteriaUtils.defineDefaultPeriodForCriteria(
+        criteria, periodDataProvider, PeriodDataProvider.DataSource.SYSTEM_DEFINED);
+
+    // then
+    assertEquals(
+        criteria.getStartDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate().getYear(),
+        1975);
+    assertEquals(
+        criteria.getEndDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate().getYear(),
+        now().plusYears(25).getYear());
+  }
+
+  @Test
+  void testDefineDefaultPeriodForCriteria_with_period() {
+    // given
+    final String period = "pe:LAST_YEAR";
+    EnrollmentAnalyticsQueryCriteria criteria = new EnrollmentAnalyticsQueryCriteria();
+    criteria.setDimension(Set.of(period));
+    PeriodDataProvider periodDataProvider = new PeriodDataProvider(new JdbcTemplate());
+
+    // when
+    AnalyticsPeriodCriteriaUtils.defineDefaultPeriodForCriteria(
+        criteria, periodDataProvider, PeriodDataProvider.DataSource.SYSTEM_DEFINED);
+
+    // then
+    assertNull(criteria.getStartDate());
+    assertNull(criteria.getEndDate());
+    assertEquals(criteria.getDimension(), Set.of(period));
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsPeriodCriteriaUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsPeriodCriteriaUtilsTest.java
@@ -38,7 +38,7 @@ import org.hisp.dhis.period.PeriodDataProvider;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
 
-public class AnalyticsPeriodCriteriaUtilsTest {
+class AnalyticsPeriodCriteriaUtilsTest {
   @Test
   void testDefineDefaultPeriodForCriteria_without_period() {
     // given
@@ -52,11 +52,11 @@ public class AnalyticsPeriodCriteriaUtilsTest {
 
     // then
     assertEquals(
-        criteria.getStartDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate().getYear(),
-        1975);
+        1975,
+        criteria.getStartDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate().getYear());
     assertEquals(
-        criteria.getEndDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate().getYear(),
-        now().plusYears(25).getYear());
+        now().plusYears(25).getYear(),
+        criteria.getEndDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate().getYear());
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/EnrollmentQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/EnrollmentQueryTest.java
@@ -301,4 +301,40 @@ public class EnrollmentQueryTest extends AnalyticsApiTest {
             "25.0",
             ""));
   }
+
+  @Test
+  public void queryWithoutPeriodDimension() {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("dimension=ou:USER_ORGUNIT,edqlbukwRfQ.vANAXwtLwcT")
+            .add("headers=ouname,edqlbukwRfQ.vANAXwtLwcT,enrollmentdate")
+            .add("pageSize=5")
+            .add("page=1");
+
+    // When
+    ApiResponse response = enrollmentsActions.query().get("WSGAb5XwJ3Y", JSON, JSON, params);
+    response.validate().statusCode(200).body("headers", hasSize(equalTo(3)));
+
+    validateHeader(
+        response, 0, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, true);
+    validateHeader(
+        response,
+        1,
+        "edqlbukwRfQ.vANAXwtLwcT",
+        "WHOMCH Hemoglobin value",
+        "NUMBER",
+        "java.lang.Double",
+        false,
+        true);
+    validateHeader(
+        response,
+        2,
+        "enrollmentdate",
+        "Date of first visit",
+        "DATE",
+        "java.time.LocalDate",
+        false,
+        true);
+  }
 }


### PR DESCRIPTION
BACKPORT
The analytics API supports the period dimension, and the related query parameter is mandatory. New feature implementation removes this restriction for the enrollment/query entry point. When the period dimension is not included in the parameter set, the default rules are applied, wherein the start date and end date are equal to the maximum interval used for analytics export.