### PR TITLE
fix: Investigate the reason of differences in events x enrollments in analytics query[2.40-DHIS2-16227]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -90,7 +90,9 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
 
   private static final String ANALYTICS_EVENT = "analytics_event_";
 
-  private static final String ORDER_BY_EXECUTION_DATE = "order by executiondate ";
+  private static final String DIRECTION_PLACEHOLDER = "#DIRECTION_PLACEHOLDER";
+  private static final String ORDER_BY_EXECUTION_DATE =
+      "order by executiondate " + DIRECTION_PLACEHOLDER + ", created " + DIRECTION_PLACEHOLDER;
 
   private static final String LIMIT_1 = "limit 1";
 
@@ -508,8 +510,9 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
               + colName
               + IS_NOT_NULL
               + psCondition
-              + ORDER_BY_EXECUTION_DATE
-              + createOrderTypeAndOffset(item.getProgramStageOffset())
+              + createOrderType(item.getProgramStageOffset())
+              + " "
+              + createOffset(item.getProgramStageOffset())
               + " "
               + LIMIT_1
               + " )",
@@ -560,8 +563,9 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
             + getExecutionDateFilter(
                 item.getRepeatableStageParams().getStartDate(),
                 item.getRepeatableStageParams().getEndDate())
-            + ORDER_BY_EXECUTION_DATE
-            + createOrderTypeAndOffset(item.getProgramStageOffset())
+            + createOrderType(item.getProgramStageOffset())
+            + " "
+            + createOffset(item.getProgramStageOffset())
             + getLimit(item.getRepeatableStageParams().getCount())
             + " ) as t1)";
       }
@@ -582,8 +586,9 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
             + getExecutionDateFilter(
                 item.getRepeatableStageParams().getStartDate(),
                 item.getRepeatableStageParams().getEndDate())
-            + ORDER_BY_EXECUTION_DATE
-            + createOrderTypeAndOffset(item.getProgramStageOffset())
+            + createOrderType(item.getProgramStageOffset())
+            + " "
+            + createOffset(item.getProgramStageOffset())
             + " "
             + LIMIT_1
             + " )";
@@ -609,8 +614,9 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
           + "and ps = '"
           + item.getProgramStage().getUid()
           + "' "
-          + ORDER_BY_EXECUTION_DATE
-          + createOrderTypeAndOffset(item.getProgramStageOffset())
+          + createOrderType(item.getProgramStageOffset())
+          + " "
+          + createOffset(item.getProgramStageOffset())
           + " "
           + LIMIT_1
           + " )";
@@ -667,14 +673,26 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
     return AnalyticsType.ENROLLMENT;
   }
 
-  private String createOrderTypeAndOffset(int offset) {
+  private String createOffset(int offset) {
     if (offset == 0) {
-      return "desc";
+      return EMPTY;
+    }
+
+    if (offset < 0) {
+      return "offset " + (-1 * offset);
+    } else {
+      return "offset " + (offset - 1);
+    }
+  }
+
+  private String createOrderType(int offset) {
+    if (offset == 0) {
+      return ORDER_BY_EXECUTION_DATE.replace(DIRECTION_PLACEHOLDER, "desc");
     }
     if (offset < 0) {
-      return "desc offset " + (-1 * offset);
+      return ORDER_BY_EXECUTION_DATE.replace(DIRECTION_PLACEHOLDER, "desc");
     } else {
-      return "asc offset " + (offset - 1);
+      return ORDER_BY_EXECUTION_DATE.replace(DIRECTION_PLACEHOLDER, "asc");
     }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -204,7 +204,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + programA.getUid()
             + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
             + programStage.getUid()
-            + "' order by executiondate desc limit 1 )";
+            + "' order by executiondate desc, created desc  limit 1 )";
 
     if (valueType == ValueType.NUMBER) {
       subSelect = subSelect + " as \"fWIAEtYVEGk\"";
@@ -257,7 +257,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + programUid
             + ".pi = ax.pi and ps = '"
             + repeatableProgramStage.getUid()
-            + "' order by executiondate desc offset 1 limit 1 ) "
+            + "' order by executiondate desc, created desc offset 1 limit 1 ) "
             + "as \""
             + programStageUid
             + "[-1]."
@@ -272,7 +272,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + programUid
             + ".pi = ax.pi and ps = '"
             + programStageUid
-            + "' order by executiondate desc offset 1 limit 1 )) "
+            + "' order by executiondate desc, created desc offset 1 limit 1 )) "
             + "as \""
             + programStageUid
             + "[-1]."
@@ -303,7 +303,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + programA.getUid()
             + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
             + programStage.getUid()
-            + "' order by executiondate desc limit 1 )";
+            + "' order by executiondate desc, created desc  limit 1 )";
 
     String expected =
         "ax.\"quarterly\",ax.\"ou\","
@@ -377,7 +377,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + programA.getUid()
             + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
             + programStage.getUid()
-            + "' order by executiondate desc limit 1 )";
+            + "' order by executiondate desc, created desc  limit 1 )";
 
     String expected =
         "ax.\"quarterly\",ax.\"ou\","
@@ -404,7 +404,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + programA.getUid()
             + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
             + programStage.getUid()
-            + "' order by executiondate desc limit 1 )";
+            + "' order by executiondate desc, created desc  limit 1 )";
 
     String expected = subSelect + " is null";
 
@@ -423,7 +423,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + programA.getUid()
             + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
             + programStage.getUid()
-            + "' order by executiondate desc limit 1 )";
+            + "' order by executiondate desc, created desc  limit 1 )";
 
     String expected = subSelect + " is not null";
     testIt(
@@ -441,7 +441,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + programA.getUid()
             + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
             + programStage.getUid()
-            + "' order by executiondate desc limit 1 )";
+            + "' order by executiondate desc, created desc  limit 1 )";
 
     String numericValues = String.join(OPTION_SEP, "10", "11", "12");
     String expected =
@@ -469,7 +469,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + programA.getUid()
             + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
             + programStage.getUid()
-            + "' order by executiondate desc limit 1 )";
+            + "' order by executiondate desc, created desc  limit 1 )";
 
     String numericValues = String.join(OPTION_SEP, "10", "11", "12");
     String expected = subSelect + " in (" + String.join(",", numericValues.split(OPTION_SEP)) + ")";
@@ -488,7 +488,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + programA.getUid()
             + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
             + programStage.getUid()
-            + "' order by executiondate desc limit 1 )";
+            + "' order by executiondate desc, created desc  limit 1 )";
 
     String expected = subSelect + " is null";
     String unexpected = "(" + subSelect + " in (";
@@ -720,7 +720,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
                 + dataElementA.getUid()
                 + "\" is not null and ps = '"
                 + programStage.getUid()
-                + "' order by executiondate desc limit 1 )"));
+                + "' order by executiondate desc, created desc  limit 1 )"));
   }
 
   @Test
@@ -752,7 +752,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
                 + programB.getUid()
                 + ".pi = ax.pi and ps = '"
                 + repeatableProgramStage.getUid()
-                + "' and executiondate >= '2022-01-01'  and executiondate <= '2022-01-31' order by executiondate desc LIMIT 100 ) as t1)"));
+                + "' and executiondate >= '2022-01-01'  and executiondate <= '2022-01-31' order by executiondate desc, created desc  LIMIT 100 ) as t1)"));
   }
 
   @Test
@@ -782,7 +782,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
                 + programB.getUid()
                 + ".pi = ax.pi and ps = '"
                 + repeatableProgramStage.getUid()
-                + "' order by executiondate desc limit 1 )"));
+                + "' order by executiondate desc, created desc  limit 1 )"));
   }
 
   @Test
@@ -818,8 +818,8 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
                 + "and "
                 + colName
                 + " is not null "
-                + "order by executiondate "
-                + "desc limit 1 )"));
+                + "order by executiondate desc, created desc "
+                + " limit 1 )"));
   }
 
   @Test
@@ -858,8 +858,8 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
                 + " is not null "
                 + "and ps = '"
                 + item.getProgramStage().getUid()
-                + "' order by executiondate "
-                + "desc limit 1 )"));
+                + "' order by executiondate desc, created desc "
+                + " limit 1 )"));
   }
 
   @Test

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery3AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery3AutoTest.java
@@ -54,15 +54,15 @@ public class EnrollmentsQuery3AutoTest extends AnalyticsApiTest {
     QueryParamsBuilder params =
         new QueryParamsBuilder()
             .add("includeMetadataDetails=true")
-            .add("headers=ouname,EPEcjy3FWmI.lJTx9EZ1dk1,enrollmentdate")
+            .add("headers=ouname,EPEcjy3FWmI[-1].lJTx9EZ1dk1,enrollmentdate")
             .add("displayProperty=NAME")
             .add("totalPages=false")
             .add("enrollmentDate=2022")
             .add("rowContext=true")
             .add("outputType=ENROLLMENT")
-            .add("pageSize=100")
+            .add("pageSize=5")
             .add("page=1")
-            .add("dimension=ou:USER_ORGUNIT,EPEcjy3FWmI.lJTx9EZ1dk1:IN:NV");
+            .add("dimension=ou:USER_ORGUNIT,EPEcjy3FWmI[-1].lJTx9EZ1dk1:IN:NV");
 
     // When
     ApiResponse response = actions.query().get("ur1Edk5Oe2n", JSON, JSON, params);
@@ -89,7 +89,7 @@ public class EnrollmentsQuery3AutoTest extends AnalyticsApiTest {
     validateHeader(
         response,
         1,
-        "EPEcjy3FWmI.lJTx9EZ1dk1",
+        "EPEcjy3FWmI[-1].lJTx9EZ1dk1",
         "Tb lab Glucose",
         "TRUE_ONLY",
         "java.lang.Boolean",
@@ -253,9 +253,9 @@ public class EnrollmentsQuery3AutoTest extends AnalyticsApiTest {
         true);
 
     // Assert rowContext
-    validateRowContext(response, 0, 1, "NS");
+    validateRowContext(response, 0, 2, "NS");
 
     // Assert rows.
-    validateRow(response, 0, List.of("Motorbong MCHP", "", "1", "2022-02-18 12:27:49.129"));
+    validateRow(response, 0, List.of("Motorbong MCHP", "1", "", "2022-02-18 12:27:49.129"));
   }
 }


### PR DESCRIPTION
There is the problem with sorting of the repeatable stages. The issue was pinpointed to the event report date in the repeatable stage. The capture app allowed users to add new events in the repeatable stage. The report date (found in the executiondate column of the event table in the tracker database) is treated as a date without a time section. When analytics queries for repeatable stage events using an position index, the executiondate is crucial for ensuring the correct outcome, as it serves as the sorting criteria. Sorting on non-unique data can yield inconsistent results. This is the scenario described in the ticket. Report dates of events within the repeatable stage are not unique, and sorting may yield different outcomes.