### PR TITLE
Revert "backport: ci: send all Jenkins build failure notifications to backend channel [2.38]"

### DIFF
--- a/jenkinsfiles/canary
+++ b/jenkinsfiles/canary
@@ -131,11 +131,7 @@ pipeline {
     post {
         failure {
             script {
-                slack.sendMessage(
-                    '#ff0000',
-                    slack.buildUrl() + "\nLatest run on ${GIT_BRANCH} failed and needs investigation. :detective-duck:\nCommit: <${GIT_URL}/commit/${GIT_COMMIT}|${GIT_COMMIT}>",
-                    'team-backend'
-                )
+                slack.sendFailureMessage()
             }
         }
 

--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -47,6 +47,18 @@ pipeline {
                 always {
                     implementIoBuildEnded(buildName: "${STAGE_NAME}")
                 }
+
+                failure {
+                    script {
+                        if (buildLog.getLines().contains('There are test failures')) {
+                            slack.sendMessage(
+                                '#ff0000',
+                                slack.buildUrl() + "\nLatest test run on ${GIT_BRANCH} failed and needs investigation. :detective-duck:\nCommit: <${GIT_URL}/commit/${GIT_COMMIT}|${GIT_COMMIT}>",
+                                'team-backend'
+                            )
+                        }
+                    }
+                }
             }
         }
 
@@ -223,11 +235,7 @@ pipeline {
 
         failure {
             script {
-                slack.sendMessage(
-                    '#ff0000',
-                    slack.buildUrl() + "\nLatest run on ${GIT_BRANCH} failed and needs investigation. :detective-duck:\nCommit: <${GIT_URL}/commit/${GIT_COMMIT}|${GIT_COMMIT}>",
-                    'team-backend'
-                )
+                slack.sendFailureMessage()
             }
         }
 

--- a/jenkinsfiles/eos
+++ b/jenkinsfiles/eos
@@ -46,11 +46,7 @@ pipeline {
     post {
         failure {
             script {
-                slack.sendMessage(
-                    '#ff0000',
-                    slack.buildUrl() + "\nLatest run on ${GIT_BRANCH} failed and needs investigation. :detective-duck:\nCommit: <${GIT_URL}/commit/${GIT_COMMIT}|${GIT_COMMIT}>",
-                    'team-backend'
-                )
+                slack.sendFailureMessage()
             }
         }
 

--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -222,11 +222,7 @@ pipeline {
     post {
         failure {
             script {
-                slack.sendMessage(
-                    '#ff0000',
-                    slack.buildUrl() + "\nLatest run on ${GIT_BRANCH} failed and needs investigation. :detective-duck:\nCommit: <${GIT_URL}/commit/${GIT_COMMIT}|${GIT_COMMIT}>",
-                    'team-backend'
-                )
+                slack.sendFailureMessage()
             }
         }
 


### PR DESCRIPTION
Reverts dhis2/dhis2-core#17618, as `2.38` is out of support now.