### PR TITLE
fix: Fix TE ownership validation in Tracker importer [DHIS2-17251]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerAccessManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerAccessManager.java
@@ -63,9 +63,6 @@ public interface TrackerAccessManager {
   List<String> canReadProgramAndTrackedEntityType(
       UserDetails user, TrackedEntity trackedEntity, Program program);
 
-  List<String> canWrite(
-      UserDetails user, TrackedEntity trackedEntity, Program program, boolean skipOwnershipCheck);
-
   List<String> canRead(UserDetails user, Enrollment enrollment, boolean skipOwnershipCheck);
 
   List<String> canCreate(UserDetails user, Enrollment enrollment, boolean skipOwnershipCheck);

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/tracker/imports/validation/ValidationCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/tracker/imports/validation/ValidationCode.java
@@ -36,7 +36,7 @@ public enum ValidationCode {
   E1000("User: `{0}`, has no write access to OrganisationUnit: `{1}`."),
   E1001("User: `{0}`, has no data write access to TrackedEntityType: `{1}`."),
   E1002("TrackedEntity: `{0}`, already exists."),
-  E1003("TrackedEntity: `{0}` is not accessible."),
+  E1003("User: `{0}`, has no write access to TrackedEntity: `{1}`."),
   E1005("Could not find TrackedEntityType: `{0}`."),
   E1006("Attribute: `{0}`, does not exist."),
   E1007("Error validating attribute value type: `{0}`; Error: `{1}`."),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/tracker/imports/validation/ValidationCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/tracker/imports/validation/ValidationCode.java
@@ -36,7 +36,7 @@ public enum ValidationCode {
   E1000("User: `{0}`, has no write access to OrganisationUnit: `{1}`."),
   E1001("User: `{0}`, has no data write access to TrackedEntityType: `{1}`."),
   E1002("TrackedEntity: `{0}`, already exists."),
-  E1003("OrganisationUnit: `{0}` of TrackedEntity is outside search scope of User: `{1}`."),
+  E1003("TrackedEntity: `{0}` is not accessible."),
   E1005("Could not find TrackedEntityType: `{0}`."),
   E1006("Attribute: `{0}`, does not exist."),
   E1007("Error validating attribute value type: `{0}`; Error: `{1}`."),

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
@@ -50,6 +50,7 @@ import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -135,28 +136,56 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
     }
   }
 
+  /**
+   * Check the data write permissions and ownership of a tracked entity given the programs for which
+   * the user has metadata access to.
+   *
+   * @return No errors if a user has access to at least one program
+   */
   @Override
+  @Transactional(readOnly = true)
   public List<String> canWrite(UserDetails user, TrackedEntity trackedEntity) {
     // always allow if user == null (internal process) or user is superuser
     if (user == null || user.isSuper() || trackedEntity == null) {
       return List.of();
     }
 
-    OrganisationUnit ou = trackedEntity.getOrganisationUnit();
+    return canWrite(user, trackedEntity, programService.getAllPrograms());
+  }
 
-    List<String> errors = new ArrayList<>();
-    // ou should never be null, but needs to be checked for legacy reasons
-    if (ou != null && !user.isInUserSearchHierarchy(ou.getPath())) {
-      errors.add("User has no write access to organisation unit: " + ou.getUid());
-    }
+  private List<String> canWrite(
+      UserDetails user, TrackedEntity trackedEntity, List<Program> programs) {
 
     TrackedEntityType trackedEntityType = trackedEntity.getTrackedEntityType();
 
-    if (!aclService.canDataWrite(user, trackedEntityType)) {
-      errors.add("User has no data write access to tracked entity: " + trackedEntityType.getUid());
+    if (!aclService.canDataRead(user, trackedEntityType)) {
+      return List.of(
+          "User has no data read access to tracked entity type: " + trackedEntityType.getUid());
     }
 
-    return errors;
+    initializeTrackedEntityOrgUnitParents(trackedEntity);
+
+    List<Program> tetPrograms =
+        programs.stream()
+            .filter(
+                p -> Objects.equals(p.getTrackedEntityType(), trackedEntity.getTrackedEntityType()))
+            .toList();
+
+    if (tetPrograms.isEmpty()) {
+      return List.of("User has no access to any program");
+    }
+
+    if (tetPrograms.stream().anyMatch(p -> canWrite(user, trackedEntity, p))) {
+      return List.of();
+    } else {
+      return List.of(OWNERSHIP_ACCESS_DENIED);
+    }
+  }
+
+  /** Check Program data write access and Tracked Entity Program Ownership */
+  private boolean canWrite(UserDetails user, TrackedEntity trackedEntity, Program program) {
+    return aclService.canDataWrite(user, program)
+        && ownershipAccessManager.hasAccess(user, trackedEntity, program);
   }
 
   @Override
@@ -189,32 +218,6 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
     if (!aclService.canDataRead(user, trackedEntityType)) {
       errors.add(
           "User has no data read access to tracked entity type: " + trackedEntityType.getUid());
-    }
-
-    return errors;
-  }
-
-  @Override
-  public List<String> canWrite(
-      UserDetails user, TrackedEntity trackedEntity, Program program, boolean skipOwnershipCheck) {
-    // always allow if user == null (internal process) or user is superuser
-    if (user == null || user.isSuper() || trackedEntity == null) {
-      return List.of();
-    }
-
-    List<String> errors = new ArrayList<>();
-    if (!aclService.canDataWrite(user, program)) {
-      errors.add("User has no data write access to program: " + program.getUid());
-    }
-
-    TrackedEntityType trackedEntityType = trackedEntity.getTrackedEntityType();
-
-    if (!aclService.canDataWrite(user, trackedEntityType)) {
-      errors.add("User has no data write access to tracked entity: " + trackedEntityType.getUid());
-    }
-
-    if (!skipOwnershipCheck && !ownershipAccessManager.hasAccess(user, trackedEntity, program)) {
-      errors.add(OWNERSHIP_ACCESS_DENIED);
     }
 
     return errors;
@@ -587,6 +590,7 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
   }
 
   @Override
+  @Transactional(readOnly = true)
   public List<String> canWrite(UserDetails user, Relationship relationship) {
     // always allow if user == null (internal process) or user is superuser
     if (user == null || user.isSuper() || relationship == null) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidator.java
@@ -159,7 +159,7 @@ class SecurityOwnershipValidator
         programService.getAllPrograms().stream()
             .filter(
                 p ->
-                    p.getTrackedEntityType() != null
+                    p.isRegistration()
                         && p.getTrackedEntityType()
                             .getUid()
                             .equals(te.getTrackedEntityType().getUid()))

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidator.java
@@ -104,7 +104,8 @@ class SecurityOwnershipValidator
     else {
       TrackedEntity te = bundle.getPreheat().getTrackedEntity(trackedEntity.getTrackedEntity());
       if (!trackerAccessManager.canWrite(UserDetails.fromUser(bundle.getUser()), te).isEmpty()) {
-        reporter.addError(trackedEntity, ValidationCode.E1003, te.getUid());
+        reporter.addError(
+            trackedEntity, ValidationCode.E1003, bundle.getUser().getUid(), te.getUid());
       }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidator.java
@@ -95,13 +95,10 @@ class SecurityOwnershipValidator
                 .getOrganisationUnit()
             : bundle.getPreheat().getOrganisationUnit(trackedEntity.getOrgUnit());
 
-    // If trackedEntity is newly created, capture scope has to be checked
     if (strategy.isCreate()) {
-      checkTeiTypeWriteAccess(reporter, bundle, trackedEntity, trackedEntityType);
+      checkTeTypeWriteAccess(reporter, bundle, trackedEntity, trackedEntityType);
       checkOrgUnitInCaptureScope(reporter, bundle, trackedEntity, organisationUnit);
-    }
-    // if its to update or delete trackedEntity, write access has to be checked
-    else {
+    } else {
       TrackedEntity te = bundle.getPreheat().getTrackedEntity(trackedEntity.getTrackedEntity());
       if (!trackerAccessManager.canWrite(UserDetails.fromUser(bundle.getUser()), te).isEmpty()) {
         reporter.addError(
@@ -119,7 +116,7 @@ class SecurityOwnershipValidator
     }
   }
 
-  private void checkTeiTypeWriteAccess(
+  private void checkTeTypeWriteAccess(
       Reporter reporter,
       TrackerBundle bundle,
       org.hisp.dhis.tracker.imports.domain.TrackedEntity trackedEntity,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidator.java
@@ -156,13 +156,8 @@ class SecurityOwnershipValidator
   private void checkWriteAccess(
       Reporter reporter, TrackerDto dto, TrackedEntity te, TrackerBundle bundle) {
     List<Program> programsToCheck =
-        programService.getAllPrograms().stream()
-            .filter(
-                p ->
-                    p.isRegistration()
-                        && p.getTrackedEntityType()
-                            .getUid()
-                            .equals(te.getTrackedEntityType().getUid()))
+        programService.getProgramsByTrackedEntityType(te.getTrackedEntityType()).stream()
+            .filter(Program::isRegistration)
             .toList();
     if (!programsToCheck.isEmpty()
         && programsToCheck.stream()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidator.java
@@ -34,14 +34,18 @@ import static org.hisp.dhis.tracker.imports.validation.validator.TrackerImporter
 import static org.hisp.dhis.tracker.imports.validation.validator.TrackerImporterAssertErrors.TRACKED_ENTITY_TYPE_CANT_BE_NULL;
 import static org.hisp.dhis.tracker.imports.validation.validator.TrackerImporterAssertErrors.USER_CANT_BE_NULL;
 
+import java.util.List;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.imports.domain.TrackerDto;
@@ -49,6 +53,7 @@ import org.hisp.dhis.tracker.imports.validation.Reporter;
 import org.hisp.dhis.tracker.imports.validation.ValidationCode;
 import org.hisp.dhis.tracker.imports.validation.Validator;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 
 /**
@@ -63,6 +68,10 @@ class SecurityOwnershipValidator
   @Nonnull private final AclService aclService;
 
   @Nonnull private final OrganisationUnitService organisationUnitService;
+
+  @Nonnull private final ProgramService programService;
+
+  @Nonnull private final TrackerAccessManager trackerAccessManager;
 
   @Override
   public void validate(
@@ -91,14 +100,15 @@ class SecurityOwnershipValidator
                 .getOrganisationUnit()
             : bundle.getPreheat().getOrganisationUnit(trackedEntity.getOrgUnit());
 
-    // If trackedEntity is newly created, or going to be deleted, capture
-    // scope has to be checked
-    if (strategy.isCreate() || strategy.isDelete()) {
+    // If trackedEntity is newly created, capture scope has to be checked
+    if (strategy.isCreate()) {
+      checkTeiTypeWriteAccess(reporter, bundle, trackedEntity, trackedEntityType);
       checkOrgUnitInCaptureScope(reporter, bundle, trackedEntity, organisationUnit);
     }
-    // if its to update trackedEntity, search scope has to be checked
+    // if its to update or delete trackedEntity, write access has to be checked
     else {
-      checkOrgUnitInSearchScope(reporter, bundle, trackedEntity, organisationUnit);
+      TrackedEntity te = bundle.getPreheat().getTrackedEntity(trackedEntity.getTrackedEntity());
+      checkWriteAccess(reporter, trackedEntity, te, bundle);
     }
 
     if (strategy.isDelete()) {
@@ -109,8 +119,6 @@ class SecurityOwnershipValidator
         reporter.addError(trackedEntity, E1100, user, te);
       }
     }
-
-    checkTeiTypeWriteAccess(reporter, bundle, trackedEntity, trackedEntityType);
   }
 
   private void checkTeiTypeWriteAccess(
@@ -145,15 +153,25 @@ class SecurityOwnershipValidator
     }
   }
 
-  private void checkOrgUnitInSearchScope(
-      Reporter reporter, TrackerBundle bundle, TrackerDto dto, OrganisationUnit orgUnit) {
-    User user = bundle.getUser();
-
-    checkNotNull(user, USER_CANT_BE_NULL);
-    checkNotNull(orgUnit, ORGANISATION_UNIT_CANT_BE_NULL);
-
-    if (!organisationUnitService.isInUserSearchHierarchyCached(user, orgUnit)) {
-      reporter.addError(dto, ValidationCode.E1003, orgUnit, user);
+  private void checkWriteAccess(
+      Reporter reporter, TrackerDto dto, TrackedEntity te, TrackerBundle bundle) {
+    List<Program> programsToCheck =
+        programService.getAllPrograms().stream()
+            .filter(
+                p ->
+                    p.getTrackedEntityType() != null
+                        && p.getTrackedEntityType()
+                            .getUid()
+                            .equals(te.getTrackedEntityType().getUid()))
+            .toList();
+    if (!programsToCheck.isEmpty()
+        && programsToCheck.stream()
+            .noneMatch(
+                p ->
+                    trackerAccessManager
+                        .canWrite(UserDetails.fromUser(bundle.getUser()), te, p, false)
+                        .isEmpty())) {
+      reporter.addError(dto, ValidationCode.E1003, te.getUid());
     }
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidatorTest.java
@@ -146,7 +146,8 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     TrackedEntity te = teWithEnrollments();
     when(preheat.getTrackedEntity(TE_ID)).thenReturn(te);
     when(bundle.getStrategy(trackedEntity)).thenReturn(TrackerImportStrategy.UPDATE);
-    when(programService.getAllPrograms()).thenReturn(List.of(program));
+    when(programService.getProgramsByTrackedEntityType(trackedEntityType))
+        .thenReturn(List.of(program));
     when(trackerAccessManager.canWrite(any(), eq(te), eq(program), eq(false)))
         .thenReturn(List.of());
     validator.validate(reporter, bundle, trackedEntity);
@@ -166,7 +167,8 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     when(bundle.getStrategy(trackedEntity)).thenReturn(TrackerImportStrategy.DELETE);
     TrackedEntity te = teWithNoEnrollments();
     when(preheat.getTrackedEntity(TE_ID)).thenReturn(te);
-    when(programService.getAllPrograms()).thenReturn(List.of(program));
+    when(programService.getProgramsByTrackedEntityType(trackedEntityType))
+        .thenReturn(List.of(program));
     when(trackerAccessManager.canWrite(any(), eq(te), eq(program), eq(false)))
         .thenReturn(List.of());
 
@@ -210,7 +212,8 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     when(bundle.getStrategy(trackedEntity)).thenReturn(TrackerImportStrategy.DELETE);
     TrackedEntity te = teWithDeleteEnrollments();
     when(preheat.getTrackedEntity(TE_ID)).thenReturn(te);
-    when(programService.getAllPrograms()).thenReturn(List.of(program));
+    when(programService.getProgramsByTrackedEntityType(trackedEntityType))
+        .thenReturn(List.of(program));
     when(trackerAccessManager.canWrite(any(), eq(te), eq(program), eq(false)))
         .thenReturn(List.of());
 
@@ -232,7 +235,8 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     when(bundle.getStrategy(trackedEntity)).thenReturn(TrackerImportStrategy.DELETE);
     TrackedEntity te = teWithEnrollments();
     when(preheat.getTrackedEntity(TE_ID)).thenReturn(te);
-    when(programService.getAllPrograms()).thenReturn(List.of(program));
+    when(programService.getProgramsByTrackedEntityType(trackedEntityType))
+        .thenReturn(List.of(program));
     when(trackerAccessManager.canWrite(any(), eq(te), eq(program), eq(false)))
         .thenReturn(List.of());
 
@@ -253,7 +257,8 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     when(bundle.getStrategy(trackedEntity)).thenReturn(TrackerImportStrategy.DELETE);
     TrackedEntity te = teWithEnrollments();
     when(preheat.getTrackedEntity(TE_ID)).thenReturn(te);
-    when(programService.getAllPrograms()).thenReturn(List.of(program));
+    when(programService.getProgramsByTrackedEntityType(trackedEntityType))
+        .thenReturn(List.of(program));
     when(trackerAccessManager.canWrite(any(), eq(te), eq(program), eq(false)))
         .thenReturn(List.of());
 
@@ -302,7 +307,8 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     when(preheat.getTrackedEntityType(MetadataIdentifier.ofUid(TE_TYPE_ID)))
         .thenReturn(trackedEntityType);
     when(bundle.getStrategy(trackedEntity)).thenReturn(TrackerImportStrategy.CREATE_AND_UPDATE);
-    when(programService.getAllPrograms()).thenReturn(List.of(program));
+    when(programService.getProgramsByTrackedEntityType(trackedEntityType))
+        .thenReturn(List.of(program));
     when(trackerAccessManager.canWrite(any(), eq(te), eq(program), eq(false)))
         .thenReturn(List.of("error"));
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidatorTest.java
@@ -44,7 +44,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.security.Authorities;
@@ -91,8 +90,6 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
 
   @Mock private OrganisationUnitService organisationUnitService;
 
-  @Mock private ProgramService programService;
-
   @Mock private TrackerAccessManager trackerAccessManager;
 
   private User user;
@@ -129,8 +126,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     reporter = new Reporter(idSchemes);
 
     validator =
-        new SecurityOwnershipValidator(
-            aclService, organisationUnitService, programService, trackerAccessManager);
+        new SecurityOwnershipValidator(aclService, organisationUnitService, trackerAccessManager);
   }
 
   @Test
@@ -146,10 +142,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     TrackedEntity te = teWithEnrollments();
     when(preheat.getTrackedEntity(TE_ID)).thenReturn(te);
     when(bundle.getStrategy(trackedEntity)).thenReturn(TrackerImportStrategy.UPDATE);
-    when(programService.getProgramsByTrackedEntityType(trackedEntityType))
-        .thenReturn(List.of(program));
-    when(trackerAccessManager.canWrite(any(), eq(te), eq(program), eq(false)))
-        .thenReturn(List.of());
+    when(trackerAccessManager.canWrite(any(), eq(te))).thenReturn(List.of());
     validator.validate(reporter, bundle, trackedEntity);
 
     assertIsEmpty(reporter.getErrors());
@@ -167,10 +160,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     when(bundle.getStrategy(trackedEntity)).thenReturn(TrackerImportStrategy.DELETE);
     TrackedEntity te = teWithNoEnrollments();
     when(preheat.getTrackedEntity(TE_ID)).thenReturn(te);
-    when(programService.getProgramsByTrackedEntityType(trackedEntityType))
-        .thenReturn(List.of(program));
-    when(trackerAccessManager.canWrite(any(), eq(te), eq(program), eq(false)))
-        .thenReturn(List.of());
+    when(trackerAccessManager.canWrite(any(), eq(te))).thenReturn(List.of());
 
     validator.validate(reporter, bundle, trackedEntity);
 
@@ -212,10 +202,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     when(bundle.getStrategy(trackedEntity)).thenReturn(TrackerImportStrategy.DELETE);
     TrackedEntity te = teWithDeleteEnrollments();
     when(preheat.getTrackedEntity(TE_ID)).thenReturn(te);
-    when(programService.getProgramsByTrackedEntityType(trackedEntityType))
-        .thenReturn(List.of(program));
-    when(trackerAccessManager.canWrite(any(), eq(te), eq(program), eq(false)))
-        .thenReturn(List.of());
+    when(trackerAccessManager.canWrite(any(), eq(te))).thenReturn(List.of());
 
     validator.validate(reporter, bundle, trackedEntity);
 
@@ -235,10 +222,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     when(bundle.getStrategy(trackedEntity)).thenReturn(TrackerImportStrategy.DELETE);
     TrackedEntity te = teWithEnrollments();
     when(preheat.getTrackedEntity(TE_ID)).thenReturn(te);
-    when(programService.getProgramsByTrackedEntityType(trackedEntityType))
-        .thenReturn(List.of(program));
-    when(trackerAccessManager.canWrite(any(), eq(te), eq(program), eq(false)))
-        .thenReturn(List.of());
+    when(trackerAccessManager.canWrite(any(), eq(te))).thenReturn(List.of());
 
     validator.validate(reporter, bundle, trackedEntity);
 
@@ -257,10 +241,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     when(bundle.getStrategy(trackedEntity)).thenReturn(TrackerImportStrategy.DELETE);
     TrackedEntity te = teWithEnrollments();
     when(preheat.getTrackedEntity(TE_ID)).thenReturn(te);
-    when(programService.getProgramsByTrackedEntityType(trackedEntityType))
-        .thenReturn(List.of(program));
-    when(trackerAccessManager.canWrite(any(), eq(te), eq(program), eq(false)))
-        .thenReturn(List.of());
+    when(trackerAccessManager.canWrite(any(), eq(te))).thenReturn(List.of());
 
     validator.validate(reporter, bundle, trackedEntity);
 
@@ -307,10 +288,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     when(preheat.getTrackedEntityType(MetadataIdentifier.ofUid(TE_TYPE_ID)))
         .thenReturn(trackedEntityType);
     when(bundle.getStrategy(trackedEntity)).thenReturn(TrackerImportStrategy.CREATE_AND_UPDATE);
-    when(programService.getProgramsByTrackedEntityType(trackedEntityType))
-        .thenReturn(List.of(program));
-    when(trackerAccessManager.canWrite(any(), eq(te), eq(program), eq(false)))
-        .thenReturn(List.of("error"));
+    when(trackerAccessManager.canWrite(any(), eq(te))).thenReturn(List.of("error"));
 
     validator.validate(reporter, bundle, trackedEntity);
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackerAccessManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackerAccessManagerTest.java
@@ -224,9 +224,7 @@ class TrackerAccessManagerTest extends TransactionalIntegrationTest {
     // Cannot Read
     assertHasError(trackerAccessManager.canRead(userDetails, te), OWNERSHIP_ACCESS_DENIED);
     // Cannot write
-    assertHasError(
-        trackerAccessManager.canWrite(userDetails, te),
-        "User has no write access to organisation unit:");
+    assertHasError(trackerAccessManager.canWrite(userDetails, te), OWNERSHIP_ACCESS_DENIED);
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TrackedEntityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TrackedEntityImportValidationTest.java
@@ -33,6 +33,7 @@ import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_1;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_3;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_4;
+import static org.hisp.dhis.tracker.imports.validation.Users.USER_5;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_7;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -147,9 +148,9 @@ class TrackedEntityImportValidationTest extends TrackerTest {
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
     assertNoErrors(importReport);
     assertEquals(3, importReport.getStats().getCreated());
-    dbmsManager.clearSession();
+
     trackerObjects = fromJson("tracker/validations/te-data_with_different_ou.json");
-    User user = userService.getUser(USER_7);
+    User user = userService.getUser(USER_5);
     params.setUserId(user.getUid());
     params.setImportStrategy(TrackerImportStrategy.CREATE_AND_UPDATE);
     params.setAtomicMode(AtomicMode.OBJECT);
@@ -177,9 +178,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
     TrackerImportParams params = new TrackerImportParams();
     User user = userService.getUser(USER_3);
     params.setUserId(user.getUid());
-    params.setUserId(user.getUid());
-    user.setPassword("user4password");
-    injectSecurityContextUser(user);
+
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
     assertNoErrors(importReport);
   }
@@ -226,9 +225,6 @@ class TrackedEntityImportValidationTest extends TrackerTest {
     TrackerImportParams params = new TrackerImportParams();
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
     assertNoErrors(importReport);
-
-    manager.flush();
-    manager.clear();
 
     TrackerObjects deleteTrackerObjects = fromJson("tracker/validations/te-data-delete.json");
     params.setImportStrategy(TrackerImportStrategy.DELETE);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TrackedEntityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TrackedEntityImportValidationTest.java
@@ -31,15 +31,21 @@ import static org.hisp.dhis.tracker.Assertions.assertHasErrors;
 import static org.hisp.dhis.tracker.Assertions.assertHasOnlyErrors;
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_1;
+import static org.hisp.dhis.tracker.imports.validation.Users.USER_10;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_3;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_4;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_5;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_7;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_8;
+import static org.hisp.dhis.tracker.imports.validation.Users.USER_9;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
+import org.hisp.dhis.trackedentity.TrackerOwnershipManager;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.imports.AtomicMode;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
@@ -59,6 +65,8 @@ class TrackedEntityImportValidationTest extends TrackerTest {
   @Autowired protected TrackedEntityService trackedEntityService;
 
   @Autowired private TrackerImportService trackerImportService;
+
+  @Autowired private TrackerOwnershipManager trackerOwnershipManager;
 
   @Autowired protected UserService _userService;
 
@@ -220,6 +228,80 @@ class TrackedEntityImportValidationTest extends TrackerTest {
   }
 
   @Test
+  void shouldFailToDeleteWhenUserHasAccessToRegistrationUnitAndTEWasTransferred()
+      throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/validations/enrollments_te_te-data.json");
+    TrackerImportParams params = new TrackerImportParams();
+    assertNoErrors(trackerImportService.importTracker(params, trackerObjects));
+    importEnrollments();
+    manager.flush();
+    manager.clear();
+    TrackedEntity te = manager.get(TrackedEntity.class, "Kj6vYde4LHh");
+    OrganisationUnit orgUnit = manager.get(OrganisationUnit.class, "QfUVllTs6cW");
+    Program program = manager.get(Program.class, "E8o1E9tAppy");
+    trackerOwnershipManager.transferOwnership(te, program, orgUnit, true, false);
+    manager.flush();
+    manager.clear();
+    ImportReport importReport = deleteTransferredTrackedEntity(userService.getUser(USER_10));
+    assertHasErrors(importReport, 1, ValidationCode.E1003);
+  }
+
+  @Test
+  void shouldDeleteWhenTEWasTransferredAndUserHasAccessToTransferredOrgUnit() throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/validations/enrollments_te_te-data.json");
+    TrackerImportParams params = new TrackerImportParams();
+    assertNoErrors(trackerImportService.importTracker(params, trackerObjects));
+    importEnrollments();
+    manager.flush();
+    manager.clear();
+    TrackedEntity te = manager.get(TrackedEntity.class, "Kj6vYde4LHh");
+    OrganisationUnit orgUnit = manager.get(OrganisationUnit.class, "QfUVllTs6cW");
+    Program program = manager.get(Program.class, "E8o1E9tAppy");
+    trackerOwnershipManager.transferOwnership(te, program, orgUnit, true, false);
+    manager.flush();
+    manager.clear();
+    ImportReport importReport = deleteTransferredTrackedEntity(userService.getUser(USER_9));
+    assertNoErrors(importReport);
+  }
+
+  @Test
+  void shouldFailToUpdateWhenUserHasAccessToRegistrationUnitAndTEWasTransferred()
+      throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/validations/enrollments_te_te-data.json");
+    TrackerImportParams params = new TrackerImportParams();
+    assertNoErrors(trackerImportService.importTracker(params, trackerObjects));
+    importEnrollments();
+    manager.flush();
+    manager.clear();
+    TrackedEntity te = manager.get(TrackedEntity.class, "Kj6vYde4LHh");
+    OrganisationUnit orgUnit = manager.get(OrganisationUnit.class, "QfUVllTs6cW");
+    Program program = manager.get(Program.class, "E8o1E9tAppy");
+    trackerOwnershipManager.transferOwnership(te, program, orgUnit, true, false);
+    manager.flush();
+    manager.clear();
+    ImportReport importReport = updateTransferredTrackedEntity(userService.getUser(USER_10));
+    assertHasErrors(importReport, 1, ValidationCode.E1003);
+  }
+
+  @Test
+  void shouldUpdateWhenTEWasTransferredAndUserHasAccessToTransferredOrgUnit() throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/validations/enrollments_te_te-data.json");
+    TrackerImportParams params = new TrackerImportParams();
+    assertNoErrors(trackerImportService.importTracker(params, trackerObjects));
+    importEnrollments();
+    manager.flush();
+    manager.clear();
+    TrackedEntity te = manager.get(TrackedEntity.class, "Kj6vYde4LHh");
+    OrganisationUnit orgUnit = manager.get(OrganisationUnit.class, "QfUVllTs6cW");
+    Program program = manager.get(Program.class, "E8o1E9tAppy");
+    trackerOwnershipManager.transferOwnership(te, program, orgUnit, true, false);
+    manager.flush();
+    manager.clear();
+    ImportReport importReport = updateTransferredTrackedEntity(userService.getUser(USER_9));
+    assertNoErrors(importReport);
+  }
+
+  @Test
   void testTeDeleteOk() throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/te-data.json");
     TrackerImportParams params = new TrackerImportParams();
@@ -241,5 +323,21 @@ class TrackedEntityImportValidationTest extends TrackerTest {
     ImportReport importReport =
         trackerImportService.importTracker(new TrackerImportParams(), trackerObjects);
     assertNoErrors(importReport);
+  }
+
+  protected ImportReport deleteTransferredTrackedEntity(User user) throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/validations/te-transferred-data-delete.json");
+    TrackerImportParams params = new TrackerImportParams();
+    params.setImportStrategy(TrackerImportStrategy.DELETE);
+    params.setUserId(user.getUid());
+    return trackerImportService.importTracker(params, trackerObjects);
+  }
+
+  protected ImportReport updateTransferredTrackedEntity(User user) throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/validations/te-transferred-data-update.json");
+    TrackerImportParams params = new TrackerImportParams();
+    params.setImportStrategy(TrackerImportStrategy.UPDATE);
+    params.setUserId(user.getUid());
+    return trackerImportService.importTracker(params, trackerObjects);
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/Users.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/Users.java
@@ -43,4 +43,8 @@ public class Users {
   public static final String USER_7 = "E5AiPnHG3t5";
 
   public static final String USER_8 = "xbgFeL0l3Ap";
+
+  public static final String USER_9 = "KpknKHptuF4";
+
+  public static final String USER_10 = "Xl2V8x8R1R5";
 }

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/tracker_basic_metadata.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/tracker_basic_metadata.json
@@ -588,7 +588,12 @@
         "public": "rw------",
         "external": false,
         "owner": "M5zQapPyTZI",
-        "users": {},
+        "users": {
+          "oajYcE7VMBs": {
+            "id": "oajYcE7VMBs",
+            "access": "rwrw----"
+          }
+        },
         "userGroups": {}
       }
     },
@@ -626,9 +631,6 @@
       ],
       "onlyEnrollOnce": false,
       "lastUpdated": "2019-03-29T12:41:33.039",
-      "trackedEntityType": {
-        "id": "bPJ0FMtcnEh"
-      },
       "name": "Tracker Program X",
       "enrollmentDateLabel": "EnrollmentDate",
       "maxTeiCountToReturn": 0,
@@ -687,9 +689,6 @@
       ],
       "onlyEnrollOnce": false,
       "lastUpdated": "2019-03-29T12:41:33.039",
-      "trackedEntityType": {
-        "id": "bPJ0FMtcnEh"
-      },
       "name": "Tracker Program Y",
       "enrollmentDateLabel": "EnrollmentDate",
       "maxTeiCountToReturn": 0,
@@ -748,9 +747,6 @@
       ],
       "onlyEnrollOnce": false,
       "lastUpdated": "2019-03-29T12:41:33.039",
-      "trackedEntityType": {
-        "id": "bPJ0FMtcnEh"
-      },
       "name": "Tracker Program Y",
       "enrollmentDateLabel": "EnrollmentDate",
       "maxTeiCountToReturn": 0,
@@ -826,7 +822,16 @@
         "public": "rw------",
         "external": false,
         "owner": "M5zQapPyTZI",
-        "users": {},
+        "users": {
+          "oajYcE7VMBs": {
+            "id": "oajYcE7VMBs",
+            "access": "rwrw----"
+          },
+          "iAji3gyZYQL": {
+            "id": "iAji3gyZYQL",
+            "access": "rwrw----"
+          }
+        },
         "userGroups": {}
       }
     },
@@ -864,9 +869,6 @@
       ],
       "onlyEnrollOnce": false,
       "lastUpdated": "2019-03-29T12:41:33.039",
-      "trackedEntityType": {
-        "id": "bPJ0FMtcnEh"
-      },
       "name": "Tracker Program X",
       "enrollmentDateLabel": "EnrollmentDate",
       "maxTeiCountToReturn": 0,
@@ -884,7 +886,7 @@
         }
       ],
       "sharing": {
-        "public": "rw------",
+        "public": "rwrw----",
         "external": false,
         "owner": "M5zQapPyTZI",
         "users": {},
@@ -1160,7 +1162,11 @@
           "id": "QfUVllTs6cS"
         }
       ],
-      "teiSearchOrganisationUnits": [],
+      "teiSearchOrganisationUnits": [
+        {
+        "id": "QfUVllTs6cZ"
+        }
+      ],
       "created": "2019-03-25T13:58:35.560",
       "code": "user5",
       "organisationUnits": [],
@@ -2131,7 +2137,16 @@
         "public": "rw------",
         "external": false,
         "owner": "M5zQapPyTZI",
-        "users": {},
+        "users": {
+          "xbgFeL0l3Ap": {
+            "id": "xbgFeL0l3Ap",
+            "access": "rwrw----"
+          },
+          "oajYcE7VMBs": {
+            "id": "oajYcE7VMBs",
+            "access": "rwrw----"
+          }
+        },
         "userGroups": {
           "jCDKJBruqjc": {
             "id": "jCDKJBruqjc",

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/tracker_basic_metadata.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/tracker_basic_metadata.json
@@ -415,6 +415,35 @@
         "users": {},
         "userGroups": {}
       }
+    },
+    {
+      "level": 2,
+      "openingDate": "2019-03-25T00:00:00.000",
+      "id": "QfUVllTs6cW",
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "parent": {
+        "id": "QfUVllTs6cS"
+      },
+      "attributeValues": [],
+      "name": "Another State",
+      "translations": [],
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "code": "State2",
+      "created": "2019-03-25T13:59:02.598",
+      "path": "/QfUVllTs6cS/QfUVllTs6cW",
+      "shortName": "State2",
+      "lastUpdated": "2019-03-25T13:59:02.692",
+      "sharing": {
+        "public": "rw------",
+        "external": false,
+        "owner": "M5zQapPyTZI",
+        "users": {},
+        "userGroups": {}
+      }
     }
   ],
   "programs": [
@@ -591,6 +620,14 @@
         "users": {
           "oajYcE7VMBs": {
             "id": "oajYcE7VMBs",
+            "access": "rwrw----"
+          },
+          "Xl2V8x8R1R5": {
+            "id": "Xl2V8x8R1R5",
+            "access": "rwrw----"
+          },
+          "KpknKHptuF4": {
+            "id": "KpknKHptuF4",
             "access": "rwrw----"
           }
         },
@@ -1438,6 +1475,116 @@
       "password": "Test123###...",
       "id": "xbgFeL0l3Ap",
       "attributeValues": []
+    },
+    {
+      "dataViewOrganisationUnits": [
+        {
+          "id": "QfUVllTs6cW"
+        }
+      ],
+      "teiSearchOrganisationUnits": [
+        {
+          "id": "QfUVllTs6cW"
+        }
+      ],
+      "created": "2019-03-25T13:58:35.560",
+      "code": "user9",
+      "organisationUnits": [
+        {
+          "id": "QfUVllTs6cW"
+        }
+      ],
+      "lastUpdated": "2019-03-29T08:57:41.890",
+      "lastCheckedInterpretations": "2019-03-29T08:57:20.392",
+      "favorite": false,
+      "catDimensionConstraints": [],
+      "userAccesses": [],
+      "disabled": false,
+      "userRoles": [
+        {
+          "id": "BBB6vc5Ip3r"
+        }
+      ],
+      "name": "Another State Capture Search",
+      "displayName": "Another State Capture Search",
+      "favorites": [],
+      "selfRegistered": false,
+      "externalAccess": false,
+      "externalAuth": false,
+      "twoFA": false,
+      "username": "user9",
+      "userGroupAccesses": [],
+      "access": {
+        "externalize": true,
+        "read": true,
+        "manage": true,
+        "delete": true,
+        "write": true,
+        "update": true
+      },
+      "cogsDimensionConstraints": [],
+      "invitation": false,
+      "lastLogin": "2019-03-29T12:42:06.495",
+      "translations": [],
+      "passwordLastUpdated": "2019-03-29T08:57:41.766",
+      "firstName": "State2",
+      "surname": "Capture Search",
+      "id": "KpknKHptuF4",
+      "password": "Test123###...",
+      "attributeValues": []
+    },
+    {
+      "dataViewOrganisationUnits": [
+        {
+          "id": "QfUVllTs6cZ"
+        }
+      ],
+      "teiSearchOrganisationUnits": [],
+      "created": "2019-03-25T13:58:35.560",
+      "code": "user10",
+      "organisationUnits": [
+        {
+          "id": "QfUVllTs6cZ"
+        }
+      ],
+      "lastUpdated": "2019-03-29T08:57:41.890",
+      "lastCheckedInterpretations": "2019-03-29T08:57:20.392",
+      "favorite": false,
+      "catDimensionConstraints": [],
+      "userAccesses": [],
+      "disabled": false,
+      "userRoles": [
+        {
+          "id": "BBB6vc5Ip3r"
+        }
+      ],
+      "name": "state user",
+      "displayName": "state user",
+      "favorites": [],
+      "selfRegistered": false,
+      "externalAccess": false,
+      "externalAuth": false,
+      "twoFA": false,
+      "username": "user10",
+      "userGroupAccesses": [],
+      "access": {
+        "externalize": true,
+        "read": true,
+        "manage": true,
+        "delete": true,
+        "write": true,
+        "update": true
+      },
+      "cogsDimensionConstraints": [],
+      "invitation": false,
+      "lastLogin": "2019-03-29T12:42:06.495",
+      "translations": [],
+      "passwordLastUpdated": "2019-03-29T08:57:41.766",
+      "firstName": "state",
+      "surname": "state",
+      "id": "Xl2V8x8R1R5",
+      "password": "Test123###...",
+      "attributeValues": []
     }
   ],
   "userGroups": [
@@ -2207,6 +2354,14 @@
           },
           "oajYcE7VMBs": {
             "id": "oajYcE7VMBs",
+            "access": "rwrw----"
+          },
+          "Xl2V8x8R1R5": {
+            "id": "Xl2V8x8R1R5",
+            "access": "rwrw----"
+          },
+          "KpknKHptuF4": {
+            "id": "KpknKHptuF4",
             "access": "rwrw----"
           }
         },

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/tracker_basic_metadata.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/tracker_basic_metadata.json
@@ -836,6 +836,69 @@
       }
     },
     {
+      "ignoreOverdueEvents": false,
+      "programSections": [],
+      "shortName": "Tracker Program Different TET",
+      "incidentDateLabel": "IncidentDate",
+      "translations": [],
+      "style": {
+        "color": "#d32f2f"
+      },
+      "expiryDays": 0,
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "selectEnrollmentDatesInFuture": false,
+      "categoryCombo": {
+        "id": "FLsH8ClLGNB"
+      },
+      "notificationTemplates": [],
+      "displayIncidentDate": true,
+      "accessLevel": "OPEN",
+      "id": "YYY1E9tAbbW",
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "completeEventsExpiryDays": 0,
+      "organisationUnits": [
+        {
+          "id": "QfUVllTs6cS"
+        }
+      ],
+      "onlyEnrollOnce": false,
+      "lastUpdated": "2019-03-29T12:41:33.039",
+      "trackedEntityType": {
+        "id": "XXXbPJ0FMtc"
+      },
+      "name": "Tracker Program Different TET",
+      "enrollmentDateLabel": "EnrollmentDate",
+      "maxTeiCountToReturn": 0,
+      "attributeValues": [],
+      "useFirstStageDuringRegistration": false,
+      "minAttributesRequiredToSearch": 1,
+      "skipOffline": false,
+      "version": 0,
+      "programType": "WITH_REGISTRATION",
+      "selectIncidentDatesInFuture": false,
+      "displayFrontPageList": false,
+      "sharing": {
+        "public": "rw------",
+        "external": false,
+        "owner": "M5zQapPyTZI",
+        "users": {
+          "oajYcE7VMBs": {
+            "id": "oajYcE7VMBs",
+            "access": "rwrw----"
+          },
+          "iAji3gyZYQL": {
+            "id": "iAji3gyZYQL",
+            "access": "rwrw----"
+          }
+        },
+        "userGroups": {}
+      }
+    },
+    {
       "featureType": "NONE",
       "ignoreOverdueEvents": false,
       "programSections": [],

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/validations/enrollments_te_te-data.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/validations/enrollments_te_te-data.json
@@ -39,7 +39,7 @@
       },
       "orgUnit": {
         "idScheme": "UID",
-        "identifier": "QfUVllTs6cS"
+        "identifier": "QfUVllTs6cZ"
       },
       "inactive": false,
       "deleted": false,

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/validations/te-transferred-data-delete.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/validations/te-transferred-data-delete.json
@@ -1,0 +1,48 @@
+{
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": {
+      "idScheme": "UID"
+    },
+    "orgUnitIdScheme": {
+      "idScheme": "UID"
+    },
+    "programIdScheme": {
+      "idScheme": "UID"
+    },
+    "programStageIdScheme": {
+      "idScheme": "UID"
+    },
+    "idScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionComboIdScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionIdScheme": {
+      "idScheme": "UID"
+    }
+  },
+  "importStrategy": "CREATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
+  "trackedEntities": [
+    {
+      "trackedEntity": "Kj6vYde4LHh",
+      "inactive": false,
+      "deleted": false,
+      "potentialDuplicate": false,
+      "relationships": [],
+      "attributes": [],
+      "enrollments": []
+    }
+  ],
+  "enrollments": [],
+  "events": [],
+  "relationships": [],
+  "username": "system-process"
+}

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/validations/te-transferred-data-update.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/validations/te-transferred-data-update.json
@@ -1,0 +1,56 @@
+{
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": {
+      "idScheme": "UID"
+    },
+    "orgUnitIdScheme": {
+      "idScheme": "UID"
+    },
+    "programIdScheme": {
+      "idScheme": "UID"
+    },
+    "programStageIdScheme": {
+      "idScheme": "UID"
+    },
+    "idScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionComboIdScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionIdScheme": {
+      "idScheme": "UID"
+    }
+  },
+  "importStrategy": "CREATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
+  "trackedEntities": [
+    {
+      "trackedEntity": "Kj6vYde4LHh",
+      "trackedEntityType": {
+        "idScheme": "UID",
+        "identifier": "bPJ0FMtcnEh"
+      },
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cZ"
+      },
+      "inactive": false,
+      "deleted": false,
+      "potentialDuplicate": false,
+      "relationships": [],
+      "attributes": [],
+      "enrollments": []
+    }
+  ],
+  "enrollments": [],
+  "events": [],
+  "relationships": [],
+  "username": "system-process"
+}


### PR DESCRIPTION
In the importer we need to validate access to Tracked Entity the same way we are now doing in the exporter.
We have 3 different cases in the importer:

- CREATE: Check capture scope of the user using registration unit
- UPDATE or DELETE: Check if the user has access to any TE/program pair, by first matching by the owner, or the registering org unit if no owner is found
