### PR TITLE
test: tracker e2e test fails due to interdependence DHIS2-16564

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/tei/TeiImportTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/imports/tei/TeiImportTests.java
@@ -135,11 +135,11 @@ public class TeiImportTests extends TrackerApiTest {
         new FileReaderUtils()
             .readJsonAndGenerateData(
                 new File(
-                    "src/test/resources/tracker/importer/teis/teisWithEnrollmentsAndEvents.json"));
+                    "src/test/resources/tracker/importer/teis/tesWithEnrollmentsEventsAndRelationships.json"));
 
     JsonObject teiToTeiRelationship =
         new RelationshipDataBuilder()
-            .buildTrackedEntityRelationship("Kj6vYde4LHh", "Nav6inZRw1u", "xLmPUYJX8Ks");
+            .buildTrackedEntityRelationship("v4LGvFNxdYH", "bXanyK15d68", "xLmPUYJX8Ks");
 
     JsonObjectBuilder.jsonObject(teiPayload).addArray("relationships", teiToTeiRelationship);
 

--- a/dhis-2/dhis-test-e2e/src/test/resources/tracker/importer/teis/tesWithEnrollmentsEventsAndRelationships.json
+++ b/dhis-2/dhis-test-e2e/src/test/resources/tracker/importer/teis/tesWithEnrollmentsEventsAndRelationships.json
@@ -1,0 +1,111 @@
+{
+  "trackedEntities": [
+    {
+      "trackedEntity": "v4LGvFNxdYH",
+      "orgUnit": "O6uvpzGd5pu",
+      "trackedEntityType": "Q9GufDoplCL",
+      "enrollments": [
+        {
+          "orgUnit": "O6uvpzGd5pu",
+          "program": "f1AyMswryyQ",
+          "enrolledAt": "2019-08-19T00:00:00.000",
+          "occurredAt": "2019-08-19T00:00:00.000",
+          "status": "ACTIVE",
+          "events": [
+            {
+              "scheduledAt": "2019-08-19T13:59:13.688",
+              "program": "f1AyMswryyQ",
+              "programStage": "nlXNK4b7LVr",
+              "orgUnit": "O6uvpzGd5pu",
+              "status": "ACTIVE",
+              "occurredAt": "2019-08-01T00:00:00.000",
+              "dataValues": [
+                {
+                  "updatedAt": "2019-08-19T13:58:37.477",
+                  "storedBy": "admin",
+                  "dataElement": "BuZ5LGNfGEU",
+                  "value": "20"
+                },
+                {
+                  "updatedAt": "2019-08-19T13:58:40.031",
+                  "storedBy": "admin",
+                  "dataElement": "ZrqtjjveTFc",
+                  "value": "Male"
+                },
+                {
+                  "updatedAt": "2019-08-19T13:59:13.691",
+                  "storedBy": "admin",
+                  "dataElement": "mB2QHw1tU96",
+                  "value": "[-11.566044,9.477801]"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "attributes": [
+        {
+          "displayName": "TA First name",
+          "valueType": "TEXT",
+          "attribute": "dIVt4l5vIOa",
+          "value": "John"
+        },
+        {
+          "valueType": "TEXT",
+          "attribute": "kZeSYCgaHTk",
+          "value": "Bravo"
+        }
+      ]
+    },
+    {
+      "trackedEntity": "bXanyK15d68",
+      "orgUnit": "O6uvpzGd5pu",
+      "trackedEntityType": "Q9GufDoplCL",
+      "enrollments": [
+        {
+          "orgUnit": "O6uvpzGd5pu",
+          "program": "f1AyMswryyQ",
+          "enrolledAt": "2019-08-19T00:00:00.000",
+          "occurredAt": "2019-09-19T00:00:00.000",
+          "status": "ACTIVE",
+          "events": [
+            {
+              "scheduledAt": "2019-08-19T13:34:52.793",
+              "program": "f1AyMswryyQ",
+              "programStage": "nlXNK4b7LVr",
+              "orgUnit": "O6uvpzGd5pu",
+              "status": "ACTIVE",
+              "occurredAt": "2019-08-07T00:00:00.000",
+              "dataValues": [
+                {
+                  "updatedAt": "2019-08-19T13:34:47.403",
+                  "storedBy": "admin",
+                  "dataElement": "BuZ5LGNfGEU",
+                  "value": "22"
+                },
+                {
+                  "dataElement": "ZrqtjjveTFc",
+                  "value": "Male"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "attributes": [
+        {
+          "displayName": "TA Last name",
+          "valueType": "TEXT",
+          "attribute": "kZeSYCgaHTk",
+          "value": "Test,Test"
+        },
+        {
+          "displayName": "TA First name",
+          "valueType": "TEXT",
+          "attribute": "dIVt4l5vIOa",
+          "value": "Test:Test"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
TeiImportTests fails as its trying to create a relationship that TrackerExportTest already created. Tracker e2e tests do not clean up after themselves. We will fix that issue later.

Decouple TeiImportTests from TrackerExportTest by creating different TEs.