### PR TITLE
fix: oulevels are now dynamic in TE export [DHIS2-17549]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcTeiAnalyticsTableManager.java
@@ -45,7 +45,6 @@ import static org.hisp.dhis.db.model.DataType.TIMESTAMP;
 import static org.hisp.dhis.db.model.DataType.VARCHAR_255;
 import static org.hisp.dhis.db.model.DataType.VARCHAR_50;
 import static org.hisp.dhis.db.model.constraint.Nullable.NOT_NULL;
-import static org.hisp.dhis.db.model.constraint.Nullable.NULL;
 import static org.hisp.dhis.util.DateUtils.toLongDate;
 
 import java.util.ArrayList;
@@ -160,13 +159,11 @@ public class JdbcTeiAnalyticsTableManager extends AbstractJdbcTableManager {
           AnalyticsTableColumn.builder()
               .name("featuretype")
               .dataType(VARCHAR_255)
-              .nullable(NULL)
               .selectExpression("tei.featuretype")
               .build(),
           AnalyticsTableColumn.builder()
               .name("coordinates")
               .dataType(TEXT)
-              .nullable(NULL)
               .selectExpression("tei.coordinates")
               .build(),
           AnalyticsTableColumn.builder()
@@ -177,55 +174,26 @@ public class JdbcTeiAnalyticsTableManager extends AbstractJdbcTableManager {
           AnalyticsTableColumn.builder()
               .name("potentialduplicate")
               .dataType(BOOLEAN)
-              .nullable(NULL)
               .selectExpression("tei.potentialduplicate")
-              .build(),
-          AnalyticsTableColumn.builder()
-              .name("uidlevel1")
-              .dataType(CHARACTER_11)
-              .nullable(NULL)
-              .selectExpression("ous.uidlevel1")
-              .build(),
-          AnalyticsTableColumn.builder()
-              .name("uidlevel2")
-              .dataType(CHARACTER_11)
-              .nullable(NULL)
-              .selectExpression("ous.uidlevel2")
-              .build(),
-          AnalyticsTableColumn.builder()
-              .name("uidlevel3")
-              .dataType(CHARACTER_11)
-              .nullable(NULL)
-              .selectExpression("ous.uidlevel3")
-              .build(),
-          AnalyticsTableColumn.builder()
-              .name("uidlevel4")
-              .dataType(CHARACTER_11)
-              .nullable(NULL)
-              .selectExpression("ous.uidlevel4")
               .build(),
           AnalyticsTableColumn.builder()
               .name("ou")
               .dataType(CHARACTER_11)
-              .nullable(NULL)
               .selectExpression("ou.uid")
               .build(),
           AnalyticsTableColumn.builder()
               .name("ouname")
               .dataType(VARCHAR_255)
-              .nullable(NULL)
               .selectExpression("ou.name")
               .build(),
           AnalyticsTableColumn.builder()
               .name("oucode")
               .dataType(VARCHAR_50)
-              .nullable(NULL)
               .selectExpression("ou.code")
               .build(),
           AnalyticsTableColumn.builder()
               .name("oulevel")
               .dataType(INTEGER)
-              .nullable(NULL)
               .selectExpression("ous.level")
               .build());
 
@@ -360,13 +328,12 @@ public class JdbcTeiAnalyticsTableManager extends AbstractJdbcTableManager {
 
     List<AnalyticsTableColumn> columns = new ArrayList<>(getFixedColumns());
 
-    String selectExpression =
+    String enrolledInProgramExpression =
         """
         \s exists(select 1 from enrollment pi_0 \
         where pi_0.trackedentityid = tei.trackedentityid \
         and pi_0.programid = ${programId})""";
 
-    // Review this logic, it could result in many columns
     CollectionUtils.emptyIfNull(programsByTetUid.get(tet.getUid()))
         .forEach(
             program ->
@@ -376,7 +343,7 @@ public class JdbcTeiAnalyticsTableManager extends AbstractJdbcTableManager {
                         .dataType(BOOLEAN)
                         .selectExpression(
                             replace(
-                                selectExpression,
+                                enrolledInProgramExpression,
                                 Map.of("programId", String.valueOf(program.getId()))))
                         .build()));
 
@@ -464,6 +431,7 @@ public class JdbcTeiAnalyticsTableManager extends AbstractJdbcTableManager {
   private List<AnalyticsTableColumn> getFixedColumns() {
     List<AnalyticsTableColumn> columns = new ArrayList<>();
     columns.addAll(FIXED_GROUP_BY_COLS);
+    columns.addAll(getOrganisationUnitLevelColumns());
     columns.add(getOrganisationUnitNameHierarchyColumn());
     columns.addAll(FIXED_NON_GROUP_BY_COLS);
 


### PR DESCRIPTION
This pull request updates the TE export from a static, hard-coded, 4-level hierarchy to the dynamic configuration used in other Analytics Table Managers.

