### PR TITLE
fix: custom format for integer types [DHIS2-15841]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/GridUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/GridUtils.java
@@ -349,7 +349,7 @@ public class GridUtils {
       for (Object column : columns) {
         if (column != null && Number.class.isAssignableFrom(column.getClass())) {
           Cell cell = xlsRow.createCell(columnIndex++, CellType.NUMERIC);
-          if (column instanceof Integer || column instanceof Long || column instanceof BigInteger) {
+          if (isIntegerType(column)) {
             cell.setCellStyle(numberCellStyleForIntegerTypes);
           } else {
             cell.setCellStyle(numberCellStyle);
@@ -364,6 +364,19 @@ public class GridUtils {
 
       rowNumber++;
     }
+  }
+
+  /**
+   * determines if the given column is of integer type or not
+   *
+   * @param column the column to check
+   * @return true if the column is of integer type, false otherwise
+   */
+  private static boolean isIntegerType(Object column) {
+    return column instanceof Integer
+        || column instanceof Long
+        || column instanceof Short
+        || column instanceof BigInteger;
   }
 
   /**

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/GridUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/GridUtils.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -170,6 +171,9 @@ public class GridUtils {
   private static final String ATTR_FIELD = "field";
 
   private static final String DECIMAL_DIGITS_MASK = "#.##########";
+
+  // 3 comes from org.apache.poi.ss.usermodel.BuiltinFormats and corresponds to the format: #,##0
+  private static final short POI_BUILTIN_FORMAT_INDEX_FOR_INTEGER_TYPES = 3;
 
   private static final Locale DEFAULT_LOCALE = Locale.ENGLISH;
 
@@ -333,6 +337,7 @@ public class GridUtils {
     rowNumber++;
 
     CellStyle numberCellStyle = getNumberCellStyle(sheet);
+    CellStyle numberCellStyleForIntegerTypes = getNumberCellStyleForIntegerTypes(sheet);
 
     for (List<Object> row : grid.getVisibleRows()) {
       Row xlsRow = sheet.createRow(rowNumber);
@@ -344,7 +349,11 @@ public class GridUtils {
       for (Object column : columns) {
         if (column != null && Number.class.isAssignableFrom(column.getClass())) {
           Cell cell = xlsRow.createCell(columnIndex++, CellType.NUMERIC);
-          cell.setCellStyle(numberCellStyle);
+          if (column instanceof Integer || column instanceof Long || column instanceof BigInteger) {
+            cell.setCellStyle(numberCellStyleForIntegerTypes);
+          } else {
+            cell.setCellStyle(numberCellStyle);
+          }
           cell.setCellValue(((Number) column).doubleValue());
         } else {
           xlsRow
@@ -370,6 +379,19 @@ public class GridUtils {
     CellStyle cs = wb.createCellStyle();
     cs.setDataFormat(format.getFormat(DECIMAL_DIGITS_MASK));
 
+    return cs;
+  }
+
+  /**
+   * Returns a {@CellStyle} object with a default number format/mask.
+   *
+   * @param sheet the {@link Sheet}
+   * @return the cell style object
+   */
+  private static CellStyle getNumberCellStyleForIntegerTypes(Sheet sheet) {
+    Workbook wb = sheet.getWorkbook();
+    CellStyle cs = wb.createCellStyle();
+    cs.setDataFormat(POI_BUILTIN_FORMAT_INDEX_FOR_INTEGER_TYPES);
     return cs;
   }
 


### PR DESCRIPTION
Previously, when exporting a data visualizer table containing columns with integer values, the output would display numbers ending with a comma or dot. This issue arose from the usage of a custom number format in Excel, which works well for numbers with decimals but caused the issue.
This PR introduces a specific formatting mechanism for integer values so that the decimal part is skipped when the type of the numeric value is an integer.