### PR TITLE
chore: OpenAPI - remove @Tags (and replace it with @Document where needed)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/OpenApi.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/OpenApi.java
@@ -158,20 +158,6 @@ public @interface OpenApi {
     Class<?>[] excludes() default {};
   }
 
-  /**
-   * When annotated on type level the tags are added to all endpoints of the controller.
-   *
-   * <p>When annotated on method level the tags are added to the annotated endpoint (operation).
-   *
-   * <p>Tags can be used to split generation into multiple OpenAPI document.
-   */
-  @Inherited
-  @Target({ElementType.METHOD, ElementType.TYPE})
-  @Retention(RetentionPolicy.RUNTIME)
-  @interface Tags {
-    String[] value();
-  }
-
   @Target({ElementType.METHOD, ElementType.TYPE})
   @Retention(RetentionPolicy.RUNTIME)
   @interface Document {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/OpenApiControllerTest.java
@@ -99,7 +99,7 @@ class OpenApiControllerTest extends DhisControllerConvenienceTest {
                 "/api/users/invites",
                 "/api/users/sharing"));
     assertLessOrEqual(151, doc.getObject("paths").size());
-    assertLessOrEqual(70, doc.getObject("components.schemas").size());
+    assertLessOrEqual(80, doc.getObject("components.schemas").size());
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AccountController.java
@@ -94,7 +94,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags({"user", "login"})
+@OpenApi.Document(domain = User.class)
 @Controller
 @RequestMapping("/api/account")
 @Slf4j

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AggregateDataExchangeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AggregateDataExchangeController.java
@@ -35,6 +35,7 @@ import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dataexchange.aggregate.AggregateDataExchange;
 import org.hisp.dhis.dataexchange.aggregate.AggregateDataExchangeService;
 import org.hisp.dhis.dataexchange.aggregate.SourceDataQueryParams;
+import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.dxf2.datavalueset.DataValueSet;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
@@ -54,7 +55,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = DataValue.class)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/aggregateDataExchanges")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AnalyticsController.java
@@ -48,6 +48,7 @@ import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.cache.CacheStrategy;
+import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.dxf2.datavalueset.DataValueSet;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.security.RequiresAuthority;
@@ -61,7 +62,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("analytics")
+@OpenApi.Document(domain = DataValue.class)
 @Controller
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
 @AllArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AnalyticsTableHookController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AnalyticsTableHookController.java
@@ -28,14 +28,12 @@
 package org.hisp.dhis.webapi.controller;
 
 import org.hisp.dhis.analytics.AnalyticsTableHook;
-import org.hisp.dhis.common.OpenApi;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("analytics")
 @Controller
 @RequestMapping("/api/analyticsTableHooks")
 public class AnalyticsTableHookController extends AbstractCrudController<AnalyticsTableHook> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
@@ -93,7 +93,7 @@ import org.springframework.web.multipart.MultipartFile;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("ui")
+@OpenApi.Document(domain = App.class)
 @Controller
 @RequestMapping("/api/apps")
 @Slf4j

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppHubController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppHubController.java
@@ -35,6 +35,7 @@ import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.apphub.AppHubService;
+import org.hisp.dhis.appmanager.App;
 import org.hisp.dhis.appmanager.AppManager;
 import org.hisp.dhis.appmanager.AppStatus;
 import org.hisp.dhis.common.DhisApiVersion;
@@ -55,7 +56,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @author Zubair Asghar
  */
-@OpenApi.Tags("ui")
+@OpenApi.Document(domain = App.class)
 @RestController
 @RequestMapping("/api/appHub")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AttributeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AttributeController.java
@@ -28,14 +28,12 @@
 package org.hisp.dhis.webapi.controller;
 
 import org.hisp.dhis.attribute.Attribute;
-import org.hisp.dhis.common.OpenApi;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/attributes")
 public class AttributeController extends AbstractCrudController<Attribute> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChangeLogController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChangeLogController.java
@@ -43,6 +43,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.audit.Audit;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.common.DhisApiVersion;
@@ -107,7 +108,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = Audit.class)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/audits")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CompleteDataSetRegistrationController.java
@@ -54,6 +54,7 @@ import org.hisp.dhis.dataset.CompleteDataSetRegistration;
 import org.hisp.dhis.dataset.CompleteDataSetRegistrationService;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetService;
+import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.dataset.CompleteDataSetRegistrationExchangeService;
 import org.hisp.dhis.dxf2.dataset.ExportParams;
@@ -90,7 +91,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  * @author Halvdan Hoem Grelland <halvdan@dhis2.org>
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = DataValue.class)
 @Controller
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
 @RequestMapping("/api/completeDataSetRegistrations")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ConfigurationController.java
@@ -75,7 +75,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("system")
+@OpenApi.Document(domain = Configuration.class)
 @Controller
 @RequestMapping("/api/configuration")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ConstantController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ConstantController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.constant.Constant;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,7 +34,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/constants")
 public class ConstantController extends AbstractCrudController<Constant> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardController.java
@@ -32,7 +32,6 @@ import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 
 import java.util.List;
 import java.util.Set;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dashboard.Dashboard;
 import org.hisp.dhis.dashboard.DashboardItem;
 import org.hisp.dhis.dashboard.DashboardItemType;
@@ -59,7 +58,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("ui")
 @Controller
 @RequestMapping("/api/dashboards")
 public class DashboardController extends AbstractCrudController<Dashboard> {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardItemController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardItemController.java
@@ -51,7 +51,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("ui")
+@OpenApi.Document(domain = Dashboard.class)
 @Controller
 @RequestMapping("/api/dashboardItems")
 public class DashboardItemController extends AbstractCrudController<DashboardItem> {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataAnalysisController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataAnalysisController.java
@@ -110,7 +110,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 /**
  * @author Joao Antunes
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = ValidationRule.class)
 @Controller
 @RequestMapping("/api/dataAnalysis")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataApprovalController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataApprovalController.java
@@ -61,6 +61,7 @@ import org.hisp.dhis.dataapproval.DataApprovalStatus;
 import org.hisp.dhis.dataapproval.DataApprovalWorkflow;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetService;
+import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
@@ -102,7 +103,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
  *
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = DataValue.class)
 @Controller
 @RequestMapping("/api/dataApprovals")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataApprovalLevelController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataApprovalLevelController.java
@@ -27,14 +27,12 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dataapproval.DataApprovalLevel;
 import org.hisp.dhis.dataapproval.DataApprovalLevelService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/dataApprovalLevels")
 public class DataApprovalLevelController extends AbstractCrudController<DataApprovalLevel> {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataApprovalWorkflowController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataApprovalWorkflowController.java
@@ -27,12 +27,10 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dataapproval.DataApprovalWorkflow;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/dataApprovalWorkflows")
 public class DataApprovalWorkflowController extends AbstractCrudController<DataApprovalWorkflow> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataEntryFormController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataEntryFormController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dataentryform.DataEntryForm;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,7 +34,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/dataEntryForms")
 public class DataEntryFormController extends AbstractCrudController<DataEntryForm> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataIntegrityController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataIntegrityController.java
@@ -72,7 +72,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Halvdan Hoem Grelland <halvdanhg@gmail.com>
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = DataIntegrityCheck.class)
 @Controller
 @RequestMapping("/api/dataIntegrity")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetController.java
@@ -65,7 +65,6 @@ import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.DisplayDensity;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.commons.jackson.domain.JsonRoot;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataentryform.DataEntryForm;
@@ -113,7 +112,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/dataSets")
 public class DataSetController extends AbstractCrudController<DataSet> {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetReportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataSetReportController.java
@@ -62,7 +62,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Stian Sandvold
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = DataSet.class)
 @Controller
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
 public class DataSetReportController {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
@@ -58,6 +58,7 @@ import org.hisp.dhis.common.Compression;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.datavalue.DataExportParams;
+import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.dxf2.adx.AdxDataService;
 import org.hisp.dhis.dxf2.adx.AdxException;
 import org.hisp.dhis.dxf2.common.ImportOptions;
@@ -92,7 +93,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = DataValue.class)
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/api/dataValueSets")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DatastoreController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DatastoreController.java
@@ -71,7 +71,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 /**
  * @author Stian Sandvold
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = DatastoreEntry.class)
 @Controller
 @RequestMapping("/api/dataStore")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DeletedObjectController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DeletedObjectController.java
@@ -51,7 +51,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = DeletedObject.class)
 @RestController
 @RequestMapping("/api/deletedObjects")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DocumentController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DocumentController.java
@@ -35,7 +35,6 @@ import java.io.InputStream;
 import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.document.Document;
 import org.hisp.dhis.document.DocumentService;
@@ -58,7 +57,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("metadata")
 @Controller
 @Slf4j
 @RequestMapping("/api/documents")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EmailController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EmailController.java
@@ -60,7 +60,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Halvdan Hoem Grelland <halvdanhg@gmail.com>
  */
-@OpenApi.Tags("messaging")
+@OpenApi.Document(domain = Email.class)
 @Controller
 @RequestMapping("/api/email")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EnrollmentAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EnrollmentAnalyticsController.java
@@ -57,6 +57,7 @@ import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.RequestTypeAware;
 import org.hisp.dhis.common.RequestTypeAware.EndpointAction;
 import org.hisp.dhis.common.cache.CacheStrategy;
+import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.period.PeriodDataProvider;
 import org.hisp.dhis.period.RelativePeriodEnum;
 import org.hisp.dhis.security.RequiresAuthority;
@@ -79,7 +80,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Markus Bekken
  */
-@OpenApi.Tags("analytics")
+@OpenApi.Document(domain = DataValue.class)
 @Controller
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
 @RequestMapping("/api/analytics/enrollments")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EventAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EventAnalyticsController.java
@@ -58,6 +58,7 @@ import org.hisp.dhis.common.PrefixedDimension;
 import org.hisp.dhis.common.RequestTypeAware;
 import org.hisp.dhis.common.RequestTypeAware.EndpointAction;
 import org.hisp.dhis.common.cache.CacheStrategy;
+import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorMessage;
 import org.hisp.dhis.period.RelativePeriodEnum;
@@ -82,7 +83,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("analytics")
+@OpenApi.Document(domain = DataValue.class)
 @Controller
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
 @AllArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ExpressionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ExpressionController.java
@@ -34,6 +34,7 @@ import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.webmessage.DescriptiveWebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
+import org.hisp.dhis.expression.Expression;
 import org.hisp.dhis.expression.ExpressionService;
 import org.hisp.dhis.expression.ExpressionValidationOutcome;
 import org.hisp.dhis.feedback.Status;
@@ -50,7 +51,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("analytics")
+@OpenApi.Document(domain = Expression.class)
 @Controller
 @RequestMapping("/api/expressions")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ExpressionDimensionItemController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ExpressionDimensionItemController.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.webapi.controller;
 
 import org.hisp.dhis.common.DhisApiVersion;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.expressiondimensionitem.ExpressionDimensionItem;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -36,7 +35,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /** CRUD Controller for ExpressionDimensionItem entity */
-@OpenApi.Tags("analytics")
 @Controller
 @RequestMapping("/api/expressionDimensionItems")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ExternalFileResourceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ExternalFileResourceController.java
@@ -58,7 +58,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Stian Sandvold
  */
-@OpenApi.Tags("system")
+@OpenApi.Document(domain = ExternalFileResource.class)
 @Controller
 @RequestMapping("/api/externalFileResources")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileController.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.setting.SettingKey;
+import org.hisp.dhis.setting.SystemSetting;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.ContextUtils;
@@ -58,7 +59,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("system")
+@OpenApi.Document(domain = SystemSetting.class)
 @Controller
 @RequestMapping("/api/files")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
@@ -75,7 +75,6 @@ import org.springframework.web.multipart.MultipartFile;
 /**
  * @author Halvdan Hoem Grelland
  */
-@OpenApi.Tags("system")
 @RestController
 @RequestMapping("/api/fileResources")
 @Slf4j

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/GeoJsonImportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/GeoJsonImportController.java
@@ -48,6 +48,7 @@ import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.feedback.Status;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobConfigurationService;
 import org.hisp.dhis.scheduling.JobSchedulerService;
@@ -69,7 +70,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @author Jan Bernitt
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = OrganisationUnit.class)
 @RequestMapping("/api/organisationUnits")
 @RestController
 @RequiredArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/I18nController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/I18nController.java
@@ -47,7 +47,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("ui")
+@OpenApi.Document(domain = I18n.class)
 @Controller
 @RequestMapping("/api/i18n")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IdentifiableObjectController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IdentifiableObjectController.java
@@ -33,7 +33,6 @@ import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.user.CurrentUser;
@@ -47,7 +46,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/identifiableObjects")
 public class IdentifiableObjectController extends AbstractCrudController<IdentifiableObject> {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IndexController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IndexController.java
@@ -35,6 +35,7 @@ import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.setting.SettingKey;
+import org.hisp.dhis.setting.SystemSetting;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.hisp.dhis.webapi.utils.ContextUtils;
@@ -47,7 +48,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("system")
+@OpenApi.Document(domain = SystemSetting.class)
 @Controller
 public class IndexController {
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/InterpretationController.java
@@ -40,7 +40,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.AnalyticalObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
@@ -87,7 +86,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("ui")
 @Controller
 @RequestMapping("/api/interpretations")
 public class InterpretationController extends AbstractCrudController<Interpretation> {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LegendSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LegendSetController.java
@@ -34,7 +34,6 @@ import static org.hisp.dhis.security.Authorities.F_LEGEND_SET_PUBLIC_ADD;
 import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ForbiddenException;
@@ -51,7 +50,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("ui")
 @Controller
 @RequestMapping("/api/legendSets")
 public class LegendSetController extends AbstractCrudController<LegendSet> {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LocaleController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LocaleController.java
@@ -44,6 +44,7 @@ import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
+import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.i18n.I18nLocaleService;
 import org.hisp.dhis.i18n.locale.I18nLocale;
 import org.hisp.dhis.i18n.locale.LocaleManager;
@@ -66,7 +67,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-@OpenApi.Tags("ui")
+@OpenApi.Document(domain = I18n.class)
 @Controller
 @RequestMapping("/api/locales")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LockExceptionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LockExceptionController.java
@@ -39,7 +39,6 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.PagerUtils;
 import org.hisp.dhis.dataset.DataSet;
@@ -87,7 +86,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 /**
  * @author Viet Nguyen <viet@dhis2.org>
  */
-@OpenApi.Tags("data")
 @Controller
 @RequestMapping("/api/lockExceptions")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MaintenanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MaintenanceController.java
@@ -67,7 +67,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("system")
+@OpenApi.Document(domain = Server.class)
 @Controller
 @RequestMapping("/api/maintenance")
 @RequiresAuthority(anyOf = F_PERFORM_MAINTENANCE)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MenuController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MenuController.java
@@ -45,7 +45,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-@OpenApi.Tags("ui")
+@OpenApi.Document(domain = User.class)
 @Controller
 @RequestMapping("/api/menu")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MessageConversationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MessageConversationController.java
@@ -47,7 +47,6 @@ import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
@@ -110,7 +109,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("messaging")
 @Controller
 @RequestMapping("/api/messageConversations")
 @RequiredArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxDataElementController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxDataElementController.java
@@ -70,7 +70,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Viet Nguyen <viet@dhis2.org>
  */
-@OpenApi.Tags("analytics")
+@OpenApi.Document(domain = DataElement.class)
 @Controller
 @RequestMapping("/api/minMaxDataElements")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxValueGenerationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxValueGenerationController.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.dataanalysis.MinMaxDataAnalysisService;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetService;
+import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.minmax.MinMaxDataElementService;
 import org.hisp.dhis.minmax.MinMaxValueParams;
@@ -65,7 +66,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
  *
  * @author Joao Antunes
  */
-@OpenApi.Tags("analytics")
+@OpenApi.Document(domain = DataValue.class)
 @Controller
 @RequestMapping("/api/minMaxValues")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/OAuth2ClientController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/OAuth2ClientController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.security.oauth2.OAuth2Client;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,7 +34,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags({"user", "login"})
 @Controller
 @RequestMapping("/api/oAuth2Clients")
 public class OAuth2ClientController extends AbstractCrudController<OAuth2Client> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/OrgUnitAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/OrgUnitAnalyticsController.java
@@ -36,6 +36,7 @@ import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.cache.CacheStrategy;
+import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.system.grid.GridUtils;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.UserSettingKey;
@@ -50,7 +51,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("analytics")
+@OpenApi.Document(domain = DataValue.class)
 @Controller
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
 public class OrgUnitAnalyticsController {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PdfFormController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PdfFormController.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.commons.util.StreamUtils;
+import org.hisp.dhis.dataentryform.DataEntryForm;
 import org.hisp.dhis.dataset.DataSetService;
 import org.hisp.dhis.dxf2.common.ImportOptions;
 import org.hisp.dhis.dxf2.datavalueset.DataValueSetService;
@@ -71,7 +72,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author James Chang <jamesbchang@gmail.com>
  */
-@OpenApi.Tags("ui")
+@OpenApi.Document(domain = DataEntryForm.class)
 @Controller
 @RequestMapping("/api/pdfForm")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PeriodTypeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PeriodTypeController.java
@@ -37,6 +37,7 @@ import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.commons.jackson.domain.JsonRoot;
 import org.hisp.dhis.fieldfiltering.FieldFilterParams;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
+import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.RelativePeriodEnum;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.webdomain.PeriodType;
@@ -49,7 +50,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
+@OpenApi.Document(domain = Period.class)
 @RestController
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
 @RequestMapping("/api/periodTypes")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictionController.java
@@ -42,6 +42,7 @@ import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.feedback.Status;
 import org.hisp.dhis.predictor.PredictionService;
 import org.hisp.dhis.predictor.PredictionSummary;
+import org.hisp.dhis.predictor.Predictor;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobConfigurationService;
 import org.hisp.dhis.scheduling.JobSchedulerService;
@@ -61,7 +62,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Jim Grace
  */
-@OpenApi.Tags("analytics")
+@OpenApi.Document(domain = Predictor.class)
 @Controller
 @RequestMapping("/api/predictions")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictorController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictorController.java
@@ -36,7 +36,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import java.util.Date;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.common.TranslateParams;
 import org.hisp.dhis.dxf2.webmessage.DescriptiveWebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
@@ -63,7 +62,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Ken Haase (ken@dhis2.org)
  */
-@OpenApi.Tags("metadata")
 @Controller
 @Slf4j
 @RequestMapping("/api/predictors")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictorGroupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictorGroupController.java
@@ -33,7 +33,6 @@ import static org.hisp.dhis.security.Authorities.F_PREDICTOR_RUN;
 
 import java.util.Date;
 import java.util.List;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.common.TranslateParams;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.predictor.PredictionService;
@@ -52,7 +51,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Jim Grace
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/predictorGroups")
 public class PredictorGroupController extends AbstractCrudController<PredictorGroup> {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ProgramStageWorkingListController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ProgramStageWorkingListController.java
@@ -28,13 +28,11 @@
 package org.hisp.dhis.webapi.controller;
 
 import org.hisp.dhis.common.DhisApiVersion;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.programstageworkinglist.ProgramStageWorkingList;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@OpenApi.Tags("tracker")
 @Controller
 @RequestMapping("/api/programStageWorkingLists")
 @ApiVersion(include = {DhisApiVersion.ALL, DhisApiVersion.DEFAULT})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PrometheusScrapeEndpointController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PrometheusScrapeEndpointController.java
@@ -44,7 +44,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Luciano Fiandesio
  */
-@OpenApi.Tags("system")
+@OpenApi.Document(domain = Server.class)
 @Profile("!test")
 @Controller
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PushAnalysisController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PushAnalysisController.java
@@ -34,7 +34,6 @@ import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.DhisApiVersion;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.feedback.ConflictException;
@@ -61,7 +60,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 /**
  * @author Stian Sandvold
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/pushAnalysis")
 @Slf4j

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportController.java
@@ -39,7 +39,6 @@ import javax.servlet.http.HttpServletResponse;
 import net.sf.jasperreports.engine.JasperPrint;
 import net.sf.jasperreports.j2ee.servlets.BaseHttpServlet;
 import net.sf.jasperreports.j2ee.servlets.ImageServlet;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -69,7 +68,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/reports")
 public class ReportController extends AbstractCrudController<Report> {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTemplateController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ReportTemplateController.java
@@ -36,6 +36,7 @@ import org.apache.commons.io.IOUtils;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.cache.CacheStrategy;
+import org.hisp.dhis.report.Report;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,7 +47,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("analytics")
+@OpenApi.Document(domain = Report.class)
 @Controller
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
 public class ReportTemplateController {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/RequestInfoController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/RequestInfoController.java
@@ -44,7 +44,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
  *
  * @author Jan Bernitt
  */
-@OpenApi.Tags("system")
+@OpenApi.Document(domain = Server.class)
 @Controller
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
 @RequestMapping("/api/request")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ResourceTableController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ResourceTableController.java
@@ -75,7 +75,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
  * @author Lars Helge Overland. This is the AnalyticsExportController
  */
 @Slf4j
-@OpenApi.Tags("analytics")
+@OpenApi.Document(domain = Server.class)
 @Controller
 @RequestMapping("/api/resourceTables")
 @ApiVersion({DEFAULT, ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/RouteController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/RouteController.java
@@ -32,7 +32,6 @@ import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.DhisApiVersion;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
@@ -51,7 +50,6 @@ import org.springframework.web.bind.annotation.RestController;
  * @author Morten Olav Hansen
  */
 @RestController
-@OpenApi.Tags("integration")
 @RequiredArgsConstructor
 @RequestMapping("/api/routes")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SchemaController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SchemaController.java
@@ -64,7 +64,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("system")
+@OpenApi.Document(domain = Server.class)
 @RestController
 @RequestMapping("/api/schemas")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SectionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SectionController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dataset.Section;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,7 +34,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/sections")
 public class SectionController extends AbstractCrudController<Section> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/Server.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2024, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,41 +27,9 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import java.util.List;
-import org.hisp.dhis.common.DhisApiVersion;
-import org.hisp.dhis.common.IllegalQueryException;
-import org.hisp.dhis.programstagefilter.EventFilter;
-import org.hisp.dhis.programstagefilter.EventFilterService;
-import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 /**
- * @author Ameen Mohamed <ameen@dhis2.org>
+ * This is just a namespace to group some controller that do not fit with a particular domain
+ *
+ * @author Jan Bernitt
  */
-@RestController
-@RequestMapping("/api/eventFilters")
-@ApiVersion(include = {DhisApiVersion.ALL, DhisApiVersion.DEFAULT})
-public class EventFilterController extends AbstractCrudController<EventFilter> {
-  private final EventFilterService eventFilterService;
-
-  public EventFilterController(EventFilterService eventFilterService) {
-    this.eventFilterService = eventFilterService;
-  }
-
-  @Override
-  public void preCreateEntity(EventFilter eventFilter) {
-    List<String> errors = eventFilterService.validate(eventFilter);
-    if (!errors.isEmpty()) {
-      throw new IllegalQueryException(errors.toString());
-    }
-  }
-
-  @Override
-  public void preUpdateEntity(EventFilter oldEventFilter, EventFilter newEventFilter) {
-    List<String> errors = eventFilterService.validate(newEventFilter);
-    if (!errors.isEmpty()) {
-      throw new IllegalQueryException(errors.toString());
-    }
-  }
-}
+public final class Server {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SharingController.java
@@ -89,7 +89,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
+@OpenApi.Document(domain = Sharing.class)
 @Controller
 @RequestMapping("/api/sharing")
 @Slf4j

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SqlViewController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SqlViewController.java
@@ -40,7 +40,6 @@ import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridResponse;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
@@ -70,7 +69,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("system")
 @Controller
 @RequestMapping("/api/sqlViews")
 @RequiredArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/StaticContentController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/StaticContentController.java
@@ -89,7 +89,7 @@ import org.springframework.web.multipart.MultipartFile;
  *
  * @author Stian Sandvold
  */
-@OpenApi.Tags("system")
+@OpenApi.Document(domain = Server.class)
 @RestController
 @RequestMapping("/api/staticContent")
 @Slf4j

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/StaticRenderingConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/StaticRenderingConfigurationController.java
@@ -37,7 +37,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@OpenApi.Tags("system")
+@OpenApi.Document(domain = Server.class)
 @RestController
 @RequestMapping("/api/staticConfiguration/")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SvgConversionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SvgConversionController.java
@@ -53,7 +53,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@OpenApi.Tags("system")
+@OpenApi.Document(domain = Server.class)
 @Controller
 @RequestMapping
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SynchronizationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SynchronizationController.java
@@ -56,7 +56,7 @@ import org.springframework.web.client.RestTemplate;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = Server.class)
 @Controller
 @RequestMapping("/api/synchronization")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemController.java
@@ -89,7 +89,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("system")
+@OpenApi.Document(domain = Server.class)
 @Controller
 @RequestMapping("/api/system")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemSettingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemSettingController.java
@@ -53,6 +53,7 @@ import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.setting.SettingKey;
+import org.hisp.dhis.setting.SystemSetting;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.user.CurrentUser;
 import org.hisp.dhis.user.UserDetails;
@@ -79,7 +80,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
  * @author Lars Helge Overland
  * @author David Katuscak <katuscak.d@gmail.com>
  */
-@OpenApi.Tags("system")
+@OpenApi.Document(domain = SystemSetting.class)
 @Controller
 @RequestMapping("/api/systemSettings")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/TokenController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/TokenController.java
@@ -50,7 +50,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags({"user", "login"})
+@OpenApi.Document(domain = Server.class)
 @Controller
 @RequestMapping("/api/tokens")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/TrackedEntityFilterController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/TrackedEntityFilterController.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.webapi.controller;
 import java.util.List;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.IllegalQueryException;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.trackedentityfilter.TrackedEntityFilter;
 import org.hisp.dhis.trackedentityfilter.TrackedEntityFilterService;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -40,7 +39,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Abyot Asalefew Gizaw <abyota@gmail.com>
  */
-@OpenApi.Tags("tracker")
 @Controller
 @RequestMapping("/api/trackedEntityInstanceFilters")
 @ApiVersion(include = {DhisApiVersion.ALL, DhisApiVersion.DEFAULT})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserDatastoreController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserDatastoreController.java
@@ -68,7 +68,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Stian Sandvold
  */
-@OpenApi.Tags({"user", "query"})
+@OpenApi.Document(domain = UserDatastoreEntry.class)
 @Controller
 @RequestMapping("/api/userDataStore")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationController.java
@@ -44,7 +44,6 @@ import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.DataDimensionItem;
 import org.hisp.dhis.common.DimensionService;
 import org.hisp.dhis.common.IllegalQueryException;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.dxf2.expressiondimensionitem.ExpressionDimensionItemService;
@@ -60,7 +59,6 @@ import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/visualizations")
 public class VisualizationController extends AbstractCrudController<Visualization> {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationDataController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationDataController.java
@@ -76,7 +76,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
-@OpenApi.Tags("ui")
+@OpenApi.Document(domain = Visualization.class)
 @RestController
 @RequiredArgsConstructor
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryComboController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryComboController.java
@@ -32,7 +32,6 @@ import java.util.Set;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.IdentifiableObjectUtils;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.datavalue.DataValueService;
 import org.hisp.dhis.dxf2.metadata.MetadataExportParams;
 import org.hisp.dhis.feedback.ConflictException;
@@ -50,7 +49,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/categoryCombos")
 public class CategoryComboController extends AbstractCrudController<CategoryCombo> {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryController.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.webapi.controller.category;
 
 import org.hisp.dhis.category.Category;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/categories")
 public class CategoryController extends AbstractCrudController<Category> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryOptionComboController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryOptionComboController.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.webapi.controller.category;
 
 import org.hisp.dhis.category.CategoryOptionCombo;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/categoryOptionCombos")
 public class CategoryOptionComboController extends AbstractCrudController<CategoryOptionCombo> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryOptionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryOptionController.java
@@ -36,7 +36,6 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.SetValuedMap;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryService;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -47,7 +46,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/categoryOptions")
 @RequiredArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryOptionGroupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryOptionGroupController.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.webapi.controller.category;
 
 import org.hisp.dhis.category.CategoryOptionGroup;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/categoryOptionGroups")
 public class CategoryOptionGroupController extends AbstractCrudController<CategoryOptionGroup> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryOptionGroupSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryOptionGroupSetController.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.webapi.controller.category;
 
 import org.hisp.dhis.category.CategoryOptionGroupSet;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/categoryOptionGroupSets")
 public class CategoryOptionGroupSetController

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/cluster/ClusterController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/cluster/ClusterController.java
@@ -37,6 +37,7 @@ import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.leader.election.LeaderManager;
 import org.hisp.dhis.leader.election.LeaderNodeInfo;
 import org.hisp.dhis.security.RequiresAuthority;
+import org.hisp.dhis.webapi.controller.Server;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -47,7 +48,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @author Ameen Mohamed
  */
-@OpenApi.Tags("system")
+@OpenApi.Document(domain = Server.class)
 @RestController
 @RequestMapping("/api/cluster")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementController.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.webapi.controller.dataelement;
 
 import lombok.AllArgsConstructor;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
@@ -38,7 +37,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/dataElements")
 @AllArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementGroupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementGroupController.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryService;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.PagerUtils;
 import org.hisp.dhis.dataelement.DataElementGroup;
@@ -61,7 +60,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/dataElementGroups")
 public class DataElementGroupController extends AbstractCrudController<DataElementGroup> {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementGroupSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementGroupSetController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.dataelement;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dataelement.DataElementGroupSet;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
@@ -36,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/dataElementGroupSets")
 public class DataElementGroupSetController extends AbstractCrudController<DataElementGroupSet> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandController.java
@@ -76,7 +76,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
+@OpenApi.Document(domain = DataElementOperand.class)
 @Controller
 @RequestMapping("/api/dataElementOperands")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/CustomDataEntryFormController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/CustomDataEntryFormController.java
@@ -31,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.dataentryform.DataEntryForm;
 import org.hisp.dhis.dataentryform.DataEntryFormService;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -43,7 +44,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = DataEntryForm.class)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/dataEntry")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/DataSetCompletionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/DataSetCompletionController.java
@@ -35,6 +35,7 @@ import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dataset.CompleteDataSetRegistration;
 import org.hisp.dhis.dataset.CompleteDataSetRegistrationService;
 import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.webapi.controller.datavalue.DataValidator;
@@ -50,7 +51,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = DataValue.class)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/dataEntry")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/DataSetLockExceptionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/DataSetLockExceptionController.java
@@ -45,7 +45,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = LockException.class)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/dataEntry")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/DataSetMetadataController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/DataSetMetadataController.java
@@ -34,6 +34,7 @@ import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.dxf2.metadata.DataSetMetadataExportService;
 import org.hisp.dhis.user.CurrentUser;
 import org.hisp.dhis.user.UserDetails;
@@ -47,7 +48,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = DataValue.class)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/dataEntry")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/DataSetValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/DataSetValueController.java
@@ -61,7 +61,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = DataValue.class)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/dataEntry")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/DataValueContextController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/DataValueContextController.java
@@ -53,7 +53,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = DataValue.class)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/dataEntry")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/MinMaxValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/MinMaxValueController.java
@@ -34,6 +34,7 @@ import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.minmax.MinMaxDataElement;
 import org.hisp.dhis.minmax.MinMaxDataElementService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -53,7 +54,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = DataValue.class)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/dataEntry")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataitem/DataItemQueryController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataitem/DataItemQueryController.java
@@ -73,7 +73,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * @author maikel arabori
  */
-@OpenApi.Tags("metadata")
+@OpenApi.Document(domain = DataItem.class)
 @Slf4j
 @ApiVersion({DEFAULT, ALL})
 @RequiredArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datastatistics/DataStatisticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datastatistics/DataStatisticsController.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.analytics.SortOrder;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.datastatistics.AggregatedStatistics;
+import org.hisp.dhis.datastatistics.DataStatistics;
 import org.hisp.dhis.datastatistics.DataStatisticsEvent;
 import org.hisp.dhis.datastatistics.DataStatisticsEventType;
 import org.hisp.dhis.datastatistics.DataStatisticsService;
@@ -73,7 +74,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
  * @author Yrjan A. F. Fraschetti
  * @author Julie Hill Roa
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = DataStatistics.class)
 @Controller
 @RequiredArgsConstructor
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datasummary/DataSummaryController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datasummary/DataSummaryController.java
@@ -47,7 +47,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
  *
  * @author Joao Antunes
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = DataSummary.class)
 @Controller
 @RequestMapping("/api/dataSummary")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
@@ -100,7 +100,7 @@ import org.springframework.web.multipart.MultipartFile;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = DataValue.class)
 @RestController
 @RequestMapping("/api/dataValues")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/deduplication/DeduplicationController.java
@@ -71,7 +71,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpStatusCodeException;
 
-@OpenApi.Tags("tracker")
+@OpenApi.Document(domain = PotentialDuplicate.class)
 @RestController
 @RequestMapping("/api/potentialDuplicates")
 @ApiVersion(include = {DhisApiVersion.ALL, DhisApiVersion.DEFAULT})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dimension/DimensionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dimension/DimensionController.java
@@ -49,7 +49,6 @@ import org.hisp.dhis.common.DimensionService;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.commons.jackson.domain.JsonRoot;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dxf2.common.OrderParams;
@@ -87,7 +86,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/dimensions")
 @RequiredArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/DataSetNotificationTemplateController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/DataSetNotificationTemplateController.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.webapi.controller.event;
 
 import org.hisp.dhis.common.DhisApiVersion;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dataset.notifications.DataSetNotificationTemplate;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -36,7 +35,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /** Created by zubair on 02.07.17. */
-@OpenApi.Tags("tracker")
 @Controller
 @RequestMapping("/api/dataSetNotificationTemplates")
 @ApiVersion(include = {DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventVisualizationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventVisualizationController.java
@@ -52,7 +52,6 @@ import javax.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import org.hisp.dhis.common.DimensionService;
 import org.hisp.dhis.common.DimensionalObject;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.eventvisualization.EventVisualization;
 import org.hisp.dhis.eventvisualization.EventVisualizationService;
@@ -86,7 +85,6 @@ import org.springframework.web.bind.annotation.RequestParam;
  *
  * @author maikel arabori
  */
-@OpenApi.Tags("analytics")
 @Controller
 @RequestMapping("/api/eventVisualizations")
 @ApiVersion({DEFAULT, ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramController.java
@@ -39,7 +39,6 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.SetValuedMap;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.copy.CopyService;
 import org.hisp.dhis.dxf2.metadata.MetadataExportParams;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
@@ -71,7 +70,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("tracker")
 @Controller
 @RequestMapping("/api/programs")
 @RequiredArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramDataElementController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramDataElementController.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.Map;
 import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.PagerUtils;
@@ -62,7 +63,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("tracker")
+@OpenApi.Document(domain = DimensionalItemObject.class)
 @Controller
 @RequestMapping("/api/programDataElements")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramIndicatorController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramIndicatorController.java
@@ -32,7 +32,6 @@ import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.webmessage.DescriptiveWebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.expression.Expression;
@@ -52,7 +51,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("tracker")
 @Controller
 @RequestMapping("/api/programIndicators")
 @RequiredArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramIndicatorGroupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramIndicatorGroupController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.event;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.program.ProgramIndicatorGroup;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
@@ -36,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Mark Polak
  */
-@OpenApi.Tags("tracker")
 @Controller
 @RequestMapping("/api/programIndicatorGroups")
 public class ProgramIndicatorGroupController

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramMessageController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramMessageController.java
@@ -67,7 +67,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Zubair <rajazubair.asghar@gmail.com> */
-@OpenApi.Tags("tracker")
 @RestController
 @RequestMapping("/api/messages")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceController.java
@@ -54,7 +54,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Zubair Asghar
  */
-@OpenApi.Tags("tracker")
+@OpenApi.Document(domain = ProgramNotificationInstance.class)
 @Controller
 @RequestMapping("/api/programNotificationInstances")
 @ApiVersion(include = {DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationTemplateController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationTemplateController.java
@@ -31,7 +31,6 @@ import static org.hisp.dhis.security.Authorities.ALL;
 
 import java.util.List;
 import org.hisp.dhis.common.DhisApiVersion;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStageService;
@@ -52,7 +51,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Halvdan Hoem Grelland
  */
-@OpenApi.Tags("tracker")
 @Controller
 @RequestMapping("/api/programNotificationTemplates")
 @ApiVersion(include = {DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramRuleActionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramRuleActionController.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.webapi.controller.event;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.webmessage.DescriptiveWebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.feedback.Status;
@@ -51,7 +50,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author markusbekken
  */
-@OpenApi.Tags("tracker")
 @Controller
 @RequestMapping("/api/programRuleActions")
 public class ProgramRuleActionController extends AbstractCrudController<ProgramRuleAction> {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramRuleController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramRuleController.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.webapi.controller.event;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import lombok.AllArgsConstructor;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.webmessage.DescriptiveWebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.feedback.Status;
@@ -52,7 +51,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author markusbekken
  */
-@OpenApi.Tags("tracker")
 @Controller
 @AllArgsConstructor
 @RequestMapping("/api/programRules")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramRuleVariableController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramRuleVariableController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.event;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.programrule.ProgramRuleVariable;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
@@ -36,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author markusbekken
  */
-@OpenApi.Tags("tracker")
 @Controller
 @RequestMapping("/api/programRuleVariables")
 public class ProgramRuleVariableController extends AbstractCrudController<ProgramRuleVariable> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramSectionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramSectionController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.event;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.program.ProgramSection;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
@@ -36,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Henning Håkonsen
  */
-@OpenApi.Tags("tracker")
 @Controller
 @RequestMapping("/api/programSections")
 public class ProgramSectionController extends AbstractCrudController<ProgramSection> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramStageController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramStageController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.event;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
@@ -36,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("tracker")
 @Controller
 @RequestMapping("/api/programStages")
 public class ProgramStageController extends AbstractCrudController<ProgramStage> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramStageSectionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramStageSectionController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.event;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.program.ProgramStageSection;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
@@ -36,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("tracker")
 @Controller
 @RequestMapping("/api/programStageSections")
 public class ProgramStageSectionController extends AbstractCrudController<ProgramStageSection> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/RelationshipTypeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/RelationshipTypeController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.event;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
@@ -36,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("tracker")
 @Controller
 @RequestMapping("/api/relationshipTypes")
 public class RelationshipTypeController extends AbstractCrudController<RelationshipType> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityAttributeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityAttributeController.java
@@ -39,7 +39,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.reservedvalue.ReserveValueException;
 import org.hisp.dhis.reservedvalue.ReservedValue;
@@ -66,7 +65,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("tracker")
 @Controller
 @RequestMapping("/api/trackedEntityAttributes")
 public class TrackedEntityAttributeController

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityTypeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityTypeController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.event;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
@@ -36,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("tracker")
 @Controller
 @RequestMapping("/api/trackedEntityTypes")
 public class TrackedEntityTypeController extends AbstractCrudController<TrackedEntityType> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackerOwnershipController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackerOwnershipController.java
@@ -38,6 +38,7 @@ import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.trackedentity.TrackerOwnershipManager;
@@ -56,7 +57,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Ameen Mohamed <ameen@dhis2.org>
  */
-@OpenApi.Tags("tracker")
+@OpenApi.Document(domain = Program.class)
 @Controller
 @RequestMapping("/api/tracker/ownership")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/icon/IconController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/icon/IconController.java
@@ -82,7 +82,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @author Kristian Wærstad
  */
-@OpenApi.Tags("ui")
+@OpenApi.Document(domain = Icon.class)
 @RestController
 @RequestMapping("/api/icons")
 @Slf4j

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/indicator/IndicatorController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/indicator/IndicatorController.java
@@ -35,7 +35,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.analytics.resolver.ExpressionResolver;
 import org.hisp.dhis.analytics.resolver.ExpressionResolverCollection;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.webmessage.DescriptiveWebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
@@ -62,7 +61,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @Slf4j
 @RequiredArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/indicator/IndicatorGroupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/indicator/IndicatorGroupController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.indicator;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.indicator.IndicatorGroup;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
@@ -36,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/indicatorGroups")
 public class IndicatorGroupController extends AbstractCrudController<IndicatorGroup> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/indicator/IndicatorGroupSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/indicator/IndicatorGroupSetController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.indicator;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.indicator.IndicatorGroupSet;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
@@ -36,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/indicatorGroupSets")
 public class IndicatorGroupSetController extends AbstractCrudController<IndicatorGroupSet> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/indicator/IndicatorTypeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/indicator/IndicatorTypeController.java
@@ -32,7 +32,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.feedback.ConflictException;
@@ -54,7 +53,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/indicatorTypes")
 @RequiredArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/ExternalMapLayerController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/ExternalMapLayerController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.mapping;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.mapping.ExternalMapLayer;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
@@ -36,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Viet Nguyen <viet@dhis2.org>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/externalMapLayers")
 public class ExternalMapLayerController extends AbstractCrudController<ExternalMapLayer> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/GeoFeatureController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/GeoFeatureController.java
@@ -56,7 +56,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("metadata")
+@OpenApi.Document(domain = GeoFeature.class)
 @Controller
 @RequestMapping("/api/geoFeatures")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
@@ -46,7 +46,6 @@ import org.hisp.dhis.attribute.AttributeService;
 import org.hisp.dhis.common.DimensionService;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.MergeMode;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.dxf2.metadata.MetadataImportParams;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
@@ -89,7 +88,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/maps")
 public class MapController extends AbstractCrudController<Map> {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapViewController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapViewController.java
@@ -34,7 +34,6 @@ import java.awt.image.BufferedImage;
 import java.util.List;
 import javax.imageio.ImageIO;
 import javax.servlet.http.HttpServletResponse;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.fieldfilter.Defaults;
@@ -61,7 +60,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/mapViews")
 public class MapViewController extends AbstractCrudController<MapView> {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportExportController.java
@@ -97,7 +97,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
+@OpenApi.Document(domain = Metadata.class)
 @Controller
 @RequestMapping("/api/metadata")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataWorkflowController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataWorkflowController.java
@@ -37,7 +37,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import javax.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
 import org.hisp.dhis.common.DhisApiVersion;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.metadata.MetadataValidationException;
 import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
@@ -74,7 +73,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
  *
  * @author Jan Bernitt
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/metadata/proposals")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/sync/MetadataSyncController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/sync/MetadataSyncController.java
@@ -33,6 +33,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.dxf2.metadata.Metadata;
 import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
 import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncParams;
 import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncService;
@@ -62,7 +63,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * @author vanyas
  */
-@OpenApi.Tags("metadata")
+@OpenApi.Document(domain = Metadata.class)
 @RestController
 @RequestMapping("/api/metadata/sync")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/version/MetadataVersionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/version/MetadataVersionController.java
@@ -72,7 +72,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
  *
  * @author aamerm
  */
-@OpenApi.Tags("metadata")
+@OpenApi.Document(domain = MetadataVersion.class)
 @Controller
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
 @RequestMapping("/api/metadata/version")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/option/OptionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/option/OptionController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.option;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
@@ -36,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/options")
 public class OptionController extends AbstractCrudController<Option> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/option/OptionGroupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/option/OptionGroupController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.option;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.option.OptionGroup;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
@@ -36,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Viet Nguyen <viet@dhis2.org>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/optionGroups")
 public class OptionGroupController extends AbstractCrudController<OptionGroup> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/option/OptionGroupSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/option/OptionGroupSetController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.option;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.option.OptionGroupSet;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
@@ -36,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Viet Nguyen <viet@dhis2.org>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/optionGroupSets")
 public class OptionGroupSetController extends AbstractCrudController<OptionGroupSet> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/option/OptionSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/option/OptionSetController.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.webapi.controller.option;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 
 import lombok.AllArgsConstructor;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.metadata.MetadataExportParams;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.feedback.ConflictException;
@@ -47,7 +46,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/optionSets")
 @AllArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/FilledOrganisationUnitLevelController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/FilledOrganisationUnitLevelController.java
@@ -59,7 +59,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("metadata")
+@OpenApi.Document(domain = OrganisationUnitLevel.class)
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/api/filledOrganisationUnitLevels")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
@@ -87,7 +87,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/organisationUnits")
 public class OrganisationUnitController extends AbstractCrudController<OrganisationUnit> {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitGroupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitGroupController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.organisationunit;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
@@ -36,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/organisationUnitGroups")
 public class OrganisationUnitGroupController

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitGroupSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitGroupSetController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.organisationunit;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroupSet;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
@@ -36,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/organisationUnitGroupSets")
 public class OrganisationUnitGroupSetController

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitLevelController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitLevelController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.organisationunit;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.organisationunit.OrganisationUnitLevel;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
@@ -36,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("metadata")
 @Controller
 @RequestMapping("/api/organisationUnitLevels")
 public class OrganisationUnitLevelController

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitLocationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitLocationController.java
@@ -52,7 +52,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author James Chang <jamesbchang@gmail.com>
  */
-@OpenApi.Tags("metadata")
+@OpenApi.Document(domain = OrganisationUnit.class)
 @Controller
 @RequestMapping("/api/organisationUnitLocations")
 public class OrganisationUnitLocationController {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitProfileController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitProfileController.java
@@ -35,6 +35,7 @@ import lombok.AllArgsConstructor;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.orgunitprofile.OrgUnitProfile;
 import org.hisp.dhis.orgunitprofile.OrgUnitProfileData;
 import org.hisp.dhis.orgunitprofile.OrgUnitProfileService;
@@ -50,7 +51,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-@OpenApi.Tags("metadata")
+@OpenApi.Document(domain = OrganisationUnit.class)
 @RestController
 @AllArgsConstructor
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/outlierdetection/AnalyticsOutlierDetectionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/outlierdetection/AnalyticsOutlierDetectionController.java
@@ -47,6 +47,7 @@ import org.hisp.dhis.analytics.outlier.service.AnalyticsOutlierService;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.ContextUtils;
@@ -59,7 +60,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * @author Dusan Bernat
  */
-@OpenApi.Tags("analytics")
+@OpenApi.Document(domain = DataValue.class)
 @RestController
 @AllArgsConstructor
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/outlierdetection/OutlierDetectionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/outlierdetection/OutlierDetectionController.java
@@ -37,6 +37,7 @@ import lombok.AllArgsConstructor;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.cache.CacheStrategy;
+import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.outlierdetection.OutlierDetectionQuery;
 import org.hisp.dhis.outlierdetection.OutlierDetectionRequest;
 import org.hisp.dhis.outlierdetection.OutlierDetectionResponse;
@@ -55,7 +56,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = DataValue.class)
 @RestController
 @AllArgsConstructor
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -70,7 +70,6 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * @author Henning Håkonsen
  */
-@OpenApi.Tags("system")
 @RestController
 @RequestMapping("/api/jobConfigurations")
 @RequiredArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobSchedulerController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobSchedulerController.java
@@ -77,7 +77,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * @author Jan Bernitt
  */
-@OpenApi.Tags("system")
+@OpenApi.Document(domain = JobConfiguration.class)
 @RestController
 @RequestMapping("/api/scheduler")
 @RequiredArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/SchedulingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/SchedulingController.java
@@ -40,6 +40,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobProgress.Process;
 import org.hisp.dhis.scheduling.JobProgress.Progress;
 import org.hisp.dhis.scheduling.JobProgress.Stage;
@@ -61,7 +62,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * @author Jan Bernitt
  */
-@OpenApi.Tags("system")
+@OpenApi.Document(domain = JobConfiguration.class)
 @RestController
 @RequestMapping("/api/scheduling")
 @AllArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ApiTokenController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ApiTokenController.java
@@ -40,7 +40,6 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.validator.routines.InetAddressValidator;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.hisp.dhis.common.DhisApiVersion;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dxf2.metadata.MetadataImportParams;
 import org.hisp.dhis.dxf2.metadata.MetadataObjects;
@@ -66,7 +65,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-@OpenApi.Tags({"user", "login"})
 @Controller
 @RequestMapping({"/api/apiToken", "/api/apiTokens"})
 @RequiredArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthenticationController.java
@@ -87,7 +87,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-@OpenApi.Tags({"login"})
+@OpenApi.Document(domain = User.class)
 @RestController
 @RequestMapping("/api/auth")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthoritiesController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthoritiesController.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.security.SystemAuthoritiesProvider;
+import org.hisp.dhis.webapi.controller.Server;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -52,7 +53,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * @author Jan Bernitt
  */
-@OpenApi.Tags({"user", "query"})
+@OpenApi.Document(domain = Server.class)
 @RestController
 @RequestMapping("/api/authorities")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ImpersonateUserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ImpersonateUserController.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.security.ImpersonatingUserDetailsChecker;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.user.CurrentUser;
+import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Conditional;
@@ -79,7 +80,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-@OpenApi.Tags({"user", "login"})
+@OpenApi.Document(domain = User.class)
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/LoginConfigController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/LoginConfigController.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.security.oidc.DhisOidcProviderRepository;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.SystemService;
+import org.hisp.dhis.webapi.controller.Server;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -55,7 +56,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-@OpenApi.Tags({"login"})
+@OpenApi.Document(domain = Server.class)
 @RestController
 @RequestMapping("/api/loginConfig")
 @RequiredArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/TwoFactorController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/TwoFactorController.java
@@ -67,7 +67,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @author Henning Håkonsen
  * @author Morten Svanaes
  */
-@OpenApi.Tags({"user", "login"})
+@OpenApi.Document(domain = User.class)
 @RestController
 @RequestMapping("/api/2fa")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/UserAccountController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/UserAccountController.java
@@ -77,7 +77,7 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-@OpenApi.Tags({"user"})
+@OpenApi.Document(domain = User.class)
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsCommandController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsCommandController.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.webapi.controller.sms;
 
 import org.hisp.dhis.common.DhisApiVersion;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -36,7 +35,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /** Created by zubair@dhis2.org on 18.08.17. */
-@OpenApi.Tags("messaging")
 @Controller
 @RequestMapping("/api/smsCommands")
 @ApiVersion(include = {DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsGatewayController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsGatewayController.java
@@ -50,6 +50,7 @@ import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.sms.config.GatewayAdministrationService;
 import org.hisp.dhis.sms.config.SmsConfiguration;
 import org.hisp.dhis.sms.config.SmsConfigurationManager;
+import org.hisp.dhis.sms.config.SmsGateway;
 import org.hisp.dhis.sms.config.SmsGatewayConfig;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,7 +66,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Zubair <rajazubair.asghar@gmail.com> */
-@OpenApi.Tags("messaging")
+@OpenApi.Document(domain = SmsGateway.class)
 @RestController
 @RequestMapping("/api/gateways")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsInboundController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsInboundController.java
@@ -39,7 +39,6 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
 import org.hisp.dhis.common.DhisApiVersion;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.render.RenderService;
@@ -64,7 +63,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Zubair <rajazubair.asghar@gmail.com> */
-@OpenApi.Tags("messaging")
 @RestController
 @RequestMapping("/api/sms/inbound")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsOutboundController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsOutboundController.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import org.hisp.dhis.common.DhisApiVersion;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
@@ -61,7 +60,6 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @author Zubair Asghar
  */
-@OpenApi.Tags("messaging")
 @RestController
 @RequestMapping("/api/sms/outbound")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/system/SystemUpdateNotifyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/system/SystemUpdateNotifyController.java
@@ -35,6 +35,7 @@ import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.system.SystemUpdateNotificationService;
+import org.hisp.dhis.webapi.controller.Server;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -46,7 +47,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-@OpenApi.Tags("system")
+@OpenApi.Document(domain = Server.class)
 @Controller
 @RequestMapping("/api/systemUpdates")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tei/TeiAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tei/TeiAnalyticsController.java
@@ -65,6 +65,7 @@ import org.hisp.dhis.analytics.tei.TeiQueryRequestMapper;
 import org.hisp.dhis.common.DimensionsCriteria;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.webapi.dimension.DimensionFilteringAndPagingService;
 import org.hisp.dhis.webapi.dimension.DimensionMapperService;
@@ -81,7 +82,7 @@ import org.springframework.web.bind.annotation.RestController;
  * Controller class responsible exclusively for querying operations on top of tracker entity
  * instances objects. Methods in this controller should not change any state.
  */
-@OpenApi.Tags("analytics")
+@OpenApi.Document(domain = DataValue.class)
 @ApiVersion({DEFAULT, ALL})
 @RestController
 @RequiredArgsConstructor

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentsExportController.java
@@ -61,7 +61,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @OpenApi.EntityType(Enrollment.class)
-@OpenApi.Tags("tracker")
+@OpenApi.Document(domain = org.hisp.dhis.program.Enrollment.class)
 @RestController
 @RequestMapping("/api/tracker/enrollments")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipsExportController.java
@@ -59,7 +59,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @OpenApi.EntityType(org.hisp.dhis.relationship.Relationship.class)
-@OpenApi.Tags("tracker")
+@OpenApi.Document(domain = org.hisp.dhis.relationship.Relationship.class)
 @RestController
 @RequestMapping(produces = APPLICATION_JSON_VALUE, value = "/api/tracker/relationships")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntitiesExportController.java
@@ -86,7 +86,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @OpenApi.EntityType(TrackedEntity.class)
-@OpenApi.Tags("tracker")
+@OpenApi.Document(domain = org.hisp.dhis.trackedentity.TrackedEntity.class)
 @RestController
 @RequestMapping("/api/tracker/trackedEntities")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trigramsummary/TrigramSummaryController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trigramsummary/TrigramSummaryController.java
@@ -59,7 +59,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
  *
  * @author Ameen Mohamed
  */
-@OpenApi.Tags("tracker")
+@OpenApi.Document(domain = TrackedEntityAttribute.class)
 @Controller
 @RequestMapping("/api/trigramSummary")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
@@ -53,6 +53,7 @@ import org.hisp.dhis.scheduling.JobSchedulerService;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.system.notification.Notification;
 import org.hisp.dhis.system.notification.Notifier;
+import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.tracker.imports.TrackerBundleReportMode;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
@@ -83,7 +84,7 @@ import org.springframework.web.client.HttpStatusCodeException;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("tracker")
+@OpenApi.Document(domain = TrackedEntity.class)
 @RestController
 @RequestMapping("/api/tracker")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserGroupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserGroupController.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.webapi.controller.user;
 
 import org.hisp.dhis.common.IdentifiableObjects;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
@@ -37,7 +36,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags({"user", "management"})
 @Controller
 @RequestMapping("/api/userGroups")
 public class UserGroupController extends AbstractCrudController<UserGroup> {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserRoleController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserRoleController.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.webapi.controller.user;
 
 import java.util.List;
 import javax.servlet.http.HttpServletResponse;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
@@ -54,7 +53,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags({"user", "management"})
 @Controller
 @RequestMapping("/api/userRoles")
 public class UserRoleController extends AbstractCrudController<UserRole> {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationController.java
@@ -63,7 +63,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @author Lars Helge Overland
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = DataSet.class)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/validation")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationNotificationTemplateController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationNotificationTemplateController.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.webapi.controller.validation;
 
 import org.hisp.dhis.common.DhisApiVersion;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.validation.notification.ValidationNotificationTemplate;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -38,7 +37,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Halvdan Hoem Grelland
  */
-@OpenApi.Tags("data")
 @Controller
 @RequestMapping("/api/validationNotificationTemplates")
 @ApiVersion(include = {DhisApiVersion.DEFAULT, DhisApiVersion.ALL})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationResultController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationResultController.java
@@ -61,7 +61,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @author Stian Sandvold
  */
-@OpenApi.Tags("data")
+@OpenApi.Document(domain = ValidationResult.class)
 @RestController
 @RequestMapping("/api/validationResults")
 @ApiVersion({DhisApiVersion.ALL, DhisApiVersion.DEFAULT})

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationRuleController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationRuleController.java
@@ -32,7 +32,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import com.google.common.collect.Lists;
 import java.util.List;
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetService;
 import org.hisp.dhis.dxf2.webmessage.DescriptiveWebMessage;
@@ -59,7 +58,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("data")
 @Controller
 @RequestMapping("/api/validationRules")
 public class ValidationRuleController extends AbstractCrudController<ValidationRule> {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationRuleGroupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationRuleGroupController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.validation;
 
-import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.validation.ValidationRuleGroup;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.springframework.stereotype.Controller;
@@ -36,7 +35,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@OpenApi.Tags("data")
 @Controller
 @RequestMapping("/api/validationRuleGroups")
 public class ValidationRuleGroupController extends AbstractCrudController<ValidationRuleGroup> {}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiIntegrator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiIntegrator.java
@@ -364,7 +364,8 @@ public class ApiIntegrator {
   private Api.Schema generateIdObject(Api.Schema of) {
     Class<?> schemaType = of.getIdentifyAs();
     Api.Schema object = Api.Schema.ofObject(of.getSource(), schemaType);
-    Map<Class<?>, Api.Schema> idSchemas = api.getGeneratorSchemas().get(UID.class);
+    Map<Class<?>, Api.Schema> idSchemas =
+        api.getGeneratorSchemas().computeIfAbsent(UID.class, key -> new ConcurrentHashMap<>());
 
     Api.Schema idType =
         idSchemas.computeIfAbsent(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/OAuth2ConfirmAccessController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/OAuth2ConfirmAccessController.java
@@ -33,6 +33,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.system.velocity.VelocityManager;
+import org.hisp.dhis.webapi.controller.Server;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
@@ -44,7 +45,7 @@ import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.View;
 import org.springframework.web.util.HtmlUtils;
 
-@OpenApi.Tags({"user", "login"})
+@OpenApi.Document(domain = Server.class)
 @Controller
 @SessionAttributes("authorizationRequest")
 public class OAuth2ConfirmAccessController {


### PR DESCRIPTION
The `@OpenApi.Tags` annotation has not been evaluated any longer to split controllers into documents (files). 
For controllers extending `AbstractCrudController` no new annotation is needed as the `domain` is correctly inferred from the generics. Controllers that do not extend a superclass with fitting generics got a `@OpenApi.Document` annotation to specify the `domain`. Each domain is one document.

`DataValue` was used in many cases that were unclear but had something to do with data. This ranges from aggregate to tracker and analytics. While it should be split up more I don't know enough to make a better split.

Another group of controllers are about providing general "server wide services". I created a `Server` class just to act as a domain these can be gathered under. 