### PR TITLE
fix: Validate events in relationships [DHIS2-16460]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.tracker.export.event;
 
+import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -138,16 +140,17 @@ class DefaultEventService implements EventService {
       throw new NotFoundException(Event.class, uid);
     }
 
-    return getEvent(event, eventParams);
-  }
-
-  public Event getEvent(@Nonnull Event event, EventParams eventParams) throws ForbiddenException {
     UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
     List<String> errors = trackerAccessManager.canRead(currentUser, event, false);
     if (!errors.isEmpty()) {
       throw new ForbiddenException(errors.toString());
     }
 
+    return getEvent(event, eventParams, currentUser);
+  }
+
+  private Event getEvent(@Nonnull Event event, EventParams eventParams, UserDetails currentUser)
+      throws ForbiddenException {
     Event result = new Event();
     result.setId(event.getId());
     result.setUid(event.getUid());
@@ -229,6 +232,25 @@ class DefaultEventService implements EventService {
       throws BadRequestException, ForbiddenException {
     EventQueryParams queryParams = paramsMapper.map(operationParams);
     return eventStore.getEvents(queryParams, pageParams);
+  }
+
+  public RelationshipItem getEventInRelationshipItem(String uid, EventParams eventParams)
+      throws NotFoundException, ForbiddenException {
+    RelationshipItem relationshipItem = new RelationshipItem();
+
+    Event event = eventService.getEvent(uid);
+    if (event == null) {
+      throw new NotFoundException(Event.class, uid);
+    }
+
+    UserDetails currentUser = getCurrentUserDetails();
+    List<String> errors = trackerAccessManager.canRead(currentUser, event, false);
+    if (!errors.isEmpty()) {
+      return null;
+    }
+
+    relationshipItem.setEvent(getEvent(event, eventParams, currentUser));
+    return relationshipItem;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
@@ -35,6 +35,7 @@ import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fileresource.ImageFileDimension;
 import org.hisp.dhis.program.Event;
+import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.tracker.export.FileResourceStream;
 import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
@@ -59,6 +60,9 @@ public interface EventService {
   /** Get a page of events matching given params. */
   Page<Event> getEvents(EventOperationParams params, PageParams pageParams)
       throws BadRequestException, ForbiddenException;
+
+  RelationshipItem getEventInRelationshipItem(String uid, EventParams eventParams)
+      throws NotFoundException, ForbiddenException;
 
   /**
    * Fields the {@link #getEvents(EventOperationParams)} and {@link #getEvents(EventOperationParams,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -419,9 +419,9 @@ class DefaultTrackedEntityService implements TrackedEntityService {
               EnrollmentParams.TRUE.withIncludeRelationships(false),
               false);
     } else if (item.getEvent() != null) {
-      result.setEvent(
-          eventService.getEvent(
-              item.getEvent().getUid(), EventParams.TRUE.withIncludeRelationships(false)));
+      result =
+          eventService.getEventInRelationshipItem(
+              item.getEvent().getUid(), EventParams.TRUE.withIncludeRelationships(false));
     }
 
     return result;


### PR DESCRIPTION
Same as we did for relationships with TEs, we also don't want to raise an exception in case on of the items of a relationship is an event which is not accessible to the logged in user.

https://dhis2.atlassian.net/browse/DHIS2-16460
