### PR TITLE
fix: api/maps/uid/data return error 500

### DIFF
--- a/dhis-2/dhis-services/dhis-service-reporting/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-reporting/pom.xml
@@ -205,7 +205,14 @@
       <groupId>org.locationtech.jts</groupId>
       <artifactId>jts-core</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-epsg-hsql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-cql</artifactId>
+    </dependency>
     <!-- Test -->
     <dependency>
       <groupId>org.hisp.dhis</groupId>
@@ -235,6 +242,11 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-geojson</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/mapgeneration/InternalMapObject.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/mapgeneration/InternalMapObject.java
@@ -171,7 +171,7 @@ public class InternalMapObject {
     }
 
     try {
-      return DataUtilities.createType(GEOMETRIES, "geometry:" + type + ":srid=3785");
+      return DataUtilities.createType(GEOMETRIES, "geometry:" + type + ":srid=3857");
     } catch (SchemaException ex) {
       throw new RuntimeException("failed to create geometry", ex);
     }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/mapgeneration/GeoToolsMapObjectTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/mapgeneration/GeoToolsMapObjectTest.java
@@ -27,11 +27,16 @@
  */
 package org.hisp.dhis.mapgeneration;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.awt.Color;
+import java.io.IOException;
+import org.geotools.geojson.geom.GeometryJSON;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Geometry;
 
 /**
  * @author Kenneth Solbø Andersen <kennetsa@ifi.uio.no>
@@ -39,6 +44,11 @@ import org.junit.jupiter.api.Test;
 class GeoToolsMapObjectTest {
 
   private InternalMapObject geoToolsMapObject;
+  private GeometryJSON geometryJSON = new GeometryJSON();
+  private String multiPolygonCoordinates =
+      "[[[[11.11,22.22],[33.33,44.44],[55.55,66.66],[11.11,22.22]]],"
+          + "[[[77.77,88.88],[99.99,11.11],[22.22,33.33],[77.77,88.88]]],"
+          + "[[[44.44,55.55],[66.66,77.77],[88.88,99.99],[44.44,55.55]]]]";
 
   @BeforeEach
   void before() {
@@ -91,5 +101,17 @@ class GeoToolsMapObjectTest {
     assertEquals(Color.GREEN, geoToolsMapObject.getStrokeColor());
     geoToolsMapObject.setStrokeColor(Color.WHITE);
     assertEquals(Color.WHITE, geoToolsMapObject.getStrokeColor());
+  }
+
+  @Test
+  void testCreateFeatureType() throws IOException {
+    Geometry geometry =
+        geometryJSON.read(
+            "{\"type\":\"MultiPolygon\", \"coordinates\":" + multiPolygonCoordinates + "}");
+    geoToolsMapObject.setGeometry(geometry);
+    assertDoesNotThrow(
+        () -> {
+          assertNotNull(MapUtils.createFeatureLayerFromMapObject(geoToolsMapObject));
+        });
   }
 }

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1383,6 +1383,16 @@
         <artifactId>gt-referencing</artifactId>
         <version>${geotools.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.geotools</groupId>
+        <artifactId>gt-epsg-hsql</artifactId>
+        <version>${geotools.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geotools</groupId>
+        <artifactId>gt-cql</artifactId>
+        <version>${geotools.version}</version>
+      </dependency>
 
       <!-- JAXB -->
       <dependency>
@@ -2032,6 +2042,8 @@ jasperreports.version=${jasperreports.version}
             <failOnWarning>true</failOnWarning>
             <ignoredUnusedDeclaredDependencies>
               <ignoredUnusedDeclaredDependency>org.geotools:gt-main</ignoredUnusedDeclaredDependency>
+              <ignoredUnusedDeclaredDependency>org.geotools:gt-epsg-hsql</ignoredUnusedDeclaredDependency>
+              <ignoredUnusedDeclaredDependency>org.geotools:gt-cql</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>net.postgis:postgis-jdbc</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.springframework.boot:spring-boot-starter-tomcat</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.flywaydb:flyway-database-postgresql</ignoredUnusedDeclaredDependency>


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-12003

- Moves from the deprecated `EPSG 3785` to `EPSG 3857`  [https://epsg.io/3785](https://epsg.io/3785)
- Added unit test to verify that the error is not thrown.

```
Caused by: org.opengis.referencing.NoSuchAuthorityCodeException: No code "EPSG:3857" from authority "EPSG" found for object of type "EngineeringCRS".
```
