### PR TITLE
fix: Add trackedEntityType field to enrollment exporter [DHIS2-17407]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -104,6 +104,7 @@ class DefaultEnrollmentService
     if (enrollment.getTrackedEntity() != null) {
       TrackedEntity trackedEntity = new TrackedEntity();
       trackedEntity.setUid(enrollment.getTrackedEntity().getUid());
+      trackedEntity.setTrackedEntityType(enrollment.getTrackedEntity().getTrackedEntityType());
       result.setTrackedEntity(trackedEntity);
     }
     result.setOrganisationUnit(enrollment.getOrganisationUnit());

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonEnrollment.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/JsonEnrollment.java
@@ -40,6 +40,10 @@ public interface JsonEnrollment extends JsonObject {
     return getString("trackedEntity").string();
   }
 
+  default String getTrackedEntityType() {
+    return getString("trackedEntityType").string();
+  }
+
   default String getProgram() {
     return getString("program").string();
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportControllerTest.java
@@ -164,13 +164,18 @@ class EnrollmentsExportControllerTest extends DhisControllerConvenienceTest {
   @Test
   void getEnrollmentByIdWithFields() {
     JsonEnrollment enrollment =
-        GET("/tracker/enrollments/{id}?fields=orgUnit,status", this.enrollment.getUid())
+        GET(
+                "/tracker/enrollments/{id}?fields=orgUnit,status,trackedEntityType",
+                this.enrollment.getUid())
             .content(HttpStatus.OK)
             .as(JsonEnrollment.class);
 
-    assertHasOnlyMembers(enrollment, "orgUnit", "status");
+    assertHasOnlyMembers(enrollment, "orgUnit", "status", "trackedEntityType");
     assertEquals(this.enrollment.getOrganisationUnit().getUid(), enrollment.getOrgUnit());
     assertEquals(this.enrollment.getStatus().toString(), enrollment.getStatus());
+    assertEquals(
+        this.enrollment.getTrackedEntity().getTrackedEntityType().getUid(),
+        enrollment.getTrackedEntityType());
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentMapper.java
@@ -72,6 +72,7 @@ public interface EnrollmentMapper
   @Mapping(target = "updatedAt", source = "lastUpdated")
   @Mapping(target = "updatedAtClient", source = "lastUpdatedAtClient")
   @Mapping(target = "trackedEntity", source = "trackedEntity.uid")
+  @Mapping(target = "trackedEntityType", source = "trackedEntity.trackedEntityType.uid")
   @Mapping(target = "program", source = "program.uid")
   @Mapping(target = "orgUnit", source = "organisationUnit.uid")
   @Mapping(target = "enrolledAt", source = "enrollmentDate")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Enrollment.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/Enrollment.java
@@ -65,6 +65,8 @@ public class Enrollment {
   @JsonProperty
   private String trackedEntity;
 
+  @JsonProperty private String trackedEntityType;
+
   @JsonProperty private String program;
 
   @JsonProperty private EnrollmentStatus status;


### PR DESCRIPTION
Field `trackedEntityType` was present in the old API and it was present in our documentation.
This PR is adding it to the new API.