### PR TITLE
fix: Bad SQL syntax exception in /analytics/Event/aggregate[2.42-DHIS2-16235]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryValidator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryValidator.java
@@ -97,22 +97,17 @@ public class DefaultEventQueryValidator implements EventQueryValidator {
         && params.getDimensionalObjectItems().contains(params.getValue())) {
       return new ErrorMessage(ErrorCode.E7203);
     }
-    if (params.hasAggregationType()
-        && !(params.hasValueDimension() || params.isAggregateData())) {
+    if (params.hasAggregationType() && !(params.hasValueDimension() || params.isAggregateData())) {
       return new ErrorMessage(ErrorCode.E7204);
     }
-    if (!params.hasPeriods()
-        && (params.getStartDate() == null || params.getEndDate() == null)) {
+    if (!params.hasPeriods() && (params.getStartDate() == null || params.getEndDate() == null)) {
       return new ErrorMessage(ErrorCode.E7205);
     }
     if (params.getStartDate() != null
         && params.getEndDate() != null
         && params.getStartDate().after(params.getEndDate())) {
-      return
-          new ErrorMessage(
-              ErrorCode.E7206,
-              toMediumDate(params.getStartDate()),
-              toMediumDate(params.getEndDate()));
+      return new ErrorMessage(
+          ErrorCode.E7206, toMediumDate(params.getStartDate()), toMediumDate(params.getEndDate()));
     }
     if (params.getPage() != null && params.getPage() <= 0) {
       return new ErrorMessage(ErrorCode.E7207, params.getPage());
@@ -135,8 +130,7 @@ public class DefaultEventQueryValidator implements EventQueryValidator {
     if (params.hasBbox() && !ValidationUtils.bboxIsValid(params.getBbox())) {
       return new ErrorMessage(ErrorCode.E7213, params.getBbox());
     }
-    if ((params.hasBbox() || params.hasClusterSize())
-        && params.getCoordinateFields() == null) {
+    if ((params.hasBbox() || params.hasClusterSize()) && params.getCoordinateFields() == null) {
       return new ErrorMessage(ErrorCode.E7214);
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryValidator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryValidator.java
@@ -126,6 +126,10 @@ public class DefaultEventQueryValidator implements EventQueryValidator {
       error = new ErrorMessage(ErrorCode.E7214);
     }
 
+    if(error != null){
+      return error;
+    }
+
     for (QueryItem item : params.getItemsAndItemFilters()) {
       if (item.hasLegendSet() && item.hasOptionSet()) {
         error = new ErrorMessage(ErrorCode.E7215, item.getItemId());

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryValidator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryValidator.java
@@ -80,75 +80,83 @@ public class DefaultEventQueryValidator implements EventQueryValidator {
 
   @Override
   public ErrorMessage validateForErrorMessage(EventQueryParams params) {
-    ErrorMessage error = null;
 
     if (params == null) {
       throw new IllegalQueryException(ErrorCode.E7100);
-    } else if (!params.hasOrganisationUnits()) {
-      error = new ErrorMessage(ErrorCode.E7200);
-    } else if (!params.getDuplicateDimensions().isEmpty()) {
-      error = new ErrorMessage(ErrorCode.E7201, params.getDuplicateDimensions());
-    } else if (!params.getDuplicateQueryItems().isEmpty()) {
-      error = new ErrorMessage(ErrorCode.E7202, params.getDuplicateQueryItems());
-    } else if (params.hasValueDimension()
+    }
+    if (!params.hasOrganisationUnits()) {
+      return new ErrorMessage(ErrorCode.E7200);
+    }
+    if (!params.getDuplicateDimensions().isEmpty()) {
+      return new ErrorMessage(ErrorCode.E7201, params.getDuplicateDimensions());
+    }
+    if (!params.getDuplicateQueryItems().isEmpty()) {
+      return new ErrorMessage(ErrorCode.E7202, params.getDuplicateQueryItems());
+    }
+    if (params.hasValueDimension()
         && params.getDimensionalObjectItems().contains(params.getValue())) {
-      error = new ErrorMessage(ErrorCode.E7203);
-    } else if (params.hasAggregationType()
+      return new ErrorMessage(ErrorCode.E7203);
+    }
+    if (params.hasAggregationType()
         && !(params.hasValueDimension() || params.isAggregateData())) {
-      error = new ErrorMessage(ErrorCode.E7204);
-    } else if (!params.hasPeriods()
+      return new ErrorMessage(ErrorCode.E7204);
+    }
+    if (!params.hasPeriods()
         && (params.getStartDate() == null || params.getEndDate() == null)) {
-      error = new ErrorMessage(ErrorCode.E7205);
-    } else if (params.getStartDate() != null
+      return new ErrorMessage(ErrorCode.E7205);
+    }
+    if (params.getStartDate() != null
         && params.getEndDate() != null
         && params.getStartDate().after(params.getEndDate())) {
-      error =
+      return
           new ErrorMessage(
               ErrorCode.E7206,
               toMediumDate(params.getStartDate()),
               toMediumDate(params.getEndDate()));
-    } else if (params.getPage() != null && params.getPage() <= 0) {
-      error = new ErrorMessage(ErrorCode.E7207, params.getPage());
-    } else if (params.getPageSize() != null && params.getPageSize() < 0) {
-      error = new ErrorMessage(ErrorCode.E7208, params.getPageSize());
-    } else if (params.hasLimit() && getMaxLimit() > 0 && params.getLimit() > getMaxLimit()) {
-      error = new ErrorMessage(ErrorCode.E7209, params.getLimit(), getMaxLimit());
-    } else if (params.hasTimeField() && !params.timeFieldIsValid()) {
-      error = new ErrorMessage(ErrorCode.E7210, params.getTimeField());
-    } else if (!params.orgUnitFieldIsValid()) {
-      error = new ErrorMessage(ErrorCode.E7211, params.getOrgUnitField());
-    } else if (params.hasClusterSize() && params.getClusterSize() <= 0) {
-      error = new ErrorMessage(ErrorCode.E7212, params.getClusterSize());
-    } else if (params.hasBbox() && !ValidationUtils.bboxIsValid(params.getBbox())) {
-      error = new ErrorMessage(ErrorCode.E7213, params.getBbox());
-    } else if ((params.hasBbox() || params.hasClusterSize())
-        && params.getCoordinateFields() == null) {
-      error = new ErrorMessage(ErrorCode.E7214);
     }
-
-    if(error != null){
-      return error;
+    if (params.getPage() != null && params.getPage() <= 0) {
+      return new ErrorMessage(ErrorCode.E7207, params.getPage());
+    }
+    if (params.getPageSize() != null && params.getPageSize() < 0) {
+      return new ErrorMessage(ErrorCode.E7208, params.getPageSize());
+    }
+    if (params.hasLimit() && getMaxLimit() > 0 && params.getLimit() > getMaxLimit()) {
+      return new ErrorMessage(ErrorCode.E7209, params.getLimit(), getMaxLimit());
+    }
+    if (params.hasTimeField() && !params.timeFieldIsValid()) {
+      return new ErrorMessage(ErrorCode.E7210, params.getTimeField());
+    }
+    if (!params.orgUnitFieldIsValid()) {
+      return new ErrorMessage(ErrorCode.E7211, params.getOrgUnitField());
+    }
+    if (params.hasClusterSize() && params.getClusterSize() <= 0) {
+      return new ErrorMessage(ErrorCode.E7212, params.getClusterSize());
+    }
+    if (params.hasBbox() && !ValidationUtils.bboxIsValid(params.getBbox())) {
+      return new ErrorMessage(ErrorCode.E7213, params.getBbox());
+    }
+    if ((params.hasBbox() || params.hasClusterSize())
+        && params.getCoordinateFields() == null) {
+      return new ErrorMessage(ErrorCode.E7214);
     }
 
     for (QueryItem item : params.getItemsAndItemFilters()) {
       if (item.hasLegendSet() && item.hasOptionSet()) {
-        error = new ErrorMessage(ErrorCode.E7215, item.getItemId());
+        return new ErrorMessage(ErrorCode.E7215, item.getItemId());
       } else if (params.isAggregateData() && !item.getAggregationType().isAggregatable()) {
-        error = new ErrorMessage(ErrorCode.E7216, item.getItemId());
-      }
-
-      for (QueryFilter filter : item.getFilters()) {
-        error = validateQueryFilter(filter, item.getValueType());
-
-        if (error != null) {
-          return error;
+        return new ErrorMessage(ErrorCode.E7216, item.getItemId());
+      } else {
+        for (QueryFilter filter : item.getFilters()) {
+          ErrorMessage error = validateQueryFilter(filter, item.getValueType());
+          if (error != null) {
+            return error;
+          }
         }
       }
     }
 
     // TODO validate coordinate field
-
-    return error;
+    return null;
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -408,6 +408,7 @@ public class JdbcEventAnalyticsManager extends AbstractJdbcEventAnalyticsManager
     // ---------------------------------------------------------------------
     // Periods
     // ---------------------------------------------------------------------
+
     if (!params.getAggregationTypeFallback().isFirstOrLastPeriodAggregationType()) {
       sql += hlp.whereAnd() + " " + timeFieldSqlRenderer.renderPeriodTimeFieldSql(params);
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -408,7 +408,6 @@ public class JdbcEventAnalyticsManager extends AbstractJdbcEventAnalyticsManager
     // ---------------------------------------------------------------------
     // Periods
     // ---------------------------------------------------------------------
-
     if (!params.getAggregationTypeFallback().isFirstOrLastPeriodAggregationType()) {
       sql += hlp.whereAnd() + " " + timeFieldSqlRenderer.renderPeriodTimeFieldSql(params);
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
@@ -614,7 +614,7 @@ public class JdbcAnalyticsTableManager extends AbstractJdbcTableManager {
 
     sql.append(
         """
-        where oulevel > ${aggregationLevel} \
+         where oulevel > ${aggregationLevel} \
         and dx in ( ${dataElements} )\s""");
 
     String updateQuery =

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
@@ -611,10 +611,10 @@ public class JdbcAnalyticsTableManager extends AbstractJdbcTableManager {
     }
 
     sql.deleteCharAt(sql.length() - ",".length());
-
+    sql.append(" ");
     sql.append(
         """
-         where oulevel > ${aggregationLevel} \
+        where oulevel > ${aggregationLevel} \
         and dx in ( ${dataElements} )\s""");
 
     String updateQuery =


### PR DESCRIPTION
The issue was pinpointed through query parameter validation, specifically within the period dimension. When the parameters are found to be invalid, the error message sent to the client should appear as follows:
 {
    "httpStatus": "Conflict",
    "httpStatusCode": 409,
    "status": "ERROR",
    "message": "Start and end dates or at least one period must be specified",
    "errorCode": "E7205"
}
The instantiation of the error message was incorrectly implemented, resulting in certain special cases overwriting existing instances of the error message. This issue has now been rectified.
