### PR TITLE
fix: Data Values will return the legend label when LegendSet is specified [DHIS2-17145]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/DimensionIdentifier.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/DimensionIdentifier.java
@@ -152,4 +152,11 @@ public class DimensionIdentifier<D extends UidObject> implements IdentifiableKey
   public String getKeyNoOffset() {
     return withoutOffset().toString();
   }
+
+  public boolean hasLegendSet() {
+    if (dimension instanceof DimensionParam dimensionParam && dimensionParam.isQueryItem()) {
+      return dimensionParam.getQueryItem().hasLegendSet();
+    }
+    return false;
+  }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/DataElementCondition.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/DataElementCondition.java
@@ -29,14 +29,12 @@ package org.hisp.dhis.analytics.tei.query;
 
 import static org.hisp.dhis.commons.util.TextUtils.doubleQuote;
 
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.analytics.common.ValueTypeMapping;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifier;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionParam;
 import org.hisp.dhis.analytics.common.query.BaseRenderable;
 import org.hisp.dhis.analytics.tei.query.context.sql.QueryContext;
-import org.hisp.dhis.common.QueryItem;
 
 @RequiredArgsConstructor(staticName = "of")
 public class DataElementCondition extends BaseRenderable {
@@ -46,17 +44,9 @@ public class DataElementCondition extends BaseRenderable {
 
   @Override
   public String render() {
-    return hasLegendSet(dimensionIdentifier)
+    return dimensionIdentifier.hasLegendSet()
         ? DataElementWithLegendSetCondition.of(queryContext, dimensionIdentifier).render()
         : DataElementWithStaticValuesCondition.of(queryContext, dimensionIdentifier).render();
-  }
-
-  private boolean hasLegendSet(DimensionIdentifier<DimensionParam> dimId) {
-    return Optional.of(dimId)
-        .map(DimensionIdentifier::getDimension)
-        .map(DimensionParam::getQueryItem)
-        .filter(QueryItem::hasLegendSet)
-        .isPresent();
   }
 
   static RenderableDataValue getDataValueRenderable(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/context/querybuilder/DataElementQueryBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/context/querybuilder/DataElementQueryBuilder.java
@@ -53,6 +53,7 @@ import org.hisp.dhis.analytics.common.query.Field;
 import org.hisp.dhis.analytics.common.query.GroupableCondition;
 import org.hisp.dhis.analytics.common.query.IndexedOrder;
 import org.hisp.dhis.analytics.common.query.Order;
+import org.hisp.dhis.analytics.common.query.Renderable;
 import org.hisp.dhis.analytics.tei.query.DataElementCondition;
 import org.hisp.dhis.analytics.tei.query.RenderableDataValue;
 import org.hisp.dhis.analytics.tei.query.StageExistsRenderable;
@@ -67,18 +68,16 @@ import org.springframework.stereotype.Service;
 
 /** Query builder for data elements. */
 @Service
+@Getter
 @org.springframework.core.annotation.Order(999)
 public class DataElementQueryBuilder implements SqlQueryBuilder {
 
-  @Getter
   private final List<Predicate<DimensionIdentifier<DimensionParam>>> headerFilters =
       List.of(DataElementQueryBuilder::isDataElement);
 
-  @Getter
   private final List<Predicate<DimensionIdentifier<DimensionParam>>> dimensionFilters =
       List.of(DataElementQueryBuilder::isDataElement);
 
-  @Getter
   private final List<Predicate<AnalyticsSortingParams>> sortingFilters =
       List.of(DataElementQueryBuilder::isDataElementOrder);
 
@@ -92,10 +91,10 @@ public class DataElementQueryBuilder implements SqlQueryBuilder {
 
   @Override
   public RenderableSqlQuery buildSqlQuery(
-      QueryContext queryContext,
-      List<DimensionIdentifier<DimensionParam>> acceptedHeaders,
-      List<DimensionIdentifier<DimensionParam>> acceptedDimensions,
-      List<AnalyticsSortingParams> acceptedSortingParams) {
+      @Nonnull QueryContext queryContext,
+      @Nonnull List<DimensionIdentifier<DimensionParam>> acceptedHeaders,
+      @Nonnull List<DimensionIdentifier<DimensionParam>> acceptedDimensions,
+      @Nonnull List<AnalyticsSortingParams> acceptedSortingParams) {
     RenderableSqlQuery.RenderableSqlQueryBuilder builder = RenderableSqlQuery.builder();
 
     // Select fields are the union of headers, dimensions and sorting params
@@ -136,6 +135,12 @@ public class DataElementQueryBuilder implements SqlQueryBuilder {
     return builder.build();
   }
 
+  /**
+   * Returns the fields holding the "hasValue" flag of the data elements.
+   *
+   * @param dimensions the list of dimensions.
+   * @return the stream of fields holding the "hasValue" flag of the data elements.
+   */
   private Stream<Field> getHasValueFields(List<DimensionIdentifier<DimensionParam>> dimensions) {
     return dimensions.stream()
         .map(
@@ -152,6 +157,12 @@ public class DataElementQueryBuilder implements SqlQueryBuilder {
             });
   }
 
+  /**
+   * Returns the fields holding the status of the stages.
+   *
+   * @param dimensions the list of dimensions.
+   * @return the stream of fields holding the status of the stages.
+   */
   private Stream<Field> getStatusFields(List<DimensionIdentifier<DimensionParam>> dimensions) {
     return dimensions.stream()
         .map(
@@ -162,18 +173,48 @@ public class DataElementQueryBuilder implements SqlQueryBuilder {
                     dimId.toString() + STATUS));
   }
 
+  /**
+   * Returns the fields holding the "exists" flag of the stages.
+   *
+   * @param dimensions the list of dimensions.
+   * @return the stream of fields holding the "exists" flag of the stages.
+   */
   private Stream<Field> getExistsFields(List<DimensionIdentifier<DimensionParam>> dimensions) {
     return dimensions.stream()
         .map(dim -> ofUnquoted(EMPTY, StageExistsRenderable.of(dim), dim.getKey() + EXISTS));
   }
 
+  /**
+   * Returns the fields holding the value of data elements.
+   *
+   * @param dimensions the list of dimensions.
+   * @return the stream of fields holding the value of data elements.
+   */
   @Nonnull
   private static Stream<Field> getValueFields(
       List<DimensionIdentifier<DimensionParam>> dimensions) {
-    return dimensions.stream().map(DataElementQueryBuilder::getRenderableDataValue);
+    return dimensions.stream().map(DataElementQueryBuilder::toField);
   }
 
-  private static Field getRenderableDataValue(
+  /**
+   * Converts the given dimension identifier to a field.
+   *
+   * @param dimensionIdentifier the dimension identifier to convert.
+   * @return the field.
+   */
+  private static Field toField(DimensionIdentifier<DimensionParam> dimensionIdentifier) {
+    Renderable renderableDataValue = getRenderableDataValue(dimensionIdentifier);
+    return ofUnquoted(EMPTY, renderableDataValue, dimensionIdentifier.toString());
+  }
+
+  /**
+   * Returns the renderable data value for the given dimension identifier, applying the necessary
+   * logic based on id scheme and value type.
+   *
+   * @param dimensionIdentifier the dimension identifier.
+   * @return the renderable data value.
+   */
+  private static Renderable getRenderableDataValue(
       DimensionIdentifier<DimensionParam> dimensionIdentifier) {
     IdScheme idScheme = dimensionIdentifier.getDimension().getIdScheme();
     ValueType valueType = dimensionIdentifier.getDimension().getValueType();
@@ -182,23 +223,35 @@ public class DataElementQueryBuilder implements SqlQueryBuilder {
         && ID_SCHEME_SUPPORTING_VALUE_TYPES.contains(
             dimensionIdentifier.getDimension().getValueType())
         && SUFFIX_BY_ID_SCHEME.containsKey(idScheme)) {
-      return ofUnquoted(
-          EMPTY,
-          SuffixedRenderableDataValue.of(
-              doubleQuote(dimensionIdentifier.getPrefix()),
-              dimensionIdentifier.getDimension().getUid(),
-              fromValueType(dimensionIdentifier.getDimension().getValueType()),
-              SUFFIX_BY_ID_SCHEME.get(idScheme)),
-          dimensionIdentifier.toString());
+      return SuffixedRenderableDataValue.of(
+          doubleQuote(dimensionIdentifier.getPrefix()),
+          dimensionIdentifier.getDimension().getUid(),
+          fromValueType(dimensionIdentifier.getDimension().getValueType()),
+          SUFFIX_BY_ID_SCHEME.get(idScheme));
     }
-    return ofUnquoted(
-        EMPTY,
+    return withMaybeLegendSet(dimensionIdentifier);
+  }
+
+  /**
+   * Returns the renderable data value for the given dimension identifier, applying the necessary
+   * logic based on whether the dimension identifier has a legend set.
+   *
+   * @param dimensionIdentifier the dimension identifier.
+   * @return the renderable data value.
+   */
+  private static Renderable withMaybeLegendSet(
+      DimensionIdentifier<DimensionParam> dimensionIdentifier) {
+    RenderableDataValue renderableDataValue =
         RenderableDataValue.of(
-                doubleQuote(dimensionIdentifier.getPrefix()),
-                dimensionIdentifier.getDimension().getUid(),
-                fromValueType(dimensionIdentifier.getDimension().getValueType()))
-            .transformedIfNecessary(),
-        dimensionIdentifier.toString());
+            doubleQuote(dimensionIdentifier.getPrefix()),
+            dimensionIdentifier.getDimension().getUid(),
+            fromValueType(dimensionIdentifier.getDimension().getValueType()));
+    if (dimensionIdentifier.hasLegendSet()) {
+      return RenderableDataValue.withLegendSet(
+          renderableDataValue, dimensionIdentifier.getDimension().getQueryItem().getLegendSet());
+    } else {
+      return renderableDataValue.transformedIfNecessary();
+    }
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/query/DataElementConditionTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/query/DataElementConditionTest.java
@@ -97,6 +97,7 @@ class DataElementConditionTest {
     DimensionParam dimensionParam = mock(DimensionParam.class);
     QueryItem queryItem = mock(QueryItem.class);
     DimensionParamItem dimensionParamItem = mock(DimensionParamItem.class);
+    when(dimensionIdentifier.hasLegendSet()).thenReturn(true);
     when(dimensionIdentifier.getDimension()).thenReturn(dimensionParam);
 
     when(dimensionParam.getQueryItem()).thenReturn(queryItem);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/query/RenderableDataValueTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/query/RenderableDataValueTest.java
@@ -28,8 +28,14 @@
 package org.hisp.dhis.analytics.tei.query;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.util.Set;
 import org.hisp.dhis.analytics.common.ValueTypeMapping;
+import org.hisp.dhis.analytics.common.query.Renderable;
+import org.hisp.dhis.legend.Legend;
+import org.hisp.dhis.legend.LegendSet;
 import org.junit.jupiter.api.Test;
 
 class RenderableDataValueTest {
@@ -61,5 +67,25 @@ class RenderableDataValueTest {
         RenderableDataValue.of("alias", "dataValue", ValueTypeMapping.TIME);
     String result = renderableDataValue.transformedIfNecessary().render();
     assertEquals("(alias.\"eventdatavalues\" -> 'dataValue' ->> 'value')::varchar", result);
+  }
+
+  @Test
+  void testRenderWithLegendSet() {
+    LegendSet legendSet = mock(LegendSet.class);
+    Legend legend = mock(Legend.class);
+    when(legendSet.getLegends()).thenReturn(Set.of(legend));
+
+    when(legend.getStartValue()).thenReturn(1.0);
+    when(legend.getEndValue()).thenReturn(2.0);
+
+    Renderable renderableDataValue =
+        RenderableDataValue.withLegendSet(
+            RenderableDataValue.of("alias", "dataValue", ValueTypeMapping.STRING), legendSet);
+
+    String result = renderableDataValue.render();
+
+    assertEquals(
+        "CASE WHEN (alias.\"eventdatavalues\" -> 'dataValue' ->> 'value')::STRING BETWEEN '1.0' AND '2.0' THEN 'null' END",
+        result);
   }
 }


### PR DESCRIPTION
When a Data Value specifies the legendSet in the query, the backend will now return the label of the legend rather than the value.