### PR TITLE
fix: field filter parsing exits block [DHIS2-17391]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterParser.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterParser.java
@@ -119,7 +119,9 @@ public class FieldFilterParser {
           } else if ((insideParameters && isParameterEnd(token))) {
             transformerParameters.add(transformerNameBuilder.toString());
             break;
-          } else if (isFieldSeparator(token) || (token.equals("[") && !insideParameters)) {
+          } else if (isFieldSeparator(token)
+              || (token.equals("]") && !insideParameters)
+              || (token.equals("[") && !insideParameters)) {
             idx--;
             break;
           }


### PR DESCRIPTION
### Summary
The issue in the parser is that `]` did not exit the parsing loop that was reading the transformation.

It seemed reasonable that a transformation name would end in a similar way when another level of block nesting opened so I added a corresponding condition to the existing case which appears to solve the issue.

With the way the parser works it is hard to tell if it is correct or where cases are missing. 
I kept the fix minimal for less impact for the release and easier backport but long term we should rewrite the parser using PEG technique (simple version with Java methods).

### Automatic Testing
A test case was added for the field filter that failed according to the reported ticket.

### Manual Testing
* try `/api/dataElements?fields=id,categoryCombo[categoryOptionCombos~size],displayName`
* try `/api/dataElements?fields=id,categoryCombo[categoryOptionCombos~size],displayName,code`

In both cases the `displayName` (and `code`) should not be nested (under `categoryCombo`)