### PR TITLE
perf: Fix load programs query in old tracker [2.40]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ProgramSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ProgramSupplier.java
@@ -259,11 +259,7 @@ public class ProgramSupplier extends AbstractSupplier<Map<String, Program>> {
             + " from program p "
             + "LEFT JOIN categorycombo c on p.categorycomboid = c.categorycomboid "
             + "LEFT JOIN trackedentitytype tet on p.trackedentitytypeid = tet.trackedentitytypeid "
-            + "LEFT JOIN programstage ps on p.programid = ps.programid "
-            + "LEFT JOIN program_organisationunits pou on p.programid = pou.programid "
-            + "LEFT JOIN organisationunit ou on pou.organisationunitid = ou.organisationunitid "
-            + "group by p.programid, tet.trackedentitytypeid, c.categorycomboid, ps.programstageid, ps.sort_order "
-            + "order by p.programid, ps.sort_order";
+            + "LEFT JOIN programstage ps on p.programid = ps.programid";
 
     return jdbcTemplate.query(
         sql,

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ProgramSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ProgramSupplier.java
@@ -259,7 +259,8 @@ public class ProgramSupplier extends AbstractSupplier<Map<String, Program>> {
             + " from program p "
             + "LEFT JOIN categorycombo c on p.categorycomboid = c.categorycomboid "
             + "LEFT JOIN trackedentitytype tet on p.trackedentitytypeid = tet.trackedentitytypeid "
-            + "LEFT JOIN programstage ps on p.programid = ps.programid";
+            + "LEFT JOIN programstage ps on p.programid = ps.programid "
+            + "group by p.programid, tet.trackedentitytypeid, c.categorycomboid, ps.programstageid, ps.sort_order";
 
     return jdbcTemplate.query(
         sql,

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ProgramSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ProgramSupplier.java
@@ -260,7 +260,7 @@ public class ProgramSupplier extends AbstractSupplier<Map<String, Program>> {
             + "LEFT JOIN categorycombo c on p.categorycomboid = c.categorycomboid "
             + "LEFT JOIN trackedentitytype tet on p.trackedentitytypeid = tet.trackedentitytypeid "
             + "LEFT JOIN programstage ps on p.programid = ps.programid "
-            + "group by p.programid, tet.trackedentitytypeid, c.categorycomboid, ps.programstageid, ps.sort_order";
+            + "order by p.programid";
 
     return jdbcTemplate.query(
         sql,


### PR DESCRIPTION
This is a quick fix for this https://dhis2.atlassian.net/browse/DHIS2-17246 found doing an analysis in glowroot with @JMAlcantara.
`ProgramSupplier` in the old tracker is retrieving all the programs in a query that is joining some of the DB biggest tables without using them. Removing those joins is not affecting the result and it is speeding up the system.