### PR TITLE
fix: Add write access validation for relationships in Tracker Importer [DHIS2-17252]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerAccessManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerAccessManager.java
@@ -37,7 +37,6 @@ import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.user.UserDetails;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -85,7 +84,6 @@ public interface TrackerAccessManager {
 
   List<String> canWrite(UserDetails user, Relationship relationship);
 
-  @Transactional(readOnly = true)
   List<String> canDelete(UserDetails user, @Nonnull Relationship relationship);
 
   /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerAccessManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerAccessManager.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.trackedentity;
 
 import java.util.List;
+import javax.annotation.Nonnull;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -36,6 +37,7 @@ import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.user.UserDetails;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -82,6 +84,9 @@ public interface TrackerAccessManager {
   List<String> canRead(UserDetails user, Relationship relationship);
 
   List<String> canWrite(UserDetails user, Relationship relationship);
+
+  @Transactional(readOnly = true)
+  List<String> canDelete(UserDetails user, @Nonnull Relationship relationship);
 
   /**
    * Checks the sharing read access to EventDataValue

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/tracker/imports/validation/ValidationCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/tracker/imports/validation/ValidationCode.java
@@ -172,6 +172,7 @@ public enum ValidationCode {
   E4017("Relationship: `{0}`, is already deleted and cannot be modified."),
   E4018("Relationship: `{0}`, linking {1}: `{2}` to {3}: `{4}` already exists."),
   E4019("User: `{0}`, has no data write access to relationship type: `{1}`."),
+  E4020("User: `{0}`, has no write access to relationship: `{1}`."),
   E5000(
       "\"{0}\" `{1}` cannot be persisted because \"{2}\" `{3}` referenced by it cannot be persisted."),
   E5001(

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
@@ -34,6 +34,7 @@ import static org.hisp.dhis.trackedentity.TrackerOwnershipManager.PROGRAM_ACCESS
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
@@ -606,15 +607,47 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
 
     RelationshipItem from = relationship.getFrom();
     RelationshipItem to = relationship.getTo();
+    boolean isBidirectional = relationshipType.isBidirectional();
 
     errors.addAll(canWrite(user, from.getTrackedEntity()));
     errors.addAll(canUpdate(user, from.getEnrollment(), false));
     errors.addAll(canUpdate(user, from.getEvent(), false));
 
-    errors.addAll(canWrite(user, to.getTrackedEntity()));
-    errors.addAll(canUpdate(user, to.getEnrollment(), false));
-    errors.addAll(canUpdate(user, to.getEvent(), false));
+    if (isBidirectional) {
+      errors.addAll(canWrite(user, to.getTrackedEntity()));
+      errors.addAll(canUpdate(user, to.getEnrollment(), false));
+      errors.addAll(canUpdate(user, to.getEvent(), false));
+    } else {
+      errors.addAll(canRead(user, to.getTrackedEntity()));
+      errors.addAll(canRead(user, to.getEnrollment(), false));
+      errors.addAll(canRead(user, to.getEvent(), false));
+    }
+    return errors;
+  }
 
+  @Override
+  @Transactional(readOnly = true)
+  public List<String> canDelete(UserDetails user, @Nonnull Relationship relationship) {
+    RelationshipType relationshipType = relationship.getRelationshipType();
+    List<String> errors = new ArrayList<>();
+
+    if (!aclService.canDataWrite(user, relationshipType)) {
+      errors.add("User has no data write access to relationshipType: " + relationshipType.getUid());
+    }
+
+    RelationshipItem from = relationship.getFrom();
+    RelationshipItem to = relationship.getTo();
+    boolean isBidirectional = relationshipType.isBidirectional();
+
+    errors.addAll(canWrite(user, from.getTrackedEntity()));
+    errors.addAll(canUpdate(user, from.getEnrollment(), false));
+    errors.addAll(canUpdate(user, from.getEvent(), false));
+
+    if (isBidirectional) {
+      errors.addAll(canWrite(user, to.getTrackedEntity()));
+      errors.addAll(canUpdate(user, to.getEnrollment(), false));
+      errors.addAll(canUpdate(user, to.getEvent(), false));
+    }
     return errors;
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/RelationshipMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/RelationshipMapper.java
@@ -28,12 +28,15 @@
 package org.hisp.dhis.tracker.imports.preheat.mappers;
 
 import org.hisp.dhis.relationship.Relationship;
+import org.hisp.dhis.relationship.RelationshipConstraint;
+import org.hisp.dhis.relationship.RelationshipItem;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(uses = {DebugMapper.class, RelationshipTypeMapper.class, AttributeValueMapper.class})
+@Mapper(uses = {DebugMapper.class, RelationshipTypeMapper.class, TrackedEntityMapper.class, EnrollmentMapper.class, EventMapper.class,AttributeValueMapper.class})
 public interface RelationshipMapper extends PreheatMapper<Relationship> {
   RelationshipMapper INSTANCE = Mappers.getMapper(RelationshipMapper.class);
 
@@ -42,8 +45,8 @@ public interface RelationshipMapper extends PreheatMapper<Relationship> {
   @Mapping(target = "id")
   @Mapping(target = "uid")
   @Mapping(target = "code")
-  @Mapping(target = "from")
-  @Mapping(target = "to")
+  @Mapping(target = "from", qualifiedByName = "itemMapper")
+  @Mapping(target = "to", qualifiedByName = "itemMapper")
   @Mapping(target = "key")
   @Mapping(target = "invertedKey")
   @Mapping(target = "created")
@@ -53,4 +56,12 @@ public interface RelationshipMapper extends PreheatMapper<Relationship> {
   @Mapping(target = "createdAtClient")
   @Mapping(target = "deleted")
   Relationship map(Relationship relationship);
+
+  @Named("itemMapper")
+  @BeanMapping(ignoreByDefault = true)
+  @Mapping(target = "id")
+  @Mapping(target = "trackedEntity")
+  @Mapping(target = "enrollment")
+  @Mapping(target = "event")
+  RelationshipItem mapItem(RelationshipItem relationshipItem);
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/RelationshipMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/RelationshipMapper.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.tracker.imports.preheat.mappers;
 
 import org.hisp.dhis.relationship.Relationship;
-import org.hisp.dhis.relationship.RelationshipConstraint;
 import org.hisp.dhis.relationship.RelationshipItem;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
@@ -36,7 +35,15 @@ import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(uses = {DebugMapper.class, RelationshipTypeMapper.class, TrackedEntityMapper.class, EnrollmentMapper.class, EventMapper.class,AttributeValueMapper.class})
+@Mapper(
+    uses = {
+      DebugMapper.class,
+      RelationshipTypeMapper.class,
+      TrackedEntityMapper.class,
+      EnrollmentMapper.class,
+      EventMapper.class,
+      AttributeValueMapper.class
+    })
 public interface RelationshipMapper extends PreheatMapper<Relationship> {
   RelationshipMapper INSTANCE = Mappers.getMapper(RelationshipMapper.class);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/TrackedEntityMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/mappers/TrackedEntityMapper.java
@@ -63,6 +63,6 @@ public interface TrackedEntityMapper extends PreheatMapper<TrackedEntity> {
   @Mapping(target = "name")
   @Mapping(target = "attributeValues")
   @Mapping(target = "user")
-  @Mapping(target = "parent")
+  @Mapping(target = "parent", qualifiedByName = "organisationUnit")
   OrganisationUnit map(OrganisationUnit organisationUnit);
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/relationship/RelationshipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/relationship/RelationshipValidator.java
@@ -51,9 +51,9 @@ public class RelationshipValidator implements Validator<TrackerBundle> {
                 new ExistenceValidator(),
                 new MandatoryFieldsValidator(),
                 new MetaValidator(),
+                securityOwnershipValidator,
                 new LinkValidator(),
                 new ConstraintValidator(),
-                securityOwnershipValidator,
                 new DuplicationValidator()));
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/relationship/RelationshipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/relationship/RelationshipValidator.java
@@ -51,9 +51,9 @@ public class RelationshipValidator implements Validator<TrackerBundle> {
                 new ExistenceValidator(),
                 new MandatoryFieldsValidator(),
                 new MetaValidator(),
-                securityOwnershipValidator,
                 new LinkValidator(),
                 new ConstraintValidator(),
+                securityOwnershipValidator,
                 new DuplicationValidator()));
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/relationship/SecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/relationship/SecurityOwnershipValidator.java
@@ -27,36 +27,47 @@
  */
 package org.hisp.dhis.tracker.imports.validation.validator.relationship;
 
-import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
-import org.hisp.dhis.relationship.RelationshipType;
-import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
+import org.hisp.dhis.tracker.imports.converter.RelationshipTrackerConverterService;
 import org.hisp.dhis.tracker.imports.domain.Relationship;
 import org.hisp.dhis.tracker.imports.validation.Reporter;
 import org.hisp.dhis.tracker.imports.validation.ValidationCode;
 import org.hisp.dhis.tracker.imports.validation.Validator;
+import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
 
 @Component(
     "org.hisp.dhis.tracker.imports.validation.validator.relationship.SecurityOwnershipValidator")
 @RequiredArgsConstructor
 class SecurityOwnershipValidator implements Validator<Relationship> {
-
-  @Nonnull private final AclService aclService;
+  private final TrackerAccessManager trackerAccessManager;
+  private final RelationshipTrackerConverterService relationshipTrackerConverterService;
 
   @Override
   public void validate(Reporter reporter, TrackerBundle bundle, Relationship relationship) {
     TrackerImportStrategy strategy = bundle.getStrategy(relationship);
-    RelationshipType relationshipType =
-        strategy.isUpdateOrDelete()
-            ? bundle.getPreheat().getRelationship(relationship).getRelationshipType()
-            : bundle.getPreheat().getRelationshipType(relationship.getRelationshipType());
 
-    if (!aclService.canDataWrite(bundle.getUser(), relationshipType)) {
+    if (strategy.isDelete()
+        && (!trackerAccessManager
+            .canDelete(
+                UserDetails.fromUser(bundle.getUser()),
+                bundle.getPreheat().getRelationship(relationship))
+            .isEmpty())) {
       reporter.addError(
-          relationship, ValidationCode.E4019, bundle.getUser(), relationship.getRelationshipType());
+          relationship, ValidationCode.E4020, bundle.getUser(), relationship.getRelationship());
+    }
+
+    if (strategy.isCreate()
+        && (!trackerAccessManager
+            .canWrite(
+                UserDetails.fromUser(bundle.getUser()),
+                relationshipTrackerConverterService.from(bundle.getPreheat(), relationship))
+            .isEmpty())) {
+      reporter.addError(
+          relationship, ValidationCode.E4020, bundle.getUser(), relationship.getRelationship());
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/EnrollmentSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/EnrollmentSupplierTest.java
@@ -86,6 +86,7 @@ class EnrollmentSupplierTest extends DhisConvenienceTest {
     enrollments = rnd.objects(Enrollment.class, 2).collect(Collectors.toList());
     // set the OrgUnit parent to null to avoid recursive errors when mapping
     enrollments.forEach(p -> p.getOrganisationUnit().setParent(null));
+    enrollments.forEach(p -> p.getTrackedEntity().getOrganisationUnit().setParent(null));
 
     programWithRegistration = createProgram('A');
     programWithRegistration.setProgramType(WITH_REGISTRATION);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/relationship/SecurityOwnershipValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/relationship/SecurityOwnershipValidatorTest.java
@@ -28,16 +28,20 @@
 package org.hisp.dhis.tracker.imports.validation.validator.relationship;
 
 import static org.hisp.dhis.tracker.imports.TrackerImportStrategy.CREATE;
-import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E4019;
+import static org.hisp.dhis.tracker.imports.TrackerImportStrategy.DELETE;
+import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E4020;
 import static org.hisp.dhis.tracker.imports.validation.validator.AssertValidations.assertHasError;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import org.hisp.dhis.relationship.RelationshipType;
+import java.util.List;
 import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.tracker.imports.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
+import org.hisp.dhis.tracker.imports.converter.RelationshipTrackerConverterService;
 import org.hisp.dhis.tracker.imports.domain.Relationship;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.validation.Reporter;
@@ -58,15 +62,19 @@ class SecurityOwnershipValidatorTest {
 
   @Mock private AclService aclService;
 
+  @Mock private TrackerAccessManager trackerAccessManager;
+
+  @Mock private RelationshipTrackerConverterService converterService;
+
+  private org.hisp.dhis.relationship.Relationship convertedRelationship;
+
   private Reporter reporter;
 
   private Relationship relationship;
 
-  private RelationshipType relationshipType;
-
   @BeforeEach
   public void setUp() {
-    validator = new SecurityOwnershipValidator(aclService);
+    validator = new SecurityOwnershipValidator(trackerAccessManager, converterService);
 
     when(bundle.getPreheat()).thenReturn(preheat);
 
@@ -74,27 +82,53 @@ class SecurityOwnershipValidatorTest {
     reporter = new Reporter(idSchemes);
     relationship = new Relationship();
     relationship.setRelationship("relationshipUid");
-    relationshipType = new RelationshipType();
 
-    when(bundle.getPreheat().getRelationshipType(any())).thenReturn(relationshipType);
+    convertedRelationship = new org.hisp.dhis.relationship.Relationship();
+  }
+
+  @Test
+  void shouldCreateWhenUserHasWriteAccessToRelationship() {
     when(bundle.getStrategy(relationship)).thenReturn(CREATE);
-  }
-
-  @Test
-  void shouldFailWhenUserHasNoAccessToRelationshipType() {
-    when(aclService.canDataWrite(bundle.getUser(), relationshipType)).thenReturn(false);
-
-    validator.validate(reporter, bundle, relationship);
-
-    assertHasError(reporter, relationship, E4019);
-  }
-
-  @Test
-  void shouldWorkWhenUserHasAccessToRelationshipType() {
-    when(aclService.canDataWrite(bundle.getUser(), relationshipType)).thenReturn(true);
+    when(converterService.from(preheat, relationship)).thenReturn(convertedRelationship);
+    when(trackerAccessManager.canWrite(any(), eq(convertedRelationship))).thenReturn(List.of());
 
     validator.validate(reporter, bundle, relationship);
 
     assertIsEmpty(reporter.getErrors());
+  }
+
+  @Test
+  void shouldFailToCreateWhenUserHasNoWriteAccessToRelationship() {
+    when(bundle.getStrategy(relationship)).thenReturn(CREATE);
+    when(converterService.from(preheat, relationship)).thenReturn(convertedRelationship);
+    when(trackerAccessManager.canWrite(any(), eq(convertedRelationship)))
+        .thenReturn(List.of("error"));
+
+    validator.validate(reporter, bundle, relationship);
+
+    assertHasError(reporter, relationship, E4020);
+  }
+
+  @Test
+  void shouldDeleteWhenUserHasWriteAccessToRelationship() {
+    when(bundle.getStrategy(relationship)).thenReturn(DELETE);
+    when(preheat.getRelationship(relationship)).thenReturn(convertedRelationship);
+    when(trackerAccessManager.canDelete(any(), eq(convertedRelationship))).thenReturn(List.of());
+
+    validator.validate(reporter, bundle, relationship);
+
+    assertIsEmpty(reporter.getErrors());
+  }
+
+  @Test
+  void shouldFailToDeleteWhenUserHasNoWriteAccessToRelationship() {
+    when(bundle.getStrategy(relationship)).thenReturn(DELETE);
+    when(preheat.getRelationship(relationship)).thenReturn(convertedRelationship);
+    when(trackerAccessManager.canDelete(any(), eq(convertedRelationship)))
+        .thenReturn(List.of("error"));
+
+    validator.validate(reporter, bundle, relationship);
+
+    assertHasError(reporter, relationship, E4020);
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/RelationshipImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/RelationshipImportTest.java
@@ -90,7 +90,7 @@ class RelationshipImportTest extends TrackerTest {
     ImportReport importReport =
         trackerImportService.importTracker(params, fromJson("tracker/relationships.json"));
 
-    assertHasError(importReport, ValidationCode.E4019);
+    assertHasError(importReport, ValidationCode.E4020);
     assertThat(importReport.getStats().getIgnored(), is(2));
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/RelationshipSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/RelationshipSecurityImportValidationTest.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.validation;
+
+import static org.hisp.dhis.tracker.Assertions.assertHasOnlyErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
+import static org.hisp.dhis.tracker.imports.validation.Users.USER_11;
+import static org.hisp.dhis.tracker.imports.validation.Users.USER_12;
+import static org.hisp.dhis.tracker.imports.validation.ValidationCode.E4020;
+
+import java.io.IOException;
+import org.hisp.dhis.program.EnrollmentService;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.relationship.RelationshipType;
+import org.hisp.dhis.tracker.TrackerTest;
+import org.hisp.dhis.tracker.imports.TrackerImportParams;
+import org.hisp.dhis.tracker.imports.TrackerImportService;
+import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
+import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
+import org.hisp.dhis.tracker.imports.report.ImportReport;
+import org.hisp.dhis.user.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class RelationshipSecurityImportValidationTest extends TrackerTest {
+
+  @Autowired protected EnrollmentService enrollmentService;
+
+  @Autowired private TrackerImportService trackerImportService;
+
+  @Autowired protected UserService _userService;
+
+  @Override
+  protected void initTest() throws IOException {
+    userService = _userService;
+    setUpMetadata("tracker/tracker_basic_metadata.json");
+    injectAdminUser();
+    assertNoErrors(
+        trackerImportService.importTracker(
+            new TrackerImportParams(), fromJson("tracker/validations/te_relationship.json")));
+    manager.flush();
+  }
+
+  @Test
+  void shouldCreateWhenUserHasAccessToRelationshipTypeAndWriteAccessToBidirectionalRelationship()
+      throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_siblings.json");
+    TrackerImportParams params = new TrackerImportParams();
+    params.setUserId(USER_11);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+    assertNoErrors(importReport);
+  }
+
+  @Test
+  void
+      shouldFailToCreateWhenUserHasNoAccessToRelationshipTypeAndWriteAccessToBidirectionalRelationship()
+          throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_siblings.json");
+    TrackerImportParams params = new TrackerImportParams();
+    params.setUserId(USER_11);
+
+    RelationshipType relationshipType = manager.get(RelationshipType.class, "xLmPUYJX8Ks");
+    relationshipType.getSharing().getUsers().remove(USER_11);
+    manager.update(relationshipType);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertHasOnlyErrors(importReport, E4020);
+  }
+
+  @Test
+  void
+      shouldFailToCreateWhenUserHasAccessToRelationshipTypeAndNoWriteAccessToBidirectionalRelationshipFrom()
+          throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_siblings.json");
+    TrackerImportParams params = new TrackerImportParams();
+    params.setUserId(USER_11);
+
+    Program program = manager.get(Program.class, "E8o1E9tAppy");
+    program.getSharing().getUsers().get(USER_11).setAccess("r-r-----");
+    manager.update(program);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertHasOnlyErrors(importReport, E4020);
+  }
+
+  @Test
+  void
+      shouldFailToCreateWhenUserHasAccessToRelationshipTypeAndNoWriteAccessToBidirectionalBidirectionalRelationshipTo()
+          throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_siblings.json");
+    TrackerImportParams params = new TrackerImportParams();
+    params.setUserId(USER_11);
+
+    Program program = manager.get(Program.class, "YYY1E9tAbbW");
+    program.getSharing().getUsers().get(USER_11).setAccess("r-r-----");
+    manager.update(program);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertHasOnlyErrors(importReport, E4020);
+  }
+
+  @Test
+  void shouldDeleteWhenUserHasAccessToRelationshipTypeAndWriteAccessToBidirectionalRelationship()
+      throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_siblings.json");
+    TrackerImportParams params = new TrackerImportParams();
+    params.setUserId(USER_11);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+    assertNoErrors(importReport);
+
+    params.setImportStrategy(TrackerImportStrategy.DELETE);
+    importReport = trackerImportService.importTracker(params, trackerObjects);
+    assertNoErrors(importReport);
+  }
+
+  @Test
+  void
+      shouldFailToDeleteWhenUserHasNoAccessToRelationshipTypeAndWriteAccessToBidirectionalRelationship()
+          throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_siblings.json");
+    TrackerImportParams params = new TrackerImportParams();
+    params.setUserId(USER_11);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+    assertNoErrors(importReport);
+
+    RelationshipType relationshipType = manager.get(RelationshipType.class, "xLmPUYJX8Ks");
+    relationshipType.getSharing().getUsers().remove(USER_11);
+    manager.update(relationshipType);
+
+    params.setImportStrategy(TrackerImportStrategy.DELETE);
+    importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertHasOnlyErrors(importReport, E4020);
+  }
+
+  @Test
+  void
+      shouldFailToDeleteWhenUserHasAccessToRelationshipTypeAndNoWriteAccessToBidirectionalRelationshipFrom()
+          throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_siblings.json");
+    TrackerImportParams params = new TrackerImportParams();
+    params.setUserId(USER_11);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+    assertNoErrors(importReport);
+
+    Program program = manager.get(Program.class, "E8o1E9tAppy");
+    program.getSharing().getUsers().get(USER_11).setAccess("r-r-----");
+    manager.update(program);
+
+    params.setImportStrategy(TrackerImportStrategy.DELETE);
+    importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertHasOnlyErrors(importReport, E4020);
+  }
+
+  @Test
+  void
+      shouldFailToDeleteWhenUserHasAccessToRelationshipTypeAndNoWriteAccessToBidirectionalRelationshipTo()
+          throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_siblings.json");
+    TrackerImportParams params = new TrackerImportParams();
+    params.setUserId(USER_11);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+    assertNoErrors(importReport);
+
+    Program program = manager.get(Program.class, "YYY1E9tAbbW");
+    program.getSharing().getUsers().get(USER_11).setAccess("r-r-----");
+    manager.update(program);
+
+    params.setImportStrategy(TrackerImportStrategy.DELETE);
+    importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertHasOnlyErrors(importReport, E4020);
+  }
+
+  @Test
+  void shouldCreateWhenUserHasAccessToRelationshipTypeAndWriteAccessToRelationship()
+      throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_parent_child.json");
+    TrackerImportParams params = new TrackerImportParams();
+    params.setUserId(USER_12);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+    assertNoErrors(importReport);
+  }
+
+  @Test
+  void shouldFailToCreateWhenUserHasNoAccessToRelationshipTypeAndWriteAccessToRelationship()
+      throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_parent_child.json");
+    TrackerImportParams params = new TrackerImportParams();
+    params.setUserId(USER_12);
+
+    RelationshipType relationshipType = manager.get(RelationshipType.class, "TV9oB9LT3sh");
+    relationshipType.getSharing().getUsers().remove(USER_12);
+    manager.update(relationshipType);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertHasOnlyErrors(importReport, E4020);
+  }
+
+  @Test
+  void shouldFailToCreateWhenUserHasAccessToRelationshipTypeAndNoWriteAccessToRelationshipFrom()
+      throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_parent_child.json");
+    TrackerImportParams params = new TrackerImportParams();
+    params.setUserId(USER_12);
+
+    Program program = manager.get(Program.class, "E8o1E9tAppy");
+    program.getSharing().getUsers().get(USER_12).setAccess("r-r-----");
+    manager.update(program);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertHasOnlyErrors(importReport, E4020);
+  }
+
+  @Test
+  void shouldFailToCreateWhenUserHasAccessToRelationshipTypeAndNoWriteAccessToRelationshipTo()
+      throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_parent_child.json");
+    TrackerImportParams params = new TrackerImportParams();
+    params.setUserId(USER_12);
+
+    Program program = manager.get(Program.class, "YYY1E9tAbbW");
+    program.getSharing().getUsers().remove(USER_12);
+    manager.update(program);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertHasOnlyErrors(importReport, E4020);
+  }
+
+  @Test
+  void shouldDeleteWhenUserHasAccessToRelationshipTypeAndWriteAccessToRelationship()
+      throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_parent_child.json");
+    TrackerImportParams params = new TrackerImportParams();
+    params.setUserId(USER_12);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+    assertNoErrors(importReport);
+
+    Program program = manager.get(Program.class, "YYY1E9tAbbW");
+    program.getSharing().getUsers().remove(USER_12);
+    manager.update(program);
+
+    params.setImportStrategy(TrackerImportStrategy.DELETE);
+    importReport = trackerImportService.importTracker(params, trackerObjects);
+    assertNoErrors(importReport);
+  }
+
+  @Test
+  void shouldFailToDeleteWhenUserHasNoAccessToRelationshipTypeAndWriteAccessToRelationship()
+      throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_parent_child.json");
+    TrackerImportParams params = new TrackerImportParams();
+    params.setUserId(USER_12);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+    assertNoErrors(importReport);
+
+    RelationshipType relationshipType = manager.get(RelationshipType.class, "TV9oB9LT3sh");
+    relationshipType.getSharing().getUsers().remove(USER_12);
+    manager.update(relationshipType);
+
+    params.setImportStrategy(TrackerImportStrategy.DELETE);
+    importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertHasOnlyErrors(importReport, E4020);
+  }
+
+  @Test
+  void shouldFailToDeleteWhenUserHasAccessToRelationshipTypeAndNoWriteAccessToRelationshipFrom()
+      throws IOException {
+    TrackerObjects trackerObjects = fromJson("tracker/validations/relationship_parent_child.json");
+    TrackerImportParams params = new TrackerImportParams();
+    params.setUserId(USER_12);
+
+    ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
+    assertNoErrors(importReport);
+
+    Program program = manager.get(Program.class, "E8o1E9tAppy");
+    program.getSharing().getUsers().get(USER_12).setAccess("r-r-----");
+    manager.update(program);
+
+    params.setImportStrategy(TrackerImportStrategy.DELETE);
+    importReport = trackerImportService.importTracker(params, trackerObjects);
+
+    assertHasOnlyErrors(importReport, E4020);
+  }
+}

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/Users.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/Users.java
@@ -47,4 +47,8 @@ public class Users {
   public static final String USER_9 = "KpknKHptuF4";
 
   public static final String USER_10 = "Xl2V8x8R1R5";
+
+  public static final String USER_11 = "xkMgMi7Ci2D";
+
+  public static final String USER_12 = "jiFUk9o7gH3";
 }

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/tracker_basic_metadata.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/tracker_basic_metadata.json
@@ -446,6 +446,79 @@
       }
     }
   ],
+  "relationshipTypes": [
+    {
+      "created": "2019-04-23T09:20:41.834",
+      "lastUpdated": "2019-04-23T09:21:18.063",
+      "name": "TA Sibling",
+      "code": "TA_SIBLING",
+      "id": "xLmPUYJX8Ks",
+      "bidirectional": true,
+      "toFromName": "Sibling of",
+      "fromToName": "Sibling of",
+      "fromConstraint": {
+        "relationshipEntity": "TRACKED_ENTITY_INSTANCE",
+        "trackedEntityType": {
+          "id": "bPJ0FMtcnEh",
+          "code": "TA_PERSON_TET"
+        }
+      },
+      "toConstraint": {
+        "relationshipEntity": "TRACKED_ENTITY_INSTANCE",
+        "trackedEntityType": {
+          "id": "XXXbPJ0FMtc",
+          "code": "TA_PERSON_YYY"
+        }
+      },
+      "sharing": {
+        "public": "rw------",
+        "external": false,
+        "users": {
+          "xkMgMi7Ci2D": {
+            "id": "xkMgMi7Ci2D",
+            "access": "rwrw----"
+          }
+        }
+      },
+      "translations": []
+    },
+    {
+      "lastUpdated": "2020-11-20T09:06:23.348",
+      "id": "TV9oB9LT3sh",
+      "created": "2020-11-20T09:06:23.348",
+      "name": "TA Parent to Child",
+      "code": "TA_PARENT_TO_CHILD_RELATIONSHIP",
+      "bidirectional": false,
+      "displayName": "TA Parent to Child",
+      "fromToName": "Parent Of",
+      "displayFromToName": "Parent Of",
+      "favorite": false,
+      "fromConstraint": {
+        "relationshipEntity": "TRACKED_ENTITY_INSTANCE",
+        "trackedEntityType": {
+          "id": "bPJ0FMtcnEh",
+          "code": "TA_PERSON_TET"
+        }
+      },
+      "toConstraint": {
+        "relationshipEntity": "TRACKED_ENTITY_INSTANCE",
+        "trackedEntityType": {
+          "id": "XXXbPJ0FMtc",
+          "code": "TA_PERSON_YYY"
+        }
+      },
+      "sharing": {
+        "public": "rw------",
+        "external": false,
+        "users": {
+          "jiFUk9o7gH3": {
+            "id": "jiFUk9o7gH3",
+            "access": "rwrw----"
+          }
+        }
+      }
+    }
+  ],
   "programs": [
     {
       "ignoreOverdueEvents": false,
@@ -634,6 +707,14 @@
           },
           "KpknKHptuF4": {
             "id": "KpknKHptuF4",
+            "access": "rwrw----"
+          },
+          "xkMgMi7Ci2D": {
+            "id": "xkMgMi7Ci2D",
+            "access": "rwrw----"
+          },
+          "jiFUk9o7gH3": {
+            "id": "jiFUk9o7gH3",
             "access": "rwrw----"
           }
         },
@@ -943,6 +1024,14 @@
           "iAji3gyZYQL": {
             "id": "iAji3gyZYQL",
             "access": "rwrw----"
+          },
+          "xkMgMi7Ci2D": {
+            "id": "xkMgMi7Ci2D",
+            "access": "rwrw----"
+          },
+          "jiFUk9o7gH3": {
+            "id": "jiFUk9o7gH3",
+            "access": "r-r-----"
           }
         },
         "userGroups": {}
@@ -1596,6 +1685,118 @@
       "firstName": "state",
       "surname": "state",
       "id": "Xl2V8x8R1R5",
+      "password": "Test123###...",
+      "attributeValues": []
+    },
+    {
+      "dataViewOrganisationUnits": [
+        {
+          "id": "QfUVllTs6cZ"
+        }
+      ],
+      "teiSearchOrganisationUnits": [],
+      "created": "2019-03-25T13:58:35.560",
+      "code": "user11",
+      "organisationUnits": [
+        {
+          "id": "QfUVllTs6cZ"
+        },
+        {
+          "id": "QfUVllTs6cW"
+        }
+      ],
+      "lastUpdated": "2019-03-29T08:57:41.890",
+      "lastCheckedInterpretations": "2019-03-29T08:57:20.392",
+      "favorite": false,
+      "catDimensionConstraints": [],
+      "userAccesses": [],
+      "disabled": false,
+      "userRoles": [
+        {
+          "id": "BBB6vc5Ip3r"
+        }
+      ],
+      "name": "state user",
+      "displayName": "state user",
+      "favorites": [],
+      "selfRegistered": false,
+      "externalAccess": false,
+      "externalAuth": false,
+      "twoFA": false,
+      "username": "user11",
+      "userGroupAccesses": [],
+      "access": {
+        "externalize": true,
+        "read": true,
+        "manage": true,
+        "delete": true,
+        "write": true,
+        "update": true
+      },
+      "cogsDimensionConstraints": [],
+      "invitation": false,
+      "lastLogin": "2019-03-29T12:42:06.495",
+      "translations": [],
+      "passwordLastUpdated": "2019-03-29T08:57:41.766",
+      "firstName": "state",
+      "surname": "state",
+      "id": "xkMgMi7Ci2D",
+      "password": "Test123###...",
+      "attributeValues": []
+    },
+    {
+      "dataViewOrganisationUnits": [
+        {
+          "id": "QfUVllTs6cZ"
+        }
+      ],
+      "teiSearchOrganisationUnits": [],
+      "created": "2019-03-25T13:58:35.560",
+      "code": "user12",
+      "organisationUnits": [
+        {
+          "id": "QfUVllTs6cZ"
+        },
+        {
+          "id": "QfUVllTs6cW"
+        }
+      ],
+      "lastUpdated": "2019-03-29T08:57:41.890",
+      "lastCheckedInterpretations": "2019-03-29T08:57:20.392",
+      "favorite": false,
+      "catDimensionConstraints": [],
+      "userAccesses": [],
+      "disabled": false,
+      "userRoles": [
+        {
+          "id": "BBB6vc5Ip3r"
+        }
+      ],
+      "name": "state user",
+      "displayName": "state user",
+      "favorites": [],
+      "selfRegistered": false,
+      "externalAccess": false,
+      "externalAuth": false,
+      "twoFA": false,
+      "username": "user12",
+      "userGroupAccesses": [],
+      "access": {
+        "externalize": true,
+        "read": true,
+        "manage": true,
+        "delete": true,
+        "write": true,
+        "update": true
+      },
+      "cogsDimensionConstraints": [],
+      "invitation": false,
+      "lastLogin": "2019-03-29T12:42:06.495",
+      "translations": [],
+      "passwordLastUpdated": "2019-03-29T08:57:41.766",
+      "firstName": "state",
+      "surname": "state",
+      "id": "jiFUk9o7gH3",
       "password": "Test123###...",
       "attributeValues": []
     }
@@ -2376,6 +2577,14 @@
           "KpknKHptuF4": {
             "id": "KpknKHptuF4",
             "access": "rwrw----"
+          },
+          "xkMgMi7Ci2D": {
+            "id": "xkMgMi7Ci2D",
+            "access": "rwrw----"
+          },
+          "jiFUk9o7gH3": {
+            "id": "jiFUk9o7gH3",
+            "access": "r-r-----"
           }
         },
         "userGroups": {
@@ -2407,7 +2616,16 @@
         "public": "rw------",
         "external": false,
         "owner": "M5zQapPyTZI",
-        "users": {},
+        "users": {
+          "xkMgMi7Ci2D": {
+            "id": "xkMgMi7Ci2D",
+            "access": "rwrw----"
+          },
+          "jiFUk9o7gH3": {
+            "id": "jiFUk9o7gH3",
+            "access": "r-r-----"
+          }
+        },
         "userGroups": {
           "jCDKJBruqjc": {
             "id": "jCDKJBruqjc",

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/validations/relationship_parent_child.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/validations/relationship_parent_child.json
@@ -1,0 +1,52 @@
+{
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": {
+      "idScheme": "UID"
+    },
+    "orgUnitIdScheme": {
+      "idScheme": "UID"
+    },
+    "programIdScheme": {
+      "idScheme": "UID"
+    },
+    "programStageIdScheme": {
+      "idScheme": "UID"
+    },
+    "idScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionComboIdScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionIdScheme": {
+      "idScheme": "UID"
+    }
+  },
+  "importStrategy": "CREATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
+  "trackedEntities": [],
+  "enrollments": [],
+  "events": [],
+  "relationships": [
+    {
+      "relationship": "R3Akl4Ts6r9",
+      "relationshipType": {
+        "idScheme": "UID",
+        "identifier": "TV9oB9LT3sh"
+      },
+      "from": {
+        "trackedEntity": "Kj6vYde4LHh"
+      },
+      "to": {
+        "trackedEntity": "KKKKj6vYdes"
+      }
+    }
+  ],
+  "username": "system-process"
+}

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/validations/relationship_siblings.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/validations/relationship_siblings.json
@@ -1,0 +1,52 @@
+{
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": {
+      "idScheme": "UID"
+    },
+    "orgUnitIdScheme": {
+      "idScheme": "UID"
+    },
+    "programIdScheme": {
+      "idScheme": "UID"
+    },
+    "programStageIdScheme": {
+      "idScheme": "UID"
+    },
+    "idScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionComboIdScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionIdScheme": {
+      "idScheme": "UID"
+    }
+  },
+  "importStrategy": "CREATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
+  "trackedEntities": [],
+  "enrollments": [],
+  "events": [],
+  "relationships": [
+    {
+      "relationship": "R3Akl4Ts6r9",
+      "relationshipType": {
+        "idScheme": "UID",
+        "identifier": "xLmPUYJX8Ks"
+      },
+      "from": {
+        "trackedEntity": "Kj6vYde4LHh"
+      },
+      "to": {
+        "trackedEntity": "KKKKj6vYdes"
+      }
+    }
+  ],
+  "username": "system-process"
+}

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/validations/te_relationship.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/validations/te_relationship.json
@@ -1,0 +1,73 @@
+{
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": {
+      "idScheme": "UID"
+    },
+    "orgUnitIdScheme": {
+      "idScheme": "UID"
+    },
+    "programIdScheme": {
+      "idScheme": "UID"
+    },
+    "programStageIdScheme": {
+      "idScheme": "UID"
+    },
+    "idScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionComboIdScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionIdScheme": {
+      "idScheme": "UID"
+    }
+  },
+  "importStrategy": "CREATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
+  "trackedEntities": [
+    {
+      "trackedEntity": "Kj6vYde4LHh",
+      "trackedEntityType": {
+        "idScheme": "UID",
+        "identifier": "bPJ0FMtcnEh"
+      },
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cZ"
+      },
+      "inactive": false,
+      "deleted": false,
+      "potentialDuplicate": false,
+      "relationships": [],
+      "attributes": [],
+      "enrollments": []
+    },
+    {
+      "trackedEntity": "KKKKj6vYdes",
+      "trackedEntityType": {
+        "idScheme": "UID",
+        "identifier": "XXXbPJ0FMtc"
+      },
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cW"
+      },
+      "inactive": false,
+      "deleted": false,
+      "potentialDuplicate": false,
+      "relationships": [],
+      "attributes": [],
+      "enrollments": []
+    }
+  ],
+  "enrollments": [],
+  "events": [],
+  "relationships": [],
+  "username": "system-process"
+}


### PR DESCRIPTION
Relationships were not validating write access for `from` and `to` items.
Now when importing a relationship, the rules are the following:
- Create bidirectional relationship: `from` and `to` must have write access
- Create unidirectional relationship: `from` must have write access and `to` must have write access
- Delete bidirectional relationship: `from` and `to` must have write access
- Delete unidirectional relationship: `from` must have write access `to`doesn't need any access

Relationships cannot be updated.
As the `SecurityOwnershipValidator` is accessing the `from` and `to` items, it must be moved after the constraint validator that checks the existence and validity of items.