### PR TITLE
fix: Fix Metadata Sync job lastExecutedStatus [DHIS2-17292]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/SchedulingManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/SchedulingManagerTest.java
@@ -64,7 +64,9 @@ import org.hisp.dhis.scheduling.parameters.AnalyticsJobParameters;
 import org.hisp.dhis.scheduling.parameters.ContinuousAnalyticsJobParameters;
 import org.hisp.dhis.system.notification.Notifier;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.mockito.ArgumentCaptor;
 import org.springframework.context.ApplicationContext;
@@ -152,6 +154,78 @@ class SchedulingManagerTest {
         .thenReturn(new MockFuture<>());
     schedulingManager.scheduleWithStartTime(conf, new Date());
     return createTestCases(conf, this::createStartTimeJobConfiguration, startTimeTask.getValue());
+  }
+
+  @Test
+  @DisplayName("cancelled job should show as unsuccessful when lastExecutedStatus is not RUNNING")
+  void cancelledJobNotInRunningStateTest() {
+    // given
+    JobConfiguration config = new JobConfiguration();
+    config.setJobType(JobType.META_DATA_SYNC);
+    config.setInMemoryJob(true);
+    config.setLastExecutedStatus(JobStatus.SCHEDULED);
+
+    ControlledJobProgress jobProgress = new ControlledJobProgress(config);
+    jobProgress.requestCancellation();
+
+    // then
+    assertFalse(schedulingManager.checkWasSuccessfulRun(config, jobProgress));
+  }
+
+  @Test
+  @DisplayName(
+      "cancelled job should show as unsuccessful and state should be STOPPED after being in a RUNNING state")
+  void cancelledJobInRunningStateTest() {
+    // given
+    JobConfiguration config = new JobConfiguration();
+    config.setJobType(JobType.META_DATA_SYNC);
+    config.setInMemoryJob(true);
+    config.setJobStatus(JobStatus.NOT_STARTED);
+    config.setLastExecutedStatus(JobStatus.RUNNING);
+
+    ControlledJobProgress jobProgress = new ControlledJobProgress(config);
+    jobProgress.requestCancellation();
+
+    // then
+    assertFalse(schedulingManager.checkWasSuccessfulRun(config, jobProgress));
+    assertEquals(JobStatus.STOPPED, config.getLastExecutedStatus());
+  }
+
+  @Test
+  @DisplayName(
+      "job should show as successful and state should be COMPLETED after being in a RUNNING state")
+  void jobShouldBeCompletedTest() {
+    // given
+    JobConfiguration config = new JobConfiguration();
+    config.setJobType(JobType.META_DATA_SYNC);
+    config.setInMemoryJob(true);
+    config.setJobStatus(JobStatus.SCHEDULED);
+    config.setLastExecutedStatus(JobStatus.RUNNING);
+
+    ControlledJobProgress jobProgress = new ControlledJobProgress(config);
+
+    // then
+    assertTrue(schedulingManager.checkWasSuccessfulRun(config, jobProgress));
+    assertEquals(JobStatus.COMPLETED, config.getLastExecutedStatus());
+  }
+
+  @Test
+  @DisplayName(
+      "job should show as unsuccessful and state should be FAILED when all processes not in SUCCESS state")
+  void jobShouldBeFailedTest() {
+    // given
+    JobConfiguration config = new JobConfiguration();
+    config.setJobType(JobType.META_DATA_SYNC);
+    config.setInMemoryJob(true);
+    config.setJobStatus(JobStatus.SCHEDULED);
+    config.setLastExecutedStatus(JobStatus.RUNNING);
+
+    ControlledJobProgress jobProgress = new ControlledJobProgress(config);
+    jobProgress.startingProcess("Test process");
+
+    // then
+    assertFalse(schedulingManager.checkWasSuccessfulRun(config, jobProgress));
+    assertEquals(JobStatus.FAILED, config.getLastExecutedStatus());
   }
 
   private JobConfiguration createCronJobConfiguration() {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJob.java
@@ -149,12 +149,8 @@ public class MetadataSyncJob implements Job {
     metadataSyncPreProcessor.handleEventProgramsDataPush(context, params, progress);
     metadataSyncPreProcessor.handleCompleteDataSetRegistrationDataPush(context, progress);
     metadataSyncPreProcessor.handleTrackerProgramsDataPush(context, params, progress);
-
-    MetadataVersion version =
-        metadataSyncPreProcessor.handleCurrentMetadataVersion(context, progress);
-
     List<MetadataVersion> versions =
-        metadataSyncPreProcessor.handleMetadataVersionsList(context, version, progress);
+        metadataSyncPreProcessor.handleMetadataVersions(context, progress);
 
     handleMetadataSync(context, versions, progress);
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPreProcessor.java
@@ -71,9 +71,10 @@ public class MetadataSyncPreProcessor {
   private final CompleteDataSetRegistrationSynchronization completeDataSetRegistrationSync;
 
   public void setUp(MetadataRetryContext context, JobProgress progress) {
-    progress.startingStage("Setting up metadata synchronisation");
+    progress.startingProcess("Setting up metadata synchronisation");
     progress.runStage(
         () -> systemSettingManager.saveSystemSetting(SettingKey.METADATAVERSION_ENABLED, true));
+    progress.completedProcess("Finished setting up metadata synchronisation");
   }
 
   public void handleDataValuePush(
@@ -183,6 +184,15 @@ public class MetadataSyncPreProcessor {
       progress.failedStage(ex);
       throw new MetadataSyncServiceException(ex.getMessage(), ex);
     }
+  }
+
+  public List<MetadataVersion> handleMetadataVersions(
+      MetadataRetryContext context, JobProgress progress) {
+    progress.startingProcess("Starting Metadata version comparison");
+    MetadataVersion version = handleCurrentMetadataVersion(context, progress);
+    List<MetadataVersion> metadataVersions = handleMetadataVersionsList(context, version, progress);
+    progress.completedProcess("Finished Metadata version comparison");
+    return metadataVersions;
   }
 
   // ----------------------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobParametersTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobParametersTest.java
@@ -121,10 +121,7 @@ class MetadataSyncJobParametersTest {
   void testShouldRunAllTasksInSequence() throws DhisVersionMismatchException {
     when(metadataSyncService.doMetadataSync(any(MetadataSyncParams.class)))
         .thenReturn(metadataSyncSummary);
-    when(metadataSyncPreProcessor.handleCurrentMetadataVersion(metadataRetryContext, JOB_PROGRESS))
-        .thenReturn(metadataVersion);
-    when(metadataSyncPreProcessor.handleMetadataVersionsList(
-            metadataRetryContext, metadataVersion, JOB_PROGRESS))
+    when(metadataSyncPreProcessor.handleMetadataVersions(metadataRetryContext, JOB_PROGRESS))
         .thenReturn(metadataVersions);
     when(metadataSyncService.isSyncRequired(any(MetadataSyncParams.class))).thenReturn(true);
     metadataSyncJob.runSyncTask(metadataRetryContext, metadataSyncJobParameters, JOB_PROGRESS);
@@ -137,10 +134,7 @@ class MetadataSyncJobParametersTest {
     verify(metadataSyncPreProcessor)
         .handleTrackerProgramsDataPush(
             metadataRetryContext, metadataSyncJobParameters, JOB_PROGRESS);
-    verify(metadataSyncPreProcessor)
-        .handleCurrentMetadataVersion(metadataRetryContext, JOB_PROGRESS);
-    verify(metadataSyncPreProcessor)
-        .handleMetadataVersionsList(metadataRetryContext, metadataVersion, JOB_PROGRESS);
+    verify(metadataSyncPreProcessor).handleMetadataVersions(metadataRetryContext, JOB_PROGRESS);
     verify(metadataSyncService).doMetadataSync(any(MetadataSyncParams.class));
     verify(metadataSyncPostProcessor)
         .handleSyncNotificationsAndAbortStatus(
@@ -151,10 +145,7 @@ class MetadataSyncJobParametersTest {
   void testHandleMetadataSyncIsThrowingException() throws DhisVersionMismatchException {
     when(metadataSyncService.doMetadataSync(any(MetadataSyncParams.class)))
         .thenThrow(new MetadataSyncServiceException(""));
-    when(metadataSyncPreProcessor.handleCurrentMetadataVersion(metadataRetryContext, JOB_PROGRESS))
-        .thenReturn(metadataVersion);
-    when(metadataSyncPreProcessor.handleMetadataVersionsList(
-            metadataRetryContext, metadataVersion, JOB_PROGRESS))
+    when(metadataSyncPreProcessor.handleMetadataVersions(metadataRetryContext, JOB_PROGRESS))
         .thenReturn(metadataVersions);
     doNothing()
         .when(metadataRetryContext)
@@ -175,10 +166,7 @@ class MetadataSyncJobParametersTest {
     verify(metadataSyncPreProcessor)
         .handleTrackerProgramsDataPush(
             metadataRetryContext, metadataSyncJobParameters, JOB_PROGRESS);
-    verify(metadataSyncPreProcessor)
-        .handleCurrentMetadataVersion(metadataRetryContext, JOB_PROGRESS);
-    verify(metadataSyncPreProcessor)
-        .handleMetadataVersionsList(metadataRetryContext, metadataVersion, JOB_PROGRESS);
+    verify(metadataSyncPreProcessor).handleMetadataVersions(metadataRetryContext, JOB_PROGRESS);
     verify(metadataSyncService).doMetadataSync(any(MetadataSyncParams.class));
     verify(metadataSyncPostProcessor, never())
         .handleSyncNotificationsAndAbortStatus(
@@ -189,10 +177,7 @@ class MetadataSyncJobParametersTest {
   void testShouldAbortIfDHISVersionMismatch() throws DhisVersionMismatchException {
     metadataVersions.add(metadataVersion);
 
-    when(metadataSyncPreProcessor.handleCurrentMetadataVersion(metadataRetryContext, JOB_PROGRESS))
-        .thenReturn(metadataVersion);
-    when(metadataSyncPreProcessor.handleMetadataVersionsList(
-            metadataRetryContext, metadataVersion, JOB_PROGRESS))
+    when(metadataSyncPreProcessor.handleMetadataVersions(metadataRetryContext, JOB_PROGRESS))
         .thenReturn(metadataVersions);
     when(metadataSyncService.doMetadataSync(any(MetadataSyncParams.class)))
         .thenThrow(new DhisVersionMismatchException(""));
@@ -212,10 +197,7 @@ class MetadataSyncJobParametersTest {
     verify(metadataSyncPreProcessor, times(1))
         .handleTrackerProgramsDataPush(
             metadataRetryContext, metadataSyncJobParameters, JOB_PROGRESS);
-    verify(metadataSyncPreProcessor, times(1))
-        .handleCurrentMetadataVersion(metadataRetryContext, JOB_PROGRESS);
-    verify(metadataSyncPreProcessor, times(1))
-        .handleMetadataVersionsList(metadataRetryContext, metadataVersion, JOB_PROGRESS);
+    verify(metadataSyncPreProcessor).handleMetadataVersions(metadataRetryContext, JOB_PROGRESS);
     verify(metadataSyncService, times(1)).doMetadataSync(any(MetadataSyncParams.class));
   }
 
@@ -223,10 +205,7 @@ class MetadataSyncJobParametersTest {
   void testShouldAbortIfErrorInSyncSummary() throws DhisVersionMismatchException {
     metadataVersions.add(metadataVersion);
 
-    when(metadataSyncPreProcessor.handleCurrentMetadataVersion(metadataRetryContext, JOB_PROGRESS))
-        .thenReturn(metadataVersion);
-    when(metadataSyncPreProcessor.handleMetadataVersionsList(
-            metadataRetryContext, metadataVersion, JOB_PROGRESS))
+    when(metadataSyncPreProcessor.handleMetadataVersions(metadataRetryContext, JOB_PROGRESS))
         .thenReturn(metadataVersions);
     when(metadataSyncService.doMetadataSync(any(MetadataSyncParams.class)))
         .thenReturn(metadataSyncSummary);
@@ -244,10 +223,7 @@ class MetadataSyncJobParametersTest {
     verify(metadataSyncPreProcessor, times(1))
         .handleTrackerProgramsDataPush(
             metadataRetryContext, metadataSyncJobParameters, JOB_PROGRESS);
-    verify(metadataSyncPreProcessor, times(1))
-        .handleCurrentMetadataVersion(metadataRetryContext, JOB_PROGRESS);
-    verify(metadataSyncPreProcessor, times(1))
-        .handleMetadataVersionsList(metadataRetryContext, metadataVersion, JOB_PROGRESS);
+    verify(metadataSyncPreProcessor).handleMetadataVersions(metadataRetryContext, JOB_PROGRESS);
     verify(metadataSyncService, times(1)).doMetadataSync(any(MetadataSyncParams.class));
     verify(metadataSyncPostProcessor, times(1))
         .handleSyncNotificationsAndAbortStatus(

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobTest.java
@@ -1,0 +1,121 @@
+package org.hisp.dhis.dxf2.metadata.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.hisp.dhis.cache.CacheProvider;
+import org.hisp.dhis.common.AsyncTaskExecutor;
+import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncPreProcessor;
+import org.hisp.dhis.dxf2.metadata.version.MetadataVersionDelegate;
+import org.hisp.dhis.leader.election.LeaderManager;
+import org.hisp.dhis.message.MessageService;
+import org.hisp.dhis.metadata.version.MetadataVersion;
+import org.hisp.dhis.metadata.version.MetadataVersionService;
+import org.hisp.dhis.metadata.version.VersionType;
+import org.hisp.dhis.scheduling.ControlledJobProgress;
+import org.hisp.dhis.scheduling.DefaultJobService;
+import org.hisp.dhis.scheduling.DefaultSchedulingManager;
+import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobConfigurationService;
+import org.hisp.dhis.scheduling.JobProgress.Status;
+import org.hisp.dhis.scheduling.JobStatus;
+import org.hisp.dhis.scheduling.JobType;
+import org.hisp.dhis.setting.SystemSettingManager;
+import org.hisp.dhis.system.notification.Notifier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+import org.springframework.scheduling.TaskScheduler;
+
+@ExtendWith(MockitoExtension.class)
+class MetadataSyncJobTest {
+
+  private DefaultSchedulingManager schedulingManager;
+  @Mock private SystemSettingManager systemSettingManager;
+  @Mock private MetadataVersionService metadataVersionService;
+  @Mock private MetadataVersionDelegate metadataVersionDelegate;
+
+  @BeforeEach
+  void setUp() {
+    schedulingManager =
+        new DefaultSchedulingManager(
+            new DefaultJobService(mock(ApplicationContext.class)),
+            mock(JobConfigurationService.class),
+            mock(MessageService.class),
+            mock(Notifier.class),
+            mock(LeaderManager.class),
+            mock(TaskScheduler.class),
+            mock(AsyncTaskExecutor.class),
+            mock(CacheProvider.class));
+  }
+
+  @Test
+  @DisplayName(
+      "Last executed status should be COMPLETED after metadata sync pre-processor setup completes and progress process status is success")
+  void preprocessSetupTest() {
+    // given
+    JobConfiguration config = new JobConfiguration();
+    config.setJobType(JobType.META_DATA_SYNC);
+    config.setInMemoryJob(true);
+    config.setLastExecutedStatus(JobStatus.RUNNING);
+
+    ControlledJobProgress jobProgress = new ControlledJobProgress(config);
+
+    MetadataSyncPreProcessor preProcessor =
+        new MetadataSyncPreProcessor(systemSettingManager, null, null, null, null, null, null);
+
+    // when
+    preProcessor.setUp(null, jobProgress);
+    boolean wasSuccessfulRun = schedulingManager.checkWasSuccessfulRun(config, jobProgress);
+
+    // then
+    assertTrue(wasSuccessfulRun);
+    assertEquals(JobStatus.COMPLETED, config.getLastExecutedStatus());
+    assertEquals(1, jobProgress.getProcesses().size());
+    assertEquals(Status.SUCCESS, jobProgress.getProcesses().getFirst().getStatus());
+  }
+
+  @Test
+  @DisplayName(
+      "Last executed status should be COMPLETED after metadata sync pre-processor handle metadata versions completes and progress process status is success")
+  void handleMetadataVersionsTest() {
+    // given
+    JobConfiguration config = new JobConfiguration();
+    config.setJobType(JobType.META_DATA_SYNC);
+    config.setInMemoryJob(true);
+    config.setLastExecutedStatus(JobStatus.RUNNING);
+
+    ControlledJobProgress jobProgress = new ControlledJobProgress(config);
+
+    MetadataSyncPreProcessor preProcessor =
+        new MetadataSyncPreProcessor(
+            systemSettingManager,
+            metadataVersionService,
+            metadataVersionDelegate,
+            null,
+            null,
+            null,
+            null);
+
+    MetadataVersion mdVersion = new MetadataVersion("test", VersionType.BEST_EFFORT);
+    when(metadataVersionService.getCurrentVersion()).thenReturn(mdVersion);
+    when(metadataVersionDelegate.getMetaDataDifference(mdVersion)).thenReturn(List.of());
+
+    // when
+    preProcessor.handleMetadataVersions(null, jobProgress);
+    boolean wasSuccessfulRun = schedulingManager.checkWasSuccessfulRun(config, jobProgress);
+
+    // then
+    assertTrue(wasSuccessfulRun);
+    assertEquals(JobStatus.COMPLETED, config.getLastExecutedStatus());
+    assertEquals(1, jobProgress.getProcesses().size());
+    assertEquals(Status.SUCCESS, jobProgress.getProcesses().getFirst().getStatus());
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobTest.java
@@ -1,3 +1,30 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.dxf2.metadata.jobs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
# Issue
The `lastExecutedStatus` shows as `FAILED` even after a successful `MetadataSyncJob` run.
- only in versions `39` & `40`

# Cause
The `MetadataSyncJob` has several processes and some of them are not started and completed (some of them only start and run a stage). The `AbstractSchedulingManager` sees the job run as a failure if all of the `JobProgress` processes are not in a `SUCCESS` state.

# Fix
Start and complete these 2 processes in the `MetadataSyncJob` so a successful job run is seen as `COMPLETED`:
1. set up metadata job process
2. metadata sync process

# Testing
## Automated
Automated tests added confirming the correct state for a successful `MetadataSyncJob`
Unit tests added for the newly-extracted method `AbstractSchedulingManager#checkWasSuccessfulRun`

## Manual
Tested through Instance Manager using [this guide](https://github.com/dhis2/wow-backend/blob/master/guides/testing/metadata_sync_testing.md)
Once the job completes, make a `GET` call to `/api/jobConfigurations/{jobId}` and verify that `lastExecutedStatus` is `COMPLETED`

# Other Changes
- Extracted `AbstractSchedulingManager#checkWasSuccessfulRun` method from the rather large `protected final boolean execute(JobConfiguration configuration)` method in `AbstractSchedulingManager` to reduce complexity and allow part of the flow to be easily testable
- Wrapped the `handleCurrentVersion` and `currentVersionList` stages into one process which fixes that part of the bug