### PR TITLE
fix: Validate user TE access [DHIS2-17236]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -433,14 +433,14 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
       }
     }
 
-    return "SELECT distinct " + String.join(", ", columns);
+    return "SELECT DISTINCT " + String.join(", ", columns);
   }
 
   private String joinPrograms(TrackedEntityQueryParams params) {
     StringBuilder trackedEntity = new StringBuilder();
 
-    trackedEntity.append(" inner join program P ");
-    trackedEntity.append(" on P.trackedentitytypeid = TE.trackedentitytypeid ");
+    trackedEntity.append(" INNER JOIN program P ");
+    trackedEntity.append(" ON P.trackedentitytypeid = TE.trackedentitytypeid ");
 
     if (!params.hasProgram()) {
       trackedEntity


### PR DESCRIPTION
When requesting multiple tracked entities without specifying a program, we need to validate whether the user has access to any TE/program combination. If they have access to at least one, the user will be able to see the tracked entity attributes.

To do that, I refactored the query that fetches tracked entities, so now I join the program table and then, one by one, I retrieve the owner of each entity to further narrow it down depending on the requested parameters. If there's at least one result, it means the user has access to see the attributes of that particular TE.