### PR TITLE
feat: OpenAPI ignore type and file description sources

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/OpenApi.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/OpenApi.java
@@ -457,6 +457,7 @@ public @interface OpenApi {
    *   <li>parameter description when placed on an endpoint method's parameter
    *   <li>property description when placed on a field or accessor method of a type that becomes a
    *       schema
+   *   <li>endpoint exception
    * </ul>
    *
    * When placed on a {@link Class} which is used as parameter type and that parameter has no
@@ -478,6 +479,18 @@ public @interface OpenApi {
      */
     @Language("markdown")
     String[] value();
+
+    /**
+     * @return when true any {@link Description} annotation present on the type (of a parameter) is
+     *     ignored and only the text from this annotation is included
+     */
+    boolean ignoreTypeDescription() default false;
+
+    /**
+     * @return when true any matching text present in a markdown file for the annotated element is
+     *     ignored and only the text from this annotation is included
+     */
+    boolean ignoreFileDescription() default false;
   }
 
   /*

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParams.java
@@ -116,7 +116,6 @@ public class EnrollmentRequestParams implements PageRequestParams {
 
   private Boolean followUp;
 
-  @OpenApi.Description("and this")
   private StartDateTime updatedAfter;
 
   private String updatedWithin;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/enrollment/EnrollmentRequestParams.java
@@ -116,6 +116,7 @@ public class EnrollmentRequestParams implements PageRequestParams {
 
   private Boolean followUp;
 
+  @OpenApi.Description("and this")
   private StartDateTime updatedAfter;
 
   private String updatedWithin;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiDescriptions.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiDescriptions.java
@@ -41,6 +41,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.OpenApi;
@@ -255,9 +256,9 @@ final class ApiDescriptions {
     return null;
   }
 
+  @Nonnull
   @Language("markdown")
-  static String toMarkdown(OpenApi.Description desc) {
-    if (desc == null) return null;
+  static String toMarkdown(@Nonnull OpenApi.Description desc) {
     String[] items = desc.value();
     if (items.length == 0) return null;
     if (items.length == 1) return items[0];

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiDescriptions.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiDescriptions.java
@@ -260,7 +260,7 @@ final class ApiDescriptions {
   @Language("markdown")
   static String toMarkdown(@Nonnull OpenApi.Description desc) {
     String[] items = desc.value();
-    if (items.length == 0) return null;
+    if (items.length == 0) return "";
     if (items.length == 1) return items[0];
     return Stream.of(items).map(line -> "\n* " + line).collect(joining());
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/DirectType.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/DirectType.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.openapi;
 
 import static org.hisp.dhis.common.CodeGenerator.UID_REGEXP;
+import static org.hisp.dhis.webapi.openapi.ApiDescriptions.toMarkdown;
 
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -131,8 +132,7 @@ class DirectType {
         source.isAnnotationPresent(OpenApi.Description.class)
             && source.isAnnotationPresent(OpenApi.Shared.class)
             && source.getAnnotation(OpenApi.Shared.class).value();
-    if (autoShare)
-      b.description(ApiDescriptions.toMarkdown(source.getAnnotation(OpenApi.Description.class)));
+    if (autoShare) b.description(toMarkdown(source.getAnnotation(OpenApi.Description.class)));
     schema.accept(b);
     SimpleType type = b.build();
     TYPES.compute(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/EndDateTime.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/EndDateTime.java
@@ -44,8 +44,6 @@ import org.hisp.dhis.util.DateUtils;
  */
 @OpenApi.Description(
     """
-  {md}
-
   Use a valid ISO8601 date _`YYYY[-]MM[-]DD`_ or date-time _`YYYY[-]MM[-]DD'T'hh[:mm[:ss[.sss]]]`_ pattern.
   When the time part is omitted the end of the day is assumed.""")
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/StartDateTime.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/StartDateTime.java
@@ -44,8 +44,6 @@ import org.hisp.dhis.util.DateUtils;
  */
 @OpenApi.Description(
     """
-  {md}
-
   Use a valid ISO8601 date _`YYYY[-]MM[-]DD`_ or date-time _`YYYY[-]MM[-]DD'T'hh[:mm[:ss[.sss]]]`_ pattern.
   When the time part is omitted the start of the day is assumed.""")
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)


### PR DESCRIPTION
### Summary
After today's meeting I got an idea on how to avoid the need of knowing or using the placeholder `{md}` directly and instead have additional properties in the `@OpenApi.Description` annotation.

The key is that internally this still uses the placeholder but users don't have to use it to compose the text from multiple sources. Instead, by default, the text is always composed from all possible sources:

1. annotation on a specific element (e.g. a parameter)
2. annotation on the type of the element
3. a markdown file 

User then can opt-out of this automatic composition using two new properties in the `@OpenApi.Description` annotation:

* `ignoreTypeDescription`
* `ignoreFileDescription` 

As this internally is still based on the placeholder to combine annotation based and file based sources users can even continue to use the placeholder directly in their description text to place it differently than it is compose otherwise.

The composition of sources uses this sequence:

1. annotation on a specific element (e.g. a parameter)
2. annotation on the type of the element
3. a markdown file

This is so the most specific text comes first. For example, the text on the specific parameter is first, followed by the text on the type of the parameter, finally followed by the text from the markdown files which is assumed to be general as well when used in combination. 