### PR TITLE
chore: velocity and velocity-tools upgraded to latest version

### DIFF
--- a/dhis-2/dhis-services/dhis-service-reporting/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-reporting/pom.xml
@@ -117,7 +117,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.velocity</groupId>
-      <artifactId>velocity</artifactId>
+      <artifactId>velocity-engine-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>

--- a/dhis-2/dhis-support/dhis-support-system/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-system/pom.xml
@@ -166,7 +166,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.velocity</groupId>
-      <artifactId>velocity</artifactId>
+      <artifactId>velocity-engine-core</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -140,8 +140,8 @@
     <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
 
     <!-- Velocity -->
-    <velocity.version>1.7</velocity.version>
-    <velocity-tools.version>2.0</velocity-tools.version>
+    <velocity.version>2.3</velocity.version>
+    <velocity-tools.version>3.1</velocity-tools.version>
 
     <!-- Jackson -->
     <jackson.version>2.17.1</jackson.version>
@@ -706,12 +706,12 @@
       <!-- Velocity -->
       <dependency>
         <groupId>org.apache.velocity</groupId>
-        <artifactId>velocity</artifactId>
+        <artifactId>velocity-engine-core</artifactId>
         <version>${velocity.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.velocity</groupId>
-        <artifactId>velocity-tools</artifactId>
+        <groupId>org.apache.velocity.tools</groupId>
+        <artifactId>velocity-tools-generic</artifactId>
         <version>${velocity-tools.version}</version>
         <exclusions>
           <exclusion>
@@ -2045,7 +2045,7 @@ jasperreports.version=${jasperreports.version}
               <!-- Needed by dhis-web modules -->
               <ignoredUnusedDeclaredDependency>io.lettuce:lettuce-core</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.apache.struts:struts2-spring-plugin</ignoredUnusedDeclaredDependency>
-              <ignoredUnusedDeclaredDependency>org.apache.velocity:velocity-tools</ignoredUnusedDeclaredDependency>
+              <ignoredUnusedDeclaredDependency>org.apache.velocity.tools:velocity-tools-generic</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.springframework:spring-context-support</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-codec</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>commons-fileupload:commons-fileupload</ignoredUnusedDeclaredDependency>


### PR DESCRIPTION
**This PR will upgrade Velocity to the latest version.**

### Reasons:

1. `commons-lang` is a forbidden dependency (we should use `commons-lang3` instead).
2. The currently used Velocity version (from 2010) still relies on `commons-lang`.
3. It would be safer to upgrade Velocity (and Velocity-Tools) to the latest version to ensure we have the most recent (and secure) version and to eliminate `commons-lang` from the classpath.

It would be helpful if someone from @dhis2/platform-backend could investigate any potential regressions.

Cheers
