### PR TITLE
fix: GridUtils throw duplicate sheet error [17415]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/GridUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/GridUtils.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.system.grid;
 
 import static org.hisp.dhis.common.DimensionalObject.DIMENSION_SEP;
 import static org.hisp.dhis.common.adapter.OutputFormatter.maybeFormat;
+import static org.hisp.dhis.system.util.CodecUtils.filenameEncode;
 import static org.hisp.dhis.system.util.PDFUtils.addTableToDocument;
 import static org.hisp.dhis.system.util.PDFUtils.closeDocument;
 import static org.hisp.dhis.system.util.PDFUtils.getEmptyCell;
@@ -85,7 +86,6 @@ import org.hisp.dhis.common.Reference;
 import org.hisp.dhis.commons.collection.ListUtils;
 import org.hisp.dhis.commons.util.Encoder;
 import org.hisp.dhis.commons.util.TextUtils;
-import org.hisp.dhis.system.util.CodecUtils;
 import org.hisp.dhis.system.util.MathUtils;
 import org.hisp.dhis.system.velocity.VelocityManager;
 import org.hisp.dhis.util.DateUtils;
@@ -107,6 +107,7 @@ import org.springframework.jdbc.support.rowset.SqlRowSet;
  */
 @Slf4j
 public class GridUtils {
+
   private static final String EMPTY = "";
 
   private static final char CSV_DELIMITER = ',';
@@ -261,12 +262,14 @@ public class GridUtils {
 
     for (int i = 0; i < grids.size(); i++) {
       Grid grid = grids.get(i);
-
       String sheetName =
-          CodecUtils.filenameEncode(
-              StringUtils.defaultIfEmpty(grid.getTitle(), XLS_SHEET_PREFIX + (i + 1)));
+          filenameEncode(StringUtils.defaultIfEmpty(grid.getTitle(), XLS_SHEET_PREFIX + (i + 1)));
+      Sheet sheet = workbook.getSheet(sheetName);
+      if (sheet == null) {
+        sheet = workbook.createSheet(sheetName);
+      }
 
-      toXlsInternal(grid, workbook.createSheet(sheetName), headerCellStyle, cellStyle);
+      toXlsInternal(grid, sheet, headerCellStyle, cellStyle);
     }
 
     workbook.write(out);
@@ -278,8 +281,7 @@ public class GridUtils {
     Workbook workbook = new HSSFWorkbook();
 
     String sheetName =
-        CodecUtils.filenameEncode(
-            StringUtils.defaultIfEmpty(grid.getTitle(), XLS_SHEET_PREFIX + 1));
+        filenameEncode(StringUtils.defaultIfEmpty(grid.getTitle(), XLS_SHEET_PREFIX + 1));
 
     toXlsInternal(
         grid,

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/grid/GridUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/grid/GridUtilsTest.java
@@ -27,10 +27,13 @@
  */
 package org.hisp.dhis.system.grid;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.google.common.collect.Lists;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -84,5 +87,19 @@ class GridUtilsTest {
     // value
     row2.add(10.22D);
     assertEquals(2, GridUtils.getGridIndexByDimensionItem(row2, periods, 2));
+  }
+
+  @Test
+  void testToXls() throws Exception {
+    List<Grid> grids = new ArrayList<>();
+    Grid gridA = new ListGrid();
+    gridA.setTitle("Grid");
+    grids.add(gridA);
+    Grid gridB = new ListGrid();
+    gridB.setTitle("Grid");
+    grids.add(gridA);
+    grids.add(gridB);
+    OutputStream outputStream = new ByteArrayOutputStream();
+    assertDoesNotThrow(() -> GridUtils.toXls(grids, outputStream));
   }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/grid/GridUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/grid/GridUtilsTest.java
@@ -90,7 +90,7 @@ class GridUtilsTest {
   }
 
   @Test
-  void testToXls() throws Exception {
+  void testToXls() {
     List<Grid> grids = new ArrayList<>();
     Grid gridA = new ListGrid();
     gridA.setTitle("Grid");


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-17415
- In `GridUtils.toXls` should only create new `Sheet` if couldn't find a sheet with same sheet name in `WorkBook`
- Added unit test