### PR TITLE
fix: skip rounding when dimension has option set [DHIS2-17257]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/TeiListGrid.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/TeiListGrid.java
@@ -93,9 +93,22 @@ public class TeiListGrid extends ListGrid {
                   .map(DimensionIdentifier::getKey)
                   .anyMatch(columnLabel::equals);
 
+          boolean columnHasOptionSet =
+              teiQueryParams
+                  .getCommonParams()
+                  .streamDimensions()
+                  .filter(DimensionIdentifier::hasOptionSet)
+                  .map(DimensionIdentifier::getKey)
+                  .anyMatch(columnLabel::equals);
+
+          boolean skipRounding =
+              teiQueryParams.getCommonParams().isSkipRounding()
+                  || columnHasLegendSet
+                  || columnHasOptionSet;
+
           Object value =
               getValueAndRoundIfNecessary(
-                  rs, columnHasLegendSet ? columnLabel + LEGEND : columnLabel);
+                  rs, columnHasLegendSet ? columnLabel + LEGEND : columnLabel, skipRounding);
           addValue(value);
           headersSet.add(columnLabel);
 
@@ -114,9 +127,10 @@ public class TeiListGrid extends ListGrid {
     return this;
   }
 
-  private Object getValueAndRoundIfNecessary(SqlRowSet rs, String columnLabel) {
+  private Object getValueAndRoundIfNecessary(
+      SqlRowSet rs, String columnLabel, boolean skipRounding) {
     ValueType valueType = getValueType(columnLabel);
-    if (isNotRoundableType(valueType)) {
+    if (skipRounding || isNotRoundableType(valueType)) {
       return rs.getObject(columnLabel);
     }
     return roundIfNecessary(rs, columnLabel);

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/DimensionIdentifier.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/params/dimension/DimensionIdentifier.java
@@ -33,11 +33,13 @@ import static org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifie
 import static org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifier.DimensionIdentifierType.TEI;
 import static org.hisp.dhis.analytics.common.params.dimension.DimensionIdentifierHelper.DIMENSION_SEPARATOR;
 
+import java.util.function.Predicate;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.With;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.common.params.IdentifiableKey;
+import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.UidObject;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
@@ -153,10 +155,18 @@ public class DimensionIdentifier<D extends UidObject> implements IdentifiableKey
     return withoutOffset().toString();
   }
 
-  public boolean hasLegendSet() {
+  private boolean has(Predicate<QueryItem> function) {
     if (dimension instanceof DimensionParam dimensionParam && dimensionParam.isQueryItem()) {
-      return dimensionParam.getQueryItem().hasLegendSet();
+      return function.test(dimensionParam.getQueryItem());
     }
     return false;
+  }
+
+  public boolean hasLegendSet() {
+    return has(QueryItem::hasLegendSet);
+  }
+
+  public boolean hasOptionSet() {
+    return has(QueryItem::hasOptionSet);
   }
 }


### PR DESCRIPTION
This pull request addresses a problem where numeric codes associated with data element option sets were being rounded in the response. The fix ensures an accurate representation of numeric codes, enhancing data integrity.