### PR TITLE
test: fix junit warning about 2 properties files

### DIFF
--- a/dhis-2/dhis-test-e2e/src/main/resources/junit-platform.properties
+++ b/dhis-2/dhis-test-e2e/src/main/resources/junit-platform.properties
@@ -1,1 +1,3 @@
 junit.jupiter.extensions.autodetection.enabled=true
+# Enables the execution of ordering of classes through the annotation @Order
+junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation

--- a/dhis-2/dhis-test-e2e/src/test/resources/junit-platform.properties
+++ b/dhis-2/dhis-test-e2e/src/test/resources/junit-platform.properties
@@ -1,2 +1,0 @@
-# Enables the execution of ordering of classes through the annotation @Order
-junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation


### PR DESCRIPTION
```
May 16, 2024 1:02:32 PM org.junit.platform.launcher.core.LauncherConfigurationParameters loadClasspathResource
WARNING: Discovered 2 'junit-platform.properties' configuration files in the classpath; only the first will be used.
```

moving the config from src/test/resources to src/main/resources as this is where all other test related config is