### PR TITLE
fix: resolve objects by ID identifier (UID alias) [DHIS2-17186]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
@@ -836,6 +836,7 @@ public class DefaultIdentifiableObjectManager implements IdentifiableObjectManag
     }
 
     switch (property) {
+      case ID:
       case UID:
         return store.getByUid(identifiers);
       case CODE:


### PR DESCRIPTION
As mentioned in the meeting I opted not to write a test for this fix as it feels like a bad time trade-off.
It is unlikely this will break (be changed/removed) but an integration test would require much effort in relation and a unit test would only be possible with mock setup increasing the maintenance burden for little benefit. 