### PR TITLE
fix: flaky gist filter test

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFilterControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/GistFilterControllerTest.java
@@ -124,7 +124,6 @@ class GistFilterControllerTest extends AbstractGistControllerTest {
 
   @Test
   void testFilter_Like() {
-    assertEquals(1, GET("/users/gist?filter=surname:like:mi&headless=true").content().size());
     assertEquals(
         1, GET("/users/gist?filter=surname:like:?urnameuserA&headless=true").content().size());
     assertEquals(3, GET("/users/gist?filter=surname:like:Surna*&headless=true").content().size());


### PR DESCRIPTION
I assume the "mi" value was meant to match "admin" and that some other test leaves another user with that work in the name behind. 

Since the next assert tests the same scenario just with a more unique value "urnameuserA" matching "SurnameuserA" which is the value for the test user created in the setup I just removed the flaky assert.