### PR TITLE
fix: avoid resetting housekeeping job when it is alive

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobSchedulerLoopService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobSchedulerLoopService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.scheduling;
 
 import static java.lang.String.format;
+import static java.lang.System.currentTimeMillis;
 import static java.util.stream.Collectors.joining;
 import static org.hisp.dhis.eventhook.EventUtils.schedulerCompleted;
 import static org.hisp.dhis.eventhook.EventUtils.schedulerFailed;
@@ -93,7 +94,9 @@ public class DefaultJobSchedulerLoopService implements JobSchedulerLoopService {
     JobConfiguration config = jobConfigurationStore.getByUid(defaults.uid());
     if (config == null) {
       jobConfigurationService.createDefaultJob(JobType.HOUSEKEEPING, actingUser);
-    } else if (config.getJobStatus() != JobStatus.SCHEDULED) {
+    } else if (config.getJobStatus() != JobStatus.SCHEDULED
+        && (config.getLastAlive() == null
+            || currentTimeMillis() - config.getLastAlive().getTime() > 60_000)) {
       finishRunCancel(config.getUid());
     }
   }


### PR DESCRIPTION
### Summary
When the housekeeping job would take longer than 20sec it would potentially be cancelled (as it is wrongly identified as stale /dead; phantom `RUNNING`) as part of resetting it to a `SCHEDULED` state.
When this happens there also is a chance that more than one worker thread runs the housekeeping job as the a new one is started 40 sec after the previous one. If that is still running after 40sec there would be 2, after 80sec there would be 3 and so on.

This could happen now when default icon insert was particularly slow due to network reasons. Each icon would take 500ms in the test setup causing the insert to run for several minutes. When this spawned more than one housekeeping job the jobs would run concurrently and compete with each other when it comes to inserting default icons making the insert fail for all but one of them.
This exception would be logged. This eventually consolidates when all icons have been inserted successfully. Apart from logging exceptions and doing unnecessary work this error is self repairing. 

To avoid misidentifying the housekeeping job as dead an additional check was added to only do a reset if the `lastAlive` timestamp is more than 60sec in the past. This would be updated every 10sec as long as some progress has been made like adding an icon every 500ms. Thereby this effectively prevents to deem the housekeeping job dead when it is still running.

### Manual Testing
A few scenarios should be tested. All of these require starting/stopping the server and direct DB access.

1. start from clean slate
  * delete all jobs in DB   
  * start the server
  * check after 20-40sec the housekeeping job exist and has created the other system jobs

2. start from a housekeeping job terminated with job in `RUNNING` state
  * stop server
  * update the housekeeping job `jobstatus` column to `RUNNING`
  * start the server
  * check that after 1-2min the hoursekeeping job is back to `SCHEDULED` (log will contain a row that the job was cancelled)

3. start with no icons so all default icons are inserted on startup
  * stop server
  * delete all icons and all file resources for `domain` `ICON`
  * optional: put the housekeeping job in `jobstatus` in state `RUNNING` 
  * start the server
  * observe the logs and check that eventually (1-2min) the housekeeping job runs and inserts the icons without causing unique key conflicts due to concurrent running icon inserts