### PR TITLE
fix: rootJunction OR return empty result

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaCriteriaQueryEngine.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaCriteriaQueryEngine.java
@@ -261,14 +261,14 @@ public class JpaCriteriaQueryEngine<T extends IdentifiableObject> implements Que
   }
 
   private <Y> Predicate buildPredicates(CriteriaBuilder builder, Root<Y> root, Query query) {
-    Predicate junction = getJpaJunction(builder, query.getRootJunctionType());
-
-    for (org.hisp.dhis.query.Criterion criterion : query.getCriterions()) {
-      addPredicate(builder, root, junction, criterion);
+    Predicate junction = builder.conjunction();
+    if (!query.getCriterions().isEmpty()) {
+      junction = getJpaJunction(builder, query.getRootJunctionType());
+      for (org.hisp.dhis.query.Criterion criterion : query.getCriterions()) {
+        addPredicate(builder, root, junction, criterion);
+      }
     }
-
     query.getAliases().forEach(alias -> root.get(alias).alias(alias));
-
     return junction;
   }
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
@@ -45,10 +45,12 @@ import java.util.Set;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeValue;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataelement.DataElementGroup;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.user.User;
@@ -66,6 +68,7 @@ import org.hisp.dhis.webapi.json.domain.JsonTranslation;
 import org.hisp.dhis.webapi.json.domain.JsonTypeReport;
 import org.hisp.dhis.webapi.json.domain.JsonUser;
 import org.hisp.dhis.webapi.json.domain.JsonWebMessage;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
@@ -1082,6 +1085,22 @@ class AbstractCrudControllerTest extends DhisControllerConvenienceTest {
 
     HttpResponse response = GET("/organisationUnits.csv?fields=id,name,openingDate");
     assertTrue(response.content("text").contains("2020-01-01T00:00:00.000"));
+  }
+
+  @Test
+  @DisplayName("Should return dataElements that are part of a dataElementGroup")
+  void testRootJunctionOR() {
+    DataElement dataElement = createDataElement('A');
+    manager.save(dataElement);
+    DataElementGroup dataElementGroup = createDataElementGroup('A');
+    dataElementGroup.addDataElement(dataElement);
+    manager.save(dataElementGroup);
+
+    JsonMixed response =
+        GET("/dataElements?filter=dataElementGroups.id:in:[%s]&rootJunction=OR"
+                .formatted(dataElementGroup.getUid()))
+            .content();
+    assertFalse(response.getArray("dataElements").isEmpty());
   }
 
   private void assertUserGroupHasOnlyUser(String groupId, String userId) {


### PR DESCRIPTION
https://dhis2.atlassian.net/issues/DHIS2-17449
### Issue
- For api request `api/dataElements?fields=id,code,name&filter=dataElementGroups.id:in:[h9cuJOkOwY2]&rootJunction=OR` the filter is included in the memory query, which leads to a database query with empty `Predicate`.
-  In database query, the `rootJunction=OR` will be converted to an empty `disjunction`. [As per java doc](https://docs.oracle.com/javaee/6/api/javax/persistence/criteria/CriteriaBuilder.html#disjunction()), the empty disjunction will return false, hence, query returns empty result.

### Fix
- If the database query has empty `criterions` then just build a default `conjunction`.

### Test
- Added unit test
- Can manual test by access `api/dataElements?fields=id,code,name&filter=dataElementGroups.id:in:[h9cuJOkOwY2]&rootJunction=OR`. The response should not have an empty `dataElements` array.
