### PR TITLE
fix: Add org unit mode to event async method  [DHIS2-17296][2.41]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/AbstractEventService.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.dxf2.deprecated.tracker.event;
 import static java.util.Collections.emptyMap;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 import static org.hisp.dhis.common.Pager.DEFAULT_PAGE_SIZE;
 import static org.hisp.dhis.common.SlimPager.FIRST_PAGE;
 import static org.hisp.dhis.dxf2.deprecated.tracker.event.EventSearchParams.EVENT_ATTRIBUTE_OPTION_COMBO_ID;
@@ -500,7 +501,8 @@ public abstract class AbstractEventService
             .setProgramType(ProgramType.WITHOUT_REGISTRATION)
             .setIncludeDeleted(true)
             .setSynchronizationQuery(true)
-            .setSkipChangedBefore(skipChangedBefore);
+            .setSkipChangedBefore(skipChangedBefore)
+            .setOrgUnitSelectionMode(ACCESSIBLE);
 
     return eventStore.getEventCount(params);
   }
@@ -518,7 +520,8 @@ public abstract class AbstractEventService
             .setIncludeDeleted(true)
             .setSynchronizationQuery(true)
             .setPageSize(pageSize)
-            .setSkipChangedBefore(skipChangedBefore);
+            .setSkipChangedBefore(skipChangedBefore)
+            .setOrgUnitSelectionMode(ACCESSIBLE);
 
     Events anonymousEvents = new Events();
     List<org.hisp.dhis.dxf2.deprecated.tracker.event.Event> events =

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/JdbcEventStore.java
@@ -362,9 +362,9 @@ public class JdbcEventStore implements EventStore {
   @Override
   public List<org.hisp.dhis.dxf2.deprecated.tracker.event.Event> getEvents(
       EventSearchParams params, Map<String, Set<String>> psdesWithSkipSyncTrue) {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
 
-    setAccessiblePrograms(isSuper(currentUser), params);
+    setAccessiblePrograms(currentUser.isSuper(), params);
 
     List<org.hisp.dhis.dxf2.deprecated.tracker.event.Event> events = new ArrayList<>();
     List<Long> relationshipIds = new ArrayList<>();
@@ -578,9 +578,9 @@ public class JdbcEventStore implements EventStore {
 
   @Override
   public List<Map<String, String>> getEventsGrid(EventSearchParams params) {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
 
-    setAccessiblePrograms(isSuper(currentUser), params);
+    setAccessiblePrograms(currentUser.isSuper(), params);
 
     final MapSqlParameterSource mapSqlParameterSource = new MapSqlParameterSource();
 
@@ -614,9 +614,9 @@ public class JdbcEventStore implements EventStore {
 
   @Override
   public List<EventRow> getEventRows(EventSearchParams params) {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
 
-    setAccessiblePrograms(isSuper(currentUser), params);
+    setAccessiblePrograms(currentUser.isSuper(), params);
 
     List<EventRow> eventRows = new ArrayList<>();
 
@@ -822,9 +822,9 @@ public class JdbcEventStore implements EventStore {
 
   @Override
   public int getEventCount(EventSearchParams params) {
-    User currentUser = userService.getUserByUsername(CurrentUserUtil.getCurrentUsername());
+    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
 
-    setAccessiblePrograms(isSuper(currentUser), params);
+    setAccessiblePrograms(currentUser.isSuper(), params);
 
     String sql;
 
@@ -862,7 +862,7 @@ public class JdbcEventStore implements EventStore {
   }
 
   private String buildGridSql(
-      EventSearchParams params, User user, MapSqlParameterSource mapSqlParameterSource) {
+      EventSearchParams params, UserDetails user, MapSqlParameterSource mapSqlParameterSource) {
     SqlHelper hlp = new SqlHelper();
 
     StringBuilder selectBuilder =
@@ -892,7 +892,7 @@ public class JdbcEventStore implements EventStore {
    * on events.
    */
   private String buildSql(
-      EventSearchParams params, MapSqlParameterSource mapSqlParameterSource, User user) {
+      EventSearchParams params, MapSqlParameterSource mapSqlParameterSource, UserDetails user) {
     StringBuilder sqlBuilder = new StringBuilder().append("select * from (");
 
     sqlBuilder.append(getEventSelectQuery(params, mapSqlParameterSource, user));
@@ -1011,7 +1011,7 @@ public class JdbcEventStore implements EventStore {
   }
 
   private String getEventSelectQuery(
-      EventSearchParams params, MapSqlParameterSource mapSqlParameterSource, User user) {
+      EventSearchParams params, MapSqlParameterSource mapSqlParameterSource, UserDetails user) {
     SqlHelper hlp = new SqlHelper();
 
     StringBuilder selectBuilder =
@@ -1076,7 +1076,7 @@ public class JdbcEventStore implements EventStore {
   private StringBuilder getFromWhereClause(
       EventSearchParams params,
       MapSqlParameterSource mapSqlParameterSource,
-      User user,
+      UserDetails user,
       SqlHelper hlp,
       StringBuilder dataElementAndFiltersSql) {
     StringBuilder fromBuilder =
@@ -1462,7 +1462,7 @@ public class JdbcEventStore implements EventStore {
 
   private String getFromWhereClause(
       EventSearchParams params,
-      User user,
+      UserDetails user,
       StringBuilder dataElementAndFiltersSql,
       MapSqlParameterSource mapSqlParameterSource,
       SqlHelper hlp) {
@@ -1723,7 +1723,7 @@ public class JdbcEventStore implements EventStore {
    *   <li>A user must have access to all COs of the events COC to have access to an event.
    * </ul>
    */
-  private String getCategoryOptionComboQuery(User user) {
+  private String getCategoryOptionComboQuery(UserDetails user) {
     String joinCondition =
         "inner join categoryoptioncombo coc on coc.categoryoptioncomboid = psi.attributeoptioncomboid "
             + " inner join lateral (select coc.categoryoptioncomboid as id,"
@@ -1734,12 +1734,12 @@ public class JdbcEventStore implements EventStore {
             + " where psi.attributeoptioncomboid = coc.categoryoptioncomboid"
             + " group by coc.categoryoptioncomboid ";
 
-    if (!isSuper(user)) {
+    if (!user.isSuper()) {
       joinCondition =
           joinCondition
               + " having bool_and(case when "
               + JpaQueryUtils.generateSQlQueryForSharingCheck(
-                  "co.sharing", UserDetails.fromUser(user), AclService.LIKE_READ_DATA)
+                  "co.sharing", user, AclService.LIKE_READ_DATA)
               + " then true else false end) = True ";
     }
 
@@ -2109,7 +2109,7 @@ public class JdbcEventStore implements EventStore {
   }
 
   private String getOrgUnitSql(
-      EventSearchParams params, User user, MapSqlParameterSource mapSqlParameterSource) {
+      EventSearchParams params, UserDetails user, MapSqlParameterSource mapSqlParameterSource) {
     switch (params.getOrgUnitSelectionMode()) {
       case CAPTURE:
         return createCaptureSql(user, mapSqlParameterSource);
@@ -2126,12 +2126,12 @@ public class JdbcEventStore implements EventStore {
     }
   }
 
-  private String createCaptureSql(User user, MapSqlParameterSource mapSqlParameterSource) {
+  private String createCaptureSql(UserDetails user, MapSqlParameterSource mapSqlParameterSource) {
     return createCaptureScopeQuery(user, mapSqlParameterSource, "");
   }
 
   private String createAccessibleSql(
-      User user, EventSearchParams params, MapSqlParameterSource mapSqlParameterSource) {
+      UserDetails user, EventSearchParams params, MapSqlParameterSource mapSqlParameterSource) {
 
     if (isProgramRestricted(params.getProgram()) || isUserSearchScopeNotSet(user)) {
       return createCaptureSql(user, mapSqlParameterSource);
@@ -2142,7 +2142,7 @@ public class JdbcEventStore implements EventStore {
   }
 
   private String createDescendantsSql(
-      User user, EventSearchParams params, MapSqlParameterSource mapSqlParameterSource) {
+      UserDetails user, EventSearchParams params, MapSqlParameterSource mapSqlParameterSource) {
     mapSqlParameterSource.addValue(COLUMN_ORG_UNIT_PATH, params.getOrgUnit().getPath());
 
     if (isProgramRestricted(params.getProgram())) {
@@ -2155,7 +2155,7 @@ public class JdbcEventStore implements EventStore {
   }
 
   private String createChildrenSql(
-      User user, EventSearchParams params, MapSqlParameterSource mapSqlParameterSource) {
+      UserDetails user, EventSearchParams params, MapSqlParameterSource mapSqlParameterSource) {
     mapSqlParameterSource.addValue(COLUMN_ORG_UNIT_PATH, params.getOrgUnit().getPath());
 
     String customChildrenQuery =
@@ -2178,7 +2178,7 @@ public class JdbcEventStore implements EventStore {
   }
 
   private String createSelectedSql(
-      User user, EventSearchParams params, MapSqlParameterSource mapSqlParameterSource) {
+      UserDetails user, EventSearchParams params, MapSqlParameterSource mapSqlParameterSource) {
     mapSqlParameterSource.addValue(COLUMN_ORG_UNIT_PATH, params.getOrgUnit().getPath());
 
     String orgUnitPathEqualsMatchQuery =
@@ -2201,12 +2201,12 @@ public class JdbcEventStore implements EventStore {
     return program != null && (program.isProtected() || program.isClosed());
   }
 
-  private boolean isUserSearchScopeNotSet(User user) {
-    return user.getTeiSearchOrganisationUnits().isEmpty();
+  private boolean isUserSearchScopeNotSet(UserDetails user) {
+    return user.getUserSearchOrgUnitIds().isEmpty();
   }
 
   private String createCaptureScopeQuery(
-      User user, MapSqlParameterSource mapSqlParameterSource, String customClause) {
+      UserDetails user, MapSqlParameterSource mapSqlParameterSource, String customClause) {
     mapSqlParameterSource.addValue(COLUMN_USER_UID, user.getUid());
 
     return " exists(select cs.organisationunitid "

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/JdbcEventStore.java
@@ -1734,7 +1734,7 @@ public class JdbcEventStore implements EventStore {
             + " where psi.attributeoptioncomboid = coc.categoryoptioncomboid"
             + " group by coc.categoryoptioncomboid ";
 
-    if (!user.isSuper()) {
+    if (!isSuper(user)) {
       joinCondition =
           joinCondition
               + " having bool_and(case when "

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/JdbcEventStore.java
@@ -364,7 +364,7 @@ public class JdbcEventStore implements EventStore {
       EventSearchParams params, Map<String, Set<String>> psdesWithSkipSyncTrue) {
     UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
 
-    setAccessiblePrograms(currentUser.isSuper(), params);
+    setAccessiblePrograms(isSuper(currentUser), params);
 
     List<org.hisp.dhis.dxf2.deprecated.tracker.event.Event> events = new ArrayList<>();
     List<Long> relationshipIds = new ArrayList<>();
@@ -580,7 +580,7 @@ public class JdbcEventStore implements EventStore {
   public List<Map<String, String>> getEventsGrid(EventSearchParams params) {
     UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
 
-    setAccessiblePrograms(currentUser.isSuper(), params);
+    setAccessiblePrograms(isSuper(currentUser), params);
 
     final MapSqlParameterSource mapSqlParameterSource = new MapSqlParameterSource();
 
@@ -616,7 +616,7 @@ public class JdbcEventStore implements EventStore {
   public List<EventRow> getEventRows(EventSearchParams params) {
     UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
 
-    setAccessiblePrograms(currentUser.isSuper(), params);
+    setAccessiblePrograms(isSuper(currentUser), params);
 
     List<EventRow> eventRows = new ArrayList<>();
 
@@ -824,7 +824,7 @@ public class JdbcEventStore implements EventStore {
   public int getEventCount(EventSearchParams params) {
     UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
 
-    setAccessiblePrograms(currentUser.isSuper(), params);
+    setAccessiblePrograms(isSuper(currentUser), params);
 
     String sql;
 
@@ -1841,7 +1841,7 @@ public class JdbcEventStore implements EventStore {
         + "inner join trackedentityattribute ta on pav.trackedentityattributeid=ta.trackedentityattributeid ";
   }
 
-  private boolean isSuper(User user) {
+  private boolean isSuper(UserDetails user) {
     return user == null || user.isSuper();
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/AclEventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/AclEventExporterTest.java
@@ -41,6 +41,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.hisp.dhis.category.CategoryOption;
@@ -399,9 +403,35 @@ class AclEventExporterTest extends TrackerTest {
         events.stream().map(Event::getOrgUnit).collect(Collectors.toSet()));
   }
 
+  @Test
+  void shouldGetAllEventsWaitingForSyncWhenRequested() {
+    Date date = createDateFromYear(2019);
+
+    assertEquals(7, eventService.getAnonymousEventReadyForSynchronizationCount(date));
+  }
+
+  @Test
+  void shouldGetAllAnonymousEventsWaitingForSyncWhenRequested() {
+    Date date = createDateFromYear(2019);
+
+    assertEquals(
+        7,
+        eventService
+            .getAnonymousEventsForSync(10, date, Collections.emptyMap())
+            .getEvents()
+            .size());
+  }
+
   private <T extends IdentifiableObject> T get(Class<T> type, String uid) {
     T t = manager.get(type, uid);
     assertNotNull(t, () -> String.format("metadata with uid '%s' should have been created", uid));
     return t;
+  }
+
+  private Date createDateFromYear(int year) {
+    LocalDateTime localDate = LocalDateTime.of(year, 1, 1, 0, 0).minusYears(10);
+    Date date = Date.from(localDate.atZone(ZoneId.systemDefault()).toInstant());
+
+    return date;
   }
 }


### PR DESCRIPTION
The methods used to synchronize metadata are not using the event mapper, thus are skipping all validations.
Since they are using the old API, I added the necessary params to keep them working.