### PR TITLE
fix: System user should be authorized by default

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/SystemUser.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/SystemUser.java
@@ -141,12 +141,12 @@ public class SystemUser implements UserDetails {
 
   @Override
   public boolean hasAnyAuthority(Collection<String> auths) {
-    return false;
+    return true;
   }
 
   @Override
   public boolean isAuthorized(String auth) {
-    return false;
+    return true;
   }
 
   @Nonnull

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/user/SystemUserTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/user/SystemUserTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.user;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SystemUserTest {
+
+  @Test
+  @DisplayName("SystemUser always has authority by default")
+  void systemUserAlwaysHasAuthorityByDefaultTest() {
+    SystemUser systemUser = new SystemUser();
+    assertTrue(systemUser.hasAnyAuthority(List.of("MADE_UP_AUTH")));
+  }
+
+  @Test
+  @DisplayName("SystemUser is always authorized by default")
+  void systemUserIsAlwaysAuthorizedByDefaultTest() {
+    SystemUser systemUser = new SystemUser();
+    assertTrue(systemUser.isAuthorized("MADE_UP_AUTH"));
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/message/DefaultMessageService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/message/DefaultMessageService.java
@@ -452,7 +452,7 @@ public class DefaultMessageService implements MessageService {
   public boolean hasAccessToManageFeedbackMessages(UserDetails userDetails) {
     userDetails = (userDetails != null ? userDetails : CurrentUserUtil.getCurrentUserDetails());
     return configurationService.isUserInFeedbackRecipientUserGroup(userDetails)
-        || userDetails.isAuthorized("ALL");
+        || userDetails.isAuthorized("ALL"); //
   }
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/message/DefaultMessageService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/message/DefaultMessageService.java
@@ -452,7 +452,7 @@ public class DefaultMessageService implements MessageService {
   public boolean hasAccessToManageFeedbackMessages(UserDetails userDetails) {
     userDetails = (userDetails != null ? userDetails : CurrentUserUtil.getCurrentUserDetails());
     return configurationService.isUserInFeedbackRecipientUserGroup(userDetails)
-        || userDetails.isAuthorized("ALL"); //
+        || userDetails.isAuthorized("ALL");
   }
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/message/DefaultMessageServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/message/DefaultMessageServiceTest.java
@@ -37,10 +37,14 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
+import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.message.hibernate.HibernateMessageConversationStore;
+import org.hisp.dhis.user.SystemUser;
 import org.hisp.dhis.user.UserSettingService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -55,6 +59,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class DefaultMessageServiceTest {
 
   @Mock private DhisConfigurationProvider configurationProvider;
+  @Mock private ConfigurationService configurationService;
 
   @Mock private EmailMessageSender emailMessageSender;
 
@@ -100,6 +105,13 @@ class DefaultMessageServiceTest {
     String footer = footerCaptor.getValue();
     assertTrue(
         footer.contains("https://dhis2.org/dhis-web-messaging/#/" + messageType + "/" + uid));
+  }
+
+  @Test
+  @DisplayName("SystemUser is authorized by default")
+  void systemUserIsAuthorizedByDefaultTest() {
+    SystemUser systemUser = new SystemUser();
+    assertTrue(messageService.hasAccessToManageFeedbackMessages(systemUser));
   }
 
   private static Stream<Arguments> provideArgCombos() {


### PR DESCRIPTION
# Issue
The `SystemUser` (which implements `UserDetails`) currently returns `false` from these methods:
- `public boolean hasAnyAuthority(Collection<String> auths)`
- `public boolean isAuthorized(String auth)`

The `SystemUser` should always have authorization by default. This change corrects this.

# Fix
Return `true` from both methods

# Testing
- 2 unit tests added for `SystemUser`
- 1 unit test added for `DefaultMessageService#hasAccessToManageFeedbackMessages ` which actually does call the `isAuthorized` method for `SuperUser` (most checks usually make a call to `isSuper` but this one doesn't so it's a perfect test for this new behaviour)

# Info
Can't really manually test this as it's more of an internal behaviour (can't trigger as a normal user).
We're aware of no instances where this has actually caused any issues, it's just that we spotted it while working on something else.
Also `isSuper` is usually called first in most auth checks so these 2 method paths are very rarely hit (if ever) for `SuperUser`