### PR TITLE
fix: Enrollment dim. restriction SQL [DHIS2-16349]

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
@@ -695,6 +695,20 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
             "Current user is constrained by a dimension but has access to no dimension items"));
   }
 
+  @Test
+  void testEnrollmentWithCategoryDimensionRestriction() {
+    injectSecurityContextUser(userA);
+    EventQueryParams params = getEnrollmentQueryBuilderA().build();
+    Grid grid = enrollmentTarget.getEnrollments(params);
+
+    assertGridContains(
+        // Headers
+        List.of("enrollmentdate", "ou", "tei", "teaAttribuU"),
+        // Grid
+        List.of(List.of("2017-01-01 00:00:00.0", "ouabcdefghE", "trackEntInA", "ouabcdefghF")),
+        grid);
+  }
+
   // -------------------------------------------------------------------------
   // Test getAggregatedEventData with OrgUnitFields
   // -------------------------------------------------------------------------


### PR DESCRIPTION
See [DHIS2-16349](https://dhis2.atlassian.net/browse/DHIS2-16349).

The problem was:
- Enrollments don't use attribute option combos. "Attribute" Category columns (and Category Option Group Set columns) are not present in the analytics enrollment tables
- When an analytics WebAPI query is processed for a dimension-restricted user, `DefaultAnalyticsSecurityManager.applyDimensionConstraints` adds the user's dimension constraints as filters if the dimensions aren't already specified (Category constraints and/or Category Option Group Set constraints). Note that these constraints are added to the entire WebAPI query which could possibly contain many different items (indicators, data elements, event PIs, enrollment PIs, etc.) This is efficient because the constrains are added once for the entire WebAPI request
- `JdbcEnrollmentAnalyticsManager.getWhereClause` was adding the category constraints to the SQL `WHERE` clause for attribute Category columns that do not exist in the analytics enrollment tables. (This was not a problem for Category Option Group Set restrictions, because this method does not add any COGS dimensions to the SQL query.)

The fix is:
- Don't add Category filters to the query if they are Attribute categories. (Disaggregation categories are still allowed.)

The test added to `EventAnalyticsServiceTest` fails without the fix and succeeds with it.

[DHIS2-16349]: https://dhis2.atlassian.net/browse/DHIS2-16349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ