### PR TITLE
ci: add workflow for requesting PR reviews based on changed files

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -1,0 +1,19 @@
+# See https://github.com/marketplace/actions/auto-request-review for more configuration options.
+files:
+  '.github/**':
+    - team:devops
+  'dhis-2/*.sh':
+    - team:devops
+  'dhis-2/dhis-web-apps/apps-to-bundle.json':
+    - team:devops
+  'docker/**':
+    - team:devops
+  'jenkinsfiles/**':
+    - team:devops
+  'docker-compose.yml':
+    - team:devops
+  'jib.yaml':
+    - team:devops
+
+options:
+  ignore_draft: false

--- a/.github/workflows/request-pr-review.yml
+++ b/.github/workflows/request-pr-review.yml
@@ -1,0 +1,17 @@
+# Automatically requests PR review, based on the conditions specified in the configuration file .github/reviewers.yml
+name: "Request PR review"
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  request-pr-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Request PR review'
+        uses: necojackarc/auto-request-review@v0.13.0
+        with:
+          token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}
+          config: .github/reviewers.yml


### PR DESCRIPTION
UPDATE: superseded by https://github.com/dhis2/dhis2-core/pull/17693

This workflow requests a PR review via the [Auto Request Review action](https://github.com/marketplace/actions/auto-request-review). The current configuration only specifies adding the DevOps team as reviewers based on a certain set of files that can cause CI/build related failures, but can be exptended beyond that for more use cases.

