### PR TITLE
fix: Change DATE columns to DATETIME [DHIS2-17299]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/DimensionParam.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/DimensionParam.java
@@ -44,7 +44,6 @@ import static org.hisp.dhis.analytics.tei.query.context.TeiStaticField.TRACKED_E
 import static org.hisp.dhis.common.DimensionType.PERIOD;
 import static org.hisp.dhis.common.QueryOperator.EQ;
 import static org.hisp.dhis.common.ValueType.COORDINATE;
-import static org.hisp.dhis.common.ValueType.DATE;
 import static org.hisp.dhis.common.ValueType.DATETIME;
 import static org.hisp.dhis.common.ValueType.GEOJSON;
 import static org.hisp.dhis.common.ValueType.TEXT;
@@ -252,10 +251,10 @@ public class DimensionParam implements UidObject {
     OUCODE("Organisation Unit Code", TEXT, ORGANISATION_UNIT, ORG_UNIT_CODE),
     OUNAMEHIERARCHY(
         "Organisation Unit Name Hierarchy", TEXT, ORGANISATION_UNIT, ORG_UNIT_NAME_HIERARCHY),
-    ENROLLMENTDATE("Enrollment Date", DATE, DimensionParamObjectType.PERIOD),
+    ENROLLMENTDATE("Enrollment Date", DATETIME, DimensionParamObjectType.PERIOD),
     ENDDATE("End Date", DATETIME, DimensionParamObjectType.PERIOD),
-    INCIDENTDATE("Incident Date", DATE, DimensionParamObjectType.PERIOD),
-    OCCURREDDATE("Execution Date", DATE, DimensionParamObjectType.PERIOD),
+    INCIDENTDATE("Incident Date", DATETIME, DimensionParamObjectType.PERIOD),
+    OCCURREDDATE("Execution Date", DATETIME, DimensionParamObjectType.PERIOD),
     LASTUPDATED(DATETIME, DimensionParamObjectType.PERIOD, TeiStaticField.LAST_UPDATED),
     LASTUPDATEDBYDISPLAYNAME("Last Updated By", TEXT, STATIC),
     CREATED("Created", DATETIME, DimensionParamObjectType.PERIOD),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEnrollmentAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEnrollmentAnalyticsService.java
@@ -49,7 +49,7 @@ import static org.hisp.dhis.analytics.event.LabelMapper.getEnrollmentDateLabel;
 import static org.hisp.dhis.analytics.event.LabelMapper.getEnrollmentLabel;
 import static org.hisp.dhis.analytics.event.LabelMapper.getIncidentDateLabel;
 import static org.hisp.dhis.analytics.event.LabelMapper.getOrgUnitLabel;
-import static org.hisp.dhis.common.ValueType.DATE;
+import static org.hisp.dhis.common.ValueType.DATETIME;
 import static org.hisp.dhis.common.ValueType.NUMBER;
 import static org.hisp.dhis.common.ValueType.TEXT;
 
@@ -128,14 +128,14 @@ public class DefaultEnrollmentAnalyticsService extends AbstractAnalyticsService
             new GridHeader(
                 ENROLLMENT_DATE.getItem(),
                 getEnrollmentDateLabel(params.getProgram(), ENROLLMENT_DATE.getName()),
-                DATE,
+                DATETIME,
                 false,
                 true))
         .addHeader(
             new GridHeader(
                 INCIDENT_DATE.getItem(),
                 getIncidentDateLabel(params.getProgram(), INCIDENT_DATE.getName()),
-                DATE,
+                DATETIME,
                 false,
                 true))
         .addHeader(new GridHeader(STORED_BY.getItem(), STORED_BY.getName(), TEXT, false, true))
@@ -154,7 +154,7 @@ public class DefaultEnrollmentAnalyticsService extends AbstractAnalyticsService
                 false,
                 true))
         .addHeader(
-            new GridHeader(LAST_UPDATED.getItem(), LAST_UPDATED.getName(), DATE, false, true))
+            new GridHeader(LAST_UPDATED.getItem(), LAST_UPDATED.getName(), DATETIME, false, true))
         .addHeader(new GridHeader(GEOMETRY.getItem(), GEOMETRY.getName(), TEXT, false, true))
         .addHeader(new GridHeader(LONGITUDE.getItem(), LONGITUDE.getName(), NUMBER, false, true))
         .addHeader(new GridHeader(LATITUDE.getItem(), LATITUDE.getName(), NUMBER, false, true))

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
@@ -74,7 +74,7 @@ import static org.hisp.dhis.common.DimensionalObject.DATA_X_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 import static org.hisp.dhis.common.ValueType.BOOLEAN;
-import static org.hisp.dhis.common.ValueType.DATE;
+import static org.hisp.dhis.common.ValueType.DATETIME;
 import static org.hisp.dhis.common.ValueType.NUMBER;
 import static org.hisp.dhis.common.ValueType.TEXT;
 
@@ -708,7 +708,7 @@ public class DefaultEventAnalyticsService extends AbstractAnalyticsService
             new GridHeader(
                 EVENT_DATE.getItem(),
                 getEventDateLabel(params.getProgramStage(), EVENT_DATE.getName()),
-                DATE,
+                DATETIME,
                 false,
                 true))
         .addHeader(new GridHeader(STORED_BY.getItem(), STORED_BY.getName(), TEXT, false, true))
@@ -727,12 +727,12 @@ public class DefaultEventAnalyticsService extends AbstractAnalyticsService
                 false,
                 true))
         .addHeader(
-            new GridHeader(LAST_UPDATED.getItem(), LAST_UPDATED.getName(), DATE, false, true))
+            new GridHeader(LAST_UPDATED.getItem(), LAST_UPDATED.getName(), DATETIME, false, true))
         .addHeader(
             new GridHeader(
                 SCHEDULED_DATE.getItem(),
                 getScheduledDateLabel(params.getProgramStage(), SCHEDULED_DATE.getName()),
-                DATE,
+                DATETIME,
                 false,
                 true));
 
@@ -741,14 +741,14 @@ public class DefaultEventAnalyticsService extends AbstractAnalyticsService
               new GridHeader(
                   ENROLLMENT_DATE.getItem(),
                   getEnrollmentDateLabel(params.getProgram(), ENROLLMENT_DATE.getName()),
-                  DATE,
+                  DATETIME,
                   false,
                   true))
           .addHeader(
               new GridHeader(
                   INCIDENT_DATE.getItem(),
                   getIncidentDateLabel(params.getProgram(), INCIDENT_DATE.getName()),
-                  DATE,
+                  DATETIME,
                   false,
                   true))
           .addHeader(

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentQueryTest.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.analytics.enrollment;
+package org.hisp.dhis.analytics.enrollment.query;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -104,12 +104,19 @@ public class EnrollmentQueryTest extends AnalyticsApiTest {
         2,
         "enrollmentdate",
         "Date of enrollment",
-        "DATE",
-        "java.time.LocalDate",
+        "DATETIME",
+        "java.time.LocalDateTime",
         false,
         true);
     validateHeader(
-        response, 3, "incidentdate", "Date of birth", "DATE", "java.time.LocalDate", false, true);
+        response,
+        3,
+        "incidentdate",
+        "Date of birth",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(response, 4, "storedby", "Stored by", "TEXT", "java.lang.String", false, true);
     validateHeader(
         response, 5, "createdbydisplayname", "Created by", "TEXT", "java.lang.String", false, true);
@@ -123,7 +130,14 @@ public class EnrollmentQueryTest extends AnalyticsApiTest {
         false,
         true);
     validateHeader(
-        response, 7, "lastupdated", "Last updated on", "DATE", "java.time.LocalDate", false, true);
+        response,
+        7,
+        "lastupdated",
+        "Last updated on",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(response, 8, "geometry", "Geometry", "TEXT", "java.lang.String", false, true);
     validateHeader(
         response, 9, "longitude", "Longitude", "NUMBER", "java.lang.Double", false, true);
@@ -332,8 +346,8 @@ public class EnrollmentQueryTest extends AnalyticsApiTest {
         2,
         "enrollmentdate",
         "Date of first visit",
-        "DATE",
-        "java.time.LocalDate",
+        "DATETIME",
+        "java.time.LocalDateTime",
         false,
         true);
   }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery1AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery1AutoTest.java
@@ -101,8 +101,8 @@ public class EnrollmentsQuery1AutoTest extends AnalyticsApiTest {
         6,
         "enrollmentdate",
         "Start of treatment date",
-        "DATE",
-        "java.time.LocalDate",
+        "DATETIME",
+        "java.time.LocalDateTime",
         false,
         true);
     validateHeader(response, 7, "uIuxlbV1vRT", "Area", "TEXT", "java.lang.String", false, true);
@@ -1466,7 +1466,14 @@ public class EnrollmentsQuery1AutoTest extends AnalyticsApiTest {
     validateHeader(
         response, 6, "Bpx0589u8y0", "Facility Ownership", "TEXT", "java.lang.String", false, true);
     validateHeader(
-        response, 7, "lastupdated", "Last updated on", "DATE", "java.time.LocalDate", false, true);
+        response,
+        7,
+        "lastupdated",
+        "Last updated on",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
 
     // Assert rows.
     validateRow(
@@ -2713,7 +2720,14 @@ public class EnrollmentsQuery1AutoTest extends AnalyticsApiTest {
     validateHeader(
         response, 1, "Bpx0589u8y0", "Facility Ownership", "TEXT", "java.lang.String", false, true);
     validateHeader(
-        response, 2, "lastupdated", "Last updated on", "DATE", "java.time.LocalDate", false, true);
+        response,
+        2,
+        "lastupdated",
+        "Last updated on",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(
         response, 3, "Kv4fmHVAzwX", "Focus Name", "TEXT", "java.lang.String", false, true);
 
@@ -2811,7 +2825,14 @@ public class EnrollmentsQuery1AutoTest extends AnalyticsApiTest {
     validateHeader(
         response, 1, "Bpx0589u8y0", "Facility Ownership", "TEXT", "java.lang.String", false, true);
     validateHeader(
-        response, 2, "lastupdated", "Last updated on", "DATE", "java.time.LocalDate", false, true);
+        response,
+        2,
+        "lastupdated",
+        "Last updated on",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(
         response, 3, "Kv4fmHVAzwX", "Focus Name", "TEXT", "java.lang.String", false, true);
     validateHeader(

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery2AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery2AutoTest.java
@@ -92,7 +92,14 @@ public class EnrollmentsQuery2AutoTest extends AnalyticsApiTest {
     validateHeader(
         response, 1, "Bpx0589u8y0", "Facility Ownership", "TEXT", "java.lang.String", false, true);
     validateHeader(
-        response, 2, "lastupdated", "Last updated on", "DATE", "java.time.LocalDate", false, true);
+        response,
+        2,
+        "lastupdated",
+        "Last updated on",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(
         response, 3, "Kv4fmHVAzwX", "Focus Name", "TEXT", "java.lang.String", false, true);
     validateHeader(
@@ -285,7 +292,14 @@ public class EnrollmentsQuery2AutoTest extends AnalyticsApiTest {
     validateHeader(
         response, 1, "Bpx0589u8y0", "Facility Ownership", "TEXT", "java.lang.String", false, true);
     validateHeader(
-        response, 2, "lastupdated", "Last updated on", "DATE", "java.time.LocalDate", false, true);
+        response,
+        2,
+        "lastupdated",
+        "Last updated on",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(
         response, 3, "coaSpbzZiTB", "System Focus ID", "TEXT", "java.lang.String", false, true);
     validateHeader(
@@ -386,7 +400,14 @@ public class EnrollmentsQuery2AutoTest extends AnalyticsApiTest {
     validateHeader(
         response, 1, "Bpx0589u8y0", "Facility Ownership", "TEXT", "java.lang.String", false, true);
     validateHeader(
-        response, 2, "lastupdated", "Last updated on", "DATE", "java.time.LocalDate", false, true);
+        response,
+        2,
+        "lastupdated",
+        "Last updated on",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(
         response, 3, "coaSpbzZiTB", "System Focus ID", "TEXT", "java.lang.String", false, true);
     validateHeader(
@@ -485,7 +506,14 @@ public class EnrollmentsQuery2AutoTest extends AnalyticsApiTest {
     validateHeader(
         response, 1, "Bpx0589u8y0", "Facility Ownership", "TEXT", "java.lang.String", false, true);
     validateHeader(
-        response, 2, "lastupdated", "Last updated on", "DATE", "java.time.LocalDate", false, true);
+        response,
+        2,
+        "lastupdated",
+        "Last updated on",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(
         response,
         3,
@@ -539,8 +567,8 @@ public class EnrollmentsQuery2AutoTest extends AnalyticsApiTest {
         10,
         "enrollmentdate",
         "Date of enrollment",
-        "DATE",
-        "java.time.LocalDate",
+        "DATETIME",
+        "java.time.LocalDateTime",
         false,
         true);
   }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery3AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/enrollment/query/EnrollmentsQuery3AutoTest.java
@@ -100,8 +100,8 @@ public class EnrollmentsQuery3AutoTest extends AnalyticsApiTest {
         2,
         "enrollmentdate",
         "Start of treatment date",
-        "DATE",
-        "java.time.LocalDate",
+        "DATETIME",
+        "java.time.LocalDateTime",
         false,
         true);
   }
@@ -159,8 +159,8 @@ public class EnrollmentsQuery3AutoTest extends AnalyticsApiTest {
         2,
         "enrollmentdate",
         "Start of treatment date",
-        "DATE",
-        "java.time.LocalDate",
+        "DATETIME",
+        "java.time.LocalDateTime",
         false,
         true);
 
@@ -254,8 +254,8 @@ public class EnrollmentsQuery3AutoTest extends AnalyticsApiTest {
         3,
         "enrollmentdate",
         "Start of treatment date",
-        "DATE",
-        "java.time.LocalDate",
+        "DATETIME",
+        "java.time.LocalDateTime",
         false,
         true);
 
@@ -308,12 +308,19 @@ public class EnrollmentsQuery3AutoTest extends AnalyticsApiTest {
         2,
         "enrollmentdate",
         "Date of Focus Registration",
-        "DATE",
-        "java.time.LocalDate",
+        "DATETIME",
+        "java.time.LocalDateTime",
         false,
         true);
     validateHeader(
-        response, 3, "incidentdate", "Incident date", "DATE", "java.time.LocalDate", false, true);
+        response,
+        3,
+        "incidentdate",
+        "Incident date",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(response, 4, "storedby", "Stored by", "TEXT", "java.lang.String", false, true);
     validateHeader(
         response, 5, "createdbydisplayname", "Created by", "TEXT", "java.lang.String", false, true);
@@ -327,7 +334,14 @@ public class EnrollmentsQuery3AutoTest extends AnalyticsApiTest {
         false,
         true);
     validateHeader(
-        response, 7, "lastupdated", "Last updated on", "DATE", "java.time.LocalDate", false, true);
+        response,
+        7,
+        "lastupdated",
+        "Last updated on",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(response, 8, "geometry", "Geometry", "TEXT", "java.lang.String", false, true);
     validateHeader(
         response, 9, "longitude", "Longitude", "NUMBER", "java.lang.Double", false, true);
@@ -577,12 +591,19 @@ public class EnrollmentsQuery3AutoTest extends AnalyticsApiTest {
         1,
         "enrollmentdate",
         "Date of enrollment",
-        "DATE",
-        "java.time.LocalDate",
+        "DATETIME",
+        "java.time.LocalDateTime",
         false,
         true);
     validateHeader(
-        response, 2, "incidentdate", "Date of birth", "DATE", "java.time.LocalDate", false, true);
+        response,
+        2,
+        "incidentdate",
+        "Date of birth",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
 
     // Assert rows.
     validateRow(
@@ -646,12 +667,19 @@ public class EnrollmentsQuery3AutoTest extends AnalyticsApiTest {
         1,
         "enrollmentdate",
         "Date of enrollment",
-        "DATE",
-        "java.time.LocalDate",
+        "DATETIME",
+        "java.time.LocalDateTime",
         false,
         true);
     validateHeader(
-        response, 2, "incidentdate", "Date of birth", "DATE", "java.time.LocalDate", false, true);
+        response,
+        2,
+        "incidentdate",
+        "Date of birth",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
 
     // Assert rows.
     validateRow(
@@ -716,12 +744,19 @@ public class EnrollmentsQuery3AutoTest extends AnalyticsApiTest {
         1,
         "enrollmentdate",
         "Date of enrollment",
-        "DATE",
-        "java.time.LocalDate",
+        "DATETIME",
+        "java.time.LocalDateTime",
         false,
         true);
     validateHeader(
-        response, 2, "incidentdate", "Date of birth", "DATE", "java.time.LocalDate", false, true);
+        response,
+        2,
+        "incidentdate",
+        "Date of birth",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
 
     // Assert rows.
     validateRow(

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventQueryTest.java
@@ -98,7 +98,7 @@ public class EventQueryTest extends AnalyticsApiTest {
     validateHeader(response, 0, "psi", "Event", "TEXT", "java.lang.String", false, true);
     validateHeader(response, 1, "ps", "Program stage", "TEXT", "java.lang.String", false, true);
     validateHeader(
-        response, 2, "eventdate", "Visit date", "DATE", "java.time.LocalDate", false, true);
+        response, 2, "eventdate", "Visit date", "DATETIME", "java.time.LocalDateTime", false, true);
     validateHeader(response, 3, "storedby", "Stored by", "TEXT", "java.lang.String", false, true);
     validateHeader(
         response, 4, "createdbydisplayname", "Created by", "TEXT", "java.lang.String", false, true);
@@ -112,9 +112,23 @@ public class EventQueryTest extends AnalyticsApiTest {
         false,
         true);
     validateHeader(
-        response, 6, "lastupdated", "Last updated on", "DATE", "java.time.LocalDate", false, true);
+        response,
+        6,
+        "lastupdated",
+        "Last updated on",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(
-        response, 7, "scheduleddate", "Scheduled date", "DATE", "java.time.LocalDate", false, true);
+        response,
+        7,
+        "scheduleddate",
+        "Scheduled date",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(response, 8, "geometry", "Geometry", "TEXT", "java.lang.String", false, true);
     validateHeader(
         response, 9, "longitude", "Longitude", "NUMBER", "java.lang.Double", false, true);
@@ -249,7 +263,7 @@ public class EventQueryTest extends AnalyticsApiTest {
     validateHeader(response, 0, "psi", "Event", "TEXT", "java.lang.String", false, true);
     validateHeader(response, 1, "ps", "Program stage", "TEXT", "java.lang.String", false, true);
     validateHeader(
-        response, 2, "eventdate", "Visit date", "DATE", "java.time.LocalDate", false, true);
+        response, 2, "eventdate", "Visit date", "DATETIME", "java.time.LocalDateTime", false, true);
     validateHeader(response, 3, "storedby", "Stored by", "TEXT", "java.lang.String", false, true);
     validateHeader(
         response, 4, "createdbydisplayname", "Created by", "TEXT", "java.lang.String", false, true);
@@ -263,9 +277,23 @@ public class EventQueryTest extends AnalyticsApiTest {
         false,
         true);
     validateHeader(
-        response, 6, "lastupdated", "Last updated on", "DATE", "java.time.LocalDate", false, true);
+        response,
+        6,
+        "lastupdated",
+        "Last updated on",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(
-        response, 7, "scheduleddate", "Scheduled date", "DATE", "java.time.LocalDate", false, true);
+        response,
+        7,
+        "scheduleddate",
+        "Scheduled date",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(response, 8, "geometry", "Geometry", "TEXT", "java.lang.String", false, true);
     validateHeader(
         response, 9, "longitude", "Longitude", "NUMBER", "java.lang.Double", false, true);
@@ -417,11 +445,25 @@ public class EventQueryTest extends AnalyticsApiTest {
 
     // Validate headers.
     validateHeader(
-        response, 0, "eventdate", "Report date", "DATE", "java.time.LocalDate", false, true);
+        response,
+        0,
+        "eventdate",
+        "Report date",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(
         response, 1, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, true);
     validateHeader(
-        response, 2, "lastupdated", "Last updated on", "DATE", "java.time.LocalDate", false, true);
+        response,
+        2,
+        "lastupdated",
+        "Last updated on",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
 
     // Validate the first three rows, as samples.
     validateRow(
@@ -477,7 +519,14 @@ public class EventQueryTest extends AnalyticsApiTest {
 
     // Validate headers.
     validateHeader(
-        response, 0, "eventdate", "Report date", "DATE", "java.time.LocalDate", false, true);
+        response,
+        0,
+        "eventdate",
+        "Report date",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(
         response, 1, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, true);
 
@@ -528,7 +577,14 @@ public class EventQueryTest extends AnalyticsApiTest {
 
     // Validate headers.
     validateHeader(
-        response, 0, "eventdate", "Report date", "DATE", "java.time.LocalDate", false, true);
+        response,
+        0,
+        "eventdate",
+        "Report date",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(
         response, 1, "ouname", "Organisation unit name", "TEXT", "java.lang.String", false, true);
 
@@ -608,7 +664,14 @@ public class EventQueryTest extends AnalyticsApiTest {
     validateHeader(
         response, 1, "p2Zxg0wcPQ3", "BCG doses", "NUMBER", "java.lang.Double", false, true);
     validateHeader(
-        response, 2, "eventdate", "Report date", "DATE", "java.time.LocalDate", false, true);
+        response,
+        2,
+        "eventdate",
+        "Report date",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
 
     // Validate the first three rows, as samples.
     validateRow(response, 0, List.of("Ngelehun CHC", "0", "2022-02-27 00:00:00.0"));
@@ -661,7 +724,14 @@ public class EventQueryTest extends AnalyticsApiTest {
     validateHeader(
         response, 1, "p2Zxg0wcPQ3", "BCG doses", "NUMBER", "java.lang.Double", false, true);
     validateHeader(
-        response, 2, "eventdate", "Report date", "DATE", "java.time.LocalDate", false, true);
+        response,
+        2,
+        "eventdate",
+        "Report date",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
 
     // Validate the first three rows, as samples.
     validateRow(response, 0, List.of("Ngelehun CHC", "0", "2022-02-27 00:00:00.0"));

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery1AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery1AutoTest.java
@@ -85,7 +85,14 @@ public class EventsQuery1AutoTest extends AnalyticsApiTest {
     validateHeader(response, 0, "psi", "Event", "TEXT", "java.lang.String", false, true);
     validateHeader(response, 1, "ps", "Program stage", "TEXT", "java.lang.String", false, true);
     validateHeader(
-        response, 2, "eventdate", "Report date", "DATE", "java.time.LocalDate", false, true);
+        response,
+        2,
+        "eventdate",
+        "Report date",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(response, 3, "storedby", "Stored by", "TEXT", "java.lang.String", false, true);
     validateHeader(
         response, 4, "createdbydisplayname", "Created by", "TEXT", "java.lang.String", false, true);
@@ -99,9 +106,23 @@ public class EventsQuery1AutoTest extends AnalyticsApiTest {
         false,
         true);
     validateHeader(
-        response, 6, "lastupdated", "Last updated on", "DATE", "java.time.LocalDate", false, true);
+        response,
+        6,
+        "lastupdated",
+        "Last updated on",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(
-        response, 7, "scheduleddate", "Scheduled date", "DATE", "java.time.LocalDate", false, true);
+        response,
+        7,
+        "scheduleddate",
+        "Scheduled date",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(response, 8, "geometry", "Geometry", "TEXT", "java.lang.String", false, true);
     validateHeader(
         response, 9, "longitude", "Longitude", "NUMBER", "java.lang.Double", false, true);
@@ -2805,7 +2826,14 @@ public class EventsQuery1AutoTest extends AnalyticsApiTest {
     validateHeader(response, 0, "psi", "Event", "TEXT", "java.lang.String", false, true);
     validateHeader(response, 1, "ps", "Program stage", "TEXT", "java.lang.String", false, true);
     validateHeader(
-        response, 2, "eventdate", "Report date", "DATE", "java.time.LocalDate", false, true);
+        response,
+        2,
+        "eventdate",
+        "Report date",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(response, 3, "storedby", "Stored by", "TEXT", "java.lang.String", false, true);
     validateHeader(
         response, 4, "createdbydisplayname", "Created by", "TEXT", "java.lang.String", false, true);
@@ -2819,9 +2847,23 @@ public class EventsQuery1AutoTest extends AnalyticsApiTest {
         false,
         true);
     validateHeader(
-        response, 6, "lastupdated", "Last updated on", "DATE", "java.time.LocalDate", false, true);
+        response,
+        6,
+        "lastupdated",
+        "Last updated on",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(
-        response, 7, "scheduleddate", "Scheduled date", "DATE", "java.time.LocalDate", false, true);
+        response,
+        7,
+        "scheduleddate",
+        "Scheduled date",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(response, 8, "geometry", "Geometry", "TEXT", "java.lang.String", false, true);
     validateHeader(
         response, 9, "longitude", "Longitude", "NUMBER", "java.lang.Double", false, true);
@@ -5634,7 +5676,14 @@ public class EventsQuery1AutoTest extends AnalyticsApiTest {
     validateHeader(response, 0, "psi", "Event", "TEXT", "java.lang.String", false, true);
     validateHeader(response, 1, "ps", "Program stage", "TEXT", "java.lang.String", false, true);
     validateHeader(
-        response, 2, "eventdate", "Report date", "DATE", "java.time.LocalDate", false, true);
+        response,
+        2,
+        "eventdate",
+        "Report date",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(response, 3, "storedby", "Stored by", "TEXT", "java.lang.String", false, true);
     validateHeader(
         response, 4, "createdbydisplayname", "Created by", "TEXT", "java.lang.String", false, true);
@@ -5648,9 +5697,23 @@ public class EventsQuery1AutoTest extends AnalyticsApiTest {
         false,
         true);
     validateHeader(
-        response, 6, "lastupdated", "Last updated on", "DATE", "java.time.LocalDate", false, true);
+        response,
+        6,
+        "lastupdated",
+        "Last updated on",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(
-        response, 7, "scheduleddate", "Scheduled date", "DATE", "java.time.LocalDate", false, true);
+        response,
+        7,
+        "scheduleddate",
+        "Scheduled date",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(response, 8, "geometry", "Geometry", "TEXT", "java.lang.String", false, true);
     validateHeader(
         response, 9, "longitude", "Longitude", "NUMBER", "java.lang.Double", false, true);
@@ -8463,7 +8526,14 @@ public class EventsQuery1AutoTest extends AnalyticsApiTest {
     validateHeader(response, 0, "psi", "Event", "TEXT", "java.lang.String", false, true);
     validateHeader(response, 1, "ps", "Program stage", "TEXT", "java.lang.String", false, true);
     validateHeader(
-        response, 2, "eventdate", "Report date", "DATE", "java.time.LocalDate", false, true);
+        response,
+        2,
+        "eventdate",
+        "Report date",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(response, 3, "storedby", "Stored by", "TEXT", "java.lang.String", false, true);
     validateHeader(
         response, 4, "createdbydisplayname", "Created by", "TEXT", "java.lang.String", false, true);
@@ -8477,9 +8547,23 @@ public class EventsQuery1AutoTest extends AnalyticsApiTest {
         false,
         true);
     validateHeader(
-        response, 6, "lastupdated", "Last updated on", "DATE", "java.time.LocalDate", false, true);
+        response,
+        6,
+        "lastupdated",
+        "Last updated on",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(
-        response, 7, "scheduleddate", "Scheduled date", "DATE", "java.time.LocalDate", false, true);
+        response,
+        7,
+        "scheduleddate",
+        "Scheduled date",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(response, 8, "geometry", "Geometry", "TEXT", "java.lang.String", false, true);
     validateHeader(
         response, 9, "longitude", "Longitude", "NUMBER", "java.lang.Double", false, true);

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery2AutoTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/event/query/EventsQuery2AutoTest.java
@@ -85,7 +85,14 @@ public class EventsQuery2AutoTest extends AnalyticsApiTest {
     validateHeader(response, 0, "psi", "Event", "TEXT", "java.lang.String", false, true);
     validateHeader(response, 1, "ps", "Program stage", "TEXT", "java.lang.String", false, true);
     validateHeader(
-        response, 2, "eventdate", "Report date", "DATE", "java.time.LocalDate", false, true);
+        response,
+        2,
+        "eventdate",
+        "Report date",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(response, 3, "storedby", "Stored by", "TEXT", "java.lang.String", false, true);
     validateHeader(
         response, 4, "createdbydisplayname", "Created by", "TEXT", "java.lang.String", false, true);
@@ -99,9 +106,23 @@ public class EventsQuery2AutoTest extends AnalyticsApiTest {
         false,
         true);
     validateHeader(
-        response, 6, "lastupdated", "Last updated on", "DATE", "java.time.LocalDate", false, true);
+        response,
+        6,
+        "lastupdated",
+        "Last updated on",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(
-        response, 7, "scheduleddate", "Scheduled date", "DATE", "java.time.LocalDate", false, true);
+        response,
+        7,
+        "scheduleddate",
+        "Scheduled date",
+        "DATETIME",
+        "java.time.LocalDateTime",
+        false,
+        true);
     validateHeader(response, 8, "geometry", "Geometry", "TEXT", "java.lang.String", false, true);
     validateHeader(
         response, 9, "longitude", "Longitude", "NUMBER", "java.lang.Double", false, true);


### PR DESCRIPTION
Convert all DATE columns to DATETIME across all `/analytics/query` endpoints.
This is needed to align the types with the DB columns.