### PR TITLE
fix: visualizations api returns incorrect  relativePeriods

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/visualization/hibernate/Visualization.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/visualization/hibernate/Visualization.hbm.xml
@@ -211,7 +211,7 @@
 
     <property name="endDate"/>
 
-    <many-to-one name="relatives" unique="true" class="org.hisp.dhis.period.RelativePeriods" column="relativeperiodsid"
+    <many-to-one name="relatives" lazy="false" unique="true" class="org.hisp.dhis.period.RelativePeriods" column="relativeperiodsid"
                  cascade="all-delete-orphan" foreign-key="fk_visualization_relativeperiodsid"/>
 
     <property name="fontStyle" type="jbVisualizationFontStyle"/>

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/VisualizationControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/VisualizationControllerTest.java
@@ -34,6 +34,8 @@ import static org.hisp.dhis.web.HttpStatus.CONFLICT;
 import static org.hisp.dhis.web.HttpStatus.CREATED;
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.indicator.Indicator;
@@ -294,5 +296,19 @@ class VisualizationControllerTest extends DhisControllerConvenienceTest {
     assertThat(response.get("sorting").toString(), containsString("pe"));
     assertThat(response.get("sorting").toString(), containsString("ASC"));
     assertThat(response.get("sorting").toString(), not(containsString("DESC")));
+  }
+
+  @Test
+  void testRelativePeriods() {
+    POST(
+            "/metadata?importStrategy=CREATE_AND_UPDATE&async=false",
+            WebClient.Body("metadata/metadata_with_visualization.json"))
+        .content(HttpStatus.OK)
+        .as(JsonImportSummary.class);
+    JsonMixed visualization =
+        GET("/visualizations/qD72aBqsHvt").content(HttpStatus.OK).as(JsonMixed.class);
+    assertNotNull(visualization);
+    assertTrue(
+        visualization.getObject("relativePeriods").getBoolean("last12Months").booleanValue());
   }
 }


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-17303

### Issue
- `api/visualizations/{uid}` api return object with all relativePeriods set to `false` although database has `true` value.
- The Visualization entity retrieved from database with a hibernate lazy proxy of `RelativePeriods` object. The proxy has all incorrect values of `periods`.  When entity is deserialized by Jackson, the proxy doesn't trigger database query, instead it just return a default `RelativePeriods` object which has all boolean values default to `false`.
- Adding `Hibernate5Module` to JacksonObjectMapper could solve the issue, however it is a risky solution as there could be side effect because objectMapper is used in many other places.
- I couldn't find out why this suddenly become a problem in 2.41, not sure which code update/refactor caused the issue.
### Fix
- Since `RelativePeriods` is a light weight object with just boolean values, we can just set `lazy=false` to the hibernate mapping so the object will always be fetched when Visualization is loaded. 

### Test
- Added unit test.
- Can manually verify by browsing any Visualization using `api/visualizations/{uid}`

### Todo
- This is however a quick fix, we need to spend time investigate to find out the root cause.