### PR TITLE
fix: Add tests confirming default cat combo behavior [DHIS2-16129]

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataSetMetadataControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataSetMetadataControllerTest.java
@@ -49,7 +49,7 @@ class DataSetMetadataControllerTest extends DhisControllerIntegrationTest {
   @MethodSource("defaultCatComboData")
   @DisplayName(
       "The correct amount of category combos and default category combos are present in the payload")
-  void testGetDatasetMetadata_1DatasetCatCombo_1DataElementCatCombo(
+  void getDatasetMetadataDefaultCatComboTest(
       String testData,
       int expectedCatComboSize,
       int expectedDefaultCatComboCount,

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataSetMetadataControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/DataSetMetadataControllerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+import org.hisp.dhis.jsontree.JsonArray;
+import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.web.HttpStatus;
+import org.hisp.dhis.web.WebClient;
+import org.hisp.dhis.webapi.DhisControllerIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * @author david mackessy
+ */
+class DataSetMetadataControllerTest extends DhisControllerIntegrationTest {
+
+  @ParameterizedTest
+  @MethodSource("defaultCatComboData")
+  @DisplayName(
+      "The correct amount of category combos and default category combos are present in the payload")
+  void testGetDatasetMetadata_1DatasetCatCombo_1DataElementCatCombo(
+      String testData,
+      int expectedCatComboSize,
+      int expectedDefaultCatComboCount,
+      String catComboSizeCondition,
+      String defaultCatComboCondition) {
+    // given
+    POST("/metadata", WebClient.Body(testData)).content(HttpStatus.OK);
+
+    // when the data entry metadata is retrieved
+    JsonArray categoryCombos = GET("/dataEntry/metadata").content().getArray("categoryCombos");
+
+    // then
+    assertEquals(expectedCatComboSize, categoryCombos.size(), catComboSizeCondition);
+    long count =
+        categoryCombos.asList(JsonObject.class).stream()
+            .filter(cc -> cc.getString("name").string().equals("default"))
+            .count();
+    assertEquals(expectedDefaultCatComboCount, count, defaultCatComboCondition);
+  }
+
+  private static Stream<Arguments> defaultCatComboData() {
+    return Stream.of(
+        Arguments.of(
+            "dataset/data_element_and_dataset_with_catcombo.json",
+            2,
+            0,
+            "2 cat combos should be present",
+            "0 default cat combo should be present"),
+        Arguments.of(
+            "dataset/data_element_with_catcombo.json",
+            2,
+            1,
+            "2 cat combos should be present",
+            "1 default cat combo should be present"),
+        Arguments.of(
+            "dataset/dataset_with_catcombo.json",
+            2,
+            1,
+            "2 cat combos should be present",
+            "1 default cat combo should be present"),
+        Arguments.of(
+            "dataset/dataset_and_data_element_with_no_catcombo.json",
+            1,
+            1,
+            "1 cat combos should be present",
+            "1 default cat combo should be present"));
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/resources/dataset/data_element_and_dataset_with_catcombo.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/dataset/data_element_and_dataset_with_catcombo.json
@@ -1,0 +1,95 @@
+{
+  "categories": [
+    {
+      "name": "sex",
+      "id": "Tv9b9dYOHMG",
+      "code": "sex",
+      "shortName": "sex",
+      "dataDimensionType": "DISAGGREGATION",
+      "categoryOptions": [
+        {
+          "id": "j8ft17oIEID"
+        },
+        {
+          "id": "paLPcwxxBRs"
+        }
+      ]
+    }
+  ],
+  "categoryOptions": [
+    {
+      "name": "Male3",
+      "id": "j8ft17oIEID",
+      "code": "M",
+      "shortName": "M"
+    },
+    {
+      "name": "Female3",
+      "id": "paLPcwxxBRs",
+      "code": "F",
+      "shortName": "F"
+    }
+  ],
+  "categoryCombos": [
+    {
+      "name": "ageGroup_sex",
+      "id": "UBCZTtKoxWg",
+      "code": "age_sex",
+      "shortName": "age_sex",
+      "categories": [
+        {
+          "id": "Tv9b9dYOHMG"
+        }
+      ],
+      "dataDimensionType": "DISAGGREGATION"
+    },
+    {
+      "name": "ageGroup_sex2",
+      "id": "UBCZTtKoxWh",
+      "code": "age_sex2",
+      "shortName": "age_sex2",
+      "categories": [
+        {
+          "id": "Tv9b9dYOHMG"
+        }
+      ],
+      "dataDimensionType": "DISAGGREGATION"
+    }
+  ],
+  "dataElements": [
+    {
+      "name": "NB_INSUREES",
+      "id": "IjXDFHSWw8n",
+      "code": "NB_INSUREES",
+      "shortName": "NB_INSUREES",
+      "aggregationType": "SUM",
+      "domainType": "AGGREGATE",
+      "valueType": "NUMBER",
+      "categoryCombo": {
+        "id": "UBCZTtKoxWh"
+      }
+    }
+  ],
+  "dataSets": [
+    {
+      "name": "Enrolment",
+      "id": "tS4D4c2HiTk",
+      "code": "Enrolment",
+      "shortName": "Enrolment",
+      "categoryCombo": {
+        "id": "UBCZTtKoxWg"
+      },
+      "dataSetElements": [
+        {
+          "dataElement": {
+            "id": "IjXDFHSWw8n"
+          },
+          "dataSet": {
+            "id": "tS4D4c2HiTk"
+          }
+        }
+      ],
+      "periodType": "Monthly"
+    }
+  ]
+}

--- a/dhis-2/dhis-test-web-api/src/test/resources/dataset/data_element_with_catcombo.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/dataset/data_element_with_catcombo.json
@@ -1,0 +1,80 @@
+{
+  "categories": [
+    {
+      "name": "sex",
+      "id": "Tv9b9dYOHMG",
+      "code": "sex",
+      "shortName": "sex",
+      "dataDimensionType": "DISAGGREGATION",
+      "categoryOptions": [
+        {
+          "id": "j8ft17oIEID"
+        },
+        {
+          "id": "paLPcwxxBRs"
+        }
+      ]
+    }
+  ],
+  "categoryOptions": [
+    {
+      "name": "Male3",
+      "id": "j8ft17oIEID",
+      "code": "M",
+      "shortName": "M"
+    },
+    {
+      "name": "Female3",
+      "id": "paLPcwxxBRs",
+      "code": "F",
+      "shortName": "F"
+    }
+  ],
+  "categoryCombos": [
+    {
+      "name": "ageGroup_sex",
+      "id": "UBCZTtKoxWg",
+      "code": "age_sex",
+      "shortName": "age_sex",
+      "categories": [
+        {
+          "id": "Tv9b9dYOHMG"
+        }
+      ],
+      "dataDimensionType": "DISAGGREGATION"
+    }
+  ],
+  "dataElements": [
+    {
+      "name": "NB_INSUREES",
+      "id": "IjXDFHSWw8n",
+      "code": "NB_INSUREES",
+      "shortName": "NB_INSUREES",
+      "aggregationType": "SUM",
+      "domainType": "AGGREGATE",
+      "valueType": "NUMBER",
+      "categoryCombo": {
+        "id": "UBCZTtKoxWg"
+      }
+    }
+  ],
+  "dataSets": [
+    {
+      "name": "Enrolment",
+      "id": "tS4D4c2HiTk",
+      "code": "Enrolment",
+      "shortName": "Enrolment",
+      "dataSetElements": [
+        {
+          "dataElement": {
+            "id": "IjXDFHSWw8n"
+          },
+          "dataSet": {
+            "id": "tS4D4c2HiTk"
+          }
+        }
+      ],
+      "periodType": "Monthly"
+    }
+  ]
+}

--- a/dhis-2/dhis-test-web-api/src/test/resources/dataset/dataset_and_data_element_with_no_catcombo.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/dataset/dataset_and_data_element_with_no_catcombo.json
@@ -1,0 +1,32 @@
+{
+  "dataElements": [
+    {
+      "name": "NB_INSUREES",
+      "id": "IjXDFHSWw8n",
+      "code": "NB_INSUREES",
+      "shortName": "NB_INSUREES",
+      "aggregationType": "SUM",
+      "domainType": "AGGREGATE",
+      "valueType": "NUMBER"
+    }
+  ],
+  "dataSets": [
+    {
+      "name": "Enrolment",
+      "id": "tS4D4c2HiTk",
+      "code": "Enrolment",
+      "shortName": "Enrolment",
+      "dataSetElements": [
+        {
+          "dataElement": {
+            "id": "IjXDFHSWw8n"
+          },
+          "dataSet": {
+            "id": "tS4D4c2HiTk"
+          }
+        }
+      ],
+      "periodType": "Monthly"
+    }
+  ]
+}

--- a/dhis-2/dhis-test-web-api/src/test/resources/dataset/dataset_with_catcombo.json
+++ b/dhis-2/dhis-test-web-api/src/test/resources/dataset/dataset_with_catcombo.json
@@ -1,0 +1,80 @@
+{
+  "categories": [
+    {
+      "name": "sex",
+      "id": "Tv9b9dYOHMG",
+      "code": "sex",
+      "shortName": "sex",
+      "dataDimensionType": "DISAGGREGATION",
+      "categoryOptions": [
+        {
+          "id": "j8ft17oIEID"
+        },
+        {
+          "id": "paLPcwxxBRs"
+        }
+      ]
+    }
+  ],
+  "categoryOptions": [
+    {
+      "name": "Male3",
+      "id": "j8ft17oIEID",
+      "code": "M",
+      "shortName": "M"
+    },
+    {
+      "name": "Female3",
+      "id": "paLPcwxxBRs",
+      "code": "F",
+      "shortName": "F"
+    }
+  ],
+  "categoryCombos": [
+    {
+      "name": "ageGroup_sex",
+      "id": "UBCZTtKoxWg",
+      "code": "age_sex",
+      "shortName": "age_sex",
+      "categories": [
+        {
+          "id": "Tv9b9dYOHMG"
+        }
+      ],
+      "dataDimensionType": "DISAGGREGATION"
+    }
+  ],
+  "dataElements": [
+    {
+      "name": "NB_INSUREES",
+      "id": "IjXDFHSWw8n",
+      "code": "NB_INSUREES",
+      "shortName": "NB_INSUREES",
+      "aggregationType": "SUM",
+      "domainType": "AGGREGATE",
+      "valueType": "NUMBER"
+    }
+  ],
+  "dataSets": [
+    {
+      "name": "Enrolment",
+      "id": "tS4D4c2HiTk",
+      "code": "Enrolment",
+      "shortName": "Enrolment",
+      "dataSetElements": [
+        {
+          "dataElement": {
+            "id": "IjXDFHSWw8n"
+          },
+          "dataSet": {
+            "id": "tS4D4c2HiTk"
+          }
+        }
+      ],
+      "periodType": "Monthly",
+      "categoryCombo": {
+        "id": "UBCZTtKoxWg"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
port of #17665 
`v41` already contains the fix from #15847 
`v40` and `v39` will have the tests and the fix backported.