### PR TITLE
fix: Return enrollments from specified program only [DHIS2-14300]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -236,7 +236,8 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       UserDetails userDetails = getCurrentUserDetails();
 
       trackedEntity =
-          mapTrackedEntity(getTrackedEntity(uid, userDetails), params, userDetails, includeDeleted);
+          mapTrackedEntity(
+              getTrackedEntity(uid, userDetails), params, userDetails, null, includeDeleted);
 
       mapTrackedEntityTypeAttributes(trackedEntity);
     }
@@ -273,7 +274,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       throw new ForbiddenException(error);
     }
 
-    return mapTrackedEntity(trackedEntity, params, userDetails, includeDeleted);
+    return mapTrackedEntity(trackedEntity, params, userDetails, program, includeDeleted);
   }
 
   /**
@@ -318,6 +319,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       TrackedEntity trackedEntity,
       TrackedEntityParams params,
       UserDetails currentUser,
+      Program program,
       boolean includeDeleted) {
     TrackedEntity result = new TrackedEntity();
     result.setId(trackedEntity.getId());
@@ -340,7 +342,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       result.setRelationshipItems(getRelationshipItems(trackedEntity, currentUser, includeDeleted));
     }
     if (params.isIncludeEnrollments()) {
-      result.setEnrollments(getEnrollments(trackedEntity, currentUser, includeDeleted));
+      result.setEnrollments(getEnrollments(trackedEntity, currentUser, includeDeleted, program));
     }
     if (params.isIncludeProgramOwners()) {
       result.setProgramOwners(trackedEntity.getProgramOwners());
@@ -366,23 +368,21 @@ class DefaultTrackedEntityService implements TrackedEntityService {
   }
 
   private Set<Enrollment> getEnrollments(
-      TrackedEntity trackedEntity, UserDetails user, boolean includeDeleted) {
-    Set<Enrollment> enrollments = new HashSet<>();
-
-    for (Enrollment enrollment : trackedEntity.getEnrollments()) {
-      if (trackerAccessManager.canRead(user, enrollment, false).isEmpty()
-          && (includeDeleted || !enrollment.isDeleted())) {
-        Set<Event> events = new HashSet<>();
-        for (Event event : enrollment.getEvents()) {
-          if (includeDeleted || !event.isDeleted()) {
-            events.add(event);
-          }
-        }
-        enrollment.setEvents(events);
-        enrollments.add(enrollment);
-      }
-    }
-    return enrollments;
+      TrackedEntity trackedEntity, UserDetails user, boolean includeDeleted, Program program) {
+    return trackedEntity.getEnrollments().stream()
+        .filter(e -> program == null || program.getUid().equals(e.getProgram().getUid()))
+        .filter(e -> trackerAccessManager.canRead(user, e, false).isEmpty())
+        .filter(e -> includeDeleted || !e.isDeleted())
+        .map(
+            e -> {
+              Set<Event> filteredEvents =
+                  e.getEvents().stream()
+                      .filter(event -> includeDeleted || !event.isDeleted())
+                      .collect(Collectors.toSet());
+              e.setEvents(filteredEvents);
+              return e;
+            })
+        .collect(Collectors.toSet());
   }
 
   private Set<TrackedEntityAttributeValue> getTrackedEntityAttributeValues(
@@ -452,7 +452,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
     }
 
     relationshipItem.setTrackedEntity(
-        mapTrackedEntity(trackedEntity, params, currentUser, includeDeleted));
+        mapTrackedEntity(trackedEntity, params, currentUser, null, includeDeleted));
     return relationshipItem;
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -371,8 +371,8 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       TrackedEntity trackedEntity, UserDetails user, boolean includeDeleted, Program program) {
     return trackedEntity.getEnrollments().stream()
         .filter(e -> program == null || program.getUid().equals(e.getProgram().getUid()))
-        .filter(e -> trackerAccessManager.canRead(user, e, false).isEmpty())
         .filter(e -> includeDeleted || !e.isDeleted())
+        .filter(e -> trackerAccessManager.canRead(user, e, false).isEmpty())
         .map(
             e -> {
               Set<Event> filteredEvents =

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -158,13 +158,9 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
 
   private Enrollment enrollmentB;
 
-  private Enrollment enrollmentC;
-
   private Event eventA;
 
   private Event eventB;
-
-  private Event eventC;
 
   private TrackedEntity trackedEntityA;
 
@@ -384,10 +380,10 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     trackedEntityB.setTrackedEntityType(trackedEntityTypeA);
     manager.save(trackedEntityB, false);
 
-    enrollmentC =
+    Enrollment enrollmentC =
         enrollmentService.enrollTrackedEntity(
             trackedEntityB, programB, new Date(), new Date(), orgUnitB);
-    eventC = new Event();
+    Event eventC = new Event();
     eventC.setEnrollment(enrollmentC);
     eventC.setProgramStage(programStageB1);
     eventC.setOrganisationUnit(orgUnitB);
@@ -605,6 +601,12 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
             .user(user)
             .build();
 
+    TrackedEntity te =
+        trackedEntityService.getTrackedEntity(
+            trackedEntityA.getUid(), programA.getUid(), TrackedEntityParams.TRUE, false);
+    assertEquals(1, te.getEnrollments().size());
+    assertEquals(enrollmentA.getUid(), te.getEnrollments().stream().findFirst().get().getUid());
+
     final List<TrackedEntity> trackedEntities =
         trackedEntityService.getTrackedEntities(operationParams);
 
@@ -670,6 +672,37 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     assertContainsOnly(
         Set.of("A", "B", "C"),
         attributeNames(trackedEntities.get(0).getTrackedEntityAttributeValues()));
+  }
+
+  @Test
+  void shouldReturnEnrollmentsFromSpecifiedProgramWhenRequestingSingleTrackedEntity()
+      throws ForbiddenException, NotFoundException, BadRequestException {
+    Enrollment enrollmentProgramB =
+        enrollmentService.enrollTrackedEntity(
+            trackedEntityA, programB, new Date(), new Date(), orgUnitA);
+    manager.save(enrollmentProgramB);
+
+    TrackedEntity trackedEntity =
+        trackedEntityService.getTrackedEntity(
+            trackedEntityA.getUid(), programA.getUid(), TrackedEntityParams.TRUE, false);
+
+    assertContainsOnly(Set.of(enrollmentA), trackedEntity.getEnrollments());
+  }
+
+  @Test
+  void shouldReturnAllEnrollmentsWhenRequestingSingleTrackedEntityAndNoProgramSpecified()
+      throws ForbiddenException, NotFoundException, BadRequestException {
+    Enrollment enrollmentProgramB =
+        enrollmentService.enrollTrackedEntity(
+            trackedEntityA, programB, new Date(), new Date(), orgUnitA);
+    manager.save(enrollmentProgramB);
+
+    TrackedEntity trackedEntity =
+        trackedEntityService.getTrackedEntity(
+            trackedEntityA.getUid(), null, TrackedEntityParams.TRUE, false);
+
+    assertContainsOnly(
+        Set.of(enrollmentA, enrollmentB, enrollmentProgramB), trackedEntity.getEnrollments());
   }
 
   @Test


### PR DESCRIPTION
Previously, when requesting a single TE in the context of a program, we returned all TE enrollments regardless of the specific program. With this PR, we will now return only the enrollments for the specified program. If no program is specified, all enrollments will be returned.

Ticket: https://dhis2.atlassian.net/browse/DHIS2-14300