### PR TITLE
fix: make oidcuser use parent isAuthorized method

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUser.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUser.java
@@ -174,7 +174,7 @@ public class DhisOidcUser extends DefaultOAuth2User implements UserDetails, Oidc
 
   @Override
   public boolean isAuthorized(String auth) {
-    return false;
+    return user.isAuthorized(auth);
   }
 
   @Nonnull

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUser.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUser.java
@@ -169,7 +169,7 @@ public class DhisOidcUser extends DefaultOAuth2User implements UserDetails, Oidc
 
   @Override
   public boolean hasAnyAuthority(Collection<String> auths) {
-    return false;
+    return user.hasAnyAuthority(auths);
   }
 
   @Override

--- a/dhis-2/dhis-test-integration/pom.xml
+++ b/dhis-2/dhis-test-integration/pom.xml
@@ -334,6 +334,11 @@
       <artifactId>quick</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-oauth2-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserRoleTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserRoleTest.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Set;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 import org.hisp.dhis.security.oidc.DhisOidcUser;
 import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
@@ -104,8 +105,13 @@ class UserRoleTest extends SingleSetupIntegrationTestBase {
     assertEquals(dhisOidcUser, principal);
 
     Collection<? extends GrantedAuthority> authorities = oidc.getAuthorities();
+
     for (GrantedAuthority authority : authorities) {
       assertTrue(oidc.isAuthorized(authority.getAuthority()));
+    }
+
+    for (GrantedAuthority authority : authorities) {
+      assertTrue(oidc.hasAnyAuthority(Set.of(authority.getAuthority())));
     }
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserRoleTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserRoleTest.java
@@ -30,12 +30,20 @@ package org.hisp.dhis.user;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Collection;
+import java.util.HashMap;
 import org.hisp.dhis.common.IdentifiableObjectStore;
+import org.hisp.dhis.security.oidc.DhisOidcUser;
 import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
 
 class UserRoleTest extends SingleSetupIntegrationTestBase {
 
@@ -77,5 +85,27 @@ class UserRoleTest extends SingleSetupIntegrationTestBase {
     assertNotNull(userRoleStore.get(idA));
     assertNull(userRoleStore.get(idB));
     assertNotNull(userRoleStore.get(idA));
+  }
+
+  @Test
+  void testOidcUserIsAuthorizedCheck() {
+    UserDetails currentUserDetails = CurrentUserUtil.getCurrentUserDetails();
+    HashMap<String, Object> attributes = new HashMap<>();
+    attributes.put("sub", "test-sub");
+
+    DhisOidcUser dhisOidcUser =
+        new DhisOidcUser(currentUserDetails, attributes, IdTokenClaimNames.SUB, null);
+    injectSecurityContext(dhisOidcUser);
+
+    UserDetails oidc = CurrentUserUtil.getCurrentUserDetails();
+
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    Object principal = authentication.getPrincipal();
+    assertEquals(dhisOidcUser, principal);
+
+    Collection<? extends GrantedAuthority> authorities = oidc.getAuthorities();
+    for (GrantedAuthority authority : authorities) {
+      assertTrue(oidc.isAuthorized(authority.getAuthority()));
+    }
   }
 }


### PR DESCRIPTION
## Summary
Adds a missing implementation of the `isAuthorized` and `hasAnyAuthority` on the OidcUser.

### Automatic test
UserRoleTest#testOidcUserIsAuthorizedCheck