### PR TITLE
fix: Compare TET by UID [DHIS2-17251]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
@@ -100,7 +100,11 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
     List<Program> tetPrograms =
         programs.stream()
             .filter(
-                p -> Objects.equals(p.getTrackedEntityType(), trackedEntity.getTrackedEntityType()))
+                p ->
+                    p.isRegistration()
+                        && Objects.equals(
+                            p.getTrackedEntityType().getUid(),
+                            trackedEntity.getTrackedEntityType().getUid()))
             .toList();
 
     if (tetPrograms.isEmpty()) {
@@ -169,7 +173,11 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
     List<Program> tetPrograms =
         programs.stream()
             .filter(
-                p -> Objects.equals(p.getTrackedEntityType(), trackedEntity.getTrackedEntityType()))
+                p ->
+                    p.isRegistration()
+                        && Objects.equals(
+                            p.getTrackedEntityType().getUid(),
+                            trackedEntity.getTrackedEntityType().getUid()))
             .toList();
 
     if (tetPrograms.isEmpty()) {


### PR DESCRIPTION
Comparing the object type of the tracked entity with that of the program's tracked entity type object isn't always reliable. I've observed instances where they differ; for example, one may have a description set while the other doesn't. Using their UID for comparison should be enough to determine their equality.