### PR TITLE
fix: broken authority listing in the user admin

### DIFF
--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AuthoritiesControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AuthoritiesControllerTest.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -51,7 +50,33 @@ class AuthoritiesControllerTest extends DhisControllerConvenienceTest {
     List<String> listAuthNames =
         systemAuthorities.asList(JsonObject.class).stream()
             .map(o -> o.getString("name").string().toLowerCase())
-            .collect(toList());
+            .toList();
+
     assertTrue(ListUtils.isSorted(listAuthNames, String::compareToIgnoreCase));
+  }
+
+  @Test
+  void testGetAllAuthorities() {
+    JsonArray systemAuthorities = GET("/authorities").content().getArray("systemAuthorities");
+    assertTrue(systemAuthorities.size() > 10);
+
+    // Get all authority ids/names
+    List<String> listIds =
+        systemAuthorities.asList(JsonObject.class).stream()
+            .map(o -> o.getString("id").string())
+            .toList();
+
+    // Authorities from AppManager.getApps()
+    assertTrue(listIds.contains("M_androidsettingsapp"));
+
+    // Authorities from AppManager.BUNDLED_APPS
+    List<String> moduleAuths = listIds.stream().filter(id -> id.startsWith("M_dhis-web-")).toList();
+    assertTrue(moduleAuths.size() > 4);
+
+    // Authorities from schemaService
+    assertTrue(listIds.contains("F_USER_ADD"));
+
+    // System authorities fom Authorities enum
+    assertTrue(listIds.contains("ALL"));
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AuthoritiesControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AuthoritiesControllerTest.java
@@ -60,7 +60,7 @@ class AuthoritiesControllerTest extends DhisControllerConvenienceTest {
     JsonArray systemAuthorities = GET("/authorities").content().getArray("systemAuthorities");
     assertTrue(systemAuthorities.size() > 10);
 
-    // Get all authority ids/names
+    // Get all authority ids
     List<String> listIds =
         systemAuthorities.asList(JsonObject.class).stream()
             .map(o -> o.getString("id").string())

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AuthoritiesControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AuthoritiesControllerTest.java
@@ -60,7 +60,7 @@ class AuthoritiesControllerTest extends DhisControllerConvenienceTest {
     JsonArray systemAuthorities = GET("/authorities").content().getArray("systemAuthorities");
     assertTrue(systemAuthorities.size() > 10);
 
-    // Get all authority ids
+    // Get all authority ids/names
     List<String> listIds =
         systemAuthorities.asList(JsonObject.class).stream()
             .map(o -> o.getString("id").string())

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthoritiesController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/AuthoritiesController.java
@@ -30,16 +30,23 @@ package org.hisp.dhis.webapi.controller.security;
 import static java.util.Collections.singletonMap;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.appmanager.AndroidSettingsApp;
 import org.hisp.dhis.appmanager.App;
+import org.hisp.dhis.appmanager.AppManager;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.i18n.I18nManager;
+import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.security.SystemAuthoritiesProvider;
 import org.hisp.dhis.webapi.controller.Server;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -58,19 +65,34 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/authorities")
 @ApiVersion({DhisApiVersion.DEFAULT, DhisApiVersion.ALL})
 public class AuthoritiesController {
-  @Autowired private I18nManager i18nManager;
 
+  @Autowired private I18nManager i18nManager;
   @Autowired private SystemAuthoritiesProvider authoritiesProvider;
+  @Autowired private SchemaService schemaService;
+  @Autowired private AppManager appManager;
 
   @GetMapping
   public Map<String, List<Map<String, String>>> getAuthorities(HttpServletResponse response) {
     I18n i18n = i18nManager.getI18n();
-    List<String> authorities = new ArrayList<>(authoritiesProvider.getSystemAuthorities());
+
+    List<String> authorities = new ArrayList<>();
+
+    Collection<String> systemAuthorities = authoritiesProvider.getSystemAuthorities();
+    authorities.addAll(systemAuthorities);
+
+    Collection<String> schemaAuthorities = schemaService.collectAuthorities();
+    authorities.addAll(schemaAuthorities);
+
+    Collection<String> appAuthorities = getAppAuthorities();
+    authorities.addAll(appAuthorities);
+
+    List<String> bundledAppsAuthorities = getBundledAppsAuthorities();
+    authorities.addAll(bundledAppsAuthorities);
+
     List<Map<String, String>> entries = new ArrayList<>();
     for (String auth : authorities) {
-      String name = getAuthName(auth, i18n);
-
       Map<String, String> authority = new LinkedHashMap<>();
+      String name = getAuthName(auth, i18n);
       authority.put("id", auth);
       authority.put("name", name);
       entries.add(authority);
@@ -79,14 +101,35 @@ public class AuthoritiesController {
     return singletonMap("systemAuthorities", entries);
   }
 
+  public Collection<String> getAppAuthorities() {
+    Set<String> authorities = new HashSet<>();
+    appManager.getApps(null).stream()
+        .filter(app -> !StringUtils.isEmpty(app.getShortName()) && !app.isBundled())
+        .forEach(
+            app -> {
+              authorities.add(app.getSeeAppAuthority());
+              authorities.addAll(app.getAuthorities());
+            });
+    authorities.add(AndroidSettingsApp.AUTHORITY);
+    return authorities;
+  }
+
+  private List<String> getBundledAppsAuthorities() {
+    List<String> authorities = new ArrayList<>();
+    Set<String> bundledApps = AppManager.BUNDLED_APPS;
+    for (String app : bundledApps) {
+      String key = "M_dhis-web-" + app;
+      authorities.add(key);
+    }
+    return authorities;
+  }
+
   private static String getAuthName(String auth, I18n i18n) {
     auth = i18n.getString(auth);
-
     // Custom App doesn't have translation for See App authority
     if (auth.startsWith(App.SEE_APP_AUTHORITY_PREFIX)) {
       auth = auth.replaceFirst(App.SEE_APP_AUTHORITY_PREFIX, "").replace("_", " ") + " app";
     }
-
     return auth;
   }
 }


### PR DESCRIPTION
## Summary
After removal of Struts in 2.42, the app and schema authority listing system was also removed. This PR replaces the Struts pre-removal listing system with a new much simpler one, that directly lists the app authorities from the app manager and the schema service.

### Automatic tests
AuthoritiesControllerTest#testGetAllAuthorities() 

### Manual test
1. Navigate to the user admin app
2. Validate that all metadata authorities is listed
3. Validate that all installed app authorities is listed
4. Validate that all bundled app authorities is listed
5. Validate that all system authorities is listed

### Jira
[DHIS2-17441](https://dhis2.atlassian.net/browse/DHIS2-17441)

[DHIS2-17441]: https://dhis2.atlassian.net/browse/DHIS2-17441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ