### PR TITLE
fix: Remove unused tracker services from program-rule module

### DIFF
--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/NotificationRuleActionImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/NotificationRuleActionImplementer.java
@@ -37,9 +37,7 @@ import org.hisp.dhis.notification.logging.ExternalNotificationLogEntry;
 import org.hisp.dhis.notification.logging.NotificationLoggingService;
 import org.hisp.dhis.notification.logging.NotificationValidationResult;
 import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplateService;
 import org.hisp.dhis.rules.models.RuleAction;
@@ -61,10 +59,6 @@ abstract class NotificationRuleActionImplementer implements RuleActionImplemente
   protected final ProgramNotificationTemplateService programNotificationTemplateService;
 
   protected final NotificationLoggingService notificationLoggingService;
-
-  protected final EnrollmentService enrollmentService;
-
-  protected final EventService eventService;
 
   protected ExternalNotificationLogEntry createLogEntry(String key, String templateUid) {
     ExternalNotificationLogEntry entry = new ExternalNotificationLogEntry();

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionScheduleMessageImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionScheduleMessageImplementer.java
@@ -36,9 +36,7 @@ import org.hisp.dhis.notification.logging.NotificationLoggingService;
 import org.hisp.dhis.notification.logging.NotificationTriggerEvent;
 import org.hisp.dhis.notification.logging.NotificationValidationResult;
 import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.notification.ProgramNotificationInstance;
 import org.hisp.dhis.program.notification.ProgramNotificationInstanceService;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
@@ -70,15 +68,9 @@ public class RuleActionScheduleMessageImplementer extends NotificationRuleAction
   public RuleActionScheduleMessageImplementer(
       ProgramNotificationTemplateService programNotificationTemplateService,
       NotificationLoggingService notificationLoggingService,
-      EnrollmentService enrollmentService,
-      EventService eventService,
       ProgramNotificationInstanceService programNotificationInstanceService,
       NotificationTemplateService notificationTemplateService) {
-    super(
-        programNotificationTemplateService,
-        notificationLoggingService,
-        enrollmentService,
-        eventService);
+    super(programNotificationTemplateService, notificationLoggingService);
     this.programNotificationInstanceService = programNotificationInstanceService;
     this.notificationTemplateService = notificationTemplateService;
   }

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionSendMessageImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionSendMessageImplementer.java
@@ -34,9 +34,7 @@ import org.hisp.dhis.notification.logging.NotificationLoggingService;
 import org.hisp.dhis.notification.logging.NotificationTriggerEvent;
 import org.hisp.dhis.notification.logging.NotificationValidationResult;
 import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplateService;
 import org.hisp.dhis.program.notification.event.ProgramRuleEnrollmentEvent;
@@ -72,14 +70,8 @@ public class RuleActionSendMessageImplementer extends NotificationRuleActionImpl
   public RuleActionSendMessageImplementer(
       ProgramNotificationTemplateService programNotificationTemplateService,
       NotificationLoggingService notificationLoggingService,
-      EnrollmentService enrollmentService,
-      EventService eventService,
       ApplicationEventPublisher publisher) {
-    super(
-        programNotificationTemplateService,
-        notificationLoggingService,
-        enrollmentService,
-        eventService);
+    super(programNotificationTemplateService, notificationLoggingService);
     this.publisher = publisher;
   }
 


### PR DESCRIPTION
Some classes in `dhis-service-program-rule` were declaring `EnrollmentService` and `EventService` and never using them