### PR TITLE
fix: Report App got 500 error due to jasperreport lib upgraded[DHIS2-17378](41)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,7 +67,10 @@ updates:
       - dependency-name: "net.sf.jasperreports:jasperreports" # will update in https://dhis2.atlassian.net/browse/DHIS2-16796
         versions:
           - ">= 6.20.1"
-  - package-ecosystem: "maven"
+      - dependency-name: "net.sf.jasperreports:jasperreports-fonts" # will update in https://dhis2.atlassian.net/browse/DHIS2-16796
+        versions:
+          - ">= 6.20.1" 
+ - package-ecosystem: "maven"
     directory: "/dhis-2/dhis-test-e2e"
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,10 +67,7 @@ updates:
       - dependency-name: "net.sf.jasperreports:jasperreports" # will update in https://dhis2.atlassian.net/browse/DHIS2-16796
         versions:
           - ">= 6.20.1"
-      - dependency-name: "net.sf.jasperreports:jasperreports-fonts" # will update in https://dhis2.atlassian.net/browse/DHIS2-16796
-        versions:
-          - ">= 6.20.1" 
- - package-ecosystem: "maven"
+  - package-ecosystem: "maven"
     directory: "/dhis-2/dhis-test-e2e"
     schedule:
       interval: "daily"

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/EventReportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/EventReportControllerTest.java
@@ -35,6 +35,7 @@ import static org.hisp.dhis.web.HttpStatus.CREATED;
 import static org.hisp.dhis.web.HttpStatus.OK;
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -260,5 +261,19 @@ class EventReportControllerTest extends DhisControllerConvenienceTest {
     assertStatus(OK, POST("/metadata/", WebClient.Body("metadata/map_new.json")));
     final JsonObject response = GET("/mapViews/zyFOjTfzLws").content();
     assertTrue(response.getObject("relativePeriods").getBoolean("last12Months").booleanValue());
+  }
+
+  @Test
+  void testReportPdf() {
+    String body =
+        """
+            {"name": "Name Test", "relativePeriods": {"last12Months": true},
+            "designContent": "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>\\n<jasperReport xmlns=\\"http://jasperreports.sourceforge.net/jasperreports\\" xmlns:xsi=\\"http://www.w3.org/2001/XMLSchema-instance\\" xsi:schemaLocation=\\"http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd\\" name=\\"dpt\\" pageWidth=\\"595\\" pageHeight=\\"842\\" columnWidth=\\"555\\" leftMargin=\\"20\\" rightMargin=\\"20\\" topMargin=\\"20\\" bottomMargin=\\"20\\"></jasperReport>"
+            }""";
+    String uid = assertStatus(CREATED, POST("/reports/", body));
+    assertFalse(
+        GET("/reports/" + uid + "/data.pdf?t=1715330660314&ou=ImspTQPwCqd&pe=2023&date=2023-01-01")
+            .content("application/pdf")
+            .isEmpty());
   }
 }

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -145,7 +145,7 @@
     <jclouds.version>2.6.0</jclouds.version>
 
     <!-- Reporting -->
-    <jasperreports.version>6.21.3</jasperreports.version>
+    <jasperreports.version>6.20.0</jasperreports.version>
     <jfreechart.version>1.5.4</jfreechart.version>
     <htmlparser.version>2.1</htmlparser.version>
     <htmllexer.version>2.1</htmllexer.version>


### PR DESCRIPTION
- Backport https://github.com/dhis2/dhis2-core/pull/17382

- Changes in dependabot.yml is removed because only the config in master branch is utilized. 