### PR TITLE
fix: TEXT and LONG_TEXT with single quote (') [DHIS2-17129] [2.41]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/DefaultEventPersistenceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/deprecated/tracker/event/persistence/DefaultEventPersistenceService.java
@@ -152,6 +152,10 @@ public class DefaultEventPersistenceService implements EventPersistenceService {
     } else {
       // merge
       de.setDataElement(null); // de uid is used as a key in the json, so we don't need it here
+      de.setValue(
+          de.getValue()
+              .replace(
+                  "'", "''")); // escape single quote used also as a json delimiter in the query
 
       query =
           String.format(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventImportTest.java
@@ -258,7 +258,7 @@ class EventImportTest extends TransactionalIntegrationTest {
   }
 
   @Test
-  void shouldUpdateEventDataValues_whenAddingDataValuesToEvent() throws IOException {
+  void shouldUpdateEventDataValuesWhenAddingDataValuesToEvent() throws IOException {
     InputStream is =
         createEventJsonInputStream(
             programB.getUid(),
@@ -279,12 +279,12 @@ class EventImportTest extends TransactionalIntegrationTest {
     // add a new data value and update an existing one
 
     DataValue dataValueA = new DataValue();
-    dataValueA.setValue("10'000");
+    dataValueA.setValue("10'''000'''");
     dataValueA.setDataElement(dataElementA.getUid());
     dataValueA.setStoredBy(superUser.getName());
 
     DataValue dataValueB = new DataValue();
-    dataValueB.setValue("20");
+    dataValueB.setValue("20'''000'''");
     dataValueB.setDataElement(dataElementB.getUid());
     dataValueB.setStoredBy(superUser.getName());
 
@@ -337,7 +337,7 @@ class EventImportTest extends TransactionalIntegrationTest {
   }
 
   @Test
-  void shouldDeleteDataElementFromEventDataValues_whenSetDataValueToNull() throws IOException {
+  void shouldDeleteDataElementFromEventDataValuesWhenSetDataValueToNull() throws IOException {
     InputStream is =
         createEventJsonInputStream(
             programB.getUid(),

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/deprecated/tracker/EventImportTest.java
@@ -279,7 +279,7 @@ class EventImportTest extends TransactionalIntegrationTest {
     // add a new data value and update an existing one
 
     DataValue dataValueA = new DataValue();
-    dataValueA.setValue("10");
+    dataValueA.setValue("10'000");
     dataValueA.setDataElement(dataElementA.getUid());
     dataValueA.setStoredBy(superUser.getName());
 


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-17129

In the old tracker, it is possible to update the data element value using the put request for _/events/{uid}/{dataElementUid}_ and send a payload with the new data values, for example:
```json
{
  "event": "ce2BE0tNVYJ",
  "dataValues": [
    {
      "dataElement": "aRz66hGQRnQ",
      "value": "no",
      "providedElsewhere": false
    }
  ]
}
```
The endpoint had a concurrent issue fixed in https://github.com/dhis2/dhis2-core/pull/15793. That PR replaces the whole event's record update with an SQL statement using a Postgres native function to update only the data elements in the `eventdatavalues` column, so we no longer have concurrency issues.
However, the SQL statement happens to use single quotes to delimit the data element's JSON replacement, and if the data element value contains a single quote, the query breaks.
With this fix, we escape the single quote and update a test with that case.
