### PR TITLE
fix: Analytics events query API: 500 error when dimension is not present in the query[2.42-DHIS2-17231_2]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EnrollmentAnalyticsQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EnrollmentAnalyticsQueryCriteria.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.common;
 
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Set;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -57,21 +58,21 @@ public class EnrollmentAnalyticsQueryCriteria extends AnalyticsPagingCriteria {
 
   private String timeField;
 
-  private Set<String> dimension;
+  private Set<String> dimension = new HashSet<>();
 
-  private Set<String> filter;
+  private Set<String> filter = new HashSet<>();
 
   /**
    * This parameter selects the headers to be returned as part of the response. The implementation
    * for this Set will be LinkedHashSet as the ordering is important.
    */
-  private Set<String> headers;
+  private Set<String> headers = new HashSet<>();
 
   private OrganisationUnitSelectionMode ouMode;
 
-  private Set<String> asc;
+  private Set<String> asc = new HashSet<>();
 
-  private Set<String> desc;
+  private Set<String> desc = new HashSet<>();
 
   private boolean skipMeta;
 
@@ -97,7 +98,7 @@ public class EnrollmentAnalyticsQueryCriteria extends AnalyticsPagingCriteria {
    */
   private IdScheme outputIdScheme;
 
-  private Set<ProgramStatus> programStatus;
+  private Set<ProgramStatus> programStatus = new HashSet<>();
 
   private DisplayProperty displayProperty;
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteria.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.common;
 
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Set;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -79,20 +80,20 @@ public class EventsAnalyticsQueryCriteria extends AnalyticsPagingCriteria {
    * organisation units and organisation unit group sets. Parameter can be repeated any number of
    * times.
    */
-  private Set<String> dimension;
+  private Set<String> dimension = new HashSet<>();
 
   /**
    * Filters to apply to the analytics: a Set of identifiers including data elements, attributes,
    * periods, organisation units and organisation unit group sets. Parameter can be repeated any
    * number of times.
    */
-  private Set<String> filter;
+  private Set<String> filter = new HashSet<>();
 
   /**
    * This parameter selects the headers to be returned as part of the response. The implementation
    * for this Set will be LinkedHashSet as the ordering is important.
    */
-  private Set<String> headers;
+  private Set<String> headers = new HashSet<>();
 
   /**
    * Whether to include names of organisation unit ancestors and hierarchy paths of organisation
@@ -101,10 +102,10 @@ public class EventsAnalyticsQueryCriteria extends AnalyticsPagingCriteria {
   private boolean hierarchyMeta;
 
   /** Specify ths status of events to include. */
-  private Set<EventStatus> eventStatus;
+  private Set<EventStatus> eventStatus = new HashSet<>();
 
   /** Specify the enrollment status of events to include. */
-  private Set<ProgramStatus> programStatus;
+  private Set<ProgramStatus> programStatus = new HashSet<>();
 
   /** Overrides the start date of the relative period. */
   private Date relativePeriodDate;
@@ -216,13 +217,13 @@ public class EventsAnalyticsQueryCriteria extends AnalyticsPagingCriteria {
    * Dimensions identifier to be sorted ascending, can reference event date, org unit name and code
    * and any item identifiers.
    */
-  private Set<String> asc;
+  private Set<String> asc = new HashSet<>();
 
   /**
    * Dimensions identifier to be sorted descending, can reference event date, org unit name and code
    * and any item identifiers.
    */
-  private Set<String> desc;
+  private Set<String> desc = new HashSet<>();
 
   /** Whether to only return events which have coordinates. */
   private boolean coordinatesOnly;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/PeriodCriteriaUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/PeriodCriteriaUtils.java
@@ -60,7 +60,7 @@ public class PeriodCriteriaUtils {
    */
   public static void defineDefaultPeriodForCriteria(
       EnrollmentAnalyticsQueryCriteria criteria, RelativePeriodEnum defaultPeriod) {
-    if (!hasPeriod(criteria)) {
+    if (!hasPeriod(criteria) && criteria.getDimension() != null) {
       criteria.getDimension().add(PERIOD_DIM_ID + ":" + defaultPeriod.name());
     }
   }
@@ -73,10 +73,8 @@ public class PeriodCriteriaUtils {
    *     False, otherwise.
    */
   public static boolean hasPeriod(EventsAnalyticsQueryCriteria criteria) {
-    return (criteria.getDimension() != null
-            && criteria.getDimension().stream().anyMatch(d -> d.startsWith(PERIOD_DIM_ID)))
-        || (criteria.getFilter() != null
-            && criteria.getFilter().stream().anyMatch(d -> d.startsWith(PERIOD_DIM_ID)))
+    return (criteria.getDimension().stream().anyMatch(d -> d.startsWith(PERIOD_DIM_ID)))
+        || (criteria.getFilter().stream().anyMatch(d -> d.startsWith(PERIOD_DIM_ID)))
         || !isBlank(criteria.getEventDate())
         || !isBlank(criteria.getEnrollmentDate())
         || (criteria.getStartDate() != null && criteria.getEndDate() != null)


### PR DESCRIPTION
There was a simple bug (a null dimension set handling) preventing the application from reacting properly. Instead of delivering the standard error message (409, "At least one organization unit must be specified"), it delivered an internal error message (500).