### PR TITLE
feat: a lean JobProgress for synchonous execution

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
@@ -121,6 +121,17 @@ import org.slf4j.helpers.MessageFormatter;
  * @author Jan Bernitt
  */
 public interface JobProgress {
+
+  /**
+   * Main use case are tests and use as NULL object for the tracker progress delegate.
+   *
+   * @return A {@link JobProgress} that literally does nothing, this includes any form of abort or
+   *     cancel logic
+   */
+  static JobProgress noop() {
+    return NoopJobProgress.INSTANCE;
+  }
+
   /*
    * Flow Control API:
    */

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/NoopJobProgress.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/NoopJobProgress.java
@@ -34,7 +34,7 @@ package org.hisp.dhis.scheduling;
  *
  * @author Jan Bernitt
  */
-public class NoopJobProgress implements JobProgress {
+class NoopJobProgress implements JobProgress {
   public static final JobProgress INSTANCE = new NoopJobProgress();
 
   private NoopJobProgress() {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DefaultDataSetNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DefaultDataSetNotificationService.java
@@ -69,7 +69,6 @@ import org.hisp.dhis.program.message.ProgramMessage;
 import org.hisp.dhis.program.message.ProgramMessageRecipients;
 import org.hisp.dhis.program.message.ProgramMessageService;
 import org.hisp.dhis.scheduling.JobProgress;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.util.DateUtils;
@@ -174,7 +173,7 @@ public class DefaultDataSetNotificationService implements DataSetNotificationSer
     sendBatch(
         "completion",
         createBatchForCompletionNotifications(registration, templates),
-        NoopJobProgress.INSTANCE);
+        JobProgress.noop());
   }
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobSchedulerLoopService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobSchedulerLoopService.java
@@ -171,7 +171,7 @@ public class DefaultJobSchedulerLoopService implements JobSchedulerLoopService {
       authenticationService.obtainSystemAuthentication();
     }
     JobConfiguration job = jobConfigurationStore.getByUid(jobId);
-    if (job == null) return NoopJobProgress.INSTANCE;
+    if (job == null) return JobProgress.noop();
     return startRecording(job, observer);
   }
 
@@ -261,14 +261,14 @@ public class DefaultJobSchedulerLoopService implements JobSchedulerLoopService {
     JobProgress tracker =
         job.getJobType().isUsingNotifications()
             ? new NotifierJobProgress(notifier, job)
-            : NoopJobProgress.INSTANCE;
+            : JobProgress.noop();
     boolean logInfoOnDebug =
         job.getSchedulingType() != SchedulingType.ONCE_ASAP
             && job.getLastExecuted() != null
             && Duration.between(job.getLastExecuted().toInstant(), Instant.now()).getSeconds()
                 < systemSettings.getIntSetting(SettingKey.JOBS_LOG_DEBUG_BELOW_SECONDS);
     RecordingJobProgress progress =
-        new RecordingJobProgress(messages, job, tracker, true, observer, logInfoOnDebug);
+        new RecordingJobProgress(messages, job, tracker, true, observer, logInfoOnDebug, false);
     recordingsById.put(job.getUid(), progress);
     return progress;
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/RecordingJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/RecordingJobProgress.java
@@ -124,12 +124,11 @@ public class RecordingJobProgress implements JobProgress {
 
   public void requestCancellation() {
     if (cancellationRequested.compareAndSet(false, true)) {
-      if (!skipRecording)
-        progress.sequence.forEach(
-            p -> {
-              p.cancel();
-              logWarn(p, "cancelled", "cancellation requested by user");
-            });
+      progress.sequence.forEach(
+          p -> {
+            p.cancel();
+            logWarn(p, "cancelled", "cancellation requested by user");
+          });
     }
   }
 
@@ -387,8 +386,7 @@ public class RecordingJobProgress implements JobProgress {
         // if we already cancelled manually we do not abort but cancel
         && cancellationRequested.compareAndSet(false, true)
         && abortAfterFailure.compareAndSet(false, true)
-        && abortProcess
-        && !skipRecording) {
+        && abortProcess) {
       progress.sequence.forEach(
           process -> {
             if (!process.isComplete()) {

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/ProgramNotificationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/ProgramNotificationServiceTest.java
@@ -67,6 +67,7 @@ import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.program.message.ProgramMessage;
 import org.hisp.dhis.program.message.ProgramMessageService;
 import org.hisp.dhis.program.notification.template.snapshot.NotificationTemplateMapper;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/ProgramNotificationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/ProgramNotificationServiceTest.java
@@ -67,7 +67,6 @@ import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.program.message.ProgramMessage;
 import org.hisp.dhis.program.message.ProgramMessageService;
 import org.hisp.dhis.program.notification.template.snapshot.NotificationTemplateMapper;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
@@ -619,7 +618,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest {
     when(programNotificationRenderer.render(any(Enrollment.class), any(NotificationTemplate.class)))
         .thenReturn(notificationMessage);
 
-    programNotificationService.sendScheduledNotifications(NoopJobProgress.INSTANCE);
+    programNotificationService.sendScheduledNotifications(JobProgress.noop());
 
     assertEquals(1, sentProgramMessages.size());
   }
@@ -628,7 +627,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest {
   void testScheduledNotificationsWithDateInPast() {
     sentInternalMessages.clear();
 
-    programNotificationService.sendScheduledNotifications(NoopJobProgress.INSTANCE);
+    programNotificationService.sendScheduledNotifications(JobProgress.noop());
 
     assertEquals(0, sentProgramMessages.size());
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/job/TrackerTrigramIndexingJobTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/job/TrackerTrigramIndexingJobTest.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.parameters.TrackerTrigramIndexJobParameters;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/job/TrackerTrigramIndexingJobTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/job/TrackerTrigramIndexingJobTest.java
@@ -42,7 +42,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hisp.dhis.scheduling.JobConfiguration;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.scheduling.parameters.TrackerTrigramIndexJobParameters;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
@@ -83,7 +82,7 @@ class TrackerTrigramIndexingJobTest {
     TrackerTrigramIndexJobParameters jp = new TrackerTrigramIndexJobParameters();
     jobConfiguration.setJobParameters(jp);
 
-    job.execute(jobConfiguration, NoopJobProgress.INSTANCE);
+    job.execute(jobConfiguration, JobProgress.noop());
 
     verify(trackedEntityAttributeTableManager, never()).createTrigramIndex(any());
     verify(trackedEntityAttributeTableManager, never()).dropTrigramIndex(any());
@@ -98,7 +97,7 @@ class TrackerTrigramIndexingJobTest {
     TrackerTrigramIndexJobParameters jp = new TrackerTrigramIndexJobParameters();
     jobConfiguration.setJobParameters(jp);
 
-    job.execute(jobConfiguration, NoopJobProgress.INSTANCE);
+    job.execute(jobConfiguration, JobProgress.noop());
 
     verify(trackedEntityAttributeTableManager, never()).createTrigramIndex(any());
     verify(trackedEntityAttributeTableManager, times(2)).dropTrigramIndex(any());
@@ -114,7 +113,7 @@ class TrackerTrigramIndexingJobTest {
     jp.setAttributes(Collections.singleton("aaaa"));
     jobConfiguration.setJobParameters(jp);
 
-    job.execute(jobConfiguration, NoopJobProgress.INSTANCE);
+    job.execute(jobConfiguration, JobProgress.noop());
 
     verify(trackedEntityAttributeTableManager, never()).createTrigramIndex(any());
   }
@@ -140,7 +139,7 @@ class TrackerTrigramIndexingJobTest {
     jp.setAttributes(Stream.of("tea2", "tea3").collect(Collectors.toSet()));
     jobConfiguration.setJobParameters(jp);
 
-    job.execute(jobConfiguration, NoopJobProgress.INSTANCE);
+    job.execute(jobConfiguration, JobProgress.noop());
 
     verify(trackedEntityAttributeTableManager, times(2)).createTrigramIndex(any());
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/job/AccountExpiryAlertJobTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/job/AccountExpiryAlertJobTest.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.when;
 import java.sql.Date;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.user.UserAccountExpiryInfo;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/job/AccountExpiryAlertJobTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/job/AccountExpiryAlertJobTest.java
@@ -39,7 +39,6 @@ import static org.mockito.Mockito.when;
 import java.sql.Date;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.scheduling.JobConfiguration;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.user.UserAccountExpiryInfo;
@@ -74,7 +73,7 @@ class AccountExpiryAlertJobTest {
   @Test
   void testDisabledJobDoesNotExecute() {
     when(settingManager.getBoolSetting(SettingKey.ACCOUNT_EXPIRY_ALERT)).thenReturn(false);
-    job.execute(new JobConfiguration(), NoopJobProgress.INSTANCE);
+    job.execute(new JobConfiguration(), JobProgress.noop());
     verify(userService, never()).getExpiringUserAccounts(anyInt());
   }
 
@@ -86,7 +85,7 @@ class AccountExpiryAlertJobTest {
             singletonList(
                 new UserAccountExpiryInfo(
                     "username", "email@example.com", Date.valueOf("2021-08-23"))));
-    job.execute(new JobConfiguration(), NoopJobProgress.INSTANCE);
+    job.execute(new JobConfiguration(), JobProgress.noop());
     ArgumentCaptor<String> subject = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> text = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> recipient = ArgumentCaptor.forClass(String.class);
@@ -101,7 +100,7 @@ class AccountExpiryAlertJobTest {
   @Test
   void testValidate_Error() {
     when(messageSender.isConfigured()).thenReturn(false);
-    job.execute(new JobConfiguration(), NoopJobProgress.INSTANCE);
+    job.execute(new JobConfiguration(), JobProgress.noop());
     verify(messageSender, never()).sendMessage(anyString(), anyString(), anyString());
   }
 }

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeServiceTest.java
@@ -60,6 +60,7 @@ import org.hisp.dhis.dxf2.importsummary.ImportStatus;
 import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeServiceTest.java
@@ -60,7 +60,6 @@ import org.hisp.dhis.dxf2.importsummary.ImportStatus;
 import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.importexport.ImportStrategy;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
@@ -144,7 +143,7 @@ class AggregateDataExchangeServiceTest {
         new AggregateDataExchange().setSource(source).setTarget(target);
 
     ImportSummaries summaries =
-        service.exchangeData(UserDetails.fromUser(new User()), exchange, NoopJobProgress.INSTANCE);
+        service.exchangeData(UserDetails.fromUser(new User()), exchange, JobProgress.noop());
 
     assertNotNull(summaries);
     assertEquals(1, summaries.getImportSummaries().size());

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataImportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataImportService.java
@@ -55,7 +55,6 @@ import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.preheat.PreheatIdentifier;
 import org.hisp.dhis.preheat.PreheatMode;
 import org.hisp.dhis.scheduling.JobProgress;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.user.CurrentUserUtil;
@@ -82,7 +81,7 @@ public class DefaultMetadataImportService implements MetadataImportService {
   @Transactional
   public ImportReport importMetadata(
       @Nonnull MetadataImportParams params, @Nonnull MetadataObjects objects) {
-    return importMetadata(params, objects, NoopJobProgress.INSTANCE);
+    return importMetadata(params, objects, JobProgress.noop());
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/DefaultObjectBundleService.java
@@ -61,7 +61,6 @@ import org.hisp.dhis.preheat.Preheat;
 import org.hisp.dhis.preheat.PreheatParams;
 import org.hisp.dhis.preheat.PreheatService;
 import org.hisp.dhis.scheduling.JobProgress;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.schema.MetadataMergeParams;
 import org.hisp.dhis.schema.MetadataMergeService;
 import org.hisp.dhis.schema.SchemaService;
@@ -117,7 +116,7 @@ public class DefaultObjectBundleService implements ObjectBundleService {
   @Override
   @Transactional
   public ObjectBundleCommitReport commit(ObjectBundle bundle) {
-    return commit(bundle, NoopJobProgress.INSTANCE);
+    return commit(bundle, JobProgress.noop());
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobParametersTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobParametersTest.java
@@ -49,7 +49,6 @@ import org.hisp.dhis.dxf2.metadata.sync.exception.DhisVersionMismatchException;
 import org.hisp.dhis.dxf2.metadata.sync.exception.MetadataSyncServiceException;
 import org.hisp.dhis.metadata.version.MetadataVersion;
 import org.hisp.dhis.scheduling.JobProgress;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.scheduling.parameters.MetadataSyncJobParameters;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.junit.jupiter.api.BeforeEach;
@@ -64,7 +63,7 @@ import org.springframework.retry.support.RetryTemplate;
  */
 @ExtendWith(MockitoExtension.class)
 class MetadataSyncJobParametersTest {
-  private static final JobProgress JOB_PROGRESS = NoopJobProgress.INSTANCE;
+  private static final JobProgress JOB_PROGRESS = JobProgress.noop();
 
   @Mock private SystemSettingManager systemSettingManager;
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DefaultValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DefaultValidationService.java
@@ -68,7 +68,6 @@ import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.program.AnalyticsType;
 import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.scheduling.JobProgress;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.system.util.Clock;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
@@ -166,7 +165,7 @@ public class DefaultValidationService implements ValidationService {
 
     context.setValidationRuleExpressionDetails(details);
 
-    Validator.validate(context, runner, NoopJobProgress.INSTANCE);
+    Validator.validate(context, runner, JobProgress.noop());
 
     details.sortByName();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/TrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/TrackerImportService.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.tracker.imports;
 
 import org.hisp.dhis.scheduling.JobProgress;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.tracker.imports.domain.TrackerObjects;
 import org.hisp.dhis.tracker.imports.report.ImportReport;
 
@@ -45,7 +44,7 @@ public interface TrackerImportService {
    * @return Report giving status of import (and any errors)
    */
   default ImportReport importTracker(TrackerImportParams params, TrackerObjects trackerObjects) {
-    return importTracker(params, trackerObjects, NoopJobProgress.INSTANCE);
+    return importTracker(params, trackerObjects, JobProgress.noop());
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerImporterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerImporterServiceTest.java
@@ -39,7 +39,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.hisp.dhis.random.BeanRandomizer;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.tracker.imports.DefaultTrackerImportService;
 import org.hisp.dhis.tracker.imports.ParamsConverter;
@@ -130,7 +129,7 @@ class TrackerImporterServiceTest {
     when(trackerBundleService.create(any(TrackerImportParams.class), any(), any()))
         .thenReturn(ParamsConverter.convert(parameters, objects, new User()));
 
-    subject.importTracker(parameters, trackerObjects, NoopJobProgress.INSTANCE);
+    subject.importTracker(parameters, trackerObjects, JobProgress.noop());
 
     verify(trackerBundleService, times(0)).handleTrackerSideEffects(anyList());
   }
@@ -143,7 +142,7 @@ class TrackerImporterServiceTest {
     when(trackerBundleService.create(any(TrackerImportParams.class), any(), any()))
         .thenReturn(ParamsConverter.convert(params, trackerObjects, new User()));
 
-    subject.importTracker(params, trackerObjects, NoopJobProgress.INSTANCE);
+    subject.importTracker(params, trackerObjects, JobProgress.noop());
 
     verify(trackerBundleService, times(1)).handleTrackerSideEffects(anyList());
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerImporterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerImporterServiceTest.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.hisp.dhis.random.BeanRandomizer;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.tracker.imports.DefaultTrackerImportService;
 import org.hisp.dhis.tracker.imports.ParamsConverter;

--- a/dhis-2/dhis-services/dhis-service-validation/src/test/java/org/hisp/dhis/validation/ValidationNotificationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/test/java/org/hisp/dhis/validation/ValidationNotificationServiceTest.java
@@ -58,6 +58,7 @@ import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodStore;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.period.PeriodTypeEnum;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.validation.notification.DefaultValidationNotificationService;

--- a/dhis-2/dhis-services/dhis-service-validation/src/test/java/org/hisp/dhis/validation/ValidationNotificationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/test/java/org/hisp/dhis/validation/ValidationNotificationServiceTest.java
@@ -58,7 +58,6 @@ import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodStore;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.period.PeriodTypeEnum;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.validation.notification.DefaultValidationNotificationService;
@@ -152,7 +151,7 @@ class ValidationNotificationServiceTest extends DhisConvenienceTest {
   @Test
   void testNoValidationResultsCausesNoNotificationsSent() {
     Set<ValidationResult> emptyResultsSet = Collections.emptySet();
-    subject.sendNotifications(emptyResultsSet, NoopJobProgress.INSTANCE);
+    subject.sendNotifications(emptyResultsSet, JobProgress.noop());
     assertTrue(
         sentMessages.isEmpty(), "No messages should have been sent but was " + sentMessages.size());
   }
@@ -161,7 +160,7 @@ class ValidationNotificationServiceTest extends DhisConvenienceTest {
   void testValidationResultGeneratesNotification() {
     setUpEntitiesA();
     ValidationResult validationResult = createValidationResultA();
-    subject.sendNotifications(Sets.newHashSet(validationResult), NoopJobProgress.INSTANCE);
+    subject.sendNotifications(Sets.newHashSet(validationResult), JobProgress.noop());
     assertEquals(1, sentMessages.size(), "A single message should have been sent");
   }
 
@@ -171,7 +170,7 @@ class ValidationNotificationServiceTest extends DhisConvenienceTest {
     User userB = makeUser("B");
     userGroupA.addUser(userB);
     ValidationResult validationResult = createValidationResultA();
-    subject.sendNotifications(Sets.newHashSet(validationResult), NoopJobProgress.INSTANCE);
+    subject.sendNotifications(Sets.newHashSet(validationResult), JobProgress.noop());
     assertEquals(1, sentMessages.size());
     assertEquals(2, sentMessages.get(0).recipients.size());
   }
@@ -185,7 +184,7 @@ class ValidationNotificationServiceTest extends DhisConvenienceTest {
             .boxed()
             .map(i -> createValidationResultA())
             .collect(Collectors.toSet());
-    subject.sendNotifications(results, NoopJobProgress.INSTANCE);
+    subject.sendNotifications(results, JobProgress.noop());
     assertEquals(
         1, sentMessages.size(), "The validation results should form a single summarized message");
     String text = sentMessages.iterator().next().text;
@@ -225,7 +224,7 @@ class ValidationNotificationServiceTest extends DhisConvenienceTest {
     template.addValidationRule(rule);
     template.setRecipientUserGroups(Sets.newHashSet(groupA));
     final ValidationResult validationResult = createValidationResult(lvlOneLeft, rule);
-    subject.sendNotifications(Sets.newHashSet(validationResult), NoopJobProgress.INSTANCE);
+    subject.sendNotifications(Sets.newHashSet(validationResult), JobProgress.noop());
     assertEquals(1, sentMessages.size());
     Collection<User> rcpt = sentMessages.iterator().next().recipients;
     assertEquals(1, rcpt.size());
@@ -284,7 +283,7 @@ class ValidationNotificationServiceTest extends DhisConvenienceTest {
     final ValidationResult resultFromMiddleLeft = createValidationResult(lvlOneLeft, rule);
     // Perform tests
     // One
-    subject.sendNotifications(Sets.newHashSet(resultFromMiddleLeft), NoopJobProgress.INSTANCE);
+    subject.sendNotifications(Sets.newHashSet(resultFromMiddleLeft), JobProgress.noop());
     assertEquals(1, sentMessages.size());
     Collection<User> rcpt = sentMessages.iterator().next().recipients;
     assertEquals(2, rcpt.size());
@@ -293,7 +292,7 @@ class ValidationNotificationServiceTest extends DhisConvenienceTest {
     sentMessages = new ArrayList<>();
     // Add the second group (with user F) to the recipients
     template.getRecipientUserGroups().add(ugB);
-    subject.sendNotifications(Sets.newHashSet(resultFromMiddleLeft), NoopJobProgress.INSTANCE);
+    subject.sendNotifications(Sets.newHashSet(resultFromMiddleLeft), JobProgress.noop());
     assertEquals(1, sentMessages.size());
     rcpt = sentMessages.iterator().next().recipients;
     // We now expect user A, which is on the root org unit and in group B to
@@ -305,7 +304,7 @@ class ValidationNotificationServiceTest extends DhisConvenienceTest {
     // Keep the hierarchy as is, but spread out the validation result from
     // the bottom left of the tree
     final ValidationResult resultFromBottomLeft = createValidationResult(lvlTwoLeftLeft, rule);
-    subject.sendNotifications(Sets.newHashSet(resultFromBottomLeft), NoopJobProgress.INSTANCE);
+    subject.sendNotifications(Sets.newHashSet(resultFromBottomLeft), JobProgress.noop());
     assertEquals(1, sentMessages.size());
     rcpt = sentMessages.iterator().next().recipients;
     assertEquals(4, rcpt.size());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceQueryModifiersTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceQueryModifiersTest.java
@@ -62,6 +62,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceQueryModifiersTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceQueryModifiersTest.java
@@ -62,7 +62,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -180,7 +179,7 @@ class AnalyticsServiceQueryModifiersTest extends SingleSetupIntegrationTestBase 
     // Generate analytics tables
     analyticsTableGenerator.generateAnalyticsTables(
         AnalyticsTableUpdateParams.newBuilder().withStartTime(oneSecondFromNow).build(),
-        NoopJobProgress.INSTANCE);
+        JobProgress.noop());
   }
 
   @Override

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
@@ -87,6 +87,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.util.CsvUtils;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
@@ -87,7 +87,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.util.CsvUtils;
@@ -266,7 +265,7 @@ class AnalyticsServiceTest extends SingleSetupIntegrationTestBase {
     // Generate analytics tables
     analyticsTableGenerator.generateAnalyticsTables(
         AnalyticsTableUpdateParams.newBuilder().withStartTime(tenSecondsFromNow).build(),
-        NoopJobProgress.INSTANCE);
+        JobProgress.noop());
   }
 
   private void setUpMetadata() {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
@@ -116,6 +116,7 @@ import org.hisp.dhis.program.ProgramOwnershipHistory;
 import org.hisp.dhis.program.ProgramOwnershipHistoryService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.security.acl.AccessStringHelper;
 import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
 import org.hisp.dhis.trackedentity.TrackedEntity;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
@@ -116,7 +116,6 @@ import org.hisp.dhis.program.ProgramOwnershipHistory;
 import org.hisp.dhis.program.ProgramOwnershipHistoryService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.security.acl.AccessStringHelper;
 import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
 import org.hisp.dhis.trackedentity.TrackedEntity;
@@ -587,7 +586,7 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
     // Generate resource tables and analytics tables
     analyticsTableGenerator.generateAnalyticsTables(
         AnalyticsTableUpdateParams.newBuilder().withStartTime(oneSecondFromNow).build(),
-        NoopJobProgress.INSTANCE);
+        JobProgress.noop());
   }
 
   /** Adds a program ownership history entry. */

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateQueryCacheTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateQueryCacheTest.java
@@ -39,6 +39,7 @@ import org.hibernate.jpa.QueryHints;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.scheduling.HousekeepingJob;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.AfterEach;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateQueryCacheTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/cache/HibernateQueryCacheTest.java
@@ -39,7 +39,6 @@ import org.hibernate.jpa.QueryHints;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.scheduling.HousekeepingJob;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.AfterEach;
@@ -102,7 +101,7 @@ class HibernateQueryCacheTest extends HibernateCacheBaseTest {
     setUpData();
     createSelectQuery(10);
     assertEquals(9, sessionFactory.getStatistics().getQueryCacheHitCount());
-    housekeepingJob.execute(null, NoopJobProgress.INSTANCE);
+    housekeepingJob.execute(null, JobProgress.noop());
     createSelectQuery(1);
     assertEquals(
         10,

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datastatistics/DataStatisticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datastatistics/DataStatisticsServiceTest.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Calendar;
 import java.util.Date;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datastatistics/DataStatisticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datastatistics/DataStatisticsServiceTest.java
@@ -32,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Calendar;
 import java.util.Date;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
@@ -98,7 +97,7 @@ class DataStatisticsServiceTest extends SingleSetupIntegrationTestBase {
         new DataStatisticsEvent(DataStatisticsEventType.VISUALIZATION_VIEW, startDate, "TestUser");
     dataStatisticsService.addEvent(dse1);
     dataStatisticsService.addEvent(dse2);
-    long snapId2 = dataStatisticsService.saveDataStatisticsSnapshot(NoopJobProgress.INSTANCE);
+    long snapId2 = dataStatisticsService.saveDataStatisticsSnapshot(JobProgress.noop());
     assertTrue(snapId2 != 0);
     assertTrue(snapId1 != snapId2);
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/gml/GmlImportServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/gml/GmlImportServiceTest.java
@@ -47,6 +47,7 @@ import org.hisp.dhis.organisationunit.FeatureType;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
 import org.hisp.dhis.user.User;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/gml/GmlImportServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/gml/GmlImportServiceTest.java
@@ -48,7 +48,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobType;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
@@ -131,7 +130,7 @@ class GmlImportServiceTest extends TransactionalIntegrationTest {
   void testImportGml() {
     MetadataImportParams importParams = new MetadataImportParams();
     importParams.setUser(UID.of(user));
-    gmlImportService.importGml(inputStream, importParams, NoopJobProgress.INSTANCE);
+    gmlImportService.importGml(inputStream, importParams, JobProgress.noop());
     assertNotNull(boOrgUnit.getGeometry());
     assertNotNull(bontheOrgUnit.getGeometry());
     assertNotNull(ojdOrgUnit.getGeometry());
@@ -156,7 +155,7 @@ class GmlImportServiceTest extends TransactionalIntegrationTest {
     importParams.setUser(UID.of(user));
 
     ImportReport importReport =
-        gmlImportService.importGml(maliciousInputStream, importParams, NoopJobProgress.INSTANCE);
+        gmlImportService.importGml(maliciousInputStream, importParams, JobProgress.noop());
 
     ErrorReport errorReport = importReport.getFirstObjectReport().getErrorReports().get(0);
     assertTrue(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPreProcessorTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPreProcessorTest.java
@@ -49,6 +49,7 @@ import org.hisp.dhis.dxf2.sync.SynchronizationManager;
 import org.hisp.dhis.metadata.version.MetadataVersion;
 import org.hisp.dhis.metadata.version.MetadataVersionService;
 import org.hisp.dhis.metadata.version.VersionType;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.parameters.MetadataSyncJobParameters;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPreProcessorTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPreProcessorTest.java
@@ -49,7 +49,6 @@ import org.hisp.dhis.dxf2.sync.SynchronizationManager;
 import org.hisp.dhis.metadata.version.MetadataVersion;
 import org.hisp.dhis.metadata.version.MetadataVersionService;
 import org.hisp.dhis.metadata.version.VersionType;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.scheduling.parameters.MetadataSyncJobParameters;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
@@ -87,7 +86,7 @@ class MetadataSyncPreProcessorTest extends IntegrationTestBase {
     AvailabilityStatus availabilityStatus = new AvailabilityStatus(true, "test_message", null);
     when(synchronizationManager.isRemoteServerAvailable()).thenReturn(availabilityStatus);
     metadataSyncPreProcessor.handleDataValuePush(
-        mockRetryContext, metadataSyncJobParameters, NoopJobProgress.INSTANCE);
+        mockRetryContext, metadataSyncJobParameters, JobProgress.noop());
     verify(synchronizationManager, times(1)).executeDataValuePush();
   }
 
@@ -100,12 +99,12 @@ class MetadataSyncPreProcessorTest extends IntegrationTestBase {
     when(synchronizationManager.isRemoteServerAvailable()).thenReturn(availabilityStatus);
     doThrow(MetadataSyncServiceException.class)
         .when(metadataSyncPreProcessor)
-        .handleDataValuePush(mockRetryContext, metadataSyncJobParameters, NoopJobProgress.INSTANCE);
+        .handleDataValuePush(mockRetryContext, metadataSyncJobParameters, JobProgress.noop());
     assertThrows(
         MetadataSyncServiceException.class,
         () ->
             metadataSyncPreProcessor.handleDataValuePush(
-                mockRetryContext, metadataSyncJobParameters, NoopJobProgress.INSTANCE));
+                mockRetryContext, metadataSyncJobParameters, JobProgress.noop()));
   }
 
   @Test
@@ -117,11 +116,11 @@ class MetadataSyncPreProcessorTest extends IntegrationTestBase {
     when(synchronizationManager.isRemoteServerAvailable()).thenReturn(availabilityStatus);
     doNothing()
         .when(metadataSyncPreProcessor)
-        .handleDataValuePush(mockRetryContext, metadataSyncJobParameters, NoopJobProgress.INSTANCE);
+        .handleDataValuePush(mockRetryContext, metadataSyncJobParameters, JobProgress.noop());
     metadataSyncPreProcessor.handleDataValuePush(
-        mockRetryContext, metadataSyncJobParameters, NoopJobProgress.INSTANCE);
+        mockRetryContext, metadataSyncJobParameters, JobProgress.noop());
     verify(metadataSyncPreProcessor, times(1))
-        .handleDataValuePush(mockRetryContext, metadataSyncJobParameters, NoopJobProgress.INSTANCE);
+        .handleDataValuePush(mockRetryContext, metadataSyncJobParameters, JobProgress.noop());
   }
 
   @Test
@@ -142,7 +141,7 @@ class MetadataSyncPreProcessorTest extends IntegrationTestBase {
     when(metadataVersionDelegate.getMetaDataDifference(currentVersion)).thenReturn(listOfVersions);
     List<MetadataVersion> expectedListOfVersions =
         metadataSyncPreProcessor.handleMetadataVersionsList(
-            mockRetryContext, currentVersion, NoopJobProgress.INSTANCE);
+            mockRetryContext, currentVersion, JobProgress.noop());
     assertEquals(listOfVersions.size(), expectedListOfVersions.size());
     assertEquals(expectedListOfVersions, listOfVersions);
   }
@@ -161,7 +160,7 @@ class MetadataSyncPreProcessorTest extends IntegrationTestBase {
         .thenReturn(new ArrayList<>());
     List<MetadataVersion> expectedListOfVersions =
         metadataSyncPreProcessor.handleMetadataVersionsList(
-            mockRetryContext, currentVersion, NoopJobProgress.INSTANCE);
+            mockRetryContext, currentVersion, JobProgress.noop());
     assertEquals(0, expectedListOfVersions.size());
   }
 
@@ -179,7 +178,7 @@ class MetadataSyncPreProcessorTest extends IntegrationTestBase {
     when(metadataVersionDelegate.getMetaDataDifference(currentVersion)).thenReturn(listOfVersions);
     List<MetadataVersion> expectedListOfVersions =
         metadataSyncPreProcessor.handleMetadataVersionsList(
-            mockRetryContext, currentVersion, NoopJobProgress.INSTANCE);
+            mockRetryContext, currentVersion, JobProgress.noop());
     assertEquals(0, expectedListOfVersions.size());
   }
 
@@ -201,7 +200,7 @@ class MetadataSyncPreProcessorTest extends IntegrationTestBase {
         MetadataSyncServiceException.class,
         () ->
             metadataSyncPreProcessor.handleMetadataVersionsList(
-                mockRetryContext, currentVersion, NoopJobProgress.INSTANCE));
+                mockRetryContext, currentVersion, JobProgress.noop()));
   }
 
   @Test
@@ -214,8 +213,7 @@ class MetadataSyncPreProcessorTest extends IntegrationTestBase {
     currentVersion.setHashCode("samplehashcode");
     when(metadataVersionService.getCurrentVersion()).thenReturn(currentVersion);
     MetadataVersion actualVersion =
-        metadataSyncPreProcessor.handleCurrentMetadataVersion(
-            mockRetryContext, NoopJobProgress.INSTANCE);
+        metadataSyncPreProcessor.handleCurrentMetadataVersion(mockRetryContext, JobProgress.noop());
     assertEquals(currentVersion, actualVersion);
   }
 
@@ -245,7 +243,7 @@ class MetadataSyncPreProcessorTest extends IntegrationTestBase {
         .thenReturn(metadataVersionList);
     List<MetadataVersion> expectedListOfVersions =
         metadataSyncPreProcessor.handleMetadataVersionsList(
-            mockRetryContext, currentVersion, NoopJobProgress.INSTANCE);
+            mockRetryContext, currentVersion, JobProgress.noop());
     verify(systemSettingManager)
         .saveSystemSetting(SettingKey.REMOTE_METADATA_VERSION, version4.getName());
     assertEquals(3, expectedListOfVersions.size());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
@@ -49,6 +49,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.test.integration.IntegrationTestBase;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
@@ -49,7 +49,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.test.integration.IntegrationTestBase;
@@ -132,7 +131,7 @@ class FileResourceCleanUpJobTest extends IntegrationTestBase {
 
     dataValueService.deleteDataValue(dataValueA);
 
-    cleanUpJob.execute(null, NoopJobProgress.INSTANCE);
+    cleanUpJob.execute(null, JobProgress.noop());
 
     assertNull(fileResourceService.getFileResource(dataValueA.getValue()));
   }
@@ -162,7 +161,7 @@ class FileResourceCleanUpJobTest extends IntegrationTestBase {
     audit.setCreated(getDate(2000, 1, 1));
     dataValueAuditStore.updateDataValueAudit(audit);
 
-    cleanUpJob.execute(null, NoopJobProgress.INSTANCE);
+    cleanUpJob.execute(null, JobProgress.noop());
 
     assertNotNull(fileResourceService.getFileResource(dataValueA.getValue()));
     assertTrue(fileResourceService.getFileResource(dataValueA.getValue()).isAssigned());
@@ -196,7 +195,7 @@ class FileResourceCleanUpJobTest extends IntegrationTestBase {
     assertNotNull(fileResourceService.getFileResource(uidA));
     assertNotNull(fileResourceService.getFileResource(uidB));
 
-    cleanUpJob.execute(null, NoopJobProgress.INSTANCE);
+    cleanUpJob.execute(null, JobProgress.noop());
 
     assertNull(fileResourceService.getFileResource(uidA));
     assertNotNull(fileResourceService.getFileResource(uidB));
@@ -222,7 +221,7 @@ class FileResourceCleanUpJobTest extends IntegrationTestBase {
     ex.getFileResource().setAssigned(false);
     fileResourceService.updateFileResource(ex.getFileResource());
 
-    cleanUpJob.execute(null, NoopJobProgress.INSTANCE);
+    cleanUpJob.execute(null, JobProgress.noop());
 
     assertNotNull(
         externalFileResourceService.getExternalFileResourceByAccessToken(ex.getAccessToken()));
@@ -243,7 +242,7 @@ class FileResourceCleanUpJobTest extends IntegrationTestBase {
     ex.getFileResource().setStorageStatus(FileResourceStorageStatus.PENDING);
     fileResourceService.updateFileResource(ex.getFileResource());
 
-    cleanUpJob.execute(null, NoopJobProgress.INSTANCE);
+    cleanUpJob.execute(null, JobProgress.noop());
 
     assertNull(
         externalFileResourceService.getExternalFileResourceByAccessToken(ex.getAccessToken()));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/PredictionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/PredictionServiceTest.java
@@ -71,7 +71,6 @@ import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.scheduling.JobProgress;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.test.integration.IntegrationTestBase;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
@@ -86,7 +85,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @author Jim Grace
  */
 class PredictionServiceTest extends IntegrationTestBase {
-  private final JobProgress progress = NoopJobProgress.INSTANCE;
+  private final JobProgress progress = JobProgress.noop();
 
   @Autowired private PredictionService predictionService;
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/AnalyticsValidationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/AnalyticsValidationServiceTest.java
@@ -80,6 +80,7 @@ import org.hisp.dhis.program.ProgramIndicatorService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageService;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.system.grid.ListGrid;
 import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
 import org.hisp.dhis.trackedentity.TrackedEntity;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/AnalyticsValidationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/AnalyticsValidationServiceTest.java
@@ -80,7 +80,6 @@ import org.hisp.dhis.program.ProgramIndicatorService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageService;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.system.grid.ListGrid;
 import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
 import org.hisp.dhis.trackedentity.TrackedEntity;
@@ -445,7 +444,7 @@ class AnalyticsValidationServiceTest extends TransactionalIntegrationTest {
     ValidationAnalysisParams params1 =
         validationService.newParamsBuilder(null, orgUnitA, startDate, endDate).build();
     Collection<ValidationResult> results =
-        validationService.validationAnalysis(params1, NoopJobProgress.INSTANCE);
+        validationService.validationAnalysis(params1, JobProgress.noop());
     assertResultsEquals(reference, results);
     // ---------------------------------------
     // Test validation rule expression details

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationServiceIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationServiceIntegrationTest.java
@@ -47,6 +47,7 @@ import org.hisp.dhis.period.MonthlyPeriodType;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.test.integration.IntegrationTestBase;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationServiceIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationServiceIntegrationTest.java
@@ -47,7 +47,6 @@ import org.hisp.dhis.period.MonthlyPeriodType;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.test.integration.IntegrationTestBase;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
@@ -137,7 +136,7 @@ class ValidationServiceIntegrationTest extends IntegrationTestBase {
                 .newParamsBuilder(
                     Lists.newArrayList(validationRule), orgUnitA, Lists.newArrayList(periodA))
                 .build(),
-            NoopJobProgress.INSTANCE);
+            JobProgress.noop());
     ValidationResult referenceA =
         new ValidationResult(
             validationRule, periodA, orgUnitA, defaultCombo, 20.0, 10.0, dayInPeriodA);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
@@ -85,6 +85,7 @@ import org.hisp.dhis.period.WeeklyPeriodType;
 import org.hisp.dhis.period.YearlyPeriodType;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.test.integration.IntegrationTestBase;
 import org.hisp.dhis.translation.Translation;
 import org.hisp.dhis.user.CurrentUserUtil;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
@@ -85,7 +85,6 @@ import org.hisp.dhis.period.WeeklyPeriodType;
 import org.hisp.dhis.period.YearlyPeriodType;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.test.integration.IntegrationTestBase;
 import org.hisp.dhis.translation.Translation;
 import org.hisp.dhis.user.CurrentUserUtil;
@@ -1706,7 +1705,7 @@ class ValidationServiceTest extends IntegrationTestBase {
   }
 
   private List<ValidationResult> runValidationAnalysis(ValidationAnalysisParams params) {
-    return validationService.validationAnalysis(params, NoopJobProgress.INSTANCE);
+    return validationService.validationAnalysis(params, JobProgress.noop());
   }
 
   private ValidationAnalysisParams createParamsMonthlySourceAPeriodA() {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AggregateDataExchangeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AggregateDataExchangeController.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.dxf2.datavalueset.DataValueSet;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.user.CurrentUser;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AggregateDataExchangeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AggregateDataExchangeController.java
@@ -39,7 +39,6 @@ import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.dxf2.datavalueset.DataValueSet;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.user.CurrentUser;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -68,7 +67,7 @@ public class AggregateDataExchangeController extends AbstractCrudController<Aggr
   public WebMessage runDataExchange(
       @RequestBody AggregateDataExchange exchange, @CurrentUser UserDetails userDetails) {
     return WebMessageUtils.importSummaries(
-        service.exchangeData(userDetails, exchange, NoopJobProgress.INSTANCE));
+        service.exchangeData(userDetails, exchange, JobProgress.noop()));
   }
 
   @PostMapping("/{uid}/exchange")
@@ -76,7 +75,7 @@ public class AggregateDataExchangeController extends AbstractCrudController<Aggr
   public WebMessage runDataExchangeByUid(
       @PathVariable String uid, @CurrentUser UserDetails userDetails) {
     return WebMessageUtils.importSummaries(
-        service.exchangeData(userDetails, uid, NoopJobProgress.INSTANCE));
+        service.exchangeData(userDetails, uid, JobProgress.noop()));
   }
 
   @GetMapping("/{uid}/sourceData")

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataAnalysisController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataAnalysisController.java
@@ -78,7 +78,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.system.grid.GridUtils;
 import org.hisp.dhis.system.grid.ListGrid;
@@ -182,7 +181,7 @@ public class DataAnalysisController {
             .build();
 
     List<ValidationResult> validationResults =
-        validationService.validationAnalysis(params, NoopJobProgress.INSTANCE);
+        validationService.validationAnalysis(params, JobProgress.noop());
 
     validationResults.sort(new ValidationResultComparator());
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataAnalysisController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataAnalysisController.java
@@ -78,6 +78,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.system.grid.GridUtils;
 import org.hisp.dhis.system.grid.ListGrid;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MaintenanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MaintenanceController.java
@@ -50,6 +50,7 @@ import org.hisp.dhis.maintenance.MaintenanceService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.resourcetable.ResourceTableService;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MaintenanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MaintenanceController.java
@@ -50,7 +50,6 @@ import org.hisp.dhis.maintenance.MaintenanceService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.resourcetable.ResourceTableService;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -223,7 +222,7 @@ public class MaintenanceController {
       method = {RequestMethod.PUT, RequestMethod.POST})
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public void createSqlViews() {
-    resourceTableService.createAllSqlViews(NoopJobProgress.INSTANCE);
+    resourceTableService.createAllSqlViews(JobProgress.noop());
   }
 
   @RequestMapping(
@@ -231,7 +230,7 @@ public class MaintenanceController {
       method = {RequestMethod.PUT, RequestMethod.POST})
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public void dropSqlViews() {
-    resourceTableService.dropAllSqlViews(NoopJobProgress.INSTANCE);
+    resourceTableService.dropAllSqlViews(JobProgress.noop());
   }
 
   @RequestMapping(
@@ -393,7 +392,7 @@ public class MaintenanceController {
     }
 
     if (resourceTableUpdate) {
-      analyticsTableGenerator.generateResourceTables(NoopJobProgress.INSTANCE);
+      analyticsTableGenerator.generateResourceTables(JobProgress.noop());
     }
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictionController.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.predictor.PredictionSummary;
 import org.hisp.dhis.predictor.Predictor;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobConfigurationService;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobSchedulerService;
 import org.hisp.dhis.scheduling.parameters.PredictorJobParameters;
 import org.hisp.dhis.security.RequiresAuthority;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictionController.java
@@ -46,7 +46,6 @@ import org.hisp.dhis.predictor.Predictor;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobConfigurationService;
 import org.hisp.dhis.scheduling.JobSchedulerService;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.scheduling.parameters.PredictorJobParameters;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.user.CurrentUser;
@@ -103,7 +102,7 @@ public class PredictionController {
     }
     PredictionSummary predictionSummary =
         predictionService.predictTask(
-            startDate, endDate, predictors, predictorGroups, NoopJobProgress.INSTANCE);
+            startDate, endDate, predictors, predictorGroups, JobProgress.noop());
 
     return new WebMessage(Status.OK, HttpStatus.OK)
         .setResponse(predictionSummary)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictorGroupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictorGroupController.java
@@ -38,7 +38,6 @@ import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.predictor.PredictionService;
 import org.hisp.dhis.predictor.PredictionSummary;
 import org.hisp.dhis.predictor.PredictorGroup;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -68,8 +67,7 @@ public class PredictorGroupController extends AbstractCrudController<PredictorGr
       TranslateParams translateParams) {
     try {
       PredictionSummary predictionSummary =
-          predictionService.predictAll(
-              startDate, endDate, null, List.of(uid), NoopJobProgress.INSTANCE);
+          predictionService.predictAll(startDate, endDate, null, List.of(uid), JobProgress.noop());
 
       return ok("Generated " + predictionSummary.getPredictions() + " predictions");
     } catch (Exception ex) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictorGroupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictorGroupController.java
@@ -38,6 +38,7 @@ import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.predictor.PredictionService;
 import org.hisp.dhis.predictor.PredictionSummary;
 import org.hisp.dhis.predictor.PredictorGroup;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datastatistics/DataStatisticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datastatistics/DataStatisticsController.java
@@ -54,7 +54,6 @@ import org.hisp.dhis.datastatistics.FavoriteStatistics;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.fieldfiltering.FieldFilterParams;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.util.DateUtils;
@@ -167,6 +166,6 @@ public class DataStatisticsController {
   @ResponseStatus(HttpStatus.CREATED)
   @PostMapping("/snapshot")
   public void saveSnapshot() {
-    dataStatisticsService.saveDataStatisticsSnapshot(NoopJobProgress.INSTANCE);
+    dataStatisticsService.saveDataStatisticsSnapshot(JobProgress.noop());
   }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datastatistics/DataStatisticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datastatistics/DataStatisticsController.java
@@ -54,6 +54,7 @@ import org.hisp.dhis.datastatistics.FavoriteStatistics;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.fieldfiltering.FieldFilterParams;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.util.DateUtils;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportExportController.java
@@ -75,7 +75,6 @@ import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobConfigurationService;
 import org.hisp.dhis.scheduling.JobSchedulerService;
 import org.hisp.dhis.scheduling.JobType;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
@@ -181,7 +180,7 @@ public class MetadataImportExportController {
       return startAsyncMetadata(params, MimeType.valueOf("application/xml"), request);
     }
     ImportReport importReport =
-        gmlImportService.importGml(request.getInputStream(), params, NoopJobProgress.INSTANCE);
+        gmlImportService.importGml(request.getInputStream(), params, JobProgress.noop());
     return importReport(importReport).withPlainResponseBefore(DhisApiVersion.V38);
   }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportExportController.java
@@ -73,6 +73,7 @@ import org.hisp.dhis.render.RenderFormat;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobConfigurationService;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobSchedulerService;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.schema.SchemaService;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/system/SystemUpdateNotifyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/system/SystemUpdateNotifyController.java
@@ -33,7 +33,6 @@ import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.system.SystemUpdateNotificationService;
 import org.hisp.dhis.webapi.controller.Server;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -69,7 +68,7 @@ public class SystemUpdateNotifyController {
     Map<Semver, Map<String, String>> newerVersions =
         SystemUpdateNotificationService.getLatestNewerThanFetchFirst(currentVersion);
 
-    service.sendMessageForEachVersion(newerVersions, NoopJobProgress.INSTANCE);
+    service.sendMessageForEachVersion(newerVersions, JobProgress.noop());
 
     WebMessage ok = WebMessageUtils.ok();
     ok.setResponse(new SoftwareUpdateResponse(newerVersions));

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/system/SystemUpdateNotifyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/system/SystemUpdateNotifyController.java
@@ -33,6 +33,7 @@ import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.system.SystemUpdateNotificationService;
 import org.hisp.dhis.webapi.controller.Server;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationController.java
@@ -43,6 +43,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobConfigurationService;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobSchedulerService;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.security.Authorities;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/validation/ValidationController.java
@@ -45,7 +45,6 @@ import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobConfigurationService;
 import org.hisp.dhis.scheduling.JobSchedulerService;
 import org.hisp.dhis.scheduling.JobType;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.validation.ValidationAnalysisParams;
@@ -98,7 +97,7 @@ public class ValidationController {
             .build();
 
     summary.setValidationRuleViolations(
-        validationService.validationAnalysis(params, NoopJobProgress.INSTANCE));
+        validationService.validationAnalysis(params, JobProgress.noop()));
     summary.setCommentRequiredViolations(
         validationService.validateRequiredComments(dataSet, period, orgUnit, attributeOptionCombo));
 


### PR DESCRIPTION
Adds a new factory method `discardingRecorderOf` to construct a `JobProgress` that behaves like the one with recording but it has the minimum tracking that is possible to have while still showing the same behaviour.
To do this it does not remember finished objects, when a new one is started the most recent completed one is discarded.

The main change is in https://github.com/dhis2/dhis2-core/pull/17555/files#diff-4ec64dc99f9539bbb431307311b0f5d6a27abfdded5b707dbff3b4a2d695bf73 
* always run `observer.run()` first (just a consistency thing) - this tells the observer that progress was made 
* remember the current user in a field (for performance)

I also decided that instead of exposing `NoopJobProgress.INSTANCE` this should be accessed via `JobProgress.noop()`.

