### PR TITLE
chore: fix redirection issue with / and non slash root paths

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IndexController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IndexController.java
@@ -34,6 +34,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.setting.SettingKey;
+import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.hisp.dhis.webapi.webdomain.IndexResource;
@@ -48,28 +50,35 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @OpenApi.Tags("system")
 @Controller
 public class IndexController {
-  private final SchemaService schemaService;
 
+  private final SystemSettingManager settingManager;
+  private final SchemaService schemaService;
   private final ContextService contextService;
 
-  public IndexController(SchemaService schemaService, ContextService contextService) {
+  public IndexController(
+      SchemaService schemaService,
+      ContextService contextService,
+      SystemSettingManager settingManager) {
     this.schemaService = schemaService;
     this.contextService = contextService;
-  }
-
-  // --------------------------------------------------------------------------
-  // GET
-  // --------------------------------------------------------------------------
-
-  @GetMapping("/api")
-  public void getIndex(HttpServletRequest request, HttpServletResponse response)
-      throws IOException {
-    String location = response.encodeRedirectURL("/api/resources");
-    response.sendRedirect(ContextUtils.getRootPath(request) + location);
+    this.settingManager = settingManager;
   }
 
   @GetMapping("/")
   public void getIndexWithSlash(HttpServletRequest request, HttpServletResponse response)
+      throws IOException {
+    String redirectUrl =
+        request.getContextPath() + "/" + settingManager.getStringSetting(SettingKey.START_MODULE);
+
+    if (!redirectUrl.endsWith("/")) {
+      redirectUrl += "/";
+    }
+    String location = response.encodeRedirectURL(redirectUrl);
+    response.sendRedirect(location);
+  }
+
+  @GetMapping("/api")
+  public void getIndex(HttpServletRequest request, HttpServletResponse response)
       throws IOException {
     String location = response.encodeRedirectURL("/api/resources");
     response.sendRedirect(ContextUtils.getRootPath(request) + location);
@@ -82,7 +91,6 @@ public class IndexController {
 
   private IndexResources createIndexResources() {
     IndexResources indexResources = new IndexResources();
-
     for (Schema schema : schemaService.getSchemas()) {
       if (schema.hasApiEndpoint()) {
         indexResources
@@ -95,7 +103,6 @@ public class IndexController {
                     contextService.getApiPath() + schema.getRelativeApiEndpoint()));
       }
     }
-
     return indexResources;
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/system/SystemUpdateNotifyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/system/SystemUpdateNotifyController.java
@@ -48,14 +48,14 @@ import org.springframework.web.bind.annotation.ResponseBody;
  */
 @OpenApi.Tags("system")
 @Controller
-@RequestMapping
+@RequestMapping("/api/systemUpdates")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
 public class SystemUpdateNotifyController {
-  public static final String RESOURCE_PATH = "/systemUpdates";
+  public static final String RESOURCE_PATH = "";
 
   @Autowired private SystemUpdateNotificationService service;
 
-  @GetMapping(SystemUpdateNotifyController.RESOURCE_PATH)
+  @GetMapping
   @ResponseBody
   public WebMessage checkForSystemUpdates(
       @RequestParam(value = "forceVersion", required = false) String forceVersion) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/XmlPathMappingJackson2XmlHttpMessageConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/XmlPathMappingJackson2XmlHttpMessageConverter.java
@@ -68,9 +68,12 @@ public class XmlPathMappingJackson2XmlHttpMessageConverter
     }
 
     String pathInfo = request.getPathInfo();
+    if (pathInfo == null) {
+      return false;
+    }
 
     for (var pathPattern : WebMvcConfig.XML_PATTERNS) {
-      if (pathPattern.matcher(pathInfo).matches()) {
+      if (pathPattern != null && pathPattern.matcher(pathInfo).matches()) {
         return super.canWrite(clazz, mediaType);
       }
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/servlet/DhisWebApiWebAppInitializer.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/servlet/DhisWebApiWebAppInitializer.java
@@ -91,14 +91,12 @@ public class DhisWebApiWebAppInitializer implements WebApplicationInitializer {
 
   public static void setupServlets(
       ServletContext context, AnnotationConfigWebApplicationContext webApplicationContext) {
-    DispatcherServlet servlet = new DispatcherServlet(webApplicationContext);
 
+    DispatcherServlet servlet = new DispatcherServlet(webApplicationContext);
     ServletRegistration.Dynamic dispatcher = context.addServlet("dispatcher", servlet);
     dispatcher.setAsyncSupported(true);
     dispatcher.setLoadOnStartup(1);
     dispatcher.addMapping("/*");
-
-    context.addServlet("RedirectRootServlet", RedirectRootServlet.class).addMapping("");
 
     context
         .addServlet("TempGetAppMenuServlet", TempGetAppMenuServlet.class)


### PR DESCRIPTION
## Summary
Fixes an issue with redirection and Tomcat, causing the lack of a `/` in the end of the base mapping to redirect to `/api/resources`.
This was caused by the `IndexController` not being updated after the migration from `/api` to `/` root servlet mapping, and the manual `RedirectRootServlet` not working similar on Tomcat as on Jetty.   