### PR TITLE
fix: data entry audit history audit type column lookup [DHIS2-16887]

### DIFF
--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/history.vm
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/history.vm
@@ -128,7 +128,7 @@ $( document ).ready( function() {
                                         #end
                                     </td>
                                     <td>
-                                        $i18n.getString( $dataValueAudit.auditType.getValue() )
+                                        $i18n.getString( $dataValueAudit.auditType.name() )
                                     </td>
                                 </tr>
                             #end

--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/history.vm
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/history.vm
@@ -128,7 +128,7 @@ $( document ).ready( function() {
                                         #end
                                     </td>
                                     <td>
-                                        $i18n.getString( $dataValueAudit.auditType.name() )
+                                        $i18n.getString( $dataValueAudit.auditType.name().toLowerCase() )
                                     </td>
                                 </tr>
                             #end


### PR DESCRIPTION
### Summary
In the history velocity script a wrong path was used. `.autitType` returns an `enum` value. The `.getValue()` does not exist for the type and apparently this then computed to `null`. Instead the `.name().toLowerCase()` is used to get what `getValue()` originally returned (before it was removed a while back) so that the i18n lookup ends up with the same outcome.

Issue was introduced by https://github.com/dhis2/dhis2-core/commit/756f98b38ceb8b7b0155d68215f632699bd9f604

### Manual Testing
* open data entry app (old)
* select data set "Emergency Response"
* select Period "January 2024"
* select Target vs Result "Result"
* fill in a value in the top left cell
* change that value
* double click into the cell
* check you get a history popup (not an error)

![Screenshot at 2024-06-05 16-25-48](https://github.com/dhis2/dhis2-core/assets/309438/9df239bc-933a-4771-b925-88df6a5c0558)

Note the _Modification_ column stating _Update_ (not _UPDATE_ or _update_), meaning it is a translation text for the key `update` as found in `i18n_global`. 