### PR TITLE
fix: use addSynchronizedEntityClass when using native SQL via hibernate

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/hibernate/HibernateDataIntegrityStore.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/hibernate/HibernateDataIntegrityStore.java
@@ -57,6 +57,7 @@ public class HibernateDataIntegrityStore implements DataIntegrityStore {
   @Transactional(readOnly = true)
   public DataIntegritySummary querySummary(DataIntegrityCheck check, String sql) {
     Date startTime = new Date();
+    // Note! that the SQL here can be touching any table so we cannot sync it
     Object summary = entityManager.createNativeQuery(sql).getSingleResult();
     return new DataIntegritySummary(
         check, startTime, new Date(), null, parseCount(summary), parsePercentage(summary));
@@ -66,6 +67,7 @@ public class HibernateDataIntegrityStore implements DataIntegrityStore {
   @Transactional(readOnly = true)
   public DataIntegrityDetails queryDetails(DataIntegrityCheck check, String sql) {
     Date startTime = new Date();
+    // Note! that the SQL here can be touching any table so we cannot sync it
     @SuppressWarnings("unchecked")
     List<Object[]> rows = entityManager.createNativeQuery(sql).getResultList();
     return new DataIntegrityDetails(

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateAnalyticalObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateAnalyticalObjectStore.java
@@ -196,7 +196,7 @@ public class HibernateAnalyticalObjectStore<T extends BaseAnalyticalObject>
     group by v.visualizationid
     """;
 
-    return getSession().createNativeQuery(sql, clazz).setParameter("indicators", indicators).list();
+    return nativeSynchronizedTypedQuery(sql).setParameter("indicators", indicators).list();
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateAnalyticalObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateAnalyticalObjectStore.java
@@ -188,7 +188,6 @@ public class HibernateAnalyticalObjectStore<T extends BaseAnalyticalObject>
 
   @Override
   public List<T> getVisualizationsBySortingIndicator(List<String> indicators) {
-    // language=sql
     String sql =
         """
     select v.* from visualization v, jsonb_array_elements(sorting) as sort

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
@@ -46,7 +46,6 @@ import javax.persistence.criteria.Root;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.hibernate.query.NativeQuery;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.common.AuditLogUtil;
 import org.hisp.dhis.common.BaseIdentifiableObject;
@@ -957,17 +956,6 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     }
     query.where(builder.or(predicates.toArray(new Predicate[0])));
     return !getSession().createQuery(query).setMaxResults(1).getResultList().isEmpty();
-  }
-
-  /**
-   * Create a Hibernate {@link NativeQuery} instance with {@code SynchronizedEntityClass} set to the
-   * current class. Use this to avoid all Hibernate second level caches from being invalidated.
-   *
-   * @param sql the SQL query to execute
-   * @return the {@link NativeQuery} instance
-   */
-  protected NativeQuery nativeUpdateQuery(String sql) {
-    return getSession().createNativeQuery(sql).addSynchronizedEntityClass(getClazz());
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datadimensionitem/hibernate/HibernateDataDimensionItemStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datadimensionitem/hibernate/HibernateDataDimensionItemStore.java
@@ -50,7 +50,6 @@ public class HibernateDataDimensionItemStore extends HibernateGenericStore<DataD
 
   @Override
   public List<DataDimensionItem> getIndicatorDataDimensionItems(List<Indicator> indicators) {
-    // language=sql
     String sql =
         """
       select * from datadimensionitem d

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datadimensionitem/hibernate/HibernateDataDimensionItemStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datadimensionitem/hibernate/HibernateDataDimensionItemStore.java
@@ -56,9 +56,6 @@ public class HibernateDataDimensionItemStore extends HibernateGenericStore<DataD
       select * from datadimensionitem d
       where d.indicatorid in :indicators
     """;
-    return getSession()
-        .createNativeQuery(sql, DataDimensionItem.class)
-        .setParameter("indicators", indicators)
-        .list();
+    return nativeSynchronizedTypedQuery(sql).setParameter("indicators", indicators).list();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateLockExceptionStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateLockExceptionStore.java
@@ -174,8 +174,7 @@ public class HibernateLockExceptionStore extends HibernateGenericStore<LockExcep
   @Override
   public int deleteExpiredLockExceptions(Date createdBefore) {
     String sql = "delete from lockexception where created < :date";
-
-    return getSession().createNativeQuery(sql).setParameter("date", createdBefore).executeUpdate();
+    return nativeSynchronizedQuery(sql).setParameter("date", createdBefore).executeUpdate();
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateSectionStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateSectionStore.java
@@ -67,17 +67,15 @@ public class HibernateSectionStore extends HibernateIdentifiableObjectStore<Sect
 
   @Override
   public List<Section> getSectionsByDataElement(String dataElementUid) {
-    String hql =
+    // language=SQL
+    String sql =
         "select * from section s"
             + " left join sectiondataelements sde on s.sectionid = sde.sectionid"
             + " left join sectiongreyedfields sgf on s.sectionid = sgf.sectionid"
             + " left join dataelementoperand deo on sgf.dataelementoperandid = deo.dataelementoperandid"
             + ", dataelement de"
             + " where de.uid = :dataElementId and (sde.dataelementid = de.dataelementid or deo.dataelementid = de.dataelementid);";
-    return getSession()
-        .createNativeQuery(hql, Section.class)
-        .setParameter("dataElementId", dataElementUid)
-        .list();
+    return nativeSynchronizedTypedQuery(sql).setParameter("dataElementId", dataElementUid).list();
   }
 
   @Override
@@ -90,9 +88,6 @@ public class HibernateSectionStore extends HibernateIdentifiableObjectStore<Sect
             where si.indicatorid in :indicators
             group by s.sectionid
           """;
-    return getSession()
-        .createNativeQuery(sql, Section.class)
-        .setParameter("indicators", indicators)
-        .list();
+    return nativeSynchronizedTypedQuery(sql).setParameter("indicators", indicators).list();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateSectionStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateSectionStore.java
@@ -67,7 +67,6 @@ public class HibernateSectionStore extends HibernateIdentifiableObjectStore<Sect
 
   @Override
   public List<Section> getSectionsByDataElement(String dataElementUid) {
-    // language=SQL
     String sql =
         "select * from section s"
             + " left join sectiondataelements sde on s.sectionid = sde.sectionid"
@@ -80,7 +79,6 @@ public class HibernateSectionStore extends HibernateIdentifiableObjectStore<Sect
 
   @Override
   public List<Section> getSectionsByIndicators(List<Indicator> indicators) {
-    // language=sql
     String sql =
         """
             select s.* from section s

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datastore/hibernate/HibernateDatastoreStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datastore/hibernate/HibernateDatastoreStore.java
@@ -168,14 +168,14 @@ public class HibernateDatastoreStore extends HibernateIdentifiableObjectStore<Da
   public void deleteNamespace(String ns) {
     // language=SQL
     String sql = "delete from keyjsonvalue ds where ds.namespace = :ns";
-    getSession().createNativeQuery(sql).setParameter("ns", ns).executeUpdate();
+    nativeSynchronizedQuery(sql).setParameter("ns", ns).executeUpdate();
   }
 
   @Override
   public int countKeysInNamespace(String ns) {
     // language=SQL
     String sql = "select count(*) from keyjsonvalue v where v.namespace = :ns";
-    Object count = getSession().createNativeQuery(sql).setParameter("ns", ns).uniqueResult();
+    Object count = nativeSynchronizedQuery(sql).setParameter("ns", ns).uniqueResult();
     if (count == null) return 0;
     if (count instanceof Number n) return n.intValue();
     throw new IllegalStateException("Count did not return a number but: " + count);
@@ -221,8 +221,7 @@ public class HibernateDatastoreStore extends HibernateIdentifiableObjectStore<Da
             else jsonb_set(jbvalue, cast(:path as text[]), to_jsonb(ARRAY[cast(:value as jsonb)]))
             end
           where namespace = :ns and namespacekey = :key""";
-    return getSession()
-            .createNativeQuery(sql)
+    return nativeSynchronizedQuery(sql)
             .setParameter("ns", ns)
             .setParameter("key", key)
             .setParameter("value", value)
@@ -247,8 +246,7 @@ public class HibernateDatastoreStore extends HibernateIdentifiableObjectStore<Da
         else cast(:value as jsonb)
         end
       where namespace = :ns and namespacekey = :key""";
-    return getSession()
-            .createNativeQuery(sql)
+    return nativeSynchronizedQuery(sql)
             .setParameter("ns", ns)
             .setParameter("key", key)
             .setParameter("value", value)
@@ -259,8 +257,7 @@ public class HibernateDatastoreStore extends HibernateIdentifiableObjectStore<Da
 
   private boolean updateEntryPathSetToValue(
       @Nonnull String ns, @Nonnull String key, @Nonnull String value, @Nonnull String path) {
-    return getSession()
-            .createNativeQuery(
+    return nativeSynchronizedQuery(
                 "update keyjsonvalue set jbvalue = jsonb_set(jbvalue, cast(:path as text[]), cast(:value as jsonb), false) where namespace = :ns and namespacekey = :key")
             .setParameter("ns", ns)
             .setParameter("key", key)
@@ -272,8 +269,7 @@ public class HibernateDatastoreStore extends HibernateIdentifiableObjectStore<Da
 
   private boolean updateEntryRootSetToValue(
       @Nonnull String ns, @Nonnull String key, @Nonnull String value) {
-    return getSession()
-            .createNativeQuery(
+    return nativeSynchronizedQuery(
                 "update keyjsonvalue set jbvalue = cast(:value as jsonb) where namespace = :ns and namespacekey = :key")
             .setParameter("ns", ns)
             .setParameter("key", key)
@@ -284,8 +280,7 @@ public class HibernateDatastoreStore extends HibernateIdentifiableObjectStore<Da
 
   private boolean updateEntryPathSetToNull(
       @Nonnull String ns, @Nonnull String key, @Nonnull String path) {
-    return getSession()
-            .createNativeQuery(
+    return nativeSynchronizedQuery(
                 "update keyjsonvalue set jbvalue = jsonb_set(jbvalue, cast(:path as text[]), 'null', false) where namespace = :ns and namespacekey = :key")
             .setParameter("ns", ns)
             .setParameter("key", key)
@@ -296,8 +291,7 @@ public class HibernateDatastoreStore extends HibernateIdentifiableObjectStore<Da
 
   private boolean updateEntryRootDelete(@Nonnull String ns, @Nonnull String key) {
     // delete
-    return getSession()
-            .createNativeQuery(
+    return nativeSynchronizedQuery(
                 "delete from keyjsonvalue where namespace = :ns and namespacekey = :key")
             .setParameter("ns", ns)
             .setParameter("key", key)

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datastore/hibernate/HibernateDatastoreStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datastore/hibernate/HibernateDatastoreStore.java
@@ -166,14 +166,12 @@ public class HibernateDatastoreStore extends HibernateIdentifiableObjectStore<Da
 
   @Override
   public void deleteNamespace(String ns) {
-    // language=SQL
     String sql = "delete from keyjsonvalue ds where ds.namespace = :ns";
     nativeSynchronizedQuery(sql).setParameter("ns", ns).executeUpdate();
   }
 
   @Override
   public int countKeysInNamespace(String ns) {
-    // language=SQL
     String sql = "select count(*) from keyjsonvalue v where v.namespace = :ns";
     Object count = nativeSynchronizedQuery(sql).setParameter("ns", ns).uniqueResult();
     if (count == null) return 0;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueStore.java
@@ -190,8 +190,7 @@ public class HibernateDataValueStore extends HibernateGenericStore<DataValue>
         and deleted is true""";
 
     return getSingleResult(
-        getSession()
-            .createNativeQuery(sql, DataValue.class)
+        nativeSynchronizedTypedQuery(sql)
             .setParameter("deid", dataValue.getDataElement().getId())
             .setParameter("periodid", storedPeriod.getId())
             .setParameter("attributeOptionCombo", dataValue.getAttributeOptionCombo().getId())
@@ -240,12 +239,15 @@ public class HibernateDataValueStore extends HibernateGenericStore<DataValue>
     String cocIdsSql =
         "select distinct categoryoptioncomboid from categorycombos_optioncombos where categorycomboid = :cc";
     List<?> cocIds =
-        getSession().createNativeQuery(cocIdsSql).setParameter("cc", combo.getId()).list();
+        getSession()
+            .createNativeQuery(cocIdsSql)
+            .addSynchronizedEntityClass(CategoryOptionCombo.class)
+            .setParameter("cc", combo.getId())
+            .list();
     String anyDataValueSql =
         "select 1 from datavalue dv "
             + "where dv.categoryoptioncomboid in :cocIds or dv.attributeoptioncomboid in :cocIds limit 1";
-    return !getSession()
-        .createNativeQuery(anyDataValueSql)
+    return !nativeSynchronizedQuery(anyDataValueSql)
         .setParameter("cocIds", cocIds)
         .list()
         .isEmpty();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deduplication/hibernate/HibernatePotentialDuplicateStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/deduplication/hibernate/HibernatePotentialDuplicateStore.java
@@ -188,10 +188,9 @@ public class HibernatePotentialDuplicateStore
     }
 
     NativeQuery<BigInteger> query =
-        getSession()
-            .createNativeQuery(
-                "select count(potentialduplicateid) from potentialduplicate pd "
-                    + "where (pd.original = :original and pd.duplicate = :duplicate) or (pd.original = :duplicate and pd.duplicate = :original)");
+        nativeSynchronizedQuery(
+            "select count(potentialduplicateid) from potentialduplicate pd "
+                + "where (pd.original = :original and pd.duplicate = :duplicate) or (pd.original = :duplicate and pd.duplicate = :original)");
 
     query.setParameter("original", potentialDuplicate.getOriginal());
     query.setParameter("duplicate", potentialDuplicate.getDuplicate());

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/hibernate/HibernateFileResourceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/hibernate/HibernateFileResourceStore.java
@@ -34,12 +34,19 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.persistence.EntityManager;
+import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
+import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.datavalue.DataValueKey;
+import org.hisp.dhis.document.Document;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.fileresource.FileResourceDomain;
 import org.hisp.dhis.fileresource.FileResourceStore;
+import org.hisp.dhis.icon.Icon;
+import org.hisp.dhis.message.Message;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.User;
 import org.joda.time.DateTime;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -61,24 +68,20 @@ public class HibernateFileResourceStore extends HibernateIdentifiableObjectStore
 
   @Override
   public List<FileResource> getExpiredFileResources(DateTime expires) {
-    List<FileResource> results =
-        getSession()
-            .createNativeQuery(
-                "select fr.* "
-                    + "from fileresource fr "
-                    + "inner join (select dva.value "
-                    + "from datavalueaudit dva "
-                    + "where dva.created < :date "
-                    + "and dva.audittype in ('DELETE', 'UPDATE') "
-                    + "and dva.dataelementid in "
-                    + "(select dataelementid from dataelement where valuetype = 'FILE_RESOURCE')) dva "
-                    + "on dva.value = fr.uid "
-                    + "where fr.isassigned = true; ",
-                FileResource.class)
-            .setParameter("date", expires.toDate())
-            .getResultList();
-
-    return results;
+    String sql =
+        """
+        select fr.*
+        from fileresource fr
+        inner join (select dva.value
+        from datavalueaudit dva
+        where dva.created < :date
+        and dva.audittype in ('DELETE', 'UPDATE')
+        and dva.dataelementid in
+        (select dataelementid from dataelement where valuetype = 'FILE_RESOURCE')) dva
+        on dva.value = fr.uid
+        where fr.isassigned = true;
+        """;
+    return nativeSynchronizedTypedQuery(sql).setParameter("date", expires.toDate()).getResultList();
   }
 
   @Override
@@ -94,9 +97,8 @@ public class HibernateFileResourceStore extends HibernateIdentifiableObjectStore
 
   @Override
   public Optional<FileResource> findByStorageKey(@Nonnull String storageKey) {
-    return getSession()
-        .createNativeQuery(
-            "select fr.* from fileresource fr where fr.storagekey = :key", FileResource.class)
+    return nativeSynchronizedTypedQuery(
+            "select fr.* from fileresource fr where fr.storagekey = :key")
         .setParameter("key", storageKey)
         .getResultStream()
         .findFirst();
@@ -105,9 +107,8 @@ public class HibernateFileResourceStore extends HibernateIdentifiableObjectStore
   @Override
   public Optional<FileResource> findByUidAndDomain(
       @Nonnull String uid, @Nonnull FileResourceDomain domain) {
-    return getSession()
-        .createNativeQuery(
-            "select * from fileresource where uid = :uid and domain = :domain", FileResource.class)
+    return nativeSynchronizedTypedQuery(
+            "select * from fileresource where uid = :uid and domain = :domain")
         .setParameter("uid", uid)
         .setParameter("domain", domain.name())
         .getResultList()
@@ -119,28 +120,40 @@ public class HibernateFileResourceStore extends HibernateIdentifiableObjectStore
   public List<String> findOrganisationUnitsByImageFileResource(@Nonnull String uid) {
     String sql =
         "select o.uid from organisationunit o left join fileresource fr on fr.fileresourceid = o.image where fr.uid = :uid";
-    return getSession().createNativeQuery(sql).setParameter("uid", uid).list();
+    return nativeSynchronizedQuery(sql)
+        .addSynchronizedEntityClass(OrganisationUnit.class)
+        .setParameter("uid", uid)
+        .list();
   }
 
   @Override
   public List<String> findUsersByAvatarFileResource(@Nonnull String uid) {
     String sql =
         "select u.uid from userinfo u left join fileresource fr on fr.fileresourceid = u.avatar where fr.uid = :uid";
-    return getSession().createNativeQuery(sql).setParameter("uid", uid).list();
+    return nativeSynchronizedQuery(sql)
+        .addSynchronizedEntityClass(User.class)
+        .setParameter("uid", uid)
+        .list();
   }
 
   @Override
   public List<String> findDocumentsByFileResource(@Nonnull String uid) {
     String sql =
         "select d.uid from document d left join fileresource fr on fr.fileresourceid = d.fileresource where fr.uid = :uid";
-    return getSession().createNativeQuery(sql).setParameter("uid", uid).list();
+    return nativeSynchronizedQuery(sql)
+        .addSynchronizedEntityClass(Document.class)
+        .setParameter("uid", uid)
+        .list();
   }
 
   @Override
   public List<String> findCustomIconByFileResource(@Nonnull String uid) {
     String sql =
         "select ci.key from customicon ci left join fileresource fr on fr.fileresourceid = ci.fileresourceid where fr.uid = :uid";
-    return getSession().createNativeQuery(sql).setParameter("uid", uid).list();
+    return nativeSynchronizedQuery(sql)
+        .addSynchronizedEntityClass(Icon.class)
+        .setParameter("uid", uid)
+        .list();
   }
 
   @Override
@@ -149,7 +162,10 @@ public class HibernateFileResourceStore extends HibernateIdentifiableObjectStore
         "select m.uid from message m "
             + "left join messageattachments ma on m.messageid = ma.messageid "
             + "left join fileresource fr on fr.fileresourceid = ma.fileresourceid where fr.uid = :uid";
-    return getSession().createNativeQuery(sql).setParameter("uid", uid).list();
+    return nativeSynchronizedQuery(sql)
+        .addSynchronizedEntityClass(Message.class)
+        .setParameter("uid", uid)
+        .list();
   }
 
   @Override
@@ -160,7 +176,13 @@ public class HibernateFileResourceStore extends HibernateIdentifiableObjectStore
             + " inner join organisationunit o on dv.sourceid = o.organisationunitid"
             + " inner join categoryoptioncombo co on dv.categoryoptioncomboid = co.categoryoptioncomboid"
             + " where de.valuetype = 'FILE_RESOURCE' and dv.value = :uid";
-    Stream<Object[]> stream = getSession().createNativeQuery(sql).setParameter("uid", uid).stream();
+    Stream<Object[]> stream =
+        nativeSynchronizedQuery(sql)
+            .addSynchronizedEntityClass(DataValue.class)
+            .addSynchronizedEntityClass(OrganisationUnit.class)
+            .addSynchronizedEntityClass(CategoryOptionCombo.class)
+            .setParameter("uid", uid)
+            .stream();
     return stream
         .map(
             col ->

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/message/hibernate/HibernateMessageConversationStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/message/hibernate/HibernateMessageConversationStore.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
 import org.hibernate.query.Query;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
+import org.hisp.dhis.message.Message;
 import org.hisp.dhis.message.MessageConversation;
 import org.hisp.dhis.message.MessageConversationStatus;
 import org.hisp.dhis.message.MessageConversationStore;
@@ -152,7 +153,7 @@ public class HibernateMessageConversationStore
             + sender.getId()
             + ")";
 
-    getSqlQuery(sql).executeUpdate();
+    nativeSynchronizedQuery(sql).addSynchronizedEntityClass(Message.class).executeUpdate();
 
     String hql = "delete Message m where m.sender = :sender";
 
@@ -169,7 +170,7 @@ public class HibernateMessageConversationStore
             + user.getId()
             + ")";
 
-    getSqlQuery(sql).executeUpdate();
+    nativeSynchronizedQuery(sql).addSynchronizedEntityClass(UserMessage.class).executeUpdate();
 
     String hql = "delete UserMessage u where u.user = :user";
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/note/hibernate/HibernateNoteStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/note/hibernate/HibernateNoteStore.java
@@ -53,8 +53,7 @@ public class HibernateNoteStore extends HibernateIdentifiableObjectStore<Note>
   @Override
   public boolean exists(String uid) {
     return (boolean)
-        entityManager
-            .createNativeQuery("select exists(select 1 from note where uid=:uid)")
+        nativeSynchronizedQuery("select exists(select 1 from note where uid=:uid)")
             .setParameter("uid", uid)
             .getSingleResult();
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEnrollmentStore.java
@@ -117,9 +117,8 @@ public class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enr
     }
 
     Query<?> query =
-        getSession()
-            .createNativeQuery(
-                "select exists(select 1 from enrollment where uid=:uid and deleted is false)");
+        nativeSynchronizedQuery(
+            "select exists(select 1 from enrollment where uid=:uid and deleted is false)");
     query.setParameter("uid", uid);
 
     return ((Boolean) query.getSingleResult()).booleanValue();
@@ -132,7 +131,7 @@ public class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enr
     }
 
     Query<?> query =
-        getSession().createNativeQuery("select exists(select 1 from enrollment where uid=:uid)");
+        nativeSynchronizedQuery("select exists(select 1 from enrollment where uid=:uid)");
     query.setParameter("uid", uid);
 
     return ((Boolean) query.getSingleResult()).booleanValue();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventStore.java
@@ -90,9 +90,8 @@ public class HibernateEventStore extends SoftDeleteHibernateObjectStore<Event>
     }
 
     Query<?> query =
-        getSession()
-            .createNativeQuery(
-                "select exists(select 1 from event where uid=:uid and deleted is false)");
+        nativeSynchronizedQuery(
+            "select exists(select 1 from event where uid=:uid and deleted is false)");
     query.setParameter("uid", uid);
 
     return ((Boolean) query.getSingleResult()).booleanValue();
@@ -104,8 +103,7 @@ public class HibernateEventStore extends SoftDeleteHibernateObjectStore<Event>
       return false;
     }
 
-    Query<?> query =
-        getSession().createNativeQuery("select exists(select 1 from event where uid=:uid)");
+    Query<?> query = nativeSynchronizedQuery("select exists(select 1 from event where uid=:uid)");
     query.setParameter("uid", uid);
 
     return ((Boolean) query.getSingleResult()).booleanValue();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramStore.java
@@ -108,9 +108,8 @@ public class HibernateProgramStore extends HibernateIdentifiableObjectStore<Prog
   @SuppressWarnings("unchecked")
   public boolean hasOrgUnit(Program program, OrganisationUnit organisationUnit) {
     NativeQuery<Long> query =
-        getSession()
-            .createNativeQuery(
-                "select programid from program_organisationunits where programid = :pid and organisationunitid = :ouid");
+        nativeSynchronizedQuery(
+            "select programid from program_organisationunits where programid = :pid and organisationunitid = :ouid");
     query.setParameter("pid", program.getId());
     query.setParameter("ouid", organisationUnit.getId());
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationTemplateStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationTemplateStore.java
@@ -80,9 +80,8 @@ public class DefaultProgramNotificationTemplateStore
   @Override
   public boolean isProgramLinkedToWebHookNotification(Long pId) {
     NativeQuery<BigInteger> query =
-        getSession()
-            .createNativeQuery(
-                "select count(*) from programnotificationtemplate where programid = :pid and notificationrecipienttype = :recipient");
+        nativeSynchronizedQuery(
+            "select count(*) from programnotificationtemplate where programid = :pid and notificationrecipienttype = :recipient");
     query.setParameter(PROGRAM_ID, pId);
     query.setParameter(NOTIFICATION_RECIPIENT, ProgramNotificationRecipient.WEB_HOOK.name());
 
@@ -92,9 +91,8 @@ public class DefaultProgramNotificationTemplateStore
   @Override
   public boolean isProgramStageLinkedToWebHookNotification(Long psId) {
     NativeQuery<BigInteger> query =
-        getSession()
-            .createNativeQuery(
-                "select count(*) from programnotificationtemplate where programstageid = :psid and notificationrecipienttype = :recipient");
+        nativeSynchronizedQuery(
+            "select count(*) from programnotificationtemplate where programstageid = :psid and notificationrecipienttype = :recipient");
     query.setParameter(PROGRAM_STAGE_ID, psId);
     query.setParameter(NOTIFICATION_RECIPIENT, ProgramNotificationRecipient.WEB_HOOK.name());
 
@@ -104,10 +102,8 @@ public class DefaultProgramNotificationTemplateStore
   @Override
   public List<ProgramNotificationTemplate> getProgramLinkedToWebHookNotifications(Program program) {
     NativeQuery<ProgramNotificationTemplate> query =
-        getSession()
-            .createNativeQuery(
-                "select * from programnotificationtemplate where programid = :pid and notificationrecipienttype = :recipient",
-                ProgramNotificationTemplate.class);
+        nativeSynchronizedTypedQuery(
+            "select * from programnotificationtemplate where programid = :pid and notificationrecipienttype = :recipient");
     query.setParameter(PROGRAM_ID, program.getId());
     query.setParameter(NOTIFICATION_RECIPIENT, ProgramNotificationRecipient.WEB_HOOK.name());
 
@@ -118,10 +114,8 @@ public class DefaultProgramNotificationTemplateStore
   public List<ProgramNotificationTemplate> getProgramStageLinkedToWebHookNotifications(
       ProgramStage programStage) {
     NativeQuery<ProgramNotificationTemplate> query =
-        getSession()
-            .createNativeQuery(
-                "select * from programnotificationtemplate where programstageid = :psid and notificationrecipienttype = :recipient",
-                ProgramNotificationTemplate.class);
+        nativeSynchronizedTypedQuery(
+            "select * from programnotificationtemplate where programstageid = :psid and notificationrecipienttype = :recipient");
     query.setParameter(PROGRAM_STAGE_ID, programStage.getId());
     query.setParameter(NOTIFICATION_RECIPIENT, ProgramNotificationRecipient.WEB_HOOK.name());
 
@@ -131,9 +125,8 @@ public class DefaultProgramNotificationTemplateStore
   @Override
   public int countProgramNotificationTemplates(ProgramNotificationTemplateParam param) {
     Query query =
-        getSession()
-            .createNativeQuery(
-                "select count(*) from programnotificationtemplate where programstageid = :psid or  programid = :pid");
+        nativeSynchronizedQuery(
+            "select count(*) from programnotificationtemplate where programstageid = :psid or  programid = :pid");
     query.setParameter(
         PROGRAM_STAGE_ID, param.hasProgramStage() ? param.getProgramStage().getId() : 0);
     query.setParameter(PROGRAM_ID, param.hasProgram() ? param.getProgram().getId() : 0);
@@ -145,10 +138,8 @@ public class DefaultProgramNotificationTemplateStore
   public List<ProgramNotificationTemplate> getProgramNotificationTemplates(
       ProgramNotificationTemplateParam param) {
     NativeQuery<ProgramNotificationTemplate> query =
-        getSession()
-            .createNativeQuery(
-                "select * from programnotificationtemplate where programstageid = :psid or  programid = :pid",
-                ProgramNotificationTemplate.class);
+        nativeSynchronizedTypedQuery(
+            "select * from programnotificationtemplate where programstageid = :psid or  programid = :pid");
 
     query.setParameter(
         PROGRAM_STAGE_ID, param.hasProgramStage() ? param.getProgramStage().getId() : 0);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HibernateJobConfigurationStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/HibernateJobConfigurationStore.java
@@ -69,7 +69,6 @@ public class HibernateJobConfigurationStore
 
   @Override
   public String getLastRunningId(@Nonnull JobType type) {
-    // language=SQL
     String sql =
         """
       select uid from jobconfiguration
@@ -80,7 +79,6 @@ public class HibernateJobConfigurationStore
 
   @Override
   public String getLastCompletedId(@Nonnull JobType type) {
-    // language=SQL
     String sql =
         """
       select uid from jobconfiguration
@@ -91,7 +89,6 @@ public class HibernateJobConfigurationStore
 
   @Override
   public String getProgress(@Nonnull String jobId) {
-    // language=SQL
     String sql =
         """
       select
@@ -107,7 +104,6 @@ public class HibernateJobConfigurationStore
 
   @Override
   public String getErrors(@Nonnull String jobId) {
-    // language=SQL
     String sql =
         """
           select
@@ -122,28 +118,24 @@ public class HibernateJobConfigurationStore
 
   @Override
   public Set<String> getAllIds() {
-    // language=SQL
     String sql = "select uid from jobconfiguration";
     return getResultSet(nativeSynchronizedQuery(sql), Object::toString);
   }
 
   @Override
   public Set<String> getAllCancelledIds() {
-    // language=SQL
     String sql = "select uid from jobconfiguration where cancel = true";
     return getResultSet(nativeSynchronizedQuery(sql), Object::toString);
   }
 
   @Override
   public Set<JobType> getRunningTypes() {
-    // language=SQL
     String sql = "select distinct jobtype from jobconfiguration where jobstatus = 'RUNNING'";
     return getResultSet(nativeSynchronizedQuery(sql), JobType::valueOf);
   }
 
   @Override
   public Set<JobType> getCompletedTypes() {
-    // language=SQL
     String sql =
         """
       select distinct jobtype from jobconfiguration
@@ -156,14 +148,12 @@ public class HibernateJobConfigurationStore
 
   @Override
   public Set<String> getAllQueueNames() {
-    // language=SQL
     String sql = "select distinct queuename from jobconfiguration where queuename is not null";
     return getResultSet(nativeSynchronizedQuery(sql), Object::toString);
   }
 
   @Override
   public List<JobConfiguration> getJobsInQueue(@Nonnull String queue) {
-    // language=SQL
     String sql = "select * from jobconfiguration where queuename = :queue order by queueposition;";
     return nativeSynchronizedTypedQuery(sql).setParameter("queue", queue).list();
   }
@@ -171,7 +161,6 @@ public class HibernateJobConfigurationStore
   @Override
   @CheckForNull
   public JobConfiguration getNextInQueue(@Nonnull String queue, int fromPosition) {
-    // language=SQL
     String sql = "select * from jobconfiguration where queuename = :queue and queueposition = :pos";
     List<JobConfiguration> res =
         nativeSynchronizedTypedQuery(sql)
@@ -205,7 +194,6 @@ public class HibernateJobConfigurationStore
 
   @Override
   public Stream<JobConfiguration> getDueJobConfigurations(boolean includeWaiting) {
-    // language=SQL
     String sql =
         """
         select * from jobconfiguration j1
@@ -226,7 +214,6 @@ public class HibernateJobConfigurationStore
   @Nonnull
   @Override
   public Stream<String> findJobRunErrors(@Nonnull JobRunErrorsParams params) {
-    // language=SQL
     String sql =
         """
     select jsonb_build_object(
@@ -285,7 +272,6 @@ public class HibernateJobConfigurationStore
   @Override
   @Transactional(propagation = REQUIRES_NEW)
   public boolean tryExecuteNow(@Nonnull String jobId) {
-    // language=SQL
     String sql =
         """
         update jobconfiguration
@@ -304,7 +290,6 @@ public class HibernateJobConfigurationStore
   @Override
   public boolean tryStart(@Nonnull String jobId) {
     // only flip from SCHEDULED to RUNNING if no other job of same type is RUNNING
-    // language=SQL
     String sql =
         """
         update jobconfiguration j1
@@ -330,7 +315,6 @@ public class HibernateJobConfigurationStore
 
   @Override
   public boolean tryCancel(@Nonnull String jobId) {
-    // language=SQL
     String sql =
         """
         update jobconfiguration
@@ -360,7 +344,6 @@ public class HibernateJobConfigurationStore
 
   @Override
   public boolean tryFinish(@Nonnull String jobId, JobStatus status) {
-    // language=SQL
     String sql =
         """
         update jobconfiguration
@@ -393,7 +376,6 @@ public class HibernateJobConfigurationStore
 
   @Override
   public boolean trySkip(@Nonnull String queue) {
-    // language=SQL
     String sql =
         """
         update jobconfiguration
@@ -418,7 +400,6 @@ public class HibernateJobConfigurationStore
   @Override
   public void updateProgress(
       @Nonnull String jobId, @CheckForNull String progressJson, @CheckForNull String errorCodes) {
-    // language=SQL
     String sql =
         """
         update jobconfiguration
@@ -437,7 +418,6 @@ public class HibernateJobConfigurationStore
 
   @Override
   public int updateDisabledJobs() {
-    // language=SQL
     String sql =
         """
         update jobconfiguration
@@ -452,7 +432,6 @@ public class HibernateJobConfigurationStore
 
   @Override
   public int deleteFinishedJobs(int ttlMinutes) {
-    // language=SQL
     String sql =
         """
         delete from jobconfiguration
@@ -481,7 +460,6 @@ public class HibernateJobConfigurationStore
 
   @Override
   public int rescheduleStaleJobs(int timeoutMinutes) {
-    // language=SQL
     String sql =
         """
         update jobconfiguration
@@ -511,7 +489,6 @@ public class HibernateJobConfigurationStore
 
   @Override
   public boolean tryRevertNow(@Nonnull String jobId) {
-    // language=SQL
     String sql =
         """
         update jobconfiguration

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityChangeLogStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityChangeLogStore.java
@@ -100,7 +100,7 @@ public class HibernateTrackedEntityChangeLogStore
     final String values =
         trackedEntityChangeLog.stream().map(mapToString).collect(Collectors.joining(","));
 
-    getSession().createNativeQuery(sql + values).executeUpdate();
+    nativeSynchronizedQuery(sql + values).executeUpdate();
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
@@ -1056,9 +1056,8 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
   @Override
   public boolean exists(String uid) {
     Query<?> query =
-        getSession()
-            .createNativeQuery(
-                "select count(*) from trackedentity where uid=:uid and deleted is false");
+        nativeSynchronizedQuery(
+            "select count(*) from trackedentity where uid=:uid and deleted is false");
     query.setParameter("uid", uid);
     int count = ((Number) query.getSingleResult()).intValue();
 
@@ -1067,8 +1066,7 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
 
   @Override
   public boolean existsIncludingDeleted(String uid) {
-    Query<?> query =
-        getSession().createNativeQuery("select count(*) from trackedentity where uid=:uid");
+    Query<?> query = nativeSynchronizedQuery("select count(*) from trackedentity where uid=:uid");
     query.setParameter("uid", uid);
     int count = ((Number) query.getSingleResult()).intValue();
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -76,6 +76,7 @@ import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserAccountExpiryInfo;
+import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.UserInvitationStatus;
 import org.hisp.dhis.user.UserQueryParams;
 import org.hisp.dhis.user.UserStore;
@@ -497,7 +498,9 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
               and u.userinfoid in (select m.userid from usergroup g inner join usergroupmembers m on m.usergroupid = g.usergroupid where g.uid = :group);
             """;
     NativeQuery<?> emailsByUsername =
-        getSession().createNativeQuery(sql).setParameter("group", userGroupId);
+        nativeSynchronizedQuery(sql)
+            .addSynchronizedEntityClass(UserGroup.class)
+            .setParameter("group", userGroupId);
     return emailsByUsername.stream()
         .collect(
             toMap(
@@ -509,7 +512,7 @@ public class HibernateUserStore extends HibernateIdentifiableObjectStore<User>
   @SuppressWarnings("unchecked")
   public String getDisplayName(String userUid) {
     String sql = "select concat(firstname, ' ', surname) from userinfo where uid =:uid";
-    Query<String> query = getSession().createNativeQuery(sql);
+    Query<String> query = nativeSynchronizedQuery(sql);
     query.setParameter("uid", userUid);
     return getSingleResult(query);
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/userdatastore/hibernate/HibernateUserDatastoreStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/userdatastore/hibernate/HibernateUserDatastoreStore.java
@@ -194,8 +194,7 @@ public class HibernateUserDatastoreStore
             else jsonb_set(jbvalue, cast(:path as text[]), to_jsonb(ARRAY[cast(:value as jsonb)]))
             end
           where namespace = :ns and userkey = :key""";
-    return getSession()
-            .createNativeQuery(sql)
+    return nativeSynchronizedQuery(sql)
             .setParameter("ns", ns)
             .setParameter("key", key)
             .setParameter("value", value)
@@ -220,8 +219,7 @@ public class HibernateUserDatastoreStore
         else cast(:value as jsonb)
         end
       where namespace = :ns and userkey = :key""";
-    return getSession()
-            .createNativeQuery(sql)
+    return nativeSynchronizedQuery(sql)
             .setParameter("ns", ns)
             .setParameter("key", key)
             .setParameter("value", value)
@@ -232,8 +230,7 @@ public class HibernateUserDatastoreStore
 
   private boolean updateEntryPathSetToValue(
       @Nonnull String ns, @Nonnull String key, @Nonnull String value, @Nonnull String path) {
-    return getSession()
-            .createNativeQuery(
+    return nativeSynchronizedQuery(
                 "update userkeyjsonvalue set jbvalue = jsonb_set(jbvalue, cast(:path as text[]), cast(:value as jsonb), false) where namespace = :ns and userkey = :key")
             .setParameter("ns", ns)
             .setParameter("key", key)
@@ -245,8 +242,7 @@ public class HibernateUserDatastoreStore
 
   private boolean updateEntryRootSetToValue(
       @Nonnull String ns, @Nonnull String key, @Nonnull String value) {
-    return getSession()
-            .createNativeQuery(
+    return nativeSynchronizedQuery(
                 "update userkeyjsonvalue set jbvalue = cast(:value as jsonb) where namespace = :ns and userkey = :key")
             .setParameter("ns", ns)
             .setParameter("key", key)
@@ -257,8 +253,7 @@ public class HibernateUserDatastoreStore
 
   private boolean updateEntryPathSetToNull(
       @Nonnull String ns, @Nonnull String key, @Nonnull String path) {
-    return getSession()
-            .createNativeQuery(
+    return nativeSynchronizedQuery(
                 "update userkeyjsonvalue set jbvalue = jsonb_set(jbvalue, cast(:path as text[]), 'null', false) where namespace = :ns and userkey = :key")
             .setParameter("ns", ns)
             .setParameter("key", key)
@@ -269,8 +264,7 @@ public class HibernateUserDatastoreStore
 
   private boolean updateEntryRootDelete(@Nonnull String ns, @Nonnull String key) {
     // delete
-    return getSession()
-            .createNativeQuery(
+    return nativeSynchronizedQuery(
                 "delete from userkeyjsonvalue where namespace = :ns and userkey = :key")
             .setParameter("ns", ns)
             .setParameter("key", key)

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/hibernate/HibernateProgramRuleStore.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/hibernate/HibernateProgramRuleStore.java
@@ -125,8 +125,7 @@ public class HibernateProgramRuleStore extends HibernateIdentifiableObjectStore<
                 """;
 
     List<ProgramRule> programRules =
-        getSession()
-            .createNativeQuery(sql, ProgramRule.class)
+        nativeSynchronizedTypedQuery(sql)
             .setParameter("programId", program.getId())
             .setParameter("implementableTypes", actionTypeNames)
             .setParameter("programStageUid", programStageUid)
@@ -145,6 +144,7 @@ public class HibernateProgramRuleStore extends HibernateIdentifiableObjectStore<
     Map<ProgramRule, Set<ProgramRuleAction>> ruleActions =
         getSession()
             .createNativeQuery(sql, ProgramRuleAction.class)
+            .addSynchronizedEntityClass(ProgramRuleAction.class)
             .setParameter(
                 "programRuleIds", programRules.stream().map(BaseIdentifiableObject::getId).toList())
             .setParameter("implementableTypes", actionTypeNames)
@@ -219,12 +219,12 @@ public class HibernateProgramRuleStore extends HibernateIdentifiableObjectStore<
   public List<ProgramRule> getProgramRulesByEvaluationEnvironment(
       ProgramRuleActionEvaluationEnvironment environment) {
     List<BigInteger> bigIntegerList =
-        getSession()
-            .createNativeQuery(
+        nativeSynchronizedQuery(
                 "select pra.programruleactionid from programrule pr JOIN programruleaction pra ON pr.programruleid=pra.programruleid "
                     + "where environments@> '[\""
                     + environment
                     + "\"]';")
+            .addSynchronizedEntityClass(ProgramRuleAction.class)
             .list();
     List<Long> idList =
         bigIntegerList.stream()

--- a/dhis-2/dhis-support/dhis-support-hibernate/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/pom.xml
@@ -222,6 +222,11 @@
       <groupId>javax.persistence</groupId>
       <artifactId>javax.persistence-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>24.1.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/HibernateGenericStore.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/HibernateGenericStore.java
@@ -61,6 +61,7 @@ import org.hisp.dhis.common.AuditLogUtil;
 import org.hisp.dhis.common.GenericStore;
 import org.hisp.dhis.common.ObjectDeletionRequestedEvent;
 import org.hisp.dhis.hibernate.jsonb.type.JsonAttributeValueBinaryType;
+import org.intellij.lang.annotations.Language;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 
@@ -707,5 +708,25 @@ public class HibernateGenericStore<T> implements GenericStore<T> {
               }
             })
         .collect(Collectors.toList());
+  }
+
+  /**
+   * Create a Hibernate {@link NativeQuery} instance with {@code SynchronizedEntityClass} set to the
+   * current class of the store. Use this to avoid all Hibernate second level caches from being
+   * invalidated.
+   *
+   * <p>Be aware that it is only correct to use this if and only if the only table touched by the
+   * native query is the one table belonging to the store.
+   *
+   * @param sql the SQL query to execute
+   * @return the {@link NativeQuery} instance
+   */
+  @SuppressWarnings("rawtypes")
+  protected NativeQuery nativeSynchronizedQuery(@Language("SQL") String sql) {
+    return getSession().createNativeQuery(sql).addSynchronizedEntityClass(getClazz());
+  }
+
+  protected NativeQuery<T> nativeSynchronizedTypedQuery(@Language("SQL") String sql) {
+    return getSession().createNativeQuery(sql, clazz).addSynchronizedEntityClass(getClazz());
   }
 }

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/HibernateGenericStore.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/HibernateGenericStore.java
@@ -352,30 +352,27 @@ public class HibernateGenericStore<T> implements GenericStore<T> {
   // ------------------------------------------------------------------------------------------
 
   /**
-   * Creates a SqlQuery.
+   * Create a Hibernate {@link NativeQuery} instance with {@code SynchronizedEntityClass} set to the
+   * current class of the store. Use this to avoid all Hibernate second level caches from being
+   * invalidated.
    *
-   * @param sql the SQL query String.
-   * @return a NativeQuery<T> instance.
+   * <p>Be aware that it is only correct to use this if and only if the only table touched by the
+   * native query is the one table belonging to the store.
+   *
+   * @param sql the SQL query to execute
+   * @return the {@link NativeQuery} instance
    */
-  @SuppressWarnings("unchecked")
-  protected final NativeQuery<T> getSqlQuery(String sql) {
-    return getSession()
-        .createNativeQuery(sql)
-        .setCacheable(cacheable)
-        .setHint(QueryHints.CACHEABLE, cacheable);
+  @SuppressWarnings("rawtypes")
+  protected NativeQuery nativeSynchronizedQuery(@Language("SQL") String sql) {
+    return getSession().createNativeQuery(sql).addSynchronizedEntityClass(getClazz());
   }
 
   /**
-   * Creates a untyped SqlQuery.
-   *
-   * @param sql the SQL query String.
-   * @return a NativeQuery<T> instance.
+   * Same as {@link #nativeSynchronizedQuery(String)} just with the return type being specified as
+   * the store entity type. Use only when the result is a of the store entity type or a list of it.
    */
-  protected final NativeQuery<?> getUntypedSqlQuery(String sql) {
-    return getSession()
-        .createNativeQuery(sql)
-        .setCacheable(cacheable)
-        .setHint(QueryHints.CACHEABLE, cacheable);
+  protected NativeQuery<T> nativeSynchronizedTypedQuery(@Language("SQL") String sql) {
+    return getSession().createNativeQuery(sql, clazz).addSynchronizedEntityClass(getClazz());
   }
 
   // -------------------------------------------------------------------------
@@ -708,25 +705,5 @@ public class HibernateGenericStore<T> implements GenericStore<T> {
               }
             })
         .collect(Collectors.toList());
-  }
-
-  /**
-   * Create a Hibernate {@link NativeQuery} instance with {@code SynchronizedEntityClass} set to the
-   * current class of the store. Use this to avoid all Hibernate second level caches from being
-   * invalidated.
-   *
-   * <p>Be aware that it is only correct to use this if and only if the only table touched by the
-   * native query is the one table belonging to the store.
-   *
-   * @param sql the SQL query to execute
-   * @return the {@link NativeQuery} instance
-   */
-  @SuppressWarnings("rawtypes")
-  protected NativeQuery nativeSynchronizedQuery(@Language("SQL") String sql) {
-    return getSession().createNativeQuery(sql).addSynchronizedEntityClass(getClazz());
-  }
-
-  protected NativeQuery<T> nativeSynchronizedTypedQuery(@Language("SQL") String sql) {
-    return getSession().createNativeQuery(sql, clazz).addSynchronizedEntityClass(getClazz());
   }
 }


### PR DESCRIPTION
When mixing hibernate DB usage with native SQL (via hibernate) the native queries have to specify which tables they are working with using `addSynchronizedEntityClass` to avoid unwanted flushes or updates being triggered.

As far as I understand it `addSynchronizedEntityClass` needs to be called with each table type that is involved in the native SQL. Since there (often) is no corresponding class for mapping tables I would assume these are implicitly included when they are mapped as a collection.

There are now two new methods
* `nativeSynchronizedQuery(String)`
* `nativeSynchronizedTypedQuery(String)`

Both add the object type of the store, but the typed one also maps the result to the store object type.

There were only two usages of the existing `getSqlQuery` method which I moved to `nativeSynchronizedQuery` and removed both the existing SQL helpers.

To have IDE support understanding that the `String` argument of the new methods is SQL I used `@Language("SQL")`. With that none of the callers has to mention the language via a comment `//language=SQL` any longer. I just needed to add the dependency to the annotations artefact.