### PR TITLE
fix: filter out null pluginTypes [DHIS2-17492]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
@@ -271,10 +271,10 @@ public interface AppManager {
    *
    * @return list of installed apps with given isBundled property
    */
-  public static List<App> filterAppsByPluginType(String pluginType, Collection<App> apps) {
+  static List<App> filterAppsByPluginType(String pluginType, Collection<App> apps) {
     return apps.stream()
         .filter(app -> app.getPluginType() != null)
         .filter(app -> app.getPluginType().equals(pluginType))
-        .collect(Collectors.toList());
+        .toList();
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
@@ -273,6 +273,7 @@ public interface AppManager {
    */
   public static List<App> filterAppsByPluginType(String pluginType, Collection<App> apps) {
     return apps.stream()
+        .filter(app -> app.getPluginType() != null)
         .filter(app -> app.getPluginType().equals(pluginType))
         .collect(Collectors.toList());
   }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/appmanager/AppManagerTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/appmanager/AppManagerTest.java
@@ -1,3 +1,30 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.appmanager;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/appmanager/AppManagerTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/appmanager/AppManagerTest.java
@@ -1,0 +1,33 @@
+package org.hisp.dhis.appmanager;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AppManagerTest {
+
+  @Test
+  @DisplayName("filter by plugin type should not thrown a null pointer exception")
+  void filterByPluginTypeTest() {
+    // given 2 apps, 1 with a plugin type and 1 with none
+    App app1 = new App();
+    app1.setName("app 1");
+    app1.setVersion("v1");
+    app1.setPluginType("plugin1");
+
+    App app2 = new App();
+    app2.setName("app 2");
+    app2.setVersion("v2");
+
+    // when filtering by plugin type
+    List<App> filteredApps =
+        assertDoesNotThrow(() -> AppManager.filterAppsByPluginType("plugin1", List.of(app1, app2)));
+
+    // then 1 app is returned and no error is thrown
+    assertEquals(1, filteredApps.size());
+    assertEquals("app 1", filteredApps.get(0).getName());
+  }
+}


### PR DESCRIPTION
This is a fix to avoid null pointer exceptions when filtering on pluginType in api/apps (see [DHIS2-17492](https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-17492)). I'm open to better ideas for how to do this 😄

I think there are some more things we might want to improve in terms of these filters (including why the url filter is `pluginType`, but the property is `plugin_type`), but I'm just addressing the immediate issue in the ticket here for now to be able to test UI updates in the app management app ([DHIS2-17490](https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-17490)).



[DHIS2-17492]: https://dhis2.atlassian.net/browse/DHIS2-17492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-17490]: https://dhis2.atlassian.net/browse/DHIS2-17490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ