### PR TITLE
chore: bump bundled version of Capture app

### DIFF
--- a/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
+++ b/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
@@ -3,7 +3,7 @@
     "https://github.com/d2-ci/approval-app#v100.0.11",
     "https://github.com/d2-ci/app-management-app#v100.2.33",
     "https://github.com/d2-ci/cache-cleaner-app#v100.1.14",
-    "https://github.com/d2-ci/capture-app#v100.67.6",
+    "https://github.com/d2-ci/capture-app#v100.68.10",
     "https://github.com/d2-ci/dashboard-app#v100.2.0",
     "https://github.com/d2-ci/data-administration-app#v100.0.3",
     "https://github.com/d2-ci/data-visualizer-app#v100.5.1",


### PR DESCRIPTION
Bumping Capture app version to a version that includes fixes approved by RCB.