### PR TITLE
ci: dependabot.yml to ignore jasperreports-fonts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,7 +69,7 @@ updates:
           - ">= 6.20.1"
       - dependency-name: "net.sf.jasperreports:jasperreports-fonts" # will update in https://dhis2.atlassian.net/browse/DHIS2-16796
         versions:
-          - ">= 6.20.1" 
+          - ">= 6.20.1"
   - package-ecosystem: "maven"
     directory: "/dhis-2/dhis-test-e2e"
     schedule:
@@ -151,6 +151,9 @@ updates:
         versions:
           - ">= 2.0"
       - dependency-name: "net.sf.jasperreports:jasperreports" # will update in https://dhis2.atlassian.net/browse/DHIS2-16796
+        versions:
+          - ">= 6.20.1"
+      - dependency-name: "net.sf.jasperreports:jasperreports-fonts" # will update in https://dhis2.atlassian.net/browse/DHIS2-16796
         versions:
           - ">= 6.20.1"
   - package-ecosystem: "maven"
@@ -240,6 +243,9 @@ updates:
       - dependency-name: "net.sf.jasperreports:jasperreports" # will update in https://dhis2.atlassian.net/browse/DHIS2-16796
         versions:
           - ">= 6.20.1"
+      - dependency-name: "net.sf.jasperreports:jasperreports-fonts" # will update in https://dhis2.atlassian.net/browse/DHIS2-16796
+        versions:
+          - ">= 6.20.1"
   # 2.39
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -314,6 +320,9 @@ updates:
         versions:
           - ">= 2.0"
       - dependency-name: "net.sf.jasperreports:jasperreports" # will update in https://dhis2.atlassian.net/browse/DHIS2-16796
+        versions:
+          - ">= 6.20.1"
+      - dependency-name: "net.sf.jasperreports:jasperreports-fonts" # will update in https://dhis2.atlassian.net/browse/DHIS2-16796
         versions:
           - ">= 6.20.1"
     target-branch: "2.39"
@@ -392,6 +401,9 @@ updates:
         versions:
           - ">= 2.0"
       - dependency-name: "net.sf.jasperreports:jasperreports" # will update in https://dhis2.atlassian.net/browse/DHIS2-16796
+        versions:
+          - ">= 6.20.1"
+      - dependency-name: "net.sf.jasperreports:jasperreports-fonts" # will update in https://dhis2.atlassian.net/browse/DHIS2-16796
         versions:
           - ">= 6.20.1"
     target-branch: "2.38"


### PR DESCRIPTION
- Follow up on https://github.com/dhis2/dhis2-core/pull/17382, ignore ` jasperreports-fonts` in 2.41 and older versions