### PR TITLE
fix: add back CurrentUserGroupInfo cache (41.0)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
@@ -204,7 +204,7 @@ public interface UserStore extends IdentifiableObjectStore<User> {
   List<User> getLinkedUserAccounts(User currentUser);
 
   /** Return CurrentUserGroupInfo used for ACL check in {@link IdentifiableObjectStore} */
-  CurrentUserGroupInfo getCurrentUserGroupInfo(String userUID);
+  CurrentUserGroupInfo getCurrentUserGroupInfo(String userUid);
 
   /**
    * Get active linked user accounts for the given user

--- a/dhis-2/dhis-services/dhis-service-acl/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-acl/pom.xml
@@ -24,11 +24,6 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <scope>provided</scope>
-    </dependency>
 
     <!-- DHIS -->
 

--- a/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/AclService.java
+++ b/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/AclService.java
@@ -28,8 +28,10 @@
 package org.hisp.dhis.security.acl;
 
 import java.util.List;
+import java.util.function.Function;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.user.CurrentUserGroupInfo;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 
@@ -44,6 +46,13 @@ public interface AclService {
   String LIKE_READ_DATA = "__r_____";
 
   String LIKE_WRITE_DATA = "___w____";
+
+  CurrentUserGroupInfo getCurrentUserGroupInfo(
+      String userUid, Function<String, CurrentUserGroupInfo> cacheSupplier);
+
+  void invalidateCurrentUserGroupInfoCache();
+
+  void invalidateCurrentUserGroupInfoCache(String userUid);
 
   /**
    * Is type supported for acl?

--- a/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
+++ b/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
@@ -33,7 +33,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import lombok.RequiredArgsConstructor;
+import java.util.function.Function;
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.IdentifiableObject;
@@ -45,6 +47,7 @@ import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.security.AuthorityType;
 import org.hisp.dhis.security.acl.AccessStringHelper.Permission;
+import org.hisp.dhis.user.CurrentUserGroupInfo;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.sharing.Sharing;
@@ -57,11 +60,32 @@ import org.springframework.stereotype.Service;
  *
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@RequiredArgsConstructor
 @Service("org.hisp.dhis.security.acl.AclService")
 public class DefaultAclService implements AclService {
 
   private final SchemaService schemaService;
+  private final Cache<CurrentUserGroupInfo> userGroupInfoCache;
+
+  public DefaultAclService(SchemaService schemaService, CacheProvider cacheProvider) {
+    this.schemaService = schemaService;
+    this.userGroupInfoCache = cacheProvider.createCurrentUserGroupInfoCache();
+  }
+
+  @Override
+  public CurrentUserGroupInfo getCurrentUserGroupInfo(
+      String userUid, Function<String, CurrentUserGroupInfo> cacheSupplier) {
+    return userGroupInfoCache.get(userUid, cacheSupplier);
+  }
+
+  @Override
+  public void invalidateCurrentUserGroupInfoCache() {
+    userGroupInfoCache.invalidateAll();
+  }
+
+  @Override
+  public void invalidateCurrentUserGroupInfoCache(String userUid) {
+    userGroupInfoCache.invalidate(userUid);
+  }
 
   @Override
   public boolean isSupported(String type) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/InternalHibernateGenericStoreImpl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/InternalHibernateGenericStoreImpl.java
@@ -339,30 +339,31 @@ public class InternalHibernateGenericStoreImpl<T extends BaseIdentifiableObject>
   }
 
   @Override
+  public CurrentUserGroupInfo getCurrentUserGroupInfo(String userUid) {
+    return aclService.getCurrentUserGroupInfo(userUid, this::fetchCurrentUserGroupInfo);
+  }
+
   // TODO: MAS can this be removed and we rely on first fetch on login? make sure current logged in
   // users are get invalidated when group changes
-  public CurrentUserGroupInfo getCurrentUserGroupInfo(String userUID) {
+  private CurrentUserGroupInfo fetchCurrentUserGroupInfo(String userUid) {
     CriteriaBuilder builder = getCriteriaBuilder();
     CriteriaQuery<Object[]> query = builder.createQuery(Object[].class);
     Root<User> root = query.from(User.class);
-    query.where(builder.equal(root.get("uid"), userUID));
+    query.where(builder.equal(root.get("uid"), userUid));
     query.select(builder.array(root.get("uid"), root.join("groups", JoinType.LEFT).get("uid")));
 
     Session session = getSession();
     List<Object[]> results = session.createQuery(query).getResultList();
 
     CurrentUserGroupInfo currentUserGroupInfo = new CurrentUserGroupInfo();
+    currentUserGroupInfo.setUserUID(userUid);
 
     if (CollectionUtils.isEmpty(results)) {
-      currentUserGroupInfo.setUserUID(userUID);
+      currentUserGroupInfo.setUserUID(userUid);
       return currentUserGroupInfo;
     }
 
     for (Object[] result : results) {
-      if (currentUserGroupInfo.getUserUID() == null) {
-        currentUserGroupInfo.setUserUID(result[0].toString());
-      }
-
       if (result[1] != null) {
         currentUserGroupInfo.getUserGroupUIDs().add(result[1].toString());
       }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
@@ -80,7 +80,7 @@ public class DefaultUserGroupService implements UserGroupService {
   @Transactional
   public long addUserGroup(UserGroup userGroup) {
     userGroupStore.save(userGroup);
-
+    aclService.invalidateCurrentUserGroupInfoCache();
     return userGroup.getId();
   }
 
@@ -88,6 +88,7 @@ public class DefaultUserGroupService implements UserGroupService {
   @Transactional
   public void deleteUserGroup(UserGroup userGroup) {
     userGroupStore.delete(userGroup);
+    aclService.invalidateCurrentUserGroupInfoCache();
   }
 
   @Override
@@ -98,6 +99,7 @@ public class DefaultUserGroupService implements UserGroupService {
     // Clear query cache due to sharing and user group membership
 
     cacheManager.clearQueryCache();
+    aclService.invalidateCurrentUserGroupInfoCache();
   }
 
   @Override
@@ -150,6 +152,7 @@ public class DefaultUserGroupService implements UserGroupService {
         userGroupStore.updateNoAcl(userGroup);
       }
     }
+    aclService.invalidateCurrentUserGroupInfoCache();
   }
 
   @Override
@@ -162,6 +165,7 @@ public class DefaultUserGroupService implements UserGroupService {
         userGroupStore.updateNoAcl(userGroup);
       }
     }
+    aclService.invalidateCurrentUserGroupInfoCache();
   }
 
   @Override
@@ -195,6 +199,7 @@ public class DefaultUserGroupService implements UserGroupService {
             userGroupStore.updateNoAcl(userGroup);
           }
         });
+    aclService.invalidateCurrentUserGroupInfoCache();
   }
 
   private Collection<UserGroup> getUserGroupsByUid(@Nonnull Collection<String> uids) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -114,6 +114,13 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
   }
 
   @Override
+  public void save(@Nonnull User user, boolean clearSharing) {
+    super.save(user, clearSharing);
+
+    aclService.invalidateCurrentUserGroupInfoCache(user.getUid());
+  }
+
+  @Override
   public List<User> getUsers(UserQueryParams params, @Nullable List<String> orders) {
     Query<?> userQuery = getUserQuery(params, orders, false);
     return extractUserQueryUsers(userQuery.list());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserStoreTest.java
@@ -33,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.collect.Sets;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -149,19 +148,21 @@ class UserStoreTest extends SingleSetupIntegrationTestBase {
 
   @Test
   void testGetCurrentUserGroupInfo() {
-    User userA = makeUser("A");
-    userStore.save(userA);
-    UserGroup userGroupA = createUserGroup('A', Sets.newHashSet(userA));
+    UserGroup userGroupA = createUserGroup('A', null);
     userGroupService.addUserGroup(userGroupA);
-    UserGroup userGroupB = createUserGroup('B', Sets.newHashSet(userA));
+
+    UserGroup userGroupB = createUserGroup('B', null);
     userGroupService.addUserGroup(userGroupB);
-    userA.getGroups().add(userGroupA);
-    userA.getGroups().add(userGroupB);
-    // TODO: MAS - this should be refactored out
-    CurrentUserGroupInfo currentUserGroupInfo = userStore.getCurrentUserGroupInfo(userA.getUid());
-    assertNotNull(currentUserGroupInfo);
-    assertEquals(2, currentUserGroupInfo.getUserGroupUIDs().size());
-    assertEquals(userA.getUid(), currentUserGroupInfo.getUserUID());
+
+    User userA = makeUser("A");
+    userA.setGroups(Set.of(userGroupA, userGroupB));
+    userGroupA.setMembers(Set.of(userA));
+    userGroupB.setMembers(Set.of(userA));
+    userStore.save(userA);
+
+    assertEquals(
+        userA.getGroups().size(),
+        userStore.getCurrentUserGroupInfo(userA.getUid()).getUserGroupUIDs().size());
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -61,6 +61,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.attribute.AttributeValue;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.IdentifiableObjects;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.MergeMode;
 import org.hisp.dhis.common.OpenApi;
@@ -656,6 +657,11 @@ public class UserController extends AbstractCrudController<User> {
     }
 
     return importReport;
+  }
+
+  @Override
+  protected void postUpdateItems(User entity, IdentifiableObjects items) {
+    aclService.invalidateCurrentUserGroupInfoCache();
   }
 
   protected void updateUserGroups(String userUid, User parsed, User currentUser) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserGroupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserGroupController.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.user;
 
+import org.hisp.dhis.common.IdentifiableObjects;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.schema.descriptors.UserGroupSchemaDescriptor;
 import org.hisp.dhis.user.UserGroup;
@@ -45,10 +46,17 @@ public class UserGroupController extends AbstractCrudController<UserGroup> {
   @Override
   protected void postUpdateEntity(UserGroup entity) {
     hibernateCacheManager.clearCache();
+    aclService.invalidateCurrentUserGroupInfoCache();
+  }
+
+  @Override
+  protected void postUpdateItems(UserGroup entity, IdentifiableObjects items) {
+    aclService.invalidateCurrentUserGroupInfoCache();
   }
 
   @Override
   protected void postDeleteEntity(String entityUid) {
     manager.removeUserGroupFromSharing(entityUid);
+    aclService.invalidateCurrentUserGroupInfoCache();
   }
 }

--- a/dhis-2/dhis-web-embedded-jetty/pom.xml
+++ b/dhis-2/dhis-web-embedded-jetty/pom.xml
@@ -72,10 +72,6 @@
       <artifactId>spring-web</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>


### PR DESCRIPTION
backport https://github.com/dhis2/dhis2-core/pull/17183

https://dhis2.atlassian.net/browse/DHIS2-16934

### Issue
- Sharing ACL check requires database query which joins User and UserGroup table.
- In 2.40 and previous versions, the result of that query was cached for performance purpose.
- However the cache has been removed in 2.41 as a part for the CurrentUserService refactoring.

### Fix
- Add back the cache, make sure to invalidate it when userGroup or User is updated.
### Test
- We already have many sharing ACL test in SharingControllerTest and AbstractCrudControllerTest.