### PR TITLE
fix: use serverBaseUrl for recovery email[DHIS2-17317]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/UserAccountController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/UserAccountController.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.auth.UserInviteParams;
 import org.hisp.dhis.common.auth.UserRegistrationParams;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ErrorCode;
@@ -56,7 +57,6 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserAccountService;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
-import org.hisp.dhis.webapi.utils.HttpServletRequestPaths;
 import org.hisp.dhis.webmessage.WebMessageResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -89,15 +89,20 @@ public class UserAccountController {
   private final UserAccountService userAccountService;
   private final SystemSettingManager systemSettingManager;
   private final PasswordValidationService passwordValidationService;
+  private final DhisConfigurationProvider configurationProvider;
 
   @PostMapping("/forgotPassword")
   @ResponseStatus(HttpStatus.OK)
-  public void forgotPassword(
-      HttpServletRequest request, @RequestBody ForgotPasswordRequest forgotPasswordRequest)
+  public void forgotPassword(@RequestBody ForgotPasswordRequest forgotPasswordRequest)
       throws HiddenNotFoundException, ConflictException, ForbiddenException {
 
     if (!systemSettingManager.accountRecoveryEnabled()) {
       throw new ConflictException("Account recovery is not enabled");
+    }
+
+    String baseUrl = configurationProvider.getServerBaseUrl();
+    if (StringUtils.isEmpty(baseUrl)) {
+      throw new ConflictException("Server base URL is not configured");
     }
 
     User user = getUser(forgotPasswordRequest.getEmailOrUsername());
@@ -111,9 +116,7 @@ public class UserAccountController {
     }
 
     if (!userService.sendRestoreOrInviteMessage(
-        user,
-        HttpServletRequestPaths.getContextPath(request),
-        RestoreOptions.RECOVER_PASSWORD_OPTION)) {
+        user, baseUrl, RestoreOptions.RECOVER_PASSWORD_OPTION)) {
       throw new ConflictException("Account could not be recovered");
     }
 


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-17317
### Issue
- The endpoint `/api/forgotPassword` in `UserAccountController` use the `HttpRequest.hostName` to build the email message.  It is vulnerable to host header injection

### Fix
- Replace request host header with the config `server.base.url` in dhis.conf file.

### Test
- Added a test to `UserAccountControllerTest`
- Manual test can be done by 
1. Set up email server in DHIS2 instance
2. Send a recover password request as below
```
curl -X POST http://localhost:8080/api/auth/forgotPassword -H "Host: attacker.com"  -H "Content-Type: application/json" -d '{"emailOrUsername":"admin"}'
```
3. Verify the sent email content, make sure the url "attacker.com" is not included.


Screenshot
<img width="929" alt="Screen Shot 2024-05-22 at 11 30 16 AM" src="https://github.com/dhis2/dhis2-core/assets/766102/21d03a1a-c3b4-4737-9e96-6759b5b39467">


