### PR TITLE
feat: Support name in MapView [DHIS2-16088]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/MapView.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/MapView.java
@@ -312,17 +312,6 @@ public class MapView extends BaseAnalyticalObject
     return LAYER_EVENT.equals(layer);
   }
 
-  @Override
-  public String getName() {
-    if (!dataDimensionItems.isEmpty()
-        && dataDimensionItems.get(0) != null
-        && dataDimensionItems.get(0).getDimensionalItemObject() != null) {
-      return dataDimensionItems.get(0).getDimensionalItemObject().getName();
-    }
-
-    return uid;
-  }
-
   // -------------------------------------------------------------------------
   // EventAnalyticalObject
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/mapping/hibernate/MapView.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/mapping/hibernate/MapView.hbm.xml
@@ -15,6 +15,8 @@
     </id>
     &identifiableProperties;
 
+    <property name="name" length="230" />
+
     <property name="description" type="text" />
 
     <property name="layer" not-null="true" />

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.42/V2_42_1__Add_name_column_into_mapview.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.42/V2_42_1__Add_name_column_into_mapview.sql
@@ -1,0 +1,2 @@
+-- DHIS2-16088: Adds a "name" column to the table mapview.
+alter table mapview add column if not exists name varchar(230) null;


### PR DESCRIPTION
Adds a `name` column to the MapView entity/table.
Currently, it does not exist, and the `name` is evaluated based on some logic around `uid`.