### PR TITLE
fix: DE with legendSet are not duplicated in the query [DHIS2-17259]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/TeiListGrid.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/TeiListGrid.java
@@ -85,7 +85,17 @@ public class TeiListGrid extends ListGrid {
         if (headerExists(cols[i])) {
           String columnLabel = cols[i];
 
-          Object value = getValueAndRoundIfNecessary(rs, columnLabel);
+          boolean columnHasLegendSet =
+              teiQueryParams
+                  .getCommonParams()
+                  .streamDimensions()
+                  .filter(DimensionIdentifier::hasLegendSet)
+                  .map(DimensionIdentifier::getKey)
+                  .anyMatch(columnLabel::equals);
+
+          Object value =
+              getValueAndRoundIfNecessary(
+                  rs, columnHasLegendSet ? columnLabel + LEGEND : columnLabel);
           addValue(value);
           headersSet.add(columnLabel);
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/CommonParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/CommonParams.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.analytics.common.params;
 
+import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
 import static org.hisp.dhis.common.IdScheme.UID;
@@ -40,7 +41,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.Builder;
 import lombok.Getter;
@@ -227,7 +227,7 @@ public class CommonParams {
    */
   public List<DimensionIdentifier<DimensionParam>> getAllDimensionIdentifiers() {
     return streamDimensions()
-        .collect(Collectors.groupingBy(DimensionIdentifier::getKeyNoOffset))
+        .collect(groupingBy(DimensionIdentifier::getKeyNoOffset))
         .values()
         .stream()
         .map(identifiers -> identifiers.get(0))

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/context/sql/SqlQueryBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/query/context/sql/SqlQueryBuilder.java
@@ -27,11 +27,14 @@
  */
 package org.hisp.dhis.analytics.tei.query.context.sql;
 
+import static java.util.stream.Collectors.groupingBy;
+
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
+import lombok.Getter;
 import org.hisp.dhis.analytics.common.params.AnalyticsSortingParams;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifier;
 import org.hisp.dhis.analytics.common.params.dimension.DimensionParam;
@@ -101,4 +104,42 @@ public interface SqlQueryBuilder {
             sortingParams.stream().map(AnalyticsSortingParams::getOrderBy))
         .flatMap(Function.identity());
   }
+
+  /**
+   * Gets a grouped representation of the dimension identifiers, grouping them by key (the alias)
+   *
+   * @return the grouped dimensions
+   */
+  default GroupedDimensions getGroupedDimensions(
+      List<DimensionIdentifier<DimensionParam>> headers,
+      List<DimensionIdentifier<DimensionParam>> dimensions,
+      List<AnalyticsSortingParams> sortingParams) {
+    return GroupedDimensions.of(streamDimensions(headers, dimensions, sortingParams));
+  }
+
+  @Getter
+  class GroupedDimensions {
+
+    private final List<DimensionGroup> groupsByKey;
+
+    private GroupedDimensions(Stream<DimensionIdentifier<DimensionParam>> dimensions) {
+      groupsByKey =
+          dimensions.collect(groupingBy(DimensionIdentifier::getKey)).entrySet().stream()
+              .map(entry -> new DimensionGroup(entry.getKey(), entry.getValue()))
+              .toList();
+    }
+
+    public static GroupedDimensions of(
+        Stream<DimensionIdentifier<DimensionParam>> dimensionIdentifierStream) {
+      return new GroupedDimensions(dimensionIdentifierStream);
+    }
+
+    public Stream<DimensionIdentifier<DimensionParam>> streamOfFirstDimensionInEachGroup() {
+      return groupsByKey.stream()
+          .map(DimensionGroup::dimensions)
+          .map(dimensions -> dimensions.get(0));
+    }
+  }
+
+  record DimensionGroup(String key, List<DimensionIdentifier<DimensionParam>> dimensions) {}
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/query/context/querybuilder/DataElementQueryBuilderTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/query/context/querybuilder/DataElementQueryBuilderTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.tei.query.context.querybuilder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.hisp.dhis.analytics.common.params.AnalyticsSortingParams;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifier;
+import org.hisp.dhis.analytics.common.params.dimension.DimensionParam;
+import org.hisp.dhis.analytics.tei.TeiQueryParams;
+import org.hisp.dhis.analytics.tei.query.context.sql.QueryContext;
+import org.hisp.dhis.analytics.tei.query.context.sql.RenderableSqlQuery;
+import org.hisp.dhis.analytics.tei.query.context.sql.SqlParameterManager;
+import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.legend.LegendSet;
+import org.junit.jupiter.api.Test;
+
+public class DataElementQueryBuilderTest {
+
+  private final DataElementQueryBuilder dataElementQueryBuilder = new DataElementQueryBuilder();
+
+  @Test
+  void testBuildSqlQuery() {
+    DimensionIdentifier<DimensionParam> dWithLegendSet = mock(DimensionIdentifier.class);
+    DimensionParam dimensionForLegendSet = mock(DimensionParam.class);
+    when(dWithLegendSet.getDimension()).thenReturn(dimensionForLegendSet);
+    when(dWithLegendSet.hasLegendSet()).thenReturn(true);
+    QueryItem queryItem = mock(QueryItem.class);
+    when(dimensionForLegendSet.getQueryItem()).thenReturn(queryItem);
+    LegendSet legendSet = mock(LegendSet.class);
+    when(queryItem.getLegendSet()).thenReturn(legendSet);
+    when(dWithLegendSet.getKey()).thenReturn("key");
+
+    DimensionIdentifier<DimensionParam> dWithNoLegendSet = mock(DimensionIdentifier.class);
+    DimensionParam dimensionForNoLegendSet = mock(DimensionParam.class);
+    when(dWithNoLegendSet.getDimension()).thenReturn(dimensionForNoLegendSet);
+    when(dWithNoLegendSet.hasLegendSet()).thenReturn(false);
+    when(dWithNoLegendSet.getKey()).thenReturn("key");
+
+    QueryContext queryContext =
+        QueryContext.of(mock(TeiQueryParams.class), mock(SqlParameterManager.class));
+    List<DimensionIdentifier<DimensionParam>> acceptedHeaders = List.of(dWithNoLegendSet);
+    List<DimensionIdentifier<DimensionParam>> acceptedDimensions = List.of(dWithLegendSet);
+    List<AnalyticsSortingParams> acceptedSortingParams = List.of();
+    RenderableSqlQuery renderableSqlQuery =
+        dataElementQueryBuilder.buildSqlQuery(
+            queryContext, acceptedHeaders, acceptedDimensions, acceptedSortingParams);
+
+    // when 2 DE with the same key are referenced, one of them with legendSet and one without,
+    // then 5 select fields should be added to the query:
+    // 1. The DE with legendSet
+    // 2. The DE without legendSet (the "raw" value)
+    // 3. The "exists" field
+    // 4. the "status" field
+    // 5. the "hasValue" field
+    assertEquals(5, renderableSqlQuery.getSelectFields().size());
+  }
+}

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/ListGrid.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/ListGrid.java
@@ -80,6 +80,7 @@ public class ListGrid implements Grid, Serializable {
   public static final String HAS_VALUE = ".hasValue";
   public static final String STATUS = ".status";
   public static final String EXISTS = ".exists";
+  public static final String LEGEND = ".legend";
 
   private static final String REGRESSION_SUFFIX = "_regression";
 


### PR DESCRIPTION
This pull request addresses a bug where specifying a dimension with legendSet resulted in duplicate entries in the query when the same dimension was used elsewhere in the query, such as in headers or sorting parameters. This duplication caused the query to become invalid due to duplicated aliases. The fix resolves this issue by ensuring that dimensions are properly handled to prevent duplication.