### PR TITLE
fix: Validate unenrolled TE before importing [DHIS2-17280]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/SecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/SecurityOwnershipValidator.java
@@ -78,9 +78,9 @@ class SecurityOwnershipValidator implements Validator<Enrollment> {
             ? bundle.getPreheat().getEnrollment(enrollment.getEnrollment()).getProgram()
             : bundle.getPreheat().getProgram(enrollment.getProgram());
     TrackedEntity trackedEntity =
-        bundle.getStrategy(enrollment).isDelete()
+        bundle.getStrategy(enrollment).isUpdateOrDelete()
             ? bundle.getPreheat().getEnrollment(enrollment.getEnrollment()).getTrackedEntity()
-            : getTrackedEntityWhenCreateOrUpdate(bundle, enrollment, reporter);
+            : getTrackedEntityWhenStrategyCreate(bundle, enrollment);
 
     OrganisationUnit ownerOrgUnit = getOwnerOrganisationUnit(preheat, trackedEntity, program);
 
@@ -100,8 +100,8 @@ class SecurityOwnershipValidator implements Validator<Enrollment> {
         reporter, bundle, enrollment, program, ownerOrgUnit, trackedEntity.getUid());
   }
 
-  private TrackedEntity getTrackedEntityWhenCreateOrUpdate(
-      TrackerBundle bundle, Enrollment enrollment, Reporter reporter) {
+  private TrackedEntity getTrackedEntityWhenStrategyCreate(
+      TrackerBundle bundle, Enrollment enrollment) {
     TrackedEntity trackedEntity =
         bundle.getPreheat().getTrackedEntity(enrollment.getTrackedEntity());
 
@@ -118,10 +118,6 @@ class SecurityOwnershipValidator implements Validator<Enrollment> {
                 return newEntity;
               })
           .get();
-      /*.orElseGet(() -> {
-        reporter.addError(enrollment, E1063, enrollment.getTrackedEntity());
-        return null;
-      });*/
     }
 
     return trackedEntity;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/SecurityOwnershipValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/SecurityOwnershipValidatorTest.java
@@ -177,6 +177,29 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     assertIsEmpty(reporter.getErrors());
   }
 
+  /*  @Test
+  void shouldFailWhenEnrollmentTrackedEntityDoesNotExist() {
+    org.hisp.dhis.tracker.imports.domain.Enrollment enrollment =
+        org.hisp.dhis.tracker.imports.domain.Enrollment.builder()
+            .enrollment(CodeGenerator.generateUid())
+            .orgUnit(MetadataIdentifier.ofUid(ORG_UNIT_ID))
+            .trackedEntity(TE_ID)
+            .program(MetadataIdentifier.ofUid(PROGRAM_ID))
+            .build();
+
+    when(bundle.getPreheat()).thenReturn(preheat);
+    when(bundle.getStrategy(enrollment)).thenReturn(TrackerImportStrategy.CREATE_AND_UPDATE);
+    when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_ID))).thenReturn(program);
+    when(preheat.getTrackedEntity(TE_ID)).thenReturn(null);
+    when(bundle.findTrackedEntityByUid(enrollment.getTrackedEntity())).thenReturn(Optional.empty());
+    when(aclService.canDataWrite(user, program)).thenReturn(true);
+    when(aclService.canDataRead(user, program.getTrackedEntityType())).thenReturn(true);
+
+    validator.validate(reporter, bundle, enrollment);
+
+    assertHasError(reporter, enrollment, E1063);
+  }*/
+
   @Test
   void verifyCaptureScopeIsCheckedForEnrollmentCreation() {
     org.hisp.dhis.tracker.imports.domain.Enrollment enrollment =

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/SecurityOwnershipValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/SecurityOwnershipValidatorTest.java
@@ -177,29 +177,6 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     assertIsEmpty(reporter.getErrors());
   }
 
-  /*  @Test
-  void shouldFailWhenEnrollmentTrackedEntityDoesNotExist() {
-    org.hisp.dhis.tracker.imports.domain.Enrollment enrollment =
-        org.hisp.dhis.tracker.imports.domain.Enrollment.builder()
-            .enrollment(CodeGenerator.generateUid())
-            .orgUnit(MetadataIdentifier.ofUid(ORG_UNIT_ID))
-            .trackedEntity(TE_ID)
-            .program(MetadataIdentifier.ofUid(PROGRAM_ID))
-            .build();
-
-    when(bundle.getPreheat()).thenReturn(preheat);
-    when(bundle.getStrategy(enrollment)).thenReturn(TrackerImportStrategy.CREATE_AND_UPDATE);
-    when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_ID))).thenReturn(program);
-    when(preheat.getTrackedEntity(TE_ID)).thenReturn(null);
-    when(bundle.findTrackedEntityByUid(enrollment.getTrackedEntity())).thenReturn(Optional.empty());
-    when(aclService.canDataWrite(user, program)).thenReturn(true);
-    when(aclService.canDataRead(user, program.getTrackedEntityType())).thenReturn(true);
-
-    validator.validate(reporter, bundle, enrollment);
-
-    assertHasError(reporter, enrollment, E1063);
-  }*/
-
   @Test
   void verifyCaptureScopeIsCheckedForEnrollmentCreation() {
     org.hisp.dhis.tracker.imports.domain.Enrollment enrollment =

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/SecurityOwnershipValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/SecurityOwnershipValidatorTest.java
@@ -104,6 +104,8 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
 
   private Program program;
 
+  private TrackedEntity trackedEntity;
+
   private Map<String, Map<String, TrackedEntityProgramOwnerOrgUnit>> ownerOrgUnit;
 
   @BeforeEach
@@ -124,6 +126,9 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
 
     ProgramStage programStage = createProgramStage('A', program);
     programStage.setUid(PS_ID);
+
+    trackedEntity = new TrackedEntity();
+    trackedEntity.setUid(TE_ID);
 
     TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
     reporter = new Reporter(idSchemes);
@@ -163,6 +168,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     when(bundle.getPreheat()).thenReturn(preheat);
     when(bundle.getStrategy(enrollment)).thenReturn(TrackerImportStrategy.CREATE_AND_UPDATE);
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_ID))).thenReturn(program);
+    when(preheat.getTrackedEntity(TE_ID)).thenReturn(trackedEntity);
     when(aclService.canDataWrite(user, program)).thenReturn(true);
     when(aclService.canDataRead(user, program.getTrackedEntityType())).thenReturn(true);
 
@@ -184,6 +190,7 @@ class SecurityOwnershipValidatorTest extends DhisConvenienceTest {
     when(bundle.getPreheat()).thenReturn(preheat);
     when(bundle.getStrategy(enrollment)).thenReturn(TrackerImportStrategy.CREATE);
     when(preheat.getProgram(MetadataIdentifier.ofUid(PROGRAM_ID))).thenReturn(program);
+    when(preheat.getTrackedEntity(TE_ID)).thenReturn(trackedEntity);
     when(preheat.getOrganisationUnit(MetadataIdentifier.ofUid(ORG_UNIT_ID)))
         .thenReturn(organisationUnit);
     setUpUserWithOrgUnit();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentSecurityImportValidationTest.java
@@ -200,8 +200,10 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest {
     TrackedEntityType bPJ0FMtcnEh = trackedEntityTypeService.getTrackedEntityType("bPJ0FMtcnEh");
     programA.setTrackedEntityType(bPJ0FMtcnEh);
     manager.updateNoAcl(programA);
+    OrganisationUnit orgUnit = manager.get(OrganisationUnit.class, "QfUVllTs6cZ");
     User user =
-        createUserWithAuth("user1").setOrganisationUnits(Sets.newHashSet(organisationUnitA));
+        createUserWithAuth("user1")
+            .setOrganisationUnits(Sets.newHashSet(orgUnit, organisationUnitA));
     userService.addUser(user);
     injectSecurityContextUser(user);
     TrackerObjects trackerObjects = fromJson("tracker/validations/enrollments_no-access-tei.json");

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TrackedEntityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/TrackedEntityImportValidationTest.java
@@ -292,7 +292,7 @@ class TrackedEntityImportValidationTest extends TrackerTest {
     assertNoErrors(trackerImportService.importTracker(new TrackerImportParams(), trackerObjects));
     trackerObjects = fromJson("tracker/validations/enrollments_te_enrollments-data_2.json");
     TrackerImportParams trackerImportParams = new TrackerImportParams();
-    trackerImportParams.setUserId(USER_10);
+    trackerImportParams.setUserId(USER_8);
     ImportReport importReport =
         trackerImportService.importTracker(trackerImportParams, trackerObjects);
     assertNoErrors(importReport);


### PR DESCRIPTION
When importing a new enrollment with the CREATE strategy, it's possible that there's no owner of the enrollment TE/program pair if the TE is also imported at the same time. Previously, we were not handling this case correctly because we were not validating the ownership. 
With this fix, we will retrieve the registering unit and validate whether the user has access to it.