### PR TITLE
fix:Filter using "IN:NV", in analytics enrollments query should not return "ND" values[2.39-DHIS2-16418-backport] 

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/InQueryFilter.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/InQueryFilter.java
@@ -128,7 +128,9 @@ public class InQueryFilter extends QueryFilter {
     return NV.equals(filterItem);
   }
 
+  /** Select sql statement detection. The method retrieves true if sql statement detected. */
   private boolean isNestedSqlStmtInField() {
-    return field.toLowerCase().contains("select ") && field.toLowerCase().contains(" from ");
+    String maybeSql = field.toLowerCase();
+    return maybeSql.contains("select ") && maybeSql.contains(" from ");
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/InQueryFilter.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/InQueryFilter.java
@@ -79,11 +79,17 @@ public class InQueryFilter extends QueryFilter {
                   .map(this::quoteIfNecessary)
                   .collect(Collectors.joining(",", " (", ")"));
       if (hasMissingValue(filterItems)) {
-        condition = "(" + condition + " or " + field + " is null )";
+        condition =
+            isNestedSqlStmtInField()
+                ? "(" + condition + " or (" + field + " is null and exists(" + field + "))" + ")"
+                : "(" + condition + " or " + field + " is null )";
       }
     } else {
       if (hasMissingValue(filterItems)) {
-        condition = field + " is null";
+        condition =
+            isNestedSqlStmtInField()
+                ? "(" + field + " is null and exists(" + field + "))"
+                : field + " is null";
       }
     }
 
@@ -120,5 +126,9 @@ public class InQueryFilter extends QueryFilter {
 
   private boolean isMissingItem(String filterItem) {
     return NV.equals(filterItem);
+  }
+
+  private boolean isNestedSqlStmtInField() {
+    return field.toLowerCase().contains("select ") && field.toLowerCase().contains(" from ");
   }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/InQueryFilterTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/InQueryFilterTest.java
@@ -55,7 +55,7 @@ class InQueryFilterTest {
 
   @Test
   void verifyInWithNullOnly() {
-    executeTest("NV", false, "aField is null ");
+    executeTest("NV", true, "aField is null ");
   }
 
   @Test

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/InQueryFilterTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/InQueryFilterTest.java
@@ -55,10 +55,20 @@ class InQueryFilterTest {
 
   @Test
   void verifyInWithNullOnly() {
-    executeTest("NV", true, "aField is null ");
+    executeTest("NV", false, "aField is null ");
+  }
+
+  @Test
+  void verifyNestedSqlStmtInFieldWithNullOnly() {
+    String field = "(select * from xy)";
+    executeTest(field, "NV", true, "(" + field + " is null and exists((select * from xy))) ");
   }
 
   private void executeTest(String filterValue, boolean isText, String expected) {
-    assertEquals(new InQueryFilter("aField", filterValue, isText).getSqlFilter(), expected);
+    executeTest("aField", filterValue, isText, expected);
+  }
+
+  private void executeTest(String field, String filterValue, boolean isText, String expected) {
+    assertEquals(new InQueryFilter(field, filterValue, isText).getSqlFilter(), expected);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -210,7 +210,7 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
 
         ValueStatus valueStatus = ValueStatus.of(isDefined, isSet);
 
-        if (valueStatus != ValueStatus.NOT_DEFINED) {
+        if (valueStatus == ValueStatus.SET) {
           return true;
         }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -452,9 +452,11 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + subSelect
             + " in ("
             + String.join(",", numericValues.split(OPTION_SEP))
-            + ") or "
+            + ") or ("
             + subSelect
-            + " is null )";
+            + " is null and exists("
+            + subSelect
+            + ")))";
     testIt(
         IN,
         numericValues + OPTION_SEP + NV,

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery3AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery3AutoTest.java
@@ -126,7 +126,8 @@ public class EnrollmentsQuery3AutoTest extends AnalyticsApiTest {
             .add("outputType=ENROLLMENT")
             .add("pageSize=10")
             .add("page=1")
-            .add("dimension=ou:USER_ORGUNIT,EPEcjy3FWmI[-1].lJTx9EZ1dk1");
+            .add("dimension=ou:USER_ORGUNIT,EPEcjy3FWmI[-1].lJTx9EZ1dk1")
+            .add("desc=ouname,enrollmentdate");
 
     // When
     ApiResponse response = actions.query().get("ur1Edk5Oe2n", JSON, JSON, params);
@@ -180,17 +181,18 @@ public class EnrollmentsQuery3AutoTest extends AnalyticsApiTest {
     validateRowContext(response, 7, 1, "ND");
     validateRowContext(response, 8, 1, "ND");
     validateRowContext(response, 9, 1, "ND");
+
     // Assert rows.
-    validateRow(response, 0, List.of("Matholey MCHP", "", "2022-03-11 12:28:32.201"));
-    validateRow(response, 1, List.of("Bum Kaku MCHP", "", "2022-02-06 12:28:32.544"));
-    validateRow(response, 2, List.of("Daru CHC", "", "2022-03-22 12:28:34.594"));
-    validateRow(response, 3, List.of("Gboyama CHC", "", "2022-01-31 12:28:34.35"));
-    validateRow(response, 4, List.of("Joru CHC", "", "2022-03-13 12:28:35.035"));
-    validateRow(response, 5, List.of("Baiwala CHP", "", "2022-01-27 12:28:37.062"));
-    validateRow(response, 6, List.of("Rogbin MCHP", "", "2022-04-10 12:28:37.956"));
-    validateRow(response, 7, List.of("Guala MCHP", "", "2022-01-29 12:28:37.788"));
-    validateRow(response, 8, List.of("Ngiehun MCHP", "", "2022-01-16 12:28:37.841"));
-    validateRow(response, 9, List.of("Petifu Fulamasa MCHP", "", "2022-01-18 12:28:37.999"));
+    validateRow(response, 0, List.of("sonkoya MCHP", "", "2022-03-07 12:38:08.598"));
+    validateRow(response, 1, List.of("sonkoya MCHP", "", "2022-03-05 12:28:46.886"));
+    validateRow(response, 2, List.of("sonkoya MCHP", "", "2022-02-11 12:43:10.757"));
+    validateRow(response, 3, List.of("sonkoya MCHP", "", "2022-01-26 12:40:08.658"));
+    validateRow(response, 4, List.of("sonkoya MCHP", "", "2022-01-23 12:41:30.493"));
+    validateRow(response, 5, List.of("kamba mamudia", "", "2022-04-17 12:42:44.887"));
+    validateRow(response, 6, List.of("kamba mamudia", "", "2022-02-26 12:31:45.327"));
+    validateRow(response, 7, List.of("kamba mamudia", "", "2022-02-16 12:33:59.273"));
+    validateRow(response, 8, List.of("kamba mamudia", "", "2022-02-09 12:43:21.288"));
+    validateRow(response, 9, List.of("kamba mamudia", "", "2022-02-09 12:40:38.934"));
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery3AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery3AutoTest.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.enrollment.query;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hisp.dhis.analytics.ValidationHelper.validateHeader;
+import static org.hisp.dhis.analytics.ValidationHelper.validateRow;
+import static org.hisp.dhis.analytics.ValidationHelper.validateRowContext;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+import org.hisp.dhis.AnalyticsApiTest;
+import org.hisp.dhis.actions.analytics.AnalyticsEnrollmentsActions;
+import org.hisp.dhis.dto.ApiResponse;
+import org.hisp.dhis.helpers.QueryParamsBuilder;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+/** Groups e2e tests for "/enrollments/query" endpoint. */
+public class EnrollmentsQuery3AutoTest extends AnalyticsApiTest {
+  private final AnalyticsEnrollmentsActions actions = new AnalyticsEnrollmentsActions();
+
+  @Test
+  public void queryRandom9() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
+            .add("headers=ouname,EPEcjy3FWmI.lJTx9EZ1dk1,enrollmentdate")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("enrollmentDate=2022")
+            .add("rowContext=true")
+            .add("outputType=ENROLLMENT")
+            .add("pageSize=100")
+            .add("page=1")
+            .add("dimension=ou:USER_ORGUNIT,EPEcjy3FWmI.lJTx9EZ1dk1:IN:NV");
+
+    // When
+    ApiResponse response = actions.query().get("ur1Edk5Oe2n", JSON, JSON, params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(3)))
+        .body("rows", hasSize(equalTo(1)))
+        .body("height", equalTo(1))
+        .body("width", equalTo(3))
+        .body("headerWidth", equalTo(3));
+
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":true},\"items\":{\"lJTx9EZ1dk1\":{\"uid\":\"lJTx9EZ1dk1\",\"code\":\"DE_860003\",\"name\":\"Tb lab Glucose\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"BOOLEAN\",\"aggregationType\":\"NONE\",\"totalAggregationType\":\"SUM\"},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"EPEcjy3FWmI\":{\"uid\":\"EPEcjy3FWmI\",\"name\":\"Lab monitoring\",\"description\":\"Laboratory monitoring\"},\"ur1Edk5Oe2n\":{\"uid\":\"ur1Edk5Oe2n\",\"name\":\"TB program\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"jdRD35YwbRH\":{\"uid\":\"jdRD35YwbRH\",\"name\":\"Sputum smear microscopy test\",\"description\":\"Sputum smear microscopy test\"},\"2022\":{\"name\":\"2022\"},\"ZkbAXlQUYJG\":{\"uid\":\"ZkbAXlQUYJG\",\"name\":\"TB visit\",\"description\":\"Routine TB visit\"},\"EPEcjy3FWmI.lJTx9EZ1dk1\":{\"uid\":\"lJTx9EZ1dk1\",\"code\":\"DE_860003\",\"name\":\"Tb lab Glucose\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"BOOLEAN\",\"aggregationType\":\"NONE\",\"totalAggregationType\":\"SUM\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"],\"EPEcjy3FWmI.lJTx9EZ1dk1\":[]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // Assert headers.
+    validateHeader(
+        response, 0, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, true);
+    validateHeader(
+        response,
+        1,
+        "EPEcjy3FWmI.lJTx9EZ1dk1",
+        "Tb lab Glucose",
+        "TRUE_ONLY",
+        "java.lang.Boolean",
+        false,
+        true);
+    validateHeader(
+        response,
+        2,
+        "enrollmentdate",
+        "Start of treatment date",
+        "DATE",
+        "java.time.LocalDate",
+        false,
+        true);
+
+    // Assert rowContext
+    validateRowContext(response, 0, 1, "NS");
+
+    // Assert rows.
+    validateRow(response, 0, List.of("Motorbong MCHP", "", "2022-02-18 12:27:49.129"));
+  }
+
+  @Test
+  public void queryRandom10() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
+            .add("headers=ouname,EPEcjy3FWmI[-1].lJTx9EZ1dk1,enrollmentdate")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("enrollmentDate=2022")
+            .add("rowContext=true")
+            .add("outputType=ENROLLMENT")
+            .add("pageSize=10")
+            .add("page=1")
+            .add("dimension=ou:USER_ORGUNIT,EPEcjy3FWmI[-1].lJTx9EZ1dk1");
+
+    // When
+    ApiResponse response = actions.query().get("ur1Edk5Oe2n", JSON, JSON, params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(3)))
+        .body("rows", hasSize(equalTo(10)))
+        .body("height", equalTo(10))
+        .body("width", equalTo(3))
+        .body("headerWidth", equalTo(3));
+
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":10,\"isLastPage\":false},\"items\":{\"lJTx9EZ1dk1\":{\"uid\":\"lJTx9EZ1dk1\",\"code\":\"DE_860003\",\"name\":\"Tb lab Glucose\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"BOOLEAN\",\"aggregationType\":\"NONE\",\"totalAggregationType\":\"SUM\"},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"EPEcjy3FWmI\":{\"uid\":\"EPEcjy3FWmI\",\"name\":\"Lab monitoring\",\"description\":\"Laboratory monitoring\"},\"ur1Edk5Oe2n\":{\"uid\":\"ur1Edk5Oe2n\",\"name\":\"TB program\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"jdRD35YwbRH\":{\"uid\":\"jdRD35YwbRH\",\"name\":\"Sputum smear microscopy test\",\"description\":\"Sputum smear microscopy test\"},\"2022\":{\"name\":\"2022\"},\"ZkbAXlQUYJG\":{\"uid\":\"ZkbAXlQUYJG\",\"name\":\"TB visit\",\"description\":\"Routine TB visit\"},\"EPEcjy3FWmI.lJTx9EZ1dk1\":{\"uid\":\"lJTx9EZ1dk1\",\"code\":\"DE_860003\",\"name\":\"Tb lab Glucose\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"BOOLEAN\",\"aggregationType\":\"NONE\",\"totalAggregationType\":\"SUM\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"],\"EPEcjy3FWmI.lJTx9EZ1dk1\":[]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // Assert headers.
+    validateHeader(
+        response, 0, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, true);
+    validateHeader(
+        response,
+        1,
+        "EPEcjy3FWmI[-1].lJTx9EZ1dk1",
+        "Tb lab Glucose",
+        "TRUE_ONLY",
+        "java.lang.Boolean",
+        false,
+        true);
+    validateHeader(
+        response,
+        2,
+        "enrollmentdate",
+        "Start of treatment date",
+        "DATE",
+        "java.time.LocalDate",
+        false,
+        true);
+
+    // Assert rowContext
+    validateRowContext(response, 0, 1, "ND");
+    validateRowContext(response, 1, 1, "ND");
+    validateRowContext(response, 2, 1, "ND");
+    validateRowContext(response, 3, 1, "ND");
+    validateRowContext(response, 4, 1, "ND");
+    validateRowContext(response, 5, 1, "ND");
+    validateRowContext(response, 6, 1, "ND");
+    validateRowContext(response, 7, 1, "ND");
+    validateRowContext(response, 8, 1, "ND");
+    validateRowContext(response, 9, 1, "ND");
+    // Assert rows.
+    validateRow(response, 0, List.of("Matholey MCHP", "", "2022-03-11 12:28:32.201"));
+    validateRow(response, 1, List.of("Bum Kaku MCHP", "", "2022-02-06 12:28:32.544"));
+    validateRow(response, 2, List.of("Daru CHC", "", "2022-03-22 12:28:34.594"));
+    validateRow(response, 3, List.of("Gboyama CHC", "", "2022-01-31 12:28:34.35"));
+    validateRow(response, 4, List.of("Joru CHC", "", "2022-03-13 12:28:35.035"));
+    validateRow(response, 5, List.of("Baiwala CHP", "", "2022-01-27 12:28:37.062"));
+    validateRow(response, 6, List.of("Rogbin MCHP", "", "2022-04-10 12:28:37.956"));
+    validateRow(response, 7, List.of("Guala MCHP", "", "2022-01-29 12:28:37.788"));
+    validateRow(response, 8, List.of("Ngiehun MCHP", "", "2022-01-16 12:28:37.841"));
+    validateRow(response, 9, List.of("Petifu Fulamasa MCHP", "", "2022-01-18 12:28:37.999"));
+  }
+
+  @Test
+  public void queryRandom11() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
+            .add(
+                "headers=ouname,EPEcjy3FWmI[0].lJTx9EZ1dk1,EPEcjy3FWmI[-1].lJTx9EZ1dk1,enrollmentdate")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("enrollmentDate=2022")
+            .add("rowContext=true")
+            .add("outputType=ENROLLMENT")
+            .add("pageSize=100")
+            .add("page=1")
+            .add(
+                "dimension=ou:USER_ORGUNIT,EPEcjy3FWmI[0].lJTx9EZ1dk1:IN:NV,EPEcjy3FWmI[-1].lJTx9EZ1dk1:IN:NV");
+
+    // When
+    ApiResponse response = actions.query().get("ur1Edk5Oe2n", JSON, JSON, params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(4)))
+        .body("rows", hasSize(equalTo(1)))
+        .body("height", equalTo(1))
+        .body("width", equalTo(4))
+        .body("headerWidth", equalTo(4));
+
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":100,\"isLastPage\":true},\"items\":{\"lJTx9EZ1dk1\":{\"uid\":\"lJTx9EZ1dk1\",\"code\":\"DE_860003\",\"name\":\"Tb lab Glucose\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"BOOLEAN\",\"aggregationType\":\"NONE\",\"totalAggregationType\":\"SUM\"},\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"EPEcjy3FWmI\":{\"uid\":\"EPEcjy3FWmI\",\"name\":\"Lab monitoring\",\"description\":\"Laboratory monitoring\"},\"ur1Edk5Oe2n\":{\"uid\":\"ur1Edk5Oe2n\",\"name\":\"TB program\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"jdRD35YwbRH\":{\"uid\":\"jdRD35YwbRH\",\"name\":\"Sputum smear microscopy test\",\"description\":\"Sputum smear microscopy test\"},\"2022\":{\"name\":\"2022\"},\"ZkbAXlQUYJG\":{\"uid\":\"ZkbAXlQUYJG\",\"name\":\"TB visit\",\"description\":\"Routine TB visit\"},\"EPEcjy3FWmI.lJTx9EZ1dk1\":{\"uid\":\"lJTx9EZ1dk1\",\"code\":\"DE_860003\",\"name\":\"Tb lab Glucose\",\"dimensionItemType\":\"DATA_ELEMENT\",\"valueType\":\"BOOLEAN\",\"aggregationType\":\"NONE\",\"totalAggregationType\":\"SUM\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"],\"EPEcjy3FWmI.lJTx9EZ1dk1\":[]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // Assert headers.
+    validateHeader(
+        response, 0, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, true);
+    validateHeader(
+        response,
+        1,
+        "EPEcjy3FWmI[0].lJTx9EZ1dk1",
+        "Tb lab Glucose",
+        "TRUE_ONLY",
+        "java.lang.Boolean",
+        false,
+        true);
+    validateHeader(
+        response,
+        2,
+        "EPEcjy3FWmI[-1].lJTx9EZ1dk1",
+        "Tb lab Glucose",
+        "TRUE_ONLY",
+        "java.lang.Boolean",
+        false,
+        true);
+    validateHeader(
+        response,
+        3,
+        "enrollmentdate",
+        "Start of treatment date",
+        "DATE",
+        "java.time.LocalDate",
+        false,
+        true);
+
+    // Assert rowContext
+    validateRowContext(response, 0, 1, "NS");
+
+    // Assert rows.
+    validateRow(response, 0, List.of("Motorbong MCHP", "", "1", "2022-02-18 12:27:49.129"));
+  }
+}


### PR DESCRIPTION
**Backport**
There was an issue with IN:NV (seeking genuine null values within the data elements, program indicators, etc.). When utilizing a nested SQL statement to retrieve the value and compare it with null, the null representation becomes ambiguous. It can signify either an empty SQL cursor or a genuine null value. To address this concern, the "where" clause of the SQL statement needed enhancement, utilizing the "exists" SQL function. By combining equality to null with the "exists" function, the origin of the value can be accurately determined.