### PR TITLE
fix: Analytics outliers: table export seems slower than expected [DHIS2-17181]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
@@ -698,9 +698,8 @@ public class JdbcAnalyticsTableManager extends AbstractJdbcTableManager {
         + "percentile_cont(0.5) "
         + "within group (order by dv1.value::double precision) as percentile_middle_value "
         + "from datavalue dv1 "
-        + "join dataelement de on dv1.dataelementid = de.dataelementid "
         // Only numeric values (value is varchar or string) can be used for stats calculation.
-        + "where de.valuetype IN ('NUMBER', 'INTEGER', 'INTEGER_POSITIVE', 'INTEGER_ZERO_OR_POSITIVE', 'INTEGER_NEGATIVE')"
+        + "where dv1.value ~ '^[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?$' "
         + "group by dv1.dataelementid, dv1.sourceid, dv1.categoryoptioncomboid, "
         + "dv1.attributeoptioncomboid) t1 "
         + "join "
@@ -715,9 +714,8 @@ public class JdbcAnalyticsTableManager extends AbstractJdbcTableManager {
         + "dv1.value, "
         + "dv1.periodid "
         + "from datavalue dv1 "
-        + "join dataelement de on dv1.dataelementid = de.dataelementid "
         // Only numeric values (varchars) can be used for stats calculation.
-        + "where de.valuetype IN ('NUMBER', 'INTEGER', 'INTEGER_POSITIVE', 'INTEGER_ZERO_OR_POSITIVE', 'INTEGER_NEGATIVE')"
+        + "where dv1.value ~ '^[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?$' "
         + "group by dv1.dataelementid, dv1.sourceid, dv1.categoryoptioncomboid, "
         + "dv1.attributeoptioncomboid, dv1.value, dv1.periodid) t2 "
         + "on t1.sourceid = t2.sourceid "

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
@@ -698,10 +698,9 @@ public class JdbcAnalyticsTableManager extends AbstractJdbcTableManager {
         + "percentile_cont(0.5) "
         + "within group (order by dv1.value::double precision) as percentile_middle_value "
         + "from datavalue dv1 "
-        + "inner join period pe on dv1.periodid = pe.periodid "
-        + "inner join organisationunit ou on dv1.sourceid = ou.organisationunitid "
+        + "join dataelement de on dv1.dataelementid = de.dataelementid "
         // Only numeric values (value is varchar or string) can be used for stats calculation.
-        + "where dv1.value ~ '^[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?$' "
+        + "where de.valuetype IN ('NUMBER', 'INTEGER', 'INTEGER_POSITIVE', 'INTEGER_ZERO_OR_POSITIVE', 'INTEGER_NEGATIVE')"
         + "group by dv1.dataelementid, dv1.sourceid, dv1.categoryoptioncomboid, "
         + "dv1.attributeoptioncomboid) t1 "
         + "join "
@@ -716,10 +715,9 @@ public class JdbcAnalyticsTableManager extends AbstractJdbcTableManager {
         + "dv1.value, "
         + "dv1.periodid "
         + "from datavalue dv1 "
-        + "inner join period pe on dv1.periodid = pe.periodid "
-        + "inner join organisationunit ou on dv1.sourceid = ou.organisationunitid "
+        + "join dataelement de on dv1.dataelementid = de.dataelementid "
         // Only numeric values (varchars) can be used for stats calculation.
-        + "where dv1.value ~ '^[-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?$' "
+        + "where de.valuetype IN ('NUMBER', 'INTEGER', 'INTEGER_POSITIVE', 'INTEGER_ZERO_OR_POSITIVE', 'INTEGER_NEGATIVE')"
         + "group by dv1.dataelementid, dv1.sourceid, dv1.categoryoptioncomboid, "
         + "dv1.attributeoptioncomboid, dv1.value, dv1.periodid) t2 "
         + "on t1.sourceid = t2.sourceid "
@@ -730,6 +728,6 @@ public class JdbcAnalyticsTableManager extends AbstractJdbcTableManager {
         + "t3.attributeoptioncomboid) as stats "
         + "on dv.dataelementid = stats.dataelementid and dv.sourceid = stats.sourceid and "
         + "dv.categoryoptioncomboid = stats.categoryoptioncomboid and "
-        + "dv.attributeoptioncomboid = stats.attributeoptioncomboid\s";
+        + "dv.attributeoptioncomboid = stats.attributeoptioncomboid ";
   }
 }


### PR DESCRIPTION
The outliers pre-calculation query performance  were suboptimal. The optimization should significantly improve the population of data values (local database tests show a ratio of 16 seconds to 8 seconds in favor of the refactored query)