### PR TITLE
fix: Fix TE ACL to check capture scope on register OU [DHIS2-17251]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidator.java
@@ -95,10 +95,15 @@ class SecurityOwnershipValidator
                 .getOrganisationUnit()
             : bundle.getPreheat().getOrganisationUnit(trackedEntity.getOrgUnit());
 
-    if (strategy.isCreate()) {
+    if (strategy.isCreate()){
       checkTeTypeWriteAccess(reporter, bundle, trackedEntity, trackedEntityType);
+    }
+
+    if (strategy.isCreate() || strategy.isDelete()) {
       checkOrgUnitInCaptureScope(reporter, bundle, trackedEntity, organisationUnit);
-    } else {
+    }
+
+    if(!strategy.isCreate()){
       TrackedEntity te = bundle.getPreheat().getTrackedEntity(trackedEntity.getTrackedEntity());
       if (!trackerAccessManager.canWrite(UserDetails.fromUser(bundle.getUser()), te).isEmpty()) {
         reporter.addError(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidator.java
@@ -95,7 +95,7 @@ class SecurityOwnershipValidator
                 .getOrganisationUnit()
             : bundle.getPreheat().getOrganisationUnit(trackedEntity.getOrgUnit());
 
-    if (strategy.isCreate()){
+    if (strategy.isCreate()) {
       checkTeTypeWriteAccess(reporter, bundle, trackedEntity, trackedEntityType);
     }
 
@@ -103,7 +103,7 @@ class SecurityOwnershipValidator
       checkOrgUnitInCaptureScope(reporter, bundle, trackedEntity, organisationUnit);
     }
 
-    if(!strategy.isCreate()){
+    if (!strategy.isCreate()) {
       TrackedEntity te = bundle.getPreheat().getTrackedEntity(trackedEntity.getTrackedEntity());
       if (!trackerAccessManager.canWrite(UserDetails.fromUser(bundle.getUser()), te).isEmpty()) {
         reporter.addError(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidatorTest.java
@@ -212,7 +212,8 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldSuccessWhenDeleteTEWithEnrollmentsAndUserHasWriteAccessAndOUInCaptureScopeAndDeleteCascadeAuthority() {
+  void
+      shouldSuccessWhenDeleteTEWithEnrollmentsAndUserHasWriteAccessAndOUInCaptureScopeAndDeleteCascadeAuthority() {
     org.hisp.dhis.tracker.imports.domain.TrackedEntity trackedEntity =
         org.hisp.dhis.tracker.imports.domain.TrackedEntity.builder()
             .trackedEntity(TE_ID)

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/trackedentity/SecurityOwnershipValidatorTest.java
@@ -149,7 +149,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldSuccessWhenDeleteTEWithNoEnrollmentsAndUserHasWriteAccess() {
+  void shouldSuccessWhenDeleteTEWithNoEnrollmentsAndUserHasWriteAccessAndOUInCaptureScope() {
     org.hisp.dhis.tracker.imports.domain.TrackedEntity trackedEntity =
         org.hisp.dhis.tracker.imports.domain.TrackedEntity.builder()
             .trackedEntity(TE_ID)
@@ -161,6 +161,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     TrackedEntity te = teWithNoEnrollments();
     when(preheat.getTrackedEntity(TE_ID)).thenReturn(te);
     when(trackerAccessManager.canWrite(any(), eq(te))).thenReturn(List.of());
+    when(organisationUnitService.isInUserHierarchyCached(user, organisationUnit)).thenReturn(true);
 
     validator.validate(reporter, bundle, trackedEntity);
 
@@ -191,7 +192,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldSuccessWhenDeleteTEWithDeletedEnrollmentsAndUserHasWriteAccess() {
+  void shouldSuccessWhenDeleteTEWithDeletedEnrollmentsAndUserHasWriteAccessAndOUInCaptureScope() {
     org.hisp.dhis.tracker.imports.domain.TrackedEntity trackedEntity =
         org.hisp.dhis.tracker.imports.domain.TrackedEntity.builder()
             .trackedEntity(TE_ID)
@@ -203,6 +204,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     TrackedEntity te = teWithDeleteEnrollments();
     when(preheat.getTrackedEntity(TE_ID)).thenReturn(te);
     when(trackerAccessManager.canWrite(any(), eq(te))).thenReturn(List.of());
+    when(organisationUnitService.isInUserHierarchyCached(user, organisationUnit)).thenReturn(true);
 
     validator.validate(reporter, bundle, trackedEntity);
 
@@ -210,7 +212,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldSuccessWhenDeleteTEWithEnrollmentsAndUserHasWriteAccessAndDeleteCascadeAuthority() {
+  void shouldSuccessWhenDeleteTEWithEnrollmentsAndUserHasWriteAccessAndOUInCaptureScopeAndDeleteCascadeAuthority() {
     org.hisp.dhis.tracker.imports.domain.TrackedEntity trackedEntity =
         org.hisp.dhis.tracker.imports.domain.TrackedEntity.builder()
             .trackedEntity(TE_ID)
@@ -223,6 +225,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     TrackedEntity te = teWithEnrollments();
     when(preheat.getTrackedEntity(TE_ID)).thenReturn(te);
     when(trackerAccessManager.canWrite(any(), eq(te))).thenReturn(List.of());
+    when(organisationUnitService.isInUserHierarchyCached(user, organisationUnit)).thenReturn(true);
 
     validator.validate(reporter, bundle, trackedEntity);
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TrackedEntityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TrackedEntityImportValidationTest.java
@@ -32,11 +32,9 @@ import static org.hisp.dhis.tracker.Assertions.assertHasOnlyErrors;
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_1;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_10;
-import static org.hisp.dhis.tracker.imports.validation.Users.USER_2;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_3;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_4;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_5;
-import static org.hisp.dhis.tracker.imports.validation.Users.USER_6;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_7;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_8;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_9;
@@ -249,7 +247,8 @@ class TrackedEntityImportValidationTest extends TrackerTest {
   }
 
   @Test
-  void shouldFailToDeleteWhenTEWasTransferredAndUserHasAccessToTransferredOrgUnitAndTEOUIsNotInCaptureScope()
+  void
+      shouldFailToDeleteWhenTEWasTransferredAndUserHasAccessToTransferredOrgUnitAndTEOUIsNotInCaptureScope()
           throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/enrollments_te_te-data.json");
     TrackerImportParams params = new TrackerImportParams();
@@ -268,7 +267,8 @@ class TrackedEntityImportValidationTest extends TrackerTest {
   }
 
   @Test
-  void shouldDeleteWhenTEWasTransferredAndUserHasAccessToTransferredOrgUnitAndTEOUIsInCaptureScope() throws IOException {
+  void shouldDeleteWhenTEWasTransferredAndUserHasAccessToTransferredOrgUnitAndTEOUIsInCaptureScope()
+      throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/enrollments_te_te-data.json");
     TrackerImportParams params = new TrackerImportParams();
     assertNoErrors(trackerImportService.importTracker(params, trackerObjects));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TrackedEntityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TrackedEntityImportValidationTest.java
@@ -32,9 +32,11 @@ import static org.hisp.dhis.tracker.Assertions.assertHasOnlyErrors;
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_1;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_10;
+import static org.hisp.dhis.tracker.imports.validation.Users.USER_2;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_3;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_4;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_5;
+import static org.hisp.dhis.tracker.imports.validation.Users.USER_6;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_7;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_8;
 import static org.hisp.dhis.tracker.imports.validation.Users.USER_9;
@@ -247,7 +249,8 @@ class TrackedEntityImportValidationTest extends TrackerTest {
   }
 
   @Test
-  void shouldDeleteWhenTEWasTransferredAndUserHasAccessToTransferredOrgUnit() throws IOException {
+  void shouldFailToDeleteWhenTEWasTransferredAndUserHasAccessToTransferredOrgUnitAndTEOUIsNotInCaptureScope()
+          throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/enrollments_te_te-data.json");
     TrackerImportParams params = new TrackerImportParams();
     assertNoErrors(trackerImportService.importTracker(params, trackerObjects));
@@ -261,6 +264,24 @@ class TrackedEntityImportValidationTest extends TrackerTest {
     manager.flush();
     manager.clear();
     ImportReport importReport = deleteTransferredTrackedEntity(userService.getUser(USER_9));
+    assertHasErrors(importReport, 1, ValidationCode.E1000);
+  }
+
+  @Test
+  void shouldDeleteWhenTEWasTransferredAndUserHasAccessToTransferredOrgUnitAndTEOUIsInCaptureScope() throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/validations/enrollments_te_te-data.json");
+    TrackerImportParams params = new TrackerImportParams();
+    assertNoErrors(trackerImportService.importTracker(params, trackerObjects));
+    importEnrollments();
+    manager.flush();
+    manager.clear();
+    TrackedEntity te = manager.get(TrackedEntity.class, "Kj6vYde4LHh");
+    OrganisationUnit orgUnit = manager.get(OrganisationUnit.class, "QfUVllTs6cW");
+    Program program = manager.get(Program.class, "E8o1E9tAppy");
+    trackerOwnershipManager.transferOwnership(te, program, orgUnit, true, false);
+    manager.flush();
+    manager.clear();
+    ImportReport importReport = deleteTransferredTrackedEntity(userService.getUser(USER_7));
     assertNoErrors(importReport);
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TrackedEntityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TrackedEntityImportValidationTest.java
@@ -289,18 +289,22 @@ class TrackedEntityImportValidationTest extends TrackerTest {
   void shouldFailToUpdateWhenUserHasAccessToRegistrationUnitAndTEWasTransferred()
       throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/enrollments_te_te-data.json");
-    TrackerImportParams params = new TrackerImportParams();
-    assertNoErrors(trackerImportService.importTracker(params, trackerObjects));
-    importEnrollments();
+    assertNoErrors(trackerImportService.importTracker(new TrackerImportParams(), trackerObjects));
+    trackerObjects = fromJson("tracker/validations/enrollments_te_enrollments-data_2.json");
+    TrackerImportParams trackerImportParams = new TrackerImportParams();
+    trackerImportParams.setUserId(USER_10);
+    ImportReport importReport =
+        trackerImportService.importTracker(trackerImportParams, trackerObjects);
+    assertNoErrors(importReport);
     manager.flush();
     manager.clear();
-    TrackedEntity te = manager.get(TrackedEntity.class, "Kj6vYde4LHh");
+    TrackedEntity te = manager.get(TrackedEntity.class, "KKKKj6vYdes");
     OrganisationUnit orgUnit = manager.get(OrganisationUnit.class, "QfUVllTs6cW");
     Program program = manager.get(Program.class, "E8o1E9tAppy");
     trackerOwnershipManager.transferOwnership(te, program, orgUnit, true, false);
     manager.flush();
     manager.clear();
-    ImportReport importReport = updateTransferredTrackedEntity(userService.getUser(USER_10));
+    importReport = updateTransferredTrackedEntity(USER_10, "KKKKj6vYdes");
     assertHasErrors(importReport, 1, ValidationCode.E1003);
   }
 
@@ -318,7 +322,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
     trackerOwnershipManager.transferOwnership(te, program, orgUnit, true, false);
     manager.flush();
     manager.clear();
-    ImportReport importReport = updateTransferredTrackedEntity(userService.getUser(USER_9));
+    ImportReport importReport = updateTransferredTrackedEntity(USER_9, "Kj6vYde4LHh");
     assertNoErrors(importReport);
   }
 
@@ -354,11 +358,13 @@ class TrackedEntityImportValidationTest extends TrackerTest {
     return trackerImportService.importTracker(params, trackerObjects);
   }
 
-  protected ImportReport updateTransferredTrackedEntity(User user) throws IOException {
+  protected ImportReport updateTransferredTrackedEntity(String userId, String trackedEntity)
+      throws IOException {
     TrackerObjects trackerObjects = fromJson("tracker/validations/te-transferred-data-update.json");
+    trackerObjects.getTrackedEntities().get(0).setTrackedEntity(trackedEntity);
     TrackerImportParams params = new TrackerImportParams();
     params.setImportStrategy(TrackerImportStrategy.UPDATE);
-    params.setUserId(user.getUid());
+    params.setUserId(userId);
     return trackerImportService.importTracker(params, trackerObjects);
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/tracker_basic_metadata.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/tracker_basic_metadata.json
@@ -488,6 +488,12 @@
       "organisationUnits": [
         {
           "id": "QfUVllTs6cS"
+        },
+        {
+          "id": "QfUVllTs6cZ"
+        },
+        {
+          "id": "QfUVllTs6cW"
         }
       ],
       "onlyEnrollOnce": false,
@@ -832,6 +838,9 @@
       "organisationUnits": [
         {
           "id": "QfUVllTs6cS"
+        },
+        {
+          "id": "QfUVllTs6cZ"
         }
       ],
       "onlyEnrollOnce": false,
@@ -866,6 +875,10 @@
           },
           "iAji3gyZYQL": {
             "id": "iAji3gyZYQL",
+            "access": "rwrw----"
+          },
+          "Xl2V8x8R1R5": {
+            "id": "Xl2V8x8R1R5",
             "access": "rwrw----"
           }
         },

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/validations/enrollments_te_enrollments-data_2.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/validations/enrollments_te_enrollments-data_2.json
@@ -30,25 +30,31 @@
   "skipPatternValidation": false,
   "skipSideEffects": false,
   "skipRuleEngine": false,
-  "trackedEntities": [
+  "trackedEntities": [],
+  "enrollments": [
     {
-      "trackedEntityType": {
+      "enrollment": "KNWZ6hnuhS1",
+      "trackedEntity": "KKKKj6vYdes",
+      "program": {
         "idScheme": "UID",
-        "identifier": "bPJ0FMtcnEh"
+        "identifier": "E8o1E9tAppy"
       },
+      "status": "COMPLETED",
       "orgUnit": {
         "idScheme": "UID",
         "identifier": "QfUVllTs6cZ"
       },
-      "inactive": false,
+      "enrolledAt": "2019-08-19T00:00:00.000",
+      "occurredAt": "2019-08-19T00:00:00.000",
+      "followUp": false,
       "deleted": false,
-      "potentialDuplicate": false,
+      "storedBy": "admin",
+      "events": [],
       "relationships": [],
       "attributes": [],
-      "enrollments": []
+      "notes": []
     }
   ],
-  "enrollments": [],
   "events": [],
   "relationships": [],
   "username": "system-process"


### PR DESCRIPTION
In the importer, we need to validate access to the Tracked Entity in the same way we are now doing in the exporter.
We have 3 different cases in the importer:

- CREATE: Check the capture scope of the user using the registration unit and validate Tracked Entity Type write access
- UPDATE: Check if the user has access to any TE/program pair, by first matching by the owner, or the registering org unit if no owner is found
- DELETE: Check the capture scope of the user using the registration unit and check if the user has access to any TE/program pair, by first matching by the owner, or the registering org unit if no owner is found

For CREATE and DELETE, we need to check that the registration org unit is in the capture scope.
For UPDATE, we are not changing the current behavior but we will need to discuss if it is required to check if the org unit is being updated and if so what to do.

Then, we are not checking the TE/Program Pair for CREATE as we know there isn't any at this moment but we need to check it for UPDATE and DELETE.