### PR TITLE
fix: skip index for eventdatavalues [DHIS2-17508][2.41.0.1]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiEventsAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiEventsAnalyticsTableManager.java
@@ -61,6 +61,7 @@ import org.hisp.dhis.analytics.partition.PartitionManager;
 import org.hisp.dhis.analytics.table.model.AnalyticsTable;
 import org.hisp.dhis.analytics.table.model.AnalyticsTableColumn;
 import org.hisp.dhis.analytics.table.model.AnalyticsTablePartition;
+import org.hisp.dhis.analytics.table.model.Skip;
 import org.hisp.dhis.analytics.table.setting.AnalyticsTableSettings;
 import org.hisp.dhis.calendar.Calendar;
 import org.hisp.dhis.category.CategoryService;
@@ -113,7 +114,7 @@ public class JdbcTeiEventsAnalyticsTableManager extends AbstractJdbcTableManager
           new AnalyticsTableColumn("ouname", VARCHAR_255, NULL, "ou.name"),
           new AnalyticsTableColumn("oucode", CHARACTER_32, NULL, "ou.code"),
           new AnalyticsTableColumn("oulevel", INTEGER, NULL, "ous.level"),
-          new AnalyticsTableColumn("eventdatavalues", JSONB, "psi.eventdatavalues"));
+          new AnalyticsTableColumn("eventdatavalues", JSONB, "psi.eventdatavalues", Skip.SKIP));
 
   private static final String AND = " and (";
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/model/AnalyticsTableColumn.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/model/AnalyticsTableColumn.java
@@ -145,7 +145,7 @@ public class AnalyticsTableColumn {
    * @param name analytics table column name.
    * @param dataType analytics table column data type.
    * @param selectExpression source table select expression.
-   * @param indexType the index type.
+   * @param skipIndex whether to skip or include an index for column.
    */
   public AnalyticsTableColumn(
       String name, DataType dataType, String selectExpression, Skip skipIndex) {


### PR DESCRIPTION
This PR will prevent an index from being created on the jsonb column `eventdatavalues`, in the TE event table.