### PR TITLE
fix: tracker/relationships emits inaccessible program attributes  [ Dhis2-17090 ]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerAccessManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerAccessManager.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.trackedentity;
 
 import java.util.List;
+import java.util.Set;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -82,7 +83,7 @@ public interface TrackerAccessManager {
 
   List<String> canDelete(UserDetails user, Event event, boolean skipOwnershipCheck);
 
-  List<String> canRead(UserDetails user, Relationship relationship);
+  Set<String> canRead(UserDetails user, Relationship relationship);
 
   List<String> canWrite(UserDetails user, Relationship relationship);
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerAccessManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerAccessManager.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.trackedentity;
 
 import java.util.List;
-import java.util.Set;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -83,7 +82,7 @@ public interface TrackerAccessManager {
 
   List<String> canDelete(UserDetails user, Event event, boolean skipOwnershipCheck);
 
-  Set<String> canRead(UserDetails user, Relationship relationship);
+  List<String> canRead(UserDetails user, Relationship relationship);
 
   List<String> canWrite(UserDetails user, Relationship relationship);
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityAttributeService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityAttributeService.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.trackedentity;
 
+import static java.util.stream.Collectors.toList;
+
 import com.google.common.collect.ImmutableSet;
 import java.util.HashSet;
 import java.util.List;
@@ -34,7 +36,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.imageio.ImageIO;
 import lombok.RequiredArgsConstructor;
@@ -327,7 +328,7 @@ public class DefaultTrackedEntityAttributeService implements TrackedEntityAttrib
           programAttributeStore.getAttributes(
               programs.stream()
                   .filter(program -> aclService.canDataRead(userDetails, program))
-                  .collect(Collectors.toList())));
+                  .collect(toList())));
     }
 
     if (trackedEntityTypes != null && !trackedEntityTypes.isEmpty()) {
@@ -336,7 +337,7 @@ public class DefaultTrackedEntityAttributeService implements TrackedEntityAttrib
               trackedEntityTypes.stream()
                   .filter(
                       trackedEntityType -> aclService.canDataRead(userDetails, trackedEntityType))
-                  .collect(Collectors.toList())));
+                  .collect(toList())));
     }
 
     return attributes;
@@ -363,7 +364,7 @@ public class DefaultTrackedEntityAttributeService implements TrackedEntityAttrib
   public List<TrackedEntityAttribute> getAllSystemWideUniqueTrackedEntityAttributes() {
     return getAllTrackedEntityAttributes().stream()
         .filter(TrackedEntityAttribute::isSystemWideUnique)
-        .collect(Collectors.toList());
+        .collect(toList());
   }
 
   @Override
@@ -371,7 +372,7 @@ public class DefaultTrackedEntityAttributeService implements TrackedEntityAttrib
   public List<TrackedEntityAttribute> getAllUniqueTrackedEntityAttributes() {
     return getAllTrackedEntityAttributes().stream()
         .filter(TrackedEntityAttribute::isUnique)
-        .collect(Collectors.toList());
+        .collect(toList());
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
@@ -32,7 +32,10 @@ import static org.hisp.dhis.trackedentity.TrackerOwnershipManager.OWNERSHIP_ACCE
 import static org.hisp.dhis.trackedentity.TrackerOwnershipManager.PROGRAM_ACCESS_CLOSED;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
@@ -41,6 +44,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.relationship.RelationshipItem;
@@ -59,7 +63,14 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
 
   private final AclService aclService;
   private final TrackerOwnershipManager ownershipAccessManager;
+  private final ProgramService programService;
 
+  /**
+   * Check the data read permissions and ownership of a tracked entity given the programs for which
+   * the user has metadata access to.
+   *
+   * @return No errors if a user has access to at least one program
+   */
   @Override
   public List<String> canRead(UserDetails user, TrackedEntity trackedEntity) {
     // always allow if user == null (internal process) or user is superuser
@@ -67,21 +78,67 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
       return List.of();
     }
 
-    OrganisationUnit ou = trackedEntity.getOrganisationUnit();
-    List<String> errors = new ArrayList<>();
-    // ou should never be null, but needs to be checked for legacy reasons
-    if (ou != null && !user.isInUserSearchHierarchy(ou.getPath())) {
-      errors.add(NO_READ_ACCESS_TO_ORG_UNIT + ": " + ou.getUid());
+    return new ArrayList<>(canRead(user, trackedEntity, programService.getAllPrograms()));
+  }
+
+  private Set<String> canRead(
+      UserDetails user, TrackedEntity trackedEntity, List<Program> programs) {
+
+    if (null == trackedEntity) {
+      return Set.of();
     }
 
     TrackedEntityType trackedEntityType = trackedEntity.getTrackedEntityType();
 
     if (!aclService.canDataRead(user, trackedEntityType)) {
-      errors.add(
+      return Set.of(
           "User has no data read access to tracked entity type: " + trackedEntityType.getUid());
     }
 
+    initializeTrackedEntityOrgUnitParents(trackedEntity);
+
+    Set<String> errors = new HashSet<>();
+
+    List<Program> tetPrograms =
+        programs.stream()
+            .filter(
+                p -> Objects.equals(p.getTrackedEntityType(), trackedEntity.getTrackedEntityType()))
+            .toList();
+
+    if (tetPrograms.isEmpty()) {
+      return Set.of(OWNERSHIP_ACCESS_DENIED);
+    }
+
+    for (Program program : tetPrograms) {
+      List<String> e = canRead(user, trackedEntity, program);
+      if (e.isEmpty()) {
+        return Set.of();
+      } else {
+        errors.addAll(e);
+      }
+    }
     return errors;
+  }
+
+  /** Check Program data read access and Tracked Entity Program Ownership */
+  private List<String> canRead(UserDetails user, TrackedEntity trackedEntity, Program program) {
+    List<String> errors = new ArrayList<>();
+
+    if (!aclService.canDataRead(user, program)) {
+      errors.add("User has no data read access to program: " + program.getUid());
+    }
+
+    if (!ownershipAccessManager.hasAccess(user, trackedEntity, program)) {
+      errors.add(OWNERSHIP_ACCESS_DENIED);
+    }
+    return errors;
+  }
+
+  private void initializeTrackedEntityOrgUnitParents(TrackedEntity trackedEntity) {
+    OrganisationUnit organisationUnit = trackedEntity.getOrganisationUnit();
+    while (organisationUnit.getParent() != null) {
+      organisationUnit = organisationUnit.getParent();
+    }
   }
 
   @Override
@@ -507,26 +564,28 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
   }
 
   @Override
-  public List<String> canRead(UserDetails user, Relationship relationship) {
+  public Set<String> canRead(UserDetails user, Relationship relationship) {
     // always allow if user == null (internal process) or user is superuser
     if (user == null || user.isSuper() || relationship == null) {
-      return List.of();
+      return Set.of();
     }
 
     RelationshipType relationshipType = relationship.getRelationshipType();
-    List<String> errors = new ArrayList<>();
+    Set<String> errors = new HashSet<>();
     if (!aclService.canDataRead(user, relationshipType)) {
       errors.add("User has no data read access to relationshipType: " + relationshipType.getUid());
     }
 
+    List<Program> programs = programService.getAllPrograms();
+
     RelationshipItem from = relationship.getFrom();
     RelationshipItem to = relationship.getTo();
 
-    errors.addAll(canRead(user, from.getTrackedEntity()));
+    errors.addAll(canRead(user, from.getTrackedEntity(), programs));
     errors.addAll(canRead(user, from.getEnrollment(), false));
     errors.addAll(canRead(user, from.getEvent(), false));
 
-    errors.addAll(canRead(user, to.getTrackedEntity()));
+    errors.addAll(canRead(user, to.getTrackedEntity(), programs));
     errors.addAll(canRead(user, to.getEnrollment(), false));
     errors.addAll(canRead(user, to.getEvent(), false));
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
@@ -133,6 +133,16 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
     return errors;
   }
 
+  /**
+   * TODO This is a temporary fix, a more permanent solution needs to be found, maybe store the org
+   * unit path directly in the cache as a string or avoid using an Hibernate object in the cache
+   *
+   * <p>The tracked entity org unit will be used as a fallback in case no owner is found. In that
+   * case, it will be stored in the cache, but it's lazy loaded, meaning org unit parents won't be
+   * loaded unless accessed. This is a problem because we save the org unit object in the cache, and
+   * when we retrieve it, we can't get the value of the parents, since there's no session. We need
+   * the parents to build the org unit path, that later will be used to validate the ownership.
+   */
   private void initializeTrackedEntityOrgUnitParents(TrackedEntity trackedEntity) {
     OrganisationUnit organisationUnit = trackedEntity.getOrganisationUnit();
     while (organisationUnit.getParent() != null) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
@@ -106,7 +106,7 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
             .toList();
 
     if (tetPrograms.isEmpty()) {
-      return Set.of(OWNERSHIP_ACCESS_DENIED);
+      return Set.of("User has no access to any program");
     }
 
     for (Program program : tetPrograms) {
@@ -123,7 +123,6 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
   /** Check Program data read access and Tracked Entity Program Ownership */
   private List<String> canRead(UserDetails user, TrackedEntity trackedEntity, Program program) {
     List<String> errors = new ArrayList<>();
-
     if (!aclService.canDataRead(user, program)) {
       errors.add("User has no data read access to program: " + program.getUid());
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
@@ -32,10 +32,8 @@ import static org.hisp.dhis.trackedentity.TrackerOwnershipManager.OWNERSHIP_ACCE
 import static org.hisp.dhis.trackedentity.TrackerOwnershipManager.PROGRAM_ACCESS_CLOSED;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
@@ -78,26 +76,24 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
       return List.of();
     }
 
-    return new ArrayList<>(canRead(user, trackedEntity, programService.getAllPrograms()));
+    return canRead(user, trackedEntity, programService.getAllPrograms());
   }
 
-  private Set<String> canRead(
+  private List<String> canRead(
       UserDetails user, TrackedEntity trackedEntity, List<Program> programs) {
 
     if (null == trackedEntity) {
-      return Set.of();
+      return List.of();
     }
 
     TrackedEntityType trackedEntityType = trackedEntity.getTrackedEntityType();
 
     if (!aclService.canDataRead(user, trackedEntityType)) {
-      return Set.of(
+      return List.of(
           "User has no data read access to tracked entity type: " + trackedEntityType.getUid());
     }
 
     initializeTrackedEntityOrgUnitParents(trackedEntity);
-
-    Set<String> errors = new HashSet<>();
 
     List<Program> tetPrograms =
         programs.stream()
@@ -106,31 +102,20 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
             .toList();
 
     if (tetPrograms.isEmpty()) {
-      return Set.of("User has no access to any program");
+      return List.of("User has no access to any program");
     }
 
-    for (Program program : tetPrograms) {
-      List<String> e = canRead(user, trackedEntity, program);
-      if (e.isEmpty()) {
-        return Set.of();
-      } else {
-        errors.addAll(e);
-      }
+    if (tetPrograms.stream().anyMatch(p -> canRead(user, trackedEntity, p))) {
+      return List.of();
+    } else {
+      return List.of(OWNERSHIP_ACCESS_DENIED);
     }
-    return errors;
   }
 
   /** Check Program data read access and Tracked Entity Program Ownership */
-  private List<String> canRead(UserDetails user, TrackedEntity trackedEntity, Program program) {
-    List<String> errors = new ArrayList<>();
-    if (!aclService.canDataRead(user, program)) {
-      errors.add("User has no data read access to program: " + program.getUid());
-    }
-
-    if (!ownershipAccessManager.hasAccess(user, trackedEntity, program)) {
-      errors.add(OWNERSHIP_ACCESS_DENIED);
-    }
-    return errors;
+  private boolean canRead(UserDetails user, TrackedEntity trackedEntity, Program program) {
+    return aclService.canDataRead(user, program)
+        && ownershipAccessManager.hasAccess(user, trackedEntity, program);
   }
 
   /**
@@ -573,14 +558,14 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
   }
 
   @Override
-  public Set<String> canRead(UserDetails user, Relationship relationship) {
+  public List<String> canRead(UserDetails user, Relationship relationship) {
     // always allow if user == null (internal process) or user is superuser
     if (user == null || user.isSuper() || relationship == null) {
-      return Set.of();
+      return List.of();
     }
 
     RelationshipType relationshipType = relationship.getRelationshipType();
-    Set<String> errors = new HashSet<>();
+    List<String> errors = new ArrayList<>();
     if (!aclService.canDataRead(user, relationshipType)) {
       errors.add("User has no data read access to relationshipType: " + relationshipType.getUid());
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerOwnershipManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerOwnershipManager.java
@@ -218,19 +218,19 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager {
 
   @Override
   @Transactional(readOnly = true)
-  public boolean hasAccess(UserDetails user, TrackedEntity entityInstance, Program program) {
-    if (canSkipOwnershipCheck(user, program) || entityInstance == null) {
+  public boolean hasAccess(UserDetails user, TrackedEntity trackedEntity, Program program) {
+    if (canSkipOwnershipCheck(user, program) || trackedEntity == null) {
       return true;
     }
 
     OrganisationUnit ou =
-        getOwner(entityInstance.getId(), program, entityInstance::getOrganisationUnit);
+        getOwner(trackedEntity.getId(), program, trackedEntity::getOrganisationUnit);
 
     final String orgUnitPath = ou.getPath();
     return switch (program.getAccessLevel()) {
       case OPEN, AUDITED -> user.isInUserSearchHierarchy(orgUnitPath);
       case PROTECTED ->
-          user.isInUserHierarchy(orgUnitPath) || hasTemporaryAccess(entityInstance, program, user);
+          user.isInUserHierarchy(orgUnitPath) || hasTemporaryAccess(trackedEntity, program, user);
       case CLOSED -> user.isInUserHierarchy(orgUnitPath);
     };
   }
@@ -285,10 +285,7 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager {
                   entityInstanceId, program.getId());
 
           return Optional.ofNullable(trackedEntityProgramOwner)
-              .map(
-                  tepo -> {
-                    return recursivelyInitializeOrgUnit(tepo.getOrganisationUnit());
-                  })
+              .map(tepo -> recursivelyInitializeOrgUnit(tepo.getOrganisationUnit()))
               .orElseGet(orgUnitIfMissingSupplier);
         });
   }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/relationship/AbstractRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/relationship/AbstractRelationshipService.java
@@ -493,6 +493,18 @@ public abstract class AbstractRelationshipService implements RelationshipService
         tei =
             trackedEntityInstanceService.getTrackedEntityInstance(
                 dao.getTrackedEntity(), TrackedEntityInstanceParams.TRUE);
+
+        if (constraint.getTrackerDataView() != null) {
+          tei.setAttributes(
+              tei.getAttributes().stream()
+                  .filter(
+                      a ->
+                          constraint
+                              .getTrackerDataView()
+                              .getAttributes()
+                              .contains(a.getAttribute()))
+                  .toList());
+        }
       }
 
       relationshipItem.setTrackedEntityInstance(tei);
@@ -507,6 +519,18 @@ public abstract class AbstractRelationshipService implements RelationshipService
         enrollment.setEnrollment(uid);
       } else {
         enrollment = enrollmentService.getEnrollment(dao.getEnrollment(), EnrollmentParams.TRUE);
+
+        if (constraint.getTrackerDataView() != null) {
+          enrollment.setAttributes(
+              enrollment.getAttributes().stream()
+                  .filter(
+                      a ->
+                          constraint
+                              .getTrackerDataView()
+                              .getAttributes()
+                              .contains(a.getAttribute()))
+                  .toList());
+        }
       }
 
       relationshipItem.setEnrollment(enrollment);
@@ -520,6 +544,18 @@ public abstract class AbstractRelationshipService implements RelationshipService
         event.setEvent(uid);
       } else {
         event = eventService.getEvent(dao.getEvent(), EventParams.FALSE);
+
+        if (constraint.getTrackerDataView() != null) {
+          event.setDataValues(
+              event.getDataValues().stream()
+                  .filter(
+                      d ->
+                          constraint
+                              .getTrackerDataView()
+                              .getDataElements()
+                              .contains(d.getDataElement()))
+                  .collect(Collectors.toSet()));
+        }
       }
 
       relationshipItem.setEvent(event);

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/relationship/AbstractRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/relationship/AbstractRelationshipService.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.commons.collection.ListUtils;
@@ -442,7 +443,7 @@ public abstract class AbstractRelationshipService implements RelationshipService
   @Transactional(readOnly = true)
   public Optional<Relationship> findRelationship(
       org.hisp.dhis.relationship.Relationship dao, RelationshipParams params, UserDetails user) {
-    List<String> errors = trackerAccessManager.canRead(user, dao);
+    Set<String> errors = trackerAccessManager.canRead(user, dao);
 
     if (!errors.isEmpty()) {
       // Dont include relationship
@@ -455,8 +456,12 @@ public abstract class AbstractRelationshipService implements RelationshipService
     relationship.setRelationshipType(dao.getRelationshipType().getUid());
     relationship.setRelationshipName(dao.getRelationshipType().getName());
 
-    relationship.setFrom(includeRelationshipItem(dao.getFrom(), !params.isIncludeFrom()));
-    relationship.setTo(includeRelationshipItem(dao.getTo(), !params.isIncludeTo()));
+    relationship.setFrom(
+        includeRelationshipItem(
+            dao.getFrom(), !params.isIncludeFrom(), dao.getRelationshipType().getFromConstraint()));
+    relationship.setTo(
+        includeRelationshipItem(
+            dao.getTo(), !params.isIncludeTo(), dao.getRelationshipType().getToConstraint()));
 
     relationship.setBidirectional(dao.getRelationshipType().isBidirectional());
 
@@ -472,7 +477,8 @@ public abstract class AbstractRelationshipService implements RelationshipService
   }
 
   private org.hisp.dhis.dxf2.deprecated.tracker.trackedentity.RelationshipItem
-      includeRelationshipItem(RelationshipItem dao, boolean uidOnly) {
+      includeRelationshipItem(
+          RelationshipItem dao, boolean uidOnly, RelationshipConstraint constraint) {
     org.hisp.dhis.dxf2.deprecated.tracker.trackedentity.RelationshipItem relationshipItem =
         new org.hisp.dhis.dxf2.deprecated.tracker.trackedentity.RelationshipItem();
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/relationship/AbstractRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/relationship/AbstractRelationshipService.java
@@ -38,7 +38,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.commons.collection.ListUtils;
@@ -443,7 +442,7 @@ public abstract class AbstractRelationshipService implements RelationshipService
   @Transactional(readOnly = true)
   public Optional<Relationship> findRelationship(
       org.hisp.dhis.relationship.Relationship dao, RelationshipParams params, UserDetails user) {
-    Set<String> errors = trackerAccessManager.canRead(user, dao);
+    List<String> errors = trackerAccessManager.canRead(user, dao);
 
     if (!errors.isEmpty()) {
       // Dont include relationship

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -82,7 +82,7 @@ public class DefaultRelationshipService implements RelationshipService {
     }
 
     UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
-    Set<String> errors = accessErrors(currentUser, relationship);
+    List<String> errors = accessErrors(currentUser, relationship);
     if (!errors.isEmpty()) {
       throw new ForbiddenException(errors.toString());
     }
@@ -191,7 +191,7 @@ public class DefaultRelationshipService implements RelationshipService {
     throw new IllegalArgumentException("Unkown type");
   }
 
-  private Set<String> accessErrors(UserDetails user, Relationship relationship) {
+  private List<String> accessErrors(UserDetails user, Relationship relationship) {
     return trackerAccessManager.canRead(user, relationship);
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/ProgramStageValidationStrategyTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/ProgramStageValidationStrategyTest.java
@@ -153,12 +153,6 @@ class ProgramStageValidationStrategyTest extends TransactionalIntegrationTest {
     TrackedEntityType trackedEntityType = createTrackedEntityType('A');
     trackedEntityType.getSharing().addUserAccess(userAccess1);
     manager.save(trackedEntityType, false);
-    TrackedEntity maleA = createTrackedEntity(organisationUnitA);
-    maleA.setTrackedEntityType(trackedEntityType);
-    maleA.getSharing().addUserAccess(userAccess1);
-    maleA.setCreatedBy(currentUser);
-    manager.save(maleA, false);
-    trackedEntityInstanceMaleA = trackedEntityInstanceService.getTrackedEntityInstance(maleA);
     DataElement dataElementA = createDataElement('A');
     dataElementA.setValueType(ValueType.INTEGER);
     dataElementA.getSharing().addUserAccess(userAccess1);
@@ -178,6 +172,7 @@ class ProgramStageValidationStrategyTest extends TransactionalIntegrationTest {
     programA = createProgram('A', new HashSet<>(), organisationUnitA);
     programA.setProgramType(ProgramType.WITH_REGISTRATION);
     programA.getSharing().addUserAccess(userAccess1);
+    programA.setTrackedEntityType(trackedEntityType);
     manager.save(programA, false);
     // Create a compulsory PSDE
     ProgramStageDataElement programStageDataElementA = new ProgramStageDataElement();
@@ -210,6 +205,14 @@ class ProgramStageValidationStrategyTest extends TransactionalIntegrationTest {
     programA.getProgramStages().add(programStageA);
     manager.update(programStageA);
     manager.update(programA);
+
+    TrackedEntity maleA = createTrackedEntity(organisationUnitA);
+    maleA.setTrackedEntityType(trackedEntityType);
+    maleA.getSharing().addUserAccess(userAccess1);
+    maleA.setCreatedBy(currentUser);
+    manager.save(maleA, false);
+    trackedEntityInstanceMaleA = trackedEntityInstanceService.getTrackedEntityInstance(maleA);
+
     Enrollment enrollment = new Enrollment();
     enrollment.setProgram(programA);
     enrollment.setOccurredDate(new Date());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/RelationshipServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/RelationshipServiceTest.java
@@ -27,24 +27,32 @@
  */
 package org.hisp.dhis.dxf2.deprecated.tracker;
 
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Date;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.commons.util.RelationshipUtils;
+import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dxf2.common.ImportOptions;
+import org.hisp.dhis.dxf2.deprecated.tracker.event.DataValue;
 import org.hisp.dhis.dxf2.deprecated.tracker.relationship.RelationshipService;
+import org.hisp.dhis.dxf2.deprecated.tracker.trackedentity.Attribute;
 import org.hisp.dhis.dxf2.deprecated.tracker.trackedentity.Relationship;
 import org.hisp.dhis.dxf2.deprecated.tracker.trackedentity.RelationshipItem;
 import org.hisp.dhis.dxf2.deprecated.tracker.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.dxf2.importsummary.ImportStatus;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
+import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentService;
@@ -56,7 +64,10 @@ import org.hisp.dhis.relationship.RelationshipEntity;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
 import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.trackerdataview.TrackerDataView;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -80,6 +91,14 @@ class RelationshipServiceTest extends TransactionalIntegrationTest {
   private Event eventA;
 
   private Event eventB;
+
+  private TrackedEntityAttribute teaA;
+
+  private TrackedEntityAttribute teaB;
+
+  private DataElement dataElementA;
+
+  private DataElement dataElementB;
 
   private final RelationshipType relationshipTypeTeiToTei = createRelationshipType('A');
 
@@ -107,11 +126,18 @@ class RelationshipServiceTest extends TransactionalIntegrationTest {
     manager.save(teiB);
     manager.save(teiC);
 
+    teaA = createTrackedEntityAttribute('A');
+    manager.save(teaA, false);
+
+    teaB = createTrackedEntityAttribute('B');
+    manager.save(teaB, false);
+
     Program program = createProgram('A', new HashSet<>(), organisationUnit);
     program.setProgramType(ProgramType.WITH_REGISTRATION);
     ProgramStage programStage = createProgramStage('1', program);
     program.setProgramStages(
         Stream.of(programStage).collect(Collectors.toCollection(HashSet::new)));
+    program.setProgramAttributes(List.of(createProgramTrackedEntityAttribute(program, teaA)));
 
     manager.save(program);
     manager.save(programStage);
@@ -135,6 +161,12 @@ class RelationshipServiceTest extends TransactionalIntegrationTest {
     eventB.setProgramStage(programStage);
     eventB.setOrganisationUnit(organisationUnit);
     manager.save(eventB);
+
+    dataElementA = createDataElement('a');
+    manager.save(dataElementA);
+
+    dataElementB = createDataElement('b');
+    manager.save(dataElementB);
 
     relationshipTypeTeiToTei
         .getFromConstraint()
@@ -170,6 +202,25 @@ class RelationshipServiceTest extends TransactionalIntegrationTest {
 
   @Test
   void shouldAddTeiToTeiRelationship() {
+
+    teiA.setTrackedEntityAttributeValues(
+        Set.of(
+            new TrackedEntityAttributeValue(teaA, teiA, "100"),
+            new TrackedEntityAttributeValue(teaB, teiA, "100")));
+    teiB.setTrackedEntityAttributeValues(Set.of(new TrackedEntityAttributeValue(teaA, teiB, "10")));
+
+    manager.update(teiA);
+    manager.update(teiB);
+
+    TrackerDataView trackerDataView = new TrackerDataView();
+    trackerDataView.setAttributes(new LinkedHashSet<>(Set.of(teaA.getUid())));
+
+    relationshipTypeTeiToTei.getFromConstraint().setTrackerDataView(trackerDataView);
+
+    relationshipTypeTeiToTei.getToConstraint().setTrackerDataView(trackerDataView);
+
+    manager.update(relationshipTypeTeiToPi);
+
     Relationship relationshipPayload = new Relationship();
     relationshipPayload.setRelationshipType(relationshipTypeTeiToTei.getUid());
 
@@ -199,6 +250,12 @@ class RelationshipServiceTest extends TransactionalIntegrationTest {
                   Relationship r = relationshipDb.get();
                   assertEquals(r.getFrom(), from);
                   assertEquals(r.getTo(), to);
+                  assertContainsOnly(
+                      List.of(attributeFromTea(teaA, "100")),
+                      r.getFrom().getTrackedEntityInstance().getAttributes());
+                  assertContainsOnly(
+                      List.of(attributeFromTea(teaA, "10")),
+                      r.getTo().getTrackedEntityInstance().getAttributes());
                 }));
   }
 
@@ -242,6 +299,25 @@ class RelationshipServiceTest extends TransactionalIntegrationTest {
 
   @Test
   void shouldAddTeiToPiRelationship() {
+    teiA.setTrackedEntityAttributeValues(
+        Set.of(new TrackedEntityAttributeValue(teaA, teiA, "100")));
+    teiB.setTrackedEntityAttributeValues(
+        Set.of(
+            new TrackedEntityAttributeValue(teaA, teiB, "10"),
+            new TrackedEntityAttributeValue(teaB, teiB, "100")));
+
+    manager.update(teiA);
+    manager.update(teiB);
+
+    TrackerDataView trackerDataView = new TrackerDataView();
+    trackerDataView.setAttributes(new LinkedHashSet<>(Set.of(teaA.getUid())));
+
+    relationshipTypeTeiToPi.getFromConstraint().setTrackerDataView(trackerDataView);
+
+    relationshipTypeTeiToPi.getToConstraint().setTrackerDataView(trackerDataView);
+
+    manager.update(relationshipTypeTeiToPi);
+
     Relationship relationship = new Relationship();
     relationship.setRelationshipType(relationshipTypeTeiToPi.getUid());
 
@@ -250,7 +326,7 @@ class RelationshipServiceTest extends TransactionalIntegrationTest {
     RelationshipItem to = new RelationshipItem();
     org.hisp.dhis.dxf2.deprecated.tracker.enrollment.Enrollment enrollment =
         new org.hisp.dhis.dxf2.deprecated.tracker.enrollment.Enrollment();
-    enrollment.setEnrollment(enrollmentA.getUid());
+    enrollment.setEnrollment(enrollmentB.getUid());
     to.setEnrollment(enrollment);
 
     relationship.setFrom(from);
@@ -272,6 +348,12 @@ class RelationshipServiceTest extends TransactionalIntegrationTest {
                   Relationship r = relationshipDb.get();
                   assertEquals(from, r.getFrom());
                   assertEquals(to, r.getTo());
+                  assertContainsOnly(
+                      List.of(attributeFromTea(teaA, "100")),
+                      r.getFrom().getTrackedEntityInstance().getAttributes());
+                  assertContainsOnly(
+                      List.of(attributeFromTea(teaA, "10")),
+                      r.getTo().getEnrollment().getAttributes());
                 }));
   }
 
@@ -317,6 +399,35 @@ class RelationshipServiceTest extends TransactionalIntegrationTest {
 
   @Test
   void shouldAddTeiToPsiRelationship() {
+    teiA.setTrackedEntityAttributeValues(
+        Set.of(new TrackedEntityAttributeValue(teaA, teiA, "100")));
+
+    manager.update(teiA);
+
+    EventDataValue dataValueA = new EventDataValue();
+    dataValueA.setValue("10");
+    dataValueA.setDataElement(dataElementA.getUid());
+
+    EventDataValue dataValueB = new EventDataValue();
+    dataValueB.setValue("100");
+    dataValueB.setDataElement(dataElementB.getUid());
+
+    eventA.setEventDataValues(Set.of(dataValueA, dataValueB));
+
+    manager.update(eventA);
+
+    TrackerDataView trackerDataViewFrom = new TrackerDataView();
+    trackerDataViewFrom.setAttributes(new LinkedHashSet<>(Set.of(teaA.getUid())));
+
+    relationshipTypeTeiToPsi.getFromConstraint().setTrackerDataView(trackerDataViewFrom);
+
+    TrackerDataView trackerDataViewTo = new TrackerDataView();
+    trackerDataViewTo.setDataElements(new LinkedHashSet<>(Set.of(dataElementA.getUid())));
+
+    relationshipTypeTeiToPsi.getToConstraint().setTrackerDataView(trackerDataViewTo);
+
+    manager.update(relationshipTypeTeiToPsi);
+
     Relationship relationshipPayload = new Relationship();
     relationshipPayload.setRelationshipType(relationshipTypeTeiToPsi.getUid());
 
@@ -347,6 +458,12 @@ class RelationshipServiceTest extends TransactionalIntegrationTest {
                   Relationship r = relationshipDb.get();
                   assertEquals(from, r.getFrom());
                   assertEquals(to, r.getTo());
+                  assertContainsOnly(
+                      List.of(attributeFromTea(teaA, "100")),
+                      r.getFrom().getTrackedEntityInstance().getAttributes());
+                  assertContainsOnly(
+                      List.of(new DataValue(dataElementA.getUid(), "10")),
+                      r.getTo().getEvent().getDataValues());
                 }));
   }
 
@@ -387,6 +504,13 @@ class RelationshipServiceTest extends TransactionalIntegrationTest {
                   assertEquals(from, r.getFrom());
                   assertEquals(to, r.getTo());
                 }));
+  }
+
+  private Attribute attributeFromTea(TrackedEntityAttribute tea, String value) {
+    Attribute attribute = new Attribute(tea.getUid(), tea.getValueType(), value);
+    attribute.setCode(tea.getCode());
+    attribute.setDisplayName(tea.getDisplayName());
+    return attribute;
   }
 
   private RelationshipItem teiFrom() {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackerAccessManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackerAccessManagerTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.trackedentity;
 
+import static org.hisp.dhis.trackedentity.TrackerOwnershipManager.OWNERSHIP_ACCESS_DENIED;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -196,6 +197,7 @@ class TrackerAccessManagerTest extends TransactionalIntegrationTest {
   @Test
   void checkAccessPermissionForTeWhenTeOuInSearchScope() {
     programA.setPublicAccess(AccessStringHelper.FULL);
+    programA.setAccessLevel(AccessLevel.OPEN);
     manager.update(programA);
     User user = createUserWithAuth("user1").setOrganisationUnits(Sets.newHashSet(orgUnitB));
     user.setTeiSearchOrganisationUnits(Sets.newHashSet(orgUnitA, orgUnitB));
@@ -212,6 +214,7 @@ class TrackerAccessManagerTest extends TransactionalIntegrationTest {
   @Test
   void checkAccessPermissionForTeWhenTeOuOutsideSearchScope() {
     programA.setPublicAccess(AccessStringHelper.FULL);
+    programA.setAccessLevel(AccessLevel.OPEN);
     manager.update(programA);
     User user = createUserWithAuth("user1").setOrganisationUnits(Sets.newHashSet(orgUnitB));
     UserDetails userDetails = UserDetails.fromUser(user);
@@ -219,9 +222,7 @@ class TrackerAccessManagerTest extends TransactionalIntegrationTest {
     manager.update(trackedEntityType);
     TrackedEntity te = trackedEntityService.getTrackedEntity(trackedEntityA.getUid());
     // Cannot Read
-    assertHasError(
-        trackerAccessManager.canRead(userDetails, te),
-        "User has no read access to organisation unit:");
+    assertHasError(trackerAccessManager.canRead(userDetails, te), OWNERSHIP_ACCESS_DENIED);
     // Cannot write
     assertHasError(
         trackerAccessManager.canWrite(userDetails, te),

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -179,7 +179,13 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
     programA.setProgramType(ProgramType.WITH_REGISTRATION);
     programA.setTrackedEntityType(trackedEntityTypeA);
     programA.getSharing().setOwner(admin);
-    programA.getSharing().setPublicAccess(AccessStringHelper.DATA_READ);
+    programA
+        .getSharing()
+        .setPublicAccess(
+            AccessStringHelper.newInstance()
+                .enable(AccessStringHelper.Permission.READ)
+                .enable(AccessStringHelper.Permission.DATA_READ)
+                .build());
     manager.save(programA, false);
 
     Program programB = createProgram('B', new HashSet<>(), orgUnitB);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipServiceTest.java
@@ -281,7 +281,7 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase {
   }
 
   @Test
-  public void shouldNotReturnRelationshipWhenTeIsTransferredAndUserHasNoAccessToAtLeastOneProgram()
+  void shouldNotReturnRelationshipWhenTeIsTransferredAndUserHasNoAccessToAtLeastOneProgram()
       throws ForbiddenException, NotFoundException {
     injectSecurityContextUser(getAdminUser());
 
@@ -327,7 +327,7 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase {
   }
 
   @Test
-  public void shouldNotReturnRelationshipWhenUserHasNoMetadataAccessToProgram()
+  void shouldNotReturnRelationshipWhenUserHasNoMetadataAccessToProgram()
       throws ForbiddenException, NotFoundException {
     User admin = getAdminUser();
     injectSecurityContextUser(admin);
@@ -370,7 +370,7 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase {
   }
 
   @Test
-  public void shouldNotReturnRelationshipWhenUserHasNoDataReadAccessToProgram() {
+  void shouldNotReturnRelationshipWhenUserHasNoDataReadAccessToProgram() {
     User admin = getAdminUser();
     injectSecurityContextUser(admin);
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipServiceTest.java
@@ -31,12 +31,14 @@ import static org.hisp.dhis.tracker.TrackerType.ENROLLMENT;
 import static org.hisp.dhis.tracker.TrackerType.EVENT;
 import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.hisp.dhis.common.AccessLevel;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.commons.util.RelationshipUtils;
@@ -57,6 +59,7 @@ import org.hisp.dhis.security.acl.AccessStringHelper;
 import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.trackedentity.TrackerOwnershipManager;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.Test;
@@ -72,6 +75,8 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase {
 
   @Autowired private IdentifiableObjectManager manager;
 
+  @Autowired private TrackerOwnershipManager trackerOwnershipAccessManager;
+
   private TrackedEntity teA;
 
   private TrackedEntity teB;
@@ -80,7 +85,7 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase {
 
   private Event eventA;
 
-  private Event inaccessiblePsi;
+  private Event inaccessibleEvent;
 
   private final RelationshipType teToTeType = createRelationshipType('A');
 
@@ -96,66 +101,74 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase {
 
   private Enrollment enrollmentA;
 
+  private OrganisationUnit orgUnitA;
+
+  private OrganisationUnit orgUnitB;
+
+  private User user;
+
+  private Program program;
+
+  private TrackedEntityType trackedEntityType;
+
   @Override
   protected void setUpTest() throws Exception {
     userService = _userService;
-    //    User admin = preCreateInjectAdminUser();
-    User admin = userService.getUserByUsername("admin_test");
 
-    OrganisationUnit orgUnit = createOrganisationUnit('A');
-    manager.save(orgUnit, false);
+    orgUnitA = createOrganisationUnit('A');
+    manager.save(orgUnitA, false);
 
-    User user = createAndAddUser(false, "user", Set.of(orgUnit), Set.of(orgUnit), "F_EXPORT_DATA");
+    orgUnitB = createOrganisationUnit('B');
+    manager.save(orgUnitB, false);
 
-    TrackedEntityType trackedEntityType = createTrackedEntityType('A');
-    trackedEntityType.getSharing().setOwner(user);
+    user = createAndAddUser(false, "user", Set.of(orgUnitA), Set.of(orgUnitA));
+
+    trackedEntityType = createTrackedEntityType('A');
     manager.save(trackedEntityType, false);
 
     TrackedEntityType inaccessibleTrackedEntityType = createTrackedEntityType('B');
-    inaccessibleTrackedEntityType.getSharing().setOwner(admin);
     inaccessibleTrackedEntityType.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
     manager.save(inaccessibleTrackedEntityType, false);
 
-    teA = createTrackedEntity(orgUnit);
+    teA = createTrackedEntity(orgUnitA);
     teA.setTrackedEntityType(trackedEntityType);
     manager.save(teA, false);
 
-    teB = createTrackedEntity(orgUnit);
+    teB = createTrackedEntity(orgUnitA);
     teB.setTrackedEntityType(trackedEntityType);
     manager.save(teB, false);
 
-    inaccessibleTe = createTrackedEntity(orgUnit);
+    inaccessibleTe = createTrackedEntity(orgUnitA);
     inaccessibleTe.setTrackedEntityType(inaccessibleTrackedEntityType);
     manager.save(inaccessibleTe, false);
 
-    Program program = createProgram('A', new HashSet<>(), orgUnit);
+    program = createProgram('A', new HashSet<>(), orgUnitA);
     program.setProgramType(ProgramType.WITH_REGISTRATION);
-    program.getSharing().setOwner(user);
+    program.setTrackedEntityType(trackedEntityType);
     manager.save(program, false);
     ProgramStage programStage = createProgramStage('A', program);
     manager.save(programStage, false);
     ProgramStage inaccessibleProgramStage = createProgramStage('B', program);
-    inaccessibleProgramStage.getSharing().setOwner(admin);
     inaccessibleProgramStage.setPublicAccess(AccessStringHelper.DEFAULT);
     manager.save(inaccessibleProgramStage, false);
     program.setProgramStages(Set.of(programStage, inaccessibleProgramStage));
     manager.save(program, false);
 
     enrollmentA =
-        enrollmentService.enrollTrackedEntity(teA, program, new Date(), new Date(), orgUnit);
+        enrollmentService.enrollTrackedEntity(teA, program, new Date(), new Date(), orgUnitA);
     eventA = new Event();
     eventA.setEnrollment(enrollmentA);
     eventA.setProgramStage(programStage);
-    eventA.setOrganisationUnit(orgUnit);
+    eventA.setOrganisationUnit(orgUnitA);
     manager.save(eventA, false);
 
     Enrollment enrollmentB =
-        enrollmentService.enrollTrackedEntity(teB, program, new Date(), new Date(), orgUnit);
-    inaccessiblePsi = new Event();
-    inaccessiblePsi.setEnrollment(enrollmentB);
-    inaccessiblePsi.setProgramStage(inaccessibleProgramStage);
-    inaccessiblePsi.setOrganisationUnit(orgUnit);
-    manager.save(inaccessiblePsi, false);
+        enrollmentService.enrollTrackedEntity(teB, program, new Date(), new Date(), orgUnitA);
+    inaccessibleEvent = new Event();
+    inaccessibleEvent.setEnrollment(enrollmentB);
+    inaccessibleEvent.setProgramStage(inaccessibleProgramStage);
+    inaccessibleEvent.setOrganisationUnit(orgUnitA);
+    manager.save(inaccessibleEvent, false);
 
     teToTeType
         .getFromConstraint()
@@ -163,7 +176,6 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase {
     teToTeType.getFromConstraint().setTrackedEntityType(trackedEntityType);
     teToTeType.getToConstraint().setRelationshipEntity(RelationshipEntity.TRACKED_ENTITY_INSTANCE);
     teToTeType.getToConstraint().setTrackedEntityType(trackedEntityType);
-    teToTeType.getSharing().setOwner(user);
     manager.save(teToTeType, false);
 
     teToInaccessibleTeType
@@ -174,7 +186,6 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase {
         .getToConstraint()
         .setRelationshipEntity(RelationshipEntity.TRACKED_ENTITY_INSTANCE);
     teToInaccessibleTeType.getToConstraint().setTrackedEntityType(inaccessibleTrackedEntityType);
-    teToInaccessibleTeType.getSharing().setOwner(user);
     manager.save(teToInaccessibleTeType, false);
 
     teToEnType
@@ -183,7 +194,6 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase {
     teToEnType.getFromConstraint().setTrackedEntityType(trackedEntityType);
     teToEnType.getToConstraint().setRelationshipEntity(RelationshipEntity.PROGRAM_INSTANCE);
     teToEnType.getToConstraint().setProgram(program);
-    teToEnType.getSharing().setOwner(user);
     manager.save(teToEnType, false);
 
     teToInaccessibleEnType
@@ -194,7 +204,6 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase {
         .getToConstraint()
         .setRelationshipEntity(RelationshipEntity.PROGRAM_INSTANCE);
     teToInaccessibleEnType.getToConstraint().setProgram(program);
-    teToInaccessibleEnType.getSharing().setOwner(admin);
     teToInaccessibleEnType.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
     manager.save(teToInaccessibleEnType, false);
 
@@ -204,7 +213,6 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase {
     teToEvType.getFromConstraint().setTrackedEntityType(trackedEntityType);
     teToEvType.getToConstraint().setRelationshipEntity(RelationshipEntity.PROGRAM_STAGE_INSTANCE);
     teToEvType.getToConstraint().setProgramStage(programStage);
-    teToEvType.getSharing().setOwner(user);
     manager.save(teToEvType, false);
 
     eventToEventType
@@ -215,7 +223,6 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase {
         .getToConstraint()
         .setRelationshipEntity(RelationshipEntity.PROGRAM_STAGE_INSTANCE);
     eventToEventType.getToConstraint().setProgramStage(programStage);
-    eventToEventType.getSharing().setOwner(user);
     manager.save(eventToEventType, false);
 
     injectSecurityContextUser(user);
@@ -261,7 +268,7 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase {
   void shouldNotReturnRelationshipByEventIfUserHasNoAccessToProgramStage()
       throws ForbiddenException, NotFoundException {
     Relationship accessible = relationship(teA, eventA);
-    relationship(eventA, inaccessiblePsi);
+    relationship(eventA, inaccessibleEvent);
 
     RelationshipOperationParams operationParams =
         RelationshipOperationParams.builder().type(EVENT).identifier(eventA.getUid()).build();
@@ -273,12 +280,151 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase {
         relationships.stream().map(Relationship::getUid).collect(Collectors.toList()));
   }
 
+  @Test
+  public void shouldNotReturnRelationshipWhenTeIsTransferredAndUserHasNoAccessToAtLeastOneProgram()
+      throws ForbiddenException, NotFoundException {
+    injectSecurityContextUser(getAdminUser());
+
+    TrackedEntityType trackedEntityType = createTrackedEntityType('X');
+    manager.save(trackedEntityType, false);
+
+    Program program = protectedProgram('P', trackedEntityType, orgUnitA);
+    program.getSharing().setOwner(user); // set metadata access to the program
+    manager.save(program, false);
+    ProgramStage programStage = createProgramStage('P', program);
+    manager.save(programStage, false);
+
+    TrackedEntity trackedEntityFrom = createTrackedEntity(orgUnitA);
+    trackedEntityFrom.setTrackedEntityType(trackedEntityType);
+    manager.save(trackedEntityFrom);
+
+    enrollmentService.addEnrollment(createEnrollment(program, trackedEntityFrom, orgUnitA));
+
+    trackerOwnershipAccessManager.assignOwnership(
+        trackedEntityFrom, program, orgUnitA, false, true);
+
+    trackerOwnershipAccessManager.transferOwnership(
+        trackedEntityFrom, program, orgUnitB, false, true);
+
+    TrackedEntity trackedEntityTo = createTrackedEntity(orgUnitA);
+    trackedEntityTo.setTrackedEntityType(trackedEntityType);
+    manager.save(trackedEntityTo);
+
+    relationship(trackedEntityFrom, trackedEntityTo);
+
+    injectSecurityContextUser(user);
+
+    RelationshipOperationParams operationParams =
+        RelationshipOperationParams.builder()
+            .type(TRACKED_ENTITY)
+            .identifier(trackedEntityFrom.getUid())
+            .build();
+
+    assertThrows(
+        ForbiddenException.class,
+        () -> relationshipService.getRelationships(operationParams),
+        "User should not have access to a relationship in case of ownership transfer of a tracked entity");
+  }
+
+  @Test
+  public void shouldNotReturnRelationshipWhenUserHasNoMetadataAccessToProgram()
+      throws ForbiddenException, NotFoundException {
+    User admin = getAdminUser();
+    injectSecurityContextUser(admin);
+
+    TrackedEntityType trackedEntityType = createTrackedEntityType('Y');
+    manager.save(trackedEntityType, false);
+
+    Program program = createProgram('Y', new HashSet<>(), orgUnitA);
+    program.setProgramType(ProgramType.WITH_REGISTRATION);
+    program.setTrackedEntityType(trackedEntityType);
+    program.getSharing().setOwner(admin);
+    program.getSharing().setPublicAccess(AccessStringHelper.DEFAULT);
+    manager.save(program, false);
+    ProgramStage programStage = createProgramStage('Y', program);
+    manager.save(programStage, false);
+    manager.update(program);
+
+    TrackedEntity trackedEntityFrom = createTrackedEntity(orgUnitA);
+    trackedEntityFrom.setTrackedEntityType(trackedEntityType);
+    manager.save(trackedEntityFrom);
+
+    TrackedEntity trackedEntityTo = createTrackedEntity(orgUnitA);
+    trackedEntityTo.setTrackedEntityType(trackedEntityType);
+    manager.save(trackedEntityTo);
+
+    relationship(trackedEntityFrom, trackedEntityTo);
+
+    injectSecurityContextUser(user);
+
+    RelationshipOperationParams operationParams =
+        RelationshipOperationParams.builder()
+            .type(TRACKED_ENTITY)
+            .identifier(trackedEntityFrom.getUid())
+            .build();
+
+    assertThrows(
+        ForbiddenException.class,
+        () -> relationshipService.getRelationships(operationParams),
+        "User should not have access to a relationship in case of missing metadata access to at least one program");
+  }
+
+  @Test
+  public void shouldNotReturnRelationshipWhenUserHasNoDataReadAccessToProgram() {
+    User admin = getAdminUser();
+    injectSecurityContextUser(admin);
+
+    TrackedEntityType trackedEntityType = createTrackedEntityType('Y');
+    manager.save(trackedEntityType, false);
+
+    Program program = createProgram('Y', new HashSet<>(), orgUnitA);
+    program.setProgramType(ProgramType.WITH_REGISTRATION);
+    program.setTrackedEntityType(trackedEntityType);
+    program.getSharing().setPublicAccess(AccessStringHelper.READ_WRITE);
+    manager.save(program, false);
+    ProgramStage programStage = createProgramStage('Y', program);
+    manager.save(programStage, false);
+    manager.update(program);
+
+    TrackedEntity trackedEntityFrom = createTrackedEntity(orgUnitA);
+    trackedEntityFrom.setTrackedEntityType(trackedEntityType);
+    manager.save(trackedEntityFrom);
+
+    TrackedEntity trackedEntityTo = createTrackedEntity(orgUnitA);
+    trackedEntityTo.setTrackedEntityType(trackedEntityType);
+    manager.save(trackedEntityTo);
+
+    relationship(trackedEntityFrom, trackedEntityTo);
+
+    injectSecurityContextUser(user);
+
+    RelationshipOperationParams operationParams =
+        RelationshipOperationParams.builder()
+            .type(TRACKED_ENTITY)
+            .identifier(trackedEntityFrom.getUid())
+            .build();
+
+    assertThrows(
+        ForbiddenException.class,
+        () -> relationshipService.getRelationships(operationParams),
+        "User should not have access to a relationship in case of missing data read access to at least one program");
+  }
+
+  private Program protectedProgram(
+      char p, TrackedEntityType trackedEntityType, OrganisationUnit unit) {
+    Program program = createProgram(p, new HashSet<>(), unit);
+    program.setTrackedEntityType(trackedEntityType);
+    program.setProgramType(ProgramType.WITH_REGISTRATION);
+    program.setAccessLevel(AccessLevel.PROTECTED);
+    return program;
+  }
+
   private Relationship relationship(TrackedEntity from, TrackedEntity to) {
     return relationship(from, to, teToTeType, new Date());
   }
 
-  private void relationship(TrackedEntity from, TrackedEntity to, RelationshipType type) {
-    relationship(from, to, type, new Date());
+  private Relationship relationship(TrackedEntity from, TrackedEntity to, RelationshipType type) {
+    return relationship(from, to, type, new Date());
   }
 
   private Relationship relationship(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportControllerTest.java
@@ -40,6 +40,7 @@ import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertTrack
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Date;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.common.CodeGenerator;
@@ -56,6 +57,7 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.relationship.Relationship;
+import org.hisp.dhis.relationship.RelationshipConstraint;
 import org.hisp.dhis.relationship.RelationshipEntity;
 import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.relationship.RelationshipType;
@@ -66,6 +68,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityProgramOwner;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeAttribute;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.trackerdataview.TrackerDataView;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.sharing.UserAccess;
 import org.hisp.dhis.web.HttpStatus;
@@ -123,17 +126,6 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
     user.setTeiSearchOrganisationUnits(Set.of(orgUnit));
     this.userService.updateUser(user);
 
-    program = createProgram('A');
-    program.addOrganisationUnit(orgUnit);
-    program.getSharing().setOwner(owner);
-    program.getSharing().addUserAccess(userAccess());
-    manager.save(program, false);
-
-    programStage = createProgramStage('A', program);
-    programStage.getSharing().setOwner(owner);
-    programStage.getSharing().addUserAccess(userAccess());
-    manager.save(programStage, false);
-
     tea = createTrackedEntityAttribute('A');
     tea.getSharing().setOwner(owner);
     tea.getSharing().addUserAccess(userAccess());
@@ -155,6 +147,18 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
 
     trackedEntityType.setTrackedEntityTypeAttributes(List.of(trackedEntityTypeAttribute));
     manager.save(trackedEntityType, false);
+
+    program = createProgram('A');
+    program.addOrganisationUnit(orgUnit);
+    program.getSharing().setOwner(owner);
+    program.getSharing().addUserAccess(userAccess());
+    program.setTrackedEntityType(trackedEntityType);
+    manager.save(program, false);
+
+    programStage = createProgramStage('A', program);
+    programStage.getSharing().setOwner(owner);
+    programStage.getSharing().addUserAccess(userAccess());
+    manager.save(programStage, false);
 
     dataElement = createDataElement('A');
     manager.save(dataElement, false);
@@ -309,7 +313,19 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
     TrackedEntity to = trackedEntity();
     Event from = event(enrollment(to));
     from.setEventDataValues(Set.of(new EventDataValue(dataElement.getUid(), "12")));
-    relationship(from, to);
+    Relationship relationship = relationship(from, to);
+    RelationshipType type = relationship.getRelationshipType();
+
+    RelationshipConstraint toConstraint = new RelationshipConstraint();
+
+    TrackerDataView trackerDataView = new TrackerDataView();
+    trackerDataView.setDataElements(new LinkedHashSet<>(Set.of(dataElement.getUid())));
+
+    toConstraint.setTrackerDataView(trackerDataView);
+
+    type.setFromConstraint(toConstraint);
+
+    manager.update(type);
 
     JsonList<JsonRelationship> relationships =
         GET(
@@ -407,7 +423,18 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
     program.setProgramAttributes(List.of(createProgramTrackedEntityAttribute(program, tea)));
 
     Enrollment from = enrollment(to);
-    relationship(from, to);
+    Relationship relationship = relationship(from, to);
+
+    RelationshipType type = relationship.getRelationshipType();
+
+    RelationshipConstraint constraint = new RelationshipConstraint();
+
+    TrackerDataView trackerDataView = new TrackerDataView();
+    trackerDataView.setAttributes(new LinkedHashSet<>(Set.of(tea.getUid())));
+
+    constraint.setTrackerDataView(trackerDataView);
+
+    type.setFromConstraint(constraint);
 
     JsonList<JsonRelationship> relationships =
         GET(
@@ -598,7 +625,26 @@ class RelationshipsExportControllerTest extends DhisControllerConvenienceTest {
         Set.of(attributeValue(tea, to, "12"), attributeValue(tea2, to, "24")));
     program.setProgramAttributes(List.of(createProgramTrackedEntityAttribute(program, tea2)));
     Enrollment from = enrollment(to);
-    relationship(from, to);
+    Relationship relationship = relationship(from, to);
+
+    RelationshipType type = relationship.getRelationshipType();
+
+    RelationshipConstraint fromConstraint = new RelationshipConstraint();
+
+    TrackerDataView trackerDataView = new TrackerDataView();
+    trackerDataView.setAttributes(new LinkedHashSet<>(Set.of(tea2.getUid())));
+
+    fromConstraint.setTrackerDataView(trackerDataView);
+
+    RelationshipConstraint toConstraint = new RelationshipConstraint();
+
+    TrackerDataView dataView = new TrackerDataView();
+    dataView.setAttributes(new LinkedHashSet<>(Set.of(tea.getUid(), tea2.getUid())));
+
+    toConstraint.setTrackerDataView(dataView);
+
+    type.setFromConstraint(fromConstraint);
+    type.setToConstraint(toConstraint);
 
     JsonList<JsonRelationship> relationships =
         GET(


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-17090

1) Apply the configurable relationship constraints for a relationship type. As discussed with @JoakimSM, the UI only shows program attributes as a constraint.
In the code, this is done in the mapper as an @AfterMapping operation. This way, it is more maintainable and follows the model logic directly in the mapper. The alternative to this is to seek every place where we fetch relationships (directly or indirectly) and apply the filter. 
2) Apply the logic done by @muilpp for the `canRead` method of tracked entity in the `DefaultTrackerAccessManager`. This is now valid for every check in place and consistent across the tracker ( therefore, also for relationships ).

@muilpp `canRead` for enrollment and event still validates the tracked entity. In this case, we validate against a specific program, so should it be okay, or do we need to apply the new logic here?
