### PR TITLE
fix: allow displaying and sorting by OU name on TE data elements [DHIS2-17146] (#17031)[2.41]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/DimensionParam.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/DimensionParam.java
@@ -63,6 +63,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.tei.query.context.TeiHeaderProvider;
 import org.hisp.dhis.analytics.tei.query.context.TeiStaticField;
 import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.UidObject;
 import org.hisp.dhis.common.ValueType;
@@ -82,6 +83,8 @@ public class DimensionParam implements UidObject {
 
   private final DimensionParamType type;
 
+  private final IdScheme idScheme;
+
   @Builder.Default private final List<DimensionParamItem> items = new ArrayList<>();
 
   /**
@@ -99,6 +102,7 @@ public class DimensionParam implements UidObject {
   public static DimensionParam ofObject(
       Object dimensionalObjectOrQueryItem,
       DimensionParamType dimensionParamType,
+      IdScheme idScheme,
       List<String> items) {
     Objects.requireNonNull(dimensionalObjectOrQueryItem);
     Objects.requireNonNull(dimensionParamType);
@@ -110,7 +114,8 @@ public class DimensionParam implements UidObject {
     DimensionParamBuilder builder =
         DimensionParam.builder()
             .type(dimensionParamType)
-            .items(DimensionParamItem.ofStrings(items));
+            .items(DimensionParamItem.ofStrings(items))
+            .idScheme(idScheme);
 
     if (dimensionalObjectOrQueryItem instanceof DimensionalObject) {
       return builder.dimensionalObject((DimensionalObject) dimensionalObjectOrQueryItem).build();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiEventsAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiEventsAnalyticsTableManager.java
@@ -86,6 +86,30 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component("org.hisp.dhis.analytics.TeiEventsAnalyticsTableManager")
 public class JdbcTeiEventsAnalyticsTableManager extends AbstractJdbcTableManager {
+
+  private static final String EVENT_DATA_VALUE_REBUILDER =
+      """
+            (select json_object_agg(l2.keys, l2.datavalue) as value
+             from (select l1.uid,
+                          l1.keys,
+                          json_strip_nulls(json_build_object(
+                                  'value', l1.eventdatavalues -> l1.keys ->> 'value',
+                                  'created', l1.eventdatavalues -> l1.keys ->> 'created',
+                                  'storedBy', l1.eventdatavalues -> l1.keys ->> 'storedBy',
+                                  'lastUpdated', l1.eventdatavalues -> l1.keys ->> 'lastUpdated',
+                                  'providedElsewhere', l1.eventdatavalues -> l1.keys -> 'providedElsewhere',
+                                  'value_name', (select ou.name
+                                                 from organisationunit ou
+                                                 where ou.uid = l1.eventdatavalues -> l1.keys ->> 'value'),
+                                  'value_code', (select ou.code
+                                                 from organisationunit ou
+                                                 where ou.uid = l1.eventdatavalues -> l1.keys ->> 'value'))) as datavalue
+                   from (select inner_evt.*, jsonb_object_keys(inner_evt.eventdatavalues) keys
+                         from event inner_evt) as l1) as l2
+             where l2.uid = psi.uid
+             group by l2.uid)::jsonb
+      """;
+
   private static final List<AnalyticsTableColumn> FIXED_COLS =
       List.of(
           new AnalyticsTableColumn("trackedentityinstanceuid", CHARACTER_11, NOT_NULL, "tei.uid"),
@@ -115,7 +139,7 @@ public class JdbcTeiEventsAnalyticsTableManager extends AbstractJdbcTableManager
           new AnalyticsTableColumn("ouname", VARCHAR_255, NULL, "ou.name"),
           new AnalyticsTableColumn("oucode", CHARACTER_32, NULL, "ou.code"),
           new AnalyticsTableColumn("oulevel", INTEGER, NULL, "ous.level"),
-          new AnalyticsTableColumn("eventdatavalues", JSONB, "psi.eventdatavalues"));
+          new AnalyticsTableColumn("eventdatavalues", JSONB, EVENT_DATA_VALUE_REBUILDER));
 
   private static final String AND = " and (";
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/SuffixedRenderableDataValue.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/SuffixedRenderableDataValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2004, University of Oslo
+ * Copyright (c) 2004-2024, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,53 +27,22 @@
  */
 package org.hisp.dhis.analytics.tei.query;
 
-import static org.apache.commons.lang3.StringUtils.EMPTY;
-
-import java.util.function.UnaryOperator;
-import lombok.RequiredArgsConstructor;
+import lombok.Getter;
 import org.hisp.dhis.analytics.common.ValueTypeMapping;
-import org.hisp.dhis.analytics.common.query.BaseRenderable;
-import org.hisp.dhis.analytics.common.query.Field;
-import org.hisp.dhis.analytics.common.query.Renderable;
 
-@RequiredArgsConstructor
-public class RenderableDataValue extends BaseRenderable {
-  private final String alias;
+@Getter
+public class SuffixedRenderableDataValue extends RenderableDataValue {
 
-  private final String dataValue;
+  private final String valueSuffix;
 
-  private final ValueTypeMapping valueTypeMapping;
+  private SuffixedRenderableDataValue(
+      String alias, String dataValue, ValueTypeMapping valueTypeMapping, String valueSuffix) {
+    super(alias, dataValue, valueTypeMapping);
+    this.valueSuffix = valueSuffix;
+  }
 
   public static RenderableDataValue of(
-      String alias, String dataValue, ValueTypeMapping valueTypeMapping) {
-    return new RenderableDataValue(alias, dataValue, valueTypeMapping);
-  }
-
-  public Renderable transformedIfNecessary() {
-    return transformedIfNecessary(valueTypeMapping.getSelectTransformer());
-  }
-
-  public Renderable transformedIfNecessary(UnaryOperator<String> dataValueTransformer) {
-    RenderableDataValue withoutAsAlias = RenderableDataValue.of(alias, dataValue, valueTypeMapping);
-
-    return Field.ofUnquoted(
-        EMPTY, () -> dataValueTransformer.apply(withoutAsAlias.render()), EMPTY);
-  }
-
-  @Override
-  public String render() {
-    return "("
-        + Field.of(alias, () -> "eventdatavalues", EMPTY).render()
-        + " -> '"
-        + dataValue
-        + "' ->> '"
-        + "value"
-        + getValueSuffix()
-        + "')::"
-        + valueTypeMapping.getPostgresCast();
-  }
-
-  protected String getValueSuffix() {
-    return EMPTY;
+      String alias, String dataValue, ValueTypeMapping valueTypeMapping, String suffix) {
+    return new SuffixedRenderableDataValue(alias, dataValue, valueTypeMapping, suffix);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/GridAdaptorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/GridAdaptorTest.java
@@ -35,6 +35,7 @@ import static org.hisp.dhis.analytics.common.params.dimension.DimensionParamType
 import static org.hisp.dhis.analytics.common.params.dimension.ElementWithOffset.emptyElementWithOffset;
 import static org.hisp.dhis.analytics.common.query.Field.ofUnquoted;
 import static org.hisp.dhis.common.DimensionType.DATA_X;
+import static org.hisp.dhis.common.IdScheme.UID;
 import static org.hisp.dhis.common.ValueType.TEXT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -265,7 +266,7 @@ class GridAdaptorTest extends DhisConvenienceTest {
             ous.stream().map(item -> new BaseDimensionalItemObject(item)).toList(),
             TEXT);
 
-    DimensionParam dimensionParam = DimensionParam.ofObject(tea, DIMENSIONS, ous);
+    DimensionParam dimensionParam = DimensionParam.ofObject(tea, DIMENSIONS, UID, ous);
 
     ElementWithOffset<Program> program = emptyElementWithOffset();
     ElementWithOffset<ProgramStage> programStage = emptyElementWithOffset();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/SchemeIdResponseMapperTest.java
@@ -824,7 +824,7 @@ class SchemeIdResponseMapperTest {
             ous.stream().map(item -> new BaseDimensionalItemObject(item)).toList(),
             TEXT);
 
-    DimensionParam dimensionParam = DimensionParam.ofObject(tea, DIMENSIONS, ous);
+    DimensionParam dimensionParam = DimensionParam.ofObject(tea, DIMENSIONS, UID, ous);
 
     ElementWithOffset<Program> program = emptyElementWithOffset();
     ElementWithOffset<ProgramStage> programStage = emptyElementWithOffset();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/query/OrganisationUnitConditionTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/query/OrganisationUnitConditionTest.java
@@ -32,6 +32,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.hisp.dhis.analytics.common.params.dimension.DimensionParamType.DIMENSIONS;
 import static org.hisp.dhis.analytics.common.params.dimension.ElementWithOffset.emptyElementWithOffset;
 import static org.hisp.dhis.common.DimensionType.ORGANISATION_UNIT;
+import static org.hisp.dhis.common.IdScheme.UID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -358,6 +359,7 @@ class OrganisationUnitConditionTest {
             new BaseDimensionalObject(
                 "ou", ORGANISATION_UNIT, ous.stream().map(orgUnitCreator).toList()),
             DIMENSIONS,
+            UID,
             ous);
 
     ElementWithOffset<Program> program = emptyElementWithOffset();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/query/StatusConditionTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/query/StatusConditionTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.analytics.tei.query;
 
 import static org.hisp.dhis.analytics.common.params.dimension.ElementWithOffset.emptyElementWithOffset;
+import static org.hisp.dhis.common.IdScheme.UID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
@@ -139,7 +140,7 @@ class StatusConditionTest {
       DimensionParam.StaticDimension dimension,
       List<String> items) {
     DimensionParam dimensionParam =
-        DimensionParam.ofObject(dimension.name(), DimensionParamType.DIMENSIONS, items);
+        DimensionParam.ofObject(dimension.name(), DimensionParamType.DIMENSIONS, UID, items);
 
     Program program = new Program();
     program.setUid(programUid);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/query/TeiAttributeConditionTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/query/TeiAttributeConditionTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.analytics.tei.query;
 
 import static org.hisp.dhis.analytics.common.params.dimension.ElementWithOffset.emptyElementWithOffset;
+import static org.hisp.dhis.common.IdScheme.UID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
@@ -73,6 +74,7 @@ class TeiAttributeConditionTest {
                 DimensionType.PROGRAM_ATTRIBUTE,
                 items.stream().map(BaseDimensionalItemObject::new).toList()),
             DimensionParamType.DIMENSIONS,
+            UID,
             items);
 
     return DimensionIdentifier.of(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/query/TeiSqlQueryTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/query/TeiSqlQueryTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.analytics.tei.query;
 
+import static org.hisp.dhis.common.IdScheme.UID;
 import static org.hisp.dhis.utils.Assertions.assertContains;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -198,7 +199,7 @@ class TeiSqlQueryTest extends DhisConvenienceTest {
             prg,
             programStage,
             DimensionParam.ofObject(
-                dimensionalObject, DimensionParamType.SORTING, List.of(StringUtils.EMPTY)));
+                dimensionalObject, DimensionParamType.SORTING, UID, List.of(StringUtils.EMPTY)));
 
     AnalyticsSortingParams analyticsSortingParams =
         AnalyticsSortingParams.builder()


### PR DESCRIPTION
* feat: the name of orgunit is exported into the json for DE of type orgunit [DHIS2-17146]
* fix: propagate idScheme up to DimensionParam [DHIS2-17146]

(cherry picked from commit 9eddf04ff051936aa50800173701188410850fd3)

[DHIS2-17146]: https://dhis2.atlassian.net/browse/DHIS2-17146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-17146]: https://dhis2.atlassian.net/browse/DHIS2-17146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ