### PR TITLE
chore: Upgrade rule-engine version

### DIFF
--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
@@ -87,7 +87,9 @@ import org.hisp.dhis.rules.models.RuleAction;
 import org.hisp.dhis.rules.models.RuleAttributeValue;
 import org.hisp.dhis.rules.models.RuleDataValue;
 import org.hisp.dhis.rules.models.RuleEnrollment;
+import org.hisp.dhis.rules.models.RuleEnrollmentStatus;
 import org.hisp.dhis.rules.models.RuleEvent;
+import org.hisp.dhis.rules.models.RuleEventStatus;
 import org.hisp.dhis.rules.models.RuleValueType;
 import org.hisp.dhis.rules.models.RuleVariable;
 import org.hisp.dhis.rules.models.RuleVariableAttribute;
@@ -230,7 +232,7 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
             .getDate(),
         LocalDateTime.Companion.parse(DateUtils.toIso8601NoTz(enrollment.getEnrollmentDate()))
             .getDate(),
-        RuleEnrollment.Status.valueOf(enrollment.getStatus().toString()),
+        RuleEnrollmentStatus.valueOf(enrollment.getStatus().toString()),
         orgUnit,
         orgUnitCode,
         ruleAttributeValues);
@@ -259,7 +261,7 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
         eventToEvaluate.getUid(),
         eventToEvaluate.getProgramStage().getUid(),
         eventToEvaluate.getProgramStage().getName(),
-        RuleEvent.Status.valueOf(eventToEvaluate.getStatus().toString()),
+        RuleEventStatus.valueOf(eventToEvaluate.getStatus().toString()),
         eventToEvaluate.getOccurredDate() != null
             ? Instant.Companion.fromEpochMilliseconds(eventToEvaluate.getOccurredDate().getTime())
             : Instant.Companion.fromEpochMilliseconds(eventToEvaluate.getScheduledDate().getTime()),

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperServiceTest.java
@@ -72,6 +72,7 @@ import org.hisp.dhis.rules.models.Rule;
 import org.hisp.dhis.rules.models.RuleDataValue;
 import org.hisp.dhis.rules.models.RuleEnrollment;
 import org.hisp.dhis.rules.models.RuleEvent;
+import org.hisp.dhis.rules.models.RuleEventStatus;
 import org.hisp.dhis.rules.models.RuleVariable;
 import org.hisp.dhis.rules.models.RuleVariableAttribute;
 import org.hisp.dhis.rules.models.RuleVariableCalculatedValue;
@@ -448,7 +449,7 @@ class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest {
             eventA.getUid(),
             programStage.getUid(),
             programStage.getName(),
-            RuleEvent.Status.valueOf(eventA.getStatus().name()),
+            RuleEventStatus.valueOf(eventA.getStatus().name()),
             Instant.Companion.fromEpochMilliseconds(now.getTime()),
             LocalDateTime.Companion.parse(DateUtils.toIso8601NoTz(now)).getDate(),
             null,

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -99,7 +99,7 @@
     <!-- *Dependencies* -->
 
     <!-- DHIS2 Rule Engine -->
-    <dhis2-rule-engine.version>3.0.0-20240119.134348-12</dhis2-rule-engine.version>
+    <dhis2-rule-engine.version>3.0.0-20240411.110520-16</dhis2-rule-engine.version>
     <kotlinx-datetime.version>0.5.0</kotlinx-datetime.version>
 
     <!-- HISP Quick and Staxwax -->


### PR DESCRIPTION
Upgrade rule-engine version to last stable snapshot and fix build issue using last stable snapshot of expression-parser from rule-engine library.

This PR is also fixing some program-rule-related enums that were broken by last change in rule-engine library.