### PR TITLE
chore: Ban Spring PreAuthorize annotation

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -2291,6 +2291,12 @@ jasperreports.version=${jasperreports.version}
                     <bannedImport>org.hamcrest.Matchers.instanceOf</bannedImport>
                   </bannedImports>
                 </RestrictImports>
+                <RestrictImports>
+                  <reason>Use org.hisp.dhis.security.RequiresAuthority instead</reason>
+                  <bannedImports>
+                    <bannedImport>org.springframework.security.access.prepost.PreAuthorize</bannedImport>
+                  </bannedImports>
+                </RestrictImports>
               </rules>
             </configuration>
           </execution>


### PR DESCRIPTION
Use `@RequiresAuthority` instead
- discussed & agreed in backend meeting on 2024-04-18