### PR TITLE
fix: DataValues with legendset are now filtered properly in TE analytics [DHIS2-17145]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/DataElementWithStaticValuesCondition.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/DataElementWithStaticValuesCondition.java
@@ -27,43 +27,42 @@
  */
 package org.hisp.dhis.analytics.tei.query;
 
-import static org.hisp.dhis.commons.util.TextUtils.doubleQuote;
+import static org.hisp.dhis.analytics.tei.query.DataElementCondition.getDataValueRenderable;
 
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.analytics.common.ValueTypeMapping;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifier;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionParam;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionParamItem;
+import org.hisp.dhis.analytics.common.query.AndCondition;
 import org.hisp.dhis.analytics.common.query.BaseRenderable;
+import org.hisp.dhis.analytics.common.query.BinaryConditionRenderer;
+import org.hisp.dhis.analytics.common.query.Renderable;
 import org.hisp.dhis.analytics.tei.query.context.sql.QueryContext;
-import org.hisp.dhis.common.QueryItem;
 
 @RequiredArgsConstructor(staticName = "of")
-public class DataElementCondition extends BaseRenderable {
+public class DataElementWithStaticValuesCondition extends BaseRenderable {
   private final QueryContext queryContext;
 
   private final DimensionIdentifier<DimensionParam> dimensionIdentifier;
 
   @Override
   public String render() {
-    return hasLegendSet(dimensionIdentifier)
-        ? DataElementWithLegendSetCondition.of(queryContext, dimensionIdentifier).render()
-        : DataElementWithStaticValuesCondition.of(queryContext, dimensionIdentifier).render();
+    return AndCondition.of(
+            dimensionIdentifier.getDimension().getItems().stream().map(this::toCondition).toList())
+        .render();
   }
 
-  private boolean hasLegendSet(DimensionIdentifier<DimensionParam> dimId) {
-    return Optional.of(dimId)
-        .map(DimensionIdentifier::getDimension)
-        .map(DimensionParam::getQueryItem)
-        .filter(QueryItem::hasLegendSet)
-        .isPresent();
+  private ValueTypeMapping getValueTypeMapping() {
+    return ValueTypeMapping.fromValueType(dimensionIdentifier.getDimension().getValueType());
   }
 
-  static RenderableDataValue getDataValueRenderable(
-      DimensionIdentifier<DimensionParam> dimensionIdentifier, ValueTypeMapping valueTypeMapping) {
-    return RenderableDataValue.of(
-        doubleQuote(dimensionIdentifier.getPrefix()),
-        dimensionIdentifier.getDimension().getUid(),
-        valueTypeMapping);
+  private Renderable toCondition(DimensionParamItem item) {
+    return BinaryConditionRenderer.of(
+        getDataValueRenderable(dimensionIdentifier, getValueTypeMapping()),
+        item.getOperator(),
+        item.getValues(),
+        getValueTypeMapping(),
+        queryContext);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/query/DataElementConditionTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/query/DataElementConditionTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2004-2004, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.tei.query;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.List;
+import org.hisp.dhis.analytics.common.params.dimension.AnalyticsQueryOperator;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifier;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionParam;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionParamItem;
+import org.hisp.dhis.analytics.tei.query.context.sql.QueryContext;
+import org.hisp.dhis.analytics.tei.query.context.sql.SqlParameterManager;
+import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.QueryOperator;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.legend.Legend;
+import org.hisp.dhis.legend.LegendSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DataElementConditionTest {
+
+  private DimensionIdentifier<DimensionParam> dimensionIdentifier;
+
+  @BeforeEach
+  public void setUp() {
+    dimensionIdentifier = mock(DimensionIdentifier.class);
+  }
+
+  @Test
+  void testWhenNoLegendSet() {
+    SqlParameterManager sqlParameterManager = new SqlParameterManager();
+    QueryContext queryContext = QueryContext.of(null, sqlParameterManager);
+
+    // SETUP
+    DimensionParam dimensionParam = mock(DimensionParam.class);
+    QueryItem queryItem = mock(QueryItem.class);
+    DimensionParamItem dimensionParamItem = mock(DimensionParamItem.class);
+    when(dimensionIdentifier.getDimension()).thenReturn(dimensionParam);
+
+    when(dimensionParam.getQueryItem()).thenReturn(queryItem);
+    when(dimensionParam.getUid()).thenReturn("uid");
+    when(queryItem.hasLegendSet()).thenReturn(false);
+
+    when(dimensionParam.getValueType()).thenReturn(ValueType.TEXT);
+
+    when(dimensionParam.getItems()).thenReturn(List.of(dimensionParamItem));
+    when(dimensionParamItem.getOperator()).thenReturn(AnalyticsQueryOperator.of(QueryOperator.EQ));
+    when(dimensionParamItem.getValues()).thenReturn(List.of("value"));
+
+    // CALL
+    DataElementCondition dataElementCondition =
+        DataElementCondition.of(queryContext, dimensionIdentifier);
+
+    String rendered = dataElementCondition.render();
+
+    // ASSERT
+    assertEquals("(\"eventdatavalues\" -> 'uid' ->> 'value')::TEXT = :1", rendered);
+    assertEquals("value", queryContext.getParametersPlaceHolder().get("1"));
+  }
+
+  @Test
+  void testWhenLegendSet() {
+    SqlParameterManager sqlParameterManager = new SqlParameterManager();
+    QueryContext queryContext = QueryContext.of(null, sqlParameterManager);
+
+    // SETUP
+    DimensionParam dimensionParam = mock(DimensionParam.class);
+    QueryItem queryItem = mock(QueryItem.class);
+    DimensionParamItem dimensionParamItem = mock(DimensionParamItem.class);
+    when(dimensionIdentifier.getDimension()).thenReturn(dimensionParam);
+
+    when(dimensionParam.getQueryItem()).thenReturn(queryItem);
+    when(dimensionParam.getUid()).thenReturn("uid");
+    when(queryItem.hasLegendSet()).thenReturn(true);
+
+    // in the assertion we will check that the type is force to DECIMAL
+    when(dimensionParam.getValueType()).thenReturn(ValueType.TEXT);
+
+    when(dimensionParam.getItems()).thenReturn(List.of(dimensionParamItem));
+    when(dimensionParamItem.getOperator()).thenReturn(AnalyticsQueryOperator.of(QueryOperator.IN));
+    when(dimensionParamItem.getValues()).thenReturn(List.of("value"));
+
+    LegendSet legendSet = mock(LegendSet.class);
+    when(queryItem.getLegendSet()).thenReturn(legendSet);
+
+    Legend legend = mock(Legend.class);
+    when(legendSet.getLegendByUid("value")).thenReturn(legend);
+
+    when(legend.getStartValue()).thenReturn(1.0);
+    when(legend.getEndValue()).thenReturn(2.0);
+
+    // CALL
+    DataElementCondition dataElementCondition =
+        DataElementCondition.of(queryContext, dimensionIdentifier);
+
+    String rendered = dataElementCondition.render();
+
+    // ASSERT
+    assertEquals(
+        "(\"eventdatavalues\" -> 'uid' ->> 'value')::DECIMAL >= :1 "
+            + "and (\"eventdatavalues\" -> 'uid' ->> 'value')::DECIMAL < :2",
+        rendered);
+    assertEquals(new BigDecimal("1.0"), queryContext.getParametersPlaceHolder().get("1"));
+    assertEquals(new BigDecimal("2.0"), queryContext.getParametersPlaceHolder().get("2"));
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/query/DataElementConditionTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/query/DataElementConditionTest.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.analytics.tei.query;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
When a Data Value has a LegendSet, the condition needs to consider the range of values in the legend. This PR aims to implement this behavior