### PR TITLE
fix(app): use correct authority for overidden bundled-apps (#16488)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
@@ -439,6 +439,10 @@ public class App implements Serializable {
   }
 
   public String getSeeAppAuthority() {
+    if (isBundled()) {
+      return SEE_APP_AUTHORITY_PREFIX + AppManager.BUNDLED_APP_PREFIX + getShortName();
+    }
+
     return SEE_APP_AUTHORITY_PREFIX
         + getShortName().trim().replaceAll("[^a-zA-Z0-9\\s]", "").replaceAll("\\s+", "_");
   }


### PR DESCRIPTION
Backport to `patch/2.40.3.1` of #16488 

Approved by RCB for 2.40.3.1: https://dhis2.atlassian.net/browse/DHIS2-16794
