### PR TITLE
fix: add relaxedQueryChars to tomcat Main class

### DIFF
--- a/dhis-2/dhis-web-server/src/main/java/org/hisp/dhis/web/tomcat/Main.java
+++ b/dhis-2/dhis-web-server/src/main/java/org/hisp/dhis/web/tomcat/Main.java
@@ -86,6 +86,7 @@ public class Main {
     connector.setThrowOnFailure(true);
     tomcat.getService().addConnector(connector);
     connector.setPort(PORT);
+    connector.setProperty("relaxedQueryChars", "\\ { } | [ ]");
     tomcat.setConnector(connector);
     registerConnectorExecutor(tomcat, connector);
 


### PR DESCRIPTION
- When run tomcat using `org.hisp.dhis.web.tomcat.Main` , the api request `api/dataElements?fields=id,categoryCombo[cateogoryOptionCombo~size],displayName` got below error

```
HTTP Status 400 
java.lang.IllegalArgumentException: Invalid character found in the request target [/api/dataElements?fields=id,categoryCombo[cateogoryOptionCombo~size],displayName ]. The valid characters are defined in RFC 7230 and RFC 3986
	org.apache.coyote.http11.Http11InputBuffer.parseRequestLine(Http11InputBuffer.java:482)
	org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:263)
	org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63)

```

- Currently there is no test use this tomcat.
- Below is screenshot after fix successfully in local.

<img width="1228" alt="Screen Shot 2024-05-27 at 12 12 17 PM" src="https://github.com/dhis2/dhis2-core/assets/766102/a5998bcc-386a-4b5e-acd8-3cedab5ab8bb">
