### PR TITLE
fix: Enrollment dim. restriction SQL [DHIS2-16349] (#17393) (#17411)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -36,6 +36,7 @@ import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.encode;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quoteAlias;
 import static org.hisp.dhis.analytics.util.AnalyticsUtils.withExceptionHandling;
+import static org.hisp.dhis.common.DataDimensionType.ATTRIBUTE;
 import static org.hisp.dhis.common.DimensionItemType.DATA_ELEMENT;
 import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.IdentifiableObjectUtils.getUids;
@@ -56,6 +57,7 @@ import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
 import org.hisp.dhis.analytics.event.EnrollmentAnalyticsManager;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.ProgramIndicatorSubqueryBuilder;
+import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
@@ -342,17 +344,24 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
     }
 
     // ---------------------------------------------------------------------
-    // Organisation unit group sets
+    // Categories (enrollments don't have attribute categories)
     // ---------------------------------------------------------------------
 
     List<DimensionalObject> dynamicDimensions =
         params.getDimensionsAndFilters(Sets.newHashSet(DimensionType.CATEGORY));
 
     for (DimensionalObject dim : dynamicDimensions) {
-      String col = quoteAlias(dim.getDimensionName());
+      if (!isAttributeCategory(dim)) {
+        String col = quoteAlias(dim.getDimensionName());
 
-      sql += "and " + col + " in (" + getQuotedCommaDelimitedString(getUids(dim.getItems())) + ") ";
+        sql +=
+            "and " + col + " in (" + getQuotedCommaDelimitedString(getUids(dim.getItems())) + ") ";
+      }
     }
+
+    // ---------------------------------------------------------------------
+    // Organisation unit group sets
+    // ---------------------------------------------------------------------
 
     dynamicDimensions =
         params.getDimensionsAndFilters(Sets.newHashSet(DimensionType.ORGANISATION_UNIT_GROUP_SET));
@@ -627,6 +636,20 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
   @Override
   protected String getColumn(QueryItem item) {
     return getColumn(item, "");
+  }
+
+  /**
+   * Is a category dimension an attribute category (rather than a disaggregation category)?
+   * Attribute categories are not included in enrollment tables, so category user dimension
+   * restrictions (which use attribute categories) do not apply.
+   */
+  private boolean isAttributeCategory(DimensionalObject categoryDim) {
+    return ((CategoryOption) categoryDim.getItems().get(0))
+            .getCategories()
+            .iterator()
+            .next()
+            .getDataDimensionType()
+        == ATTRIBUTE;
   }
 
   private static String getExecutionDateFilter(Date startDate, Date endDate) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
@@ -645,6 +645,20 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
             "Current user is constrained by a dimension but has access to no dimension items"));
   }
 
+  @Test
+  void testEnrollmentWithCategoryDimensionRestriction() {
+    injectSecurityContext(userA);
+    EventQueryParams params = getEnrollmentQueryBuilderA().build();
+    Grid grid = enrollmentTarget.getEnrollments(params);
+
+    assertGridContains(
+        // Headers
+        List.of("enrollmentdate", "ou", "tei", "teaAttribuU"),
+        // Grid
+        List.of(List.of("2017-01-01 00:00:00.0", "ouabcdefghE", "trackEntInA", "ouabcdefghF")),
+        grid);
+  }
+
   // -------------------------------------------------------------------------
   // Test getAggregatedEventData with OrgUnitFields
   // -------------------------------------------------------------------------


### PR DESCRIPTION
* fix: Enrollment dim. restriction SQL [DHIS2-16349] (#17393)

* fix: Enrollment dim. restriction SQL [DHIS2-16349]

* trigger Github actions

(cherry picked from commit 232cd91a0006b48c3b518c25b5bd326b7264ac06)

* spotless fix

* Replace missing isAttributeCategory method

* fix testEnrollmentWithCategoryDimensionRestriction

(cherry picked from commit 05d6b7be828fb324df2bd5f43a65afc3673987a3)

[DHIS2-16349]: https://dhis2.atlassian.net/browse/DHIS2-16349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-16349]: https://dhis2.atlassian.net/browse/DHIS2-16349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ