### PR TITLE
fix: change exit roles on impersonation

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/Authorities.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/Authorities.java
@@ -73,7 +73,8 @@ public enum Authorities {
   F_DATAVALUE_ADD,
   F_IMPERSONATE_USER,
   F_SYSTEM_SETTING,
-  F_MAP_EXTERNAL_LAYER_ADD;
+  F_MAP_EXTERNAL_LAYER_ADD,
+  F_PREVIOUS_IMPERSONATOR_AUTHORITY;
 
   public static Set<String> getAllAuthorities() {
     return Arrays.stream(Authorities.values()).map(Authorities::name).collect(Collectors.toSet());

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/ImpersonateUserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/security/ImpersonateUserControllerTest.java
@@ -33,6 +33,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.ImpersonateUserControllerBaseTest;
 import org.hisp.dhis.webapi.json.domain.JsonImpersonateUserResponse;
+import org.hisp.dhis.webapi.json.domain.JsonUser;
 import org.hisp.dhis.webapi.json.domain.JsonWebMessage;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
@@ -48,13 +49,41 @@ class ImpersonateUserControllerTest extends ImpersonateUserControllerBaseTest {
     String usernameToImpersonate = "usera";
     createUserWithAuth(usernameToImpersonate, "ALL");
 
-    JsonImpersonateUserResponse responseB =
+    JsonImpersonateUserResponse response =
         POST("/auth/impersonate?username=%s".formatted(usernameToImpersonate))
             .content(HttpStatus.OK)
             .as(JsonImpersonateUserResponse.class);
 
-    assertEquals("IMPERSONATION_SUCCESS", responseB.getLoginStatus());
-    assertEquals(usernameToImpersonate, responseB.getImpersonatedUsername());
+    assertEquals("IMPERSONATION_SUCCESS", response.getLoginStatus());
+    assertEquals(usernameToImpersonate, response.getImpersonatedUsername());
+
+    JsonUser me = GET("/me?fields=username").content(HttpStatus.OK).as(JsonUser.class);
+
+    String username = me.getUsername();
+    assertEquals(usernameToImpersonate, username);
+  }
+
+  @Test
+  void testImpersonateUserOKAndExit() {
+    String usernameToImpersonate = "usera";
+    createUserWithAuth(usernameToImpersonate, "NONE");
+
+    JsonImpersonateUserResponse response =
+        POST("/auth/impersonate?username=%s".formatted(usernameToImpersonate))
+            .content(HttpStatus.OK)
+            .as(JsonImpersonateUserResponse.class);
+
+    assertEquals("IMPERSONATION_SUCCESS", response.getLoginStatus());
+    assertEquals(usernameToImpersonate, response.getImpersonatedUsername());
+
+    JsonUser me = GET("/me?fields=username").content(HttpStatus.OK).as(JsonUser.class);
+    assertEquals(usernameToImpersonate, me.getUsername());
+
+    JsonImpersonateUserResponse responseExit =
+        POST("/auth/impersonateExit").content(HttpStatus.OK).as(JsonImpersonateUserResponse.class);
+
+    assertEquals("IMPERSONATION_EXIT_SUCCESS", responseExit.getLoginStatus());
+    assertEquals("admin", responseExit.getImpersonatedUsername());
   }
 
   @Test


### PR DESCRIPTION
### Summary
Fixes previous PR making the impersonateExit endpoint too strict. This change make sure the impersonated user is able to exit, without having to have either ALL or F_IMPERSONATE_USER authority. A special F_PREVIOUS_IMPERSONATOR_AUTHORITY is added to the impersonated user, making it possible to exit the impersonating mode.

### Automated test:
ImpersonateUserControllerTest#testImpersonateUserOKAndExit
