### PR TITLE
fix: only one concurrent user allowed

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
@@ -33,6 +33,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.external.conf.ConfigurationKey;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationEnrolmentException;
 import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationException;
 import org.hisp.dhis.security.spring2fa.TwoFactorWebAuthenticationDetails;
@@ -94,24 +96,34 @@ public class AuthenticationController {
 
   @Autowired private AuthenticationManager authenticationManager;
 
+  @Autowired private DhisConfigurationProvider dhisConfig;
   @Autowired private SystemSettingManager settingManager;
   @Autowired private RequestCache requestCache;
   @Autowired private SessionRegistry sessionRegistry;
   @Autowired private UserService userService;
 
   private SessionAuthenticationStrategy sessionStrategy = new NullAuthenticatedSessionStrategy();
+
   private final SecurityContextHolderStrategy securityContextHolderStrategy =
       SecurityContextHolder.getContextHolderStrategy();
+
   private final SecurityContextRepository securityContextRepository =
       new HttpSessionSecurityContextRepository();
 
   @PostConstruct
   public void init() {
     if (sessionRegistry != null) {
+
+      int maxSessions =
+          Integer.parseInt(dhisConfig.getProperty((ConfigurationKey.MAX_SESSIONS_PER_USER)));
+      ConcurrentSessionControlAuthenticationStrategy concurrentStrategy =
+          new ConcurrentSessionControlAuthenticationStrategy(sessionRegistry);
+      concurrentStrategy.setMaximumSessions(maxSessions);
+
       sessionStrategy =
           new CompositeSessionAuthenticationStrategy(
               List.of(
-                  new ConcurrentSessionControlAuthenticationStrategy(sessionRegistry),
+                  concurrentStrategy,
                   new SessionFixationProtectionStrategy(),
                   new RegisterSessionAuthenticationStrategy(sessionRegistry)));
     }


### PR DESCRIPTION
## Summary
Fixes bug, only allowing one concurrent user session.
Caused by new login controller not setting the max session per user from the dhis.conf

### Automatic tests
N/A now, requires an E2E test.

### Jira
[DHIS2-17225](https://github.com/dhis2/dhis2-core/pull/17225)

[DHIS2-17225]: https://dhis2.atlassian.net/browse/DHIS2-17225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ