### PR TITLE
chore: remove all references to old dhis-web path

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -2,13 +2,6 @@
 host     = https://www.transifex.com
 lang_map = fa_AF: prs, uz@Cyrl: uz_UZ_Cyrl, uz@Latn: uz_UZ_Latn
 
-[o:hisp-uio:p:app-server-side-resources:r:dataentry-i18n-module-properties]
-file_filter  = dhis-2/dhis-web-dataentry/src/main/resources/org/hisp/dhis/de/i18n_module_<lang>.properties
-source_file  = dhis-2/dhis-web-dataentry/src/main/resources/org/hisp/dhis/de/i18n_module.properties
-source_lang  = en
-type         = PROPERTIES
-minimum_perc = 0
-
 [o:hisp-uio:p:app-server-side-resources:r:i18n-global-properties]
 file_filter  = dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global_<lang>.properties
 source_file  = dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties

--- a/.tx/config
+++ b/.tx/config
@@ -3,8 +3,8 @@ host     = https://www.transifex.com
 lang_map = fa_AF: prs, uz@Cyrl: uz_UZ_Cyrl, uz@Latn: uz_UZ_Latn
 
 [o:hisp-uio:p:app-server-side-resources:r:dataentry-i18n-module-properties]
-file_filter  = dhis-2/dhis-web/dhis-web-dataentry/src/main/resources/org/hisp/dhis/de/i18n_module_<lang>.properties
-source_file  = dhis-2/dhis-web/dhis-web-dataentry/src/main/resources/org/hisp/dhis/de/i18n_module.properties
+file_filter  = dhis-2/dhis-web-dataentry/src/main/resources/org/hisp/dhis/de/i18n_module_<lang>.properties
+source_file  = dhis-2/dhis-web-dataentry/src/main/resources/org/hisp/dhis/de/i18n_module.properties
 source_lang  = en
 type         = PROPERTIES
 minimum_perc = 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Go in the repo and run maven:
 
 Each project in the /dhis-2/dhis-web directory is an individual web module. The dhis-web-portal project is an assembly of all the individual web modules.
 
-This should create a ready to use war in /dhis-2/dhis-web/dhis-web-portal/target
+This should create a ready to use war in /dhis-2/dhis-web-portal/target
 
 ## Run locally
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ It should now be available at `http://localhost:8080`.
 To build using a custom tag run
 
 ```sh
-mvn -DskipTests -Dmaven.test.skip=true -f dhis-2/dhis-web/dhis-web-portal/pom.xml jib:dockerBuild -Djib.to.image=dhis2/core-dev:mytag
+mvn -DskipTests -Dmaven.test.skip=true -f dhis-2/dhis-web-portal/pom.xml jib:dockerBuild -Djib.to.image=dhis2/core-dev:mytag
 ```
 
 For more configuration options related to Jib or Docker go to the

--- a/jib.yaml
+++ b/jib.yaml
@@ -30,11 +30,11 @@ layers:
       files:
         - src: ${unarchivedWarDir}
           dest: ${imageAppRoot}
-        - src: "dhis-2/dhis-web/dhis-web-portal/src/main/jib/usr/local/tomcat/conf/server.xml"
+        - src: "dhis-2/dhis-web-portal/src/main/jib/usr/local/tomcat/conf/server.xml"
           dest: "/usr/local/tomcat/conf/server.xml"
-        - src: "dhis-2/dhis-web/dhis-web-portal/src/main/jib/usr/local/tomcat/conf/Catalina/localhost"
+        - src: "dhis-2/dhis-web-portal/src/main/jib/usr/local/tomcat/conf/Catalina/localhost"
           dest: "/usr/local/tomcat/conf/Catalina/localhost"
-        - src: "dhis-2/dhis-web/dhis-web-portal/src/main/jib/opt/dhis2"
+        - src: "dhis-2/dhis-web-portal/src/main/jib/opt/dhis2"
           dest: "/opt/dhis2"
           properties:
             user: ${imageUser}


### PR DESCRIPTION
There are some leftover references to the old `/dhis-2/dhis-web` path (from https://github.com/dhis2/dhis2-core/pull/17040), some of them in the `jib.yaml` file, which breaks building a docker image with the Jib CLI.

