### PR TITLE
chore: remove references to old dhis-web-portal path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,9 +29,9 @@ Go in the repo and run maven:
     cd dhis-web
     mvn install -U
 
-Each project in the /dhis-2/dhis-web directory is an individual web module. The dhis-web-portal project is an assembly of all the individual web modules.
+Each project in the /dhis-2/dhis-web directory is an individual web module. The dhis-web-server project is an assembly of all the individual web modules.
 
-This should create a ready to use war in /dhis-2/dhis-web-portal/target
+This should create a ready to use war in /dhis-2/dhis-web-server/target
 
 ## Run locally
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ It should now be available at `http://localhost:8080`.
 To build using a custom tag run
 
 ```sh
-mvn -DskipTests -Dmaven.test.skip=true -f dhis-2/dhis-web-portal/pom.xml jib:dockerBuild -Djib.to.image=dhis2/core-dev:mytag
+mvn -DskipTests -Dmaven.test.skip=true -f dhis-2/dhis-web-server/pom.xml jib:dockerBuild -Djib.to.image=dhis2/core-dev:mytag
 ```
 
 For more configuration options related to Jib or Docker go to the

--- a/jib.yaml
+++ b/jib.yaml
@@ -30,11 +30,11 @@ layers:
       files:
         - src: ${unarchivedWarDir}
           dest: ${imageAppRoot}
-        - src: "dhis-2/dhis-web-portal/src/main/jib/usr/local/tomcat/conf/server.xml"
+        - src: "dhis-2/dhis-web-server/src/main/jib/usr/local/tomcat/conf/server.xml"
           dest: "/usr/local/tomcat/conf/server.xml"
-        - src: "dhis-2/dhis-web-portal/src/main/jib/usr/local/tomcat/conf/Catalina/localhost"
+        - src: "dhis-2/dhis-web-server/src/main/jib/usr/local/tomcat/conf/Catalina/localhost"
           dest: "/usr/local/tomcat/conf/Catalina/localhost"
-        - src: "dhis-2/dhis-web-portal/src/main/jib/opt/dhis2"
+        - src: "dhis-2/dhis-web-server/src/main/jib/opt/dhis2"
           dest: "/opt/dhis2"
           properties:
             user: ${imageUser}


### PR DESCRIPTION
Not sure if the wording in the CONTRIBUTING.md doc is relevant at this point.