### PR TITLE
fix: Return TEA from specified program only [DHIS2-14300]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -345,7 +345,8 @@ class DefaultTrackedEntityService implements TrackedEntityService {
     if (params.isIncludeProgramOwners()) {
       result.setProgramOwners(trackedEntity.getProgramOwners());
     }
-    result.setTrackedEntityAttributeValues(getTrackedEntityAttributeValues(trackedEntity));
+
+    result.setTrackedEntityAttributeValues(getTrackedEntityAttributeValues(trackedEntity, program));
 
     return result;
   }
@@ -386,9 +387,14 @@ class DefaultTrackedEntityService implements TrackedEntityService {
   }
 
   private Set<TrackedEntityAttributeValue> getTrackedEntityAttributeValues(
-      TrackedEntity trackedEntity) {
+      TrackedEntity trackedEntity, Program program) {
     Set<TrackedEntityAttribute> readableAttributes =
-        trackedEntityAttributeService.getAllUserReadableTrackedEntityAttributes();
+        new HashSet<>(trackedEntity.getTrackedEntityType().getTrackedEntityAttributes());
+
+    if (program != null) {
+      readableAttributes.addAll(program.getTrackedEntityAttributes());
+    }
+
     return trackedEntity.getTrackedEntityAttributeValues().stream()
         .filter(av -> readableAttributes.contains(av.getAttribute()))
         .collect(Collectors.toCollection(LinkedHashSet::new));

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -236,7 +236,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       UserDetails userDetails = getCurrentUserDetails();
 
       trackedEntity =
-          mapTrackedEntity(getTrackedEntity(uid, userDetails), params, userDetails, includeDeleted);
+          mapTrackedEntity(getTrackedEntity(uid, userDetails), params, userDetails, null, includeDeleted);
 
       mapTrackedEntityTypeAttributes(trackedEntity);
     }
@@ -273,7 +273,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       throw new ForbiddenException(error);
     }
 
-    return mapTrackedEntity(trackedEntity, params, userDetails, includeDeleted);
+    return mapTrackedEntity(trackedEntity, params, userDetails, program, includeDeleted);
   }
 
   /**
@@ -318,6 +318,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       TrackedEntity trackedEntity,
       TrackedEntityParams params,
       UserDetails currentUser,
+      Program program,
       boolean includeDeleted) {
     TrackedEntity result = new TrackedEntity();
     result.setId(trackedEntity.getId());
@@ -458,7 +459,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
     }
 
     relationshipItem.setTrackedEntity(
-        mapTrackedEntity(trackedEntity, params, currentUser, includeDeleted));
+        mapTrackedEntity(trackedEntity, params, currentUser, null, includeDeleted));
     return relationshipItem;
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -236,7 +236,8 @@ class DefaultTrackedEntityService implements TrackedEntityService {
       UserDetails userDetails = getCurrentUserDetails();
 
       trackedEntity =
-          mapTrackedEntity(getTrackedEntity(uid, userDetails), params, userDetails, null, includeDeleted);
+          mapTrackedEntity(
+              getTrackedEntity(uid, userDetails), params, userDetails, null, includeDeleted);
 
       mapTrackedEntityTypeAttributes(trackedEntity);
     }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/trackedentity/TrackedEntityServiceTest.java
@@ -146,6 +146,12 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
 
   private TrackedEntityAttribute teaC;
 
+  private TrackedEntityAttributeValue trackedEntityAttributeValueA;
+
+  private TrackedEntityAttributeValue trackedEntityAttributeValueB;
+
+  private TrackedEntityAttributeValue trackedEntityAttributeValueC;
+
   private TrackedEntityType trackedEntityTypeA;
 
   private Program programA;
@@ -333,8 +339,17 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
                 new ProgramTrackedEntityAttribute(programB, teaE)));
     manager.update(programB);
 
+    trackedEntityAttributeValueA = new TrackedEntityAttributeValue(teaA, trackedEntityA, "A");
+    trackedEntityAttributeValueB = new TrackedEntityAttributeValue(teaB, trackedEntityA, "B");
+    trackedEntityAttributeValueC = new TrackedEntityAttributeValue(teaC, trackedEntityA, "C");
+
     trackedEntityA = createTrackedEntity(orgUnitA);
     trackedEntityA.setTrackedEntityType(trackedEntityTypeA);
+    trackedEntityA.setTrackedEntityAttributeValues(
+        Set.of(
+            trackedEntityAttributeValueA,
+            trackedEntityAttributeValueB,
+            trackedEntityAttributeValueC));
     manager.save(trackedEntityA, false);
 
     trackedEntityChildA = createTrackedEntity(orgUnitChildA);
@@ -1953,6 +1968,33 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     assertEquals(
         String.format("User has no access to TrackedEntity:%s", trackedEntityA.getUid()),
         exception.getMessage());
+  }
+
+  @Test
+  void shouldReturnProgramAttributesWhenSingleTERequestedAndProgramSpecified()
+      throws ForbiddenException, NotFoundException, BadRequestException {
+    TrackedEntity trackedEntity =
+        trackedEntityService.getTrackedEntity(
+            trackedEntityA.getUid(), programA.getUid(), TrackedEntityParams.TRUE, false);
+
+    assertContainsOnly(
+        Set.of(
+            trackedEntityAttributeValueA,
+            trackedEntityAttributeValueB,
+            trackedEntityAttributeValueC),
+        trackedEntity.getTrackedEntityAttributeValues());
+  }
+
+  @Test
+  void shouldReturnTrackedEntityTypeAttributesWhenSingleTERequestedAndNoProgramSpecified()
+      throws ForbiddenException, NotFoundException, BadRequestException {
+    TrackedEntity trackedEntity =
+        trackedEntityService.getTrackedEntity(
+            trackedEntityA.getUid(), null, TrackedEntityParams.TRUE, false);
+
+    assertContainsOnly(
+        Set.of(trackedEntityAttributeValueA, trackedEntityAttributeValueB),
+        trackedEntity.getTrackedEntityAttributeValues());
   }
 
   private Set<String> attributeNames(final Collection<TrackedEntityAttributeValue> attributes) {


### PR DESCRIPTION
Previously, when requesting a single TE in the context of a program, we returned all TEA regardless of the specific program. With this PR, we will now return only the attributes of the specified program + the attributes of the tracked entity type. If no program is specified, only attributes of that particular TET will be returned.

Ticket: https://dhis2.atlassian.net/browse/DHIS2-14300
