### PR TITLE
fix: tracker/relationships emits inaccessible program attributes [ Dhis2-17090 ] [2.40] 

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/relationship/AbstractRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/relationship/AbstractRelationshipService.java
@@ -463,9 +463,12 @@ public abstract class AbstractRelationshipService implements RelationshipService
     relationship.setRelationshipType(dao.getRelationshipType().getUid());
     relationship.setRelationshipName(dao.getRelationshipType().getName());
 
-    relationship.setFrom(includeRelationshipItem(dao.getFrom(), !params.isIncludeFrom()));
-    relationship.setTo(includeRelationshipItem(dao.getTo(), !params.isIncludeTo()));
-
+    relationship.setFrom(
+        includeRelationshipItem(
+            dao.getFrom(), !params.isIncludeFrom(), dao.getRelationshipType().getFromConstraint()));
+    relationship.setTo(
+        includeRelationshipItem(
+            dao.getTo(), !params.isIncludeTo(), dao.getRelationshipType().getToConstraint()));
     relationship.setBidirectional(dao.getRelationshipType().isBidirectional());
 
     relationship.setCreated(DateUtils.getIso8601NoTz(dao.getCreated()));
@@ -480,7 +483,7 @@ public abstract class AbstractRelationshipService implements RelationshipService
   }
 
   private org.hisp.dhis.dxf2.events.trackedentity.RelationshipItem includeRelationshipItem(
-      RelationshipItem dao, boolean uidOnly) {
+      RelationshipItem dao, boolean uidOnly, RelationshipConstraint constraint) {
     org.hisp.dhis.dxf2.events.trackedentity.RelationshipItem relationshipItem =
         new org.hisp.dhis.dxf2.events.trackedentity.RelationshipItem();
 
@@ -496,6 +499,18 @@ public abstract class AbstractRelationshipService implements RelationshipService
         tei =
             trackedEntityInstanceService.getTrackedEntityInstance(
                 dao.getTrackedEntityInstance(), TrackedEntityInstanceParams.TRUE);
+
+        if (constraint.getTrackerDataView() != null) {
+          tei.setAttributes(
+              tei.getAttributes().stream()
+                  .filter(
+                      a ->
+                          constraint
+                              .getTrackerDataView()
+                              .getAttributes()
+                              .contains(a.getAttribute()))
+                  .collect(Collectors.toList()));
+        }
       }
 
       relationshipItem.setTrackedEntityInstance(tei);
@@ -510,6 +525,18 @@ public abstract class AbstractRelationshipService implements RelationshipService
       } else {
         enrollment =
             enrollmentService.getEnrollment(dao.getProgramInstance(), EnrollmentParams.TRUE);
+
+        if (constraint.getTrackerDataView() != null) {
+          enrollment.setAttributes(
+              enrollment.getAttributes().stream()
+                  .filter(
+                      a ->
+                          constraint
+                              .getTrackerDataView()
+                              .getAttributes()
+                              .contains(a.getAttribute()))
+                  .collect(Collectors.toList()));
+        }
       }
 
       relationshipItem.setEnrollment(enrollment);
@@ -522,6 +549,18 @@ public abstract class AbstractRelationshipService implements RelationshipService
         event.setEvent(uid);
       } else {
         event = eventService.getEvent(dao.getProgramStageInstance(), EventParams.FALSE);
+
+        if (constraint.getTrackerDataView() != null) {
+          event.setDataValues(
+              event.getDataValues().stream()
+                  .filter(
+                      d ->
+                          constraint
+                              .getTrackerDataView()
+                              .getDataElements()
+                              .contains(d.getDataElement()))
+                  .collect(Collectors.toSet()));
+        }
       }
 
       relationshipItem.setEvent(event);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/ProgramStageValidationStrategyTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/ProgramStageValidationStrategyTest.java
@@ -146,13 +146,6 @@ class ProgramStageValidationStrategyTest extends TransactionalIntegrationTest {
     TrackedEntityType trackedEntityType = createTrackedEntityType('A');
     trackedEntityType.getSharing().addUserAccess(userAccess1);
     manager.save(trackedEntityType, false);
-    org.hisp.dhis.trackedentity.TrackedEntityInstance maleA =
-        createTrackedEntityInstance(organisationUnitA);
-    maleA.setTrackedEntityType(trackedEntityType);
-    maleA.getSharing().addUserAccess(userAccess1);
-    maleA.setCreatedBy(currentUser);
-    manager.save(maleA, false);
-    trackedEntityInstanceMaleA = trackedEntityInstanceService.getTrackedEntityInstance(maleA);
     DataElement dataElementA = createDataElement('A');
     dataElementA.setValueType(ValueType.INTEGER);
     dataElementA.getSharing().addUserAccess(userAccess1);
@@ -172,6 +165,7 @@ class ProgramStageValidationStrategyTest extends TransactionalIntegrationTest {
     programA = createProgram('A', new HashSet<>(), organisationUnitA);
     programA.setProgramType(ProgramType.WITH_REGISTRATION);
     programA.getSharing().addUserAccess(userAccess1);
+    programA.setTrackedEntityType(trackedEntityType);
     manager.save(programA, false);
     // Create a compulsory PSDE
     ProgramStageDataElement programStageDataElementA = new ProgramStageDataElement();
@@ -204,6 +198,15 @@ class ProgramStageValidationStrategyTest extends TransactionalIntegrationTest {
     programA.getProgramStages().add(programStageA);
     manager.update(programStageA);
     manager.update(programA);
+
+    org.hisp.dhis.trackedentity.TrackedEntityInstance maleA =
+        createTrackedEntityInstance(organisationUnitA);
+    maleA.setTrackedEntityType(trackedEntityType);
+    maleA.getSharing().addUserAccess(userAccess1);
+    maleA.setCreatedBy(currentUser);
+    manager.save(maleA, false);
+    trackedEntityInstanceMaleA = trackedEntityInstanceService.getTrackedEntityInstance(maleA);
+
     ProgramInstance programInstance = new ProgramInstance();
     programInstance.setProgram(programA);
     programInstance.setIncidentDate(new Date());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/RelationshipServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/RelationshipServiceTest.java
@@ -45,7 +45,6 @@ import org.hisp.dhis.commons.util.RelationshipUtils;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.events.enrollment.Enrollment;
-import org.hisp.dhis.dxf2.events.event.DataValue;
 import org.hisp.dhis.dxf2.events.event.Event;
 import org.hisp.dhis.dxf2.events.relationship.RelationshipService;
 import org.hisp.dhis.dxf2.events.trackedentity.Attribute;
@@ -364,6 +363,25 @@ class RelationshipServiceTest extends TransactionalIntegrationTest {
 
   @Test
   void shouldUpdateTeiToPiRelationship() {
+    teiA.setTrackedEntityAttributeValues(
+        Set.of(new TrackedEntityAttributeValue(teaA, teiA, "100")));
+    teiB.setTrackedEntityAttributeValues(
+        Set.of(
+            new TrackedEntityAttributeValue(teaA, teiB, "10"),
+            new TrackedEntityAttributeValue(teaB, teiB, "100")));
+
+    manager.update(teiA);
+    manager.update(teiB);
+
+    TrackerDataView trackerDataView = new TrackerDataView();
+    trackerDataView.setAttributes(new LinkedHashSet<>(Set.of(teaA.getUid())));
+
+    relationshipTypeTeiToPi.getFromConstraint().setTrackerDataView(trackerDataView);
+
+    relationshipTypeTeiToPi.getToConstraint().setTrackerDataView(trackerDataView);
+
+    manager.update(relationshipTypeTeiToPi);
+
     org.hisp.dhis.relationship.Relationship relationship =
         relationship(teiA, null, programInstanceA, null);
 
@@ -402,8 +420,8 @@ class RelationshipServiceTest extends TransactionalIntegrationTest {
                       List.of(attributeFromTea(teaA, "100")),
                       r.getFrom().getTrackedEntityInstance().getAttributes());
                   assertContainsOnly(
-                      List.of(new DataValue(dataElementA.getUid(), "10")),
-                      r.getTo().getEvent().getDataValues());
+                      List.of(attributeFromTea(teaA, "10")),
+                      r.getTo().getEnrollment().getAttributes());
                 }));
   }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportControllerTest.java
@@ -607,8 +607,8 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
   void getRelationshipsByTrackedEntityWithAttributes() {
     TrackedEntityInstance to = trackedEntityInstance(orgUnit);
     to.setTrackedEntityAttributeValues(Set.of(attributeValue(tea, to, "12")));
+
     ProgramInstance from = programInstance(to);
-    relationship(from, to);
     Relationship relationship = relationship(from, to);
 
     RelationshipType type = relationship.getRelationshipType();
@@ -629,6 +629,8 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
 
     type.setFromConstraint(fromConstraint);
     type.setToConstraint(toConstraint);
+
+    manager.update(type);
 
     JsonList<JsonRelationship> relationships =
         GET(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportControllerTest.java
@@ -38,6 +38,7 @@ import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertTrack
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Date;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.common.CodeGenerator;
@@ -53,6 +54,7 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.relationship.Relationship;
+import org.hisp.dhis.relationship.RelationshipConstraint;
 import org.hisp.dhis.relationship.RelationshipEntity;
 import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.relationship.RelationshipType;
@@ -64,6 +66,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeAttribute;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
+import org.hisp.dhis.trackerdataview.TrackerDataView;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.sharing.UserAccess;
 import org.hisp.dhis.web.HttpStatus;
@@ -119,17 +122,6 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
     user.setTeiSearchOrganisationUnits(Set.of(orgUnit));
     this.userService.updateUser(user);
 
-    program = createProgram('A');
-    program.addOrganisationUnit(orgUnit);
-    program.getSharing().setOwner(owner);
-    program.getSharing().addUserAccess(userAccess());
-    manager.save(program, false);
-
-    programStage = createProgramStage('A', program);
-    programStage.getSharing().setOwner(owner);
-    programStage.getSharing().addUserAccess(userAccess());
-    manager.save(programStage, false);
-
     tea = createTrackedEntityAttribute('A');
     tea.getSharing().setOwner(owner);
     tea.getSharing().addUserAccess(userAccess());
@@ -146,6 +138,18 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
 
     trackedEntityType.setTrackedEntityTypeAttributes(List.of(trackedEntityTypeAttribute));
     manager.save(trackedEntityType);
+
+    program = createProgram('A');
+    program.addOrganisationUnit(orgUnit);
+    program.getSharing().setOwner(owner);
+    program.getSharing().addUserAccess(userAccess());
+    program.setTrackedEntityType(trackedEntityType);
+    manager.save(program, false);
+
+    programStage = createProgramStage('A', program);
+    programStage.getSharing().setOwner(owner);
+    programStage.getSharing().addUserAccess(userAccess());
+    manager.save(programStage, false);
 
     dataElement = createDataElement('A');
     manager.save(dataElement, false);
@@ -282,7 +286,19 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
     TrackedEntityInstance to = trackedEntityInstance();
     ProgramStageInstance from = programStageInstance(programInstance(to));
     from.setEventDataValues(Set.of(new EventDataValue(dataElement.getUid(), "12")));
-    relationship(from, to);
+    Relationship relationship = relationship(from, to);
+    RelationshipType type = relationship.getRelationshipType();
+
+    RelationshipConstraint toConstraint = new RelationshipConstraint();
+
+    TrackerDataView trackerDataView = new TrackerDataView();
+    trackerDataView.setDataElements(new LinkedHashSet<>(Set.of(dataElement.getUid())));
+
+    toConstraint.setTrackerDataView(trackerDataView);
+
+    type.setFromConstraint(toConstraint);
+
+    manager.update(type);
 
     JsonList<JsonRelationship> relationships =
         GET(
@@ -380,7 +396,18 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
     program.setProgramAttributes(List.of(createProgramTrackedEntityAttribute(program, tea)));
 
     ProgramInstance from = programInstance(to);
-    relationship(from, to);
+    Relationship relationship = relationship(from, to);
+
+    RelationshipType type = relationship.getRelationshipType();
+
+    RelationshipConstraint constraint = new RelationshipConstraint();
+
+    TrackerDataView trackerDataView = new TrackerDataView();
+    trackerDataView.setAttributes(new LinkedHashSet<>(Set.of(tea.getUid())));
+
+    constraint.setTrackerDataView(trackerDataView);
+
+    type.setFromConstraint(constraint);
 
     JsonList<JsonRelationship> relationships =
         GET(
@@ -582,6 +609,26 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
     to.setTrackedEntityAttributeValues(Set.of(attributeValue(tea, to, "12")));
     ProgramInstance from = programInstance(to);
     relationship(from, to);
+    Relationship relationship = relationship(from, to);
+
+    RelationshipType type = relationship.getRelationshipType();
+
+    RelationshipConstraint fromConstraint = new RelationshipConstraint();
+
+    TrackerDataView trackerDataView = new TrackerDataView();
+    trackerDataView.setAttributes(new LinkedHashSet<>(Set.of(tea.getUid())));
+
+    fromConstraint.setTrackerDataView(trackerDataView);
+
+    RelationshipConstraint toConstraint = new RelationshipConstraint();
+
+    TrackerDataView dataView = new TrackerDataView();
+    dataView.setAttributes(new LinkedHashSet<>(Set.of(tea.getUid())));
+
+    toConstraint.setTrackerDataView(dataView);
+
+    type.setFromConstraint(fromConstraint);
+    type.setToConstraint(toConstraint);
 
     JsonList<JsonRelationship> relationships =
         GET(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportControllerTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export;
 
+import static org.hisp.dhis.trackedentity.TrackerOwnershipManager.OWNERSHIP_ACCESS_DENIED;
 import static org.hisp.dhis.utils.Assertions.assertContains;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertFirstRelationship;
 import static org.hisp.dhis.webapi.controller.tracker.JsonAssertions.assertHasMember;
@@ -115,10 +116,13 @@ class TrackerTrackedEntitiesExportControllerTest extends DhisControllerConvenien
     user.setTeiSearchOrganisationUnits(Set.of(orgUnit));
     this.userService.updateUser(user);
 
+    trackedEntityType = trackedEntityTypeAccessible();
+
     program = createProgram('A');
     program.addOrganisationUnit(orgUnit);
     program.getSharing().setOwner(owner);
     program.getSharing().addUserAccess(userAccess());
+    program.setTrackedEntityType(trackedEntityType);
     manager.save(program, false);
 
     TrackedEntityAttribute attr = createTrackedEntityAttribute('A');
@@ -129,8 +133,6 @@ class TrackerTrackedEntitiesExportControllerTest extends DhisControllerConvenien
     programStage.getSharing().setOwner(owner);
     programStage.getSharing().addUserAccess(userAccess());
     manager.save(programStage, false);
-
-    trackedEntityType = trackedEntityTypeAccessible();
   }
 
   @Test
@@ -273,7 +275,7 @@ class TrackerTrackedEntitiesExportControllerTest extends DhisControllerConvenien
         GET("/tracker/trackedEntities/{id}?fields=relationships", from.getUid())
             .error(HttpStatus.CONFLICT)
             .getMessage()
-            .contains("User has no read access to organisation unit"));
+            .contains(OWNERSHIP_ACCESS_DENIED));
   }
 
   @Test
@@ -287,7 +289,7 @@ class TrackerTrackedEntitiesExportControllerTest extends DhisControllerConvenien
         GET("/tracker/trackedEntities/{id}?fields=relationships", from.getUid())
             .error(HttpStatus.CONFLICT)
             .getMessage()
-            .contains("User has no read access to organisation unit"));
+            .contains(OWNERSHIP_ACCESS_DENIED));
   }
 
   @Test


### PR DESCRIPTION
backport of https://github.com/dhis2/dhis2-core/pull/17281

@muilpp i am not doing a clean-up of `getTrackedEntityInstance` here so if you are backporting that, any TODO or comments related to `initializeTrackedEntityOrgUnitParents` can be discarded