### PR TITLE
chore: Add system var (JVM arg) to be able to choose log appender

### DIFF
--- a/dhis-2/dhis-web-server/src/main/resources/log4j2.xml
+++ b/dhis-2/dhis-web-server/src/main/resources/log4j2.xml
@@ -27,7 +27,7 @@
     <Logger name="org.hibernate" level="ERROR" additivity="false"/>
 
     <Root level="WARN">
-      <AppenderRef ref="${env:LOG4J_APPENDER:-console}"/>
+      <AppenderRef ref="${sys:log4j.appender:-console}"/>
     </Root>
   </Loggers>
 </Configuration>

--- a/dhis-2/dhis-web-server/src/main/resources/log4j2.xml
+++ b/dhis-2/dhis-web-server/src/main/resources/log4j2.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
   <Appenders>
-    <Console name="console" target="SYSTEM_OUT">
+    <Console name="console_color" target="SYSTEM_OUT" follow="true">
       <PatternLayout
         pattern="%d{HH:mm:ss.SSS} %highlight{${LOG_LEVEL_PATTERN:-%5p}}{FATAL=red blink, ERROR=red, WARN=yellow bold, INFO=green, DEBUG=green bold, TRACE=blue} [%15.15t] %style{%-40.40C{1.}}{cyan} : %m%n%throwable"/>
+    </Console>
+    <Console name="console" target="SYSTEM_OUT">
+      <PatternLayout pattern="* %-5p %d{ISO8601} %m (%F [%t]) %X{sessionId} %X{xRequestID}%n"/>
     </Console>
   </Appenders>
 
@@ -24,7 +27,7 @@
     <Logger name="org.hibernate" level="ERROR" additivity="false"/>
 
     <Root level="WARN">
-      <AppenderRef ref="console"/>
+      <AppenderRef ref="${env:LOG4J_APPENDER:-console}"/>
     </Root>
   </Loggers>
 </Configuration>

--- a/dhis-2/dhis-web-server/src/main/resources/log4j2.xml
+++ b/dhis-2/dhis-web-server/src/main/resources/log4j2.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
   <Appenders>
-    <Console name="console_color" target="SYSTEM_OUT" follow="true">
+    <Console name="console" target="SYSTEM_OUT">
       <PatternLayout
         pattern="%d{HH:mm:ss.SSS} %highlight{${LOG_LEVEL_PATTERN:-%5p}}{FATAL=red blink, ERROR=red, WARN=yellow bold, INFO=green, DEBUG=green bold, TRACE=blue} [%15.15t] %style{%-40.40C{1.}}{cyan} : %m%n%throwable"/>
-    </Console>
-    <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout pattern="* %-5p %d{ISO8601} %m (%F [%t]) %X{sessionId} %X{xRequestID}%n"/>
     </Console>
   </Appenders>
 


### PR DESCRIPTION
During the transition to use Tomcat embedded and some module restructuring, 2 log4j files were effectively merged:
- log4j file used in production
- log4j file used in embedded Jetty (local dev)

This resulted in the formatting looking like this during local dev now:
<img width="1397" alt="Screenshot 2024-06-06 at 09 46 45" src="https://github.com/dhis2/dhis2-core/assets/131455290/fe17e1bd-4a8a-4098-9997-6e35d78f2031">

To allow a developer to choose which appender to use, a system var (JVM arg) (`log4j.appender`) has been added to the log4j file. If the system var is found, it will try to use the value provided. The current options for appenders are:
- `console` (default, used in production)
- `console_color` (nice formatting for local dev)

If the system var is not found, it will fall back to using the default `console` appender

Now, we can pass a system var (JVM arg) in the run config like so:
<img width="825" alt="Screenshot 2024-06-06 at 11 17 54" src="https://github.com/dhis2/dhis2-core/assets/131455290/e190852f-1ae5-42ea-8e26-0a422bba212b">


This will result in the formatting like this during local dev:
<img width="1341" alt="Screenshot 2024-06-06 at 09 51 08" src="https://github.com/dhis2/dhis2-core/assets/131455290/c952c3e6-dd10-4195-867b-c9614561b27b">

The reason for not having the `console_color` appender as the default (and only one) is because it can cause issues in production relating to:
- breaking parsers
- adding of special escape characters
- increases log file size