### PR TITLE
chore: Add entity mapping xml for HQL Entity detection in IDE

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/ide-entity-mapping.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/ide-entity-mapping.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!DOCTYPE hibernate-configuration PUBLIC
+  "-//Hibernate/Hibernate Configuration DTD//EN"
+  "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+
+<!--
+  This file exists purely to provide a link from the hibernate .hbm Entity mappings to
+  the IDE, which enables the following IDE perks in HQL queries:
+    - automatic property detection for Entity types
+    - warning for incorrect Entity type or Entity property
+
+  The mapping type used is jar, so the 'dhis-service-core' module requires building in order
+  for the jar to be available for mapping.
+-->
+<hibernate-configuration>
+  <session-factory>
+    <mapping jar="../../dhis-service-core-2.42-SNAPSHOT.jar"/>
+  </session-factory>
+</hibernate-configuration>


### PR DESCRIPTION
- file added purely to provide a link for the IDE to see Entities
- provides value when writing HQL
  - Entity detection
  - Entity property auto completion
  - warning for incorrect Entity / property name

This file is usually called `hibernate.cfg.xml` if the datasource if wired and started from xml config. We do not do this. We load the datastore config programmatically.

This file should not interfere with our datasource config as it is not referenced anywhere and the attributes required to actually start up a session factory are excluded from the file.

[Guide](https://github.com/dhis2/wow-backend/blob/master/guides/idea_hql_autodetection.md) for local setup