### PR TITLE
fix: Min/max limits in analytics rep. rates [DHIS2-15892]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -1278,6 +1278,10 @@ public class DataQueryParams {
     return startDate != null && endDate != null;
   }
 
+  public boolean hasReportingRates() {
+    return isNotEmpty(getAllReportingRates());
+  }
+
   /**
    * Indicates whether this query has a continuous list of dates range or is empty. It assumes that
    * the datesRange IS SORTED.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManager.java
@@ -323,7 +323,10 @@ public class JdbcAnalyticsManager implements AnalyticsManager {
 
     builder.append(getGroupByClause(params));
 
-    if (params.hasMeasureCriteria() && params.isDataType(DataType.NUMERIC)) {
+    if (params.hasMeasureCriteria()
+        && params.isDataType(DataType.NUMERIC)
+        && !params.hasReportingRates()) {
+      /* Reporting rates applies the measure criteria after the rates calculation phase. It cannot be done at this stage. */
       builder.append(getMeasureCriteriaSql(params));
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -710,13 +710,29 @@ public class DataHandler {
     String reportingRate = getDimensionItem(dataRow.get(DX_INDEX), metric);
     dataRow.set(DX_INDEX, reportingRate);
 
-    grid.addRow()
-        .addValues(dataRow.toArray())
-        .addValue(params.isSkipRounding() ? value : getRoundedValueObject(params, value));
+    if (satisfiesMeasureCriteria(params, value)) {
+      grid.addRow()
+          .addValues(dataRow.toArray())
+          .addValue(params.isSkipRounding() ? value : getRoundedValueObject(params, value));
 
-    if (params.isIncludeNumDen()) {
-      grid.addValue(actual).addValue(target).addValue(PERCENT).addNullValues(2);
+      if (params.isIncludeNumDen()) {
+        grid.addValue(actual).addValue(target).addValue(PERCENT).addNullValues(2);
+      }
     }
+  }
+
+  private boolean satisfiesMeasureCriteria(DataQueryParams params, Double value) {
+    if (params.hasMeasureCriteria() && value != null) {
+      Double finalValue =
+          params.isSkipRounding() ? value : (Double) getRoundedValueObject(params, value);
+
+      return params.getMeasureCriteria().entrySet().stream()
+          .anyMatch(
+              measureValue ->
+                  measureValue.getKey().measureIsValid(finalValue, measureValue.getValue()));
+    }
+
+    return true;
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -723,13 +723,15 @@ public class DataHandler {
 
   private boolean satisfiesMeasureCriteria(DataQueryParams params, Double value) {
     if (params.hasMeasureCriteria() && value != null) {
-      Double finalValue =
-          params.isSkipRounding() ? value : (Double) getRoundedValueObject(params, value);
+      Number finalValue =
+          params.isSkipRounding() ? value : (Number) getRoundedValueObject(params, value);
 
       return params.getMeasureCriteria().entrySet().stream()
           .anyMatch(
               measureValue ->
-                  measureValue.getKey().measureIsValid(finalValue, measureValue.getValue()));
+                  measureValue
+                      .getKey()
+                      .measureIsValid(finalValue.doubleValue(), measureValue.getValue()));
     }
 
     return true;

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/aggregate/AnalyticsQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/aggregate/AnalyticsQueryTest.java
@@ -216,4 +216,226 @@ public class AnalyticsQueryTest extends AnalyticsApiTest {
     // Then
     response.validate().statusCode(200);
   }
+
+  @Test
+  public void testQueryForReportingRatesWithMeasureCriteriaLT() {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("dimension=dx:PLq9sJluXvc.REPORTING_RATE,ou:USER_ORGUNIT;USER_ORGUNIT_CHILDREN")
+            .add("filter=pe:LAST_5_YEARS")
+            .add("displayProperty=NAME")
+            .add("measureCriteria=LT:25")
+            .add("includeNumDen=true")
+            .add("relativePeriodDate=2024-04-25")
+            .add("skipMeta=true")
+            .add("skipData=false");
+
+    // When
+    ApiResponse response = analyticsActions.get(params);
+
+    // Then
+    response.validate().statusCode(200).body("rows", hasSize(equalTo(3)));
+
+    validateRow(
+        response,
+        List.of(
+            "PLq9sJluXvc.REPORTING_RATE",
+            "bL4ooGhyHRQ",
+            "24.82",
+            "983.0",
+            "3960.0",
+            "100",
+            "",
+            ""));
+
+    validateRow(
+        response,
+        List.of(
+            "PLq9sJluXvc.REPORTING_RATE",
+            "at6UHUQatSo",
+            "24.71",
+            "1542.0",
+            "6240.0",
+            "100",
+            "",
+            ""));
+
+    validateRow(
+        response,
+        List.of(
+            "PLq9sJluXvc.REPORTING_RATE",
+            "at6UHUQatSo",
+            "24.71",
+            "1542.0",
+            "6240.0",
+            "100",
+            "",
+            ""));
+  }
+
+  @Test
+  public void testQueryForReportingRatesWithMeasureCriteriaGT_NoNumeratorDenominator() {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("dimension=dx:PLq9sJluXvc.REPORTING_RATE,ou:USER_ORGUNIT;USER_ORGUNIT_CHILDREN")
+            .add("filter=pe:LAST_5_YEARS")
+            .add("displayProperty=NAME")
+            .add("measureCriteria=GT:25")
+            .add("includeNumDen=false")
+            .add("relativePeriodDate=2024-04-25")
+            .add("skipMeta=true")
+            .add("skipData=false");
+
+    // When
+    ApiResponse response = analyticsActions.get(params);
+
+    // Then
+    response.validate().statusCode(200).body("rows", hasSize(equalTo(11)));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "Vth0fbpFcsO", "25.69"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "PMa2VCrupOd", "25.27"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "O6uvpzGd5pu", "25.56"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "lc3eMKXaEfw", "25.55"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "qhqAxPSTUXp", "25.57"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "ImspTQPwCqd", "25.21"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "fdc6uOvgoji", "25.38"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "jmIPBj66vD6", "25.34"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "jUb8gELQApl", "25.19"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "eIQbndfxQMb", "25.11"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "TEQlaapDQoK", "25.09"));
+  }
+
+  @Test
+  public void testQueryForReportingRatesWithMeasureCriteriaGTE_NoNumeratorDenominator() {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("dimension=dx:PLq9sJluXvc.REPORTING_RATE,ou:USER_ORGUNIT;USER_ORGUNIT_CHILDREN")
+            .add("filter=pe:LAST_5_YEARS")
+            .add("displayProperty=NAME")
+            .add("measureCriteria=GT:25")
+            .add("includeNumDen=false")
+            .add("relativePeriodDate=2024-04-25")
+            .add("skipMeta=true")
+            .add("skipData=false");
+
+    // When
+    ApiResponse response = analyticsActions.get(params);
+
+    // Then
+    response.validate().statusCode(200).body("rows", hasSize(equalTo(11)));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "Vth0fbpFcsO", "25.69"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "PMa2VCrupOd", "25.27"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "O6uvpzGd5pu", "25.56"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "lc3eMKXaEfw", "25.55"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "qhqAxPSTUXp", "25.57"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "ImspTQPwCqd", "25.21"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "fdc6uOvgoji", "25.38"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "jmIPBj66vD6", "25.34"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "jUb8gELQApl", "25.19"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "eIQbndfxQMb", "25.11"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "TEQlaapDQoK", "25.09"));
+  }
+
+  @Test
+  public void testQueryForReportingRatesWithMeasureCriteriaLT_Negative() {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("dimension=dx:PLq9sJluXvc.REPORTING_RATE,ou:USER_ORGUNIT;USER_ORGUNIT_CHILDREN")
+            .add("filter=pe:LAST_5_YEARS")
+            .add("displayProperty=NAME")
+            .add("measureCriteria=LT:-5")
+            .add("includeNumDen=true")
+            .add("relativePeriodDate=2024-04-25")
+            .add("skipMeta=true")
+            .add("skipData=false");
+
+    // When
+    ApiResponse response = analyticsActions.get(params);
+
+    // Then
+    response.validate().statusCode(200).body("rows", hasSize(equalTo(0)));
+  }
+
+  @Test
+  public void testQueryForReportingRatesWithMeasureCriteriaEQ_WithRounding() {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("dimension=dx:PLq9sJluXvc.REPORTING_RATE,ou:USER_ORGUNIT;USER_ORGUNIT_CHILDREN")
+            .add("filter=pe:LAST_5_YEARS")
+            .add("displayProperty=NAME")
+            .add("measureCriteria=EQ:25.11")
+            .add("includeNumDen=true")
+            .add("skipRounding=false")
+            .add("relativePeriodDate=2024-04-25")
+            .add("skipMeta=true")
+            .add("skipData=false");
+
+    // When
+    ApiResponse response = analyticsActions.get(params);
+
+    // Then
+    response.validate().statusCode(200).body("rows", hasSize(equalTo(1)));
+
+    validateRow(
+        response,
+        List.of(
+            "PLq9sJluXvc.REPORTING_RATE",
+            "eIQbndfxQMb",
+            "25.11",
+            "1401.0",
+            "5580.0",
+            "100",
+            "",
+            ""));
+  }
+
+  @Test
+  public void testQueryForReportingRatesWithMeasureCriteriaEQ_SkipRounding() {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("dimension=dx:PLq9sJluXvc.REPORTING_RATE,ou:USER_ORGUNIT;USER_ORGUNIT_CHILDREN")
+            .add("filter=pe:LAST_5_YEARS")
+            .add("displayProperty=NAME")
+            .add("measureCriteria=EQ:25.268817204301076")
+            .add("skipRounding=true")
+            .add("relativePeriodDate=2024-04-25")
+            .add("skipMeta=true")
+            .add("skipData=false");
+
+    // When
+    ApiResponse response = analyticsActions.get(params);
+
+    // Then
+    response.validate().statusCode(200).body("rows", hasSize(equalTo(1)));
+
+    validateRow(
+        response, List.of("PLq9sJluXvc.REPORTING_RATE", "PMa2VCrupOd", "25.268817204301076"));
+  }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/aggregate/AnalyticsQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/aggregate/AnalyticsQueryTest.java
@@ -318,14 +318,14 @@ public class AnalyticsQueryTest extends AnalyticsApiTest {
   }
 
   @Test
-  public void testQueryForReportingRatesWithMeasureCriteriaGTE_NoNumeratorDenominator() {
+  public void testQueryForReportingRatesWithMeasureCriteriaGE_NoNumeratorDenominator() {
     // Given
     QueryParamsBuilder params =
         new QueryParamsBuilder()
             .add("dimension=dx:PLq9sJluXvc.REPORTING_RATE,ou:USER_ORGUNIT;USER_ORGUNIT_CHILDREN")
             .add("filter=pe:LAST_5_YEARS")
             .add("displayProperty=NAME")
-            .add("measureCriteria=GT:25")
+            .add("measureCriteria=GE:25.55")
             .add("includeNumDen=false")
             .add("relativePeriodDate=2024-04-25")
             .add("skipMeta=true")
@@ -335,29 +335,15 @@ public class AnalyticsQueryTest extends AnalyticsApiTest {
     ApiResponse response = analyticsActions.get(params);
 
     // Then
-    response.validate().statusCode(200).body("rows", hasSize(equalTo(11)));
+    response.validate().statusCode(200).body("rows", hasSize(equalTo(4)));
 
     validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "Vth0fbpFcsO", "25.69"));
-
-    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "PMa2VCrupOd", "25.27"));
 
     validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "O6uvpzGd5pu", "25.56"));
 
     validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "lc3eMKXaEfw", "25.55"));
 
     validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "qhqAxPSTUXp", "25.57"));
-
-    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "ImspTQPwCqd", "25.21"));
-
-    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "fdc6uOvgoji", "25.38"));
-
-    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "jmIPBj66vD6", "25.34"));
-
-    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "jUb8gELQApl", "25.19"));
-
-    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "eIQbndfxQMb", "25.11"));
-
-    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "TEQlaapDQoK", "25.09"));
   }
 
   @Test
@@ -437,5 +423,40 @@ public class AnalyticsQueryTest extends AnalyticsApiTest {
 
     validateRow(
         response, List.of("PLq9sJluXvc.REPORTING_RATE", "PMa2VCrupOd", "25.268817204301076"));
+  }
+
+  @Test
+  public void testQueryForReportingRatesWithMeasureCriteriaEQ_WithZerosAsResult() {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add(
+                "dimension=pe:LAST_YEAR,dx:PLq9sJluXvc.REPORTING_RATE,ou:ImspTQPwCqd;O6uvpzGd5pu;fdc6uOvgoji;lc3eMKXaEfw;jUb8gELQApl;PMa2VCrupOd;kJq2mPyFEHo;qhqAxPSTUXp")
+            .add("displayProperty=NAME")
+            .add("measureCriteria=EQ:0")
+            .add("relativePeriodDate=2024-04-25")
+            .add("skipMeta=true");
+
+    // When
+    ApiResponse response = analyticsActions.get(params);
+
+    // Then
+    response.validate().statusCode(200).body("rows", hasSize(equalTo(8)));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "2023", "O6uvpzGd5pu", "0"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "2023", "qhqAxPSTUXp", "0"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "2023", "fdc6uOvgoji", "0"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "2023", "jUb8gELQApl", "0"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "2023", "lc3eMKXaEfw", "0"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "2023", "kJq2mPyFEHo", "0"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "2023", "ImspTQPwCqd", "0"));
+
+    validateRow(response, List.of("PLq9sJluXvc.REPORTING_RATE", "2023", "PMa2VCrupOd", "0"));
   }
 }


### PR DESCRIPTION
The `measureCriteria` parameter was not working for reporting rates (`dimension=dx:PLq9sJluXvc.REPORTING_RATE`).
This PR fixes this issue. Now it's possible to use the `measureCriteria` with its respective operands, like: `EQ`, `GT`, etc.

During my tests, I found an additional scenario not supported by the operands: numbers with decimal digits. This issue was also fixed as part of these changes.

I also added new e2e tests covering many situations, including decimals, negative numbers, and rounding scenarios.