### PR TITLE
fix: change exit roles on impersonation

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/Authorities.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/Authorities.java
@@ -108,7 +108,8 @@ public enum Authorities {
   F_MOBILE_SENDSMS,
   F_JOB_LOG_READ,
   F_MOBILE_SETTINGS,
-  // bundled authority
+  F_PREVIOUS_IMPERSONATOR_AUTHORITY,
+  // bundled authority,
   M_DHIS_WEB_APP_MANAGEMENT("M_dhis-web-app-management");
 
   private final String authorityName;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/ImpersonateUserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/ImpersonateUserControllerTest.java
@@ -66,7 +66,7 @@ class ImpersonateUserControllerTest extends ImpersonateUserControllerBaseTest {
   @Test
   void testImpersonateUserOKAndExit() {
     String usernameToImpersonate = "usera";
-    createUserWithAuth(usernameToImpersonate, "ALL");
+    createUserWithAuth(usernameToImpersonate, "NONE");
 
     JsonImpersonateUserResponse response =
         POST("/auth/impersonate?username=%s".formatted(usernameToImpersonate))

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ImpersonateUserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ImpersonateUserController.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller.security;
 
 import static org.hisp.dhis.security.Authorities.F_IMPERSONATE_USER;
+import static org.hisp.dhis.security.Authorities.F_PREVIOUS_IMPERSONATOR_AUTHORITY;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -84,8 +85,6 @@ import org.springframework.web.bind.annotation.RestController;
 @Conditional(value = UserImpersonationEnabledCondition.class)
 public class ImpersonateUserController {
 
-  public static final String ROLE_PREVIOUS_ADMINISTRATOR = "ROLE_PREVIOUS_ADMINISTRATOR";
-
   private final DhisConfigurationProvider config;
   private final UserDetailsService userDetailsService;
   private final ApplicationEventPublisher eventPublisher;
@@ -139,7 +138,7 @@ public class ImpersonateUserController {
     }
   }
 
-  @RequiresAuthority(anyOf = F_IMPERSONATE_USER)
+  @RequiresAuthority(anyOf = {F_IMPERSONATE_USER})
   @PostMapping("/impersonateExit")
   public ImpersonateUserResponse impersonateExit(
       HttpServletRequest request, HttpServletResponse response) throws ForbiddenException {
@@ -188,7 +187,8 @@ public class ImpersonateUserController {
     // which will be used to 'exit' from the current switched user.
     Authentication currentAuthentication = getCurrentAuthentication();
     GrantedAuthority switchAuthority =
-        new SwitchUserGrantedAuthority(ROLE_PREVIOUS_ADMINISTRATOR, currentAuthentication);
+        new SwitchUserGrantedAuthority(
+            F_PREVIOUS_IMPERSONATOR_AUTHORITY.name(), currentAuthentication);
 
     // add the new switch user authority
     List<GrantedAuthority> newAuths = new ArrayList<>(targetUser.getAuthorities());

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ImpersonateUserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ImpersonateUserController.java
@@ -138,7 +138,7 @@ public class ImpersonateUserController {
     }
   }
 
-  @RequiresAuthority(anyOf = {F_IMPERSONATE_USER})
+  @RequiresAuthority(anyOf = {F_IMPERSONATE_USER, F_PREVIOUS_IMPERSONATOR_AUTHORITY})
   @PostMapping("/impersonateExit")
   public ImpersonateUserResponse impersonateExit(
       HttpServletRequest request, HttpServletResponse response) throws ForbiddenException {


### PR DESCRIPTION
### Summary
Fixes previous PR making the impersonateExit endpoint too strict. This change make sure the impersonated user is able to exit, without having to have either ALL or F_IMPERSONATE_USER authority. A special F_PREVIOUS_IMPERSONATOR_AUTHORITY is added to the impersonated user, making it possible to exit the impersonating mode.

### Automated test:
ImpersonateUserControllerTest#testImpersonateUserOKAndExit
