### PR TITLE
chore: remove unused tracker tracked entity code DHIS2-16564

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeService.java
@@ -33,7 +33,6 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -138,9 +137,6 @@ public interface TrackedEntityAttributeService {
 
   Set<TrackedEntityAttribute> getAllUserReadableTrackedEntityAttributes(
       UserDetails userDetails, List<Program> programs, List<TrackedEntityType> trackedEntityTypes);
-
-  ProgramTrackedEntityAttribute getProgramTrackedEntityAttribute(
-      Program program, TrackedEntityAttribute trackedEntityAttribute);
 
   /**
    * Returns all {@link TrackedEntityAttribute} that are candidates for creating trigram indexes.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityProgramOwnerService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityProgramOwnerService.java
@@ -57,26 +57,6 @@ public interface TrackedEntityProgramOwnerService {
   void updateTrackedEntityProgramOwner(String teUid, String programUid, String orgUnitUid);
 
   /**
-   * Assign an orgUnit as the owner for a tracked entity for the given program. If another owner
-   * already exist then this method would fail.
-   *
-   * @param teId The Id of the tracked entity
-   * @param programId The program Id
-   * @param orgUnitId The organisation units Id
-   */
-  void createTrackedEntityProgramOwner(long teId, long programId, long orgUnitId);
-
-  /**
-   * Update the owner ou for a tracked entity for the given program. If no owner previously exist,
-   * then this method will fail.
-   *
-   * @param teId The tracked entity Id
-   * @param programId The program Id
-   * @param orgUnitId The organisation Unit Id
-   */
-  void updateTrackedEntityProgramOwner(long teId, long programId, long orgUnitId);
-
-  /**
    * Get the program owner details for a tracked entity.
    *
    * @param teId The tracked entity Id
@@ -103,16 +83,6 @@ public interface TrackedEntityProgramOwnerService {
    * @param orgUnitUid
    */
   void createOrUpdateTrackedEntityProgramOwner(String teUid, String programUid, String orgUnitUid);
-
-  /**
-   * Assign an orgUnit as the owner for a tracked entity for the given program. If another owner
-   * already exist then it would be overwritten.
-   *
-   * @param teUid
-   * @param programUid
-   * @param orgUnitUid
-   */
-  void createOrUpdateTrackedEntityProgramOwner(long teUid, long programUid, long orgUnitUid);
 
   /**
    * Assign an orgUnit as the owner for a tracked entity for the given program. If another owner

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityProgramOwnerStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityProgramOwnerStore.java
@@ -46,22 +46,5 @@ public interface TrackedEntityProgramOwnerStore extends GenericStore<TrackedEnti
    */
   TrackedEntityProgramOwner getTrackedEntityProgramOwner(long teId, long programId);
 
-  /**
-   * Get all Tracked entity program owner entities for the list of tracked entities.
-   *
-   * @param teIds The list of tracked entity instance ids.
-   * @return matching tracked entity program owner entities.
-   */
-  List<TrackedEntityProgramOwner> getTrackedEntityProgramOwners(List<Long> teIds);
-
-  /**
-   * Get all Tracked entity program owner entities for the list of te and program.
-   *
-   * @param teIds The list of tracked entity instance ids.
-   * @param programId The program id
-   * @return matching tracked entity program owner entities.
-   */
-  List<TrackedEntityProgramOwner> getTrackedEntityProgramOwners(List<Long> teIds, long programId);
-
   List<TrackedEntityProgramOwnerOrgUnit> getTrackedEntityProgramOwnerOrgUnits(Set<Long> teIds);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityQueryParams.java
@@ -30,10 +30,8 @@ package org.hisp.dhis.trackedentity;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CHILDREN;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -116,32 +114,14 @@ public class TrackedEntityQueryParams {
    */
   private Boolean followUp;
 
-  /** Start date for last updated. */
-  private Date lastUpdatedStartDate;
-
-  /** End date for last updated. */
-  private Date lastUpdatedEndDate;
-
   /** The last updated duration filter. */
   private String lastUpdatedDuration;
-
-  /** Start date for enrollment in the given program. */
-  private Date programEnrollmentStartDate;
-
-  /** End date for enrollment in the given program. */
-  private Date programEnrollmentEndDate;
-
-  /** Start date for incident in the given program. */
-  private Date programIncidentStartDate;
-
-  /** End date for incident in the given program. */
-  private Date programIncidentEndDate;
 
   /** Tracked entity of the instances in the response. */
   private TrackedEntityType trackedEntityType;
 
   /** Tracked entity types to fetch. */
-  private List<TrackedEntityType> trackedEntityTypes = Lists.newArrayList();
+  private List<TrackedEntityType> trackedEntityTypes = new ArrayList<>();
 
   /** Selection mode for the specified organisation units, default is DESCENDANTS. */
   private OrganisationUnitSelectionMode orgUnitMode = OrganisationUnitSelectionMode.DESCENDANTS;
@@ -151,19 +131,13 @@ public class TrackedEntityQueryParams {
   /** Set of te uids to explicitly select. */
   private Set<String> trackedEntityUids = new HashSet<>();
 
-  /** ProgramStage to be used in conjunction with eventstatus. */
+  /** ProgramStage to be used in conjunction with event status. */
   private ProgramStage programStage;
 
   /** Status of any events in the specified program. */
   private EventStatus eventStatus;
 
-  /** Start date for event for the given program. */
-  private Date eventStartDate;
-
-  /** End date for event for the given program. */
-  private Date eventEndDate;
-
-  /** Indicates whether not to include meta data in the response. */
+  /** Indicates whether not to include metadata in the response. */
   private boolean skipMeta;
 
   /** Page number. */
@@ -184,21 +158,6 @@ public class TrackedEntityQueryParams {
   /** Indicates whether to include soft-deleted elements. Default to false */
   private boolean includeDeleted = false;
 
-  /** Indicates whether to include all TE attributes */
-  private boolean includeAllAttributes;
-
-  /**
-   * Indicates whether the search is internal triggered by the system. The system should trigger
-   * superuser search to detect duplicates.
-   */
-  private boolean internalSearch;
-
-  /** Indicates whether the search is for synchronization purposes (for Program Data sync job). */
-  private boolean synchronizationQuery;
-
-  /** Indicates a point in the time used to decide the data that should not be synchronized */
-  private Date skipChangedBefore;
-
   /**
    * Potential Duplicate query parameter value. If null, we don't check whether a TE is a
    * potentialDuplicate or not
@@ -208,22 +167,10 @@ public class TrackedEntityQueryParams {
   /** TE order params */
   private List<OrderParam> orders = new ArrayList<>();
 
-  // -------------------------------------------------------------------------
-  // Transient properties
-  // -------------------------------------------------------------------------
-
   /** Current user for query. */
   private transient User user;
 
-  // -------------------------------------------------------------------------
-  // Constructors
-  // -------------------------------------------------------------------------
-
   public TrackedEntityQueryParams() {}
-
-  // -------------------------------------------------------------------------
-  // Logic
-  // -------------------------------------------------------------------------
 
   /** Adds a query item as attribute to the parameters. */
   public TrackedEntityQueryParams addAttribute(QueryItem attribute) {
@@ -303,9 +250,8 @@ public class TrackedEntityQueryParams {
     return CollectionUtils.isNotEmpty(this.trackedEntityUids);
   }
 
-  public TrackedEntityQueryParams addAttributes(List<QueryItem> attrs) {
+  public void addAttributes(List<QueryItem> attrs) {
     attributes.addAll(attrs);
-    return this;
   }
 
   public boolean hasFilterForEvents() {
@@ -314,25 +260,21 @@ public class TrackedEntityQueryParams {
   }
 
   /** Add the given attributes to this params if they are not already present. */
-  public TrackedEntityQueryParams addAttributesIfNotExist(List<QueryItem> attrs) {
+  public void addAttributesIfNotExist(List<QueryItem> attrs) {
     for (QueryItem attr : attrs) {
       if (attributes != null && !attributes.contains(attr)) {
         attributes.add(attr);
       }
     }
-
-    return this;
   }
 
-  /** Adds the given filters to this parameters if they are not already present. */
-  public TrackedEntityQueryParams addFiltersIfNotExist(List<QueryItem> filtrs) {
+  /** Adds the given filters to this parameter if they are not already present. */
+  public void addFiltersIfNotExist(List<QueryItem> filtrs) {
     for (QueryItem filter : filtrs) {
       if (filters != null && !filters.contains(filter)) {
         filters.add(filter);
       }
     }
-
-    return this;
   }
 
   /**
@@ -345,7 +287,7 @@ public class TrackedEntityQueryParams {
     return hasQuery();
   }
 
-  /** Indicates whether this parameters specifies a query. */
+  /** Indicates whether this parameter specifies a query. */
   public boolean hasQuery() {
     return query != null && query.isFilter();
   }
@@ -391,95 +333,65 @@ public class TrackedEntityQueryParams {
     return duplicates;
   }
 
-  /** Indicates whether this parameters specifies any attributes and/or filters. */
+  /** Indicates whether this parameter specifies any attributes and/or filters. */
   public boolean hasAttributesOrFilters() {
     return hasAttributes() || hasFilters();
   }
 
-  /** Indicates whether this parameters specifies any attributes. */
+  /** Indicates whether this parameter specifies any attributes. */
   public boolean hasAttributes() {
     return attributes != null && !attributes.isEmpty();
   }
 
-  /** Indicates whether this parameters specifies any filters. */
+  /** Indicates whether this parameter specifies any filters. */
   public boolean hasFilters() {
     return filters != null && !filters.isEmpty();
   }
 
-  /** Indicates whether this parameters specifies any organisation units. */
+  /** Indicates whether this parameter specifies any organisation units. */
   public boolean hasOrganisationUnits() {
     return orgUnits != null && !orgUnits.isEmpty();
   }
 
-  /** Indicates whether this parameters specifies a program. */
+  /** Indicates whether this parameter specifies a program. */
   public boolean hasProgram() {
     return program != null;
   }
 
-  /** Indicates whether this parameters specifies a program status. */
+  /** Indicates whether this parameter specifies a program status. */
   public boolean hasProgramStatus() {
     return programStatus != null;
   }
 
   /**
-   * Indicates whether this parameters specifies follow up for the given program. Follow up can be
+   * Indicates whether this parameter specifies follow up for the given program. Follow up can be
    * specified as true or false.
    */
   public boolean hasFollowUp() {
     return followUp != null;
   }
 
-  /** Indicates whether this parameters specifies a last updated start date. */
-  public boolean hasLastUpdatedStartDate() {
-    return lastUpdatedStartDate != null;
-  }
-
-  /** Indicates whether this parameters specifies a last updated end date. */
-  public boolean hasLastUpdatedEndDate() {
-    return lastUpdatedEndDate != null;
-  }
-
-  /** Indicates whether this parameters has a lastUpdatedDuration filter. */
+  /** Indicates whether this parameter has a lastUpdatedDuration filter. */
   public boolean hasLastUpdatedDuration() {
     return lastUpdatedDuration != null;
   }
 
-  /** Indicates whether this parameters specifies a program enrollment start date. */
-  public boolean hasProgramEnrollmentStartDate() {
-    return programEnrollmentStartDate != null;
-  }
-
-  /** Indicates whether this parameters specifies a program enrollment end date. */
-  public boolean hasProgramEnrollmentEndDate() {
-    return programEnrollmentEndDate != null;
-  }
-
-  /** Indicates whether this parameters specifies a program incident start date. */
-  public boolean hasProgramIncidentStartDate() {
-    return programIncidentStartDate != null;
-  }
-
-  /** Indicates whether this parameters specifies a program incident end date. */
-  public boolean hasProgramIncidentEndDate() {
-    return programIncidentEndDate != null;
-  }
-
-  /** Indicates whether this parameters specifies a tracked entity. */
+  /** Indicates whether this parameter specifies a tracked entity. */
   public boolean hasTrackedEntityType() {
     return trackedEntityType != null;
   }
 
-  /** Indicates whether this parameters is of the given organisation unit mode. */
+  /** Indicates whether this parameter is of the given organisation unit mode. */
   public boolean isOrganisationUnitMode(OrganisationUnitSelectionMode mode) {
     return orgUnitMode != null && orgUnitMode.equals(mode);
   }
 
-  /** Indicates whether this parameters specifies a programStage. */
+  /** Indicates whether this parameter specifies a programStage. */
   public boolean hasProgramStage() {
     return programStage != null;
   }
 
-  /** Indicates whether this params specifies an event status. */
+  /** Indicates whether this parameter specifies an event status. */
   public boolean hasEventStatus() {
     return eventStatus != null;
   }
@@ -491,31 +403,15 @@ public class TrackedEntityQueryParams {
     return this.eventStatus != null && this.eventStatus.equals(eventStatus);
   }
 
-  /** Indicates whether this parameters specifies an event start date. */
-  public boolean hasEventStartDate() {
-    return eventStartDate != null;
-  }
-
-  /** Indicates whether this parameters specifies an event end date. */
-  public boolean hasEventEndDate() {
-    return eventEndDate != null;
-  }
-
-  /** Indicates whether this parameters specifies a user. */
-  public boolean hasUser() {
-    return user != null;
-  }
-
   /** Check whether we are filtering for potential duplicate property. */
   public boolean hasPotentialDuplicateFilter() {
     return potentialDuplicate != null;
   }
 
   /**
-   * Checks if there is atleast one unique filter in the params. In attributes or filters.
+   * Checks if there is at least one unique filter in the params. In attributes or filters.
    *
-   * @return true if there is exist atlesast one unique filter in filters/attributes, false
-   *     otherwise.
+   * @return true if there exist at least one unique filter in filters/attributes, false otherwise.
    */
   public boolean hasUniqueFilter() {
     if (!hasFilters() && !hasAttributes()) {
@@ -557,10 +453,6 @@ public class TrackedEntityQueryParams {
     return (getPageWithDefault() - 1) * getPageSizeWithDefault();
   }
 
-  // -------------------------------------------------------------------------
-  // toString
-  // -------------------------------------------------------------------------
-
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
@@ -571,38 +463,22 @@ public class TrackedEntityQueryParams {
         .add("program", program)
         .add("programStatus", programStatus)
         .add("followUp", followUp)
-        .add("lastUpdatedStartDate", lastUpdatedStartDate)
-        .add("lastUpdatedEndDate", lastUpdatedEndDate)
         .add("lastUpdatedDuration", lastUpdatedDuration)
-        .add("programEnrollmentStartDate", programEnrollmentStartDate)
-        .add("programEnrollmentEndDate", programEnrollmentEndDate)
-        .add("programIncidentStartDate", programIncidentStartDate)
-        .add("programIncidentEndDate", programIncidentEndDate)
         .add("trackedEntityType", trackedEntityType)
         .add("orgUnitMode", orgUnitMode)
         .add("assignedUserQueryParam", assignedUserQueryParam)
         .add("eventStatus", eventStatus)
-        .add("eventStartDate", eventStartDate)
-        .add("eventEndDate", eventEndDate)
         .add("skipMeta", skipMeta)
         .add("page", page)
         .add("pageSize", pageSize)
         .add("totalPages", totalPages)
         .add("skipPaging", skipPaging)
         .add("includeDeleted", includeDeleted)
-        .add("includeAllAttributes", includeAllAttributes)
-        .add("internalSearch", internalSearch)
-        .add("synchronizationQuery", synchronizationQuery)
-        .add("skipChangedBefore", skipChangedBefore)
         .add("orders", orders)
         .add("user", user)
         .add("potentialDuplicate", potentialDuplicate)
         .toString();
   }
-
-  // -------------------------------------------------------------------------
-  // Getters and setters
-  // -------------------------------------------------------------------------
 
   public QueryFilter getQuery() {
     return query;
@@ -633,11 +509,6 @@ public class TrackedEntityQueryParams {
 
   public Set<OrganisationUnit> getOrgUnits() {
     return orgUnits;
-  }
-
-  public TrackedEntityQueryParams addOrgUnits(Set<OrganisationUnit> orgUnits) {
-    this.orgUnits.addAll(orgUnits);
-    return this;
   }
 
   public TrackedEntityQueryParams setOrgUnits(Set<OrganisationUnit> orgUnits) {
@@ -690,66 +561,12 @@ public class TrackedEntityQueryParams {
     return this;
   }
 
-  public Date getLastUpdatedStartDate() {
-    return lastUpdatedStartDate;
-  }
-
-  public TrackedEntityQueryParams setLastUpdatedStartDate(Date lastUpdatedStartDate) {
-    this.lastUpdatedStartDate = lastUpdatedStartDate;
-    return this;
-  }
-
-  public Date getLastUpdatedEndDate() {
-    return lastUpdatedEndDate;
-  }
-
-  public TrackedEntityQueryParams setLastUpdatedEndDate(Date lastUpdatedEndDate) {
-    this.lastUpdatedEndDate = lastUpdatedEndDate;
-    return this;
-  }
-
   public String getLastUpdatedDuration() {
     return lastUpdatedDuration;
   }
 
   public TrackedEntityQueryParams setLastUpdatedDuration(String lastUpdatedDuration) {
     this.lastUpdatedDuration = lastUpdatedDuration;
-    return this;
-  }
-
-  public Date getProgramEnrollmentStartDate() {
-    return programEnrollmentStartDate;
-  }
-
-  public TrackedEntityQueryParams setProgramEnrollmentStartDate(Date programEnrollmentStartDate) {
-    this.programEnrollmentStartDate = programEnrollmentStartDate;
-    return this;
-  }
-
-  public Date getProgramEnrollmentEndDate() {
-    return programEnrollmentEndDate;
-  }
-
-  public TrackedEntityQueryParams setProgramEnrollmentEndDate(Date programEnrollmentEndDate) {
-    this.programEnrollmentEndDate = programEnrollmentEndDate;
-    return this;
-  }
-
-  public Date getProgramIncidentStartDate() {
-    return programIncidentStartDate;
-  }
-
-  public TrackedEntityQueryParams setProgramIncidentStartDate(Date programIncidentStartDate) {
-    this.programIncidentStartDate = programIncidentStartDate;
-    return this;
-  }
-
-  public Date getProgramIncidentEndDate() {
-    return programIncidentEndDate;
-  }
-
-  public TrackedEntityQueryParams setProgramIncidentEndDate(Date programIncidentEndDate) {
-    this.programIncidentEndDate = programIncidentEndDate;
     return this;
   }
 
@@ -775,12 +592,6 @@ public class TrackedEntityQueryParams {
     return this.assignedUserQueryParam;
   }
 
-  public TrackedEntityQueryParams setAssignedUserQueryParam(
-      AssignedUserQueryParam assignedUserQueryParam) {
-    this.assignedUserQueryParam = assignedUserQueryParam;
-    return this;
-  }
-
   public TrackedEntityQueryParams setUser(User user) {
     this.user = user;
     return this;
@@ -792,24 +603,6 @@ public class TrackedEntityQueryParams {
 
   public TrackedEntityQueryParams setEventStatus(EventStatus eventStatus) {
     this.eventStatus = eventStatus;
-    return this;
-  }
-
-  public Date getEventStartDate() {
-    return eventStartDate;
-  }
-
-  public TrackedEntityQueryParams setEventStartDate(Date eventStartDate) {
-    this.eventStartDate = eventStartDate;
-    return this;
-  }
-
-  public Date getEventEndDate() {
-    return eventEndDate;
-  }
-
-  public TrackedEntityQueryParams setEventEndDate(Date eventEndDate) {
-    this.eventEndDate = eventEndDate;
     return this;
   }
 
@@ -862,9 +655,8 @@ public class TrackedEntityQueryParams {
     return maxTeLimit;
   }
 
-  public TrackedEntityQueryParams setMaxTeLimit(int maxTeLimit) {
+  public void setMaxTeLimit(int maxTeLimit) {
     this.maxTeLimit = maxTeLimit;
-    return this;
   }
 
   public boolean isIncludeDeleted() {
@@ -873,42 +665,6 @@ public class TrackedEntityQueryParams {
 
   public TrackedEntityQueryParams setIncludeDeleted(boolean includeDeleted) {
     this.includeDeleted = includeDeleted;
-    return this;
-  }
-
-  public boolean isIncludeAllAttributes() {
-    return includeAllAttributes;
-  }
-
-  public TrackedEntityQueryParams setIncludeAllAttributes(boolean includeAllAttributes) {
-    this.includeAllAttributes = includeAllAttributes;
-    return this;
-  }
-
-  public boolean isInternalSearch() {
-    return internalSearch;
-  }
-
-  public TrackedEntityQueryParams setInternalSearch(boolean internalSearch) {
-    this.internalSearch = internalSearch;
-    return this;
-  }
-
-  public boolean isSynchronizationQuery() {
-    return synchronizationQuery;
-  }
-
-  public TrackedEntityQueryParams setSynchronizationQuery(boolean synchronizationQuery) {
-    this.synchronizationQuery = synchronizationQuery;
-    return this;
-  }
-
-  public Date getSkipChangedBefore() {
-    return skipChangedBefore;
-  }
-
-  public TrackedEntityQueryParams setSkipChangedBefore(Date skipChangedBefore) {
-    this.skipChangedBefore = skipChangedBefore;
     return this;
   }
 
@@ -928,9 +684,8 @@ public class TrackedEntityQueryParams {
     return trackedEntityUids;
   }
 
-  public TrackedEntityQueryParams setTrackedEntityUids(Set<String> trackedEntityUids) {
+  public void setTrackedEntityUids(Set<String> trackedEntityUids) {
     this.trackedEntityUids = trackedEntityUids;
-    return this;
   }
 
   /**
@@ -940,13 +695,11 @@ public class TrackedEntityQueryParams {
    * @param mode assigned user mode
    * @param current current user with which query is made
    * @param assignedUsers assigned user uids
-   * @return this
    */
-  public TrackedEntityQueryParams setUserWithAssignedUsers(
+  public void setUserWithAssignedUsers(
       AssignedUserSelectionMode mode, User current, Set<String> assignedUsers) {
     this.assignedUserQueryParam = new AssignedUserQueryParam(mode, current, assignedUsers);
     this.user = current;
-    return this;
   }
 
   public List<TrackedEntityType> getTrackedEntityTypes() {
@@ -961,17 +714,11 @@ public class TrackedEntityQueryParams {
   @AllArgsConstructor
   public enum OrderColumn {
     TRACKEDENTITY("trackedEntity", "uid", MAIN_QUERY_ALIAS),
-    // TODO(tracker): remove with old tracker
-    CREATED("created", CREATED_ID, MAIN_QUERY_ALIAS),
     CREATED_AT("createdAt", CREATED_ID, MAIN_QUERY_ALIAS),
     CREATED_AT_CLIENT("createdAtClient", "createdatclient", MAIN_QUERY_ALIAS),
     UPDATED_AT("updatedAt", "lastupdated", MAIN_QUERY_ALIAS),
     UPDATED_AT_CLIENT("updatedAtClient", "lastupdatedatclient", MAIN_QUERY_ALIAS),
-    ENROLLED_AT(
-        "enrolledAt",
-        "enrollmentdate",
-        PROGRAM_INSTANCE_ALIAS), // this works only for the new endpoint
-    // ORGUNIT_NAME( "orgUnitName", MAIN_QUERY_ALIAS+".organisationUnit.name" ),
+    ENROLLED_AT("enrolledAt", "enrollmentdate", PROGRAM_INSTANCE_ALIAS),
     INACTIVE(INACTIVE_ID, "inactive", MAIN_QUERY_ALIAS);
 
     private final String propName;
@@ -985,7 +732,6 @@ public class TrackedEntityQueryParams {
     }
 
     /**
-     * @param property
      * @return an Optional of an OrderColumn matching by property name
      */
     public static Optional<OrderColumn> findColumn(String property) {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityService.java
@@ -30,10 +30,8 @@ package org.hisp.dhis.trackedentity;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
-import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
-import org.hisp.dhis.user.UserDetails;
 
 /**
  * This interface is responsible for retrieving tracked entities (TE). The query methods accepts a
@@ -65,7 +63,7 @@ import org.hisp.dhis.user.UserDetails;
  * params.addAttribute( new QueryItem( gender, QueryOperator.EQ, "Male", false ) );
  * params.addAttribute( new QueryItem( age, QueryOperator.LT, "5", true ) );
  * params.addFilter( new QueryItem( weight, QueryOperator.GT, "2500", true ) );
- * params.addOrganistionUnit( unit );
+ * params.addOrganisationUnit( unit );
  *
  * Grid instances = teService.getTrackedEntityGrid( params );
  *
@@ -85,21 +83,7 @@ import org.hisp.dhis.user.UserDetails;
 public interface TrackedEntityService {
   String ID = TrackedEntityService.class.getName();
 
-  int ERROR_NONE = 0;
-
-  int ERROR_DUPLICATE_IDENTIFIER = 1;
-
-  int ERROR_ENROLLMENT = 2;
-
   String SEPARATOR = "_";
-
-  /**
-   * Returns a grid with tracked entity values based on the given TrackedEntityQueryParams.
-   *
-   * @param params the TrackedEntityQueryParams.
-   * @return a grid.
-   */
-  Grid getTrackedEntitiesGrid(TrackedEntityQueryParams params);
 
   /**
    * Returns a list with tracked entity values based on the given TrackedEntityQueryParams.
@@ -130,19 +114,6 @@ public interface TrackedEntityService {
       boolean skipSearchScopeValidation);
 
   /**
-   * Return the count of the Tracked entity that meet the criteria specified in params
-   *
-   * @param params Parameteres that specify searching criteria
-   * @param skipAccessValidation If true, the access validation is skipped
-   * @param skipSearchScopeValidation If true, the search scope validation is skipped
-   * @return the count of the tracked entities that meet the criteria specified in params
-   */
-  int getTrackedEntityCount(
-      TrackedEntityQueryParams params,
-      boolean skipAccessValidation,
-      boolean skipSearchScopeValidation);
-
-  /**
    * Decides whether current user is authorized to perform the given query. IllegalQueryException is
    * thrown if not.
    *
@@ -155,11 +126,9 @@ public interface TrackedEntityService {
    * exception are thrown and the method returns normally.
    *
    * @param params the TrackedEntityQueryParams.
-   * @param isGridSearch specifies whether search is made for a Grid response
    * @throws IllegalQueryException if the given params is invalid.
    */
-  void validateSearchScope(TrackedEntityQueryParams params, boolean isGridSearch)
-      throws IllegalQueryException;
+  void validateSearchScope(TrackedEntityQueryParams params) throws IllegalQueryException;
 
   /**
    * Validates the given TrackedEntityQueryParams. The params is considered valid if no exception
@@ -173,7 +142,7 @@ public interface TrackedEntityService {
   /**
    * Adds an {@link TrackedEntity}
    *
-   * @param trackedEntity The to TrackedEntity add.
+   * @param trackedEntity The TrackedEntity to add.
    * @return A generated unique id of the added {@link TrackedEntity}.
    */
   long addTrackedEntity(TrackedEntity trackedEntity);
@@ -192,22 +161,7 @@ public interface TrackedEntityService {
    */
   void updateTrackedEntity(TrackedEntity trackedEntity);
 
-  void updateTrackedEntity(TrackedEntity trackedEntity, UserDetails user);
-
-  /**
-   * Updates a last sync timestamp on specified TrackedEntity
-   *
-   * @param trackedEntityUIDs UIDs of tracked entities where the lastSynchronized flag should be
-   *     updated
-   * @param lastSynchronized The date of last successful sync
-   */
-  void updateTrackedEntitySyncTimestamp(List<String> trackedEntityUIDs, Date lastSynchronized);
-
-  /**
-   * @param trackedEntityUIDs
-   * @param lastUpdated
-   * @param userInfoSnapshot
-   */
+  /** */
   void updateTrackedEntityLastUpdated(
       Set<String> trackedEntityUIDs, Date lastUpdated, String userInfoSnapshot);
 
@@ -228,15 +182,6 @@ public interface TrackedEntityService {
   TrackedEntity getTrackedEntity(String uid);
 
   /**
-   * Returns the {@link TrackedEntity} with the given UID.
-   *
-   * @param uid the UID.
-   * @param user User
-   * @return the TrackedEntity with the given UID, or null if no match.
-   */
-  TrackedEntity getTrackedEntity(String uid, UserDetails user);
-
-  /**
    * Checks for the existence of a TE by UID. Deleted values are not taken into account.
    *
    * @param uid Event UID to check for
@@ -253,14 +198,6 @@ public interface TrackedEntityService {
   boolean trackedEntityExistsIncludingDeleted(String uid);
 
   /**
-   * Returns UIDs of existing tracked entities (including deleted) from the provided UIDs
-   *
-   * @param uids TE UIDs to check
-   * @return Set containing UIDs of existing TEIs (including deleted)
-   */
-  List<String> getTrackedEntitiesUidsIncludingDeleted(List<String> uids);
-
-  /**
    * Register a new trackedEntity
    *
    * @param trackedEntity TrackedEntity
@@ -269,6 +206,4 @@ public interface TrackedEntityService {
    */
   long createTrackedEntity(
       TrackedEntity trackedEntity, Set<TrackedEntityAttributeValue> attributeValues);
-
-  List<TrackedEntity> getTrackedEntitiesByUid(List<String> uids, UserDetails user);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityStore.java
@@ -29,10 +29,8 @@ package org.hisp.dhis.trackedentity;
 
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import org.hisp.dhis.common.IdentifiableObjectStore;
-import org.hisp.dhis.user.UserDetails;
 
 /**
  * @author Abyot Asalefew Gizaw
@@ -44,11 +42,7 @@ public interface TrackedEntityStore extends IdentifiableObjectStore<TrackedEntit
 
   List<Long> getTrackedEntityIds(TrackedEntityQueryParams params);
 
-  List<Map<String, String>> getTrackedEntitiesGrid(TrackedEntityQueryParams params);
-
-  int getTrackedEntityCountForGrid(TrackedEntityQueryParams params);
-
-  int getTrackedEntityCountForGridWithMaxTeiLimit(TrackedEntityQueryParams params);
+  int getTrackedEntityCountWithMaxTeLimit(TrackedEntityQueryParams params);
 
   /**
    * Checks for the existence of a TE by UID. Deleted TEIs are not taken into account.
@@ -67,14 +61,6 @@ public interface TrackedEntityStore extends IdentifiableObjectStore<TrackedEntit
   boolean existsIncludingDeleted(String uid);
 
   /**
-   * Returns UIDs of existing TrackedEntity(including deleted) from the provided UIDs
-   *
-   * @param uids TE UIDs to check
-   * @return List containing UIDs of existing TEIs (including deleted)
-   */
-  List<String> getUidsIncludingDeleted(List<String> uids);
-
-  /**
    * Fetches TrackedEntity matching the given list of UIDs
    *
    * @param uids a List of UID
@@ -83,21 +69,10 @@ public interface TrackedEntityStore extends IdentifiableObjectStore<TrackedEntit
   List<TrackedEntity> getIncludingDeleted(List<String> uids);
 
   /**
-   * Set lastSynchronized timestamp to provided timestamp for provided TEIs
-   *
-   * @param trackedEntityUIDs UIDs of Tracked entity instances where the lastSynchronized flag
-   *     should be updated
-   * @param lastSynchronized The date of last successful sync
-   */
-  void updateTrackedEntitySyncTimestamp(List<String> trackedEntityUIDs, Date lastSynchronized);
-
-  /**
    * @param trackedEntityUIDs
    * @param lastUpdated
    * @param userInfoSnapshot
    */
   void updateTrackedEntityLastUpdated(
       Set<String> trackedEntityUIDs, Date lastUpdated, String userInfoSnapshot);
-
-  List<TrackedEntity> getTrackedEntityByUid(List<String> uids, UserDetails user);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityAttributeService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityAttributeService.java
@@ -49,7 +49,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.program.ProgramTrackedEntityAttributeStore;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.system.util.MathUtils;
@@ -341,12 +340,6 @@ public class DefaultTrackedEntityAttributeService implements TrackedEntityAttrib
     }
 
     return attributes;
-  }
-
-  @Override
-  public ProgramTrackedEntityAttribute getProgramTrackedEntityAttribute(
-      Program program, TrackedEntityAttribute trackedEntityAttribute) {
-    return programAttributeStore.get(program, trackedEntityAttribute);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityChangeLogService.java
@@ -32,7 +32,6 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.UserDetails;
-import org.hisp.dhis.user.UserService;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,12 +47,6 @@ public class DefaultTrackedEntityChangeLogService implements TrackedEntityChange
   private final TrackedEntityStore trackedEntityStore;
 
   private final TrackerAccessManager trackerAccessManager;
-
-  private final UserService userService;
-
-  // -------------------------------------------------------------------------
-  // TrackedEntityAuditService implementation
-  // -------------------------------------------------------------------------
 
   @Override
   @Async

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityProgramOwnerService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityProgramOwnerService.java
@@ -125,32 +125,6 @@ public class DefaultTrackedEntityProgramOwnerService implements TrackedEntityPro
   @Override
   @Transactional
   public void createOrUpdateTrackedEntityProgramOwner(
-      long teUid, long programUid, long orgUnitUid) {
-    TrackedEntity entityInstance = trackedEntityService.getTrackedEntity(teUid);
-    Program program = programService.getProgram(programUid);
-    if (entityInstance == null) {
-      return;
-    }
-    TrackedEntityProgramOwner teProgramOwner =
-        trackedEntityProgramOwnerStore.getTrackedEntityProgramOwner(
-            entityInstance.getId(), program.getId());
-    OrganisationUnit ou = orgUnitService.getOrganisationUnit(orgUnitUid);
-    if (ou == null) {
-      return;
-    }
-
-    if (teProgramOwner == null) {
-      trackedEntityProgramOwnerStore.save(
-          buildTrackedEntityProgramOwner(entityInstance, program, ou));
-    } else {
-      teProgramOwner = updateTrackedEntityProgramOwner(teProgramOwner, ou);
-      trackedEntityProgramOwnerStore.update(teProgramOwner);
-    }
-  }
-
-  @Override
-  @Transactional
-  public void createOrUpdateTrackedEntityProgramOwner(
       TrackedEntity entityInstance, Program program, OrganisationUnit ou) {
     if (entityInstance == null || program == null || ou == null) {
       return;
@@ -219,40 +193,6 @@ public class DefaultTrackedEntityProgramOwnerService implements TrackedEntityPro
     }
     teProgramOwner = updateTrackedEntityProgramOwner(teProgramOwner, ou);
     trackedEntityProgramOwnerStore.update(teProgramOwner);
-  }
-
-  @Override
-  @Transactional
-  public void createTrackedEntityProgramOwner(long teId, long programId, long orgUnitId) {
-    TrackedEntity entityInstance = trackedEntityService.getTrackedEntity(teId);
-    if (entityInstance == null) {
-      return;
-    }
-    Program program = programService.getProgram(programId);
-    if (program == null) {
-      return;
-    }
-    OrganisationUnit ou = orgUnitService.getOrganisationUnit(orgUnitId);
-    if (ou == null) {
-      return;
-    }
-    trackedEntityProgramOwnerStore.save(
-        buildTrackedEntityProgramOwner(entityInstance, program, ou));
-  }
-
-  @Override
-  @Transactional
-  public void updateTrackedEntityProgramOwner(long teId, long programId, long orgUnitId) {
-    TrackedEntityProgramOwner teProgramOwner =
-        trackedEntityProgramOwnerStore.getTrackedEntityProgramOwner(teId, programId);
-    if (teProgramOwner == null) {
-      return;
-    }
-    OrganisationUnit ou = orgUnitService.getOrganisationUnit(orgUnitId);
-    if (ou == null) {
-      return;
-    }
-    trackedEntityProgramOwnerStore.update(updateTrackedEntityProgramOwner(teProgramOwner, ou));
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityService.java
@@ -34,43 +34,23 @@ import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CHILDREN;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.DESCENDANTS;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.SELECTED;
-import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.CREATED_ID;
-import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.DELETED;
-import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.INACTIVE_ID;
-import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.LAST_UPDATED_ID;
-import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.META_DATA_NAMES_KEY;
-import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.ORG_UNIT_ID;
-import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.ORG_UNIT_NAME;
-import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.PAGER_META_KEY;
-import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.POTENTIAL_DUPLICATE;
-import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.TRACKED_ENTITY_ID;
-import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.TRACKED_ENTITY_TYPE_ID;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.changelog.ChangeLogType;
-import org.hisp.dhis.common.AccessLevel;
-import org.hisp.dhis.common.Grid;
-import org.hisp.dhis.common.GridHeader;
 import org.hisp.dhis.common.IllegalQueryException;
-import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.QueryItem;
-import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.security.acl.AclService;
-import org.hisp.dhis.system.grid.ListGrid;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueChangeLogService;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
@@ -90,10 +70,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service("org.hisp.dhis.trackedentity.TrackedEntityService")
 public class DefaultTrackedEntityService implements TrackedEntityService {
-  // -------------------------------------------------------------------------
-  // Dependencies
-  // -------------------------------------------------------------------------
-
   private final TrackedEntityStore trackedEntityStore;
 
   private final TrackedEntityAttributeValueService attributeValueService;
@@ -106,8 +82,6 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
 
   private final AclService aclService;
 
-  private final TrackerOwnershipManager trackerOwnershipAccessManager;
-
   private final TrackedEntityChangeLogService trackedEntityChangeLogService;
 
   private final TrackedEntityAttributeValueChangeLogService attributeValueAuditService;
@@ -116,8 +90,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
 
   // TODO: FIXME luciano using @Lazy here because we have circular
   // dependencies:
-  // TrackedEntityService --> TrackerOwnershipManager -->
-  // TrackedEntityProgramOwnerService --> TrackedEntityService
+  // TrackedEntityService --> TrackedEntityProgramOwnerService --> TrackedEntityService
   public DefaultTrackedEntityService(
       UserService userService,
       TrackedEntityStore trackedEntityStore,
@@ -126,7 +99,6 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
       TrackedEntityTypeService trackedEntityTypeService,
       OrganisationUnitService organisationUnitService,
       AclService aclService,
-      @Lazy TrackerOwnershipManager trackerOwnershipAccessManager,
       @Lazy TrackedEntityChangeLogService trackedEntityChangeLogService,
       @Lazy TrackedEntityAttributeValueChangeLogService attributeValueAuditService) {
     checkNotNull(trackedEntityStore);
@@ -135,7 +107,6 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
     checkNotNull(trackedEntityTypeService);
     checkNotNull(organisationUnitService);
     checkNotNull(aclService);
-    checkNotNull(trackerOwnershipAccessManager);
     checkNotNull(trackedEntityChangeLogService);
     checkNotNull(attributeValueAuditService);
 
@@ -146,14 +117,9 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
     this.trackedEntityTypeService = trackedEntityTypeService;
     this.organisationUnitService = organisationUnitService;
     this.aclService = aclService;
-    this.trackerOwnershipAccessManager = trackerOwnershipAccessManager;
     this.trackedEntityChangeLogService = trackedEntityChangeLogService;
     this.attributeValueAuditService = attributeValueAuditService;
   }
-
-  // -------------------------------------------------------------------------
-  // Implementation methods
-  // -------------------------------------------------------------------------
 
   @Override
   @Transactional(readOnly = true)
@@ -176,7 +142,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
     }
 
     if (!skipSearchScopeValidation) {
-      validateSearchScope(params, false);
+      validateSearchScope(params);
     }
 
     List<TrackedEntity> trackedEntities = trackedEntityStore.getTrackedEntities(params);
@@ -221,7 +187,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
     }
 
     if (!skipSearchScopeValidation) {
-      validateSearchScope(params, false);
+      validateSearchScope(params);
     }
 
     return trackedEntityStore.getTrackedEntityIds(params);
@@ -255,198 +221,15 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
         .noneMatch(orderColumn -> orderColumn.getPropName().equals(propName));
   }
 
-  @Override
-  @Transactional(readOnly = true)
-  public int getTrackedEntityCount(
-      TrackedEntityQueryParams params,
-      boolean skipAccessValidation,
-      boolean skipSearchScopeValidation) {
-    decideAccess(params);
-
-    if (!skipAccessValidation) {
-      validate(params);
-    }
-
-    if (!skipSearchScopeValidation) {
-      validateSearchScope(params, false);
-    }
-
-    // using countForGrid here to leverage the better performant rewritten
-    // sql query
-    return trackedEntityStore.getTrackedEntityCountForGrid(params);
-  }
-
   // TODO lower index on attribute value?
 
   @Override
   @Transactional(readOnly = true)
-  public Grid getTrackedEntitiesGrid(TrackedEntityQueryParams params) {
-    decideAccess(params);
-    validate(params);
-    validateSearchScope(params, true);
-    handleAttributes(params);
-
-    // ---------------------------------------------------------------------
-    // Conform parameters
-    // ---------------------------------------------------------------------
-
-    params.conform();
-
-    // ---------------------------------------------------------------------
-    // Grid headers
-    // ---------------------------------------------------------------------
-
-    Grid grid = new ListGrid();
-
-    grid.addHeader(new GridHeader(TRACKED_ENTITY_ID, "Instance"));
-    grid.addHeader(new GridHeader(CREATED_ID, "Created"));
-    grid.addHeader(new GridHeader(LAST_UPDATED_ID, "Last updated"));
-    grid.addHeader(new GridHeader(ORG_UNIT_ID, "Organisation unit"));
-    grid.addHeader(new GridHeader(ORG_UNIT_NAME, "Organisation unit name"));
-    grid.addHeader(new GridHeader(TRACKED_ENTITY_TYPE_ID, "Tracked entity type"));
-    grid.addHeader(new GridHeader(INACTIVE_ID, "Inactive"));
-    grid.addHeader(new GridHeader(POTENTIAL_DUPLICATE, "Potential duplicate"));
-
-    if (params.isIncludeDeleted()) {
-      grid.addHeader(new GridHeader(DELETED, "Deleted", ValueType.BOOLEAN, false, false));
-    }
-
-    for (QueryItem item : params.getAttributes()) {
-      grid.addHeader(new GridHeader(item.getItem().getUid(), item.getItem().getName()));
-    }
-
-    List<Map<String, String>> entities = trackedEntityStore.getTrackedEntitiesGrid(params);
-
-    // ---------------------------------------------------------------------
-    // Grid rows
-    // ---------------------------------------------------------------------
-
-    String accessedBy = CurrentUserUtil.getCurrentUsername();
-
-    Map<String, TrackedEntityType> trackedEntityTypes = new HashMap<>();
-
-    if (params.hasTrackedEntityType()) {
-      trackedEntityTypes.put(params.getTrackedEntityType().getUid(), params.getTrackedEntityType());
-    }
-
-    if (params.hasProgram() && params.getProgram().getTrackedEntityType() != null) {
-      trackedEntityTypes.put(
-          params.getProgram().getTrackedEntityType().getUid(),
-          params.getProgram().getTrackedEntityType());
-    }
-
-    Set<String> tes = new HashSet<>();
-
-    User user = params.getUser();
-    UserDetails userDetails = UserDetails.fromUser(user);
-    for (Map<String, String> entity : entities) {
-      if (userDetails != null
-          && !userDetails.isSuper()
-          && params.hasProgram()
-          && (params.getProgram().getAccessLevel().equals(AccessLevel.PROTECTED)
-              || params.getProgram().getAccessLevel().equals(AccessLevel.CLOSED))) {
-        TrackedEntity te = trackedEntityStore.getByUid(entity.get(TRACKED_ENTITY_ID));
-
-        if (!trackerOwnershipAccessManager.hasAccess(userDetails, te, params.getProgram())) {
-          continue;
-        }
-      }
-
-      grid.addRow();
-      grid.addValue(entity.get(TRACKED_ENTITY_ID));
-      grid.addValue(entity.get(CREATED_ID));
-      grid.addValue(entity.get(LAST_UPDATED_ID));
-      grid.addValue(entity.get(ORG_UNIT_ID));
-      grid.addValue(entity.get(ORG_UNIT_NAME));
-      grid.addValue(entity.get(TRACKED_ENTITY_TYPE_ID));
-      grid.addValue(entity.get(INACTIVE_ID));
-      grid.addValue(entity.get(POTENTIAL_DUPLICATE));
-
-      if (params.isIncludeDeleted()) {
-        grid.addValue(entity.get(DELETED));
-      }
-
-      tes.add(entity.get(TRACKED_ENTITY_TYPE_ID));
-
-      TrackedEntityType te = trackedEntityTypes.get(entity.get(TRACKED_ENTITY_TYPE_ID));
-
-      if (te == null) {
-        te = trackedEntityTypeService.getTrackedEntityType(entity.get(TRACKED_ENTITY_TYPE_ID));
-        trackedEntityTypes.put(entity.get(TRACKED_ENTITY_TYPE_ID), te);
-      }
-
-      if (te != null && te.isAllowAuditLog() && accessedBy != null) {
-        TrackedEntityChangeLog trackedEntityChangeLog =
-            new TrackedEntityChangeLog(
-                entity.get(TRACKED_ENTITY_ID), accessedBy, ChangeLogType.SEARCH);
-        trackedEntityChangeLogService.addTrackedEntityChangeLog(trackedEntityChangeLog);
-      }
-
-      for (QueryItem item : params.getAttributes()) {
-        grid.addValue(entity.get(item.getItemId()));
-      }
-    }
-
-    Map<String, Object> metaData = new HashMap<>();
-
-    if (params.isPaging()) {
-      int count = 0;
-
-      if (params.isTotalPages()) {
-        count = trackedEntityStore.getTrackedEntityCountForGrid(params);
-      }
-
-      Pager pager = new Pager(params.getPageWithDefault(), count, params.getPageSizeWithDefault());
-      metaData.put(PAGER_META_KEY, pager);
-    }
-
-    if (!params.isSkipMeta()) {
-      Map<String, String> names = new HashMap<>();
-
-      for (String te : tes) {
-        TrackedEntityType entity = trackedEntityTypes.get(te);
-        names.put(te, entity != null ? entity.getDisplayName() : null);
-      }
-
-      metaData.put(META_DATA_NAMES_KEY, names);
-    }
-
-    grid.setMetaData(metaData);
-
-    return grid;
-  }
-
-  /**
-   * Handles injection of attributes. The following combinations of parameters will lead to
-   * attributes being injected.
-   *
-   * <p>- query: add display in list attributes - attributes - program: add program attributes -
-   * query + attributes - query + program: add program attributes - attributes + program - query +
-   * attributes + program
-   */
-  private void handleAttributes(TrackedEntityQueryParams params) {
-    if (params.isOrQuery() && !params.hasAttributes() && !params.hasProgram()) {
-      Collection<TrackedEntityAttribute> attributes =
-          attributeService.getTrackedEntityAttributesDisplayInListNoProgram();
-      params.addAttributes(QueryItem.getQueryItems(attributes));
-      params.addFiltersIfNotExist(QueryItem.getQueryItems(attributes));
-    } else if (params.hasProgram()) {
-      params.addAttributesIfNotExist(
-          QueryItem.getQueryItems(params.getProgram().getTrackedEntityAttributes()));
-    } else if (params.hasTrackedEntityType()) {
-      params.addAttributesIfNotExist(
-          QueryItem.getQueryItems(params.getTrackedEntityType().getTrackedEntityAttributes()));
-    }
-  }
-
-  @Override
-  @Transactional(readOnly = true)
   public void decideAccess(TrackedEntityQueryParams params) {
-    User user = params.isInternalSearch() ? null : params.getUser();
+    User user = params.getUser();
     if (params.isOrganisationUnitMode(ALL)
         && !(user != null
-            && user.isAuthorized(Authorities.F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS))
-        && !params.isInternalSearch()) {
+            && user.isAuthorized(Authorities.F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS))) {
       throw new IllegalQueryException(
           "Current user is not authorized to query across all organisation units");
     }
@@ -481,14 +264,12 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
 
   @Override
   public void validate(TrackedEntityQueryParams params) throws IllegalQueryException {
-    String violation = null;
-
     if (params == null) {
       throw new IllegalQueryException("Params cannot be null");
     }
 
+    String violation = null;
     User user = params.getUser();
-
     if (!params.hasTrackedEntities()
         && !params.hasOrganisationUnits()
         && !(params.isOrganisationUnitMode(ALL)
@@ -524,26 +305,6 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
       violation = "Program must be defined when follow up status is defined";
     }
 
-    if (params.hasProgramEnrollmentStartDate() && !params.hasProgram()) {
-      violation = "Program must be defined when program enrollment start date is specified";
-    }
-
-    if (params.hasProgramEnrollmentEndDate() && !params.hasProgram()) {
-      violation = "Program must be defined when program enrollment end date is specified";
-    }
-
-    if (params.hasProgramIncidentStartDate() && !params.hasProgram()) {
-      violation = "Program must be defined when program incident start date is specified";
-    }
-
-    if (params.hasProgramIncidentEndDate() && !params.hasProgram()) {
-      violation = "Program must be defined when program incident end date is specified";
-    }
-
-    if (params.hasEventStatus() && (!params.hasEventStartDate() || !params.hasEventEndDate())) {
-      violation = "Event start and end date must be specified when event status is specified";
-    }
-
     if (params.isOrQuery() && params.hasFilters()) {
       violation = "Query cannot be specified together with filters";
     }
@@ -558,18 +319,12 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
     }
 
     if (params.hasLastUpdatedDuration()
-        && (params.hasLastUpdatedStartDate() || params.hasLastUpdatedEndDate())) {
-      violation =
-          "Last updated from and/or to and last updated duration cannot be specified simultaneously";
-    }
-
-    if (params.hasLastUpdatedDuration()
         && DateUtils.getDuration(params.getLastUpdatedDuration()) == null) {
       violation = "Duration is not valid: " + params.getLastUpdatedDuration();
     }
 
     if (violation != null) {
-      log.warn("Validation failed: " + violation);
+      log.warn("Validation failed: {}", violation);
 
       throw new IllegalQueryException(violation);
     }
@@ -577,8 +332,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
 
   @Override
   @Transactional(readOnly = true)
-  public void validateSearchScope(TrackedEntityQueryParams params, boolean isGridSearch)
-      throws IllegalQueryException {
+  public void validateSearchScope(TrackedEntityQueryParams params) throws IllegalQueryException {
     if (params == null) {
       throw new IllegalQueryException("Params cannot be null");
     }
@@ -598,13 +352,13 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
         && !params.hasTrackedEntityType()
         && params.hasAttributesOrFilters()
         && !params.hasOrganisationUnits()) {
-      List<String> uniqeAttributeIds =
+      List<String> uniqueAttributeIds =
           attributeService.getAllSystemWideUniqueTrackedEntityAttributes().stream()
               .map(TrackedEntityAttribute::getUid)
               .toList();
 
       for (String att : params.getAttributeAndFilterIds()) {
-        if (!uniqeAttributeIds.contains(att)) {
+        if (!uniqueAttributeIds.contains(att)) {
           throw new IllegalQueryException(
               "Either a program or tracked entity type must be specified");
         }
@@ -654,7 +408,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
         if (!violatingAttributes.isEmpty()) {
           throw new IllegalQueryException(
               "Non-searchable attribute(s) can not be used during global search:  "
-                  + violatingAttributes.toString());
+                  + violatingAttributes);
         }
       }
 
@@ -687,7 +441,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
 
   private void checkIfMaxTeiLimitIsReached(TrackedEntityQueryParams params, int maxTeiLimit) {
     if (maxTeiLimit > 0) {
-      int teCount = trackedEntityStore.getTrackedEntityCountForGridWithMaxTeiLimit(params);
+      int teCount = trackedEntityStore.getTrackedEntityCountWithMaxTeLimit(params);
 
       if (teCount > maxTeiLimit) {
         throw new IllegalQueryException("maxteicountreached");
@@ -751,31 +505,9 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
   }
 
   @Override
-  @Transactional(readOnly = true)
-  public List<TrackedEntity> getTrackedEntitiesByUid(List<String> uids, UserDetails user) {
-    if (uids == null || uids.isEmpty()) {
-      return Collections.emptyList();
-    }
-    return trackedEntityStore.getTrackedEntityByUid(uids, user);
-  }
-
-  @Override
   @Transactional
   public void updateTrackedEntity(TrackedEntity trackedEntity) {
     trackedEntityStore.update(trackedEntity);
-  }
-
-  @Override
-  @Transactional
-  public void updateTrackedEntity(TrackedEntity trackedEntity, UserDetails user) {
-    trackedEntityStore.update(trackedEntity, user);
-  }
-
-  @Override
-  @Transactional
-  public void updateTrackedEntitySyncTimestamp(
-      List<String> trackedEntityUIDs, Date lastSynchronized) {
-    trackedEntityStore.updateTrackedEntitySyncTimestamp(trackedEntityUIDs, lastSynchronized);
   }
 
   @Override
@@ -813,14 +545,6 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
   }
 
   @Override
-  public TrackedEntity getTrackedEntity(String uid, UserDetails user) {
-    TrackedEntity te = trackedEntityStore.getByUid(uid);
-    addTrackedEntityAudit(te, User.username(user), ChangeLogType.READ);
-
-    return te;
-  }
-
-  @Override
   @Transactional(readOnly = true)
   public boolean trackedEntityExists(String uid) {
     return trackedEntityStore.exists(uid);
@@ -830,11 +554,6 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
   @Transactional(readOnly = true)
   public boolean trackedEntityExistsIncludingDeleted(String uid) {
     return trackedEntityStore.existsIncludingDeleted(uid);
-  }
-
-  @Override
-  public List<String> getTrackedEntitiesUidsIncludingDeleted(List<String> uids) {
-    return trackedEntityStore.getUidsIncludingDeleted(uids);
   }
 
   private boolean isLocalSearch(TrackedEntityQueryParams params, User user) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityProgramOwnerStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityProgramOwnerStore.java
@@ -67,25 +67,6 @@ public class HibernateTrackedEntityProgramOwnerStore
   }
 
   @Override
-  public List<TrackedEntityProgramOwner> getTrackedEntityProgramOwners(List<Long> teIds) {
-    String hql = "from TrackedEntityProgramOwner tepo where tepo.trackedEntity.id in (:teIds)";
-    Query<TrackedEntityProgramOwner> q = getQuery(hql);
-    q.setParameterList("teIds", teIds);
-    return q.list();
-  }
-
-  @Override
-  public List<TrackedEntityProgramOwner> getTrackedEntityProgramOwners(
-      List<Long> teIds, long programId) {
-    String hql =
-        "from TrackedEntityProgramOwner tepo where tepo.trackedEntity.id in (:teIds) and tepo.program.id=(:programId) ";
-    Query<TrackedEntityProgramOwner> q = getQuery(hql);
-    q.setParameterList("teIds", teIds);
-    q.setParameter("programId", programId);
-    return q.list();
-  }
-
-  @Override
   public List<TrackedEntityProgramOwnerOrgUnit> getTrackedEntityProgramOwnerOrgUnits(
       Set<Long> teIds) {
     List<TrackedEntityProgramOwnerOrgUnit> trackedEntityProgramOwnerOrgUnits = new ArrayList<>();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
@@ -48,17 +48,14 @@ import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.POTENTIAL_DUP
 import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.PROGRAM_INSTANCE_ALIAS;
 import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.TRACKED_ENTITY_ID;
 import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.TRACKED_ENTITY_TYPE_ID;
-import static org.hisp.dhis.util.DateUtils.toLongDate;
 import static org.hisp.dhis.util.DateUtils.toLongGmtDate;
 
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -91,7 +88,6 @@ import org.hisp.dhis.system.util.SqlUtils;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityQueryParams;
 import org.hisp.dhis.trackedentity.TrackedEntityStore;
-import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 import org.springframework.context.ApplicationEventPublisher;
@@ -116,8 +112,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
 
   private static final String EV_EXECUTIONDATE = "EV.occurreddate";
 
-  private static final String EV_DUEDATE = "EV.scheduleddate";
-
   private static final String IS_NULL = "IS NULL";
 
   private static final String IS_NOT_NULL = "IS NOT NULL";
@@ -133,10 +127,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
   private static final String UID_VALUE_SEPARATOR = ":";
 
   private static final String UID_VALUE_PAIR_SEPARATOR = ";@//@;";
-
-  // -------------------------------------------------------------------------
-  // Dependencies
-  // -------------------------------------------------------------------------
 
   private final OrganisationUnitStore organisationUnitStore;
 
@@ -158,10 +148,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
     this.organisationUnitStore = organisationUnitStore;
     this.systemSettingManager = systemSettingManager;
   }
-
-  // -------------------------------------------------------------------------
-  // Implementation methods
-  // -------------------------------------------------------------------------
 
   @Override
   public List<TrackedEntity> getTrackedEntities(TrackedEntityQueryParams params) {
@@ -188,9 +174,7 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
 
   @Override
   public List<Long> getTrackedEntityIds(TrackedEntityQueryParams params) {
-    String sql = getQuery(params, false);
-    log.debug("Tracked entity query SQL: " + sql);
-    SqlRowSet rowSet = jdbcTemplate.queryForRowSet(sql);
+    SqlRowSet rowSet = jdbcTemplate.queryForRowSet(getQuery(params));
 
     checkMaxTeiCountReached(params, rowSet);
 
@@ -207,69 +191,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
     return getQuotedCommaDelimitedString(elements.stream().map(SqlUtils::escape).toList());
   }
 
-  @Override
-  public List<Map<String, String>> getTrackedEntitiesGrid(TrackedEntityQueryParams params) {
-    String sql = getQuery(params, true);
-    log.debug("Tracked entity query SQL: " + sql);
-
-    SqlRowSet rowSet = jdbcTemplate.queryForRowSet(sql);
-
-    checkMaxTeiCountReached(params, rowSet);
-
-    List<Map<String, String>> list = new ArrayList<>();
-
-    while (rowSet.next()) {
-      final Map<String, String> map = new HashMap<>();
-
-      map.put(TRACKED_ENTITY_ID, rowSet.getString(TRACKED_ENTITY_ID));
-      map.put(CREATED_ID, rowSet.getString(CREATED_ID));
-      map.put(LAST_UPDATED_ID, rowSet.getString(LAST_UPDATED_ID));
-      map.put(ORG_UNIT_ID, rowSet.getString(ORG_UNIT_ID));
-      map.put(ORG_UNIT_NAME, rowSet.getString(ORG_UNIT_NAME));
-      map.put(TRACKED_ENTITY_TYPE_ID, rowSet.getString(TRACKED_ENTITY_TYPE_ID));
-      map.put(INACTIVE_ID, rowSet.getString(INACTIVE_ID));
-      map.put(POTENTIAL_DUPLICATE, rowSet.getString(POTENTIAL_DUPLICATE));
-
-      if (params.isIncludeDeleted()) {
-        map.put(DELETED, rowSet.getString(DELETED));
-      }
-
-      if (!params.getAttributesAndFilters().isEmpty()) {
-        HashMap<String, String> attributeValues = new HashMap<>();
-        String teavString = rowSet.getString("tea_values");
-
-        extractFromTeavAggregatedString(attributeValues, teavString);
-
-        for (QueryItem item : params.getAttributes()) {
-          map.put(
-              item.getItemId(),
-              isOrgUnit(item) && attributeValues.containsKey(item.getItemId())
-                  ? getOrgUnitNameByUid(attributeValues.get(item.getItemId()))
-                  : attributeValues.get(item.getItemId()));
-        }
-      }
-
-      list.add(map);
-    }
-
-    return list;
-  }
-
-  private void extractFromTeavAggregatedString(
-      HashMap<String, String> attributeValues, String teavString) {
-    if (teavString != null) {
-      String[] pairs = teavString.split(UID_VALUE_PAIR_SEPARATOR);
-
-      for (String pair : pairs) {
-        String[] teav = pair.split(UID_VALUE_SEPARATOR, 2);
-
-        if (teav.length == 2) {
-          attributeValues.put(teav[0], teav[1]);
-        }
-      }
-    }
-  }
-
   private void checkMaxTeiCountReached(TrackedEntityQueryParams params, SqlRowSet rowSet) {
     if (params.getMaxTeLimit() > 0 && rowSet.last()) {
       if (rowSet.getRow() > params.getMaxTeLimit()) {
@@ -280,29 +201,8 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
   }
 
   @Override
-  public int getTrackedEntityCountForGrid(TrackedEntityQueryParams params) {
-    // ---------------------------------------------------------------------
-    // Select clause
-    // ---------------------------------------------------------------------
-
-    String sql = getCountQuery(params);
-
-    // ---------------------------------------------------------------------
-    // Query
-    // ---------------------------------------------------------------------
-
-    log.debug("Tracked entity count SQL: " + sql);
-
-    return jdbcTemplate.queryForObject(sql, Integer.class);
-  }
-
-  @Override
-  public int getTrackedEntityCountForGridWithMaxTeiLimit(TrackedEntityQueryParams params) {
-    String sql = getCountQueryWithMaxTeiLimit(params);
-
-    log.debug("Tracked entity count SQL: " + sql);
-
-    return jdbcTemplate.queryForObject(sql, Integer.class);
+  public int getTrackedEntityCountWithMaxTeLimit(TrackedEntityQueryParams params) {
+    return jdbcTemplate.queryForObject(getCountQueryWithMaxTeiLimit(params), Integer.class);
   }
 
   /**
@@ -350,7 +250,7 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
    * order again. limit_offset: The limit and offset is set based on a combination of params:
    * program and tet can have a maxte limit, which only applies during a search outside the users
    * capture scope. If applied, it will throw an error if the number of results exceeds the limit.
-   * Otherwise we use paging. If no paging is set, there is no limit. additional_information: Here
+   * Otherwise, we use paging. If no paging is set, there is no limit. additional_information: Here
    * we do a left join with any relevant information needed for the result: tet name, any attributes
    * to project, etc. We left join, since we don't want to reduce the results, just add information.
    * main_groupby: The purpose of this group by, is to aggregate any attributes added in
@@ -359,43 +259,21 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
    * @param params params defining the query
    * @return SQL string
    */
-  private String getQuery(TrackedEntityQueryParams params, boolean isGridQuery) {
+  private String getQuery(TrackedEntityQueryParams params) {
     if (params.isOrQuery() && params.getAttributesAndFilters().isEmpty()) {
       throw new IllegalQueryException(
           "A query parameter is used in the request but there aren't filterable attributes");
     }
 
     StringBuilder stringBuilder = new StringBuilder(getQuerySelect(params));
-
-    if (!isGridQuery) {
-      stringBuilder.append(", TE.trackedentityid AS teId ");
-    }
+    stringBuilder.append(", TE.trackedentityid AS teId ");
 
     return stringBuilder
         .append("FROM ")
-        .append(getFromSubQuery(params, false, isGridQuery))
+        .append(getFromSubQuery(params, false, false))
         .append(getQueryRelatedTables(params))
         .append(getQueryGroupBy(params))
-        .append(getQueryOrderBy(false, params, isGridQuery))
-        .toString();
-  }
-
-  /**
-   * Uses the same basis as the getQuery method, but replaces the projection with a count and
-   * ignores order and limit
-   *
-   * @param params params defining the query
-   * @return a count SQL query
-   */
-  private String getCountQuery(TrackedEntityQueryParams params) {
-    return new StringBuilder()
-        .append(getQueryCountSelect())
-        .append(getQuerySelect(params))
-        .append("FROM ")
-        .append(getFromSubQuery(params, true, true))
-        .append(getQueryRelatedTables(params))
-        .append(getQueryGroupBy(params))
-        .append(" ) tecount")
+        .append(getQueryOrderBy(false, params, false))
         .toString();
   }
 
@@ -426,7 +304,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
    * Generates the projection of the main query. Includes two optional columns, deleted and
    * tea_values
    *
-   * @param params
    * @return an SQL projection
    */
   private String getQuerySelect(TrackedEntityQueryParams params) {
@@ -471,7 +348,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
    * Generates the SQL of the subquery, used to find the correct subset of tracked entity instances
    * to return. Orchestrates all the different segments of the SQL into a complete subquery.
    *
-   * @param params
    * @return an SQL subquery
    */
   private String getFromSubQuery(
@@ -512,7 +388,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
    * The sub-query projection. If we are sorting by attribute, we need to include the value in the
    * sub-query projection.
    *
-   * @param params
    * @return a SQL projection
    */
   private String getFromSubQuerySelect(TrackedEntityQueryParams params) {
@@ -547,15 +422,9 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
     return "SELECT " + String.join(", ", columns);
   }
 
-  /**
-   * Get a set of QueryItem that contains sortable attributes also defined as filers
-   *
-   * @param params
-   * @return List of QueryItem
-   */
+  /** Get a set of QueryItem that contains sortable attributes also defined as filers */
   private Set<QueryItem> sortableAttributesAndFilters(TrackedEntityQueryParams params) {
-    List<String> ordersIdentifier =
-        params.getOrders().stream().map(OrderParam::getField).collect(Collectors.toList());
+    List<String> ordersIdentifier = params.getOrders().stream().map(OrderParam::getField).toList();
     return params.getAttributesAndFilters().stream()
         .filter(queryItem -> ordersIdentifier.contains(queryItem.getItemId()))
         .collect(Collectors.toSet());
@@ -565,7 +434,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
    * Generates the WHERE-clause of the subquery SQL related to tracked entity instances.
    *
    * @param whereAnd tracking if where has been invoked or not
-   * @param params
    * @return a SQL segment for the WHERE clause used in the subquery
    */
   private String getFromSubQueryTrackedEntityConditions(
@@ -600,30 +468,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
           .append(" TE.lastupdated >= '")
           .append(toLongGmtDate(DateUtils.nowMinusDuration(params.getLastUpdatedDuration())))
           .append(SINGLE_QUOTE);
-    } else {
-      if (params.hasLastUpdatedStartDate()) {
-        trackedEntity
-            .append(whereAnd.whereAnd())
-            .append(" TE.lastupdated >= '")
-            .append(toLongDate(params.getLastUpdatedStartDate()))
-            .append(SINGLE_QUOTE);
-      }
-      if (params.hasLastUpdatedEndDate()) {
-        trackedEntity
-            .append(whereAnd.whereAnd())
-            .append(" TE.lastupdated <='")
-            .append(toLongDate(params.getLastUpdatedEndDate()))
-            .append(SINGLE_QUOTE);
-      }
-    }
-    if (params.isSynchronizationQuery()) {
-      trackedEntity.append(whereAnd.whereAnd()).append(" TE.lastupdated >= TE.lastsynchronized ");
-      if (params.getSkipChangedBefore() != null) {
-        trackedEntity
-            .append(" AND TE.lastupdated >= '")
-            .append(toLongDate(params.getSkipChangedBefore()))
-            .append(SINGLE_QUOTE);
-      }
     }
 
     if (!params.isIncludeDeleted()) {
@@ -645,7 +489,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
    * Generates SQL for INNER JOINing attribute values. One INNER JOIN for each attribute to search
    * for.
    *
-   * @param params
    * @return a series of 1 or more SQL INNER JOINs, or empty string if no query or attribute filters
    *     exists.
    */
@@ -659,12 +502,10 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
 
   /**
    * Generates a single INNER JOIN for searching for an attribute by query strings. Searches are
-   * done using lower() expression, since attribute values are case insensitive. The query search is
+   * done using lower() expression, since attribute values are case-insensitive. The query search is
    * extremely slow compared to alternatives. A query string (Can be multiple) has to match at least
    * 1 attribute value for each attribute we have access to. We use Regex to search, allowing both
    * exact match and with wildcards (EQ or LIKE).
-   *
-   * @param params
    */
   private String joinAttributeValueWithQueryParameter(TrackedEntityQueryParams params) {
     StringBuilder attributes = new StringBuilder();
@@ -707,17 +548,13 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
 
   /**
    * Generates a single INNER JOIN for each attribute we are searching on. We can search by a range
-   * of operators. All searching is using lower() since attribute values are case insensitive.
-   *
-   * @param params
+   * of operators. All searching is using lower() since attribute values are case-insensitive.
    */
   private String joinAttributeValueWithoutQueryParameter(TrackedEntityQueryParams params) {
     StringBuilder attributes = new StringBuilder();
 
     List<QueryItem> filterItems =
-        params.getAttributesAndFilters().stream()
-            .filter(QueryItem::hasFilter)
-            .collect(Collectors.toList());
+        params.getAttributesAndFilters().stream().filter(QueryItem::hasFilter).toList();
 
     for (QueryItem queryItem : filterItems) {
       String col = quote(queryItem.getItemId());
@@ -755,7 +592,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
    * avoid removing any rows if there is no value for a given attribute and te. The result of this
    * LEFT JOIN is used in the subquery projection, and ordering in the subquery and main query.
    *
-   * @param params
    * @return a SQL LEFT JOIN for attributes used for ordering, or empty string if not attributes is
    *     used in order.
    */
@@ -787,7 +623,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
    * Generates an INNER JOIN for program owner. This segment is only included if program is
    * specified or user is not super.
    *
-   * @param params
    * @return a SQL INNER JOIN for program owner, or empty string if no program is specified.
    */
   private String getFromSubQueryJoinProgramOwnerConditions(TrackedEntityQueryParams params) {
@@ -809,7 +644,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
    * to either DESCENDANTS (requiring matching on PATH), ALL (No constraints) or not DESCENDANTS or
    * ALL (SELECTED) which will match against a collection of ids.
    *
-   * @param params
    * @return a SQL INNER JOIN for organisation units
    */
   private String getFromSubQueryJoinOrgUnitConditions(TrackedEntityQueryParams params) {
@@ -857,7 +691,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
    * Generates an INNER JOIN for enrollments. If the param we need to order by is enrolledAt, we
    * need to join the enrollment table to be able to select and order by this value
    *
-   * @param params
    * @return a SQL INNER JOIN for enrollments
    */
   private String getFromSubQueryJoinEnrollmentConditions(TrackedEntityQueryParams params) {
@@ -879,7 +712,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
    * specified.
    *
    * @param whereAnd indicator tracking whether WHERE has been invoked or not
-   * @param params
    * @return an SQL EXISTS clause for enrollment, or empty string if not program is specified.
    */
   private String getFromSubQueryEnrollmentConditions(
@@ -914,34 +746,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
       program.append("AND EN.followup IS ").append(params.getFollowUp()).append(SPACE);
     }
 
-    if (params.hasProgramEnrollmentStartDate()) {
-      program
-          .append("AND EN.enrollmentdate >= '")
-          .append(toLongDate(params.getProgramEnrollmentStartDate()))
-          .append("' ");
-    }
-
-    if (params.hasProgramEnrollmentEndDate()) {
-      program
-          .append("AND EN.enrollmentdate <= '")
-          .append(toLongDate(params.getProgramEnrollmentEndDate()))
-          .append("' ");
-    }
-
-    if (params.hasProgramIncidentStartDate()) {
-      program
-          .append("AND EN.occurreddate >= '")
-          .append(toLongDate(params.getProgramIncidentStartDate()))
-          .append("' ");
-    }
-
-    if (params.hasProgramIncidentEndDate()) {
-      program
-          .append("AND EN.occurreddate <= '")
-          .append(toLongDate(params.getProgramIncidentEndDate()))
-          .append("' ");
-    }
-
     if (!params.isIncludeDeleted()) {
       program.append("AND EN.deleted is false ");
     }
@@ -955,7 +759,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
    * Generates an INNER JOIN with the enrollments if event-filters are specified. In the case of
    * user assignment is part of the filter, we join with the userinfo table as well.
    *
-   * @param params
    * @return an SQL INNER JOIN for filtering on events.
    */
   private String getFromSubQueryEvent(TrackedEntityQueryParams params) {
@@ -976,33 +779,8 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
     }
 
     if (params.hasEventStatus()) {
-      String start = toLongDate(params.getEventStartDate());
-      String end = toLongDate(params.getEventEndDate());
-
-      if (params.isEventStatus(EventStatus.COMPLETED)) {
+      if (params.isEventStatus(EventStatus.SCHEDULE)) {
         events
-            .append(getQueryDateConditionBetween(whereHlp, EV_EXECUTIONDATE, start, end))
-            .append(whereHlp.whereAnd())
-            .append(EV_STATUS)
-            .append(EQUALS)
-            .append(SINGLE_QUOTE)
-            .append(EventStatus.COMPLETED.name())
-            .append(SINGLE_QUOTE)
-            .append(SPACE);
-      } else if (params.isEventStatus(EventStatus.VISITED)
-          || params.isEventStatus(EventStatus.ACTIVE)) {
-        events
-            .append(getQueryDateConditionBetween(whereHlp, EV_EXECUTIONDATE, start, end))
-            .append(whereHlp.whereAnd())
-            .append(EV_STATUS)
-            .append(EQUALS)
-            .append(SINGLE_QUOTE)
-            .append(EventStatus.ACTIVE.name())
-            .append(SINGLE_QUOTE)
-            .append(SPACE);
-      } else if (params.isEventStatus(EventStatus.SCHEDULE)) {
-        events
-            .append(getQueryDateConditionBetween(whereHlp, EV_DUEDATE, start, end))
             .append(whereHlp.whereAnd())
             .append(EV_STATUS)
             .append(SPACE)
@@ -1015,7 +793,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
             .append("date(now()) <= date(EV.scheduleddate) ");
       } else if (params.isEventStatus(EventStatus.OVERDUE)) {
         events
-            .append(getQueryDateConditionBetween(whereHlp, EV_DUEDATE, start, end))
             .append(whereHlp.whereAnd())
             .append(EV_STATUS)
             .append(SPACE)
@@ -1026,9 +803,27 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
             .append(IS_NULL)
             .append(whereHlp.whereAnd())
             .append("date(now()) > date(EV.scheduleddate) ");
+      } else if (params.isEventStatus(EventStatus.COMPLETED)) {
+        events
+            .append(whereHlp.whereAnd())
+            .append(EV_STATUS)
+            .append(EQUALS)
+            .append(SINGLE_QUOTE)
+            .append(EventStatus.COMPLETED.name())
+            .append(SINGLE_QUOTE)
+            .append(SPACE);
+      } else if (params.isEventStatus(EventStatus.VISITED)
+          || params.isEventStatus(EventStatus.ACTIVE)) {
+        events
+            .append(whereHlp.whereAnd())
+            .append(EV_STATUS)
+            .append(EQUALS)
+            .append(SINGLE_QUOTE)
+            .append(EventStatus.ACTIVE.name())
+            .append(SINGLE_QUOTE)
+            .append(SPACE);
       } else if (params.isEventStatus(EventStatus.SKIPPED)) {
         events
-            .append(getQueryDateConditionBetween(whereHlp, EV_DUEDATE, start, end))
             .append(whereHlp.whereAnd())
             .append(EV_STATUS)
             .append(EQUALS)
@@ -1065,40 +860,10 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
   }
 
   /**
-   * Helper method for making a date condition. The format is "[WHERE|AND] date >= start AND date <=
-   * end".
-   *
-   * @param whereHelper tracking whether WHERE has been invoked or not
-   * @param column the column for filter on
-   * @param start the start date
-   * @param end the end date
-   * @return a SQL filter for finding dates between two dates.
-   */
-  private String getQueryDateConditionBetween(
-      SqlHelper whereHelper, String column, String start, String end) {
-    StringBuilder dateBetween = new StringBuilder();
-
-    dateBetween
-        .append(whereHelper.whereAnd())
-        .append(column)
-        .append(" >= '")
-        .append(start)
-        .append(SINGLE_QUOTE)
-        .append(whereHelper.whereAnd())
-        .append(column)
-        .append(" <= '")
-        .append(end)
-        .append("' ");
-
-    return dateBetween.toString();
-  }
-
-  /**
    * Generates SQL for LEFT JOINing relevant tables with the tracked entities we have in our result.
    * After the subquery, we know which tracked entities we are returning, but these LEFT JOINs will
    * add any extra information we need. For example attribute values, tet uid, tea uid, etc.
    *
-   * @param params
    * @return a SQL with several LEFT JOINS, one for each relevant table to retrieve information
    *     from.
    */
@@ -1137,7 +902,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
    * attributes. If any attributes are present we are aggregating them into a string. In case we are
    * ordering by an attribute, we also need to include that column in the group by.
    *
-   * @param params
    * @return a SQL GROUP BY clause, or empty string if no attributes are specified.
    */
   private String getQueryGroupBy(TrackedEntityQueryParams params) {
@@ -1176,7 +940,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
    * might be mixed after GROUP BY.
    *
    * @param innerOrder indicates whether this is the subquery order by or main query order by
-   * @param params
    * @param isGridQuery indicates whether this is used for grid query or not.
    * @return a SQL ORDER BY clause.
    */
@@ -1232,14 +995,13 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
    *
    * <p>If we have maxtelimit and paging on, we set the limit to maxtelimit.
    *
-   * <p>If we dont have maxtelimit, and paging on, we set normal paging parameters
+   * <p>If we don't have maxtelimit, and paging on, we set normal paging parameters
    *
-   * <p>If neither maxtelimit or paging is set, we have no limit set by the user, so system will set
-   * the limit to TRACKED_ENTITY_MAX_LIMIT which can be configured in system settings.
+   * <p>If neither maxtelimit nor paging is set, we have no limit set by the user, so system will
+   * set the limit to TRACKED_ENTITY_MAX_LIMIT which can be configured in system settings.
    *
    * <p>The limit is set in the subquery, so the latter joins have fewer rows to consider.
    *
-   * @param params
    * @return a SQL LIMIT and OFFSET clause, or empty string if no LIMIT can be deducted.
    */
   private String getFromSubQueryLimitAndOffset(TrackedEntityQueryParams params) {
@@ -1314,22 +1076,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
   }
 
   @Override
-  public List<String> getUidsIncludingDeleted(List<String> uids) {
-    String hql = "select te.uid " + TE_HQL_BY_UIDS;
-    List<String> resultUids = new ArrayList<>();
-    List<List<String>> uidsPartitions = Lists.partition(Lists.newArrayList(uids), 20000);
-
-    for (List<String> uidsPartition : uidsPartitions) {
-      if (!uidsPartition.isEmpty()) {
-        resultUids.addAll(
-            getSession().createQuery(hql, String.class).setParameter("uids", uidsPartition).list());
-      }
-    }
-
-    return resultUids;
-  }
-
-  @Override
   public List<TrackedEntity> getIncludingDeleted(List<String> uids) {
     List<TrackedEntity> trackedEntities = new ArrayList<>();
     List<List<String>> uidsPartitions = Lists.partition(Lists.newArrayList(uids), 20000);
@@ -1345,18 +1091,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
     }
 
     return trackedEntities;
-  }
-
-  @Override
-  public void updateTrackedEntitySyncTimestamp(
-      List<String> trackedEntityUIDs, Date lastSynchronized) {
-    final String hql =
-        "update TrackedEntity set lastSynchronized = :lastSynchronized WHERE uid in :trackedEntityInstances";
-
-    getQuery(hql)
-        .setParameter("lastSynchronized", lastSynchronized)
-        .setParameter("trackedEntityInstances", trackedEntityUIDs)
-        .executeUpdate();
   }
 
   @Override
@@ -1378,22 +1112,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
   }
 
   @Override
-  public List<TrackedEntity> getTrackedEntityByUid(List<String> uids, UserDetails user) {
-    List<List<String>> uidPartitions = Lists.partition(uids, 20000);
-
-    List<TrackedEntity> instances = new ArrayList<>();
-
-    for (List<String> partition : uidPartitions) {
-      instances.addAll(
-          getList(
-              getCriteriaBuilder(),
-              newJpaParameters().addPredicate(root -> root.get("uid").in(partition))));
-    }
-
-    return instances;
-  }
-
-  @Override
   protected void preProcessPredicates(
       CriteriaBuilder builder, List<Function<Root<TrackedEntity>, Predicate>> predicates) {
     predicates.add(root -> builder.equal(root.get("deleted"), false));
@@ -1402,20 +1120,6 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
   @Override
   protected TrackedEntity postProcessObject(TrackedEntity trackedEntity) {
     return (trackedEntity == null || trackedEntity.isDeleted()) ? null : trackedEntity;
-  }
-
-  private boolean isOrgUnit(QueryItem item) {
-    return item.getValueType().isOrganisationUnit();
-  }
-
-  private String getOrgUnitNameByUid(String uid) {
-    if (uid != null) {
-      return Optional.ofNullable(organisationUnitStore.getByUid(uid))
-          .orElseGet(() -> new OrganisationUnit(""))
-          .getName();
-    }
-
-    return StringUtils.EMPTY;
   }
 
   private boolean skipOwnershipCheck(TrackedEntityQueryParams params) {

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityServiceTest.java
@@ -69,8 +69,6 @@ class DefaultTrackedEntityServiceTest {
 
   @Mock private AclService aclService;
 
-  @Mock private TrackerOwnershipManager trackerOwnershipAccessManager;
-
   @Mock private TrackedEntityChangeLogService trackedEntityChangeLogService;
 
   @Mock private TrackedEntityAttributeValueChangeLogService attributeValueAuditService;
@@ -92,7 +90,6 @@ class DefaultTrackedEntityServiceTest {
             trackedEntityTypeService,
             organisationUnitService,
             aclService,
-            trackerOwnershipAccessManager,
             trackedEntityChangeLogService,
             attributeValueAuditService);
 
@@ -112,7 +109,7 @@ class DefaultTrackedEntityServiceTest {
 
   @Test
   void exceptionThrownWhenTeiLimitReached() {
-    when(trackedEntityStore.getTrackedEntityCountForGridWithMaxTeiLimit(
+    when(trackedEntityStore.getTrackedEntityCountWithMaxTeLimit(
             any(TrackedEntityQueryParams.class)))
         .thenReturn(20);
 
@@ -122,7 +119,7 @@ class DefaultTrackedEntityServiceTest {
     IllegalQueryException expectedException =
         assertThrows(
             IllegalQueryException.class,
-            () -> teiService.validateSearchScope(params, true),
+            () -> teiService.validateSearchScope(params),
             "test message");
 
     assertEquals("maxteicountreached", expectedException.getMessage());
@@ -130,13 +127,13 @@ class DefaultTrackedEntityServiceTest {
 
   @Test
   void noExceptionThrownWhenTeiLimitNotReached() {
-    when(trackedEntityStore.getTrackedEntityCountForGridWithMaxTeiLimit(
+    when(trackedEntityStore.getTrackedEntityCountWithMaxTeLimit(
             any(TrackedEntityQueryParams.class)))
         .thenReturn(0);
 
     String currentUsername = CurrentUserUtil.getCurrentUsername();
     when(userService.getUserByUsername(currentUsername)).thenReturn(user);
 
-    teiService.validateSearchScope(params, true);
+    teiService.validateSearchScope(params);
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityQueryTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityQueryTest.java
@@ -28,7 +28,9 @@
 package org.hisp.dhis.trackedentity;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.common.IllegalQueryException;
@@ -61,6 +63,7 @@ class TrackedEntityQueryTest extends SingleSetupIntegrationTestBase {
   void testTeiQueryParamsWithoutEitherProgramOrTrackedEntityType() {
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
     params.setOrgUnitMode(OrganisationUnitSelectionMode.ALL);
+
     IllegalQueryException exception =
         assertThrows(IllegalQueryException.class, () -> instanceService.validate(params));
     assertEquals(
@@ -85,14 +88,14 @@ class TrackedEntityQueryTest extends SingleSetupIntegrationTestBase {
     params.addAttribute(nonUniq1);
     params.addAttribute(nonUniq2);
     params.addAttribute(uniq1);
-    assertEquals(params.hasUniqueFilter(), false);
+    assertFalse(params.hasUniqueFilter());
     uniq1.getFilters().add(qf);
-    assertEquals(params.hasUniqueFilter(), true);
+    assertTrue(params.hasUniqueFilter());
     params.getAttributes().clear();
     params.addFilter(nonUniq1);
     params.addFilter(nonUniq2);
-    assertEquals(params.hasUniqueFilter(), false);
+    assertFalse(params.hasUniqueFilter());
     params.addFilter(uniq1);
-    assertEquals(params.hasUniqueFilter(), true);
+    assertTrue(params.hasUniqueFilter());
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentityfilter/TrackedEntityFilterServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentityfilter/TrackedEntityFilterServiceTest.java
@@ -182,7 +182,7 @@ class TrackedEntityFilterServiceTest extends SingleSetupIntegrationTestBase {
   @Test
   void testValidateOrderParamsInTeiFilter() {
     TrackedEntityFilter trackedEntityFilterA = createTrackedEntityFilter('A', programA);
-    trackedEntityFilterA.getEntityQueryCriteria().setOrder("aaa:asc,created:desc");
+    trackedEntityFilterA.getEntityQueryCriteria().setOrder("aaa:asc,createdAt:desc");
     List<String> errors = trackedEntityFilterService.validate(trackedEntityFilterA);
     assertEquals(1, errors.size());
     assertEquals(errors.get(0), "Invalid order property: aaa");


### PR DESCRIPTION
Removed unused tracker tracked entity code in module dhis-api/dhis-service-core.

Some of the code was only used in tests which is why you see me removing tests.

Many fields in `TrackedEntityQueryParams` were never used. This means that in all the client code you need to think of the field being initialized to their default value like `null` for the `lastUpdatedStartDate` or `false` for a `boolean`.

Also fixed many linting issues like typos, missing javadoc descriptions, ...
