### PR TITLE
chore: make serviceworker.js non-public

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -272,10 +272,6 @@ public class DhisWebApiWebSecurityConfig {
 
           // Temporary solution for Struts less login page, will be removed when apps are fully
           // migrated
-          .antMatchers("/*/service-worker.js.map")
-          .permitAll()
-          .antMatchers("/*/service-worker.js")
-          .permitAll()
           .antMatchers("/index.html")
           .permitAll()
           .antMatchers("/external-static/**")

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
@@ -131,19 +131,13 @@ public class DhisWebCommonsWebSecurityConfig {
     @Override
     public void configure(WebSecurity web) {
       web.ignoring()
-          .antMatchers("/api/ping")
-          .antMatchers("/*/service-worker.js.map")
-          .antMatchers("/*/service-worker.js");
+          .antMatchers("/api/ping");
     }
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
       http.authorizeRequests()
           .accessDecisionManager(accessDecisionManager())
-          .antMatchers("/*/service-worker.js.map")
-          .permitAll()
-          .antMatchers("/*/service-worker.js")
-          .permitAll()
           .antMatchers("/dhis-web-login/**")
           .permitAll()
           .requestMatchers(analyticsPluginResources())

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/DhisWebCommonsWebSecurityConfig.java
@@ -130,8 +130,7 @@ public class DhisWebCommonsWebSecurityConfig {
 
     @Override
     public void configure(WebSecurity web) {
-      web.ignoring()
-          .antMatchers("/api/ping");
+      web.ignoring().antMatchers("/api/ping");
     }
 
     @Override


### PR DESCRIPTION
## Summary
Removes the non-public URL request matchers for the service-worker.js and .map files.