### PR TITLE
fix: Validate event parameters together in TE endpoint [DHIS2-16927]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
@@ -48,6 +48,7 @@ import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityOperationParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityOperationParams.TrackedEntityOperationParamsBuilder;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;
+import org.hisp.dhis.util.ObjectUtils;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.springframework.stereotype.Component;
 
@@ -198,10 +199,17 @@ class TrackedEntityRequestParamsMapper {
       }
     }
 
-    if (params.getEventStatus() != null
-        && (params.getEventOccurredAfter() == null || params.getEventOccurredBefore() == null)) {
+    if (ObjectUtils.firstNonNull(
+                params.getEventStatus(),
+                params.getEventOccurredAfter(),
+                params.getEventOccurredBefore())
+            != null
+        && !ObjectUtils.allNonNull(
+            params.getEventStatus(),
+            params.getEventOccurredAfter(),
+            params.getEventOccurredBefore())) {
       throw new BadRequestException(
-          "`eventOccurredAfter` and `eventOccurredBefore` must be specified when `eventStatus` is specified");
+          "`eventOccurredAfter`, `eventOccurredBefore` and `eventStatus` must be specified together");
     }
 
     if (params.getUpdatedWithin() != null

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityImportRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityImportRequestParamsMapperTest.java
@@ -276,6 +276,29 @@ class TrackedEntityImportRequestParamsMapperTest {
   }
 
   @Test
+  void shouldFailIfGivenStatusAndNotOccurredEventDates() {
+    trackedEntityRequestParams.setEventStatus(EventStatus.ACTIVE);
+
+    assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, user));
+  }
+
+  @Test
+  void shouldFailIfGivenStatusAndOccurredAfterEventDateButNoOccurredBeforeEventDate() {
+    trackedEntityRequestParams.setEventStatus(EventStatus.ACTIVE);
+    trackedEntityRequestParams.setEventOccurredAfter(new Date());
+
+    assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, user));
+  }
+
+  @Test
+  void shouldFailIfGivenOccurredEventDatesAndNotEventStatus() {
+    trackedEntityRequestParams.setEventOccurredBefore(new Date());
+    trackedEntityRequestParams.setEventOccurredAfter(new Date());
+
+    assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, user));
+  }
+
+  @Test
   void shouldFailIfGivenOrgUnitAndOrgUnits() {
     trackedEntityRequestParams.setOrgUnit("IsdLBTOBzMi");
     trackedEntityRequestParams.setOrgUnits(Set.of(UID.of("IsdLBTOBzMi")));


### PR DESCRIPTION
`eventOccurredAfter`, `eventOccurredBefore`, and `eventStatus` are dependent parameters and they should either be all defined or none.

Docs are going to be updated accordingly.

This dependency between parameters should be avoided. This fix is needed because it should be fixed for new release but we should find a better way to deal with it.
