### PR TITLE
chore: allow users to enable jclouds logging DHIS2-17232

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -226,6 +226,10 @@
       <groupId>org.apache.jclouds.provider</groupId>
       <artifactId>aws-s3</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.driver</groupId>
+      <artifactId>jclouds-slf4j</artifactId>
+    </dependency>
 
     <!-- Image Processing -->
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/jclouds/JCloudsStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/jclouds/JCloudsStore.java
@@ -31,6 +31,7 @@ import static org.jclouds.Constants.PROPERTY_ENDPOINT;
 
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
@@ -50,6 +51,7 @@ import org.jclouds.domain.Location;
 import org.jclouds.domain.LocationBuilder;
 import org.jclouds.domain.LocationScope;
 import org.jclouds.filesystem.reference.FilesystemConstants;
+import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
 import org.jclouds.s3.reference.S3Constants;
 import org.springframework.stereotype.Component;
 
@@ -90,10 +92,12 @@ public class JCloudsStore {
 
     String identity = configurationProvider.getProperty(ConfigurationKey.FILESTORE_IDENTITY);
     String secret = configurationProvider.getProperty(ConfigurationKey.FILESTORE_SECRET);
+
     blobStoreContext =
         ContextBuilder.newBuilder(provider)
             .credentials(identity, secret)
             .overrides(configureOverrides(provider, endpoint))
+            .modules(Set.of(new SLF4JLoggingModule()))
             .build(BlobStoreContext.class);
   }
 

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1127,6 +1127,11 @@
         <artifactId>aws-s3</artifactId>
         <version>${jclouds.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.jclouds.driver</groupId>
+        <artifactId>jclouds-slf4j</artifactId>
+        <version>${jclouds.version}</version>
+      </dependency>
 
       <!-- Reporting -->
       <dependency>


### PR DESCRIPTION
as described in https://jclouds.apache.org/reference/logging/

Adding

```xml
<Logger name="org.jclouds" level="debug" additivity="false">
    <AppenderRef ref="console"/>
</Logger>
<Logger name="jclouds.wire" level="debug" additivity="false">
    <AppenderRef ref="console"/>
</Logger>
<Logger name="jclouds.headers" level="debug" additivity="false">
    <AppenderRef ref="console"/>
</Logger>
```

to a log4j2 config like https://github.com/dhis2/dhis2-core/blob/d3eb8fec4b6fe10d554ca88d53f00fea29e8cc27/docker/log4j2.xml#L20 would show what requests jclouds is making.

You then see logs like

```
DEBUG org.jclouds.rest.internal.InvokeHttpMethod [main] >> invoking CreateBucket
DEBUG org.jclouds.http.internal.JavaUrlHttpCommandExecutorService [main] Sending request -229704820: PUT http://minio:9000/dhis2 HTTP/1.1
DEBUG jclouds.headers [main] >> PUT http://minio:9000/dhis2 HTTP/1.1
DEBUG jclouds.headers [main] >> Date: Tue, 16 Apr 2024 05:55:26 GMT
DEBUG jclouds.headers [main] >> Authorization: AWS dhis:gf0YH8j+KIzX0MtXKo1DA4125d4=
[2024-04-16 05:55:26.377] SP: pin java.io.IOException
DEBUG org.jclouds.http.internal.JavaUrlHttpCommandExecutorService [main] Receiving response -229704820: HTTP/1.1 409 Conflict
DEBUG jclouds.headers [main] << HTTP/1.1 409 Conflict
DEBUG jclouds.headers [main] << Accept-Ranges: bytes
DEBUG jclouds.headers [main] << X-Amz-Id-2: dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8
DEBUG jclouds.headers [main] << Strict-Transport-Security: max-age=31536000; includeSubDomains
DEBUG jclouds.headers [main] << Server: MinIO
DEBUG jclouds.headers [main] << X-Content-Type-Options: nosniff
DEBUG jclouds.headers [main] << X-Xss-Protection: 1; mode=block
DEBUG jclouds.headers [main] << Vary: Accept-Encoding
DEBUG jclouds.headers [main] << Vary: Origin
DEBUG jclouds.headers [main] << Date: Tue, 16 Apr 2024 05:55:26 GMT
DEBUG jclouds.headers [main] << X-Amz-Request-Id: 17C6AD009ADFB005
DEBUG jclouds.headers [main] << Content-Type: application/xml
DEBUG jclouds.headers [main] << Content-Length: 368
DEBUG jclouds.wire [main] << "<?xml version="1.0" encoding="UTF-8"?>[\n]"
DEBUG jclouds.wire [main] << "<Error><Code>BucketAlreadyOwnedByYou</Code><Message>Your previous request to create the named bucket succeeded and you already own it.</Message><BucketName>dhis2</BucketName><Resource>/dhis2</Resource><RequestId>17C6AD009ADFB005</RequestId><HostId>dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8</HostId></Error>"
```

showing jclouds failed to create the root bucket on startup as it already exists.