### PR TITLE
fix: Remove EventChart and EventReport schemas from metadata export flow [BETA-177]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
@@ -44,6 +44,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -161,6 +162,7 @@ public class DefaultMetadataExportService implements MetadataExportService {
       schemaService.getMetadataSchemas().stream()
           .filter(schema -> schema.isIdentifiableObject() && schema.isPersisted())
           .filter(s -> !s.isSecondaryMetadata())
+          .filter(DEPRECATED_ANALYTICS_SCHEMAS)
           .forEach(
               schema ->
                   params.getClasses().add((Class<? extends IdentifiableObject>) schema.getKlass()));
@@ -208,6 +210,15 @@ public class DefaultMetadataExportService implements MetadataExportService {
 
     return metadata;
   }
+
+  /**
+   * This predicate is used to filter out deprecated Analytics schemas, {@link EventChart} & {@link
+   * EventReport}.As they are no longer used ({@link EventVisualization} has replaced them), they
+   * should be removed from the metadata export flow. This was causing issues otherwise. See <a
+   * href="https://dhis2.atlassian.net/browse/BETA-177">Jira issue</a>
+   */
+  public static final Predicate<Schema> DEPRECATED_ANALYTICS_SCHEMAS =
+      schema -> schema.getKlass() != EventChart.class && schema.getKlass() != EventReport.class;
 
   @Override
   @Transactional(readOnly = true)


### PR DESCRIPTION
# Issue
Issue originally found during QA testing of metadata sync job. The following exception was being thrown:
```
PersistentObjectException: detached entity passed to persist: org.hisp.dhis.organisationunit.OrganisationUnitGroupSetDimension 
```

All `BaseAnalyticalObject`s have the property:
```
protected List<OrganisationUnitGroupSetDimension> organisationUnitGroupSetDimensions;
```

# Cause
The root cause was eventually found after many dead ends. It was observed during debugging that `EventChart` objects were triggering the issue after a session flush. This seemed strange though, as the database being used did not have any `EventChart` data in it. It turned out that the central instance was saving a metadata snapshot which included `EventChart`s and `EventReport`s.

The reason for this was because there were 35 valid `EventVisualization`s in the database, and during the saving of the snapshot, those 35 `EventVisualization`s were also being used to instantiate 35 `EventReport`s and 35 `EventChart`s.

In the `ObjectBundleHook`, all metadata schemas are returned and used in the metadata export flow.
`EventChart` and `EventReport` `.hbm` files have their `table` set as `eventvisualization` which is the reason for retrieving unwanted objects and trying to convert them into deprecated classes.

# Fix
A filter has been added to remove the 2 schemas (`EventChart` and `EventReport`) from the metadata export flow.

# Testing
## Automated
Unit tests added for:
- metadata export service getting metadata (ensuring deprecated classes are removed)
- predicate

## Manual
Multiple manual tests during the debugging of this issue. Steps to reproduce are in the Jira issue.
Manually confirmed this fix works locally & in IM. IM screenshot below of remote sync settings showing synced version from central instance

<img width="1177" alt="Screenshot 2024-05-28 at 16 51 27" src="https://github.com/dhis2/dhis2-core/assets/131455290/30430cac-0be1-42bf-9366-573853e70945">
