### PR TITLE
fix: reject job config enable when no schedule is set [DHIS2-16408]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
@@ -380,6 +380,13 @@ public class JobConfiguration extends BaseIdentifiableObject implements Secondar
         && queueName == null;
   }
 
+  public boolean isReadyToRun() {
+    return schedulingType == SchedulingType.ONCE_ASAP
+        || schedulingType == SchedulingType.CRON && cronExpression != null
+        || schedulingType == SchedulingType.FIXED_DELAY && delay != null
+        || queueName != null && queuePosition > 0;
+  }
+
   public boolean isDueBetween(
       @Nonnull Instant now, @Nonnull Instant then, @Nonnull Duration maxCronDelay) {
     Instant dueTime = nextExecutionTime(now, maxCronDelay);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -166,6 +166,8 @@ public class JobConfigurationController extends AbstractCrudController<JobConfig
     if (obj == null) throw new NotFoundException(JobConfiguration.class, uid.getValue());
     checkModifiable(obj, "Job %s is a system job that cannot be modified.");
     if (!obj.isEnabled()) {
+      if (!obj.isReadyToRun())
+        throw new ConflictException("Job requires schedule setup before it can be enabled.");
       obj.setEnabled(true);
       jobConfigurationService.updateJobConfiguration(obj);
     }


### PR DESCRIPTION
### Summary
Ideally it is not possible to enable a job configuration that cannot run due to lack of schedule setup.
This is the state a job is in after no longer being part of a queue.

### Automatic Testing
Added a integration test scenario

### Manual Testing
* create 2 jobs
* make a queue with the 2 jobs
* delete the queue again
* verify the job(s) cannot be enabled 
* edit the job and set a schedule
* verify the job can be enabled again