### PR TITLE
fix: Analytics enrollments query API using OR instead of AND[2.42-DHIS2-17419]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
@@ -103,10 +103,10 @@ public abstract class TimeFieldSqlRenderer {
    * @return the SQL statement
    */
   private String getDateRangeCondition(EventQueryParams params) {
-    List<String> orConditions = new ArrayList<>();
+    List<String> andConditions = new ArrayList<>();
 
     if (params.hasStartEndDate()) {
-      addStartEndDateToCondition(params, orConditions);
+      addStartEndDateToCondition(params, andConditions);
     }
 
     params
@@ -123,7 +123,7 @@ public abstract class TimeFieldSqlRenderer {
                 ColumnWithDateRange columnWithDateRange =
                     ColumnWithDateRange.of(
                         getColumnName(Optional.of(timeField), params.getOutputType()), dateRange);
-                orConditions.add(getDateRangeCondition(columnWithDateRange));
+                andConditions.add(getDateRangeCondition(columnWithDateRange));
               } else {
                 dateRanges.forEach(
                     dateRange -> {
@@ -131,12 +131,12 @@ public abstract class TimeFieldSqlRenderer {
                           ColumnWithDateRange.of(
                               getColumnName(Optional.of(timeField), params.getOutputType()),
                               dateRange);
-                      orConditions.add(getDateRangeCondition(columnWithDateRange));
+                      andConditions.add(getDateRangeCondition(columnWithDateRange));
                     });
               }
             });
 
-    return isNotEmpty(orConditions) ? String.join(" or ", orConditions) : EMPTY;
+    return isNotEmpty(andConditions) ? String.join(" and ", andConditions) : EMPTY;
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.analytics.event.data;
 
-import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.hisp.dhis.analytics.event.data.JdbcEventAnalyticsManager.OPEN_IN;
@@ -38,6 +37,7 @@ import static org.hisp.dhis.util.DateUtils.toMediumDate;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -103,10 +103,10 @@ public abstract class TimeFieldSqlRenderer {
    * @return the SQL statement
    */
   private String getDateRangeCondition(EventQueryParams params) {
-    List<String> andConditions = new ArrayList<>();
+    Map<String, List<String>> conditions = new HashMap<>();
 
     if (params.hasStartEndDate()) {
-      addStartEndDateToCondition(params, andConditions);
+      addStartEndDateToCondition(params, conditions);
     }
 
     params
@@ -119,24 +119,51 @@ public abstract class TimeFieldSqlRenderer {
                     new DateRange(
                         dateRanges.get(0).getStartDate(),
                         dateRanges.get(dateRanges.size() - 1).getEndDate());
-
-                ColumnWithDateRange columnWithDateRange =
-                    ColumnWithDateRange.of(
-                        getColumnName(Optional.of(timeField), params.getOutputType()), dateRange);
-                andConditions.add(getDateRangeCondition(columnWithDateRange));
+                collectDateRangeSqlConditions(params, timeField, dateRange, conditions);
               } else {
                 dateRanges.forEach(
-                    dateRange -> {
-                      ColumnWithDateRange columnWithDateRange =
-                          ColumnWithDateRange.of(
-                              getColumnName(Optional.of(timeField), params.getOutputType()),
-                              dateRange);
-                      andConditions.add(getDateRangeCondition(columnWithDateRange));
-                    });
+                    dateRange ->
+                        collectDateRangeSqlConditions(params, timeField, dateRange, conditions));
               }
             });
 
-    return isNotEmpty(andConditions) ? String.join(" and ", andConditions) : EMPTY;
+    // the same columns are in the "OR" relation
+    // different columns are in the "AND" relation
+    String dateRangeCondition =
+        String.join(
+            " and ",
+            conditions.values().stream()
+                .map(s -> "(" + String.join(" or ", s) + ")")
+                .collect(Collectors.toSet()));
+
+    return isEmpty(dateRangeCondition) ? EMPTY : dateRangeCondition;
+  }
+
+  /**
+   * The method collects all conditions grouped by the date range column name (enrollmentdate,
+   * incidentdate, etc..).
+   *
+   * @param eventQueryParams the {@link EventQueryParams}
+   * @param timeField the {@link TimeField}
+   * @param dateRange the {@link DateRange}
+   * @param conditions the Map for conditions grouped by the date range column name
+   */
+  private void collectDateRangeSqlConditions(
+      EventQueryParams eventQueryParams,
+      TimeField timeField,
+      DateRange dateRange,
+      Map<String, List<String>> conditions) {
+    ColumnWithDateRange columnWithDateRange =
+        ColumnWithDateRange.of(
+            getColumnName(Optional.of(timeField), eventQueryParams.getOutputType()), dateRange);
+    List<String> sqlConditions = conditions.get(columnWithDateRange.column);
+    if (sqlConditions == null) {
+      sqlConditions = new ArrayList<>();
+      sqlConditions.add(getDateRangeCondition(columnWithDateRange));
+      conditions.put(columnWithDateRange.column, sqlConditions);
+    } else {
+      sqlConditions.add(getDateRangeCondition(columnWithDateRange));
+    }
   }
 
   /**
@@ -161,16 +188,18 @@ public abstract class TimeFieldSqlRenderer {
    * Adds the default data range condition into the given list of conditions.
    *
    * @param params the {@link EventQueryParams}
-   * @param conditions a list of SQL conditions
+   * @param conditions a Map of SQL conditions grouped by the date range column name
    */
-  private void addStartEndDateToCondition(EventQueryParams params, List<String> conditions) {
+  private void addStartEndDateToCondition(
+      EventQueryParams params, Map<String, List<String>> conditions) {
     ColumnWithDateRange defaultDateRangeColumn =
         ColumnWithDateRange.builder()
             .column(getColumnName(getTimeField(params), params.getOutputType()))
             .dateRange(new DateRange(params.getStartDate(), params.getEndDate()))
             .build();
-
-    conditions.add(getDateRangeCondition(defaultDateRangeColumn));
+    List<String> dateRangeConditions = new ArrayList<>();
+    dateRangeConditions.add(getDateRangeCondition(defaultDateRangeColumn));
+    conditions.put(defaultDateRangeColumn.column, dateRangeConditions);
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -155,7 +155,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
     String expected =
         "ax.\"quarterly\",ax.\"ou\"  from "
             + getTable(programA.getUid())
-            + " as ax where ((enrollmentdate >= '2017-01-01' and enrollmentdate < '2018-01-01')) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) ";
+            + " as ax where (((enrollmentdate >= '2017-01-01' and enrollmentdate < '2018-01-01'))) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) ";
 
     assertSql(sql.getValue(), expected);
     assertTrue(grid.hasLastDataRow());
@@ -177,7 +177,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
     String expected =
         "ax.\"quarterly\",ax.\"ou\"  from "
             + getTable(programA.getUid())
-            + " as ax where ((lastupdated >= '2017-01-01' and lastupdated < '2018-01-01')) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
+            + " as ax where (((lastupdated >= '2017-01-01' and lastupdated < '2018-01-01'))) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
 
     assertSql(sql.getValue(), expected);
   }
@@ -590,7 +590,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + "\"  "
             + "from analytics_enrollment_"
             + programA.getUid()
-            + " as ax where ((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09')) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
+            + " as ax where (((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09'))) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
 
     assertSql(sql.getValue(), expected);
   }
@@ -639,7 +639,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + "\"  "
             + "from analytics_enrollment_"
             + programA.getUid()
-            + " as ax where ((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09')) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
+            + " as ax where (((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09'))) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
 
     assertSql(sql.getValue(), expected);
   }
@@ -714,7 +714,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + "\"  "
             + "from analytics_enrollment_"
             + programA.getUid()
-            + " as ax where ((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09')) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
+            + " as ax where (((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09'))) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
 
     assertSql(sql.getValue(), expected);
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
@@ -92,7 +92,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
     params = new EventQueryParams.Builder(params).withStartEndDatesForPeriods().build();
 
     assertEquals(
-        "((ax.\"occurreddate\" >= '2022-04-01' and ax.\"occurreddate\" < '2022-07-01')) ",
+        "(((ax.\"occurreddate\" >= '2022-04-01' and ax.\"occurreddate\" < '2022-07-01'))) ",
         eventTimeFieldSqlRenderer.renderPeriodTimeFieldSql(params));
   }
 
@@ -106,7 +106,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
     params = new EventQueryParams.Builder(params).withStartEndDatesForPeriods().build();
 
     assertEquals(
-        "((ax.\"occurreddate\" >= '2022-04-01' and ax.\"occurreddate\" < '2022-07-01')) ",
+        "(((ax.\"occurreddate\" >= '2022-04-01' and ax.\"occurreddate\" < '2022-07-01'))) ",
         eventTimeFieldSqlRenderer.renderPeriodTimeFieldSql(params));
   }
 
@@ -120,7 +120,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
     params = new EventQueryParams.Builder(params).withStartEndDatesForPeriods().build();
 
     assertEquals(
-        "((enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-07-01')) ",
+        "(((enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-07-01'))) ",
         enrollmentTimeFieldSqlRenderer.renderPeriodTimeFieldSql(params));
   }
 
@@ -134,7 +134,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
     params = new EventQueryParams.Builder(params).withStartEndDatesForPeriods().build();
 
     assertEquals(
-        "((enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-07-01')) ",
+        "(((enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-07-01'))) ",
         enrollmentTimeFieldSqlRenderer.renderPeriodTimeFieldSql(params));
   }
 
@@ -149,7 +149,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
     params = new EventQueryParams.Builder(params).withStartEndDatesForPeriods().build();
 
     assertEquals(
-        "((lastupdated >= '2022-04-01' and lastupdated < '2022-07-01')) ",
+        "(((lastupdated >= '2022-04-01' and lastupdated < '2022-07-01'))) ",
         enrollmentTimeFieldSqlRenderer.renderPeriodTimeFieldSql(params));
   }
 
@@ -164,7 +164,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
     params = new EventQueryParams.Builder(params).withStartEndDatesForPeriods().build();
 
     assertEquals(
-        "((ax.\"occurreddate\" >= '2022-04-01' and ax.\"occurreddate\" < '2022-07-01')) ",
+        "(((ax.\"occurreddate\" >= '2022-04-01' and ax.\"occurreddate\" < '2022-07-01'))) ",
         eventTimeFieldSqlRenderer.renderPeriodTimeFieldSql(params));
   }
 
@@ -190,8 +190,8 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
     params = new EventQueryParams.Builder(params).withStartEndDatesForPeriods().build();
 
     assertEquals(
-        "((ax.\"scheduleddate\" >= '2022-03-01' and ax.\"scheduleddate\" < '2022-04-01') "
-            + "and (ax.\"scheduleddate\" >= '2022-09-01' and ax.\"scheduleddate\" < '2022-10-01')) ",
+        "(((ax.\"scheduleddate\" >= '2022-03-01' and ax.\"scheduleddate\" < '2022-04-01') "
+            + "or (ax.\"scheduleddate\" >= '2022-09-01' and ax.\"scheduleddate\" < '2022-10-01'))) ",
         eventTimeFieldSqlRenderer.renderPeriodTimeFieldSql(params));
   }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
@@ -191,7 +191,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
 
     assertEquals(
         "((ax.\"scheduleddate\" >= '2022-03-01' and ax.\"scheduleddate\" < '2022-04-01') "
-            + "or (ax.\"scheduleddate\" >= '2022-09-01' and ax.\"scheduleddate\" < '2022-10-01')) ",
+            + "and (ax.\"scheduleddate\" >= '2022-09-01' and ax.\"scheduleddate\" < '2022-10-01')) ",
         eventTimeFieldSqlRenderer.renderPeriodTimeFieldSql(params));
   }
 

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery3AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery3AutoTest.java
@@ -603,8 +603,10 @@ public class EnrollmentsQuery3AutoTest extends AnalyticsApiTest {
 
   @Test
   public void queryRandomQuery14() throws JSONException {
-// Given
-    QueryParamsBuilder params = new QueryParamsBuilder().add("includeMetadataDetails=true")
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
             .add("asc=incidentdate,ouname")
             .add("headers=ouname,enrollmentdate,incidentdate")
             .add("displayProperty=NAME")
@@ -615,41 +617,67 @@ public class EnrollmentsQuery3AutoTest extends AnalyticsApiTest {
             .add("outputType=ENROLLMENT")
             .add("page=1")
             .add("incidentDate=202308,202308")
-            .add("dimension=ou:USER_ORGUNIT")
-            ;
+            .add("dimension=ou:USER_ORGUNIT");
 
-// When
-    ApiResponse response = actions.query().get("IpHINAT79UW",JSON, JSON, params);
+    // When
+    ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
 
-// Then
-    response.validate().statusCode(200)
-            .body("headers", hasSize(equalTo(3)))
-            .body("rows", hasSize(equalTo(5)))
-            .body("height", equalTo(5))
-            .body("width", equalTo(3))
-            .body("headerWidth", equalTo(3));
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(3)))
+        .body("rows", hasSize(equalTo(5)))
+        .body("height", equalTo(5))
+        .body("width", equalTo(3))
+        .body("headerWidth", equalTo(3));
 
-// Assert metaData.
-    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202308\":{\"name\":\"August 2023\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202308\":{\"name\":\"August 2023\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
-// Assert headers.
-    validateHeader(response,0,"ouname","Organisation unit name","TEXT","java.lang.String",false,true);
-    validateHeader(response,1,"enrollmentdate","Date of enrollment","DATE","java.time.LocalDate",false,true);
-    validateHeader(response,2,"incidentdate","Date of birth","DATE","java.time.LocalDate",false,true);
+    // Assert headers.
+    validateHeader(
+        response, 0, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, true);
+    validateHeader(
+        response,
+        1,
+        "enrollmentdate",
+        "Date of enrollment",
+        "DATE",
+        "java.time.LocalDate",
+        false,
+        true);
+    validateHeader(
+        response, 2, "incidentdate", "Date of birth", "DATE", "java.time.LocalDate", false, true);
 
-// Assert rows.
-    validateRow(response,0, List.of("Banka Makuloh MCHP","2023-08-01 12:05:00.0","2023-08-01 12:05:00.0"));
-    validateRow(response,1, List.of("Baoma Station CHP","2023-08-01 12:05:00.0","2023-08-01 12:05:00.0"));
-    validateRow(response,2, List.of("Bomie MCHP","2023-08-01 12:05:00.0","2023-08-01 12:05:00.0"));
-    validateRow(response,3, List.of("Bumban MCHP","2023-08-01 12:05:00.0","2023-08-01 12:05:00.0"));
-    validateRow(response,4, List.of("Gbonkoh Kareneh MCHP","2023-08-01 12:05:00.0","2023-08-01 12:05:00.0"));
+    // Assert rows.
+    validateRow(
+        response,
+        0,
+        List.of("Banka Makuloh MCHP", "2023-08-01 12:05:00.0", "2023-08-01 12:05:00.0"));
+    validateRow(
+        response,
+        1,
+        List.of("Baoma Station CHP", "2023-08-01 12:05:00.0", "2023-08-01 12:05:00.0"));
+    validateRow(
+        response, 2, List.of("Bomie MCHP", "2023-08-01 12:05:00.0", "2023-08-01 12:05:00.0"));
+    validateRow(
+        response, 3, List.of("Bumban MCHP", "2023-08-01 12:05:00.0", "2023-08-01 12:05:00.0"));
+    validateRow(
+        response,
+        4,
+        List.of("Gbonkoh Kareneh MCHP", "2023-08-01 12:05:00.0", "2023-08-01 12:05:00.0"));
   }
 
   @Test
   public void queryRandomQuery15() throws JSONException {
-// Given
-    QueryParamsBuilder params = new QueryParamsBuilder().add("includeMetadataDetails=true")
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
             .add("asc=incidentdate,ouname")
             .add("headers=ouname,enrollmentdate,incidentdate")
             .add("displayProperty=NAME")
@@ -659,34 +687,54 @@ public class EnrollmentsQuery3AutoTest extends AnalyticsApiTest {
             .add("outputType=ENROLLMENT")
             .add("page=1")
             .add("incidentDate=202301,202401")
-            .add("dimension=ou:USER_ORGUNIT")
-            ;
+            .add("dimension=ou:USER_ORGUNIT");
 
-// When
-    ApiResponse response = actions.query().get("IpHINAT79UW",JSON, JSON, params);
+    // When
+    ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
 
-// Then
-    response.validate().statusCode(200)
-            .body("headers", hasSize(equalTo(3)))
-            .body("rows", hasSize(equalTo(5)))
-            .body("height", equalTo(5))
-            .body("width", equalTo(3))
-            .body("headerWidth", equalTo(3));
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(3)))
+        .body("rows", hasSize(equalTo(5)))
+        .body("height", equalTo(5))
+        .body("width", equalTo(3))
+        .body("headerWidth", equalTo(3));
 
-// Assert metaData.
-    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"},\"202401\":{\"name\":\"January 2024\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"},\"202401\":{\"name\":\"January 2024\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
     assertEquals(expectedMetaData, actualMetaData, false);
 
-// Assert headers.
-    validateHeader(response,0,"ouname","Organisation unit name","TEXT","java.lang.String",false,true);
-    validateHeader(response,1,"enrollmentdate","Date of enrollment","DATE","java.time.LocalDate",false,true);
-    validateHeader(response,2,"incidentdate","Date of birth","DATE","java.time.LocalDate",false,true);
+    // Assert headers.
+    validateHeader(
+        response, 0, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, true);
+    validateHeader(
+        response,
+        1,
+        "enrollmentdate",
+        "Date of enrollment",
+        "DATE",
+        "java.time.LocalDate",
+        false,
+        true);
+    validateHeader(
+        response, 2, "incidentdate", "Date of birth", "DATE", "java.time.LocalDate", false, true);
 
-// Assert rows.
-    validateRow(response,0, List.of("Ngelehun CHC","2023-01-01 00:00:00.0","2023-01-01 00:00:00.0"));
-    validateRow(response,1, List.of("Fulamansa MCHP","2023-01-01 12:05:00.0","2023-01-01 12:05:00.0"));
-    validateRow(response,2, List.of("Kordebotehun MCHP","2023-01-01 12:05:00.0","2023-01-01 12:05:00.0"));
-    validateRow(response,3, List.of("Largo CHC","2023-01-01 12:05:00.0","2023-01-01 12:05:00.0"));
-    validateRow(response,4, List.of("Manjeihun MCHP","2023-01-01 12:05:00.0","2023-01-01 12:05:00.0"));
+    // Assert rows.
+    validateRow(
+        response, 0, List.of("Ngelehun CHC", "2023-01-01 00:00:00.0", "2023-01-01 00:00:00.0"));
+    validateRow(
+        response, 1, List.of("Fulamansa MCHP", "2023-01-01 12:05:00.0", "2023-01-01 12:05:00.0"));
+    validateRow(
+        response,
+        2,
+        List.of("Kordebotehun MCHP", "2023-01-01 12:05:00.0", "2023-01-01 12:05:00.0"));
+    validateRow(
+        response, 3, List.of("Largo CHC", "2023-01-01 12:05:00.0", "2023-01-01 12:05:00.0"));
+    validateRow(
+        response, 4, List.of("Manjeihun MCHP", "2023-01-01 12:05:00.0", "2023-01-01 12:05:00.0"));
   }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery3AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery3AutoTest.java
@@ -531,4 +531,73 @@ public class EnrollmentsQuery3AutoTest extends AnalyticsApiTest {
             "DiszpKrYNg8",
             ""));
   }
+
+  @Test
+  public void queryRandomQuery13() throws JSONException {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("includeMetadataDetails=true")
+            .add("asc=incidentdate,ouname")
+            .add("headers=ouname,enrollmentdate,incidentdate")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("enrollmentDate=202301,202201")
+            .add("rowContext=true")
+            .add("pageSize=5")
+            .add("outputType=ENROLLMENT")
+            .add("page=1")
+            .add("incidentDate=202201,202301")
+            .add("dimension=ou:USER_ORGUNIT");
+
+    // When
+    ApiResponse response = actions.query().get("IpHINAT79UW", JSON, JSON, params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(200)
+        .body("headers", hasSize(equalTo(3)))
+        .body("rows", hasSize(equalTo(5)))
+        .body("height", equalTo(5))
+        .body("width", equalTo(3))
+        .body("headerWidth", equalTo(3));
+
+    // Assert metaData.
+    String expectedMetaData =
+        "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"202201\":{\"name\":\"January 2022\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";
+    String actualMetaData = new JSONObject((Map) response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+    // Assert headers.
+    validateHeader(
+        response, 0, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, true);
+    validateHeader(
+        response,
+        1,
+        "enrollmentdate",
+        "Date of enrollment",
+        "DATE",
+        "java.time.LocalDate",
+        false,
+        true);
+    validateHeader(
+        response, 2, "incidentdate", "Date of birth", "DATE", "java.time.LocalDate", false, true);
+
+    // Assert rows.
+    validateRow(
+        response, 0, List.of("Baiwala CHP", "2022-01-01 12:05:00.0", "2022-01-01 12:05:00.0"));
+    validateRow(
+        response,
+        1,
+        List.of("Bandajuma Sinneh MCHP", "2022-01-01 12:05:00.0", "2022-01-01 12:05:00.0"));
+    validateRow(
+        response,
+        2,
+        List.of("Banka Makuloh MCHP", "2022-01-01 12:05:00.0", "2022-01-01 12:05:00.0"));
+    validateRow(
+        response, 3, List.of("Conakry Dee CHC", "2022-01-01 12:05:00.0", "2022-01-01 12:05:00.0"));
+    validateRow(
+        response, 4, List.of("Dankawalie MCHP", "2022-01-01 12:05:00.0", "2022-01-01 12:05:00.0"));
+  }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery3AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery3AutoTest.java
@@ -600,4 +600,93 @@ public class EnrollmentsQuery3AutoTest extends AnalyticsApiTest {
     validateRow(
         response, 4, List.of("Dankawalie MCHP", "2022-01-01 12:05:00.0", "2022-01-01 12:05:00.0"));
   }
+
+  @Test
+  public void queryRandomQuery14() throws JSONException {
+// Given
+    QueryParamsBuilder params = new QueryParamsBuilder().add("includeMetadataDetails=true")
+            .add("asc=incidentdate,ouname")
+            .add("headers=ouname,enrollmentdate,incidentdate")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("enrollmentDate=202308")
+            .add("rowContext=true")
+            .add("pageSize=5")
+            .add("outputType=ENROLLMENT")
+            .add("page=1")
+            .add("incidentDate=202308,202308")
+            .add("dimension=ou:USER_ORGUNIT")
+            ;
+
+// When
+    ApiResponse response = actions.query().get("IpHINAT79UW",JSON, JSON, params);
+
+// Then
+    response.validate().statusCode(200)
+            .body("headers", hasSize(equalTo(3)))
+            .body("rows", hasSize(equalTo(5)))
+            .body("height", equalTo(5))
+            .body("width", equalTo(3))
+            .body("headerWidth", equalTo(3));
+
+// Assert metaData.
+    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202308\":{\"name\":\"August 2023\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+// Assert headers.
+    validateHeader(response,0,"ouname","Organisation unit name","TEXT","java.lang.String",false,true);
+    validateHeader(response,1,"enrollmentdate","Date of enrollment","DATE","java.time.LocalDate",false,true);
+    validateHeader(response,2,"incidentdate","Date of birth","DATE","java.time.LocalDate",false,true);
+
+// Assert rows.
+    validateRow(response,0, List.of("Banka Makuloh MCHP","2023-08-01 12:05:00.0","2023-08-01 12:05:00.0"));
+    validateRow(response,1, List.of("Baoma Station CHP","2023-08-01 12:05:00.0","2023-08-01 12:05:00.0"));
+    validateRow(response,2, List.of("Bomie MCHP","2023-08-01 12:05:00.0","2023-08-01 12:05:00.0"));
+    validateRow(response,3, List.of("Bumban MCHP","2023-08-01 12:05:00.0","2023-08-01 12:05:00.0"));
+    validateRow(response,4, List.of("Gbonkoh Kareneh MCHP","2023-08-01 12:05:00.0","2023-08-01 12:05:00.0"));
+  }
+
+  @Test
+  public void queryRandomQuery15() throws JSONException {
+// Given
+    QueryParamsBuilder params = new QueryParamsBuilder().add("includeMetadataDetails=true")
+            .add("asc=incidentdate,ouname")
+            .add("headers=ouname,enrollmentdate,incidentdate")
+            .add("displayProperty=NAME")
+            .add("totalPages=false")
+            .add("rowContext=true")
+            .add("pageSize=5")
+            .add("outputType=ENROLLMENT")
+            .add("page=1")
+            .add("incidentDate=202301,202401")
+            .add("dimension=ou:USER_ORGUNIT")
+            ;
+
+// When
+    ApiResponse response = actions.query().get("IpHINAT79UW",JSON, JSON, params);
+
+// Then
+    response.validate().statusCode(200)
+            .body("headers", hasSize(equalTo(3)))
+            .body("rows", hasSize(equalTo(5)))
+            .body("height", equalTo(5))
+            .body("width", equalTo(3))
+            .body("headerWidth", equalTo(3));
+
+// Assert metaData.
+    String expectedMetaData = "{\"pager\":{\"page\":1,\"pageSize\":5,\"isLastPage\":false},\"items\":{\"ImspTQPwCqd\":{\"uid\":\"ImspTQPwCqd\",\"code\":\"OU_525\",\"name\":\"Sierra Leone\",\"dimensionItemType\":\"ORGANISATION_UNIT\",\"valueType\":\"TEXT\",\"totalAggregationType\":\"SUM\"},\"IpHINAT79UW\":{\"uid\":\"IpHINAT79UW\",\"name\":\"Child Programme\"},\"ZzYYXq4fJie\":{\"uid\":\"ZzYYXq4fJie\",\"name\":\"Baby Postnatal\",\"description\":\"Baby Postnatal\"},\"USER_ORGUNIT\":{\"organisationUnits\":[\"ImspTQPwCqd\"]},\"ou\":{\"uid\":\"ou\",\"name\":\"Organisation unit\",\"dimensionType\":\"ORGANISATION_UNIT\"},\"A03MvHHogjR\":{\"uid\":\"A03MvHHogjR\",\"name\":\"Birth\",\"description\":\"Birth of the baby\"},\"202301\":{\"name\":\"January 2023\"},\"202401\":{\"name\":\"January 2024\"}},\"dimensions\":{\"pe\":[],\"ou\":[\"ImspTQPwCqd\"]}}";String actualMetaData = new JSONObject((Map)response.extract("metaData")).toString();
+    assertEquals(expectedMetaData, actualMetaData, false);
+
+// Assert headers.
+    validateHeader(response,0,"ouname","Organisation unit name","TEXT","java.lang.String",false,true);
+    validateHeader(response,1,"enrollmentdate","Date of enrollment","DATE","java.time.LocalDate",false,true);
+    validateHeader(response,2,"incidentdate","Date of birth","DATE","java.time.LocalDate",false,true);
+
+// Assert rows.
+    validateRow(response,0, List.of("Ngelehun CHC","2023-01-01 00:00:00.0","2023-01-01 00:00:00.0"));
+    validateRow(response,1, List.of("Fulamansa MCHP","2023-01-01 12:05:00.0","2023-01-01 12:05:00.0"));
+    validateRow(response,2, List.of("Kordebotehun MCHP","2023-01-01 12:05:00.0","2023-01-01 12:05:00.0"));
+    validateRow(response,3, List.of("Largo CHC","2023-01-01 12:05:00.0","2023-01-01 12:05:00.0"));
+    validateRow(response,4, List.of("Manjeihun MCHP","2023-01-01 12:05:00.0","2023-01-01 12:05:00.0"));
+  }
 }


### PR DESCRIPTION
At the request of the reporter, the dates (for example, enrollment and incident date) should be linked by an "AND" relation. This was implemented by changing the previous "OR" relation to an "AND" one.