### PR TITLE
fix: Tracker - Default Json response to browser only html requests [DHIS2-13014]

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/export/TrackerExportTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/export/TrackerExportTest.java
@@ -47,6 +47,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hisp.dhis.helpers.matchers.MatchesJson.matchesJSON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.gson.JsonObject;
 import io.restassured.http.Header;
@@ -572,7 +573,7 @@ public class TrackerExportTest extends TrackerApiTest {
             null,
             new Headers(new Header(HttpHeaders.ACCEPT, "text/html")));
 
-    assertEquals("application/csv; charset=UTF-8", response.getContentType());
+    assertTrue(response.getContentType().contains("application/csv"));
   }
 
   @Test
@@ -598,7 +599,7 @@ public class TrackerExportTest extends TrackerApiTest {
             null,
             new Headers(new Header(HttpHeaders.ACCEPT, "text/html")));
 
-    assertEquals("application/csv; charset=UTF-8", response.getContentType());
+    assertTrue(response.getContentType().contains("application/csv"));
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/export/TrackerExportTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/export/TrackerExportTest.java
@@ -76,6 +76,8 @@ import org.skyscreamer.jsonassert.JSONAssert;
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */
 public class TrackerExportTest extends TrackerApiTest {
+  private static final String DEFAULT_JSON_CONTENT_TYPE_WITH_HTML_REQUEST =
+      "%s do not default to application/json format when the Accept header is html";
   private static final String TE = "Kj6vYde4LHh";
 
   private static final String TE_POTENTIAL_DUPLICATE = "Nav6inZRw1u";
@@ -559,7 +561,7 @@ public class TrackerExportTest extends TrackerApiTest {
     assertEquals(
         List.of(event),
         events,
-        "Events do not default to application/json format when Accept header is html");
+        String.format(DEFAULT_JSON_CONTENT_TYPE_WITH_HTML_REQUEST, "Events"));
   }
 
   @Test
@@ -574,7 +576,7 @@ public class TrackerExportTest extends TrackerApiTest {
     assertEquals(
         List.of(trackedEntityA),
         trackedEntities,
-        "Tracked Entities do not default to application/json format when Accept header is html");
+        String.format(DEFAULT_JSON_CONTENT_TYPE_WITH_HTML_REQUEST, "Tracked Entities"));
   }
 
   @Test
@@ -589,7 +591,7 @@ public class TrackerExportTest extends TrackerApiTest {
     assertEquals(
         List.of(enrollment),
         enrollments,
-        "Enrollments do not default to application/json format when Accept header is html");
+        String.format(DEFAULT_JSON_CONTENT_TYPE_WITH_HTML_REQUEST, "Enrollments"));
   }
 
   @Test
@@ -604,7 +606,7 @@ public class TrackerExportTest extends TrackerApiTest {
     assertEquals(
         List.of(trackedEntityToTrackedEntityRelationship),
         relationships,
-        "Enrollments do not default to application/json format when Accept header is html");
+        String.format(DEFAULT_JSON_CONTENT_TYPE_WITH_HTML_REQUEST, "Relationships"));
   }
 
   private static QueryParamsBuilder paramsForTrackedEntitiesIncludingPotentialDuplicate() {

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/export/TrackerExportTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/export/TrackerExportTest.java
@@ -565,6 +565,17 @@ public class TrackerExportTest extends TrackerApiTest {
   }
 
   @Test
+  void whenGetEventsCsvShouldGetCsvContentTypeWithHtmlAcceptHeader() {
+    ApiResponse response =
+        trackerImportExportActions.getWithHeaders(
+            "events.csv?event=" + event,
+            null,
+            new Headers(new Header(HttpHeaders.ACCEPT, "text/html")));
+
+    assertEquals("application/csv; charset=UTF-8", response.getContentType());
+  }
+
+  @Test
   void whenGetTrackedEntitiesShouldDefaultToJsonContentTypeWithHtmlAcceptHeader() {
     ApiResponse response =
         trackerImportExportActions.getWithHeaders(
@@ -577,6 +588,17 @@ public class TrackerExportTest extends TrackerApiTest {
         List.of(trackedEntityA),
         trackedEntities,
         String.format(DEFAULT_JSON_CONTENT_TYPE_WITH_HTML_REQUEST, "Tracked Entities"));
+  }
+
+  @Test
+  void whenGetTrackedEntitiesCsvShouldGetCsvContentTypeWithHtmlAcceptHeader() {
+    ApiResponse response =
+        trackerImportExportActions.getWithHeaders(
+            "trackedEntities.csv?trackedEntities=" + trackedEntityA,
+            null,
+            new Headers(new Header(HttpHeaders.ACCEPT, "text/html")));
+
+    assertEquals("application/csv; charset=UTF-8", response.getContentType());
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/export/TrackerExportTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/export/TrackerExportTest.java
@@ -49,11 +49,14 @@ import static org.hisp.dhis.helpers.matchers.MatchesJson.matchesJSON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.gson.JsonObject;
+import io.restassured.http.Header;
+import io.restassured.http.Headers;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
+import org.apache.http.HttpHeaders;
 import org.hamcrest.Matcher;
 import org.hisp.dhis.Constants;
 import org.hisp.dhis.dto.ApiResponse;
@@ -542,6 +545,66 @@ public class TrackerExportTest extends TrackerApiTest {
         .body("trackedEntities", iterableWithSize(1))
         .body("trackedEntities[0].trackedEntity", equalTo(TE_POTENTIAL_DUPLICATE))
         .body("trackedEntities[0].potentialDuplicate", equalTo(true));
+  }
+
+  @Test
+  void whenGetEventsShouldDefaultToJsonContentTypeWithHtmlAcceptHeader() {
+    ApiResponse response =
+        trackerImportExportActions.getWithHeaders(
+            "events?event=" + event,
+            null,
+            new Headers(new Header(HttpHeaders.ACCEPT, "text/html")));
+
+    List<String> events = response.extractList("events.event.flatten()");
+    assertEquals(
+        List.of(event),
+        events,
+        "Events do not default to application/json format when Accept header is html");
+  }
+
+  @Test
+  void whenGetTrackedEntitiesShouldDefaultToJsonContentTypeWithHtmlAcceptHeader() {
+    ApiResponse response =
+        trackerImportExportActions.getWithHeaders(
+            "trackedEntities?trackedEntities=" + trackedEntityA,
+            null,
+            new Headers(new Header(HttpHeaders.ACCEPT, "text/html")));
+
+    List<String> trackedEntities = response.extractList("trackedEntities.trackedEntity.flatten()");
+    assertEquals(
+        List.of(trackedEntityA),
+        trackedEntities,
+        "Tracked Entities do not default to application/json format when Accept header is html");
+  }
+
+  @Test
+  void whenGetEnrollmentsShouldDefaultToJsonContentTypeWithHtmlAcceptHeader() {
+    ApiResponse response =
+        trackerImportExportActions.getWithHeaders(
+            "enrollments?enrollments=" + enrollment,
+            null,
+            new Headers(new Header(HttpHeaders.ACCEPT, "text/html")));
+
+    List<String> enrollments = response.extractList("enrollments.enrollment.flatten()");
+    assertEquals(
+        List.of(enrollment),
+        enrollments,
+        "Enrollments do not default to application/json format when Accept header is html");
+  }
+
+  @Test
+  void whenGetRelationshipsShouldDefaultToJsonContentTypeWithHtmlAcceptHeader() {
+    ApiResponse response =
+        trackerImportExportActions.getWithHeaders(
+            "relationships?trackedEntity=" + trackedEntityA,
+            null,
+            new Headers(new Header(HttpHeaders.ACCEPT, "text/html")));
+
+    List<String> relationships = response.extractList("relationships.relationship.flatten()");
+    assertEquals(
+        List.of(trackedEntityToTrackedEntityRelationship),
+        relationships,
+        "Enrollments do not default to application/json format when Accept header is html");
   }
 
   private static QueryParamsBuilder paramsForTrackedEntitiesIncludingPotentialDuplicate() {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
@@ -95,7 +95,12 @@ class EnrollmentsExportController {
   }
 
   @OpenApi.Response(status = Status.OK, value = Page.class)
-  @GetMapping(produces = APPLICATION_JSON_VALUE, headers = "Accept=text/html")
+  @GetMapping(
+      produces = APPLICATION_JSON_VALUE,
+      headers = "Accept=text/html"
+      // use the text/html Accept header to default to a Json response when a generic request comes
+      // from a browser
+      )
   ResponseEntity<Page<ObjectNode>> getEnrollments(EnrollmentRequestParams requestParams)
       throws BadRequestException, ForbiddenException {
     validatePaginationParameters(requestParams);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
@@ -53,6 +53,7 @@ import org.hisp.dhis.webapi.controller.tracker.view.Enrollment;
 import org.hisp.dhis.webapi.controller.tracker.view.Page;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.mapstruct.factory.Mappers;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -94,8 +95,8 @@ class EnrollmentsExportController {
   }
 
   @OpenApi.Response(status = Status.OK, value = Page.class)
-  @GetMapping(produces = APPLICATION_JSON_VALUE)
-  Page<ObjectNode> getEnrollments(EnrollmentRequestParams requestParams)
+  @GetMapping(produces = APPLICATION_JSON_VALUE, headers = "Accept=text/html")
+  ResponseEntity<Page<ObjectNode>> getEnrollments(EnrollmentRequestParams requestParams)
       throws BadRequestException, ForbiddenException {
     validatePaginationParameters(requestParams);
     EnrollmentOperationParams operationParams = paramsMapper.map(requestParams);
@@ -112,7 +113,9 @@ class EnrollmentsExportController {
               ENROLLMENT_MAPPER.fromCollection(enrollmentsPage.getItems()),
               requestParams.getFields());
 
-      return Page.withPager(ENROLLMENTS, enrollmentsPage.withItems(objectNodes));
+      return ResponseEntity.ok()
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(Page.withPager(ENROLLMENTS, enrollmentsPage.withItems(objectNodes)));
     }
 
     Collection<org.hisp.dhis.program.Enrollment> enrollments =
@@ -121,7 +124,9 @@ class EnrollmentsExportController {
         fieldFilterService.toObjectNodes(
             ENROLLMENT_MAPPER.fromCollection(enrollments), requestParams.getFields());
 
-    return Page.withoutPager(ENROLLMENTS, objectNodes);
+    return ResponseEntity.ok()
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(Page.withoutPager(ENROLLMENTS, objectNodes));
   }
 
   @OpenApi.Response(OpenApi.EntityType.class)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -142,7 +142,12 @@ class EventsExportController {
   }
 
   @OpenApi.Response(status = Status.OK, value = Page.class)
-  @GetMapping(produces = APPLICATION_JSON_VALUE, headers = "Accept=text/html")
+  @GetMapping(
+      produces = APPLICATION_JSON_VALUE,
+      headers = "Accept=text/html"
+      // use the text/html Accept header to default to a Json response when a generic request comes
+      // from a browser
+      )
   ResponseEntity<Page<ObjectNode>> getEvents(EventRequestParams requestParams)
       throws BadRequestException, ForbiddenException {
     validatePaginationParameters(requestParams);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -42,6 +42,7 @@ import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_CSV_ZIP;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_JSON_GZIP;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_JSON_ZIP;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_TEXT_CSV;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -76,6 +77,7 @@ import org.hisp.dhis.webapi.controller.tracker.view.Page;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.mapstruct.factory.Mappers;
 import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -140,8 +142,8 @@ class EventsExportController {
   }
 
   @OpenApi.Response(status = Status.OK, value = Page.class)
-  @GetMapping(produces = "application/json")
-  Page<ObjectNode> getEvents(EventRequestParams requestParams)
+  @GetMapping(produces = APPLICATION_JSON_VALUE, headers = "Accept=text/html")
+  ResponseEntity<Page<ObjectNode>> getEvents(EventRequestParams requestParams)
       throws BadRequestException, ForbiddenException {
     validatePaginationParameters(requestParams);
     EventOperationParams eventOperationParams = eventParamsMapper.map(requestParams);
@@ -157,7 +159,9 @@ class EventsExportController {
           fieldFilterService.toObjectNodes(
               EVENTS_MAPPER.fromCollection(eventsPage.getItems()), requestParams.getFields());
 
-      return Page.withPager(EVENTS, eventsPage.withItems(objectNodes));
+      return ResponseEntity.ok()
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(Page.withPager(EVENTS, eventsPage.withItems(objectNodes)));
     }
 
     List<org.hisp.dhis.program.Event> events = eventService.getEvents(eventOperationParams);
@@ -165,7 +169,9 @@ class EventsExportController {
         fieldFilterService.toObjectNodes(
             EVENTS_MAPPER.fromCollection(events), requestParams.getFields());
 
-    return Page.withoutPager(EVENTS, objectNodes);
+    return ResponseEntity.ok()
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(Page.withoutPager(EVENTS, objectNodes));
   }
 
   @GetMapping(produces = CONTENT_TYPE_JSON_GZIP)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
@@ -94,7 +94,12 @@ class RelationshipsExportController {
   }
 
   @OpenApi.Response(status = Status.OK, value = Page.class)
-  @GetMapping(produces = APPLICATION_JSON_VALUE, headers = "Accept=text/html")
+  @GetMapping(
+      produces = APPLICATION_JSON_VALUE,
+      headers = "Accept=text/html"
+      // use the text/html Accept header to default to a Json response when a generic request comes
+      // from a browser
+      )
   ResponseEntity<Page<ObjectNode>> getRelationships(RelationshipRequestParams requestParams)
       throws NotFoundException, BadRequestException, ForbiddenException {
     validatePaginationParameters(requestParams);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
@@ -51,6 +51,7 @@ import org.hisp.dhis.webapi.controller.tracker.view.Page;
 import org.hisp.dhis.webapi.controller.tracker.view.Relationship;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.mapstruct.factory.Mappers;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -93,8 +94,8 @@ class RelationshipsExportController {
   }
 
   @OpenApi.Response(status = Status.OK, value = Page.class)
-  @GetMapping
-  Page<ObjectNode> getRelationships(RelationshipRequestParams requestParams)
+  @GetMapping(produces = APPLICATION_JSON_VALUE, headers = "Accept=text/html")
+  ResponseEntity<Page<ObjectNode>> getRelationships(RelationshipRequestParams requestParams)
       throws NotFoundException, BadRequestException, ForbiddenException {
     validatePaginationParameters(requestParams);
     RelationshipOperationParams operationParams = mapper.map(requestParams);
@@ -111,7 +112,9 @@ class RelationshipsExportController {
               RELATIONSHIP_MAPPER.fromCollection(relationshipsPage.getItems()),
               requestParams.getFields());
 
-      return Page.withPager(RELATIONSHIPS, relationshipsPage.withItems(objectNodes));
+      return ResponseEntity.ok()
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(Page.withPager(RELATIONSHIPS, relationshipsPage.withItems(objectNodes)));
     }
 
     List<org.hisp.dhis.relationship.Relationship> relationships =
@@ -120,7 +123,9 @@ class RelationshipsExportController {
         fieldFilterService.toObjectNodes(
             RELATIONSHIP_MAPPER.fromCollection(relationships), requestParams.getFields());
 
-    return Page.withoutPager(RELATIONSHIPS, objectNodes);
+    return ResponseEntity.ok()
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(Page.withoutPager(RELATIONSHIPS, objectNodes));
   }
 
   @GetMapping("/{uid}")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -78,6 +78,7 @@ import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.mapstruct.factory.Mappers;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -150,8 +151,8 @@ class TrackedEntitiesExportController {
   }
 
   @OpenApi.Response(status = Status.OK, value = Page.class)
-  @GetMapping(produces = APPLICATION_JSON_VALUE)
-  Page<ObjectNode> getTrackedEntities(
+  @GetMapping(produces = APPLICATION_JSON_VALUE, headers = "Accept=text/html")
+  ResponseEntity<Page<ObjectNode>> getTrackedEntities(
       TrackedEntityRequestParams requestParams, @CurrentUser User currentUser)
       throws BadRequestException, ForbiddenException, NotFoundException {
     validatePaginationParameters(requestParams);
@@ -170,7 +171,9 @@ class TrackedEntitiesExportController {
               TRACKED_ENTITY_MAPPER.fromCollection(trackedEntitiesPage.getItems()),
               requestParams.getFields());
 
-      return Page.withPager(TRACKED_ENTITIES, trackedEntitiesPage.withItems(objectNodes));
+      return ResponseEntity.ok()
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(Page.withPager(TRACKED_ENTITIES, trackedEntitiesPage.withItems(objectNodes)));
     }
 
     List<org.hisp.dhis.trackedentity.TrackedEntity> trackedEntities =
@@ -179,7 +182,9 @@ class TrackedEntitiesExportController {
         fieldFilterService.toObjectNodes(
             TRACKED_ENTITY_MAPPER.fromCollection(trackedEntities), requestParams.getFields());
 
-    return Page.withoutPager(TRACKED_ENTITIES, objectNodes);
+    return ResponseEntity.ok()
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(Page.withoutPager(TRACKED_ENTITIES, objectNodes));
   }
 
   @GetMapping(produces = {CONTENT_TYPE_CSV, CONTENT_TYPE_TEXT_CSV})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -151,7 +151,12 @@ class TrackedEntitiesExportController {
   }
 
   @OpenApi.Response(status = Status.OK, value = Page.class)
-  @GetMapping(produces = APPLICATION_JSON_VALUE, headers = "Accept=text/html")
+  @GetMapping(
+      produces = APPLICATION_JSON_VALUE,
+      headers = "Accept=text/html"
+      // use the text/html Accept header to default to a Json response when a generic request comes
+      // from a browser
+      )
   ResponseEntity<Page<ObjectNode>> getTrackedEntities(
       TrackedEntityRequestParams requestParams, @CurrentUser User currentUser)
       throws BadRequestException, ForbiddenException, NotFoundException {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/ContextUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/ContextUtils.java
@@ -87,8 +87,6 @@ public class ContextUtils {
 
   public static final String CONTENT_TYPE_PNG = "image/png";
 
-  public static final String CONTENT_TYPE_JPG = "image/jpeg";
-
   public static final String CONTENT_TYPE_EXCEL = "application/vnd.ms-excel";
 
   public static final String CONTENT_TYPE_JAVASCRIPT = "application/javascript; charset=UTF-8";
@@ -101,8 +99,6 @@ public class ContextUtils {
 
   public static final String HEADER_LOCATION = "Location";
 
-  public static final String HEADER_EXPIRES = "Expires";
-
   public static final String HEADER_CONTENT_DISPOSITION = "Content-Disposition";
 
   public static final String HEADER_CONTENT_TRANSFER_ENCODING = "Content-Transfer-Encoding";
@@ -111,8 +107,6 @@ public class ContextUtils {
 
   public static final String HEADER_VALUE_NO_STORE =
       "no-cache, no-store, max-age=0, must-revalidate";
-
-  public static final String QUERY_PARAM_SEP = ";";
 
   public static final String HEADER_IF_NONE_MATCH = "If-None-Match";
 


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-13014

Currently, if we make a rest request to a tracker endpoint that supports multiple content types, such as events or tracked entities, the request doesn't default to JSON when it comes from a browser with a generic path like `/tracker/events`. It appears to consume the CSV endpoint, which is totally random; it could also be the gzip or zip endpoint. The need for defaulting to JSON is that other endpoints like CSV do not support pagination and could potentially run heavy requests to the server.

This issue happens because a browser uses an `Accept` header related to HTML and a null `Content-Type`.
We can see this using the `@RequestHeader("Accept")` in an endpoint. Here is an example of the `Accept` header from Chrome or Brave:

```
text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7
```

This happens even if we have correctly set up the [ContentNegotationManager](https://github.com/dhis2/dhis2-core/blob/914433ffcd4e8c5e4e59e89bdeaf042c7e9d6a9d/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java#L222) which should default the content response to `application/json` by using a `FixedContentNegotiationStrategy`. 
However, this relates only to the Content-Type, and it is also useful when, for example, we use the suffix in the path (e.g.,`/event.csv`) but appears to be usless with the `Accept` header, which is free to be any value and seems to have precedence in defining the request. 

### Fix
One way to fix this is to apply the [headers](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/bind/annotation/GetMapping.html#headers()) attribute in the GET mapping and set it to a sensible value to intercept the browser request. Then, we can use the spring `ResponseEntity` to set the response's content type because the browser request comes with a **null** `Content-Type`. We extend this to all tracker endpoints.

E2e test added. Manual tests were done with Chrome and Brave.

### Alternatives
I couldn't find any alternative to this. Could there be ways to configure the web layer, intercept the requests, or set a different relevance for some request attributes? I have yet to find any, but fixing this at a configuration level might be something we want if we already set a default JSON content type, although this seems related to the tracker endpoints because a user might want to download payloads for the export using a browser URL. Also, setting this as a general rule might affect other endpoints now or in the future, making it difficult to spot the problem.