### PR TITLE
feat: OpenAPI annotation based description for endpoint, parameters, responses

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/OpenApi.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/OpenApi.java
@@ -360,7 +360,7 @@ public @interface OpenApi {
     Pattern pattern() default Pattern.DEFAULT;
   }
 
-  @Target(ElementType.TYPE_USE)
+  @Target({ElementType.TYPE_USE, ElementType.METHOD, ElementType.PARAMETER})
   @Retention(RetentionPolicy.RUNTIME)
   @interface Description {
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/OpenApi.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/OpenApi.java
@@ -360,6 +360,13 @@ public @interface OpenApi {
     Pattern pattern() default Pattern.DEFAULT;
   }
 
+  @Target(ElementType.TYPE_USE)
+  @Retention(RetentionPolicy.RUNTIME)
+  @interface Description {
+
+    String[] value();
+  }
+
   /*
    * Repeater annotations (not for direct use)
    */

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -87,10 +87,7 @@ public class JobConfigurationController extends AbstractCrudController<JobConfig
   @GetMapping("{uid}/errors")
   public JsonObject getJobRunErrors(
       @PathVariable("uid") @OpenApi.Param({UID.class, JobConfiguration.class}) UID uid)
-      throws @OpenApi.Description({"When no such job exists", "foo"}) NotFoundException,
-          @OpenApi.Description(
-              "When the user lacks F_JOB_LOG_READ or F_PERFORM_MAINTENANCE authority")
-          ForbiddenException {
+      throws NotFoundException, ForbiddenException {
     checkExecutingUserOrAdmin(uid, true);
     List<JsonObject> errors =
         jobConfigurationService.findJobRunErrors(new JobRunErrorsParams().setJob(uid));

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -87,7 +87,10 @@ public class JobConfigurationController extends AbstractCrudController<JobConfig
   @GetMapping("{uid}/errors")
   public JsonObject getJobRunErrors(
       @PathVariable("uid") @OpenApi.Param({UID.class, JobConfiguration.class}) UID uid)
-      throws NotFoundException, ForbiddenException {
+      throws @OpenApi.Description({"When no such job exists", "foo"}) NotFoundException,
+          @OpenApi.Description(
+              "When the user lacks F_JOB_LOG_READ or F_PERFORM_MAINTENANCE authority")
+          ForbiddenException {
     checkExecutingUserOrAdmin(uid, true);
     List<JsonObject> errors =
         jobConfigurationService.findJobRunErrors(new JobRunErrorsParams().setJob(uid));

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/Api.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/Api.java
@@ -139,6 +139,12 @@ public class Api {
       return getValue();
     }
 
+    public void setIfAbsent(T value) {
+      if (this.value == null) {
+        this.value = value;
+      }
+    }
+
     T orElse(T defaultValue) {
       return value != null ? value : defaultValue;
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/Api.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/Api.java
@@ -175,45 +175,35 @@ public class Api {
     @EqualsAndHashCode.Include String name;
 
     Maybe<String> description = new Maybe<>();
-
     Maybe<String> externalDocsUrl = new Maybe<>();
-
     Maybe<String> externalDocsDescription = new Maybe<>();
   }
 
   @Value
   @EqualsAndHashCode(onlyExplicitlyIncluded = true)
   static class Controller {
+
     @ToString.Exclude Api in;
-
     @ToString.Exclude @EqualsAndHashCode.Include Class<?> source;
-
     @ToString.Exclude @EqualsAndHashCode.Include Class<?> entityClass;
 
     String name;
-
     List<String> paths = new ArrayList<>();
-
     List<Endpoint> endpoints = new ArrayList<>();
-
     Set<String> tags = new LinkedHashSet<>();
   }
 
   @Value
   @EqualsAndHashCode(onlyExplicitlyIncluded = true)
   static class Endpoint {
+
     @ToString.Exclude Controller in;
-
     @ToString.Exclude Method source;
-
     @ToString.Exclude Class<?> entityType;
 
     @EqualsAndHashCode.Include String name;
-
     Maybe<String> description = new Maybe<>();
-
     Set<String> tags = new LinkedHashSet<>();
-
     Boolean deprecated;
 
     @EqualsAndHashCode.Include Set<RequestMethod> methods = EnumSet.noneOf(RequestMethod.class);
@@ -243,12 +233,10 @@ public class Api {
   @Value
   @EqualsAndHashCode(onlyExplicitlyIncluded = true)
   static class RequestBody {
+
     @ToString.Exclude AnnotatedElement source;
-
     boolean required;
-
     Maybe<String> description = new Maybe<>();
-
     @EqualsAndHashCode.Include Map<MediaType, Schema> consumes = new TreeMap<>();
   }
 
@@ -270,11 +258,8 @@ public class Api {
     @ToString.Exclude AnnotatedElement source;
 
     @EqualsAndHashCode.Include String name;
-
     @EqualsAndHashCode.Include In in;
-
     boolean required;
-
     Schema type;
 
     /**

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiAnalyse.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiAnalyse.java
@@ -262,13 +262,11 @@ final class ApiAnalyse {
     getAnnotations(source, OpenApi.Response.class)
         .forEach(
             a -> res.putAll(newAdditionalResponse(endpoint, source, a, signatureStatus, produces)));
-    // response from method signature
 
+    // response from method signature
     res.computeIfAbsent(
-        signatureStatus,
-        status -> {
-          return newSuccessResponse(endpoint, source, status, produces);
-        });
+        signatureStatus, status -> newSuccessResponse(endpoint, source, status, produces));
+
     // error response(s) from annotated exception types in method signature and
     // error response(s) from annotations on exceptions in method signature
     for (AnnotatedType error : source.getAnnotatedExceptionTypes()) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiFinalise.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiFinalise.java
@@ -43,6 +43,7 @@ import java.util.TreeMap;
 import java.util.function.UnaryOperator;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 import lombok.Builder;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
@@ -421,32 +422,15 @@ public class ApiFinalise {
                   desc -> desc.replace("{entityType}", endpoint.getEntityTypeName());
               endpoint
                   .getDescription()
-                  .setValue(descriptions.get(subst, format("%s.description", name)));
+                  .setIfAbsent(descriptions.get(subst, format("%s.description", name)));
               endpoint
                   .getParameters()
                   .values()
                   .forEach(
-                      parameter -> {
-                        List<String> keys =
-                            parameter.isShared()
-                                ? List.of(
-                                    format(
-                                        "%s.parameter.%s.description",
-                                        name, parameter.getFullName()),
-                                    format(
-                                        "%s.parameter.%s.description",
-                                        name, getSharedNameForDeclaringType(parameter)),
-                                    format("*.parameter.%s.description", parameter.getFullName()),
-                                    format(
-                                        "*.parameter.%s.description",
-                                        getSharedNameForDeclaringType(parameter)),
-                                    format("*.parameter.*.%s.description", parameter.getName()))
-                                : List.of(
-                                    format(
-                                        "%s.parameter.%s.description", name, parameter.getName()),
-                                    format("*.parameter.%s.description", parameter.getName()));
-                        parameter.getDescription().setValue(descriptions.get(subst, keys));
-                      });
+                      p ->
+                          p.getDescription()
+                              .setIfAbsent(
+                                  descriptions.get(subst, getParameterKeySequence(name, p))));
               if (endpoint.getRequestBody().isPresent()) {
                 Api.Maybe<String> description =
                     endpoint.getRequestBody().getValue().getDescription();
@@ -461,12 +445,8 @@ public class ApiFinalise {
                         int statusCode = response.getStatus().value();
                         response
                             .getDescription()
-                            .setValue(
-                                descriptions.get(
-                                    subst,
-                                    List.of(
-                                        format("%s.response.%d.description", name, statusCode),
-                                        format("*.response.%d.description", statusCode))));
+                            .setIfAbsent(
+                                descriptions.get(subst, getResponseKeySequence(name, statusCode)));
                         Api.Schema schema = response.getContent().get(MediaType.APPLICATION_JSON);
                         if (schema != null && !schema.isShared()) {
                           schema
@@ -475,19 +455,44 @@ public class ApiFinalise {
                                   property ->
                                       property
                                           .getDescription()
-                                          .setValue(
+                                          .setIfAbsent(
                                               descriptions.get(
                                                   subst,
-                                                  List.of(
-                                                      format(
-                                                          "%s.response.%d.%s.description",
-                                                          name, statusCode, property.getName()),
-                                                      format(
-                                                          "*.response.%d.%s.description",
-                                                          statusCode, property.getName())))));
+                                                  getPropertyKeySequence(
+                                                      name, statusCode, property))));
                         }
                       });
             });
+  }
+
+  @Nonnull
+  private static List<String> getResponseKeySequence(String endpoint, int statusCode) {
+    return List.of(
+        format("%s.response.%d.description", endpoint, statusCode),
+        format("*.response.%d.description", statusCode));
+  }
+
+  @Nonnull
+  private static List<String> getPropertyKeySequence(
+      String endpoint, int statusCode, Api.Property property) {
+    return List.of(
+        format("%s.response.%d.%s.description", endpoint, statusCode, property.getName()),
+        format("*.response.%d.%s.description", statusCode, property.getName()));
+  }
+
+  @Nonnull
+  private static List<String> getParameterKeySequence(String endpoint, Parameter parameter) {
+    return parameter.isShared()
+        ? List.of(
+            format("%s.parameter.%s.description", endpoint, parameter.getFullName()),
+            format(
+                "%s.parameter.%s.description", endpoint, getSharedNameForDeclaringType(parameter)),
+            format("*.parameter.%s.description", parameter.getFullName()),
+            format("*.parameter.%s.description", getSharedNameForDeclaringType(parameter)),
+            format("*.parameter.*.%s.description", parameter.getName()))
+        : List.of(
+            format("%s.parameter.%s.description", endpoint, parameter.getName()),
+            format("*.parameter.%s.description", parameter.getName()));
   }
 
   private static void describeSchema(Api.Schema schema) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/Descriptions.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/Descriptions.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.webapi.openapi;
 
 import static java.util.Arrays.stream;
 import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.joining;
 
 import java.io.InputStream;
 import java.util.HashMap;
@@ -38,10 +39,11 @@ import java.util.Scanner;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.common.OpenApi;
 
 /**
  * Reads CommonMark markdown files into key-value pairs.
@@ -159,7 +161,7 @@ final class Descriptions {
     return stream(line.split(" "))
         .map(String::trim)
         .map(Descriptions::toKeySegment)
-        .collect(Collectors.joining("."));
+        .collect(joining("."));
   }
 
   private static String toKeySegment(String str) {
@@ -250,5 +252,13 @@ final class Descriptions {
       }
     }
     return null;
+  }
+
+  static String toMarkdown(OpenApi.Description desc) {
+    if (desc == null) return null;
+    String[] items = desc.value();
+    if (items.length == 0) return null;
+    if (items.length == 1) return items[0];
+    return Stream.of(items).map(line -> "\n* " + line).collect(joining());
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/JsonGenerator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/JsonGenerator.java
@@ -122,26 +122,32 @@ public class JsonGenerator {
                     .newLineAfterObjectStart(false)
                     .newLineBeforeObjectEnd(false)
                     .build());
-
+    // block array syntax
     String arrayStart;
     String arrayItemStart;
     String arrayEnd;
     String arrayEmpty;
+    // inline array syntax
     String arrayInlineStart;
     String arrayInlineItemSeparator;
     String arrayInlineEnd;
+    // block object syntax
     String objectStart;
     String objectItemStart;
     String objectEnd;
     String objectEmpty;
+    // object member syntax
     String objectItemSeparator;
+    // (inline) string literal syntax
     String stringStart;
     String stringEnd;
     UnaryOperator<String> escapeString;
+    // (block) text block literal syntax
     String textStart;
     String textEnd;
     boolean textIndent;
     Function<String, List<String>> escapeText;
+    // initializer for language format defaults that differ from base format
     UnaryOperator<Format> adjustFormat;
   }
 
@@ -151,7 +157,10 @@ public class JsonGenerator {
   private final Format format;
   private final Language language;
 
+  /** Current line indent (increased and decreased when entering/exiting a block) */
   private String indent = "";
+
+  /** was the last appended output an array item? */
   private boolean arrayItemLast = false;
 
   @Override
@@ -226,6 +235,10 @@ public class JsonGenerator {
     appendMemberSeparator();
   }
 
+  /**
+   * Same as {@link #addArrayMember(String, Collection)} except that the array will be formatted as
+   * an inline array
+   */
   final void addInlineArrayMember(String name, List<String> values) {
     appendMemberName(name);
     out.append(language.arrayInlineStart);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiGenerator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiGenerator.java
@@ -257,9 +257,7 @@ public class OpenApiGenerator extends JsonGenerator {
   private static final String NO_DESCRIPTION = "[no description yet]";
 
   private final Api api;
-
   private final Info info;
-
   private final Map<String, List<Api.Endpoint>> endpointsByBaseOperationId = new HashMap<>();
 
   private OpenApiGenerator(
@@ -351,7 +349,7 @@ public class OpenApiGenerator extends JsonGenerator {
           addBooleanMember("deprecated", endpoint.getDeprecated());
           addStringMultilineMember("description", endpoint.getDescription().orElse(NO_DESCRIPTION));
           addStringMember("operationId", getUniqueOperationId(endpoint));
-          addArrayMember("tags", tags);
+          addInlineArrayMember("tags", List.copyOf(tags));
           addArrayMember(
               "parameters", endpoint.getParameters().values(), this::generateParameterOrRef);
           if (endpoint.getRequestBody().isPresent()) {
@@ -521,13 +519,13 @@ public class OpenApiGenerator extends JsonGenerator {
     if (schemaType == Api.Schema.Type.ENUM) {
       addStringMember("type", "string");
       if (defaultValue != null) addStringMember("default", defaultValue);
-      addArrayMember("enum", schema.getValues());
+      addInlineArrayMember("enum", schema.getValues());
       return;
     }
     if (type.isEnum()) {
       addStringMember("type", "string");
       if (defaultValue != null) addStringMember("default", defaultValue);
-      addArrayMember(
+      addInlineArrayMember(
           "enum", stream(type.getEnumConstants()).map(e -> ((Enum<?>) e).name()).toList());
       return;
     }
@@ -595,13 +593,13 @@ public class OpenApiGenerator extends JsonGenerator {
       }
     }
     if (simpleType.getEnums() != null) {
-      addArrayMember("enum", List.of(simpleType.getEnums()));
+      addInlineArrayMember("enum", List.of(simpleType.getEnums()));
     }
   }
 
   private void generateRefTypeSchema(Api.Schema schema) {
     addStringMember("type", "object");
-    addArrayMember("required", List.of("id"));
+    addInlineArrayMember("required", List.of("id"));
     addObjectMember("properties", () -> addObjectMember("id", () -> generateUidSchema(schema)));
     addTypeDescriptionMember(schema.getRawType(), "A UID reference to a %s  \n(Java name `%s`)");
   }


### PR DESCRIPTION
### Summary
Allows to annotate endpoints with `@OpenApi.Description` to provide a description text

When annotating...
* method => endpoint description
* parameter => request body and parameter description
* return type => success response description
* exception type => error response description

As before a description text can be provided using markdown files with descriptions from the annotation taking precedence. 
The thought behind this precedence order is that something occurring in code should yield the expected outcome (principle of least surprise). 

### Improved JSON formatting
Another improvement is the more readable JSON formatting
* no longer has unnecessary blank lines after object open
* arrays of strings formatted as single line (inline) array