### PR TITLE
chore: Add query parameter enrollmentStatus to /tracker in favor of programStatus DHIS2-17484

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParams.java
@@ -106,7 +106,13 @@ public class EnrollmentRequestParams implements PageRequestParams {
   @OpenApi.Property({UID.class, Program.class})
   private UID program;
 
+  /**
+   * @deprecated use {@link #status} instead
+   */
+  @Deprecated(since = "2.42")
   private EnrollmentStatus programStatus;
+
+  private EnrollmentStatus status;
 
   private Boolean followUp;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapper.java
@@ -39,6 +39,7 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams.EnrollmentOperationParamsBuilder;
 import org.hisp.dhis.util.DateUtils;
@@ -78,6 +79,13 @@ class EnrollmentRequestParamsMapper {
 
     orgUnitMode = validateOrgUnitModeForEnrollmentsAndEvents(orgUnits, orgUnitMode);
 
+    EnrollmentStatus enrollmentStatus =
+        validateDeprecatedParameter(
+            "programStatus",
+            enrollmentRequestParams.getProgramStatus(),
+            "status",
+            enrollmentRequestParams.getStatus());
+
     validateOrderParams(enrollmentRequestParams.getOrder(), ORDERABLE_FIELD_NAMES);
     validateRequestParams(enrollmentRequestParams);
 
@@ -91,7 +99,7 @@ class EnrollmentRequestParamsMapper {
     EnrollmentOperationParamsBuilder builder =
         EnrollmentOperationParams.builder()
             .programUid(applyIfNotNull(enrollmentRequestParams.getProgram(), UID::getValue))
-            .programStatus(enrollmentRequestParams.getProgramStatus())
+            .programStatus(enrollmentStatus)
             .followUp(enrollmentRequestParams.getFollowUp())
             .lastUpdated(
                 applyIfNotNull(enrollmentRequestParams.getUpdatedAfter(), StartDateTime::toDate))
@@ -131,24 +139,30 @@ class EnrollmentRequestParamsMapper {
   private void validateRequestParams(EnrollmentRequestParams params) throws BadRequestException {
     if (params.getProgram() != null && params.getTrackedEntityType() != null) {
       throw new BadRequestException(
-          "Program and tracked entity cannot be specified simultaneously");
+          "`program` and `trackedEntityType` cannot be specified simultaneously");
     }
 
     if (params.getProgram() == null) {
       if (params.getProgramStatus() != null) {
-        throw new BadRequestException("Program must be defined when `programStatus` is defined");
+        throw new BadRequestException("`program` must be defined when `programStatus` is defined");
+      }
+      if (params.getStatus() != null) {
+        throw new BadRequestException("`program` must be defined when `status` is defined");
       }
 
       if (params.getFollowUp() != null) {
-        throw new BadRequestException("Program must be defined when `followUp` status is defined");
+        throw new BadRequestException(
+            "`program` must be defined when `followUp` status is defined");
       }
 
       if (params.getEnrolledAfter() != null) {
-        throw new BadRequestException("Program must be defined when `enrolledAfter` is specified");
+        throw new BadRequestException(
+            "`program` must be defined when `enrolledAfter` is specified");
       }
 
       if (params.getEnrolledBefore() != null) {
-        throw new BadRequestException("Program must be defined when `enrolledBefore` is specified");
+        throw new BadRequestException(
+            "`program` must be defined when `enrolledBefore` is specified");
       }
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParams.java
@@ -100,6 +100,10 @@ public class EventRequestParams implements PageRequestParams {
   @OpenApi.Property({UID.class, ProgramStage.class})
   private UID programStage;
 
+  /**
+   * @deprecated use {@link #enrollmentStatus} instead
+   */
+  @Deprecated(since = "2.42")
   private EnrollmentStatus programStatus;
 
   private Boolean followUp;
@@ -145,6 +149,8 @@ public class EventRequestParams implements PageRequestParams {
   private EndDateTime updatedBefore;
 
   private String updatedWithin;
+
+  private EnrollmentStatus enrollmentStatus;
 
   private StartDateTime enrollmentEnrolledAfter;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapper.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.tracker.export.event.EventOperationParams;
 import org.hisp.dhis.tracker.export.event.EventOperationParams.EventOperationParamsBuilder;
 import org.hisp.dhis.util.DateUtils;
@@ -79,6 +80,13 @@ class EventRequestParamsMapper {
                 ? Set.of(eventRequestParams.getOrgUnit())
                 : emptySet(),
             orgUnitMode);
+
+    EnrollmentStatus enrollmentStatus =
+        validateDeprecatedParameter(
+            "programStatus",
+            eventRequestParams.getProgramStatus(),
+            "enrollmentStatus",
+            eventRequestParams.getEnrollmentStatus());
 
     UID attributeCategoryCombo =
         validateDeprecatedParameter(
@@ -121,7 +129,7 @@ class EventRequestParamsMapper {
             .programStageUid(applyIfNotNull(eventRequestParams.getProgramStage(), UID::getValue))
             .orgUnitUid(applyIfNotNull(eventRequestParams.getOrgUnit(), UID::getValue))
             .trackedEntityUid(applyIfNotNull(eventRequestParams.getTrackedEntity(), UID::getValue))
-            .programStatus(eventRequestParams.getProgramStatus())
+            .programStatus(enrollmentStatus)
             .followUp(eventRequestParams.getFollowUp())
             .orgUnitMode(orgUnitMode)
             .assignedUserMode(eventRequestParams.getAssignedUserMode())

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParams.java
@@ -123,11 +123,14 @@ public class TrackedEntityRequestParams implements PageRequestParams {
 
   private OrganisationUnitSelectionMode orgUnitMode;
 
-  /** a Program UID for which instances in the response must be enrolled in. */
+  /** The program tracked entities are enrolled in. */
   @OpenApi.Property({UID.class, Program.class})
   private UID program;
 
-  /** The {@see ProgramStatus} of the Tracked Entity Instance in the given program. */
+  /**
+   * @deprecated use {@link #enrollmentStatus} instead
+   */
+  @Deprecated(since = "2.42")
   private EnrollmentStatus programStatus;
 
   /**
@@ -144,6 +147,8 @@ public class TrackedEntityRequestParams implements PageRequestParams {
 
   /** The last updated duration filter. */
   private String updatedWithin;
+
+  private EnrollmentStatus enrollmentStatus;
 
   /** The given Program start date. */
   private StartDateTime enrollmentEnrolledAfter;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapper.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.fieldfiltering.FieldPath;
+import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityOperationParams;
 import org.hisp.dhis.tracker.export.trackedentity.TrackedEntityOperationParams.TrackedEntityOperationParamsBuilder;
 import org.hisp.dhis.user.User;
@@ -103,6 +104,13 @@ class TrackedEntityRequestParamsMapper {
         validateOrgUnitModeForTrackedEntities(
             orgUnitUids, orgUnitMode, trackedEntityRequestParams.getTrackedEntities());
 
+    EnrollmentStatus enrollmentStatus =
+        validateDeprecatedParameter(
+            "programStatus",
+            trackedEntityRequestParams.getProgramStatus(),
+            "enrollmentStatus",
+            trackedEntityRequestParams.getEnrollmentStatus());
+
     Set<UID> trackedEntities =
         validateDeprecatedUidsParameter(
             "trackedEntity",
@@ -119,7 +127,7 @@ class TrackedEntityRequestParamsMapper {
             .programUid(applyIfNotNull(trackedEntityRequestParams.getProgram(), UID::getValue))
             .programStageUid(
                 applyIfNotNull(trackedEntityRequestParams.getProgramStage(), UID::getValue))
-            .programStatus(trackedEntityRequestParams.getProgramStatus())
+            .programStatus(enrollmentStatus)
             .followUp(trackedEntityRequestParams.getFollowUp())
             .lastUpdatedStartDate(
                 applyIfNotNull(trackedEntityRequestParams.getUpdatedAfter(), StartDateTime::toDate))
@@ -182,6 +190,10 @@ class TrackedEntityRequestParamsMapper {
 
       if (params.getProgramStatus() != null) {
         throw new BadRequestException("`program` must be defined when `programStatus` is defined");
+      }
+      if (params.getEnrollmentStatus() != null) {
+        throw new BadRequestException(
+            "`program` must be defined when `enrollmentStatus` is defined");
       }
 
       if (params.getFollowUp() != null) {

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/EnrollmentsExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/EnrollmentsExportController.md
@@ -103,9 +103,17 @@ See `orgUnitMode` for details.
 
 Get enrollments enrolled in the given program.
 
+### `*.parameter.EnrollmentRequestParams.status`
+
+Get enrollments in the given status.
+
 ### `*.parameter.EnrollmentRequestParams.programStatus`
 
-Get enrollments enrolled in a program with the given status.
+Get enrollments in the given status.
+
+**DEPRECATED as of 2.42:** Use parameter `status` instead.
+
+See `status` for details.
 
 ### `*.parameter.EnrollmentRequestParams.trackedEntityType`
 

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/EventsExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/EventsExportController.md
@@ -17,8 +17,7 @@ Get an event with given UID.
 ### `getEventByUid.parameter.fields`
 
 Get only the specified fields in the JSON response. This query parameter allows you to remove
-unnecessary fields from
-the response and in some cases decrease the response time. Refer to
+unnecessary fields from the response and in some cases decrease the response time. Refer to
 https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_metadata_field_filter
 for how to use it.
 
@@ -45,7 +44,17 @@ Get the change logs of all data elements related to that particular event UID.
 
 ### `*.parameter.EventRequestParams.programStage`
 
+### `*.parameter.EventRequestParams.enrollmentStatus`
+
+Get events from an enrollment in the given status.
+
 ### `*.parameter.EventRequestParams.programStatus`
+
+Get events from an enrollment in the given status.
+
+**DEPRECATED as of 2.42:** Use parameter `enrollmentStatus` instead.
+
+See `enrollmentStatus` for details.
 
 ### `*.parameter.EventRequestParams.followUp`
 
@@ -76,8 +85,7 @@ Get events using given organisation unit mode.
 `<user1-uid>[,<user2-uid>...]`
 
 Get events that are assigned to the given user(s). Specifying `assignedUsers` is only valid
-if `assignedUserMode` is
-either `PROVIDED` or not specified.
+if `assignedUserMode` is either `PROVIDED` or not specified.
 
 ### `*.parameter.EventRequestParams.assignedUser`
 
@@ -87,8 +95,7 @@ comma!
 `<user1-uid>[;<user2-uid>...]`
 
 Get events that are assigned to the given user(s). Specifying `assignedUser` is only valid
-if `assignedUserMode` is
-either `PROVIDED` or not specified.
+if `assignedUserMode` is either `PROVIDED` or not specified.
 
 ### `*.parameter.EventRequestParams.occurredAfter`
 
@@ -205,8 +212,7 @@ provided.
 ### `*.parameter.EventRequestParams.fields`
 
 Get only the specified fields in the JSON response. This query parameter allows you to remove
-unnecessary fields from
-the JSON response and in some cases decrease the response time. Refer to
+unnecessary fields from the JSON response and in some cases decrease the response time. Refer to
 https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_metadata_field_filter
 for how to use it.
 
@@ -219,8 +225,8 @@ NOTE: this query parameter has no effect on a CSV response!
 Get events matching given filters on data values. A filter is a colon separated data element UID
 with operator and value pairs. Example: `filter=H9IlTX2X6SL:sw:A` with operator starts with `sw`
 followed by a value. Special characters like `+` need to be percent-encoded so `%2B` instead of `+`.
-Multiple operator/value pairs for the same data element
-as `filter=AuPLng5hLbE:gt:438901703:lt:448901704` are allowed. Operator and values are
+Multiple operator/value pairs for the same data element as
+`filter=AuPLng5hLbE:gt:438901703:lt:448901704` are allowed. Operator and values are
 case-insensitive. A user needs metadata read access to the data element and data read access to the
 program (if the program is without registration) or the program stage (if the program is with
 registration).
@@ -248,15 +254,15 @@ Valid operators are:
 
 `<filter1>[,<filter2>...]`
 
-Get events matching given filters on tracked entity attributes. A filter is a colon separated 
-attribute UID with optional operator and value pairs. Example: `filter=H9IlTX2X6SL:sw:A` with 
-operator starts with `sw` followed by a value. Special characters like `+` need to be 
-percent-encoded so `%2B` instead of `+`. Characters such as `:` (colon) or `,` (comma), as part 
-of the filter value, need to be escaped by / (slash). Likewise, `/` needs to be escaped. 
-Multiple operator/value pairs for the same attribute as `filter=AuPLng5hLbE:gt:438901703:lt:448901704` 
-are allowed. Repeating the same attribute UID is not allowed. Operator and values are case-insensitive. 
-A user needs metadata read access to the attribute and data read access to the program 
-(if the program is without registration) or to the program stage (if the program is with registration).
+Get events matching given filters on tracked entity attributes. A filter is a colon separated
+attribute UID with optional operator and value pairs. Example: `filter=H9IlTX2X6SL:sw:A` with
+operator starts with `sw` followed by a value. Special characters like `+` need to be
+percent-encoded so `%2B` instead of `+`. Characters such as `:` (colon) or `,` (comma), as part of
+the filter value, need to be escaped by / (slash). Likewise, `/` needs to be escaped. Multiple
+operator/value pairs for the same attribute as `filter=AuPLng5hLbE:gt:438901703:lt:448901704` are
+allowed. Repeating the same attribute UID is not allowed. Operator and values are case-insensitive.
+A user needs metadata read access to the attribute and data read access to the program (if the
+program is without registration) or to the program stage (if the program is with registration).
 
 Valid operators are:
 

--- a/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
+++ b/dhis-2/dhis-web-api/src/main/resources/openapi/TrackedEntitiesExportController.md
@@ -19,8 +19,7 @@ Get a tracked entity with given UID.
 ### `getTrackedEntityByUid.parameter.fields`
 
 Get only the specified fields in the JSON response. This query parameter allows you to remove
-unnecessary fields from
-the response and in some cases decrease the response time. Refer to
+unnecessary fields from the response and in some cases decrease the response time. Refer to
 https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_metadata_field_filter
 for how to use it.
 
@@ -51,12 +50,12 @@ image is evaluated based on the users access to the relevant tracked entity type
 
 ### `getTrackedEntityAttributeChangeLog`
 
-Get the change logs of all tracked entity attributes related to that particular tracked entity UID. 
+Get the change logs of all tracked entity attributes related to that particular tracked entity UID.
 It will return change logs of tracked entity attributes within the tracked entity type.
 
 ### `getTrackedEntityAttributeChangeLog.parameter.program`
 
-Get the change logs of all tracked entity attributes related to that particular tracked entity and 
+Get the change logs of all tracked entity attributes related to that particular tracked entity and
 program UID. It will return change logs of tracked entity attributes within the tracked entity type
 and program attributes too.
 
@@ -89,7 +88,17 @@ Get tracked entities using given organisation unit mode.
 
 ### `*.parameter.TrackedEntityRequestParams.program`
 
+### `*.parameter.TrackedEntityRequestParams.enrollmentStatus`
+
+Get tracked entities with an enrollment in the given status.
+
 ### `*.parameter.TrackedEntityRequestParams.programStatus`
+
+Get tracked entities with an enrollment in the given status.
+
+**DEPRECATED as of 2.42:** Use parameter `enrollmentStatus` instead.
+
+See `enrollmentStatus` for details.
 
 ### `*.parameter.TrackedEntityRequestParams.followUp`
 
@@ -131,8 +140,7 @@ Get tracked entities with given UID(s).
 `<user1-uid>[,<user2-uid>...]`
 
 Get tracked entities with an event assigned to given user(s). Specifying `assignedUsers` is only
-valid
-if `assignedUserMode` is either `PROVIDED` or not specified.
+valid if `assignedUserMode` is either `PROVIDED` or not specified.
 
 ### `*.parameter.TrackedEntityRequestParams.assignedUser`
 
@@ -142,8 +150,7 @@ comma!
 `<user1-uid>[;<user2-uid>...]`
 
 Get tracked entities with an event assigned to given user(s). Specifying `assignedUsers` is only
-valid
-if `assignedUserMode` is either `PROVIDED` or not specified.
+valid if `assignedUserMode` is either `PROVIDED` or not specified.
 
 ### `*.parameter.TrackedEntityRequestParams.programStage`
 
@@ -154,13 +161,13 @@ with `eventOccurredAfter` and `eventOccurredBefore`.
 
 ### `*.parameter.TrackedEntityRequestParams.eventOccurredAfter`
 
-Get tracked entities with an event occurred after given date. `eventOccurredAfter` must be specified together
-with `eventStatus` and `eventOccurredBefore`.
+Get tracked entities with an event occurred after given date. `eventOccurredAfter` must be specified
+together with `eventStatus` and `eventOccurredBefore`.
 
 ### `*.parameter.TrackedEntityRequestParams.eventOccurredBefore`
 
-Get tracked entities with an event occurred before given date. `eventOccurredBefore` must be specified together
-with `eventStatus` and `eventOccurredAfter`.
+Get tracked entities with an event occurred before given date. `eventOccurredBefore` must be
+specified together with `eventStatus` and `eventOccurredAfter`.
 
 ### `*.parameter.TrackedEntityRequestParams.includeDeleted`
 
@@ -192,8 +199,7 @@ parameter is provided.
 ### `*.parameter.TrackedEntityRequestParams.fields`
 
 Get only the specified fields in the JSON response. This query parameter allows you to remove
-unnecessary fields from
-the JSON response and in some cases decrease the response time. Refer to
+unnecessary fields from the JSON response and in some cases decrease the response time. Refer to
 https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_metadata_field_filter
 for how to use it.
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParamsMapperTest.java
@@ -66,7 +66,7 @@ import org.mockito.quality.Strictness;
 
 @MockitoSettings(strictness = Strictness.LENIENT) // common setup
 @ExtendWith(MockitoExtension.class)
-class EnrollmentImportRequestParamsMapperTest {
+class EnrollmentRequestParamsMapperTest {
 
   private static final String ORG_UNIT_1_UID = "lW0T2U7gZUi";
 
@@ -151,6 +151,18 @@ class EnrollmentImportRequestParamsMapperTest {
   }
 
   @Test
+  void shouldFailIfDeprecatedAndNewStatusParameterIsSet() {
+    EnrollmentRequestParams enrollmentRequestParams = new EnrollmentRequestParams();
+    enrollmentRequestParams.setProgramStatus(EnrollmentStatus.ACTIVE);
+    enrollmentRequestParams.setStatus(EnrollmentStatus.ACTIVE);
+
+    BadRequestException exception =
+        assertThrows(BadRequestException.class, () -> mapper.map(enrollmentRequestParams));
+
+    assertStartsWith("Only one parameter of 'programStatus' and 'status'", exception.getMessage());
+  }
+
+  @Test
   void testMappingProgram() throws BadRequestException {
     EnrollmentRequestParams enrollmentRequestParams = new EnrollmentRequestParams();
     enrollmentRequestParams.setProgram(UID.of(PROGRAM_UID));
@@ -227,21 +239,30 @@ class EnrollmentImportRequestParamsMapperTest {
         Assertions.assertThrows(BadRequestException.class, () -> mapper.map(requestParams));
 
     assertEquals(
-        "Program and tracked entity cannot be specified simultaneously",
+        "`program` and `trackedEntityType` cannot be specified simultaneously",
         badRequestException.getMessage());
   }
 
   @Test
-  void shouldFailWhenProgramStatusProvidedAndProgramNotPresent() {
+  void shouldFailIfProgramStatusIsSetWithoutProgram() {
     EnrollmentRequestParams requestParams = new EnrollmentRequestParams();
     requestParams.setProgramStatus(EnrollmentStatus.ACTIVE);
 
-    Exception badRequestException =
+    Exception exception =
         Assertions.assertThrows(BadRequestException.class, () -> mapper.map(requestParams));
 
-    assertEquals(
-        "Program must be defined when `programStatus` is defined",
-        badRequestException.getMessage());
+    assertStartsWith("`program` must be defined when `programStatus`", exception.getMessage());
+  }
+
+  @Test
+  void shouldFailIfEnrollmentStatusIsSetWithoutProgram() {
+    EnrollmentRequestParams requestParams = new EnrollmentRequestParams();
+    requestParams.setStatus(EnrollmentStatus.ACTIVE);
+
+    Exception exception =
+        Assertions.assertThrows(BadRequestException.class, () -> mapper.map(requestParams));
+
+    assertStartsWith("`program` must be defined when `status`", exception.getMessage());
   }
 
   @Test
@@ -253,7 +274,7 @@ class EnrollmentImportRequestParamsMapperTest {
         Assertions.assertThrows(BadRequestException.class, () -> mapper.map(requestParams));
 
     assertEquals(
-        "Program must be defined when `followUp` status is defined",
+        "`program` must be defined when `followUp` status is defined",
         badRequestException.getMessage());
   }
 
@@ -266,7 +287,7 @@ class EnrollmentImportRequestParamsMapperTest {
         Assertions.assertThrows(BadRequestException.class, () -> mapper.map(requestParams));
 
     assertEquals(
-        "Program must be defined when `enrolledAfter` is specified",
+        "`program` must be defined when `enrolledAfter` is specified",
         badRequestException.getMessage());
   }
 
@@ -279,7 +300,7 @@ class EnrollmentImportRequestParamsMapperTest {
         Assertions.assertThrows(BadRequestException.class, () -> mapper.map(requestParams));
 
     assertEquals(
-        "Program must be defined when `enrolledBefore` is specified",
+        "`program` must be defined when `enrolledBefore` is specified",
         badRequestException.getMessage());
   }
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventRequestParamsMapperTest.java
@@ -59,6 +59,7 @@ import org.hisp.dhis.fieldfiltering.FieldFilterParser;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
@@ -90,7 +91,7 @@ import org.mockito.quality.Strictness;
 
 @MockitoSettings(strictness = Strictness.LENIENT) // common setup
 @ExtendWith(MockitoExtension.class)
-class EventImportRequestParamsMapperTest {
+class EventRequestParamsMapperTest {
 
   private static final String DE_1_UID = "OBzmpRP6YUh";
 
@@ -206,6 +207,19 @@ class EventImportRequestParamsMapperTest {
         assertThrows(BadRequestException.class, () -> mapper.map(eventRequestParams));
 
     assertStartsWith("Only one parameter of 'ouMode' and 'orgUnitMode'", exception.getMessage());
+  }
+
+  @Test
+  void shouldFailIfDeprecatedAndNewEnrollmentStatusParameterIsSet() {
+    EventRequestParams eventRequestParams = new EventRequestParams();
+    eventRequestParams.setProgramStatus(EnrollmentStatus.ACTIVE);
+    eventRequestParams.setEnrollmentStatus(EnrollmentStatus.ACTIVE);
+
+    BadRequestException exception =
+        assertThrows(BadRequestException.class, () -> mapper.map(eventRequestParams));
+
+    assertStartsWith(
+        "Only one parameter of 'programStatus' and 'enrollmentStatus'", exception.getMessage());
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/relationship/RelationshipRequestParamsMapperTest.java
@@ -46,7 +46,7 @@ import org.hisp.dhis.tracker.export.relationship.RelationshipOperationParams;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.junit.jupiter.api.Test;
 
-class RelationshipImportRequestParamsMapperTest {
+class RelationshipRequestParamsMapperTest {
 
   private final RelationshipRequestParamsMapper mapper = new RelationshipRequestParamsMapper();
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/trackedentity/TrackedEntityRequestParamsMapperTest.java
@@ -65,20 +65,16 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class TrackedEntityImportRequestParamsMapperTest {
+class TrackedEntityRequestParamsMapperTest {
   public static final String TEA_1_UID = "TvjwTPToKHO";
 
   public static final String TEA_2_UID = "cy2oRh2sNr6";
-
-  public static final String TEA_3_UID = "cy2oRh2sNr7";
 
   private static final String PROGRAM_UID = "XhBYIraw7sv";
 
   private static final String PROGRAM_STAGE_UID = "RpCr2u2pFqw";
 
   private static final String TRACKED_ENTITY_TYPE_UID = "Dp8baZYrLtr";
-
-  private static final String ORG_UNIT_1_UID = "lW0T2U7gZUi";
 
   @Mock private TrackedEntityFieldsParamMapper fieldsParamMapper;
 
@@ -98,7 +94,7 @@ class TrackedEntityImportRequestParamsMapperTest {
   @Test
   void shouldMapCorrectlyWhenProgramAndSpecificUpdateDatesSupplied() throws BadRequestException {
     trackedEntityRequestParams.setOuMode(CAPTURE);
-    trackedEntityRequestParams.setProgramStatus(EnrollmentStatus.ACTIVE);
+    trackedEntityRequestParams.setEnrollmentStatus(EnrollmentStatus.ACTIVE);
     trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
     trackedEntityRequestParams.setProgramStage(UID.of(PROGRAM_STAGE_UID));
     trackedEntityRequestParams.setFollowUp(true);
@@ -173,7 +169,7 @@ class TrackedEntityImportRequestParamsMapperTest {
 
   @Test
   void shouldMapOrgUnitModeGivenOrgUnitModeParam() throws BadRequestException {
-    TrackedEntityRequestParams trackedEntityRequestParams = new TrackedEntityRequestParams();
+    trackedEntityRequestParams = new TrackedEntityRequestParams();
     trackedEntityRequestParams.setOrgUnitMode(CAPTURE);
     trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
 
@@ -184,7 +180,7 @@ class TrackedEntityImportRequestParamsMapperTest {
 
   @Test
   void shouldMapOrgUnitModeGivenOuModeParam() throws BadRequestException {
-    TrackedEntityRequestParams trackedEntityRequestParams = new TrackedEntityRequestParams();
+    trackedEntityRequestParams = new TrackedEntityRequestParams();
     trackedEntityRequestParams.setOuMode(CAPTURE);
     trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
 
@@ -195,7 +191,7 @@ class TrackedEntityImportRequestParamsMapperTest {
 
   @Test
   void shouldMapOrgUnitModeToDefaultGivenNoOrgUnitModeParamIsSet() throws BadRequestException {
-    TrackedEntityRequestParams trackedEntityRequestParams = new TrackedEntityRequestParams();
+    trackedEntityRequestParams = new TrackedEntityRequestParams();
     trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
 
     TrackedEntityOperationParams params = mapper.map(trackedEntityRequestParams, null);
@@ -205,7 +201,6 @@ class TrackedEntityImportRequestParamsMapperTest {
 
   @Test
   void shouldThrowIfDeprecatedAndNewOrgUnitModeParameterIsSet() {
-    TrackedEntityRequestParams trackedEntityRequestParams = new TrackedEntityRequestParams();
     trackedEntityRequestParams.setOuMode(SELECTED);
     trackedEntityRequestParams.setOrgUnitMode(SELECTED);
 
@@ -213,6 +208,18 @@ class TrackedEntityImportRequestParamsMapperTest {
         assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, null));
 
     assertStartsWith("Only one parameter of 'ouMode' and 'orgUnitMode'", exception.getMessage());
+  }
+
+  @Test
+  void shouldFailIfDeprecatedAndNewEnrollmentStatusParameterIsSet() {
+    trackedEntityRequestParams.setProgramStatus(EnrollmentStatus.ACTIVE);
+    trackedEntityRequestParams.setEnrollmentStatus(EnrollmentStatus.ACTIVE);
+
+    BadRequestException exception =
+        assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, null));
+
+    assertStartsWith(
+        "Only one parameter of 'programStatus' and 'enrollmentStatus'", exception.getMessage());
   }
 
   @Test
@@ -284,6 +291,28 @@ class TrackedEntityImportRequestParamsMapperTest {
   }
 
   @Test
+  void shouldFailIfProgramStatusIsSetWithoutProgram() {
+    trackedEntityRequestParams.setTrackedEntityType(UID.of(TRACKED_ENTITY_TYPE_UID));
+    trackedEntityRequestParams.setProgramStatus(EnrollmentStatus.ACTIVE);
+
+    BadRequestException exception =
+        assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, null));
+
+    assertStartsWith("`program` must be defined when `programStatus`", exception.getMessage());
+  }
+
+  @Test
+  void shouldFailIfEnrollmentStatusIsSetWithoutProgram() {
+    trackedEntityRequestParams.setTrackedEntityType(UID.of(TRACKED_ENTITY_TYPE_UID));
+    trackedEntityRequestParams.setEnrollmentStatus(EnrollmentStatus.ACTIVE);
+
+    BadRequestException exception =
+        assertThrows(BadRequestException.class, () -> mapper.map(trackedEntityRequestParams, null));
+
+    assertStartsWith("`program` must be defined when `enrollmentStatus`", exception.getMessage());
+  }
+
+  @Test
   void shouldFailIfGivenStatusAndNotOccurredEventDates() {
     trackedEntityRequestParams.setEventStatus(EventStatus.ACTIVE);
 
@@ -345,7 +374,6 @@ class TrackedEntityImportRequestParamsMapperTest {
 
   @Test
   void shouldMapOrderParameterInGivenOrderWhenFieldsAreOrderable() throws BadRequestException {
-    TrackedEntityRequestParams trackedEntityRequestParams = new TrackedEntityRequestParams();
     trackedEntityRequestParams.setOrder(
         OrderCriteria.fromOrderString("createdAt:asc,zGlzbfreTOH,enrolledAt:desc"));
     trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));
@@ -382,7 +410,6 @@ class TrackedEntityImportRequestParamsMapperTest {
 
   @Test
   void shouldMapFilterParameter() throws BadRequestException {
-    TrackedEntityRequestParams trackedEntityRequestParams = new TrackedEntityRequestParams();
     trackedEntityRequestParams.setOrgUnitMode(ACCESSIBLE);
     trackedEntityRequestParams.setFilter(TEA_1_UID + ":like:value1," + TEA_2_UID + ":like:value2");
     trackedEntityRequestParams.setProgram(UID.of(PROGRAM_UID));


### PR DESCRIPTION
Add

- `/tracker/enrollment?status`
- `/tracker/trackedEntities?enrollmentStatus`
- `/tracker/events?enrollmentStatus`

in favor of the `programStatus` request parameter which we deprecate. Note that we choose `/tracker/enrollments?status` as the query parameter filters on a field on the enrollment which is called `status` in the JSON. We also follow the same approach with the `event.status` which has query parameter `/tracker/events?status`.

* for some reason the test classes had `Import` in their name 🤷🏻 
* remove odd newlines and trailing spaces from OpenAPI markdown. format with textwidth=100