### PR TITLE
fix: Bug in continuous analytics job [2.42-DHIS2-17339]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManager.java
@@ -145,7 +145,7 @@ public class JdbcCompletenessTableManager extends AbstractJdbcTableManager {
         where cdr.lastupdated >= '${startDate}' \
         and cdr.lastupdated < '${endDate}' \
         limit 1;""";
-    replace(sql, Map.of("startDate", toLongDate(startDate), "endDate", toLongDate(endDate)));
+    sql = replace(sql, Map.of("startDate", toLongDate(startDate), "endDate", toLongDate(endDate)));
 
     return !jdbcTemplate.queryForList(sql).isEmpty();
   }


### PR DESCRIPTION
There is a bug in the JdbcCompletnessTableManager. The hasUpdatedLatestData method is failing to replace placeholders in the sql statement, which is obstructing the successful execution of continuous analytics job.