### PR TITLE
fix: period cache removed [DHIS2-17405]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -868,10 +868,7 @@ public class DataQueryParams {
 
     if (dataPeriodType != null) {
       for (DimensionalItemObject aggregatePeriod : getDimensionOrFilterItems(PERIOD_DIM_ID)) {
-        Period dataPeriod =
-            dataPeriodType.createPeriod(
-                ((Period) aggregatePeriod).getStartDate(),
-                ((Period) aggregatePeriod).getDateField());
+        Period dataPeriod = dataPeriodType.createPeriod(((Period) aggregatePeriod).getStartDate());
 
         map.putValue(dataPeriod, aggregatePeriod);
 
@@ -881,10 +878,7 @@ public class DataQueryParams {
           // corresponding to the second part of the financial year so
           // that the query will count both years.
 
-          Period endYear =
-              dataPeriodType.createPeriod(
-                  ((Period) aggregatePeriod).getEndDate(),
-                  ((Period) aggregatePeriod).getDateField());
+          Period endYear = dataPeriodType.createPeriod(((Period) aggregatePeriod).getEndDate());
           map.putValue(endYear, aggregatePeriod);
         }
       }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/processing/CommonQueryRequestMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/processing/CommonQueryRequestMapper.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.analytics.common.processing;
 
 import static java.util.Arrays.stream;
 import static java.util.Collections.emptySet;
-import static java.util.Collections.unmodifiableList;
 import static org.hisp.dhis.analytics.EventOutputType.TRACKED_ENTITY_INSTANCE;
 import static org.hisp.dhis.analytics.common.params.dimension.DimensionParamType.DATE_FILTERS;
 import static org.hisp.dhis.analytics.common.params.dimension.DimensionParamType.DIMENSIONS;
@@ -47,7 +46,6 @@ import static org.hisp.dhis.feedback.ErrorCode.E7251;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -108,7 +106,7 @@ public class CommonQueryRequestMapper {
   /**
    * Maps the input request into the respective queryable objects.
    *
-   * @param request the input {@CommonQueryRequest}.
+   * @param request the input {@link CommonQueryRequest}.
    * @return the {@link CommonParams}.
    */
   public CommonParams map(CommonQueryRequest request, CommonQueryRequest originalRequest) {
@@ -168,7 +166,7 @@ public class CommonQueryRequestMapper {
       CommonQueryRequest request, List<Program> programs, List<OrganisationUnit> userOrgUnits) {
 
     return HEADERS.getUidsGetter().apply(request).stream()
-        .map(header -> toDimensionIdentifier(header, HEADERS, request, programs, userOrgUnits))
+        .map(header -> toDimIdentifiers(header, HEADERS, request, programs, userOrgUnits))
         .collect(Collectors.toSet());
   }
 
@@ -221,7 +219,7 @@ public class CommonQueryRequestMapper {
     return AnalyticsSortingParams.builder()
         .index(index)
         .sortDirection(SortDirection.of(parts[1]))
-        .orderBy(toDimensionIdentifier(parts[0], SORTING, request, programs, userOrgUnits))
+        .orderBy(toDimIdentifiers(parts[0], SORTING, request, programs, userOrgUnits))
         .build();
   }
 
@@ -265,27 +263,34 @@ public class CommonQueryRequestMapper {
       CommonQueryRequest queryRequest,
       List<Program> programs,
       List<OrganisationUnit> userOrgUnits) {
-    List<DimensionIdentifier<DimensionParam>> dimensionParams = new ArrayList<>();
 
-    Stream.of(DIMENSIONS, FILTERS, DATE_FILTERS)
-        .forEach(
-            dimensionParamType -> {
-              // A Collection of dimensions or filters coming from the request.
-              Collection<String> dimensionsOrFilter =
-                  dimensionParamType.getUidsGetter().apply(queryRequest);
+    return Stream.of(DIMENSIONS, FILTERS, DATE_FILTERS)
+        .flatMap(type -> streamByType(type, queryRequest, programs, userOrgUnits))
+        .toList();
+  }
 
-              dimensionParams.addAll(
-                  dimensionsOrFilter.stream()
-                      .map(CommonQueryRequestMapper::splitOnOrIfNecessary)
-                      .map(
-                          dof ->
-                              toDimensionIdentifier(
-                                  dof, dimensionParamType, queryRequest, programs, userOrgUnits))
-                      .flatMap(Collection::stream)
-                      .toList());
-            });
+  /**
+   * Streams the dimensions for the given {@link DimensionParamType} and maps them to {@link
+   * DimensionIdentifier} objects.
+   *
+   * @param dimensionParamType the {@link DimensionParamType}.
+   * @param queryRequest the {@link CommonQueryRequest}.
+   * @param programs the list of {@link Program}.
+   * @param userOrgUnits the list of {@link OrganisationUnit}.
+   * @return the {@link Stream} of {@link DimensionIdentifier}.
+   */
+  private Stream<DimensionIdentifier<DimensionParam>> streamByType(
+      DimensionParamType dimensionParamType,
+      CommonQueryRequest queryRequest,
+      List<Program> programs,
+      List<OrganisationUnit> userOrgUnits) {
+    // A Collection of dimensions or filters coming from the request.
+    Collection<String> dimensionString = dimensionParamType.getUidsGetter().apply(queryRequest);
 
-    return unmodifiableList(dimensionParams);
+    return dimensionString.stream()
+        .map(CommonQueryRequestMapper::splitOnOr)
+        .map(dim -> toDimIdentifiers(dim, dimensionParamType, queryRequest, programs, userOrgUnits))
+        .flatMap(Collection::stream);
   }
 
   /**
@@ -300,7 +305,7 @@ public class CommonQueryRequestMapper {
    * @return a {@link List} of {@link DimensionIdentifier}.
    * @throws IllegalQueryException if "dimensionOrFilter" is not well-formed.
    */
-  private List<DimensionIdentifier<DimensionParam>> toDimensionIdentifier(
+  private List<DimensionIdentifier<DimensionParam>> toDimIdentifiers(
       List<String> dimensions,
       DimensionParamType dimensionParamType,
       CommonQueryRequest queryRequest,
@@ -309,7 +314,7 @@ public class CommonQueryRequestMapper {
     return dimensions.stream()
         .map(
             dimensionAsString ->
-                toDimensionIdentifier(
+                toDimIdentifiers(
                     dimensionAsString, dimensionParamType, queryRequest, programs, userOrgUnits))
         .map(this::withGroupId)
         .toList();
@@ -338,7 +343,7 @@ public class CommonQueryRequestMapper {
    * @param dimensionAsString, in the format dim_OR_anotherDim.
    * @return the {@link List} of String.
    */
-  private static List<String> splitOnOrIfNecessary(String dimensionAsString) {
+  private static List<String> splitOnOr(String dimensionAsString) {
     return stream(DIMENSION_OR_SEPARATOR.split(dimensionAsString)).toList();
   }
 
@@ -353,13 +358,13 @@ public class CommonQueryRequestMapper {
    * @return the {@link DimensionIdentifier}.
    * @throws IllegalQueryException if "dimensionOrFilter" is not well-formed.
    */
-  private DimensionIdentifier<DimensionParam> toDimensionIdentifier(
+  private DimensionIdentifier<DimensionParam> toDimIdentifiers(
       String dimensionOrFilter,
       DimensionParamType dimensionParamType,
       CommonQueryRequest queryRequest,
       List<Program> programs,
       List<OrganisationUnit> userOrgUnits) {
-    return toDimensionIdentifier(
+    return toDimIdentifiers(
         dimensionOrFilter,
         dimensionParamType,
         queryRequest.getRelativePeriodDate(),
@@ -382,7 +387,7 @@ public class CommonQueryRequestMapper {
    * @return the {@link DimensionIdentifier}.
    * @throws IllegalQueryException if "dimensionOrFilter" is not well-formed.
    */
-  public DimensionIdentifier<DimensionParam> toDimensionIdentifier(
+  public DimensionIdentifier<DimensionParam> toDimIdentifiers(
       String dimensionOrFilter,
       DimensionParamType dimensionParamType,
       Date relativePeriodDate,

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/PredictionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/PredictionServiceTest.java
@@ -190,7 +190,6 @@ class PredictionServiceTest extends IntegrationTestBase {
   public void setUpTest() throws Exception {
     this.userService = _userService;
 
-    PeriodType.invalidatePeriodCache();
     orgUnitLevel1 = new OrganisationUnitLevel(1, "Level1");
     orgUnitLevel2 = new OrganisationUnitLevel(2, "Level2");
     orgUnitLevel3 = new OrganisationUnitLevel(3, "Level3");


### PR DESCRIPTION
Period cache seems to not improve performance noticeably, especially since its use shouldn't be that extensive.
Moreover, from time to time, issues arise because of this period cache, due to the lack of the dateField as a member of the cache key and the difficulty of adding it properly.
Some internal test showed no noticeable performance degradation after this cache got removed.