### PR TITLE
fix: reject job config enable when no schedule is set [DHIS2-16408] (2.41)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
@@ -380,6 +380,13 @@ public class JobConfiguration extends BaseIdentifiableObject implements Secondar
         && queueName == null;
   }
 
+  public boolean isReadyToRun() {
+    return schedulingType == SchedulingType.ONCE_ASAP
+        || schedulingType == SchedulingType.CRON && cronExpression != null
+        || schedulingType == SchedulingType.FIXED_DELAY && delay != null
+        || queueName != null && queuePosition > 0;
+  }
+
   public boolean isDueBetween(
       @Nonnull Instant now, @Nonnull Instant then, @Nonnull Duration maxCronDelay) {
     Instant dueTime = nextExecutionTime(now, maxCronDelay);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -166,6 +166,8 @@ public class JobConfigurationController extends AbstractCrudController<JobConfig
     if (obj == null) throw new NotFoundException(JobConfiguration.class, uid.getValue());
     checkModifiable(obj, "Job %s is a system job that cannot be modified.");
     if (!obj.isEnabled()) {
+      if (!obj.isReadyToRun())
+        throw new ConflictException("Job requires schedule setup before it can be enabled.");
       obj.setEnabled(true);
       jobConfigurationService.updateJobConfiguration(obj);
     }


### PR DESCRIPTION
cherry-pick backport of #17119