### PR TITLE
chore: make serviceworker.js non-public

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/AuthConfigProviderConfiguration.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/AuthConfigProviderConfiguration.java
@@ -42,8 +42,6 @@ public class AuthConfigProviderConfiguration {
             .requestMatchers(
                 new AntPathRequestMatcher("/api/ping"),
                 new AntPathRequestMatcher("/auth/login"),
-                new AntPathRequestMatcher("/*/service-worker.js.map"),
-                new AntPathRequestMatcher("/*/service-worker.js"),
                 new AntPathRequestMatcher("/favicon.ico"));
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -211,10 +211,7 @@ public class DhisWebApiWebSecurityConfig {
         web.debug(false)
             .ignoring()
             .requestMatchers(
-                new AntPathRequestMatcher("/api/ping"),
-                new AntPathRequestMatcher("/*/service-worker.js.map"),
-                new AntPathRequestMatcher("/*/service-worker.js"),
-                new AntPathRequestMatcher("/favicon.ico"));
+                new AntPathRequestMatcher("/api/ping"), new AntPathRequestMatcher("/favicon.ico"));
   }
 
   private void configureMatchers(HttpSecurity http) throws Exception {
@@ -312,10 +309,6 @@ public class DhisWebApiWebSecurityConfig {
                   .permitAll()
                   .requestMatchers(
                       new AntPathRequestMatcher("/dhis-web-commons/security/logo_mobile.png"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/*/service-worker.js.map"))
-                  .permitAll()
-                  .requestMatchers(new AntPathRequestMatcher("/*/service-worker.js"))
                   .permitAll()
                   .requestMatchers(new AntPathRequestMatcher("/external-static/**"))
                   .permitAll()


### PR DESCRIPTION
## Summary
Removes the non-public URL request matchers for the service-worker.js and .map files.