### PR TITLE
fix: reset all jobs stuck in running

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HibernateJobConfigurationStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HibernateJobConfigurationStore.java
@@ -502,6 +502,11 @@ public class HibernateJobConfigurationStore
         set
           lastupdated = now(),
           jobstatus = 'SCHEDULED',
+          enabled = case
+            when cronexpression is not null then true
+            when delay is not null then true
+            when queueposition is not null then true
+            else false end,
           cancel = false,
           lastexecutedstatus = 'FAILED',
           lastfinished = now(),
@@ -513,7 +518,6 @@ public class HibernateJobConfigurationStore
             else schedulingtype end
         where jobstatus = 'RUNNING'
         and enabled = true
-        and (schedulingtype != 'ONCE_ASAP' or lastfinished is null)
         and now() > lastalive + :timeout * interval '1 minute'
         """;
     return nativeQuery(sql).setParameter("timeout", max(1, timeoutMinutes)).executeUpdate();


### PR DESCRIPTION
All jobs (including run once) should be reset but run once jobs move to `enabled=false` which then also transitions their `jobstatus` to `DISABLED` (another housekeeping transition). From there they are cleared after 1 day. 

### Manual Testing
Scenario 1 - scheduled job:
* create a analytics table job that would run daily 1h ago from now
* run it manually
* stop the server while it is running
* start the server again
* wait 10 minutes
* check that the job is back to scheduled but did not run again

Scenario 2 - run once job:
* goto the data administration app
* select analytics tables
* click execute
* stop the server while it is running
* start the server again
* wait 10 minutes
* check the job created from clicking the button is now disabled