### PR TITLE
ci: send all Jenkins build failure notifications to backend channel

### DIFF
--- a/jenkinsfiles/canary
+++ b/jenkinsfiles/canary
@@ -130,7 +130,11 @@ pipeline {
     post {
         failure {
             script {
-                slack.sendFailureMessage()
+                slack.sendMessage(
+                    '#ff0000',
+                    slack.buildUrl() + "\nLatest run on ${GIT_BRANCH} failed and needs investigation. :detective-duck:\nCommit: <${GIT_URL}/commit/${GIT_COMMIT}|${GIT_COMMIT}>",
+                    'team-backend'
+                )
             }
         }
 

--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -46,18 +46,6 @@ pipeline {
                 always {
                     implementIoBuildEnded(buildName: "${STAGE_NAME}")
                 }
-
-                failure {
-                    script {
-                        if (buildLog.getLines().contains('There are test failures')) {
-                            slack.sendMessage(
-                                '#ff0000',
-                                slack.buildUrl() + "\nLatest test run on ${GIT_BRANCH} failed and needs investigation. :detective-duck:\nCommit: <${GIT_URL}/commit/${GIT_COMMIT}|${GIT_COMMIT}>",
-                                'team-backend'
-                            )
-                        }
-                    }
-                }
             }
         }
 
@@ -236,7 +224,11 @@ pipeline {
 
         failure {
             script {
-                slack.sendFailureMessage()
+                slack.sendMessage(
+                    '#ff0000',
+                    slack.buildUrl() + "\nLatest run on ${GIT_BRANCH} failed and needs investigation. :detective-duck:\nCommit: <${GIT_URL}/commit/${GIT_COMMIT}|${GIT_COMMIT}>",
+                    'team-backend'
+                )
             }
         }
 

--- a/jenkinsfiles/eos
+++ b/jenkinsfiles/eos
@@ -45,7 +45,11 @@ pipeline {
     post {
         failure {
             script {
-                slack.sendFailureMessage()
+                slack.sendMessage(
+                    '#ff0000',
+                    slack.buildUrl() + "\nLatest run on ${GIT_BRANCH} failed and needs investigation. :detective-duck:\nCommit: <${GIT_URL}/commit/${GIT_COMMIT}|${GIT_COMMIT}>",
+                    'team-backend'
+                )
             }
         }
 

--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -238,7 +238,11 @@ pipeline {
     post {
         failure {
             script {
-                slack.sendFailureMessage()
+                slack.sendMessage(
+                    '#ff0000',
+                    slack.buildUrl() + "\nLatest run on ${GIT_BRANCH} failed and needs investigation. :detective-duck:\nCommit: <${GIT_URL}/commit/${GIT_COMMIT}|${GIT_COMMIT}>",
+                    'team-backend'
+                )
             }
         }
 


### PR DESCRIPTION
Currently only unit/integration tests failures from the Build stage will lead to notifications in the Backend channel, while other failures will be sent to the Jenkins channel, which mostly nobody follows. A couple of times we’ve ended up in a situation where builds of `master` or other dev branches keep failing and people are not aware.

Note that this might end up being a bit spammy, as failures occur for various reasons, sometimes outside of our control (like intermitent connectivity issues, etc).