### PR TITLE
fix: Hibernate nativeQuery clear all Hibernate caches[DHIS2-16934]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
@@ -46,6 +46,7 @@ import javax.persistence.criteria.Root;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.hibernate.query.NativeQuery;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.common.AuditLogUtil;
 import org.hisp.dhis.common.BaseIdentifiableObject;
@@ -956,6 +957,17 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     }
     query.where(builder.or(predicates.toArray(new Predicate[0])));
     return !getSession().createQuery(query).setMaxResults(1).getResultList().isEmpty();
+  }
+
+  /**
+   * Create a Hibernate {@link NativeQuery} instance with {@code SynchronizedEntityClass} set to the
+   * current class. Use this to avoid all Hibernate second level caches from being invalidated.
+   *
+   * @param sql the SQL query to execute
+   * @return the {@link NativeQuery} instance
+   */
+  protected NativeQuery nativeUpdateQuery(String sql) {
+    return getSession().createNativeQuery(sql).addSynchronizedEntityClass(getClazz());
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HibernateJobConfigurationStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HibernateJobConfigurationStore.java
@@ -313,7 +313,7 @@ public class HibernateJobConfigurationStore
         and jobstatus != 'RUNNING'
         and (schedulingtype != 'ONCE_ASAP' or lastfinished is null)
         """;
-    return nativeQuery(sql).setParameter("id", jobId).executeUpdate() > 0;
+    return nativeUpdateQuery(sql).setParameter("id", jobId).executeUpdate() > 0;
   }
 
   @Override
@@ -340,7 +340,7 @@ public class HibernateJobConfigurationStore
           and j2.jobstatus = 'RUNNING'
         )
         """;
-    return nativeQuery(sql).setParameter("id", jobId).executeUpdate() > 0;
+    return nativeUpdateQuery(sql).setParameter("id", jobId).executeUpdate() > 0;
   }
 
   @Override
@@ -370,7 +370,7 @@ public class HibernateJobConfigurationStore
           jobstatus = 'SCHEDULED' and schedulingtype = 'ONCE_ASAP'
           )
         """;
-    return nativeQuery(sql).setParameter("id", jobId).executeUpdate() > 0;
+    return nativeUpdateQuery(sql).setParameter("id", jobId).executeUpdate() > 0;
   }
 
   @Override
@@ -399,7 +399,7 @@ public class HibernateJobConfigurationStore
         where uid = :id
         and jobstatus = 'RUNNING'
         """;
-    return nativeQuery(sql)
+    return nativeUpdateQuery(sql)
             .setParameter("id", jobId)
             .setParameter("status", status.name())
             .executeUpdate()
@@ -427,7 +427,7 @@ public class HibernateJobConfigurationStore
           lastexecuted is null
           or lastexecuted < (select lastexecuted from jobconfiguration where queuename = :queue and queueposition = 0 limit 1))
         """;
-    return nativeQuery(sql).setParameter("queue", queue).executeUpdate() > 0;
+    return nativeUpdateQuery(sql).setParameter("queue", queue).executeUpdate() > 0;
   }
 
   @Override
@@ -443,7 +443,7 @@ public class HibernateJobConfigurationStore
           progress = cast(:json as jsonb)
         where uid = :id
         """;
-    nativeQuery(sql)
+    nativeUpdateQuery(sql)
         .setParameter("id", jobId)
         .setParameter("json", progressJson)
         .setParameter("errors", errorCodes)
@@ -462,7 +462,7 @@ public class HibernateJobConfigurationStore
         where jobstatus = 'SCHEDULED'
         and enabled = false
         """;
-    return nativeQuery(sql).executeUpdate();
+    return nativeUpdateQuery(sql).executeUpdate();
   }
 
   @Override
@@ -478,7 +478,8 @@ public class HibernateJobConfigurationStore
         and lastfinished is not null
         and now() > lastfinished + :ttl * interval '1 minute'
         """;
-    int deletedCount = nativeQuery(sql).setParameter("ttl", max(1, ttlMinutes)).executeUpdate();
+    int deletedCount =
+        nativeUpdateQuery(sql).setParameter("ttl", max(1, ttlMinutes)).executeUpdate();
     if (deletedCount == 0) return 0;
     // jobs have the same UID as their respective FR
     // so if no job exists with the same UID the FR is not assigned
@@ -489,7 +490,7 @@ public class HibernateJobConfigurationStore
         where domain = 'JOB_DATA'
         and uid not in (select uid from jobconfiguration where schedulingtype = 'ONCE_ASAP')
         """;
-    nativeQuery(sql).executeUpdate();
+    nativeUpdateQuery(sql).executeUpdate();
     return deletedCount;
   }
 
@@ -520,7 +521,7 @@ public class HibernateJobConfigurationStore
         and enabled = true
         and now() > lastalive + :timeout * interval '1 minute'
         """;
-    return nativeQuery(sql).setParameter("timeout", max(1, timeoutMinutes)).executeUpdate();
+    return nativeUpdateQuery(sql).setParameter("timeout", max(1, timeoutMinutes)).executeUpdate();
   }
 
   private NativeQuery<?> nativeQuery(String sql) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateQueryCacheTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateQueryCacheTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.cache;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -37,6 +38,8 @@ import org.hibernate.SessionFactory;
 import org.hibernate.jpa.QueryHints;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.option.OptionSet;
+import org.hisp.dhis.scheduling.HousekeepingJob;
+import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.AfterEach;
@@ -51,6 +54,7 @@ class HibernateQueryCacheTest extends HibernateCacheBaseTest {
 
   private @Autowired EntityManagerFactory entityManagerFactory;
   private @Autowired UserService _userService;
+  private @Autowired HousekeepingJob housekeepingJob;
 
   private SessionFactory sessionFactory;
 
@@ -67,8 +71,8 @@ class HibernateQueryCacheTest extends HibernateCacheBaseTest {
     User adminUser = preCreateInjectAdminUser();
     injectSecurityContextUser(adminUser);
     integrationTestBeforeEach();
-
-    this.sessionFactory.getStatistics().setStatisticsEnabled(true);
+    sessionFactory.getStatistics().setStatisticsEnabled(true);
+    sessionFactory.getStatistics().clear();
   }
 
   @AfterEach
@@ -79,15 +83,7 @@ class HibernateQueryCacheTest extends HibernateCacheBaseTest {
   @Test
   @DisplayName("Hibernate Query cache should be used")
   void testQueryCache() {
-    OptionSet optionSet = new OptionSet();
-    optionSet.setAutoFields();
-    optionSet.setName("OptionSetA");
-    optionSet.setCode("OptionSetCodeA");
-    optionSet.setValueType(ValueType.TEXT);
-
-    entityManager.getTransaction().begin();
-    entityManager.persist(optionSet);
-    entityManager.getTransaction().commit();
+    setUpData();
 
     for (int i = 0; i < 10; i++) {
       entityManager.getTransaction().begin();
@@ -98,7 +94,44 @@ class HibernateQueryCacheTest extends HibernateCacheBaseTest {
 
     assertEquals(1, sessionFactory.getStatistics().getQueryCacheMissCount());
     assertEquals(9, sessionFactory.getStatistics().getQueryCacheHitCount());
-    entityManager.close();
+  }
+
+  @Test
+  @DisplayName("Housekeeping job must not clear Hibernate caches")
+  void testHouseKeepingJobWithCache() {
+    setUpData();
+    createSelectQuery(10);
+    assertEquals(9, sessionFactory.getStatistics().getQueryCacheHitCount());
+    housekeepingJob.execute(null, NoopJobProgress.INSTANCE);
+    createSelectQuery(1);
+    assertEquals(
+        10,
+        sessionFactory
+            .getStatistics()
+            .getCacheRegionStatistics(OptionSet.class.getName())
+            .getHitCount());
+    assertTrue(sessionFactory.getStatistics().getQueryCacheHitCount() > 10);
+  }
+
+  private void setUpData() {
+    OptionSet optionSet = new OptionSet();
+    optionSet.setAutoFields();
+    optionSet.setName("OptionSetA");
+    optionSet.setCode("OptionSetCodeA");
+    optionSet.setValueType(ValueType.TEXT);
+
+    entityManager.getTransaction().begin();
+    entityManager.persist(optionSet);
+    entityManager.getTransaction().commit();
+  }
+
+  private void createSelectQuery(int numberOfQueries) {
+    for (int i = 0; i < numberOfQueries; i++) {
+      entityManager.getTransaction().begin();
+      TypedQuery<OptionSet> query = createQuery(entityManager);
+      assertEquals(1, query.getResultList().size());
+      entityManager.getTransaction().commit();
+    }
   }
 
   private TypedQuery<OptionSet> createQuery(EntityManager entityManager) {


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-16934

### Issue
- `HouseKeepingJob` use `org.hibernate.query.NativeQuery` to update/delete records in `jobconfiguration` table.
- That causes Hibernate to invalidate all caches in `SessionFactory`. Which in result trigger multiple `select` queries to database when lazy collection are loaded. This is the default Hibernate behavior, more details [here](https://vladmihalcea.com/how-does-hibernate-query-cache-work/rl).
- The job runs every 20s, so basically there are no cache entry available for whole application.

### Fix
- In order to avoid cache from being invalidated we must use method `NativeQuery.addSynchronizedEntityClass(class)`. Hibernate will then only invalidate cached entries of specified class.

### Test
- Added new integration test in `HibernateQueryCacheTest`

### Todo
- Look for other places which use `NativeQuery` and make sure only related caches are invalidated. 