### PR TITLE
fix:Analytics events query API: 500 error when dimension is not present in the query[2.40-DHIS2-17231-backport]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/PeriodCriteriaUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/PeriodCriteriaUtils.java
@@ -72,8 +72,9 @@ public class PeriodCriteriaUtils {
    * @return true if the criteria contains a period dimension, (start and end date) or event date.
    *     False, otherwise.
    */
-  private static boolean hasPeriod(EventsAnalyticsQueryCriteria criteria) {
-    return criteria.getDimension().stream().anyMatch(d -> d.startsWith(PERIOD_DIM_ID))
+  public static boolean hasPeriod(EventsAnalyticsQueryCriteria criteria) {
+    return (criteria.getDimension() != null
+            && criteria.getDimension().stream().anyMatch(d -> d.startsWith(PERIOD_DIM_ID)))
         || (criteria.getFilter() != null
             && criteria.getFilter().stream().anyMatch(d -> d.startsWith(PERIOD_DIM_ID)))
         || !isBlank(criteria.getEventDate())

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/PeriodCriteriaUtilsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/PeriodCriteriaUtilsTest.java
@@ -204,6 +204,19 @@ class PeriodCriteriaUtilsTest {
     assertNull(enrollmentsAnalyticsQueryCriteria.getDesc());
   }
 
+  @Test
+  void testCriteriaHasPeriodWhenDimensionNull() {
+    // given
+    EventsAnalyticsQueryCriteria criteria = getDefaultEventsAnalyticsQueryCriteria();
+
+    // when
+    criteria.setDimension(null);
+    criteria.setEventDate("2020-12-01");
+
+    // then
+    assertTrue(PeriodCriteriaUtils.hasPeriod(criteria));
+  }
+
   private EventsAnalyticsQueryCriteria configureEventsAnalyticsQueryCriteriaWithPeriod(
       String period) {
     EventsAnalyticsQueryCriteria eventsAnalyticsQueryCriteria =


### PR DESCRIPTION
**Backport**
There was a simple bug (a null dimension set handling) preventing the application from reacting properly. Instead of delivering the standard error message (409, "At least one organization unit must be specified"), it delivered an internal error message (500).