### PR TITLE
feat: adds configuration for primary leader node [DHIS2-16878]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -75,6 +75,12 @@ public enum ConfigurationKey {
   /** Node identifier, optional, useful in clusters. */
   NODE_ID("node.id", "", false),
 
+  /**
+   * When true, the node will unconditionally set its node ID during leader election causing it to
+   * win the election as long as it is alive.
+   */
+  NODE_PRIMARY_LEADER("node.primary_leader", "false", false),
+
   /** Encryption password (sensitive). */
   ENCRYPTION_PASSWORD("encryption.password", "", true),
 


### PR DESCRIPTION
### Summary
Adds a new configuration `node.primary_leader` that when set to true/on the node will unconditionally set itself as the leader (as opposed to only setting its ID when no other value is present). This means (eventually) the node should always take over the leader role in a cluster as all other nodes will only set their ID in case no ID is set. This way other nodes only take over the leader role if the primary leader is in fact not able to renew (maintain) its leader role by setting its ID.