### PR TITLE
chore: rename pi to enrollment/en DHIS2-16563

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityQueryParams.java
@@ -74,10 +74,6 @@ public class TrackedEntityQueryParams {
 
   public static final String DELETED = "deleted";
 
-  public static final String META_DATA_NAMES_KEY = "names";
-
-  public static final String PAGER_META_KEY = "pager";
-
   public static final String POTENTIAL_DUPLICATE = "potentialduplicate";
 
   public static final int DEFAULT_PAGE = 1;
@@ -86,7 +82,7 @@ public class TrackedEntityQueryParams {
 
   public static final String MAIN_QUERY_ALIAS = "TE";
 
-  public static final String PROGRAM_INSTANCE_ALIAS = "pi";
+  public static final String ENROLLMENT_QUERY_ALIAS = "en";
 
   /** Query value, will apply to all relevant attributes. */
   private QueryFilter query;
@@ -718,7 +714,7 @@ public class TrackedEntityQueryParams {
     CREATED_AT_CLIENT("createdAtClient", "createdatclient", MAIN_QUERY_ALIAS),
     UPDATED_AT("updatedAt", "lastupdated", MAIN_QUERY_ALIAS),
     UPDATED_AT_CLIENT("updatedAtClient", "lastupdatedatclient", MAIN_QUERY_ALIAS),
-    ENROLLED_AT("enrolledAt", "enrollmentdate", PROGRAM_INSTANCE_ALIAS),
+    ENROLLED_AT("enrolledAt", "enrollmentdate", ENROLLMENT_QUERY_ALIAS),
     INACTIVE(INACTIVE_ID, "inactive", MAIN_QUERY_ALIAS);
 
     private final String propName;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/hibernate/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/hibernate/HibernateRelationshipStore.java
@@ -68,7 +68,7 @@ public class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<R
     implements RelationshipStore {
   private static final String TRACKED_ENTITY = "trackedEntity";
 
-  private static final String PROGRAM_INSTANCE = "enrollment";
+  private static final String ENROLLMENT = "enrollment";
 
   private static final String EVENT = "event";
 
@@ -172,7 +172,7 @@ public class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<R
 
   private <T extends IdentifiableObject> String getRelationshipEntityType(T entity) {
     if (entity instanceof TrackedEntity) return TRACKED_ENTITY;
-    else if (entity instanceof Enrollment) return PROGRAM_INSTANCE;
+    else if (entity instanceof Enrollment) return ENROLLMENT;
     else if (entity instanceof Event) return EVENT;
     else
       throw new IllegalArgumentException(
@@ -344,8 +344,7 @@ public class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<R
           getItem(direction, relationship).getTrackedEntity());
     } else if (relationshipItemDirection.getEnrollment() != null) {
       return builder.equal(
-          root.join(direction).get(PROGRAM_INSTANCE),
-          getItem(direction, relationship).getEnrollment());
+          root.join(direction).get(ENROLLMENT), getItem(direction, relationship).getEnrollment());
     } else if (relationshipItemDirection.getEvent() != null) {
       return builder.equal(
           root.join(direction).get(EVENT), getItem(direction, relationship).getEvent());

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityStore.java
@@ -37,6 +37,7 @@ import static org.hisp.dhis.system.util.SqlUtils.escape;
 import static org.hisp.dhis.system.util.SqlUtils.quote;
 import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.CREATED_ID;
 import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.DELETED;
+import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.ENROLLMENT_QUERY_ALIAS;
 import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.INACTIVE_ID;
 import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.LAST_UPDATED_ID;
 import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.MAIN_QUERY_ALIAS;
@@ -45,7 +46,6 @@ import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.ORG_UNIT_NAME
 import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.OrderColumn.ENROLLED_AT;
 import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.OrderColumn.findColumn;
 import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.POTENTIAL_DUPLICATE;
-import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.PROGRAM_INSTANCE_ALIAS;
 import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.TRACKED_ENTITY_ID;
 import static org.hisp.dhis.trackedentity.TrackedEntityQueryParams.TRACKED_ENTITY_TYPE_ID;
 import static org.hisp.dhis.util.DateUtils.toLongGmtDate;
@@ -696,9 +696,9 @@ public class HibernateTrackedEntityStore extends SoftDeleteHibernateObjectStore<
   private String getFromSubQueryJoinEnrollmentConditions(TrackedEntityQueryParams params) {
     if (params.getOrders().stream().anyMatch(p -> ENROLLED_AT.isPropertyEqualTo(p.getField()))) {
       return new StringBuilder(" INNER JOIN enrollment ")
-          .append(PROGRAM_INSTANCE_ALIAS)
+          .append(ENROLLMENT_QUERY_ALIAS)
           .append(" ON ")
-          .append(PROGRAM_INSTANCE_ALIAS + "." + "trackedentityid")
+          .append(ENROLLMENT_QUERY_ALIAS + "." + "trackedentityid")
           .append("= TE.trackedentityid ")
           .toString();
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHook.java
@@ -124,14 +124,14 @@ public class ProgramObjectBundleHook extends AbstractObjectBundleHook<Program> {
 
   private void addProgramInstance(Program program) {
     if (getProgramInstancesCount(program) == 0 && program.isWithoutRegistration()) {
-      Enrollment pi = new Enrollment();
-      pi.setEnrollmentDate(new Date());
-      pi.setOccurredDate(new Date());
-      pi.setProgram(program);
-      pi.setStatus(ProgramStatus.ACTIVE);
-      pi.setStoredBy("system-process");
+      Enrollment enrollment = new Enrollment();
+      enrollment.setEnrollmentDate(new Date());
+      enrollment.setOccurredDate(new Date());
+      enrollment.setProgram(program);
+      enrollment.setStatus(ProgramStatus.ACTIVE);
+      enrollment.setStoredBy("system-process");
 
-      this.enrollmentService.addEnrollment(pi);
+      this.enrollmentService.addEnrollment(enrollment);
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/HibernateRelationshipStore.java
@@ -72,7 +72,7 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
 
   private static final String TRACKED_ENTITY = "trackedEntity";
 
-  private static final String PROGRAM_INSTANCE = "enrollment";
+  private static final String ENROLLMENT = "enrollment";
 
   private static final String EVENT = "event";
 
@@ -236,7 +236,7 @@ class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<Relation
 
   private <T extends IdentifiableObject> String getRelationshipEntityType(T entity) {
     if (entity instanceof TrackedEntity) return TRACKED_ENTITY;
-    else if (entity instanceof Enrollment) return PROGRAM_INSTANCE;
+    else if (entity instanceof Enrollment) return ENROLLMENT;
     else if (entity instanceof Event) return EVENT;
     else
       throw new IllegalArgumentException(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/merge/orgunit/handler/TrackerOrgUnitMergeHandlerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/merge/orgunit/handler/TrackerOrgUnitMergeHandlerTest.java
@@ -147,7 +147,7 @@ class TrackerOrgUnitMergeHandlerTest extends SingleSetupIntegrationTestBase {
   private long getEnrollmentCount(OrganisationUnit target) {
     return (Long)
         entityManager
-            .createQuery("select count(*) from Enrollment pi where pi.organisationUnit = :target")
+            .createQuery("select count(*) from Enrollment en where en.organisationUnit = :target")
             .setParameter("target", target)
             .getSingleResult();
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -84,7 +84,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
 
   @Autowired protected UserService _userService;
 
-  @Autowired private EnrollmentService programInstanceService;
+  @Autowired private EnrollmentService apiEnrollmentService;
 
   @Autowired private IdentifiableObjectManager manager;
 
@@ -249,7 +249,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
     manager.save(relationshipA, false);
 
     enrollmentA =
-        programInstanceService.enrollTrackedEntity(
+        apiEnrollmentService.enrollTrackedEntity(
             trackedEntityA, programA, new Date(), new Date(), orgUnitA);
     eventA = new Event();
     eventA.setEnrollment(enrollmentA);
@@ -261,15 +261,15 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
     manager.save(enrollmentA, false);
 
     enrollmentB =
-        programInstanceService.enrollTrackedEntity(
+        apiEnrollmentService.enrollTrackedEntity(
             trackedEntityB, programB, new Date(), new Date(), orgUnitB);
 
     enrollmentChildA =
-        programInstanceService.enrollTrackedEntity(
+        apiEnrollmentService.enrollTrackedEntity(
             trackedEntityChildA, programA, new Date(), new Date(), orgUnitChildA);
 
     enrollmentGrandchildA =
-        programInstanceService.enrollTrackedEntity(
+        apiEnrollmentService.enrollTrackedEntity(
             trackedEntityGrandchildA, programA, new Date(), new Date(), orgUnitGrandchildA);
 
     injectSecurityContextUser(user);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SchemaBasedControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SchemaBasedControllerTest.java
@@ -65,7 +65,6 @@ class SchemaBasedControllerTest extends DhisControllerIntegrationTest {
           "identifiableObject", // depends on files
           "dashboard", // uses JSONB functions (improve test setup)
           "pushanalysis", // uses dashboards (see above)
-          "programInstance", // no POST endpoint
           "metadataVersion", // no POST endpoint
           "softDeletableObject", // depends on programInstance (see above)
           "relationship", // generator insufficient for embedded fields


### PR DESCRIPTION
Rename remaining programInstance/PROGRAM_INSTANCE/pi(s) to enrollment/en.

There are still a few usages of programInstance in analytics code which the analytics team will handle. There are also some deprecated parameters for which we need to create separate issues so our clients move over to the new names first before we remove the deprecated parameters.