### PR TITLE
chore: Use formatted console logs for easy reading

### DIFF
--- a/dhis-2/dhis-web-server/src/main/resources/log4j2.xml
+++ b/dhis-2/dhis-web-server/src/main/resources/log4j2.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
   <Appenders>
-    <Console name="console_color" target="SYSTEM_OUT" follow="true">
+    <Console name="console" target="SYSTEM_OUT">
       <PatternLayout
         pattern="%d{HH:mm:ss.SSS} %highlight{${LOG_LEVEL_PATTERN:-%5p}}{FATAL=red blink, ERROR=red, WARN=yellow bold, INFO=green, DEBUG=green bold, TRACE=blue} [%15.15t] %style{%-40.40C{1.}}{cyan} : %m%n%throwable"/>
-    </Console>
-    <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout pattern="* %-5p %d{ISO8601} %m (%F [%t]) %X{sessionId} %X{xRequestID}%n"/>
     </Console>
   </Appenders>
 


### PR DESCRIPTION
During the transition to use Tomcat embedded and some module restructuring, the console logging seems to have been impacted.

With this change, it will go from this:
<img width="1397" alt="Screenshot 2024-06-06 at 09 46 45" src="https://github.com/dhis2/dhis2-core/assets/131455290/fe17e1bd-4a8a-4098-9997-6e35d78f2031">


to this (which was the previous config):
<img width="1341" alt="Screenshot 2024-06-06 at 09 51 08" src="https://github.com/dhis2/dhis2-core/assets/131455290/c952c3e6-dd10-4195-867b-c9614561b27b">
