### PR TITLE
fix: job progress without errors as immutable wither

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
@@ -650,6 +650,10 @@ public interface JobProgress {
       }
     }
 
+    public Progress withoutErrors() {
+      return new Progress(sequence, Map.of());
+    }
+
     public boolean hasErrors() {
       return !errors.isEmpty();
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobSchedulerService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobSchedulerService.java
@@ -125,7 +125,7 @@ public class DefaultJobSchedulerService implements JobSchedulerService {
     if (progress == null) return null;
     UserDetails user = CurrentUserUtil.getCurrentUserDetails();
     if (user == null || !(user.isSuper() || user.isAuthorized("F_JOB_LOG_READ")))
-      progress.getErrors().clear();
+      return progress.withoutErrors();
     return progress;
   }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobSchedulingControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobSchedulingControllerTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hisp.dhis.jsontree.JsonArray;
+import org.hisp.dhis.jsontree.JsonMap;
+import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.webapi.DhisControllerIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the {@link org.hisp.dhis.webapi.controller.scheduling.SchedulingController}.
+ *
+ * @author Jan Bernitt
+ */
+public class JobSchedulingControllerTest extends DhisControllerIntegrationTest {
+
+  @Test
+  void testGetRunningProgressTypesOnly() {
+    JsonArray types = GET("/scheduling/running/types").content();
+    assertEquals(0, types.size());
+  }
+
+  @Test
+  void testGetRunningProgressTypes() {
+    JsonMap<JsonArray> types = GET("/scheduling/running").content().asMap(JsonArray.class);
+    assertEquals(0, types.size());
+  }
+
+  @Test
+  void testGetCompletedProgressTypes() {
+    JsonMap<JsonArray> types = GET("/scheduling/completed").content().asMap(JsonArray.class);
+    assertEquals(0, types.size());
+  }
+
+  @Test
+  void testGetRunningProgress() {
+    JsonObject progress = GET("/scheduling/running/DATA_INTEGRITY").content();
+    assertTrue(progress.isObject());
+    assertTrue(progress.isEmpty());
+  }
+
+  @Test
+  void testGetCompletedProgress() {
+    JsonObject progress = GET("/scheduling/completed/DATA_INTEGRITY").content();
+    assertTrue(progress.isObject());
+    assertTrue(progress.isEmpty());
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobSchedulingControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/JobSchedulingControllerTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Jan Bernitt
  */
-public class JobSchedulingControllerTest extends DhisControllerIntegrationTest {
+class JobSchedulingControllerTest extends DhisControllerIntegrationTest {
 
   @Test
   void testGetRunningProgressTypesOnly() {


### PR DESCRIPTION
The operation end in a 500 as a `Map.of()` does not support the `clear()` operation. To avoid this the errors are now removed in an immutable fashion using `withoutErrors()` wither. 