### PR TITLE
fix: Load PR with all PRA and filter later [DHIS2-17470]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/programrule/hibernate/ProgramRule.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/programrule/hibernate/ProgramRule.hbm.xml
@@ -27,7 +27,7 @@
     <many-to-one name="programStage" class="org.hisp.dhis.program.ProgramStage"
       column="programstageid" foreign-key="fk_programrule_programstage" />
 
-    <set name="programRuleActions" cascade="all-delete-orphan" lazy="false">
+    <set name="programRuleActions" cascade="all-delete-orphan">
       <cache usage="read-write"/>
       <key column="programruleid" />
       <one-to-many class="org.hisp.dhis.programrule.ProgramRuleAction" />

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/programrule/hibernate/ProgramRule.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/programrule/hibernate/ProgramRule.hbm.xml
@@ -27,7 +27,7 @@
     <many-to-one name="programStage" class="org.hisp.dhis.program.ProgramStage"
       column="programstageid" foreign-key="fk_programrule_programstage" />
 
-    <set name="programRuleActions" cascade="all-delete-orphan">
+    <set name="programRuleActions" cascade="all-delete-orphan" lazy="false">
       <cache usage="read-write"/>
       <key column="programruleid" />
       <one-to-many class="org.hisp.dhis.programrule.ProgramRuleAction" />

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
@@ -88,14 +88,12 @@ import org.hisp.dhis.rules.models.RuleVariablePreviousEvent;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Zubair Asghar
  */
 @Slf4j
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 @Service("org.hisp.dhis.programrule.engine.ProgramRuleEntityMapperService")
 public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityMapperService {
   private final ProgramRuleVariableService programRuleVariableService;

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/DefaultProgramRuleEntityMapperService.java
@@ -28,29 +28,17 @@
 package org.hisp.dhis.programrule.engine;
 
 import static org.hisp.dhis.programrule.ProgramRuleActionType.ASSIGN;
-import static org.hisp.dhis.programrule.ProgramRuleActionType.CREATEEVENT;
-import static org.hisp.dhis.programrule.ProgramRuleActionType.DISPLAYKEYVALUEPAIR;
-import static org.hisp.dhis.programrule.ProgramRuleActionType.DISPLAYTEXT;
 import static org.hisp.dhis.programrule.ProgramRuleActionType.ERRORONCOMPLETE;
-import static org.hisp.dhis.programrule.ProgramRuleActionType.HIDEFIELD;
-import static org.hisp.dhis.programrule.ProgramRuleActionType.HIDEOPTION;
-import static org.hisp.dhis.programrule.ProgramRuleActionType.HIDEOPTIONGROUP;
-import static org.hisp.dhis.programrule.ProgramRuleActionType.HIDEPROGRAMSTAGE;
-import static org.hisp.dhis.programrule.ProgramRuleActionType.HIDESECTION;
 import static org.hisp.dhis.programrule.ProgramRuleActionType.SCHEDULEMESSAGE;
 import static org.hisp.dhis.programrule.ProgramRuleActionType.SENDMESSAGE;
 import static org.hisp.dhis.programrule.ProgramRuleActionType.SETMANDATORYFIELD;
 import static org.hisp.dhis.programrule.ProgramRuleActionType.SHOWERROR;
-import static org.hisp.dhis.programrule.ProgramRuleActionType.SHOWOPTIONGROUP;
 import static org.hisp.dhis.programrule.ProgramRuleActionType.SHOWWARNING;
 import static org.hisp.dhis.programrule.ProgramRuleActionType.WARNINGONCOMPLETE;
 import static org.hisp.dhis.programrule.engine.RuleActionKey.ATTRIBUTE_TYPE;
 import static org.hisp.dhis.programrule.engine.RuleActionKey.CONTENT;
 import static org.hisp.dhis.programrule.engine.RuleActionKey.FIELD;
-import static org.hisp.dhis.programrule.engine.RuleActionKey.LOCATION;
 import static org.hisp.dhis.programrule.engine.RuleActionKey.NOTIFICATION;
-import static org.hisp.dhis.programrule.engine.RuleActionKey.PROGRAM_STAGE;
-import static org.hisp.dhis.programrule.engine.RuleActionKey.PROGRAM_STAGE_SECTION;
 import static org.hisp.dhis.rules.models.AttributeType.DATA_ELEMENT;
 import static org.hisp.dhis.rules.models.AttributeType.TRACKED_ENTITY_ATTRIBUTE;
 
@@ -309,66 +297,35 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
       return null;
     }
 
-    Set<ProgramRuleAction> programRuleActions = programRule.getProgramRuleActions();
-
-    List<RuleAction> ruleActions;
-
-    Rule rule;
     try {
-      ruleActions = programRuleActions.stream().map(this::toRuleAction).toList();
-      rule =
-          new Rule(
-              programRule.getCondition(),
-              ruleActions,
-              programRule.getUid(),
-              programRule.getName(),
-              programRule.getProgramStage() != null
-                  ? programRule.getProgramStage().getUid()
-                  : StringUtils.EMPTY,
-              programRule.getPriority());
+      List<RuleAction> ruleActions =
+          programRule.getProgramRuleActions().stream()
+              .map(this::toRuleAction)
+              .filter(Objects::nonNull)
+              .toList();
 
+      if (ruleActions.isEmpty()) {
+        return null;
+      }
+
+      return new Rule(
+          programRule.getCondition(),
+          ruleActions,
+          programRule.getUid(),
+          programRule.getName(),
+          programRule.getProgramStage() != null
+              ? programRule.getProgramStage().getUid()
+              : StringUtils.EMPTY,
+          programRule.getPriority());
     } catch (Exception e) {
       log.debug("Invalid rule action in ProgramRule: " + programRule.getUid());
 
       return null;
     }
-
-    return rule;
   }
 
   private RuleAction toRuleAction(ProgramRuleAction pra) {
     return switch (pra.getProgramRuleActionType()) {
-      case DISPLAYTEXT ->
-          new RuleAction(
-              pra.getData(),
-              DISPLAYTEXT.name(),
-              createValues(CONTENT, pra.getContent(), LOCATION, pra.getLocation()));
-      case DISPLAYKEYVALUEPAIR ->
-          new RuleAction(
-              pra.getData(),
-              DISPLAYKEYVALUEPAIR.name(),
-              createValues(CONTENT, pra.getContent(), LOCATION, pra.getLocation()));
-      case HIDEFIELD ->
-          new RuleAction(
-              null,
-              HIDEFIELD.name(),
-              createValues(
-                  CONTENT,
-                  pra.getContent(),
-                  FIELD,
-                  getAssignedParameter(pra),
-                  ATTRIBUTE_TYPE,
-                  getAttributeType(pra).name()));
-      case HIDESECTION ->
-          new RuleAction(
-              null,
-              HIDESECTION.name(),
-              createValues(PROGRAM_STAGE_SECTION, pra.getProgramStageSection().getUid()));
-      case HIDEPROGRAMSTAGE ->
-          new RuleAction(
-              null,
-              HIDEPROGRAMSTAGE.name(),
-              createValues(PROGRAM_STAGE, pra.getProgramStage().getUid()));
       case ASSIGN ->
           new RuleAction(
               pra.getData(),
@@ -424,11 +381,6 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
                   getAssignedParameter(pra),
                   ATTRIBUTE_TYPE,
                   getAttributeType(pra).name()));
-      case CREATEEVENT ->
-          new RuleAction(
-              pra.getData(),
-              CREATEEVENT.name(),
-              createValues(CONTENT, pra.getContent(), LOCATION, pra.getLocation()));
       case SETMANDATORYFIELD ->
           new RuleAction(
               null,
@@ -443,14 +395,7 @@ public class DefaultProgramRuleEntityMapperService implements ProgramRuleEntityM
               pra.getData(),
               SCHEDULEMESSAGE.name(),
               createValues(NOTIFICATION, pra.getTemplateUid()));
-      case HIDEOPTION ->
-          new RuleAction(null, HIDEOPTION.name(), createValues(FIELD, getAssignedParameter(pra)));
-      case SHOWOPTIONGROUP ->
-          new RuleAction(
-              null, SHOWOPTIONGROUP.name(), createValues(FIELD, getAssignedParameter(pra)));
-      case HIDEOPTIONGROUP ->
-          new RuleAction(
-              null, HIDEOPTIONGROUP.name(), createValues(FIELD, getAssignedParameter(pra)));
+      default -> null;
     };
   }
 

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/NotificationRuleActionImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/NotificationRuleActionImplementer.java
@@ -43,7 +43,6 @@ import org.hisp.dhis.program.notification.ProgramNotificationTemplateService;
 import org.hisp.dhis.rules.models.RuleAction;
 import org.hisp.dhis.rules.models.RuleEffect;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Zubair Asghar
@@ -70,7 +69,6 @@ abstract class NotificationRuleActionImplementer implements RuleActionImplemente
     return entry;
   }
 
-  @Transactional(readOnly = true)
   public ProgramNotificationTemplate getNotificationTemplate(RuleAction action) {
     String uid = action.getValues().get(NOTIFICATION);
     return programNotificationTemplateService.getByUid(uid);
@@ -80,7 +78,6 @@ abstract class NotificationRuleActionImplementer implements RuleActionImplemente
     return template.getUid() + enrollment.getUid();
   }
 
-  @Transactional(readOnly = true)
   public NotificationValidationResult validate(RuleEffect ruleEffect, Enrollment enrollment) {
     checkNotNull(ruleEffect, "Rule Effect cannot be null");
     checkNotNull(enrollment, "Enrollment cannot be null");

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionKey.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionKey.java
@@ -34,8 +34,5 @@ public class RuleActionKey {
   public static final String CONTENT = "content";
   public static final String FIELD = "field";
   public static final String ATTRIBUTE_TYPE = "attributeType";
-  public static final String LOCATION = "location";
   public static final String NOTIFICATION = "notification";
-  public static final String PROGRAM_STAGE = "programStage";
-  public static final String PROGRAM_STAGE_SECTION = "programStageSection";
 }

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionScheduleMessageImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionScheduleMessageImplementer.java
@@ -47,7 +47,6 @@ import org.hisp.dhis.rules.models.RuleAction;
 import org.hisp.dhis.rules.models.RuleEffect;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Zubair Asghar
@@ -81,7 +80,6 @@ public class RuleActionScheduleMessageImplementer extends NotificationRuleAction
   }
 
   @Override
-  @Transactional
   public void implement(RuleEffect ruleEffect, Enrollment enrollment) {
     NotificationValidationResult result = validate(ruleEffect, enrollment);
 
@@ -120,7 +118,6 @@ public class RuleActionScheduleMessageImplementer extends NotificationRuleAction
   }
 
   @Override
-  @Transactional
   public void implement(RuleEffect ruleEffect, Event event) {
     checkNotNull(event, "Event cannot be null");
 

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionSendMessageImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionSendMessageImplementer.java
@@ -44,7 +44,6 @@ import org.hisp.dhis.rules.models.RuleAction;
 import org.hisp.dhis.rules.models.RuleEffect;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  *
@@ -59,7 +58,6 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Zubair Asghar
  */
 @Component("org.hisp.dhis.programrule.engine.RuleActionSendMessageImplementer")
-@Transactional
 public class RuleActionSendMessageImplementer extends NotificationRuleActionImplementer {
   // -------------------------------------------------------------------------
   // Dependencies

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/hibernate/HibernateProgramRuleStore.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/hibernate/HibernateProgramRuleStore.java
@@ -28,17 +28,13 @@
 package org.hisp.dhis.programrule.hibernate;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
 import javax.persistence.criteria.CriteriaBuilder;
 import org.hibernate.Session;
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.programrule.ProgramRule;
-import org.hisp.dhis.programrule.ProgramRuleAction;
 import org.hisp.dhis.programrule.ProgramRuleActionType;
 import org.hisp.dhis.programrule.ProgramRuleStore;
 import org.hisp.dhis.security.acl.AclService;
@@ -86,7 +82,7 @@ public class HibernateProgramRuleStore extends HibernateIdentifiableObjectStore<
   public List<ProgramRule> getProgramRulesByActionTypes(
       Program program, Set<ProgramRuleActionType> actionTypes) {
     final String hql =
-        "SELECT distinct pr FROM ProgramRule pr JOIN FETCH pr.programRuleActions pra "
+        "SELECT distinct pr FROM ProgramRule pr JOIN pr.programRuleActions pra "
             + "WHERE pr.program = :program AND pra.programRuleActionType IN ( :actionTypes ) ";
 
     return getQuery(hql)
@@ -98,56 +94,16 @@ public class HibernateProgramRuleStore extends HibernateIdentifiableObjectStore<
   @Override
   public List<ProgramRule> getProgramRulesByActionTypes(
       Program program, Set<ProgramRuleActionType> types, String programStageUid) {
-    List<String> actionTypeNames = types.stream().map(Enum::name).toList();
-    String sql =
-        """
+    final String hql =
+        "SELECT distinct pr FROM ProgramRule pr JOIN pr.programRuleActions pra "
+            + "LEFT JOIN FETCH pr.programStage ps "
+            + "WHERE pr.program = :programId AND pra.programRuleActionType IN ( :implementableTypes ) "
+            + "AND (pr.programStage IS NULL OR ps.uid = :programStageUid )";
 
-                SELECT distinct pr.* FROM programrule pr
-                LEFT JOIN programruleaction pra on pra.programruleid=pr.programruleid
-                LEFT JOIN programstage prs on prs.programstageid=pr.programstageid
-                WHERE pr.programid =:programId  AND pra.actiontype IN ( :implementableTypes )
-                AND (pr.programstageid IS NULL OR prs.uid = cast(:programStageUid as text))
-                """;
-
-    List<ProgramRule> programRules =
-        nativeSynchronizedTypedQuery(sql)
-            .setParameter("programId", program.getId())
-            .setParameter("implementableTypes", actionTypeNames)
-            .setParameter("programStageUid", programStageUid)
-            .getResultList();
-
-    if (programRules.isEmpty()) {
-      return programRules;
-    }
-
-    sql =
-        """
-                SELECT distinct pra.* FROM programruleaction pra
-                WHERE pra.programruleid in ( :programRuleIds ) AND pra.actiontype IN ( :implementableTypes )
-                """;
-
-    Map<ProgramRule, Set<ProgramRuleAction>> ruleActions =
-        getSession()
-            .createNativeQuery(sql, ProgramRuleAction.class)
-            .addSynchronizedEntityClass(ProgramRuleAction.class)
-            .setParameter(
-                "programRuleIds", programRules.stream().map(BaseIdentifiableObject::getId).toList())
-            .setParameter("implementableTypes", actionTypeNames)
-            .getResultList()
-            .stream()
-            .collect(Collectors.groupingBy(ProgramRuleAction::getProgramRule, Collectors.toSet()));
-
-    if (ruleActions.isEmpty()) {
-      return programRules;
-    }
-
-    for (ProgramRule programRule : programRules) {
-      if (ruleActions.containsKey(programRule)) {
-        programRule.getProgramRuleActions().clear();
-        programRule.getProgramRuleActions().addAll(ruleActions.get(programRule));
-      }
-    }
-
-    return List.copyOf(programRules);
+    return getQuery(hql)
+        .setParameter("programId", program)
+        .setParameter("implementableTypes", types)
+        .setParameter("programStageUid", programStageUid)
+        .getResultList();
   }
 }

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/hibernate/HibernateProgramRuleStore.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/hibernate/HibernateProgramRuleStore.java
@@ -96,7 +96,7 @@ public class HibernateProgramRuleStore extends HibernateIdentifiableObjectStore<
       Program program, Set<ProgramRuleActionType> types, String programStageUid) {
     final String hql =
         "SELECT distinct pr FROM ProgramRule pr JOIN pr.programRuleActions pra "
-            + "LEFT JOIN FETCH pr.programStage ps "
+            + "LEFT JOIN pr.programStage ps "
             + "WHERE pr.program = :programId AND pra.programRuleActionType IN ( :implementableTypes ) "
             + "AND (pr.programStage IS NULL OR ps.uid = :programStageUid )";
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/programrule/ProgramRuleServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/programrule/ProgramRuleServiceTest.java
@@ -221,6 +221,9 @@ class ProgramRuleServiceTest extends IntegrationTestBase {
     programRuleService.updateProgramRule(ruleG);
     programRuleService.updateProgramRule(ruleF);
 
+    entityManager.clear();
+    entityManager.flush();
+
     List<ProgramRule> rules =
         programRuleService.getProgramRulesByActionTypes(
             programB, ProgramRuleActionType.SERVER_SUPPORTED_TYPES, null);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/programrule/ProgramRuleServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/programrule/ProgramRuleServiceTest.java
@@ -175,8 +175,10 @@ class ProgramRuleServiceTest extends IntegrationTestBase {
     ProgramRule ruleD =
         new ProgramRule("RuleD", "descriptionD", programB, null, null, "true", null);
     ProgramRule ruleG = new ProgramRule("RuleG", "descriptionG", programB, null, null, "!false", 0);
+    ProgramRule ruleF = new ProgramRule("RuleF", "descriptionF", programB, null, null, "!false", 0);
     programRuleService.addProgramRule(ruleD);
     programRuleService.addProgramRule(ruleG);
+    programRuleService.addProgramRule(ruleF);
 
     ProgramRuleAction sendMessageActionA = createProgramRuleAction('D');
     sendMessageActionA.setProgramRuleActionType(ProgramRuleActionType.SENDMESSAGE);
@@ -194,29 +196,36 @@ class ProgramRuleServiceTest extends IntegrationTestBase {
     hideFieldAction.setProgramRuleActionType(ProgramRuleActionType.HIDEFIELD);
     hideFieldAction.setProgramRule(ruleG);
 
+    ProgramRuleAction hideFieldActionF = createProgramRuleAction('H');
+    hideFieldActionF.setProgramRuleActionType(ProgramRuleActionType.HIDEFIELD);
+    hideFieldActionF.setProgramRule(ruleF);
+
+    ProgramRuleAction hideProgramStage = createProgramRuleAction('P');
+    hideProgramStage.setProgramRuleActionType(ProgramRuleActionType.HIDEPROGRAMSTAGE);
+    hideProgramStage.setProgramRule(ruleF);
+
     programRuleActonService.addProgramRuleAction(sendMessageActionA);
     programRuleActonService.addProgramRuleAction(showWarningAction);
 
     programRuleActonService.addProgramRuleAction(sendMessageActionB);
     programRuleActonService.addProgramRuleAction(hideFieldAction);
 
+    programRuleActonService.addProgramRuleAction(hideFieldActionF);
+    programRuleActonService.addProgramRuleAction(hideProgramStage);
+
     ruleD.setProgramRuleActions(Sets.newHashSet(sendMessageActionA, showWarningAction));
     ruleG.setProgramRuleActions(Sets.newHashSet(sendMessageActionB, hideFieldAction));
+    ruleF.setProgramRuleActions(Sets.newHashSet(hideFieldActionF, hideProgramStage));
 
     programRuleService.updateProgramRule(ruleD);
     programRuleService.updateProgramRule(ruleG);
+    programRuleService.updateProgramRule(ruleF);
 
     List<ProgramRule> rules =
         programRuleService.getProgramRulesByActionTypes(
             programB, ProgramRuleActionType.SERVER_SUPPORTED_TYPES, null);
 
     assertContainsOnly(rules, List.of(ruleD, ruleG));
-
-    List<ProgramRuleAction> ruleActions =
-        rules.stream().flatMap(r -> r.getProgramRuleActions().stream()).toList();
-
-    assertContainsOnly(
-        ruleActions, List.of(showWarningAction, sendMessageActionA, sendMessageActionB));
   }
 
   @Test


### PR DESCRIPTION
We were retrieving ProgramRules and filtering the linked ProgramRuleActions based on the type needed for the server. This was causing trouble as Hibernate was updating ProgramRules and deleting some of the filtered ProgramRuleActions.
In this PR we are not filtering out ProgramRuleActions anymore, we are retrieving the needed ProgramRules with all the ProgramRuleActions associated and then mapping only the required actions.

Clean up:
- Remove all the unnecessary `@Transactional` in `dhis-service-program-rule` module
- Remove the unused `RuleActionKey`s
- Remove the mapping to actions not used in Tracker