### PR TITLE
feat: OpenAPI descriptions from annotations and markdown files

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/OpenApi.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/OpenApi.java
@@ -443,6 +443,27 @@ public @interface OpenApi {
     String reason() default "";
   }
 
+  /**
+   * Provides a description text. Generally takes precedence over providing texts in markdown file,
+   * but can be combined with such text by placing a placeholder {@code {md}} in the annotated text
+   * value.
+   *
+   * <p>Can be used in various places.
+   *
+   * <p>It becomes...
+   *
+   * <ul>
+   *   <li>endpoint description when placed on an endpoint method
+   *   <li>response body description when placed on the class of the endpoint method's return type
+   *   <li>parameter description when placed on an endpoint method's parameter
+   *   <li>property description when placed on a field or accessor method of a type that becomes a
+   *       schema
+   * </ul>
+   *
+   * When placed on a {@link Class} which is used as parameter type and that parameter has no
+   * annotation directly on the parameter (includes fields in a parameter object) the type level is
+   * used as a fallback for such a parameter.
+   */
   @Target({ElementType.TYPE_USE, ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD})
   @Retention(RetentionPolicy.RUNTIME)
   @interface Description {
@@ -450,6 +471,9 @@ public @interface OpenApi {
     /**
      * If multiple values are given these are turned into a bullet list. Each item in the list is
      * left "as is" so it may use inline mark-down syntax.
+     *
+     * <p>A value may contain a placeholder {@code {md}} in which case the description text that
+     * potentially exists in a markdown file will be inserted at that location.
      *
      * @return The description, might use mark-down syntax
      */

--- a/dhis-2/dhis-web-api/pom.xml
+++ b/dhis-2/dhis-web-api/pom.xml
@@ -315,6 +315,11 @@
       <artifactId>spring-security-oauth2-jose</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+    </dependency>
+
     <!-- Batik -->
 
     <dependency>

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiDescriptions.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiDescriptions.java
@@ -44,6 +44,7 @@ import javax.annotation.CheckForNull;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.OpenApi;
+import org.intellij.lang.annotations.Language;
 
 /**
  * Reads CommonMark markdown files into key-value pairs.
@@ -254,6 +255,7 @@ final class ApiDescriptions {
     return null;
   }
 
+  @Language("markdown")
   static String toMarkdown(OpenApi.Description desc) {
     if (desc == null) return null;
     String[] items = desc.value();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiGenerator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiGenerator.java
@@ -486,6 +486,7 @@ public class OpenApiGenerator extends JsonGenerator {
     if (!simpleType.enums().isEmpty()) {
       addInlineArrayMember("enum", simpleType.enums());
     }
+    addStringMultilineMember("description", simpleType.description());
   }
 
   private void addDefaultMember(Class<?> source, String defaultValue, String type) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/EndDateTime.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/EndDateTime.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.webdomain;
 import java.util.Date;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.util.DateUtils;
 
 /**
@@ -41,6 +42,12 @@ import org.hisp.dhis.util.DateUtils;
  * <p>This behavior, combined with {@link StartDateTime}, allows to correctly implement an interval
  * search including start and end dates.
  */
+@OpenApi.Description(
+    """
+  {md}
+
+  Use a valid ISO8601 date _`YYYY[-]MM[-]DD`_ or date-time _`YYYY[-]MM[-]DD'T'hh[:mm[:ss[.sss]]]`_ pattern.
+  When the time part is omitted the end of the day is assumed.""")
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class EndDateTime {
   private final Date date;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/StartDateTime.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/StartDateTime.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.webdomain;
 import java.util.Date;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.util.DateUtils;
 
 /**
@@ -41,6 +42,12 @@ import org.hisp.dhis.util.DateUtils;
  * <p>This behavior, combined with {@link EndDateTime}, allows to correctly implement an interval
  * search including start and end dates.
  */
+@OpenApi.Description(
+    """
+  {md}
+
+  Use a valid ISO8601 date _`YYYY[-]MM[-]DD`_ or date-time _`YYYY[-]MM[-]DD'T'hh[:mm[:ss[.sss]]]`_ pattern.
+  When the time part is omitted the start of the day is assumed.""")
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class StartDateTime {
   private final Date date;


### PR DESCRIPTION
### Summary
A feature that was missed when introducing `@OpenApi.Description` was to make use of such annotations on types to propagate the description to all type usages. 

This is mostly relevant for parameters where the type used to model the parameter might be helpful to give information on the parameter. 

### Keeping it Simple
With annotation based description being generally available a new difficulty arises from two possible sources, annotations and markdown files. A parameter might have a description originating from the parameter type as well as a description on the specific parameter originating from a markdown file. Ideally these can be combined. However, this is challenging as the options are limited by the fact that descriptions from annotations become the initial description value when building the `Api` model, while the description from markdown files are inserted into a completely analysed `Api` model instance. This means when texts from files are considered there might already be a text from annotations but no knowledge on where it originated from, an annotation on the parameter itself or the parameter's type. Thus rules cannot make use of such a distinction. Similarly texts from markdown files use a sequence of keys, again, the difference in specificity  cannot be considered when making the rules on how to combine the two sources.

### Rules to Remember
Keeping the rules of how and when to combine both sources simple, useful and not prone to mistakes does not leave much options. The solution has these rules:

1. annotations **always** win 
2. annotations **can** use a `{md}` placeholder in their text in which case the description originating from a markdown file is substituted for the placeholder (if such text exists)

This is easy to remember, check and reason about. The `.java` file dictates the outcome. If there is an annotation it tells you what the outcome is. If there is none you may get a text from a markdown file if it exists. At the same time the two can be combined in a useful way (see example below) while still clearly reflecting this intent in the annotation in the form of the `{md}` placeholder being present.

### Manual Testing
Use `OpenApiTool` to generate a document for `EnrollmentsExportController` (path=`/api/tracker/enrollments`) and check the parameters of the `GET` endpoint that use `StartDateTime`. These now all have a description that has both text from a markdown file on the specific parameter as well as a general text from the `StartDateTime` type information that describes the valid formats.

For example, the `EnrollmentRequestParams.enrolledAfter`
```markdown
Get enrollments with an enrollment date after the given date.

Use a valid ISO8601 date _`YYYY[-]MM[-]DD`_ or date-time _`YYYY[-]MM[-]DD'T'hh[:mm[:ss[.sss]]]`_ pattern.
When the time part is omitted the start of the day is assumed.
```
The first sentence originating from the markdown files (unchanged), the rest originating from the `@OpenApi.Description` annotation on `StartDateTime`.