### PR TITLE
feat: use en as DB locale default [DHIS2-17408]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
@@ -59,7 +59,7 @@ import org.hisp.dhis.sms.config.SmsConfiguration;
  */
 public enum SettingKey {
   UI_LOCALE("keyUiLocale", LocaleManager.DEFAULT_LOCALE, Locale.class),
-  DB_LOCALE("keyDbLocale", Locale.class),
+  DB_LOCALE("keyDbLocale", LocaleManager.DEFAULT_LOCALE, Locale.class),
   ANALYSIS_DISPLAY_PROPERTY(
       "keyAnalysisDisplayProperty", DisplayProperty.NAME, DisplayProperty.class),
   ANALYSIS_DIGIT_GROUP_SEPARATOR(


### PR DESCRIPTION
Similar to UI locale the DB uses a locale default (EN)