### PR TITLE
ci(deps): use same DB version in docker-compose.yml as in other scenarios

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
         condition: service_healthy
 
   db:
-    image: ghcr.io/baosystems/postgis:12-3.3
+    image: ghcr.io/baosystems/postgis:13-3.4
     ports:
       - "127.0.0.1:5432:5432"
     volumes:


### PR DESCRIPTION
We updated the Postgres version in

https://github.com/dhis2/dhis2-core/pull/16879/files\#diff-9dc8ad3056e3d02e42c728bd90bf151ecc5a4add6fb497b2618386613b3a2459R21

due to a flyway update. We forgot to also update it in the `docker-compose.yml` which some use for development and others to get started with DHIS2.

Aligns with

https://github.com/dhis2/dhis2-core/blob/991eab1f76641a8f6398c911c39039646688a392/dhis-2/dhis-test-e2e/docker-compose.yml#L23

Note we are using the https://github.com/baosystems/docker-postgis instead of the official image to get ARM64 support. See https://github.com/postgis/docker-postgis/issues/216