### PR TITLE
fix: Use new start and end date types in tracker exporter [DHIS2-16019]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
@@ -142,6 +142,9 @@ public class DateUtils {
   private static final DateTimeFormatter LONG_DATE_FORMAT =
       DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss");
 
+  private static final DateTimeFormatter LONG_DATE_FORMAT_WITH_MILLIS =
+      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
+
   private static final DateTimeFormatter HTTP_DATE_FORMAT =
       DateTimeFormat.forPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'").withLocale(Locale.ENGLISH);
 
@@ -181,6 +184,16 @@ public class DateUtils {
    */
   public static String toLongGmtDate(Date date) {
     return date != null ? TIMESTAMP_UTC_TZ_FORMAT.print(new DateTime(date)) : null;
+  }
+
+  /**
+   * Formats a Date to the format yyyy-MM-dd HH:mm:ss.SSS.
+   *
+   * @param date the Date to parse.
+   * @return A formatted date string.
+   */
+  public static String toLongDateWithMillis(Date date) {
+    return date != null ? LONG_DATE_FORMAT_WITH_MILLIS.print(new DateTime(date)) : null;
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/HibernateEnrollmentStore.java
@@ -30,7 +30,7 @@ package org.hisp.dhis.tracker.export.enrollment;
 import static org.hisp.dhis.common.IdentifiableObjectUtils.getUids;
 import static org.hisp.dhis.commons.util.TextUtils.getQuotedCommaDelimitedString;
 import static org.hisp.dhis.util.DateUtils.nowMinusDuration;
-import static org.hisp.dhis.util.DateUtils.toLongDate;
+import static org.hisp.dhis.util.DateUtils.toLongDateWithMillis;
 import static org.hisp.dhis.util.DateUtils.toLongGmtDate;
 
 import java.util.List;
@@ -156,7 +156,11 @@ class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enrollment
               + toLongGmtDate(nowMinusDuration(params.getLastUpdatedDuration()))
               + "'";
     } else if (params.hasLastUpdated()) {
-      hql += hlp.whereAnd() + "en.lastUpdated >= '" + toLongDate(params.getLastUpdated()) + "'";
+      hql +=
+          hlp.whereAnd()
+              + "en.lastUpdated >= '"
+              + toLongDateWithMillis(params.getLastUpdated())
+              + "'";
     }
 
     if (params.hasTrackedEntity()) {
@@ -198,13 +202,16 @@ class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enrollment
       hql +=
           hlp.whereAnd()
               + "en.enrollmentDate >= '"
-              + toLongDate(params.getProgramStartDate())
+              + toLongDateWithMillis(params.getProgramStartDate())
               + "'";
     }
 
     if (params.hasProgramEndDate()) {
       hql +=
-          hlp.whereAnd() + "en.enrollmentDate <= '" + toLongDate(params.getProgramEndDate()) + "'";
+          hlp.whereAnd()
+              + "en.enrollmentDate <= '"
+              + toLongDateWithMillis(params.getProgramEndDate())
+              + "'";
     }
 
     if (!params.isIncludeDeleted()) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/HibernateTrackedEntityStore.java
@@ -34,7 +34,7 @@ import static org.hisp.dhis.commons.util.TextUtils.getCommaDelimitedString;
 import static org.hisp.dhis.commons.util.TextUtils.getQuotedCommaDelimitedString;
 import static org.hisp.dhis.system.util.SqlUtils.escape;
 import static org.hisp.dhis.system.util.SqlUtils.quote;
-import static org.hisp.dhis.util.DateUtils.toLongDate;
+import static org.hisp.dhis.util.DateUtils.toLongDateWithMillis;
 import static org.hisp.dhis.util.DateUtils.toLongGmtDate;
 
 import java.util.ArrayList;
@@ -494,14 +494,14 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
         trackedEntity
             .append(whereAnd.whereAnd())
             .append(" TE.lastupdated >= '")
-            .append(toLongDate(params.getLastUpdatedStartDate()))
+            .append(toLongDateWithMillis(params.getLastUpdatedStartDate()))
             .append(SINGLE_QUOTE);
       }
       if (params.hasLastUpdatedEndDate()) {
         trackedEntity
             .append(whereAnd.whereAnd())
             .append(" TE.lastupdated <= '")
-            .append(toLongDate(params.getLastUpdatedEndDate()))
+            .append(toLongDateWithMillis(params.getLastUpdatedEndDate()))
             .append(SINGLE_QUOTE);
       }
     }
@@ -779,28 +779,28 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     if (params.hasProgramEnrollmentStartDate()) {
       program
           .append("AND EN.enrollmentdate >= '")
-          .append(toLongDate(params.getProgramEnrollmentStartDate()))
+          .append(toLongDateWithMillis(params.getProgramEnrollmentStartDate()))
           .append("' ");
     }
 
     if (params.hasProgramEnrollmentEndDate()) {
       program
           .append("AND EN.enrollmentdate <= '")
-          .append(toLongDate(params.getProgramEnrollmentEndDate()))
+          .append(toLongDateWithMillis(params.getProgramEnrollmentEndDate()))
           .append("' ");
     }
 
     if (params.hasProgramIncidentStartDate()) {
       program
           .append("AND EN.occurreddate >= '")
-          .append(toLongDate(params.getProgramIncidentStartDate()))
+          .append(toLongDateWithMillis(params.getProgramIncidentStartDate()))
           .append("' ");
     }
 
     if (params.hasProgramIncidentEndDate()) {
       program
           .append("AND EN.occurreddate <= '")
-          .append(toLongDate(params.getProgramIncidentEndDate()))
+          .append(toLongDateWithMillis(params.getProgramIncidentEndDate()))
           .append("' ");
     }
 
@@ -837,8 +837,8 @@ class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<Tracked
     }
 
     if (params.hasEventStatus()) {
-      String start = toLongDate(params.getEventStartDate());
-      String end = toLongDate(params.getEventEndDate());
+      String start = toLongDateWithMillis(params.getEventStartDate());
+      String end = toLongDateWithMillis(params.getEventEndDate());
 
       if (params.isEventStatus(EventStatus.COMPLETED)) {
         events

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/export/TrackerExportTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/export/TrackerExportTest.java
@@ -469,10 +469,10 @@ public class TrackerExportTest extends TrackerApiTest {
   }
 
   @Test
-  public void shouldReturnFilteredEvent() {
+  public void shouldReturnEventWithEnrollmentOccurredOnADateWhenBeforeAndAfterIsTheSameDate() {
     trackerImportExportActions
         .get(
-            "events?enrollmentOccurredAfter=2019-08-16&enrollmentOccurredBefore=2019-08-19&event=ZwwuwNp6gVd")
+            "events?enrollmentOccurredAfter=2019-08-19&enrollmentOccurredBefore=2019-08-19&event=ZwwuwNp6gVd")
         .validate()
         .statusCode(200)
         .rootPath("events[0]")

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/export/TrackerExportTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/tracker/export/TrackerExportTest.java
@@ -472,7 +472,7 @@ public class TrackerExportTest extends TrackerApiTest {
   public void shouldReturnFilteredEvent() {
     trackerImportExportActions
         .get(
-            "events?enrollmentOccurredAfter=2019-08-16&enrollmentOccurredBefore=2019-08-20&event=ZwwuwNp6gVd")
+            "events?enrollmentOccurredAfter=2019-08-16&enrollmentOccurredBefore=2019-08-19&event=ZwwuwNp6gVd")
         .validate()
         .statusCode(200)
         .rootPath("events[0]")

--- a/dhis-2/dhis-test-e2e/src/test/resources/tracker/importer/teis/teisWithEnrollmentsAndEvents.json
+++ b/dhis-2/dhis-test-e2e/src/test/resources/tracker/importer/teis/teisWithEnrollmentsAndEvents.json
@@ -12,7 +12,7 @@
           "enrollment": "MNWZ6hnuhSw",
           "enrolledAt": "2019-08-19T00:00:00.000",
           "deleted": false,
-          "occurredAt": "2019-08-19T00:00:00.000",
+          "occurredAt": "2019-08-19T12:00:00.000",
           "status": "ACTIVE",
           "notes": [],
           "relationships": [],

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParams.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.webapi.controller.tracker.export.enrollment;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -47,6 +46,8 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.hisp.dhis.webapi.controller.tracker.export.PageRequestParams;
+import org.hisp.dhis.webapi.webdomain.EndDateTime;
+import org.hisp.dhis.webapi.webdomain.StartDateTime;
 
 /** Represents query parameters sent to {@link EnrollmentsExportController}. */
 @OpenApi.Shared(name = "EnrollmentRequestParams")
@@ -109,13 +110,13 @@ public class EnrollmentRequestParams implements PageRequestParams {
 
   private Boolean followUp;
 
-  private Date updatedAfter;
+  private StartDateTime updatedAfter;
 
   private String updatedWithin;
 
-  private Date enrolledAfter;
+  private StartDateTime enrolledAfter;
 
-  private Date enrolledBefore;
+  private EndDateTime enrolledBefore;
 
   @OpenApi.Property({UID.class, TrackedEntityType.class})
   private UID trackedEntityType;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.enrollment;
 
+import static org.hisp.dhis.util.ObjectUtils.applyIfNotNull;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateDeprecatedParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateDeprecatedUidsParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateOrderParams;
@@ -42,6 +43,8 @@ import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams.EnrollmentOperationParamsBuilder;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
+import org.hisp.dhis.webapi.webdomain.EndDateTime;
+import org.hisp.dhis.webapi.webdomain.StartDateTime;
 import org.springframework.stereotype.Component;
 
 /**
@@ -87,24 +90,20 @@ class EnrollmentRequestParamsMapper {
 
     EnrollmentOperationParamsBuilder builder =
         EnrollmentOperationParams.builder()
-            .programUid(
-                enrollmentRequestParams.getProgram() != null
-                    ? enrollmentRequestParams.getProgram().getValue()
-                    : null)
+            .programUid(applyIfNotNull(enrollmentRequestParams.getProgram(), UID::getValue))
             .programStatus(enrollmentRequestParams.getProgramStatus())
             .followUp(enrollmentRequestParams.getFollowUp())
-            .lastUpdated(enrollmentRequestParams.getUpdatedAfter())
+            .lastUpdated(
+                applyIfNotNull(enrollmentRequestParams.getUpdatedAfter(), StartDateTime::toDate))
             .lastUpdatedDuration(enrollmentRequestParams.getUpdatedWithin())
-            .programStartDate(enrollmentRequestParams.getEnrolledAfter())
-            .programEndDate(enrollmentRequestParams.getEnrolledBefore())
+            .programStartDate(
+                applyIfNotNull(enrollmentRequestParams.getEnrolledAfter(), StartDateTime::toDate))
+            .programEndDate(
+                applyIfNotNull(enrollmentRequestParams.getEnrolledBefore(), EndDateTime::toDate))
             .trackedEntityTypeUid(
-                enrollmentRequestParams.getTrackedEntityType() != null
-                    ? enrollmentRequestParams.getTrackedEntityType().getValue()
-                    : null)
+                applyIfNotNull(enrollmentRequestParams.getTrackedEntityType(), UID::getValue))
             .trackedEntityUid(
-                enrollmentRequestParams.getTrackedEntity() != null
-                    ? enrollmentRequestParams.getTrackedEntity().getValue()
-                    : null)
+                applyIfNotNull(enrollmentRequestParams.getTrackedEntity(), UID::getValue))
             .orgUnitUids(UID.toValueSet(orgUnits))
             .orgUnitMode(orgUnitMode)
             .includeDeleted(enrollmentRequestParams.isIncludeDeleted())

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParams.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.webapi.controller.tracker.export.event;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -133,13 +132,13 @@ public class EventRequestParams implements PageRequestParams {
   @OpenApi.Property({UID[].class, User.class})
   private Set<UID> assignedUsers = new HashSet<>();
 
-  private Date occurredAfter;
+  private StartDateTime occurredAfter;
 
-  private Date occurredBefore;
+  private EndDateTime occurredBefore;
 
-  private Date scheduledAfter;
+  private StartDateTime scheduledAfter;
 
-  private Date scheduledBefore;
+  private EndDateTime scheduledBefore;
 
   private StartDateTime updatedAfter;
 
@@ -147,13 +146,13 @@ public class EventRequestParams implements PageRequestParams {
 
   private String updatedWithin;
 
-  private Date enrollmentEnrolledBefore;
+  private EndDateTime enrollmentEnrolledBefore;
 
-  private Date enrollmentEnrolledAfter;
+  private StartDateTime enrollmentEnrolledAfter;
 
-  private Date enrollmentOccurredBefore;
+  private EndDateTime enrollmentOccurredBefore;
 
-  private Date enrollmentOccurredAfter;
+  private StartDateTime enrollmentOccurredAfter;
 
   private EventStatus status;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParams.java
@@ -146,13 +146,13 @@ public class EventRequestParams implements PageRequestParams {
 
   private String updatedWithin;
 
-  private EndDateTime enrollmentEnrolledBefore;
-
   private StartDateTime enrollmentEnrolledAfter;
 
-  private EndDateTime enrollmentOccurredBefore;
+  private EndDateTime enrollmentEnrolledBefore;
 
   private StartDateTime enrollmentOccurredAfter;
+
+  private EndDateTime enrollmentOccurredBefore;
 
   private EventStatus status;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
@@ -126,19 +126,31 @@ class EventRequestParamsMapper {
             .orgUnitMode(orgUnitMode)
             .assignedUserMode(eventRequestParams.getAssignedUserMode())
             .assignedUsers(UID.toValueSet(assignedUsers))
-            .occurredAfter(eventRequestParams.getOccurredAfter())
-            .occurredBefore(eventRequestParams.getOccurredBefore())
-            .scheduledAfter(eventRequestParams.getScheduledAfter())
-            .scheduledBefore(eventRequestParams.getScheduledBefore())
+            .occurredAfter(
+                applyIfNotNull(eventRequestParams.getOccurredAfter(), StartDateTime::toDate))
+            .occurredBefore(
+                applyIfNotNull(eventRequestParams.getOccurredBefore(), EndDateTime::toDate))
+            .scheduledAfter(
+                applyIfNotNull(eventRequestParams.getScheduledAfter(), StartDateTime::toDate))
+            .scheduledBefore(
+                applyIfNotNull(eventRequestParams.getScheduledBefore(), EndDateTime::toDate))
             .updatedAfter(
                 applyIfNotNull(eventRequestParams.getUpdatedAfter(), StartDateTime::toDate))
             .updatedBefore(
                 applyIfNotNull(eventRequestParams.getUpdatedBefore(), EndDateTime::toDate))
             .updatedWithin(eventRequestParams.getUpdatedWithin())
-            .enrollmentEnrolledBefore(eventRequestParams.getEnrollmentEnrolledBefore())
-            .enrollmentEnrolledAfter(eventRequestParams.getEnrollmentEnrolledAfter())
-            .enrollmentOccurredBefore(eventRequestParams.getEnrollmentOccurredBefore())
-            .enrollmentOccurredAfter(eventRequestParams.getEnrollmentOccurredAfter())
+            .enrollmentEnrolledBefore(
+                applyIfNotNull(
+                    eventRequestParams.getEnrollmentEnrolledBefore(), EndDateTime::toDate))
+            .enrollmentEnrolledAfter(
+                applyIfNotNull(
+                    eventRequestParams.getEnrollmentEnrolledAfter(), StartDateTime::toDate))
+            .enrollmentOccurredBefore(
+                applyIfNotNull(
+                    eventRequestParams.getEnrollmentOccurredBefore(), EndDateTime::toDate))
+            .enrollmentOccurredAfter(
+                applyIfNotNull(
+                    eventRequestParams.getEnrollmentOccurredAfter(), StartDateTime::toDate))
             .eventStatus(eventRequestParams.getStatus())
             .attributeCategoryCombo(applyIfNotNull(attributeCategoryCombo, UID::getValue))
             .attributeCategoryOptions(UID.toValueSet(attributeCategoryOptions))

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParams.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.webapi.controller.tracker.export.trackedentity;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -50,6 +49,8 @@ import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.hisp.dhis.webapi.controller.tracker.export.PageRequestParams;
+import org.hisp.dhis.webapi.webdomain.EndDateTime;
+import org.hisp.dhis.webapi.webdomain.StartDateTime;
 
 /**
  * Represents query parameters sent to {@link TrackedEntitiesExportController}.
@@ -136,25 +137,25 @@ public class TrackedEntityRequestParams implements PageRequestParams {
   private Boolean followUp;
 
   /** Start date for last updated. */
-  private Date updatedAfter;
+  private StartDateTime updatedAfter;
 
   /** End date for last updated. */
-  private Date updatedBefore;
+  private EndDateTime updatedBefore;
 
   /** The last updated duration filter. */
   private String updatedWithin;
 
   /** The given Program start date. */
-  private Date enrollmentEnrolledAfter;
+  private StartDateTime enrollmentEnrolledAfter;
 
   /** The given Program end date. */
-  private Date enrollmentEnrolledBefore;
+  private EndDateTime enrollmentEnrolledBefore;
 
   /** Start date for incident in the given program. */
-  private Date enrollmentOccurredAfter;
+  private StartDateTime enrollmentOccurredAfter;
 
   /** End date for incident in the given program. */
-  private Date enrollmentOccurredBefore;
+  private EndDateTime enrollmentOccurredBefore;
 
   /** Only returns Tracked Entity Instances of this type. */
   @OpenApi.Property({UID.class, TrackedEntityType.class})
@@ -195,10 +196,10 @@ public class TrackedEntityRequestParams implements PageRequestParams {
   private EventStatus eventStatus;
 
   /** Start date for Event for the given Program. */
-  private Date eventOccurredAfter;
+  private StartDateTime eventOccurredAfter;
 
   /** End date for Event for the given Program. */
-  private Date eventOccurredBefore;
+  private EndDateTime eventOccurredBefore;
 
   /** Indicates whether to include soft-deleted elements */
   private boolean includeDeleted = false;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.trackedentity;
 
+import static org.hisp.dhis.util.ObjectUtils.applyIfNotNull;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.parseFilters;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateDeprecatedParameter;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamsValidator.validateDeprecatedUidsParameter;
@@ -50,6 +51,8 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.util.ObjectUtils;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
+import org.hisp.dhis.webapi.webdomain.EndDateTime;
+import org.hisp.dhis.webapi.webdomain.StartDateTime;
 import org.springframework.stereotype.Component;
 
 /**
@@ -113,32 +116,39 @@ class TrackedEntityRequestParamsMapper {
 
     TrackedEntityOperationParamsBuilder builder =
         TrackedEntityOperationParams.builder()
-            .programUid(
-                trackedEntityRequestParams.getProgram() == null
-                    ? null
-                    : trackedEntityRequestParams.getProgram().getValue())
+            .programUid(applyIfNotNull(trackedEntityRequestParams.getProgram(), UID::getValue))
             .programStageUid(
-                trackedEntityRequestParams.getProgramStage() == null
-                    ? null
-                    : trackedEntityRequestParams.getProgramStage().getValue())
+                applyIfNotNull(trackedEntityRequestParams.getProgramStage(), UID::getValue))
             .programStatus(trackedEntityRequestParams.getProgramStatus())
             .followUp(trackedEntityRequestParams.getFollowUp())
-            .lastUpdatedStartDate(trackedEntityRequestParams.getUpdatedAfter())
-            .lastUpdatedEndDate(trackedEntityRequestParams.getUpdatedBefore())
+            .lastUpdatedStartDate(
+                applyIfNotNull(trackedEntityRequestParams.getUpdatedAfter(), StartDateTime::toDate))
+            .lastUpdatedEndDate(
+                applyIfNotNull(trackedEntityRequestParams.getUpdatedBefore(), EndDateTime::toDate))
             .lastUpdatedDuration(trackedEntityRequestParams.getUpdatedWithin())
-            .programEnrollmentStartDate(trackedEntityRequestParams.getEnrollmentEnrolledAfter())
-            .programEnrollmentEndDate(trackedEntityRequestParams.getEnrollmentEnrolledBefore())
-            .programIncidentStartDate(trackedEntityRequestParams.getEnrollmentOccurredAfter())
-            .programIncidentEndDate(trackedEntityRequestParams.getEnrollmentOccurredBefore())
+            .programEnrollmentStartDate(
+                applyIfNotNull(
+                    trackedEntityRequestParams.getEnrollmentEnrolledAfter(), StartDateTime::toDate))
+            .programEnrollmentEndDate(
+                applyIfNotNull(
+                    trackedEntityRequestParams.getEnrollmentEnrolledBefore(), EndDateTime::toDate))
+            .programIncidentStartDate(
+                applyIfNotNull(
+                    trackedEntityRequestParams.getEnrollmentOccurredAfter(), StartDateTime::toDate))
+            .programIncidentEndDate(
+                applyIfNotNull(
+                    trackedEntityRequestParams.getEnrollmentOccurredBefore(), EndDateTime::toDate))
             .trackedEntityTypeUid(
-                trackedEntityRequestParams.getTrackedEntityType() == null
-                    ? null
-                    : trackedEntityRequestParams.getTrackedEntityType().getValue())
+                applyIfNotNull(trackedEntityRequestParams.getTrackedEntityType(), UID::getValue))
             .organisationUnits(UID.toValueSet(orgUnitUids))
             .orgUnitMode(orgUnitMode)
             .eventStatus(trackedEntityRequestParams.getEventStatus())
-            .eventStartDate(trackedEntityRequestParams.getEventOccurredAfter())
-            .eventEndDate(trackedEntityRequestParams.getEventOccurredBefore())
+            .eventStartDate(
+                applyIfNotNull(
+                    trackedEntityRequestParams.getEventOccurredAfter(), StartDateTime::toDate))
+            .eventEndDate(
+                applyIfNotNull(
+                    trackedEntityRequestParams.getEventOccurredBefore(), EndDateTime::toDate))
             .assignedUserQueryParam(
                 new AssignedUserQueryParam(
                     trackedEntityRequestParams.getAssignedUserMode(),

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatesBindingTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/DatesBindingTest.java
@@ -66,30 +66,34 @@ class DatesBindingTest {
     mockMvc.perform(get(ENDPOINT).param("end", "2001-06-17")).andExpect(status().isOk());
 
     assertNull(actualStartDateTime);
-    assertEquals("2001-06-17T23:59:59", DateUtils.toLongDate(actualEndDateTime));
+    assertEquals("2001-06-17T23:59:59.999", DateUtils.toLongDateWithMillis(actualEndDateTime));
   }
 
   @Test
   void shouldReturnADateWithTimeWhenAnEndDateIsPassedWithTime() throws Exception {
-    mockMvc.perform(get(ENDPOINT).param("end", "2001-06-17T16:45:34")).andExpect(status().isOk());
+    mockMvc
+        .perform(get(ENDPOINT).param("end", "2001-06-17T16:45:34.324"))
+        .andExpect(status().isOk());
 
     assertNull(actualStartDateTime);
-    assertEquals("2001-06-17T16:45:34", DateUtils.toLongDate(actualEndDateTime));
+    assertEquals("2001-06-17T16:45:34.324", DateUtils.toLongDateWithMillis(actualEndDateTime));
   }
 
   @Test
   void shouldReturnADateAtTheStartOfTheDayWhenAnStartDateIsPassedWithoutTime() throws Exception {
     mockMvc.perform(get(ENDPOINT).param("start", "2001-06-17")).andExpect(status().isOk());
 
-    assertEquals("2001-06-17T00:00:00", DateUtils.toLongDate(actualStartDateTime));
+    assertEquals("2001-06-17T00:00:00.000", DateUtils.toLongDateWithMillis(actualStartDateTime));
     assertNull(actualEndDateTime);
   }
 
   @Test
   void shouldReturnADateWithTimeWhenAnStartDateIsPassedWithTime() throws Exception {
-    mockMvc.perform(get(ENDPOINT).param("start", "2001-06-17T16:45:34")).andExpect(status().isOk());
+    mockMvc
+        .perform(get(ENDPOINT).param("start", "2001-06-17T16:45:34.324"))
+        .andExpect(status().isOk());
 
-    assertEquals("2001-06-17T16:45:34", DateUtils.toLongDate(actualStartDateTime));
+    assertEquals("2001-06-17T16:45:34.324", DateUtils.toLongDateWithMillis(actualStartDateTime));
     assertNull(actualEndDateTime);
   }
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentImportRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentImportRequestParamsMapperTest.java
@@ -40,7 +40,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
@@ -53,6 +52,8 @@ import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentParams;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
+import org.hisp.dhis.webapi.webdomain.EndDateTime;
+import org.hisp.dhis.webapi.webdomain.StartDateTime;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -259,7 +260,7 @@ class EnrollmentImportRequestParamsMapperTest {
   @Test
   void shouldFailWhenEnrolledAfterProvidedAndProgramNotPresent() {
     EnrollmentRequestParams requestParams = new EnrollmentRequestParams();
-    requestParams.setEnrolledAfter(new Date());
+    requestParams.setEnrolledAfter(StartDateTime.of("2020-01-01"));
 
     Exception badRequestException =
         Assertions.assertThrows(BadRequestException.class, () -> mapper.map(requestParams));
@@ -272,7 +273,7 @@ class EnrollmentImportRequestParamsMapperTest {
   @Test
   void shouldFailWhenEnrolledBeforeProvidedAndProgramNotPresent() {
     EnrollmentRequestParams requestParams = new EnrollmentRequestParams();
-    requestParams.setEnrolledBefore(new Date());
+    requestParams.setEnrolledBefore(EndDateTime.of("2020-01-01"));
 
     Exception badRequestException =
         Assertions.assertThrows(BadRequestException.class, () -> mapper.map(requestParams));
@@ -285,7 +286,7 @@ class EnrollmentImportRequestParamsMapperTest {
   @Test
   void shouldFailWhenUpdatedWithinAndUpdatedAfterProvided() {
     EnrollmentRequestParams requestParams = new EnrollmentRequestParams();
-    requestParams.setUpdatedAfter(new Date());
+    requestParams.setUpdatedAfter(StartDateTime.of("2020-01-01"));
     requestParams.setUpdatedWithin("2h");
 
     Exception badRequestException =

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventImportRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventImportRequestParamsMapperTest.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.webapi.controller.tracker.export.event;
 
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.SELECTED;
-import static org.hisp.dhis.util.DateUtils.parseDate;
 import static org.hisp.dhis.utils.Assertions.assertContains;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
@@ -44,7 +43,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -234,30 +232,30 @@ class EventImportRequestParamsMapperTest {
   void testMappingOccurredAfterBefore() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
 
-    Date occurredAfter = parseDate("2020-01-01");
+    StartDateTime occurredAfter = StartDateTime.of("2020-01-01");
     eventRequestParams.setOccurredAfter(occurredAfter);
-    Date occurredBefore = parseDate("2020-09-12");
+    EndDateTime occurredBefore = EndDateTime.of("2020-09-12");
     eventRequestParams.setOccurredBefore(occurredBefore);
 
     EventOperationParams params = mapper.map(eventRequestParams);
 
-    assertEquals(occurredAfter, params.getOccurredAfter());
-    assertEquals(occurredBefore, params.getOccurredBefore());
+    assertEquals(occurredAfter.toDate(), params.getOccurredAfter());
+    assertEquals(occurredBefore.toDate(), params.getOccurredBefore());
   }
 
   @Test
   void testMappingScheduledAfterBefore() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
 
-    Date scheduledAfter = parseDate("2021-01-01");
+    StartDateTime scheduledAfter = StartDateTime.of("2021-01-01");
     eventRequestParams.setScheduledAfter(scheduledAfter);
-    Date scheduledBefore = parseDate("2021-09-12");
+    EndDateTime scheduledBefore = EndDateTime.of("2021-09-12");
     eventRequestParams.setScheduledBefore(scheduledBefore);
 
     EventOperationParams params = mapper.map(eventRequestParams);
 
-    assertEquals(scheduledAfter, params.getScheduledAfter());
-    assertEquals(scheduledBefore, params.getScheduledBefore());
+    assertEquals(scheduledAfter.toDate(), params.getScheduledAfter());
+    assertEquals(scheduledBefore.toDate(), params.getScheduledBefore());
   }
 
   @Test
@@ -309,30 +307,30 @@ class EventImportRequestParamsMapperTest {
   void testMappingEnrollmentEnrolledAtDates() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
 
-    Date enrolledBefore = parseDate("2022-01-01");
+    EndDateTime enrolledBefore = EndDateTime.of("2022-01-01");
     eventRequestParams.setEnrollmentEnrolledBefore(enrolledBefore);
-    Date enrolledAfter = parseDate("2022-02-01");
+    StartDateTime enrolledAfter = StartDateTime.of("2022-02-01");
     eventRequestParams.setEnrollmentEnrolledAfter(enrolledAfter);
 
     EventOperationParams params = mapper.map(eventRequestParams);
 
-    assertEquals(enrolledBefore, params.getEnrollmentEnrolledBefore());
-    assertEquals(enrolledAfter, params.getEnrollmentEnrolledAfter());
+    assertEquals(enrolledBefore.toDate(), params.getEnrollmentEnrolledBefore());
+    assertEquals(enrolledAfter.toDate(), params.getEnrollmentEnrolledAfter());
   }
 
   @Test
   void testMappingEnrollmentOccurredAtDates() throws BadRequestException {
     EventRequestParams eventRequestParams = new EventRequestParams();
 
-    Date enrolledBefore = parseDate("2022-01-01");
+    EndDateTime enrolledBefore = EndDateTime.of("2022-01-01");
     eventRequestParams.setEnrollmentOccurredBefore(enrolledBefore);
-    Date enrolledAfter = parseDate("2022-02-01");
+    StartDateTime enrolledAfter = StartDateTime.of("2022-02-01");
     eventRequestParams.setEnrollmentOccurredAfter(enrolledAfter);
 
     EventOperationParams params = mapper.map(eventRequestParams);
 
-    assertEquals(enrolledBefore, params.getEnrollmentOccurredBefore());
-    assertEquals(enrolledAfter, params.getEnrollmentOccurredAfter());
+    assertEquals(enrolledBefore.toDate(), params.getEnrollmentOccurredBefore());
+    assertEquals(enrolledAfter.toDate(), params.getEnrollmentOccurredAfter());
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityImportRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityImportRequestParamsMapperTest.java
@@ -29,11 +29,9 @@ package org.hisp.dhis.webapi.controller.tracker.export.trackedentity;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hisp.dhis.DhisConvenienceTest.getDate;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ACCESSIBLE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.CAPTURE;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.SELECTED;
-import static org.hisp.dhis.util.DateUtils.parseDate;
 import static org.hisp.dhis.utils.Assertions.assertContains;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
@@ -42,7 +40,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -58,6 +55,8 @@ import org.hisp.dhis.tracker.export.Order;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityOperationParams;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
+import org.hisp.dhis.webapi.webdomain.EndDateTime;
+import org.hisp.dhis.webapi.webdomain.StartDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -103,13 +102,13 @@ class TrackedEntityImportRequestParamsMapperTest {
     trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
     trackedEntityRequestParams.setProgramStage(UID.of(PROGRAM_STAGE_UID));
     trackedEntityRequestParams.setFollowUp(true);
-    trackedEntityRequestParams.setUpdatedAfter(getDate(2019, 1, 1));
-    trackedEntityRequestParams.setUpdatedBefore(getDate(2020, 1, 1));
-    trackedEntityRequestParams.setEnrollmentOccurredAfter(getDate(2019, 5, 5));
-    trackedEntityRequestParams.setEnrollmentOccurredBefore(getDate(2020, 5, 5));
+    trackedEntityRequestParams.setUpdatedAfter(StartDateTime.of("2019-01-01"));
+    trackedEntityRequestParams.setUpdatedBefore(EndDateTime.of("2020-01-01"));
+    trackedEntityRequestParams.setEnrollmentOccurredAfter(StartDateTime.of("2019-05-05"));
+    trackedEntityRequestParams.setEnrollmentOccurredBefore(EndDateTime.of("2020-05-05"));
     trackedEntityRequestParams.setEventStatus(EventStatus.COMPLETED);
-    trackedEntityRequestParams.setEventOccurredAfter(getDate(2019, 7, 7));
-    trackedEntityRequestParams.setEventOccurredBefore(getDate(2020, 7, 7));
+    trackedEntityRequestParams.setEventOccurredAfter(StartDateTime.of("2019-07-07"));
+    trackedEntityRequestParams.setEventOccurredBefore(EndDateTime.of("2020-07-07"));
     trackedEntityRequestParams.setIncludeDeleted(true);
 
     final TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
@@ -117,17 +116,23 @@ class TrackedEntityImportRequestParamsMapperTest {
     assertThat(params.getProgramUid(), is(PROGRAM_UID));
     assertThat(params.getProgramStageUid(), is(PROGRAM_STAGE_UID));
     assertThat(params.getFollowUp(), is(true));
-    assertThat(params.getLastUpdatedStartDate(), is(trackedEntityRequestParams.getUpdatedAfter()));
-    assertThat(params.getLastUpdatedEndDate(), is(trackedEntityRequestParams.getUpdatedBefore()));
+    assertThat(
+        params.getLastUpdatedStartDate(),
+        is(trackedEntityRequestParams.getUpdatedAfter().toDate()));
+    assertThat(
+        params.getLastUpdatedEndDate(), is(trackedEntityRequestParams.getUpdatedBefore().toDate()));
     assertThat(
         params.getProgramIncidentStartDate(),
-        is(trackedEntityRequestParams.getEnrollmentOccurredAfter()));
+        is(trackedEntityRequestParams.getEnrollmentOccurredAfter().toDate()));
     assertThat(
         params.getProgramIncidentEndDate(),
-        is(trackedEntityRequestParams.getEnrollmentOccurredBefore()));
+        is(trackedEntityRequestParams.getEnrollmentOccurredBefore().toDate()));
     assertThat(params.getEventStatus(), is(EventStatus.COMPLETED));
-    assertThat(params.getEventStartDate(), is(trackedEntityRequestParams.getEventOccurredAfter()));
-    assertThat(params.getEventEndDate(), is(trackedEntityRequestParams.getEventOccurredBefore()));
+    assertThat(
+        params.getEventStartDate(),
+        is(trackedEntityRequestParams.getEventOccurredAfter().toDate()));
+    assertThat(
+        params.getEventEndDate(), is(trackedEntityRequestParams.getEventOccurredBefore().toDate()));
     assertThat(
         params.getAssignedUserQueryParam().getMode(), is(AssignedUserSelectionMode.PROVIDED));
     assertThat(params.isIncludeDeleted(), is(true));
@@ -140,8 +145,8 @@ class TrackedEntityImportRequestParamsMapperTest {
     trackedEntityRequestParams.setUpdatedWithin("20h");
     trackedEntityRequestParams.setTrackedEntityType(UID.of(TRACKED_ENTITY_TYPE_UID));
     trackedEntityRequestParams.setEventStatus(EventStatus.COMPLETED);
-    trackedEntityRequestParams.setEventOccurredAfter(getDate(2019, 7, 7));
-    trackedEntityRequestParams.setEventOccurredBefore(getDate(2020, 7, 7));
+    trackedEntityRequestParams.setEventOccurredAfter(StartDateTime.of("2019-07-07"));
+    trackedEntityRequestParams.setEventOccurredBefore(EndDateTime.of("2020-07-07"));
     trackedEntityRequestParams.setIncludeDeleted(true);
 
     final TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
@@ -156,8 +161,11 @@ class TrackedEntityImportRequestParamsMapperTest {
         params.getProgramIncidentEndDate(),
         is(trackedEntityRequestParams.getEnrollmentOccurredBefore()));
     assertThat(params.getEventStatus(), is(EventStatus.COMPLETED));
-    assertThat(params.getEventStartDate(), is(trackedEntityRequestParams.getEventOccurredAfter()));
-    assertThat(params.getEventEndDate(), is(trackedEntityRequestParams.getEventOccurredBefore()));
+    assertThat(
+        params.getEventStartDate(),
+        is(trackedEntityRequestParams.getEventOccurredAfter().toDate()));
+    assertThat(
+        params.getEventEndDate(), is(trackedEntityRequestParams.getEventOccurredBefore().toDate()));
     assertThat(
         params.getAssignedUserQueryParam().getMode(), is(AssignedUserSelectionMode.PROVIDED));
     assertThat(params.isIncludeDeleted(), is(true));
@@ -209,13 +217,13 @@ class TrackedEntityImportRequestParamsMapperTest {
 
   @Test
   void testMappingProgramEnrollmentStartDate() throws BadRequestException {
-    Date date = parseDate("2022-12-13");
-    trackedEntityRequestParams.setEnrollmentEnrolledAfter(date);
+    StartDateTime startDate = StartDateTime.of("2022-12-13");
+    trackedEntityRequestParams.setEnrollmentEnrolledAfter(startDate);
     trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
 
     TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, user);
 
-    assertEquals(date, params.getProgramEnrollmentStartDate());
+    assertEquals(startDate.toDate(), params.getProgramEnrollmentStartDate());
   }
 
   @Test
@@ -285,15 +293,15 @@ class TrackedEntityImportRequestParamsMapperTest {
   @Test
   void shouldFailIfGivenStatusAndOccurredAfterEventDateButNoOccurredBeforeEventDate() {
     trackedEntityRequestParams.setEventStatus(EventStatus.ACTIVE);
-    trackedEntityRequestParams.setEventOccurredAfter(new Date());
+    trackedEntityRequestParams.setEventOccurredAfter(StartDateTime.of("2020-10-10"));
 
     assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, user));
   }
 
   @Test
   void shouldFailIfGivenOccurredEventDatesAndNotEventStatus() {
-    trackedEntityRequestParams.setEventOccurredBefore(new Date());
-    trackedEntityRequestParams.setEventOccurredAfter(new Date());
+    trackedEntityRequestParams.setEventOccurredBefore(EndDateTime.of("2020-11-11"));
+    trackedEntityRequestParams.setEventOccurredAfter(StartDateTime.of("2020-10-10"));
 
     assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, user));
   }


### PR DESCRIPTION
- Make all relevant date parameters use new `StartDateTime` and `EndDateTime` types
- Format dates in queries using `yyyy-MM-dd HH:mm:ss.SSS` format including milliseconds
- Modified a simple e2e test to prove that the `EndDateTime` default time is set to end of the day

**Next PR**
- Update OpenApi