### PR TITLE
fix: Remove EventChart and EventReport schemas from metadata export flow [BETA-177]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
@@ -44,6 +44,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -154,6 +155,7 @@ public class DefaultMetadataExportService implements MetadataExportService {
       schemaService.getMetadataSchemas().stream()
           .filter(schema -> schema.isIdentifiableObject() && schema.isPersisted())
           .filter(s -> !s.isSecondaryMetadata())
+          .filter(DEPRECATED_ANALYTICS_SCHEMAS)
           .forEach(
               schema ->
                   params.getClasses().add((Class<? extends IdentifiableObject>) schema.getKlass()));
@@ -200,6 +202,15 @@ public class DefaultMetadataExportService implements MetadataExportService {
 
     return metadata;
   }
+
+  /**
+   * This predicate is used to filter out deprecated Analytics schemas, {@link EventChart} & {@link
+   * EventReport}.As they are no longer used ({@link EventVisualization} has replaced them), they
+   * should be removed from the metadata export flow. This was causing issues otherwise. See <a
+   * href="https://dhis2.atlassian.net/browse/BETA-177">Jira issue</a>
+   */
+  public static final Predicate<Schema> DEPRECATED_ANALYTICS_SCHEMAS =
+      schema -> schema.getKlass() != EventChart.class && schema.getKlass() != EventReport.class;
 
   @Override
   @Transactional(readOnly = true)

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportServiceTest.java
@@ -28,6 +28,8 @@
 package org.hisp.dhis.dxf2.metadata;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -36,10 +38,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
+import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.SetMap;
 import org.hisp.dhis.dashboard.Dashboard;
 import org.hisp.dhis.dashboard.DashboardItem;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.eventchart.EventChart;
+import org.hisp.dhis.eventreport.EventReport;
+import org.hisp.dhis.eventvisualization.EventVisualization;
 import org.hisp.dhis.mapping.MapView;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionGroup;
@@ -49,12 +57,19 @@ import org.hisp.dhis.programrule.ProgramRule;
 import org.hisp.dhis.programrule.ProgramRuleAction;
 import org.hisp.dhis.programrule.ProgramRuleService;
 import org.hisp.dhis.programrule.ProgramRuleVariableService;
+import org.hisp.dhis.query.Query;
+import org.hisp.dhis.query.QueryService;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.user.CurrentUserService;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -72,6 +87,9 @@ class DefaultMetadataExportServiceTest {
   @Mock private ProgramRuleService programRuleService;
 
   @Mock private ProgramRuleVariableService programRuleVariableService;
+
+  @Mock private QueryService queryService;
+  @Mock private CurrentUserService userService;
 
   @InjectMocks private DefaultMetadataExportService service;
 
@@ -178,5 +196,57 @@ class DefaultMetadataExportServiceTest {
     assertNotNull(result.get(ProgramRuleAction.class));
     assertNotNull(result.get(OptionGroup.class));
     assertNotNull(result.get(OptionSet.class));
+  }
+
+  @Test
+  @DisplayName(
+      "Deprecated Analytic classes (EventChart and EventReport) should have their schemas removed from metadata export")
+  void deprecatedAnalyticClassesSchemaRemovedTest() {
+    // given
+    MetadataExportParams params = new MetadataExportParams();
+    List<Schema> schemas =
+        List.of(
+            new Schema(EventReport.class, "eventReport", "eventReports"),
+            new Schema(EventChart.class, "eventChart", "eventCharts"),
+            new Schema(EventVisualization.class, "eventVisualization", "eventVisualizations"),
+            new Schema(DataElement.class, "dataElement", "dataElements"),
+            new Schema(Program.class, "program", "programs"));
+    schemas.forEach(s -> s.setPersisted(true));
+
+    Query query = Query.from(new Schema(EventReport.class, "eventReport", "eventReports"));
+    when(queryService.getQueryFromUrl(any(), any(), any())).thenReturn(query);
+
+    // return 5 schemas, including the 2 for the deprecated classes EventChart & EventReport
+    when(schemaService.getMetadataSchemas()).thenReturn(schemas);
+
+    // when
+    service.getMetadata(params);
+
+    // then
+    assertEquals(
+        3, params.getClasses().size(), "EventChart and EventReport classes should not be present");
+  }
+
+  @ParameterizedTest
+  @MethodSource(value = "schemaSources")
+  @DisplayName("Deprecated Analytic schema predicate returns the correct result")
+  void deprecatedAnalyticSchemaPredicateTest(Schema schema, boolean expectedResult) {
+    // when
+    boolean actualResult = DefaultMetadataExportService.DEPRECATED_ANALYTICS_SCHEMAS.test(schema);
+
+    // then
+    assertEquals(expectedResult, actualResult, "expected result should match predicate result");
+  }
+
+  private static Stream<Arguments> schemaSources() {
+    return Stream.of(
+        arguments(new Schema(EventReport.class, "eventReport", "eventReports"), false),
+        arguments(new Schema(EventChart.class, "eventChart", "eventCharts"), false),
+        arguments(
+            new Schema(EventVisualization.class, "eventVisualization", "eventVisualizations"),
+            true),
+        arguments(new Schema(DataElement.class, "dataElement", "dataElements"), true),
+        arguments(new Schema(Program.class, "program", "programs"), true),
+        arguments(new Schema(CategoryCombo.class, "categoryCombo", "categoryCombos"), true));
   }
 }


### PR DESCRIPTION
port of #17619 