### PR TITLE
fix: Backport skipRounding/rounding in enrollments [DHIS2-17027]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EnrollmentAnalyticsQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EnrollmentAnalyticsQueryCriteria.java
@@ -77,6 +77,8 @@ public class EnrollmentAnalyticsQueryCriteria extends AnalyticsPagingCriteria {
 
   private boolean skipData;
 
+  private boolean skipRounding;
+
   private boolean completedOnly;
 
   private boolean hierarchyMeta;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
@@ -243,6 +243,7 @@ public class EventDataQueryRequest {
               .showHierarchy(criteria.isShowHierarchy())
               .skipRounding(criteria.isSkipRounding())
               .skipData(criteria.isSkipData())
+              .skipRounding(criteria.isSkipRounding())
               .skipMeta(criteria.isSkipMeta())
               .sortOrder(criteria.getSortOrder())
               .stage(criteria.getStage())

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -978,6 +978,7 @@ public abstract class AbstractJdbcEventAnalyticsManager {
    */
   private void addGridDoubleTypeValue(
       Double value, Grid grid, GridHeader header, EventQueryParams params) {
+    final int defaultScale = 10;
     if (header.hasOptionSet()) {
       Optional<Option> option =
           header.getOptionSetObject().getOptions().stream()
@@ -989,10 +990,16 @@ public abstract class AbstractJdbcEventAnalyticsManager {
       if (option.isPresent()) {
         grid.addValue(option.get().getCode());
       } else {
-        grid.addValue(params.isSkipRounding() ? value : MathUtils.getRoundedObject(value));
+        grid.addValue(
+            params.isSkipRounding()
+                ? MathUtils.getRoundedObject(value, defaultScale)
+                : MathUtils.getRoundedObject(value));
       }
     } else {
-      grid.addValue(params.isSkipRounding() ? value : MathUtils.getRoundedObject(value));
+      grid.addValue(
+          params.isSkipRounding()
+              ? MathUtils.getRoundedObject(value, defaultScale)
+              : MathUtils.getRoundedObject(value));
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsUtilsTest.java
@@ -189,7 +189,7 @@ class AnalyticsUtilsTest extends DhisConvenienceTest {
     assertEquals(
         67L, AnalyticsUtils.getRoundedValueObject(paramsA, 67.0), "Should be a long value: 67");
     assertEquals(
-        3.1,
+        3.12,
         (Double) AnalyticsUtils.getRoundedValueObject(paramsA, 3.123),
         0.01,
         "Should be a double value: 3.1");
@@ -226,7 +226,7 @@ class AnalyticsUtilsTest extends DhisConvenienceTest {
     DataQueryParams paramsB = DataQueryParams.newBuilder().withSkipRounding(true).build();
     assertEquals(null, AnalyticsUtils.getRoundedValue(paramsA, null, null));
     assertEquals(3d, AnalyticsUtils.getRoundedValue(paramsA, null, 3d).doubleValue(), 0.01);
-    assertEquals(3.1, AnalyticsUtils.getRoundedValue(paramsA, null, 3.123).doubleValue(), 0.01);
+    assertEquals(3.12, AnalyticsUtils.getRoundedValue(paramsA, null, 3.123).doubleValue(), 0.01);
     assertEquals(3.1, AnalyticsUtils.getRoundedValue(paramsA, 1, 3.123).doubleValue(), 0.01);
     assertEquals(3.12, AnalyticsUtils.getRoundedValue(paramsA, 2, 3.123).doubleValue(), 0.01);
     assertEquals(3.123, AnalyticsUtils.getRoundedValue(paramsB, 3, 3.123).doubleValue(), 0.01);

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/MathUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/MathUtils.java
@@ -91,21 +91,24 @@ public class MathUtils {
   }
 
   /**
-   * Returns a rounded off number.
-   *
-   * <p>
-   *
-   * <ul>
-   *   <li>If value is exclusively between 1 and -1 it will have 2 decimals.
-   *   <li>If value if greater or equal to 1 the value will have 1 decimal.
-   * </ul>
+   * Returns a rounded off number. Rounding on 2 digits.
    *
    * @param value the value to round off.
    * @return a rounded off number.
    */
   public static double getRounded(double value) {
-    int scale = (value < 1d && value > -1d) ? 2 : 1;
+    return getRounded(value, 2);
+  }
 
+  /**
+   * Returns a rounded off number.
+   *
+   * <p>Rounding on scale
+   *
+   * @param value the value to round off.
+   * @return a rounded off number.
+   */
+  public static double getRounded(double value, int scale) {
     return Precision.round(value, scale);
   }
 
@@ -118,6 +121,19 @@ public class MathUtils {
   public static Object getRoundedObject(Object value) {
     return value != null && Double.class.equals(value.getClass())
         ? getRounded((Double) value)
+        : value;
+  }
+
+  /**
+   * Returns a rounded off number. If the value class is not Double, the value is returned
+   * unchanged.
+   *
+   * @param value the value to return and potentially round off.
+   * @param scale the rounding scale.
+   */
+  public static Object getRoundedObject(Object value, int scale) {
+    return value != null && Double.class.equals(value.getClass())
+        ? getRounded((Double) value, scale)
         : value;
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
@@ -773,7 +773,7 @@ class AnalyticsServiceTest extends SingleSetupIntegrationTestBase {
         "#{" + deB.getUid() + "." + ocDef.getUid() + "}");
 
     assertDataValues(
-        Map.of("indicatorAA-2017Q1", 29.8),
+        Map.of("indicatorAA-2017Q1", 29.79),
         DataQueryParams.newBuilder()
             .withIndicators(List.of(inA))
             .withAggregationType(AnalyticsAggregationType.SUM)
@@ -796,7 +796,7 @@ class AnalyticsServiceTest extends SingleSetupIntegrationTestBase {
             + ".REPORTING_RATE} / 100)");
 
     assertDataValues(
-        Map.of("indicatorAA-ouabcdefghD-2017Q1", 199.4),
+        Map.of("indicatorAA-ouabcdefghD-2017Q1", 199.34),
         DataQueryParams.newBuilder()
             .withOrganisationUnit(ouD)
             .withIndicators(List.of(inA))
@@ -820,7 +820,7 @@ class AnalyticsServiceTest extends SingleSetupIntegrationTestBase {
             + ".REPORTING_RATE} / 100)");
 
     assertDataValues(
-        Map.of("indicatorAA-ouabcdefghD-2017Q1", 99.6),
+        Map.of("indicatorAA-ouabcdefghD-2017Q1", 99.66),
         DataQueryParams.newBuilder()
             .withOrganisationUnit(ouD)
             .withIndicators(List.of(inA))
@@ -1117,7 +1117,7 @@ class AnalyticsServiceTest extends SingleSetupIntegrationTestBase {
   @Test
   void test_reRate_2017_Q01_ouD() {
     assertDataValues(
-        Map.of("a23dataSetB.REPORTING_RATE-ouabcdefghD-2017Q1", 33.3),
+        Map.of("a23dataSetB.REPORTING_RATE-ouabcdefghD-2017Q1", 33.33),
         DataQueryParams.newBuilder()
             .withOrganisationUnit(ouD)
             .withReportingRates(List.of(reportingRateB))


### PR DESCRIPTION
**_[Backport from master/2.42]_** (#16777)

The issue was pinpointed to the event report date in the repeatable stage. The capture app allowed users to add new events in the repeatable stage. The report date (found in the occurreddate column of the event table in the tracker database) is treated as a date without a time section. When analytics queries for repeatable stage events using an position index, the occurreddate is crucial for ensuring the correct outcome, as it serves as the sorting criteria. Sorting on non-unique data can yield inconsistent results. This is the scenario described in the ticket. Report dates of events within the repeatable stage are not unique, and sorting may yield different outcomes.

The skipRounding and rounding on two decimals were fixed/introduced as well.