### PR TITLE
Analytics events query API: 500 error when dimension is not present in the query[2.39-DHIS2-17231_2-backport] 

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EnrollmentAnalyticsQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EnrollmentAnalyticsQueryCriteria.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.common;
 
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Set;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -57,21 +58,21 @@ public class EnrollmentAnalyticsQueryCriteria extends AnalyticsPagingCriteria {
 
   private String timeField;
 
-  private Set<String> dimension;
+  private Set<String> dimension = new HashSet<>();
 
-  private Set<String> filter;
+  private Set<String> filter = new HashSet<>();
 
   /**
    * This parameter selects the headers to be returned as part of the response. The implementation
    * for this Set will be LinkedHashSet as the ordering is important.
    */
-  private Set<String> headers;
+  private Set<String> headers = new HashSet<>();
 
   private OrganisationUnitSelectionMode ouMode;
 
-  private Set<String> asc;
+  private Set<String> asc = new HashSet<>();
 
-  private Set<String> desc;
+  private Set<String> desc = new HashSet<>();
 
   private boolean skipMeta;
 
@@ -95,7 +96,7 @@ public class EnrollmentAnalyticsQueryCriteria extends AnalyticsPagingCriteria {
    */
   private IdScheme outputIdScheme;
 
-  private Set<ProgramStatus> programStatus;
+  private Set<ProgramStatus> programStatus = new HashSet<>();
 
   private DisplayProperty displayProperty;
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteria.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.common;
 
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Set;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -79,20 +80,20 @@ public class EventsAnalyticsQueryCriteria extends AnalyticsPagingCriteria {
    * organisation units and organisation unit group sets. Parameter can be repeated any number of
    * times.
    */
-  private Set<String> dimension;
+  private Set<String> dimension = new HashSet<>();
 
   /**
    * Filters to apply to the analytics: a Set of identifiers including data elements, attributes,
    * periods, organisation units and organisation unit group sets. Parameter can be repeated any
    * number of times.
    */
-  private Set<String> filter;
+  private Set<String> filter = new HashSet<>();
 
   /**
    * This parameter selects the headers to be returned as part of the response. The implementation
    * for this Set will be LinkedHashSet as the ordering is important.
    */
-  private Set<String> headers;
+  private Set<String> headers = new HashSet<>();
 
   /**
    * Whether to include names of organisation unit ancestors and hierarchy paths of organisation
@@ -101,10 +102,10 @@ public class EventsAnalyticsQueryCriteria extends AnalyticsPagingCriteria {
   private boolean hierarchyMeta;
 
   /** Specify ths status of events to include. */
-  private Set<EventStatus> eventStatus;
+  private Set<EventStatus> eventStatus = new HashSet<>();
 
   /** Specify the enrollment status of events to include. */
-  private Set<ProgramStatus> programStatus;
+  private Set<ProgramStatus> programStatus = new HashSet<>();
 
   /** Overrides the start date of the relative period. */
   private Date relativePeriodDate;
@@ -216,13 +217,13 @@ public class EventsAnalyticsQueryCriteria extends AnalyticsPagingCriteria {
    * Dimensions identifier to be sorted ascending, can reference event date, org unit name and code
    * and any item identifiers.
    */
-  private Set<String> asc;
+  private Set<String> asc = new HashSet<>();
 
   /**
    * Dimensions identifier to be sorted descending, can reference event date, org unit name and code
    * and any item identifiers.
    */
-  private Set<String> desc;
+  private Set<String> desc = new HashSet<>();
 
   /** Whether to only return events which have coordinates. */
   private boolean coordinatesOnly;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/PeriodCriteriaUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/PeriodCriteriaUtils.java
@@ -60,7 +60,7 @@ public class PeriodCriteriaUtils {
    */
   public static void defineDefaultPeriodForCriteria(
       EnrollmentAnalyticsQueryCriteria criteria, RelativePeriodEnum defaultPeriod) {
-    if (!hasPeriod(criteria) && criteria.getDimension() != null) {
+    if (!hasPeriod(criteria)) {
       criteria.getDimension().add(PERIOD_DIM_ID + ":" + defaultPeriod.name());
     }
   }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/PeriodCriteriaUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/PeriodCriteriaUtils.java
@@ -60,7 +60,7 @@ public class PeriodCriteriaUtils {
    */
   public static void defineDefaultPeriodForCriteria(
       EnrollmentAnalyticsQueryCriteria criteria, RelativePeriodEnum defaultPeriod) {
-    if (!hasPeriod(criteria)) {
+    if (!hasPeriod(criteria) && criteria.getDimension() != null) {
       criteria.getDimension().add(PERIOD_DIM_ID + ":" + defaultPeriod.name());
     }
   }
@@ -73,10 +73,8 @@ public class PeriodCriteriaUtils {
    *     False, otherwise.
    */
   public static boolean hasPeriod(EventsAnalyticsQueryCriteria criteria) {
-    return (criteria.getDimension() != null
-            && criteria.getDimension().stream().anyMatch(d -> d.startsWith(PERIOD_DIM_ID)))
-        || (criteria.getFilter() != null
-            && criteria.getFilter().stream().anyMatch(d -> d.startsWith(PERIOD_DIM_ID)))
+    return (criteria.getDimension().stream().anyMatch(d -> d.startsWith(PERIOD_DIM_ID)))
+        || (criteria.getFilter().stream().anyMatch(d -> d.startsWith(PERIOD_DIM_ID)))
         || !isBlank(criteria.getEventDate())
         || !isBlank(criteria.getEnrollmentDate())
         || (criteria.getStartDate() != null && criteria.getEndDate() != null)

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EnrollmentsAnalyticsQueryCriteriaTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EnrollmentsAnalyticsQueryCriteriaTest.java
@@ -40,7 +40,7 @@ class EnrollmentsAnalyticsQueryCriteriaTest {
   @Test
   void testCriteriaHasEmptySetsByDefault() {
     // given
-    EnrollmentAnalyticsQueryCriteria criteria = getDefaultEnrollmentsAnalyticsQueryCriteria();
+    EnrollmentAnalyticsQueryCriteria criteria = new EnrollmentAnalyticsQueryCriteria();
     Class<?> targetClass = EnrollmentAnalyticsQueryCriteria.class;
     Field[] fields = targetClass.getDeclaredFields();
 
@@ -61,14 +61,5 @@ class EnrollmentsAnalyticsQueryCriteriaTest {
         }
       }
     }
-  }
-
-  private EnrollmentAnalyticsQueryCriteria getDefaultEnrollmentsAnalyticsQueryCriteria() {
-    EnrollmentAnalyticsQueryCriteria enrollmentsAnalyticsQueryCriteria =
-        new EnrollmentAnalyticsQueryCriteria();
-    Set<String> dimensions = new HashSet<>();
-    enrollmentsAnalyticsQueryCriteria.setDimension(dimensions);
-
-    return enrollmentsAnalyticsQueryCriteria;
   }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EnrollmentsAnalyticsQueryCriteriaTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EnrollmentsAnalyticsQueryCriteriaTest.java
@@ -32,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.HashSet;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EnrollmentsAnalyticsQueryCriteriaTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EnrollmentsAnalyticsQueryCriteriaTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.common;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class EnrollmentsAnalyticsQueryCriteriaTest {
+  @Test
+  void testCriteriaHasEmptySetsByDefault() {
+    // given
+    EnrollmentAnalyticsQueryCriteria criteria = getDefaultEnrollmentsAnalyticsQueryCriteria();
+    Class<?> targetClass = EnrollmentAnalyticsQueryCriteria.class;
+    Field[] fields = targetClass.getDeclaredFields();
+
+    for (Field field : fields) {
+      String fieldName = field.getName();
+      Class<?> fieldType = field.getType();
+      if (fieldType == Set.class) {
+        Method method;
+        try {
+          // when
+          method =
+              targetClass.getMethod(
+                  "get" + fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1));
+          // then
+          assertTrue(((Set<?>) method.invoke(criteria)).isEmpty());
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+          assert false;
+        }
+      }
+    }
+  }
+
+  private EnrollmentAnalyticsQueryCriteria getDefaultEnrollmentsAnalyticsQueryCriteria() {
+    EnrollmentAnalyticsQueryCriteria enrollmentsAnalyticsQueryCriteria =
+        new EnrollmentAnalyticsQueryCriteria();
+    Set<String> dimensions = new HashSet<>();
+    enrollmentsAnalyticsQueryCriteria.setDimension(dimensions);
+
+    return enrollmentsAnalyticsQueryCriteria;
+  }
+}

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteriaTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteriaTest.java
@@ -36,7 +36,7 @@ import java.util.HashSet;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
-public class EventsAnalyticsQueryCriteriaTest {
+class EventsAnalyticsQueryCriteriaTest {
   @Test
   void testCriteriaHasEmptySetsByDefault() {
     // given

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteriaTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteriaTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.common;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+public class EventsAnalyticsQueryCriteriaTest {
+  @Test
+  void testCriteriaHasEmptySetsByDefault() {
+    // given
+    EventsAnalyticsQueryCriteria criteria = getDefaultEventsAnalyticsQueryCriteria();
+    Class<?> targetClass = EventsAnalyticsQueryCriteria.class;
+    Field[] fields = targetClass.getDeclaredFields();
+
+    for (Field field : fields) {
+      String fieldName = field.getName();
+      Class<?> fieldType = field.getType();
+      if (fieldType == Set.class) {
+        Method method;
+        try {
+          // when
+          method =
+              targetClass.getMethod(
+                  "get" + fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1));
+          // then
+          assertTrue(((Set<?>) method.invoke(criteria)).isEmpty());
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+          assert false;
+        }
+      }
+    }
+  }
+
+  private EventsAnalyticsQueryCriteria getDefaultEventsAnalyticsQueryCriteria() {
+    EventsAnalyticsQueryCriteria eventsAnalyticsQueryCriteria = new EventsAnalyticsQueryCriteria();
+    Set<String> dimensions = new HashSet<>();
+    eventsAnalyticsQueryCriteria.setDimension(dimensions);
+
+    return eventsAnalyticsQueryCriteria;
+  }
+}

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteriaTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteriaTest.java
@@ -32,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.HashSet;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteriaTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteriaTest.java
@@ -40,7 +40,7 @@ public class EventsAnalyticsQueryCriteriaTest {
   @Test
   void testCriteriaHasEmptySetsByDefault() {
     // given
-    EventsAnalyticsQueryCriteria criteria = getDefaultEventsAnalyticsQueryCriteria();
+    EventsAnalyticsQueryCriteria criteria = new EventsAnalyticsQueryCriteria();
     Class<?> targetClass = EventsAnalyticsQueryCriteria.class;
     Field[] fields = targetClass.getDeclaredFields();
 
@@ -61,13 +61,5 @@ public class EventsAnalyticsQueryCriteriaTest {
         }
       }
     }
-  }
-
-  private EventsAnalyticsQueryCriteria getDefaultEventsAnalyticsQueryCriteria() {
-    EventsAnalyticsQueryCriteria eventsAnalyticsQueryCriteria = new EventsAnalyticsQueryCriteria();
-    Set<String> dimensions = new HashSet<>();
-    eventsAnalyticsQueryCriteria.setDimension(dimensions);
-
-    return eventsAnalyticsQueryCriteria;
   }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/PeriodCriteriaUtilsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/PeriodCriteriaUtilsTest.java
@@ -34,9 +34,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -226,32 +223,6 @@ class PeriodCriteriaUtilsTest {
     // when
     // then
     assertFalse(PeriodCriteriaUtils.hasPeriod(criteria) && criteria.getDimension().isEmpty());
-  }
-
-  @Test
-  void testCriteriaHasEmptySetsByDefault() {
-    // given
-    EventsAnalyticsQueryCriteria criteria = getDefaultEventsAnalyticsQueryCriteria();
-    Class<?> targetClass = EventsAnalyticsQueryCriteria.class;
-    Field[] fields = targetClass.getDeclaredFields();
-
-    for (Field field : fields) {
-      String fieldName = field.getName();
-      Class<?> fieldType = field.getType();
-      if (fieldType == Set.class) {
-        Method method;
-        try {
-          // when
-          method =
-              targetClass.getMethod(
-                  "get" + fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1));
-          // then
-          assertTrue(((Set<?>) method.invoke(criteria)).isEmpty());
-        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-          assert false;
-        }
-      }
-    }
   }
 
   private EventsAnalyticsQueryCriteria configureEventsAnalyticsQueryCriteriaWithPeriod(

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/PeriodCriteriaUtilsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/PeriodCriteriaUtilsTest.java
@@ -32,7 +32,6 @@ import static org.hisp.dhis.period.RelativePeriodEnum.LAST_3_DAYS;
 import static org.hisp.dhis.period.RelativePeriodEnum.LAST_5_YEARS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Field;
@@ -58,7 +57,7 @@ class PeriodCriteriaUtilsTest {
 
     // then
     assertTrue(eventsAnalyticsQueryCriteria.getDimension().stream().findFirst().isPresent());
-    assertNull(eventsAnalyticsQueryCriteria.getDesc());
+    assertTrue(eventsAnalyticsQueryCriteria.getDesc().isEmpty());
     assertEquals(
         eventsAnalyticsQueryCriteria.getDimension().stream().findFirst().get(),
         PERIOD_DIM_ID + ":" + LAST_5_YEARS);
@@ -75,7 +74,7 @@ class PeriodCriteriaUtilsTest {
 
     // then
     assertTrue(eventsAnalyticsQueryCriteria.getDimension().stream().findFirst().isPresent());
-    assertNull(eventsAnalyticsQueryCriteria.getDesc());
+    assertTrue(eventsAnalyticsQueryCriteria.getDesc().isEmpty());
     assertEquals(
         eventsAnalyticsQueryCriteria.getDimension().stream().findFirst().get(),
         PERIOD_DIM_ID + ":" + LAST_5_YEARS);
@@ -124,7 +123,7 @@ class PeriodCriteriaUtilsTest {
 
     // then
     assertFalse(eventsAnalyticsQueryCriteria.getDimension().stream().findFirst().isPresent());
-    assertNull(eventsAnalyticsQueryCriteria.getDesc());
+    assertTrue(eventsAnalyticsQueryCriteria.getDesc().isEmpty());
   }
 
   @Test
@@ -138,7 +137,7 @@ class PeriodCriteriaUtilsTest {
 
     // then
     assertFalse(eventsAnalyticsQueryCriteria.getDimension().stream().findFirst().isPresent());
-    assertNull(eventsAnalyticsQueryCriteria.getDesc());
+    assertTrue(eventsAnalyticsQueryCriteria.getDesc().isEmpty());
   }
 
   @Test
@@ -153,7 +152,7 @@ class PeriodCriteriaUtilsTest {
 
     // then
     assertTrue(enrollmentsAnalyticsQueryCriteria.getDimension().stream().findFirst().isPresent());
-    assertNull(enrollmentsAnalyticsQueryCriteria.getDesc());
+    assertTrue(enrollmentsAnalyticsQueryCriteria.getDesc().isEmpty());
     assertEquals(
         enrollmentsAnalyticsQueryCriteria.getDimension().stream().findFirst().get(),
         PERIOD_DIM_ID + ":" + LAST_5_YEARS);
@@ -171,7 +170,7 @@ class PeriodCriteriaUtilsTest {
 
     // then
     assertTrue(enrollmentAnalyticsQueryCriteria.getDimension().stream().findFirst().isPresent());
-    assertNull(enrollmentAnalyticsQueryCriteria.getDesc());
+    assertTrue(enrollmentAnalyticsQueryCriteria.getDesc().isEmpty());
     assertEquals(
         enrollmentAnalyticsQueryCriteria.getDimension().stream().findFirst().get(),
         PERIOD_DIM_ID + ":" + LAST_5_YEARS);
@@ -189,7 +188,7 @@ class PeriodCriteriaUtilsTest {
 
     // then
     assertFalse(enrollmentAnalyticsQueryCriteria.getDimension().stream().findFirst().isPresent());
-    assertNull(enrollmentAnalyticsQueryCriteria.getDesc());
+    assertTrue(enrollmentAnalyticsQueryCriteria.getDesc().isEmpty());
   }
 
   @Test
@@ -204,7 +203,7 @@ class PeriodCriteriaUtilsTest {
 
     // then
     assertFalse(enrollmentsAnalyticsQueryCriteria.getDimension().stream().findFirst().isPresent());
-    assertNull(enrollmentsAnalyticsQueryCriteria.getDesc());
+    assertTrue(enrollmentsAnalyticsQueryCriteria.getDesc().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
**Backport**
There was a simple bug (a null dimension set handling) preventing the application from reacting properly. Instead of delivering the standard error message (409, "At least one organization unit must be specified"), it delivered an internal error message (500).