### PR TITLE
chore: add CODEOWNERS file with initial configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# For more details see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+.github/** @dhis2/devops
+
+dhis-2/*.sh @dhis2/devops
+
+dhis-2/dhis-web-apps/apps-to-bundle.json @dhis2/devops
+
+docker/** @dhis2/devops
+
+jenkinsfiles/** @dhis2/devops
+
+docker-compose.yml @dhis2/devops
+
+jib.yaml @dhis2/devops


### PR DESCRIPTION
Initial [CODEOWNERS file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners) that specifies the DevOps team as owners of a list of files that can cause CI/build related failures. Owners of a given file/directory will be automatically added as reviewers to PRs that are ready for review (not draft PRs).

As mentioned in the docs, in order to automatically assign an owner as a reviewer to a PR, the CODEOWNERS file must exist in the base branch that the PR is going to be merged in. In this case the CODEOWNERS file doesn't exist in the `master` branch yet, so here's [a mock PR](https://github.com/dhis2/dhis2-core/compare/DEVOPS-405-v2...DEVOPS-405-v2-test?expand=1) where the base branch is the current HEAD branch of this PR (`DEVOPS-405-v2`) to test that changing a file listed in the CODEOWNERS file does add the owner as a reiviewer.

<img width="1367" alt="image" src="https://github.com/dhis2/dhis2-core/assets/8098421/ed5ff968-06ed-487c-9797-49211bae6e5a">
