### PR TITLE
fix: push analytics job locale fallback to UI locale [DHIS2-17408]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/scheduling/HtmlPushAnalyticsJob.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/scheduling/HtmlPushAnalyticsJob.java
@@ -141,6 +141,8 @@ public class HtmlPushAnalyticsJob implements Job {
     if (url.contains("{locale}")) {
       Locale locale =
           (Locale) userSettingService.getUserSetting(UserSettingKey.DB_LOCALE, username);
+      if (locale == null)
+        locale = (Locale) userSettingService.getUserSetting(UserSettingKey.UI_LOCALE, username);
       url = url.replace("{locale}", locale == null ? "" : locale.toLanguageTag());
     }
     return url;


### PR DESCRIPTION
DB locale can be undefined, therefore we fallback to the UI locale with has a default so it should always be defined.
Giving the DB locale a default might have unintended side effects so this more local solution seems the better way to make sure that we always send a locale.