### PR TITLE
fix: Return ok() in Maps PUT method [DHIS2-15978]

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MapControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/MapControllerTest.java
@@ -59,7 +59,7 @@ class MapControllerTest extends DhisControllerConvenienceTest {
             + "'";
 
     assertStatus(
-        HttpStatus.NO_CONTENT,
+        HttpStatus.OK,
         PUT("/maps/" + mapId, "{'name':'My updated map'," + mandatoryProperties + "}"));
 
     map = GET("/maps/{uid}", mapId).content();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller.mapping;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getDimensions;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.awt.image.BufferedImage;
@@ -147,7 +148,8 @@ public class MapController extends AbstractCrudController<Map> {
             .setSkipSharing(params.isSkipSharing())
             .setSkipTranslation(params.isSkipTranslation()));
     mappingService.updateMap(map);
-    return null;
+
+    return ok();
   }
 
   @Override


### PR DESCRIPTION
Returns the regular `ok()`, for the PUT method, instead of `null`.