### PR TITLE
chore: cleanup dhis-api/dhis-service-core DHIS2-16564

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentQueryParams.java
@@ -211,13 +211,6 @@ public class EnrollmentQueryParams {
     return (getPageWithDefault() - 1) * getPageSizeWithDefault();
   }
 
-  /** Sets paging properties to default values. */
-  public void setDefaultPaging() {
-    this.page = DEFAULT_PAGE;
-    this.pageSize = DEFAULT_PAGE_SIZE;
-    this.skipPaging = false;
-  }
-
   public boolean isSorting() {
     return !CollectionUtils.emptyIfNull(order).isEmpty();
   }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
@@ -34,7 +34,6 @@ import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserDetails;
 
 /**
  * @author Abyot Asalefew
@@ -79,14 +78,6 @@ public interface EnrollmentService {
   void updateEnrollment(Enrollment enrollment);
 
   /**
-   * Updates an {@link Enrollment}.
-   *
-   * @param enrollment the Enrollment to update.
-   * @param user the current user.
-   */
-  void updateEnrollment(Enrollment enrollment, UserDetails user);
-
-  /**
    * Returns a {@link Enrollment}.
    *
    * @param id the id of the Enrollment to return.
@@ -127,28 +118,12 @@ public interface EnrollmentService {
   boolean enrollmentExistsIncludingDeleted(String uid);
 
   /**
-   * Returns UIDs of existing Enrollments (including deleted) from the provided UIDs
-   *
-   * @param uids Event UIDs to check
-   * @return Set containing UIDs of existing PSIs (including deleted)
-   */
-  List<String> getEnrollmentsUidsIncludingDeleted(List<String> uids);
-
-  /**
    * Returns a list with Enrollment values based on the given EnrollmentQueryParams.
    *
    * @param params the EnrollmentQueryParams.
    * @return List of enrollments matching the params
    */
   List<Enrollment> getEnrollments(EnrollmentQueryParams params);
-
-  /**
-   * Returns the number of Enrollment matches based on the given EnrollmentQueryParams.
-   *
-   * @param params the EnrollmentQueryParams.
-   * @return Number of enrollments matching the params
-   */
-  int countEnrollments(EnrollmentQueryParams params);
 
   /**
    * Decides whether current user is authorized to perform the given query. IllegalQueryException is

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentStore.java
@@ -41,14 +41,6 @@ public interface EnrollmentStore extends IdentifiableObjectStore<Enrollment> {
   String ID = EnrollmentStore.class.getName();
 
   /**
-   * Count all enrollments by enrollment query params.
-   *
-   * @param params EnrollmentQueryParams to use
-   * @return Count of matching enrollments
-   */
-  int countEnrollments(EnrollmentQueryParams params);
-
-  /**
    * Get all enrollments by enrollment query params.
    *
    * @param params EnrollmentQueryParams to use
@@ -104,14 +96,6 @@ public interface EnrollmentStore extends IdentifiableObjectStore<Enrollment> {
   boolean existsIncludingDeleted(String uid);
 
   /**
-   * Returns UIDs of existing enrollments (including deleted) from the provided UIDs
-   *
-   * @param uids enrollment UIDs to check
-   * @return List containing UIDs of existing enrollments (including deleted)
-   */
-  List<String> getUidsIncludingDeleted(List<String> uids);
-
-  /**
    * Fetches enrollments matching the given list of UIDs
    *
    * @param uids a List of UID
@@ -137,17 +121,6 @@ public interface EnrollmentStore extends IdentifiableObjectStore<Enrollment> {
    * @return List of all enrollments that are linked to programs
    */
   List<Enrollment> getByPrograms(List<Program> programs);
-
-  /**
-   * Return all enrollment by type.
-   *
-   * <p>Warning: this is meant to be used for WITHOUT_REGISTRATION programs only, be careful if you
-   * need it for other uses.
-   *
-   * @param type ProgramType to fetch by
-   * @return List of all enrollments that matches the wanted type
-   */
-  List<Enrollment> getByType(ProgramType type);
 
   /**
    * Hard deletes a {@link Enrollment}.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventService.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.program;
 
 import java.util.Date;
-import java.util.List;
 import java.util.Map;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
@@ -59,14 +58,6 @@ public interface EventService {
   void updateEvent(Event event);
 
   /**
-   * Updates a last sync timestamp on specified events
-   *
-   * @param eventUids UIDs of events where the lastSynchronized flag should be updated
-   * @param lastSynchronized The date of last successful sync
-   */
-  void updateEventsSyncTimestamp(List<String> eventUids, Date lastSynchronized);
-
-  /**
    * Checks whether an {@link Event} with the given identifier exists. Doesn't take into account the
    * deleted values.
    *
@@ -81,14 +72,6 @@ public interface EventService {
    * @param uid the identifier.
    */
   boolean eventExistsIncludingDeleted(String uid);
-
-  /**
-   * Returns UIDs of existing events (including deleted) from the provided UIDs
-   *
-   * @param uids event UIDs to check
-   * @return Set containing UIDs of existing events (including deleted)
-   */
-  List<String> getEventUidsIncludingDeleted(List<String> uids);
 
   /**
    * Returns an {@link Event}.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventStore.java
@@ -82,14 +82,6 @@ public interface EventStore extends IdentifiableObjectStore<Event> {
   boolean existsIncludingDeleted(String uid);
 
   /**
-   * Returns UIDs of existing events (including deleted) from the provided UIDs.
-   *
-   * @param uids event UIDs to check
-   * @return List containing UIDs of existing events (including deleted)
-   */
-  List<String> getUidsIncludingDeleted(List<String> uids);
-
-  /**
    * Fetches Event matching the given list of UIDs
    *
    * @param uids a List of UID
@@ -107,12 +99,4 @@ public interface EventStore extends IdentifiableObjectStore<Event> {
    */
   List<Event> getWithScheduledNotifications(
       ProgramNotificationTemplate template, Date notificationDate);
-
-  /**
-   * Set lastSynchronized timestamp to provided timestamp for provided events.
-   *
-   * @param eventUids UIDs of events where the lastSynchronized flag should be updated
-   * @param lastSynchronized The date of last successful sync
-   */
-  void updateEventsSyncTimestamp(List<String> eventUids, Date lastSynchronized);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramService.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.program;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import org.apache.commons.collections4.SetValuedMap;
 import org.hisp.dhis.dataentryform.DataEntryForm;
@@ -42,22 +41,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityType;
  */
 public interface ProgramService {
   String ID = ProgramService.class.getName();
-
-  Pattern INPUT_PATTERN = Pattern.compile("(<input.*?/>)", Pattern.DOTALL);
-
-  Pattern DYNAMIC_ATTRIBUTE_PATTERN = Pattern.compile("attributeid=\"(\\w+)\"");
-
-  Pattern PROGRAM_PATTERN = Pattern.compile("programid=\"(\\w+)\"");
-
-  Pattern VALUE_TAG_PATTERN = Pattern.compile("value=\"(.*?)\"", Pattern.DOTALL);
-
-  Pattern TITLE_TAG_PATTERN = Pattern.compile("title=\"(.*?)\"", Pattern.DOTALL);
-
-  Pattern SUGGESTED_VALUE_PATTERN = Pattern.compile("suggested=('|\")(\\w*)('|\")");
-
-  Pattern CLASS_PATTERN = Pattern.compile("class=('|\")(\\w*)('|\")");
-
-  Pattern STYLE_PATTERN = Pattern.compile("style=('|\")([\\w|\\d\\:\\;]+)('|\")");
 
   /**
    * Adds an {@link Program}
@@ -161,15 +144,4 @@ public interface ProgramService {
    */
   SetValuedMap<String, String> getProgramOrganisationUnitsAssociationsForCurrentUser(
       Set<String> programUids);
-
-  /**
-   * Look for a program - org Unit association in a Cache. If the association exists we return true,
-   * otherwise we do a database lookup in the Store and add to the cache. This method checks the
-   * associations irrespective of the sharing settings or org unit scopes.
-   *
-   * @param program input program uid
-   * @param orgUnit
-   * @return whether a org Unit is associated to the input program
-   */
-  boolean checkProgramOrganisationUnitsAssociations(String program, String orgUnit);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageDataElementService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageDataElementService.java
@@ -28,8 +28,6 @@
 package org.hisp.dhis.program;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import org.hisp.dhis.dataelement.DataElement;
 
 /**
@@ -86,12 +84,4 @@ public interface ProgramStageDataElementService {
    *     DataElement}
    */
   List<ProgramStageDataElement> getProgramStageDataElements(DataElement dataElement);
-
-  /**
-   * Returns Map of ProgramStages containing Set of DataElements (together ProgramStageDataElements)
-   * that have skipSynchronization flag set to true
-   *
-   * @return Map<String, Set<String>>
-   */
-  Map<String, Set<String>> getProgramStageDataElementsWithSkipSynchronizationSetToTrue();
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageDataElementStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageDataElementStore.java
@@ -28,8 +28,6 @@
 package org.hisp.dhis.program;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 import org.hisp.dhis.dataelement.DataElement;
 
@@ -48,14 +46,6 @@ public interface ProgramStageDataElementStore
    * @return ProgramStageDataElement
    */
   ProgramStageDataElement get(ProgramStage programStage, DataElement dataElement);
-
-  /**
-   * Returns Map of ProgramStages containing Set of DataElements (together ProgramStageDataElements)
-   * that have skipSynchronization flag set to true
-   *
-   * @return Map<String, Set<String>>
-   */
-  Map<String, Set<String>> getProgramStageDataElementsWithSkipSynchronizationSetToTrue();
 
   List<ProgramStageDataElement> getProgramStageDataElements(DataElement dataElement);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramTempOwnershipAuditService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramTempOwnershipAuditService.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.program;
 
-import java.util.List;
-
 /**
  * @author Ameen Mohamed <ameen@dhis2.org>
  */
@@ -42,28 +40,4 @@ public interface ProgramTempOwnershipAuditService {
    * @param programTempOwnershipAudit the audit to add
    */
   void addProgramTempOwnershipAudit(ProgramTempOwnershipAudit programTempOwnershipAudit);
-
-  /**
-   * Deletes program temp ownership audit for the given enrollment
-   *
-   * @param program the program
-   */
-  void deleteProgramTempOwnershipAudit(Program program);
-
-  /**
-   * Returns program temp ownership audits matching query params
-   *
-   * @param params program temp ownership audit query params
-   * @return matching ProgramTempOwnershipAuditQueryParams
-   */
-  List<ProgramTempOwnershipAudit> getProgramTempOwnershipAudits(
-      ProgramTempOwnershipAuditQueryParams params);
-
-  /**
-   * Returns count of program temp ownership audits matching query params
-   *
-   * @param params program temp ownership audit query params
-   * @return count of ProgramTempOwnershipAuditQueryParams
-   */
-  int getProgramTempOwnershipAuditsCount(ProgramTempOwnershipAuditQueryParams params);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramTempOwnershipAuditStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramTempOwnershipAuditStore.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.program;
 
-import java.util.List;
-
 /**
  * @author Ameen Mohamed <ameen@dhis2.org>
  */
@@ -42,28 +40,4 @@ public interface ProgramTempOwnershipAuditStore {
    * @param programTempOwnershipAudit the audit to add
    */
   void addProgramTempOwnershipAudit(ProgramTempOwnershipAudit programTempOwnershipAudit);
-
-  /**
-   * Deletes audit for the given program
-   *
-   * @param program the enrollment
-   */
-  void deleteProgramTempOwnershipAudit(Program program);
-
-  /**
-   * Returns program temp ownership audits matching query params
-   *
-   * @param params program temp ownership audit query params
-   * @return matching ProgramTempOwnershipAudit
-   */
-  List<ProgramTempOwnershipAudit> getProgramTempOwnershipAudits(
-      ProgramTempOwnershipAuditQueryParams params);
-
-  /**
-   * Returns count of program temp ownership audits matching query params
-   *
-   * @param params program temp ownership audit query params
-   * @return count of ProgramTempOwnershipAudit
-   */
-  int getProgramTempOwnershipAuditsCount(ProgramTempOwnershipAuditQueryParams params);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
@@ -53,7 +53,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.trackedentity.TrackerOwnershipManager;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.context.ApplicationEventPublisher;
@@ -148,21 +147,9 @@ public class DefaultEnrollmentService implements EnrollmentService {
   }
 
   @Override
-  @Transactional(readOnly = true)
-  public List<String> getEnrollmentsUidsIncludingDeleted(List<String> uids) {
-    return enrollmentStore.getUidsIncludingDeleted(uids);
-  }
-
-  @Override
   @Transactional
   public void updateEnrollment(Enrollment enrollment) {
     enrollmentStore.update(enrollment);
-  }
-
-  @Override
-  @Transactional
-  public void updateEnrollment(Enrollment enrollment, UserDetails user) {
-    enrollmentStore.update(enrollment, user);
   }
 
   // TODO consider security
@@ -192,34 +179,6 @@ public class DefaultEnrollmentService implements EnrollmentService {
     }
 
     return enrollmentStore.getEnrollments(params);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public int countEnrollments(EnrollmentQueryParams params) {
-    decideAccess(params);
-    validate(params);
-
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
-
-    if (currentUser != null
-        && params.isOrganisationUnitMode(OrganisationUnitSelectionMode.ACCESSIBLE)) {
-      params.setOrganisationUnits(currentUser.getTeiSearchOrganisationUnitsWithFallback());
-      params.setOrganisationUnitMode(OrganisationUnitSelectionMode.DESCENDANTS);
-    } else if (params.isOrganisationUnitMode(CHILDREN)) {
-      Set<OrganisationUnit> organisationUnits = new HashSet<>();
-      organisationUnits.addAll(params.getOrganisationUnits());
-
-      for (OrganisationUnit organisationUnit : params.getOrganisationUnits()) {
-        organisationUnits.addAll(organisationUnit.getChildren());
-      }
-
-      params.setOrganisationUnits(organisationUnits);
-    }
-
-    params.setSkipPaging(true);
-
-    return enrollmentStore.countEnrollments(params);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventService.java
@@ -32,7 +32,6 @@ import static org.hisp.dhis.external.conf.ConfigurationKey.CHANGELOG_TRACKER;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -106,12 +105,6 @@ public class DefaultEventService implements EventService {
   }
 
   @Override
-  @Transactional
-  public void updateEventsSyncTimestamp(List<String> eventUids, Date lastSynchronized) {
-    eventStore.updateEventsSyncTimestamp(eventUids, lastSynchronized);
-  }
-
-  @Override
   @Transactional(readOnly = true)
   public boolean eventExists(String uid) {
     return eventStore.exists(uid);
@@ -121,12 +114,6 @@ public class DefaultEventService implements EventService {
   @Transactional(readOnly = true)
   public boolean eventExistsIncludingDeleted(String uid) {
     return eventStore.existsIncludingDeleted(uid);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public List<String> getEventUidsIncludingDeleted(List<String> uids) {
-    return eventStore.getUidsIncludingDeleted(uids);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramService.java
@@ -173,9 +173,4 @@ public class DefaultProgramService implements ProgramService {
 
     return jdbcOrgUnitAssociationsStore.getOrganisationUnitsAssociationsForCurrentUser(programUids);
   }
-
-  @Override
-  public boolean checkProgramOrganisationUnitsAssociations(String program, String orgUnit) {
-    return jdbcOrgUnitAssociationsStore.checkOrganisationUnitsAssociations(program, orgUnit);
-  }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramStageDataElementService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramStageDataElementService.java
@@ -28,8 +28,6 @@
 package org.hisp.dhis.program;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.dataelement.DataElement;
 import org.springframework.stereotype.Service;
@@ -81,12 +79,5 @@ public class DefaultProgramStageDataElementService implements ProgramStageDataEl
   @Transactional
   public void updateProgramStageDataElement(ProgramStageDataElement programStageDataElement) {
     programStageDataElementStore.update(programStageDataElement);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public Map<String, Set<String>> getProgramStageDataElementsWithSkipSynchronizationSetToTrue() {
-    return programStageDataElementStore
-        .getProgramStageDataElementsWithSkipSynchronizationSetToTrue();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramTempOwnershipAuditService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramTempOwnershipAuditService.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.program;
 
-import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -52,24 +51,5 @@ public class DefaultProgramTempOwnershipAuditService implements ProgramTempOwner
   @Transactional
   public void addProgramTempOwnershipAudit(ProgramTempOwnershipAudit programTempOwnershipAudit) {
     programTempOwnershipAuditStore.addProgramTempOwnershipAudit(programTempOwnershipAudit);
-  }
-
-  @Override
-  @Transactional
-  public void deleteProgramTempOwnershipAudit(Program program) {
-    programTempOwnershipAuditStore.deleteProgramTempOwnershipAudit(program);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public List<ProgramTempOwnershipAudit> getProgramTempOwnershipAudits(
-      ProgramTempOwnershipAuditQueryParams params) {
-    return programTempOwnershipAuditStore.getProgramTempOwnershipAudits(params);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public int getProgramTempOwnershipAuditsCount(ProgramTempOwnershipAuditQueryParams params) {
-    return programTempOwnershipAuditStore.getProgramTempOwnershipAuditsCount(params);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventStore.java
@@ -139,22 +139,6 @@ public class HibernateEventStore extends SoftDeleteHibernateObjectStore<Event>
   }
 
   @Override
-  public List<String> getUidsIncludingDeleted(List<String> uids) {
-    final String hql = "select ev.uid " + EVENT_HQL_BY_UIDS;
-    List<String> resultUids = new ArrayList<>();
-    List<List<String>> uidsPartitions = Lists.partition(Lists.newArrayList(uids), 20000);
-
-    for (List<String> uidsPartition : uidsPartitions) {
-      if (!uidsPartition.isEmpty()) {
-        resultUids.addAll(
-            getSession().createQuery(hql, String.class).setParameter("uids", uidsPartition).list());
-      }
-    }
-
-    return resultUids;
-  }
-
-  @Override
   public List<Event> getIncludingDeleted(List<String> uids) {
     List<Event> events = new ArrayList<>();
     List<List<String>> uidsPartitions = Lists.partition(Lists.newArrayList(uids), 20000);
@@ -170,16 +154,6 @@ public class HibernateEventStore extends SoftDeleteHibernateObjectStore<Event>
     }
 
     return events;
-  }
-
-  @Override
-  public void updateEventsSyncTimestamp(List<String> eventUids, Date lastSynchronized) {
-    String hql = "update Event set lastSynchronized = :lastSynchronized WHERE uid in :events";
-
-    getQuery(hql)
-        .setParameter("lastSynchronized", lastSynchronized)
-        .setParameter("events", eventUids)
-        .executeUpdate();
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramStageDataElementStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramStageDataElementStore.java
@@ -27,11 +27,7 @@
  */
 package org.hisp.dhis.program.hibernate;
 
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import javax.persistence.EntityManager;
 import javax.persistence.criteria.CriteriaBuilder;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
@@ -77,29 +73,5 @@ public class HibernateProgramStageDataElementStore
         builder,
         newJpaParameters()
             .addPredicate(root -> builder.equal(root.get("dataElement"), dataElement)));
-  }
-
-  @Override
-  public Map<String, Set<String>> getProgramStageDataElementsWithSkipSynchronizationSetToTrue() {
-    final String sql =
-        "select ps.uid as ps_uid, de.uid as de_uid from programstagedataelement psde "
-            + "join programstage ps on psde.programstageid = ps.programstageid "
-            + "join dataelement de on psde.dataelementid = de.dataelementid "
-            + "where psde.programstageid in (select distinct ( programstageid ) from event ev where ev.lastupdated > ev.lastsynchronized) "
-            + "and psde.skipsynchronization = true";
-
-    final Map<String, Set<String>> psdesWithSkipSync = new HashMap<>();
-    jdbcTemplate.query(
-        sql,
-        rs -> {
-          String programStageUid = rs.getString("ps_uid");
-          String dataElementUid = rs.getString("de_uid");
-
-          psdesWithSkipSync
-              .computeIfAbsent(programStageUid, p -> new HashSet<>())
-              .add(dataElementUid);
-        });
-
-    return psdesWithSkipSync;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramTempOwnershipAuditStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramTempOwnershipAuditStore.java
@@ -27,18 +27,9 @@
  */
 package org.hisp.dhis.program.hibernate;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Function;
 import javax.persistence.EntityManager;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
 import org.hisp.dhis.hibernate.HibernateGenericStore;
-import org.hisp.dhis.hibernate.JpaQueryParameters;
-import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramTempOwnershipAudit;
-import org.hisp.dhis.program.ProgramTempOwnershipAuditQueryParams;
 import org.hisp.dhis.program.ProgramTempOwnershipAuditStore;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -63,65 +54,5 @@ public class HibernateProgramTempOwnershipAuditStore
   @Override
   public void addProgramTempOwnershipAudit(ProgramTempOwnershipAudit programTempOwnershipAudit) {
     getSession().save(programTempOwnershipAudit);
-  }
-
-  @Override
-  public void deleteProgramTempOwnershipAudit(Program program) {
-    String hql = "delete ProgramTempOwnershipAudit where program = :program";
-    entityManager.createQuery(hql).setParameter("program", program).executeUpdate();
-  }
-
-  @Override
-  public List<ProgramTempOwnershipAudit> getProgramTempOwnershipAudits(
-      ProgramTempOwnershipAuditQueryParams params) {
-    CriteriaBuilder builder = getCriteriaBuilder();
-
-    JpaQueryParameters<ProgramTempOwnershipAudit> jpaParameters =
-        newJpaParameters()
-            .addPredicates(getProgramTempOwnershipAuditPredicates(params, builder))
-            .addOrder(root -> builder.desc(root.get("created")));
-
-    if (!params.isSkipPaging()) {
-      jpaParameters.setFirstResult(params.getFirst()).setMaxResults(params.getMax());
-    }
-
-    return getList(builder, jpaParameters);
-  }
-
-  @Override
-  public int getProgramTempOwnershipAuditsCount(ProgramTempOwnershipAuditQueryParams params) {
-    CriteriaBuilder builder = getCriteriaBuilder();
-
-    return getCount(
-            builder,
-            newJpaParameters()
-                .addPredicates(getProgramTempOwnershipAuditPredicates(params, builder))
-                .count(root -> builder.countDistinct(root.get("id"))))
-        .intValue();
-  }
-
-  private List<Function<Root<ProgramTempOwnershipAudit>, Predicate>>
-      getProgramTempOwnershipAuditPredicates(
-          ProgramTempOwnershipAuditQueryParams params, CriteriaBuilder builder) {
-    List<Function<Root<ProgramTempOwnershipAudit>, Predicate>> predicates = new ArrayList<>();
-
-    if (params.hasUsers()) {
-      predicates.add(root -> root.get("accessedBy").in(params.getUsers()));
-    }
-
-    if (params.hasStartDate()) {
-      predicates.add(
-          root -> builder.greaterThanOrEqualTo(root.get("created"), params.getStartDate()));
-    }
-
-    if (params.hasEndDate()) {
-      predicates.add(root -> builder.lessThanOrEqualTo(root.get("created"), params.getEndDate()));
-    }
-
-    if (params.hasPrograms()) {
-      predicates.add(root -> root.get("program").in(params.getPrograms()));
-    }
-
-    return predicates;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
@@ -389,7 +389,7 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
    */
   private String getCountQuery(TrackedEntityQueryParams params) {
     return new StringBuilder()
-        .append(getQueryCountSelect(params))
+        .append(getQueryCountSelect())
         .append(getQuerySelect(params))
         .append("FROM ")
         .append(getFromSubQuery(params, true, true))
@@ -408,7 +408,7 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
    */
   private String getCountQueryWithMaxTeiLimit(TrackedEntityQueryParams params) {
     return new StringBuilder()
-        .append(getQueryCountSelect(params))
+        .append(getQueryCountSelect())
         .append(getQuerySelect(params))
         .append("FROM ")
         .append(getFromSubQuery(params, true, true))
@@ -461,10 +461,9 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
   /**
    * Generates the projection of the main query when doing a count query.
    *
-   * @param params
    * @return an SQL projection
    */
-  private String getQueryCountSelect(TrackedEntityQueryParams params) {
+  private String getQueryCountSelect() {
     return "SELECT count(instance) FROM ( ";
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/strategy/TrackerEntityStrategyTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preheat/supplier/strategy/TrackerEntityStrategyTest.java
@@ -70,10 +70,4 @@ class TrackerEntityStrategyTest {
     Mockito.verify(trackedEntityStore).getIncludingDeleted(uids);
     Mockito.verify(preheat).putTrackedEntities(dbTrackedEntities);
   }
-
-  private List<org.hisp.dhis.tracker.imports.domain.TrackedEntity> trackedEntities() {
-    return List.of(
-        org.hisp.dhis.tracker.imports.domain.TrackedEntity.builder().trackedEntity("TEIA").build(),
-        org.hisp.dhis.tracker.imports.domain.TrackedEntity.builder().trackedEntity("TEIB").build());
-  }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/relationship/LinkValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/relationship/LinkValidatorTest.java
@@ -114,19 +114,7 @@ class LinkValidatorTest {
     return relType;
   }
 
-  private RelationshipItem trackedEntityRelationshipItem() {
-    return RelationshipItem.builder().trackedEntity(trackedEntity()).build();
-  }
-
   private RelationshipItem trackedEntityRelationshipItem(String trackedEntityUid) {
     return RelationshipItem.builder().trackedEntity(trackedEntityUid).build();
-  }
-
-  private String trackedEntity() {
-    return CodeGenerator.generateUid();
-  }
-
-  private String enrollment() {
-    return CodeGenerator.generateUid();
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EnrollmentSecurityImportValidationTest.java
@@ -295,7 +295,7 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest {
   }
 
   @Test
-  void shouldFailWhenTeNotEnrolledAndUserHasNoAccessToTeRegisteringOrgUnit() throws IOException {
+  void shouldFailWhenTeNotEnrolledAndUserHasNoAccessToTeRegisteringOrgUnit() {
     clearSecurityContext();
     setup();
     TrackedEntity trackedEntityB = createTrackedEntity(trackedEntityType, organisationUnitB);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventSecurityImportValidationTest.java
@@ -37,7 +37,6 @@ import java.io.IOException;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.Set;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
@@ -66,9 +65,7 @@ import org.hisp.dhis.tracker.imports.TrackerImportService;
 import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
-import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -129,9 +126,6 @@ class EventSecurityImportValidationTest extends TrackerTest {
     userService = _userService;
     setUpMetadata("tracker/tracker_basic_metadata.json");
     injectAdminUser();
-
-    UserDetails currentUserDetails = CurrentUserUtil.getCurrentUserDetails();
-    Set<String> allAuthorities = currentUserDetails.getAllAuthorities();
 
     assertNoErrors(
         trackerImportService.importTracker(


### PR DESCRIPTION
follow up after https://github.com/dhis2/dhis2-core/pull/17368

We have deleted the old tracker controllers, sync and dxf2 services and stores. This PR now removes the unused code that was previously used by the tracker dxf2 services. This mostly means interfaces in the module dhis-api and implementations in the module dhis-service-core.