### PR TITLE
fix: /tracker/trackedEntites?order=enrolledAt returns wrong order

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -500,11 +500,11 @@ class DefaultTrackedEntityService implements TrackedEntityService {
     return ids.withItems(trackedEntities);
   }
 
-  public List<Long> getTrackedEntityIds(TrackedEntityQueryParams params) {
+  private List<Long> getTrackedEntityIds(TrackedEntityQueryParams params) {
     return trackedEntityStore.getTrackedEntityIds(params);
   }
 
-  public Page<Long> getTrackedEntityIds(TrackedEntityQueryParams params, PageParams pageParams) {
+  private Page<Long> getTrackedEntityIds(TrackedEntityQueryParams params, PageParams pageParams) {
     return trackedEntityStore.getTrackedEntityIds(params, pageParams);
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/TrackedEntityAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/aggregates/TrackedEntityAggregate.java
@@ -286,7 +286,7 @@ public class TrackedEntityAggregate implements Aggregate {
     enrollmentList.addAll(
         enrollments.stream()
             .filter(e -> (programs.contains(e.getProgram().getUid()) || ctx.isSuperUser()))
-            .collect(Collectors.toList()));
+            .toList());
 
     return enrollmentList;
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/OrderAndPaginationExporterTest.java
@@ -38,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -46,6 +47,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.QueryFilter;
@@ -73,10 +75,14 @@ import org.hisp.dhis.tracker.export.event.EventParams;
 import org.hisp.dhis.tracker.export.event.EventService;
 import org.hisp.dhis.tracker.export.relationship.RelationshipOperationParams;
 import org.hisp.dhis.tracker.export.relationship.RelationshipService;
+import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityEnrollmentParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityOperationParams;
+import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityService;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
+import org.hisp.dhis.tracker.imports.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.BeforeEach;
@@ -354,6 +360,65 @@ class OrderAndPaginationExporterTest extends TrackerTest {
     List<String> trackedEntities = getTrackedEntities(params);
 
     assertEquals(List.of("QS6w44flWAf", "dUE514NMOlo"), trackedEntities);
+  }
+
+  @Test
+  void shouldExcludeEnrollmentWhoseProgramIsNotRequestedAndOrderTrackedEntitiesByEnrolledAt()
+      throws ForbiddenException, BadRequestException, NotFoundException {
+
+    String oldEnrollment = "nxP7UnKhomJ";
+    String newEnrollment = CodeGenerator.generateUid();
+
+    // enroll a tracked entity to a new program. This enrollment will be excluded because it has not
+    // the requested program
+    org.hisp.dhis.tracker.imports.domain.Enrollment enrollment =
+        new org.hisp.dhis.tracker.imports.domain.Enrollment();
+    enrollment.setEnrollment(newEnrollment);
+    enrollment.setTrackedEntity("QS6w44flWAf");
+    enrollment.setProgram(
+        MetadataIdentifier.ofUid("shPjYNifvMK")); // enroll to another program with registration
+    enrollment.setOrgUnit(MetadataIdentifier.ofUid("uoNW0E3xXUy"));
+    enrollment.setEnrolledAt(Instant.now());
+    enrollment.setOccurredAt(Instant.now());
+
+    assertNoErrors(
+        trackerImportService.importTracker(
+            TrackerImportParams.builder().build(),
+            TrackerObjects.builder().enrollments(List.of(enrollment)).build()));
+
+    manager.flush();
+    manager.clear();
+
+    TrackedEntity QS6w44flWAf = get(TrackedEntity.class, "QS6w44flWAf");
+    assertContainsOnly(
+        List.of(newEnrollment, oldEnrollment),
+        QS6w44flWAf.getEnrollments().stream().map(BaseIdentifiableObject::getUid).toList());
+
+    TrackedEntityOperationParams params =
+        TrackedEntityOperationParams.builder()
+            .organisationUnits(Set.of(orgUnit.getUid()))
+            .orgUnitMode(SELECTED)
+            .trackedEntityUids(Set.of("QS6w44flWAf", "dUE514NMOlo"))
+            .programUid("BFcipDERJnf")
+            .user(importUser)
+            .trackedEntityParams(
+                TrackedEntityParams.FALSE.withTeEnrollmentParams(
+                    TrackedEntityEnrollmentParams.TRUE)) // include enrollments
+            .orderBy("enrollment.enrollmentDate", SortDirection.DESC)
+            .build();
+
+    List<TrackedEntity> trackedEntities = trackedEntityService.getTrackedEntities(params);
+
+    assertAll(
+        () -> assertEquals(List.of("dUE514NMOlo", "QS6w44flWAf"), uids(trackedEntities)),
+        () ->
+            assertContainsOnly(
+                List.of(oldEnrollment),
+                trackedEntities.stream()
+                    .filter(t -> t.getUid().equals("QS6w44flWAf"))
+                    .flatMap(t -> t.getEnrollments().stream())
+                    .map(BaseIdentifiableObject::getUid)
+                    .toList()));
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
@@ -336,6 +336,29 @@
       "notes": []
     },
     {
+      "enrollment": "nxP8UnKhomJ",
+      "createdAtClient": "2017-01-26T13:48:13.363",
+      "trackedEntity": "QS6w44flWAf",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "shPjYNifvMK"
+      },
+      "status": "ACTIVE",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "uoNW0E3xXUy"
+      },
+      "enrolledAt": "2021-04-28T12:05:00.000",
+      "occurredAt": "2021-04-28T12:05:00.000",
+      "scheduledAt": "2021-04-28T12:05:00.000",
+      "followUp": false,
+      "deleted": false,
+      "events": [],
+      "relationships": [],
+      "attributes": [],
+      "notes": []
+    },
+    {
       "enrollment": "TvctPPhpD8z",
       "createdAtClient": "2017-01-26T13:48:13.363",
       "trackedEntity": "dUE514NMOlo",


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-16446

Add to the join with the enrollment the program ID if it is present in the request, so we exclude from ordering the enrollments that are not required

### Next
There might be more cleanup to do, so I've created another issue https://dhis2.atlassian.net/browse/DHIS2-17447 