### PR TITLE
chore: remove unused tracker data idSchemes DHIS2-16564

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdSchemes.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdSchemes.java
@@ -72,15 +72,11 @@ public class IdSchemes implements Serializable {
 
   @JsonProperty private IdScheme programStageIdScheme;
 
-  @JsonProperty private IdScheme trackedEntityIdScheme;
-
   @JsonProperty private IdScheme trackedEntityAttributeIdScheme;
 
   @JsonProperty private IdScheme dataSetIdScheme;
 
   @JsonProperty private IdScheme attributeOptionComboIdScheme;
-
-  @JsonProperty private IdScheme programStageInstanceIdScheme;
 
   public IdSchemes() {}
 
@@ -204,24 +200,6 @@ public class IdSchemes implements Serializable {
 
   public IdSchemes setProgramStageIdScheme(String idScheme) {
     this.programStageIdScheme = IdScheme.from(idScheme);
-    return this;
-  }
-
-  public IdScheme getProgramStageInstanceIdScheme() {
-    return getScheme(programStageInstanceIdScheme);
-  }
-
-  public IdSchemes setProgramStageInstanceIdScheme(String idScheme) {
-    this.programStageInstanceIdScheme = IdScheme.from(idScheme);
-    return this;
-  }
-
-  public IdScheme getTrackedEntityIdScheme() {
-    return getScheme(trackedEntityIdScheme);
-  }
-
-  public IdSchemes setTrackedEntityIdScheme(String idScheme) {
-    this.trackedEntityIdScheme = IdScheme.from(idScheme);
     return this;
   }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dxf2/common/ImportOptions.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dxf2/common/ImportOptions.java
@@ -271,12 +271,6 @@ public class ImportOptions implements JobParameters {
   }
 
   @OpenApi.Property
-  public ImportOptions setTrackedEntityIdScheme(String idScheme) {
-    idSchemes.setTrackedEntityIdScheme(idScheme);
-    return this;
-  }
-
-  @OpenApi.Property
   public ImportOptions setTrackedEntityAttributeIdScheme(String idScheme) {
     idSchemes.setTrackedEntityAttributeIdScheme(idScheme);
     return this;
@@ -285,12 +279,6 @@ public class ImportOptions implements JobParameters {
   @OpenApi.Property
   public ImportOptions setDataSetIdScheme(String idScheme) {
     idSchemes.setDataSetIdScheme(idScheme);
-    return this;
-  }
-
-  @OpenApi.Property
-  public ImportOptions setEventIdScheme(String idScheme) {
-    idSchemes.setProgramStageInstanceIdScheme(idScheme);
     return this;
   }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetQueryParams.java
@@ -126,15 +126,11 @@ public class DataValueSetQueryParams {
 
   private String programStageIdScheme;
 
-  private String trackedEntityIdScheme;
-
   private String trackedEntityAttributeIdScheme;
 
   private String dataSetIdScheme;
 
   private String attributeOptionComboIdScheme;
-
-  private String programStageInstanceIdScheme;
 
   @OpenApi.Ignore
   public IdSchemes getInputIdSchemes() {
@@ -158,12 +154,10 @@ public class DataValueSetQueryParams {
     setNonNull(schemes, orgUnitIdScheme, IdSchemes::setOrgUnitIdScheme);
     setNonNull(schemes, programIdScheme, IdSchemes::setProgramIdScheme);
     setNonNull(schemes, programStageIdScheme, IdSchemes::setProgramStageIdScheme);
-    setNonNull(schemes, trackedEntityIdScheme, IdSchemes::setTrackedEntityIdScheme);
     setNonNull(
         schemes, trackedEntityAttributeIdScheme, IdSchemes::setTrackedEntityAttributeIdScheme);
     setNonNull(schemes, dataSetIdScheme, IdSchemes::setDataSetIdScheme);
     setNonNull(schemes, attributeOptionComboIdScheme, IdSchemes::setAttributeOptionComboIdScheme);
-    setNonNull(schemes, programStageInstanceIdScheme, IdSchemes::setProgramStageInstanceIdScheme);
     return schemes;
   }
 


### PR DESCRIPTION
Old tracker endpoints `/trackedEntities`, `/enrollments`, `/events`, `/relationships` have been removed. Tracker data does not support idSchemes other than UID.