### PR TITLE
fix: only flush every 400 items when providing default COC names

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryOptionComboStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryOptionComboStore.java
@@ -109,6 +109,7 @@ public class HibernateCategoryOptionComboStore
     for (CategoryOptionCombo coc : categoryOptionCombos) {
       session.update(coc);
 
+      counter++;
       if ((counter % 400) == 0) {
         dbmsManager.clearSession();
       }


### PR DESCRIPTION
Static analysis found the `if` condition for `counter` is always `true`. We concluded that the code missed increasing the counter and that we would still need this so the inc is added now.