### PR TITLE
fix: Analytics enrollments query API using OR instead of AND[2.39-DHIS2-17149-backport]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.analytics.event.data;
 
-import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.hisp.dhis.analytics.event.data.JdbcEventAnalyticsManager.OPEN_IN;
@@ -38,6 +37,7 @@ import static org.hisp.dhis.util.DateUtils.getMediumDateString;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -98,10 +98,10 @@ public abstract class TimeFieldSqlRenderer {
    * @return the SQL statement
    */
   private String getDateRangeCondition(EventQueryParams params) {
-    List<String> orConditions = new ArrayList<>();
+    Map<String, List<String>> conditions = new HashMap<>();
 
     if (params.hasStartEndDate()) {
-      addStartEndDateToCondition(params, orConditions);
+      addStartEndDateToCondition(params, conditions);
     }
 
     params
@@ -115,24 +115,51 @@ public abstract class TimeFieldSqlRenderer {
                     new DateRange(
                         dateRanges.get(0).getStartDate(),
                         dateRanges.get(dateRanges.size() - 1).getEndDate());
-
-                ColumnWithDateRange columnWithDateRange =
-                    ColumnWithDateRange.of(
-                        getColumnName(Optional.of(timeField), params.getOutputType()), dateRange);
-                orConditions.add(getDateRangeCondition(columnWithDateRange));
+                collectDateRangeSqlConditions(params, timeField, dateRange, conditions);
               } else {
                 dateRanges.forEach(
-                    dateRange -> {
-                      ColumnWithDateRange columnWithDateRange =
-                          ColumnWithDateRange.of(
-                              getColumnName(Optional.of(timeField), params.getOutputType()),
-                              dateRange);
-                      orConditions.add(getDateRangeCondition(columnWithDateRange));
-                    });
+                    dateRange ->
+                        collectDateRangeSqlConditions(params, timeField, dateRange, conditions));
               }
             });
 
-    return isNotEmpty(orConditions) ? String.join(" or ", orConditions) : EMPTY;
+    // the same columns are in the "OR" relation
+    // different columns are in the "AND" relation
+    String dateRangeCondition =
+        String.join(
+            " and ",
+            conditions.values().stream()
+                .map(s -> "(" + String.join(" or ", s) + ")")
+                .collect(Collectors.toSet()));
+
+    return isEmpty(dateRangeCondition) ? EMPTY : dateRangeCondition;
+  }
+
+  /**
+   * The method collects all conditions grouped by the date range column name (enrollmentdate,
+   * incidentdate, etc..).
+   *
+   * @param eventQueryParams the {@link EventQueryParams}
+   * @param timeField the {@link TimeField}
+   * @param dateRange the {@link DateRange}
+   * @param conditions the Map for conditions grouped by the date range column name
+   */
+  private void collectDateRangeSqlConditions(
+      EventQueryParams eventQueryParams,
+      TimeField timeField,
+      DateRange dateRange,
+      Map<String, List<String>> conditions) {
+    ColumnWithDateRange columnWithDateRange =
+        ColumnWithDateRange.of(
+            getColumnName(Optional.of(timeField), eventQueryParams.getOutputType()), dateRange);
+    List<String> sqlConditions = conditions.get(columnWithDateRange.column);
+    if (sqlConditions == null) {
+      sqlConditions = new ArrayList<>();
+      sqlConditions.add(getDateRangeCondition(columnWithDateRange));
+      conditions.put(columnWithDateRange.column, sqlConditions);
+    } else {
+      sqlConditions.add(getDateRangeCondition(columnWithDateRange));
+    }
   }
 
   /**
@@ -157,16 +184,18 @@ public abstract class TimeFieldSqlRenderer {
    * Adds the default data range condition into the given list of conditions.
    *
    * @param params the {@link EventQueryParams}
-   * @param conditions a list of SQL conditions
+   * @param conditions a Map of SQL conditions grouped by the date range column name
    */
-  private void addStartEndDateToCondition(EventQueryParams params, List<String> conditions) {
+  private void addStartEndDateToCondition(
+      EventQueryParams params, Map<String, List<String>> conditions) {
     ColumnWithDateRange defaultDateRangeColumn =
         ColumnWithDateRange.builder()
             .column(getColumnName(getTimeField(params), params.getOutputType()))
             .dateRange(new DateRange(params.getStartDate(), params.getEndDate()))
             .build();
-
-    conditions.add(getDateRangeCondition(defaultDateRangeColumn));
+    List<String> dateRangeConditions = new ArrayList<>();
+    dateRangeConditions.add(getDateRangeCondition(defaultDateRangeColumn));
+    conditions.put(defaultDateRangeColumn.column, dateRangeConditions);
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -154,7 +154,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
     String expected =
         "ax.\"quarterly\",ax.\"ou\"  from "
             + getTable(programA.getUid())
-            + " as ax where ((enrollmentdate >= '2017-01-01' and enrollmentdate < '2018-01-01')) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) ";
+            + " as ax where (((enrollmentdate >= '2017-01-01' and enrollmentdate < '2018-01-01'))) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) ";
 
     assertTrue(grid.hasLastDataRow());
     assertSql(sql.getValue(), expected);
@@ -176,7 +176,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
     String expected =
         "ax.\"quarterly\",ax.\"ou\"  from "
             + getTable(programA.getUid())
-            + " as ax where ((lastupdated >= '2017-01-01' and lastupdated < '2018-01-01')) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
+            + " as ax where (((lastupdated >= '2017-01-01' and lastupdated < '2018-01-01'))) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
 
     assertSql(sql.getValue(), expected);
   }
@@ -558,7 +558,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + "\"  "
             + "from analytics_enrollment_"
             + programA.getUid()
-            + " as ax where ((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09')) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
+            + " as ax where (((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09'))) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
 
     assertSql(sql.getValue(), expected);
   }
@@ -607,7 +607,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + "\"  "
             + "from analytics_enrollment_"
             + programA.getUid()
-            + " as ax where ((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09')) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
+            + " as ax where (((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09'))) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
 
     assertSql(sql.getValue(), expected);
   }
@@ -682,7 +682,7 @@ class EnrollmentAnalyticsManagerTest extends EventAnalyticsTest {
             + "\"  "
             + "from analytics_enrollment_"
             + programA.getUid()
-            + " as ax where ((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09')) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
+            + " as ax where (((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09'))) and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
 
     assertSql(sql.getValue(), expected);
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
@@ -86,7 +86,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
     params = new EventQueryParams.Builder(params).withStartEndDatesForPeriods().build();
 
     assertEquals(
-        "(((ax.\"occurreddate\" >= '2022-04-01' and ax.\"occurreddate\" < '2022-07-01'))) ",
+        "(((ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-07-01'))) ",
         timeFieldSqlRenderer.renderPeriodTimeFieldSql(params));
   }
 
@@ -103,7 +103,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
     params = new EventQueryParams.Builder(params).withStartEndDatesForPeriods().build();
 
     assertEquals(
-        "(((ax.\"occurreddate\" >= '2022-04-01' and ax.\"occurreddate\" < '2022-07-01'))) ",
+        "(((ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-07-01'))) ",
         timeFieldSqlRenderer.renderPeriodTimeFieldSql(params));
   }
 
@@ -172,7 +172,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
     params = new EventQueryParams.Builder(params).withStartEndDatesForPeriods().build();
 
     assertEquals(
-        "(((ax.\"occurreddate\" >= '2022-04-01' and ax.\"occurreddate\" < '2022-07-01'))) ",
+        "(((ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-07-01'))) ",
         timeFieldSqlRenderer.renderPeriodTimeFieldSql(params));
   }
 
@@ -201,8 +201,8 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
     params = new EventQueryParams.Builder(params).withStartEndDatesForPeriods().build();
 
     assertEquals(
-        "(((ax.\"scheduleddate\" >= '2022-03-01' and ax.\"scheduleddate\" < '2022-04-01') "
-            + "or (ax.\"scheduleddate\" >= '2022-09-01' and ax.\"scheduleddate\" < '2022-10-01'))) ",
+        "(((ax.\"duedate\" >= '2022-03-01' and ax.\"duedate\" < '2022-04-01') "
+            + "or (ax.\"duedate\" >= '2022-09-01' and ax.\"duedate\" < '2022-10-01'))) ",
         timeFieldSqlRenderer.renderPeriodTimeFieldSql(params));
   }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
@@ -86,7 +86,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
     params = new EventQueryParams.Builder(params).withStartEndDatesForPeriods().build();
 
     assertEquals(
-        "((ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-07-01')) ",
+        "(((ax.\"occurreddate\" >= '2022-04-01' and ax.\"occurreddate\" < '2022-07-01'))) ",
         timeFieldSqlRenderer.renderPeriodTimeFieldSql(params));
   }
 
@@ -103,7 +103,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
     params = new EventQueryParams.Builder(params).withStartEndDatesForPeriods().build();
 
     assertEquals(
-        "((ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-07-01')) ",
+        "(((ax.\"occurreddate\" >= '2022-04-01' and ax.\"occurreddate\" < '2022-07-01'))) ",
         timeFieldSqlRenderer.renderPeriodTimeFieldSql(params));
   }
 
@@ -119,7 +119,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
     params = new EventQueryParams.Builder(params).withStartEndDatesForPeriods().build();
 
     assertEquals(
-        "((enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-07-01')) ",
+        "(((enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-07-01'))) ",
         timeFieldSqlRenderer.renderPeriodTimeFieldSql(params));
   }
 
@@ -136,7 +136,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
     params = new EventQueryParams.Builder(params).withStartEndDatesForPeriods().build();
 
     assertEquals(
-        "((enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-07-01')) ",
+        "(((enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-07-01'))) ",
         timeFieldSqlRenderer.renderPeriodTimeFieldSql(params));
   }
 
@@ -154,7 +154,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
     params = new EventQueryParams.Builder(params).withStartEndDatesForPeriods().build();
 
     assertEquals(
-        "((lastupdated >= '2022-04-01' and lastupdated < '2022-07-01')) ",
+        "(((lastupdated >= '2022-04-01' and lastupdated < '2022-07-01'))) ",
         timeFieldSqlRenderer.renderPeriodTimeFieldSql(params));
   }
 
@@ -172,7 +172,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
     params = new EventQueryParams.Builder(params).withStartEndDatesForPeriods().build();
 
     assertEquals(
-        "((ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-07-01')) ",
+        "(((ax.\"occurreddate\" >= '2022-04-01' and ax.\"occurreddate\" < '2022-07-01'))) ",
         timeFieldSqlRenderer.renderPeriodTimeFieldSql(params));
   }
 
@@ -201,8 +201,8 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest {
     params = new EventQueryParams.Builder(params).withStartEndDatesForPeriods().build();
 
     assertEquals(
-        "((ax.\"duedate\" >= '2022-03-01' and ax.\"duedate\" < '2022-04-01') "
-            + "or (ax.\"duedate\" >= '2022-09-01' and ax.\"duedate\" < '2022-10-01')) ",
+        "(((ax.\"scheduleddate\" >= '2022-03-01' and ax.\"scheduleddate\" < '2022-04-01') "
+            + "or (ax.\"scheduleddate\" >= '2022-09-01' and ax.\"scheduleddate\" < '2022-10-01'))) ",
         timeFieldSqlRenderer.renderPeriodTimeFieldSql(params));
   }
 


### PR DESCRIPTION
**Backport**
At the request of the reporter, the dates (for example, enrollment and incident date) should be linked by an "AND" relation. This was implemented by changing the previous "OR" relation to an "AND" one.