### PR TITLE
fix: lastExecuted status should be COMPLETED [DHIS2-17292]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPreProcessor.java
@@ -70,9 +70,10 @@ public class MetadataSyncPreProcessor {
   private final CompleteDataSetRegistrationSynchronization completeDataSetRegistrationSync;
 
   public void setUp(MetadataRetryContext context, JobProgress progress) {
-    progress.startingStage("Setting up metadata synchronisation");
+    progress.startingProcess("Setting up metadata synchronisation");
     progress.runStage(
         () -> systemSettingManager.saveSystemSetting(SettingKey.METADATAVERSION_ENABLED, true));
+    progress.completedProcess("finished setting up metadata synchronisation");
   }
 
   public void handleDataValuePush(
@@ -88,19 +89,19 @@ public class MetadataSyncPreProcessor {
 
   public List<MetadataVersion> handleMetadataVersionsList(
       MetadataRetryContext context, MetadataVersion version, JobProgress progress) {
-    progress.startingStage(
+    progress.startingProcess(
         "Fetching the list of remote versions"
             + (version == null ? "There is no initial version in the system" : ""));
     try {
       List<MetadataVersion> versions = metadataVersionDelegate.getMetaDataDifference(version);
 
       if (isRemoteVersionEmpty(version, versions)) {
-        progress.completedStage("There are no metadata versions created in the remote instance");
+        progress.completedProcess("There are no metadata versions created in the remote instance");
         return versions;
       }
 
       if (isUsingLatestVersion(version, versions)) {
-        progress.completedStage("Your instance is already using the latest version:" + version);
+        progress.completedProcess("Your instance is already using the latest version:" + version);
         return versions;
       }
 
@@ -109,7 +110,7 @@ public class MetadataSyncPreProcessor {
 
       systemSettingManager.saveSystemSetting(
           SettingKey.REMOTE_METADATA_VERSION, latestVersion.getName());
-      progress.completedStage("Remote system is at version: " + latestVersion.getName());
+      progress.completedProcess("Remote system is at version: " + latestVersion.getName());
       return versions;
     } catch (MetadataVersionServiceException e) {
       String message = setVersionListErrorInfoInContext(context, version, e);
@@ -149,11 +150,11 @@ public class MetadataSyncPreProcessor {
 
   public MetadataVersion handleCurrentMetadataVersion(
       MetadataRetryContext context, JobProgress progress) {
-    progress.startingStage("Getting the current version of the system");
+    progress.startingProcess("Getting the current version of the system");
 
     try {
       MetadataVersion version = metadataVersionService.getCurrentVersion();
-      progress.completedStage("Current Metadata Version of the system: {}", version);
+      progress.completedProcess("Current Metadata Version of the system: {}", version);
       return version;
     } catch (MetadataVersionServiceException ex) {
       context.updateRetryContext(MetadataSyncJob.GET_METADATAVERSION, ex.getMessage(), null, null);

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dxf2.metadata.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncPreProcessor;
+import org.hisp.dhis.dxf2.metadata.version.MetadataVersionDelegate;
+import org.hisp.dhis.metadata.version.MetadataVersion;
+import org.hisp.dhis.metadata.version.MetadataVersionService;
+import org.hisp.dhis.metadata.version.VersionType;
+import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress.Status;
+import org.hisp.dhis.scheduling.JobStatus;
+import org.hisp.dhis.scheduling.JobType;
+import org.hisp.dhis.scheduling.RecordingJobProgress;
+import org.hisp.dhis.setting.SystemSettingManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MetadataSyncJobTest {
+
+  @Mock private SystemSettingManager systemSettingManager;
+  @Mock private MetadataVersionService metadataVersionService;
+  @Mock private MetadataVersionDelegate metadataVersionDelegate;
+
+  @Test
+  @DisplayName(
+      "Job progress status should be SUCCESS after metadata sync pre-processor setup completes")
+  void preprocessSetupTest() {
+    // given
+    JobConfiguration config = new JobConfiguration();
+    config.setJobType(JobType.META_DATA_SYNC);
+    config.setLastExecutedStatus(JobStatus.RUNNING);
+
+    RecordingJobProgress jobProgress = new RecordingJobProgress(config);
+
+    MetadataSyncPreProcessor preProcessor =
+        new MetadataSyncPreProcessor(systemSettingManager, null, null, null, null);
+
+    // when
+    preProcessor.setUp(null, jobProgress);
+
+    // then
+    assertEquals(1, jobProgress.getProgress().getSequence().size());
+    assertEquals(Status.SUCCESS, jobProgress.getProgress().getSequence().getFirst().getStatus());
+  }
+
+  @Test
+  @DisplayName(
+      "Job progress status should be SUCCESS after metadata sync pre-processor handle current metadata version completes")
+  void handleCurrentMetadataVersionTest() {
+    // given
+    JobConfiguration config = new JobConfiguration();
+    config.setJobType(JobType.META_DATA_SYNC);
+    config.setLastExecutedStatus(JobStatus.RUNNING);
+
+    RecordingJobProgress jobProgress = new RecordingJobProgress(config);
+
+    MetadataSyncPreProcessor preProcessor =
+        new MetadataSyncPreProcessor(
+            systemSettingManager, metadataVersionService, metadataVersionDelegate, null, null);
+
+    MetadataVersion mdVersion = new MetadataVersion("test", VersionType.BEST_EFFORT);
+    when(metadataVersionService.getCurrentVersion()).thenReturn(mdVersion);
+
+    // when
+    preProcessor.handleCurrentMetadataVersion(null, jobProgress);
+
+    // then
+    assertEquals(1, jobProgress.getProgress().getSequence().size());
+    assertEquals(Status.SUCCESS, jobProgress.getProgress().getSequence().getFirst().getStatus());
+  }
+
+  @Test
+  @DisplayName(
+      "Job progress status should be SUCCESS after metadata sync pre-processor handle metadata versions completes")
+  void handleMetadataVersionsTest() {
+    // given
+    JobConfiguration config = new JobConfiguration();
+    config.setJobType(JobType.META_DATA_SYNC);
+    config.setLastExecutedStatus(JobStatus.RUNNING);
+
+    RecordingJobProgress jobProgress = new RecordingJobProgress(config);
+
+    MetadataSyncPreProcessor preProcessor =
+        new MetadataSyncPreProcessor(
+            systemSettingManager, metadataVersionService, metadataVersionDelegate, null, null);
+
+    MetadataVersion mdVersion = new MetadataVersion("test", VersionType.BEST_EFFORT);
+    when(metadataVersionDelegate.getMetaDataDifference(mdVersion)).thenReturn(List.of());
+
+    // when
+    preProcessor.handleMetadataVersionsList(null, mdVersion, jobProgress);
+
+    // then
+    assertEquals(1, jobProgress.getProgress().getSequence().size());
+    assertEquals(Status.SUCCESS, jobProgress.getProgress().getSequence().getFirst().getStatus());
+  }
+}


### PR DESCRIPTION
port of #17275 (fix for `v39`) with less changes as Job Scheduling was overhauled in `v41`
- same principle applies, start & complete processes instead of stages for jobs to show as `COMPLETED`