### PR TITLE
Analytics events/enrollments/trackedEntities query APIs: boost sort by dates index performance [2.41-DHIS2-17409-backport]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManager.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import org.hisp.dhis.analytics.AnalyticsTableHookService;
 import org.hisp.dhis.analytics.partition.PartitionManager;
+import org.hisp.dhis.analytics.table.model.AnalyticsColumnType;
 import org.hisp.dhis.analytics.table.model.AnalyticsTableColumn;
 import org.hisp.dhis.analytics.table.model.AnalyticsTablePartition;
 import org.hisp.dhis.analytics.table.model.Skip;
@@ -202,6 +203,7 @@ public abstract class AbstractEventJdbcTableManager extends AbstractJdbcTableMan
           AnalyticsTableColumn.builder()
               .build()
               .withName(attribute.getUid())
+              .withColumnType(AnalyticsColumnType.DYNAMIC)
               .withDataType(dataType)
               .withSelectExpression(sql)
               .withSkipIndex(skipIndex));

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -51,6 +51,7 @@ import org.hisp.dhis.analytics.AnalyticsTablePhase;
 import org.hisp.dhis.analytics.AnalyticsTableType;
 import org.hisp.dhis.analytics.AnalyticsTableUpdateParams;
 import org.hisp.dhis.analytics.partition.PartitionManager;
+import org.hisp.dhis.analytics.table.model.AnalyticsColumnType;
 import org.hisp.dhis.analytics.table.model.AnalyticsTable;
 import org.hisp.dhis.analytics.table.model.AnalyticsTableColumn;
 import org.hisp.dhis.analytics.table.model.AnalyticsTablePartition;
@@ -523,6 +524,7 @@ public abstract class AbstractJdbcTableManager implements AnalyticsTableManager 
               return AnalyticsTableColumn.builder()
                   .build()
                   .withName(name)
+                  .withColumnType(AnalyticsColumnType.DYNAMIC)
                   .withDataType(CHARACTER_11)
                   .withSelectExpression("ougs." + quote(name))
                   .withSkipIndex(skipIndex)
@@ -540,6 +542,7 @@ public abstract class AbstractJdbcTableManager implements AnalyticsTableManager 
               return AnalyticsTableColumn.builder()
                   .build()
                   .withName(name)
+                  .withColumnType(AnalyticsColumnType.DYNAMIC)
                   .withDataType(CHARACTER_11)
                   .withSelectExpression("degs." + quote(name))
                   .withSkipIndex(skipIndex)
@@ -557,6 +560,7 @@ public abstract class AbstractJdbcTableManager implements AnalyticsTableManager 
               return AnalyticsTableColumn.builder()
                   .build()
                   .withName(name)
+                  .withColumnType(AnalyticsColumnType.DYNAMIC)
                   .withDataType(CHARACTER_11)
                   .withSelectExpression("dcs." + quote(name))
                   .withSkipIndex(skipIndex)
@@ -574,6 +578,7 @@ public abstract class AbstractJdbcTableManager implements AnalyticsTableManager 
               return AnalyticsTableColumn.builder()
                   .build()
                   .withName(name)
+                  .withColumnType(AnalyticsColumnType.DYNAMIC)
                   .withDataType(CHARACTER_11)
                   .withSelectExpression("acs." + quote(name))
                   .withSkipIndex(skipIndex)
@@ -591,6 +596,7 @@ public abstract class AbstractJdbcTableManager implements AnalyticsTableManager 
               return AnalyticsTableColumn.builder()
                   .build()
                   .withName(name)
+                  .withColumnType(AnalyticsColumnType.DYNAMIC)
                   .withDataType(CHARACTER_11)
                   .withSelectExpression("dcs." + quote(name))
                   .withSkipIndex(skipIndex)
@@ -608,6 +614,7 @@ public abstract class AbstractJdbcTableManager implements AnalyticsTableManager 
               return AnalyticsTableColumn.builder()
                   .build()
                   .withName(name)
+                  .withColumnType(AnalyticsColumnType.DYNAMIC)
                   .withDataType(CHARACTER_11)
                   .withSelectExpression("acs." + quote(name))
                   .withSkipIndex(skipIndex)

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -63,6 +63,7 @@ import org.hisp.dhis.analytics.AnalyticsTableHookService;
 import org.hisp.dhis.analytics.AnalyticsTableType;
 import org.hisp.dhis.analytics.AnalyticsTableUpdateParams;
 import org.hisp.dhis.analytics.partition.PartitionManager;
+import org.hisp.dhis.analytics.table.model.AnalyticsColumnType;
 import org.hisp.dhis.analytics.table.model.AnalyticsTable;
 import org.hisp.dhis.analytics.table.model.AnalyticsTableColumn;
 import org.hisp.dhis.analytics.table.model.AnalyticsTablePartition;
@@ -608,6 +609,7 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
               AnalyticsTableColumn.builder()
                   .build()
                   .withName(category.getUid())
+                  .withColumnType(AnalyticsColumnType.DYNAMIC)
                   .withDataType(CHARACTER_11)
                   .withSelectExpression("acs." + quote(category.getUid()))
                   .withCreated(category.getCreated()));
@@ -690,6 +692,7 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
         AnalyticsTableColumn.builder()
             .build()
             .withName(attribute.getUid())
+            .withColumnType(AnalyticsColumnType.DYNAMIC)
             .withDataType(dataType)
             .withSelectExpression(sql)
             .withSkipIndex(skipIndex));
@@ -752,6 +755,7 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
         AnalyticsTableColumn.builder()
             .build()
             .withName(dataElement.getUid())
+            .withColumnType(AnalyticsColumnType.DYNAMIC)
             .withDataType(dataType)
             .withSelectExpression(sql)
             .withSkipIndex(skipIndex));
@@ -775,6 +779,7 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
           AnalyticsTableColumn.builder()
               .build()
               .withName((attribute.getUid() + OU_GEOMETRY_COL_SUFFIX))
+              .withColumnType(AnalyticsColumnType.DYNAMIC)
               .withDataType(GEOMETRY)
               .withSelectExpression(geoSql)
               .withIndexType(IndexType.GIST));
@@ -787,6 +792,7 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
         AnalyticsTableColumn.builder()
             .build()
             .withName((attribute.getUid() + OU_NAME_COL_SUFFIX))
+            .withColumnType(AnalyticsColumnType.DYNAMIC)
             .withDataType(TEXT)
             .withSelectExpression(ouNameSql)
             .withSkipIndex(SKIP));
@@ -811,6 +817,7 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
           AnalyticsTableColumn.builder()
               .build()
               .withName((dataElement.getUid() + OU_GEOMETRY_COL_SUFFIX))
+              .withColumnType(AnalyticsColumnType.DYNAMIC)
               .withDataType(GEOMETRY)
               .withSelectExpression(geoSql)
               .withIndexType(IndexType.GIST));
@@ -823,6 +830,7 @@ public class JdbcEventAnalyticsTableManager extends AbstractEventJdbcTableManage
         AnalyticsTableColumn.builder()
             .build()
             .withName((dataElement.getUid() + OU_NAME_COL_SUFFIX))
+            .withColumnType(AnalyticsColumnType.DYNAMIC)
             .withDataType(TEXT)
             .withSelectExpression(ouNameSql)
             .withSkipIndex(SKIP));

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/model/AnalyticsColumnType.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/model/AnalyticsColumnType.java
@@ -1,0 +1,8 @@
+package org.hisp.dhis.analytics.table.model;
+
+public enum AnalyticsColumnType {
+    // Column with static name
+    FIXED,
+    // Column with calculated name (uid)
+    DYNAMIC
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/model/AnalyticsColumnType.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/model/AnalyticsColumnType.java
@@ -1,8 +1,35 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.analytics.table.model;
 
 public enum AnalyticsColumnType {
-    // Column with static name
-    FIXED,
-    // Column with calculated name (uid)
-    DYNAMIC
+  // Column with static name
+  FIXED,
+  // Column with calculated name (uid)
+  DYNAMIC
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/model/AnalyticsColumnType.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/model/AnalyticsColumnType.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.analytics.table.model;
 
 public enum AnalyticsColumnType {
   // Column with static name
-  FIXED,
+  STATIC,
   // Column with calculated name (uid)
   DYNAMIC
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/model/AnalyticsTableColumn.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/model/AnalyticsTableColumn.java
@@ -74,7 +74,10 @@ public class AnalyticsTableColumn {
   /** Index column names, defaults to column name. */
   @With @Builder.Default private final List<String> indexColumns = List.of();
 
+  /** Analytics column type. */
+  @With @Builder.Default private final AnalyticsColumnType columnType = AnalyticsColumnType.FIXED;
   /** Date of creation of the underlying data dimension. */
+
   @With private Date created;
 
   //  // -------------------------------------------------------------------------
@@ -99,6 +102,11 @@ public class AnalyticsTableColumn {
   /** Indicates whether an index should not be created for this column. */
   public boolean isSkipIndex() {
     return Skip.SKIP == skipIndex;
+  }
+
+  /** Indicates column type. */
+  public boolean isDynamicColumn() {
+    return AnalyticsColumnType.DYNAMIC == columnType;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/model/AnalyticsTableColumn.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/model/AnalyticsTableColumn.java
@@ -75,7 +75,7 @@ public class AnalyticsTableColumn {
   @With @Builder.Default private final List<String> indexColumns = List.of();
 
   /** The column type indicates the column origin. */
-  @With @Builder.Default private final AnalyticsColumnType columnType = AnalyticsColumnType.FIXED;
+  @With @Builder.Default private final AnalyticsColumnType columnType = AnalyticsColumnType.STATIC;
 
   /** Date of creation of the underlying data dimension. */
   @With private Date created;
@@ -105,8 +105,8 @@ public class AnalyticsTableColumn {
   }
 
   /** Indicates whether the column type is set to a non-default value. */
-  public boolean isDynamicColumn() {
-    return AnalyticsColumnType.DYNAMIC == columnType;
+  public boolean isStatic() {
+    return AnalyticsColumnType.STATIC == columnType;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/model/AnalyticsTableColumn.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/model/AnalyticsTableColumn.java
@@ -74,7 +74,7 @@ public class AnalyticsTableColumn {
   /** Index column names, defaults to column name. */
   @With @Builder.Default private final List<String> indexColumns = List.of();
 
-  /** Analytics column type. */
+  /** The column type indicates the column origin. */
   @With @Builder.Default private final AnalyticsColumnType columnType = AnalyticsColumnType.FIXED;
 
   /** Date of creation of the underlying data dimension. */

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/model/AnalyticsTableColumn.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/model/AnalyticsTableColumn.java
@@ -76,8 +76,8 @@ public class AnalyticsTableColumn {
 
   /** Analytics column type. */
   @With @Builder.Default private final AnalyticsColumnType columnType = AnalyticsColumnType.FIXED;
-  /** Date of creation of the underlying data dimension. */
 
+  /** Date of creation of the underlying data dimension. */
   @With private Date created;
 
   //  // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/model/AnalyticsTableColumn.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/model/AnalyticsTableColumn.java
@@ -104,7 +104,7 @@ public class AnalyticsTableColumn {
     return Skip.SKIP == skipIndex;
   }
 
-  /** Indicates column type. */
+  /** Indicates whether the column type is set to a non-default value. */
   public boolean isDynamicColumn() {
     return AnalyticsColumnType.DYNAMIC == columnType;
   }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsIndexHelper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsIndexHelper.java
@@ -150,7 +150,7 @@ public class AnalyticsIndexHelper {
     boolean isSingleColumn = indexColumns.size() == 1;
 
     if (column.getDataType() == TEXT
-        && column.isDynamicColumn()
+        && !column.isStatic()
         && isValidUid(columnName)
         && isSingleColumn) {
       String name = indexName + "_lower";
@@ -174,7 +174,7 @@ public class AnalyticsIndexHelper {
 
     boolean isSingleColumn = indexColumns.size() == 1;
 
-    if (column.getDataType() == TIMESTAMP && !column.isDynamicColumn() && isSingleColumn) {
+    if (column.getDataType() == TIMESTAMP && column.isStatic() && isSingleColumn) {
       indexes.add(
           new Index(
               indexName + "_desc",

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsIndexHelper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsIndexHelper.java
@@ -175,9 +175,7 @@ public class AnalyticsIndexHelper {
     String columnName = RegExUtils.removeAll(column.getName(), "\"");
     boolean isSingleColumn = indexColumns.size() == 1;
 
-    if (column.getDataType() == TIMESTAMP
-        && !column.isDynamicColumn()
-        && isSingleColumn) {
+    if (column.getDataType() == TIMESTAMP && !column.isDynamicColumn() && isSingleColumn) {
       indexes.add(
           new Index(
               indexName + "_desc",

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsIndexHelper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsIndexHelper.java
@@ -149,7 +149,10 @@ public class AnalyticsIndexHelper {
     String columnName = RegExUtils.removeAll(column.getName(), "\"");
     boolean isSingleColumn = indexColumns.size() == 1;
 
-    if (column.getDataType() == TEXT && column.isDynamicColumn() && isValidUid(columnName) && isSingleColumn) {
+    if (column.getDataType() == TEXT
+        && column.isDynamicColumn()
+        && isValidUid(columnName)
+        && isSingleColumn) {
       String name = indexName + "_lower";
       indexes.add(
           new Index(
@@ -163,26 +166,29 @@ public class AnalyticsIndexHelper {
   }
 
   private static void maybeAddDateSortOrderIndex(
-          List<Index> indexes,
-          String indexName,
-          String tableName,
-          AnalyticsTableColumn column,
-          List<String> indexColumns) {
+      List<Index> indexes,
+      String indexName,
+      String tableName,
+      AnalyticsTableColumn column,
+      List<String> indexColumns) {
 
     String columnName = RegExUtils.removeAll(column.getName(), "\"");
     boolean isSingleColumn = indexColumns.size() == 1;
 
-    if (column.getDataType() == TIMESTAMP && ("lastupdated".equals(columnName) || !isValidUid(columnName)) && isSingleColumn) {
+    if (column.getDataType() == TIMESTAMP
+        && !column.isDynamicColumn()
+        && isSingleColumn) {
       indexes.add(
-              new Index(
-                      indexName + "_desc",
-                      tableName,
-                      column.getIndexType(),
-                      Unique.NON_UNIQUE,
-                      indexColumns,
-                      "desc nulls last"));
+          new Index(
+              indexName + "_desc",
+              tableName,
+              column.getIndexType(),
+              Unique.NON_UNIQUE,
+              indexColumns,
+              "desc nulls last"));
     }
   }
+
   /**
    * Shortens the given table name.
    *

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsIndexHelper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsIndexHelper.java
@@ -172,7 +172,6 @@ public class AnalyticsIndexHelper {
       AnalyticsTableColumn column,
       List<String> indexColumns) {
 
-    String columnName = RegExUtils.removeAll(column.getName(), "\"");
     boolean isSingleColumn = indexColumns.size() == 1;
 
     if (column.getDataType() == TIMESTAMP && !column.isDynamicColumn() && isSingleColumn) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsIndexHelper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsIndexHelper.java
@@ -31,6 +31,7 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.join;
 import static org.hisp.dhis.common.CodeGenerator.isValidUid;
 import static org.hisp.dhis.db.model.DataType.TEXT;
+import static org.hisp.dhis.db.model.DataType.TIMESTAMP;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -80,6 +81,7 @@ public class AnalyticsIndexHelper {
           indexes.add(new Index(name, partition.getName(), col.getIndexType(), columns));
 
           maybeAddTextLowerIndex(indexes, name, partition.getName(), col, columns);
+          maybeAddDateSortOrderIndex(indexes, name, partition.getName(), col, columns);
         }
       }
     }
@@ -147,7 +149,7 @@ public class AnalyticsIndexHelper {
     String columnName = RegExUtils.removeAll(column.getName(), "\"");
     boolean isSingleColumn = indexColumns.size() == 1;
 
-    if (column.getDataType() == TEXT && isValidUid(columnName) && isSingleColumn) {
+    if (column.getDataType() == TEXT && column.isDynamicColumn() && isValidUid(columnName) && isSingleColumn) {
       String name = indexName + "_lower";
       indexes.add(
           new Index(
@@ -160,11 +162,32 @@ public class AnalyticsIndexHelper {
     }
   }
 
+  private static void maybeAddDateSortOrderIndex(
+          List<Index> indexes,
+          String indexName,
+          String tableName,
+          AnalyticsTableColumn column,
+          List<String> indexColumns) {
+
+    String columnName = RegExUtils.removeAll(column.getName(), "\"");
+    boolean isSingleColumn = indexColumns.size() == 1;
+
+    if (column.getDataType() == TIMESTAMP && ("lastupdated".equals(columnName) || !isValidUid(columnName)) && isSingleColumn) {
+      indexes.add(
+              new Index(
+                      indexName + "_desc",
+                      tableName,
+                      column.getIndexType(),
+                      Unique.NON_UNIQUE,
+                      indexColumns,
+                      "desc nulls last"));
+    }
+  }
   /**
    * Shortens the given table name.
    *
    * @param table the table name
-   * @param tableType the {@link AnayticsTableType}
+   * @param tableType the {@link AnalyticsTableType}
    */
   private static String shortenTableName(String table, AnalyticsTableType tableType) {
     table = table.replace(tableType.getTableName(), "ax");

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/model/Index.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/model/Index.java
@@ -62,6 +62,8 @@ public class Index {
   /** SQL function to use for index columns. Optional, may be null. */
   private final IndexFunction function;
 
+  private final String sortOrder;
+
   /**
    * Constructor.
    *
@@ -77,6 +79,7 @@ public class Index {
     this.columns = columns;
     this.condition = null;
     this.function = null;
+    this.sortOrder = null;
   }
 
   /**
@@ -95,6 +98,7 @@ public class Index {
     this.columns = columns;
     this.condition = null;
     this.function = null;
+    this.sortOrder = null;
   }
 
   /**
@@ -113,10 +117,11 @@ public class Index {
     this.columns = columns;
     this.condition = null;
     this.function = null;
+    this.sortOrder = null;
   }
 
   /**
-   * Constructor.
+   * Constructor. e
    *
    * @param name the index name.
    * @param tableName the index table name.
@@ -139,6 +144,7 @@ public class Index {
     this.columns = columns;
     this.condition = null;
     this.function = function;
+    this.sortOrder = null;
   }
 
   /**
@@ -159,6 +165,24 @@ public class Index {
     this.columns = columns;
     this.condition = condition;
     this.function = null;
+    this.sortOrder = null;
+  }
+
+  public Index(
+      String name,
+      String tableName,
+      IndexType indexType,
+      Unique unique,
+      List<String> columns,
+      String sortOrder) {
+    this.name = name;
+    this.tableName = tableName;
+    this.indexType = indexType;
+    this.unique = unique;
+    this.columns = columns;
+    this.condition = null;
+    this.function = null;
+    this.sortOrder = sortOrder;
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/model/Index.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/model/Index.java
@@ -121,7 +121,7 @@ public class Index {
   }
 
   /**
-   * Constructor. e
+   * Constructor.
    *
    * @param name the index name.
    * @param tableName the index table name.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/model/Index.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/model/Index.java
@@ -168,6 +168,16 @@ public class Index {
     this.sortOrder = null;
   }
 
+  /**
+   * Constructor.
+   *
+   * @param name the index name.
+   * @param tableName the index table name.
+   * @param indexType the index type.
+   * @param unique the uniqueness property.
+   * @param columns the list of index column names.
+   * @param sortOrder the sort order of index.
+   */
   public Index(
       String name,
       String tableName,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/sql/PostgreSqlBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/db/sql/PostgreSqlBuilder.java
@@ -346,9 +346,15 @@ public class PostgreSqlBuilder extends AbstractSqlBuilder {
             .map(col -> toIndexColumn(index, col))
             .collect(Collectors.joining(COMMA));
 
-    return String.format(
-        "create %sindex %s on %s using %s(%s);",
-        unique, quote(index.getName()), quote(tableName), typeName, columns);
+    String sortOrder = index.getSortOrder();
+
+    return sortOrder == null
+        ? String.format(
+            "create %sindex %s on %s using %s(%s);",
+            unique, quote(index.getName()), quote(tableName), typeName, columns)
+        : String.format(
+            "create %sindex %s on %s using %s(%s %s);",
+            unique, quote(index.getName()), quote(tableName), typeName, columns, sortOrder);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/db/sql/PostgreSqlBuilderTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/db/sql/PostgreSqlBuilderTest.java
@@ -384,4 +384,17 @@ class PostgreSqlBuilderTest {
 
     assertEquals(expected, sqlBuilder.createIndex(indexes.get(3)));
   }
+
+  @Test
+  void testCreateIndexWithDescNullsLast(){
+    // given
+    String expected = "create unique index \"index_a\" on \"table_a\" using btree(\"column_a\" desc nulls last);";
+    Index index = new Index("index_a", "table_a", IndexType.BTREE, Unique.UNIQUE, List.of("column_a"), "desc nulls last");
+
+    // when
+    String createIndexStmt = sqlBuilder.createIndex(index);
+
+    // then
+    assertEquals(expected, createIndexStmt);
+  }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/db/sql/PostgreSqlBuilderTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/db/sql/PostgreSqlBuilderTest.java
@@ -386,10 +386,18 @@ class PostgreSqlBuilderTest {
   }
 
   @Test
-  void testCreateIndexWithDescNullsLast(){
+  void testCreateIndexWithDescNullsLast() {
     // given
-    String expected = "create unique index \"index_a\" on \"table_a\" using btree(\"column_a\" desc nulls last);";
-    Index index = new Index("index_a", "table_a", IndexType.BTREE, Unique.UNIQUE, List.of("column_a"), "desc nulls last");
+    String expected =
+        "create unique index \"index_a\" on \"table_a\" using btree(\"column_a\" desc nulls last);";
+    Index index =
+        new Index(
+            "index_a",
+            "table_a",
+            IndexType.BTREE,
+            Unique.UNIQUE,
+            List.of("column_a"),
+            "desc nulls last");
 
     // when
     String createIndexStmt = sqlBuilder.createIndex(index);


### PR DESCRIPTION
**Backport**
In PostgreSQL, creating an index in descending sort order can improve the performance of queries that request results in descending order. In analytics, non-default sort orders are often used to find the last value by date of incident, enrollment, etc. By default, indexes are created with ascending (ASC) sort order. This means that if there is an ORDER BY DESC clause in use, the ascending index can be ignored, resulting in poor performance.