### PR TITLE
fix: Run most preprocessors only for CREATE and UPDATE [DHIS2-17402]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preprocess/BundlePreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preprocess/BundlePreProcessor.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.imports.preprocess;
 
+import org.hisp.dhis.tracker.imports.TrackerImportStrategy;
 import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
 
 /**
@@ -40,4 +41,8 @@ import org.hisp.dhis.tracker.imports.bundle.TrackerBundle;
  */
 public interface BundlePreProcessor {
   void process(TrackerBundle bundle);
+
+  default boolean needsToRun(TrackerImportStrategy strategy) {
+    return !strategy.isDelete();
+  }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preprocess/DefaultTrackerPreprocessService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preprocess/DefaultTrackerPreprocessService.java
@@ -48,7 +48,9 @@ public class DefaultTrackerPreprocessService implements TrackerPreprocessService
   @Override
   public TrackerBundle preprocess(TrackerBundle bundle) {
     for (BundlePreProcessor preProcessor : preProcessors) {
-      preProcessor.process(bundle);
+      if (preProcessor.needsToRun(bundle.getImportStrategy())) {
+        preProcessor.process(bundle);
+      }
     }
 
     return bundle;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preprocess/EventProgramPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preprocess/EventProgramPreProcessor.java
@@ -27,10 +27,10 @@
  */
 package org.hisp.dhis.tracker.imports.preprocess;
 
+import static java.util.Objects.nonNull;
+
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.tracker.imports.TrackerIdSchemeParams;
@@ -51,14 +51,19 @@ public class EventProgramPreProcessor implements BundlePreProcessor {
   public void process(TrackerBundle bundle) {
     List<Event> eventsToPreprocess =
         bundle.getEvents().stream()
-            .filter(e -> e.getProgram().isBlank() || e.getProgramStage().isBlank())
-            .collect(Collectors.toList());
+            .filter(
+                e ->
+                    e.getProgram() == null
+                        || e.getProgram().isBlank()
+                        || e.getProgramStage() == null
+                        || e.getProgramStage().isBlank())
+            .toList();
 
     for (Event event : eventsToPreprocess) {
       // Extract program from program stage
-      if (event.getProgramStage().isNotBlank()) {
+      if (nonNull(event.getProgramStage()) && event.getProgramStage().isNotBlank()) {
         ProgramStage programStage = bundle.getPreheat().getProgramStage(event.getProgramStage());
-        if (Objects.nonNull(programStage)) {
+        if (nonNull(programStage)) {
           // TODO remove if once metadata import is fixed
           if (programStage.getProgram() == null) {
             // Program stages should always have a program! Due to
@@ -84,9 +89,9 @@ public class EventProgramPreProcessor implements BundlePreProcessor {
         }
       }
       // If it is a program event, extract program stage from program
-      else if (event.getProgram().isNotBlank()) {
+      else if (nonNull(event.getProgram()) && event.getProgram().isNotBlank()) {
         Program program = bundle.getPreheat().getProgram(event.getProgram());
-        if (Objects.nonNull(program) && program.isWithoutRegistration()) {
+        if (nonNull(program) && program.isWithoutRegistration()) {
           Optional<ProgramStage> programStage = program.getProgramStages().stream().findFirst();
           if (programStage.isPresent()) {
             TrackerIdSchemeParams idSchemes = bundle.getPreheat().getIdSchemes();
@@ -109,7 +114,7 @@ public class EventProgramPreProcessor implements BundlePreProcessor {
                     e.getAttributeOptionCombo().isBlank()
                         && !e.getAttributeCategoryOptions().isEmpty())
             .filter(e -> preheat.getProgram(e.getProgram()) != null)
-            .collect(Collectors.toList());
+            .toList();
 
     for (Event e : events) {
       Program program = preheat.getProgram(e.getProgram());

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preprocess/StrategyPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preprocess/StrategyPreProcessor.java
@@ -121,4 +121,9 @@ public class StrategyPreProcessor implements BundlePreProcessor {
       }
     }
   }
+
+  @Override
+  public boolean needsToRun(TrackerImportStrategy strategy) {
+    return true;
+  }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/EventProgramPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/preprocess/EventProgramPreProcessorTest.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.DhisConvenienceTest.createCategoryOptionCombo;
 import static org.hisp.dhis.DhisConvenienceTest.createProgram;
 import static org.hisp.dhis.DhisConvenienceTest.createProgramStage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -199,6 +200,20 @@ class EventProgramPreProcessorTest {
         MetadataIdentifier.ofUid(PROGRAM_WITH_REGISTRATION),
         bundle.getEvents().get(0).getProgram());
     assertEquals(MetadataIdentifier.EMPTY_UID, bundle.getEvents().get(0).getProgramStage());
+  }
+
+  @Test
+  void shouldNotProcessEventWhenEventIsInvalidWithNoProgramAndNoProgramStage() {
+    Event event = invalidProgramEventWithNoProgramAndNoProgramStage();
+    TrackerBundle bundle =
+        TrackerBundle.builder().events(Collections.singletonList(event)).preheat(preheat).build();
+
+    preprocessor.process(bundle);
+
+    verify(preheat, never()).getProgram(PROGRAM_WITH_REGISTRATION);
+    verify(preheat, never()).getProgramStage(PROGRAM_STAGE_WITH_REGISTRATION);
+    assertNull(bundle.getEvents().get(0).getProgram());
+    assertNull(bundle.getEvents().get(0).getProgramStage());
   }
 
   @Test
@@ -440,6 +455,14 @@ class EventProgramPreProcessorTest {
     program.setUid(PROGRAM_WITHOUT_REGISTRATION);
     program.setProgramType(ProgramType.WITHOUT_REGISTRATION);
     return program;
+  }
+
+  private Event invalidProgramEventWithNoProgramAndNoProgramStage() {
+    return Event.builder()
+        .program(null)
+        .programStage(null)
+        .attributeOptionCombo(MetadataIdentifier.EMPTY_UID)
+        .build();
   }
 
   private Event programEventWithProgram() {

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/enrollment_basic_data_for_deletion.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/enrollment_basic_data_for_deletion.json
@@ -33,17 +33,7 @@
   "trackedEntities": [],
   "enrollments": [
     {
-      "enrollment": "TvctPPhpD8u",
-      "createdAtClient": "2017-01-26T13:48:13.363",
-      "trackedEntity": "NCc1rCEOKaY",
-      "program": {
-        "idScheme": "UID",
-        "identifier": "E8o1E9tAppy"
-      },
-      "orgUnit": {
-        "idScheme": "UID",
-        "identifier": "QfUVllTs6cS"
-      }
+      "enrollment": "TvctPPhpD8u"
     }
   ],
   "events": [],

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/event_basic_data_for_deletion.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/event_basic_data_for_deletion.json
@@ -34,51 +34,7 @@
   "enrollments": [],
   "events": [
     {
-      "event": "D9PbzJY8bJ1",
-      "status": "COMPLETED",
-      "program": {
-        "idScheme": "UID",
-        "identifier": "E8o1E9tAppy"
-      },
-      "programStage": {
-        "idScheme": "UID",
-        "identifier": "Qmqxq907VNz"
-      },
-      "enrollment": "TvctPPhpD8v",
-      "orgUnit": {
-        "idScheme": "UID",
-        "identifier": "QfUVllTs6cZ"
-      },
-      "relationships": [],
-      "occurredAt": "2019-01-28T00:00:00.000",
-      "scheduledAt": "2019-01-28T12:10:38.100",
-      "storedBy": "admin",
-      "deleted": false,
-      "attributeOptionCombo": {
-        "idScheme": "UID",
-        "identifier": "KKKKX50cXC0"
-      },
-      "attributeCategoryOptions": [
-        {
-          "idScheme": "UID",
-          "identifier": "xYerKDKCefk"
-        }
-      ],
-
-      "completedAt": "2019-01-28T00:00:00.000",
-      "dataValues": [
-        {
-          "createdAt": "2019-01-28T12:10:38.113",
-          "storedBy": "admin",
-          "providedElsewhere": false,
-          "dataElement": {
-            "idScheme": "UID",
-            "identifier": "DSKTW8qFP0z"
-          },
-          "value": "2017-01-27T17:00:00.000Z"
-        }
-      ],
-      "notes": []
+      "event": "D9PbzJY8bJ1"
     }
   ],
   "relationships": [],

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/non_existent_enrollment_basic_data_for_deletion.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/non_existent_enrollment_basic_data_for_deletion.json
@@ -33,27 +33,7 @@
   "trackedEntities": [],
   "enrollments": [
     {
-      "enrollment": "TvctPPhpD8w",
-      "createdAtClient": "2017-01-26T13:48:13.363",
-      "trackedEntity": "NCc1rCEOKaY",
-      "program": {
-        "idScheme": "UID",
-        "identifier": "E8o1E9tAppy"
-      },
-      "status": "ACTIVE",
-      "orgUnit": {
-        "idScheme": "UID",
-        "identifier": "QfUVllTs6cS"
-      },
-      "orgUnitName": "Mbokie CHP",
-      "enrolledAt": "2021-03-28T12:05:00.000",
-      "occurredAt": "2021-03-28T12:05:00.000",
-      "followUp": false,
-      "deleted": false,
-      "events": [],
-      "relationships": [],
-      "attributes": [],
-      "notes": []
+      "enrollment": "TvctPPhpD8w"
     }
   ],
   "events": [],

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/tracker_data_for_deletion.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/tracker_data_for_deletion.json
@@ -32,63 +32,12 @@
   "skipRuleEngine": false,
   "trackedEntities": [
     {
-      "trackedEntity": "PB9VMezGkwA",
-      "trackedEntityType": {
-        "idScheme": "UID",
-        "identifier": "bPJ0FMtcnEh"
-      },
-      "orgUnit": {
-        "idScheme": "UID",
-        "identifier": "QfUVllTs6cS"
-      },
-      "inactive": false,
-      "deleted": false,
-      "potentialDuplicate": false,
-      "relationships": [],
-      "attributes": [
-        {
-          "attribute": {
-            "idScheme": "UID",
-            "identifier": "fmBIpOStKkF"
-          },
-          "storedBy": "admin",
-          "value": "PersonA"
-        },
-        {
-          "attribute": {
-            "idScheme": "UID",
-            "identifier": "sTJvSLN7Kcb"
-          },
-          "storedBy": "admin",
-          "value": "AddressA"
-        }
-      ],
-      "enrollments": []
+      "trackedEntity": "PB9VMezGkwA"
     }
   ],
   "enrollments": [
     {
-      "enrollment": "TvctPPhpD8u",
-      "createdAtClient": "2017-01-26T13:48:13.363",
-      "trackedEntity": "NCc1rCEOKaY",
-      "program": {
-        "idScheme": "UID",
-        "identifier": "E8o1E9tAppy"
-      },
-      "status": "ACTIVE",
-      "orgUnit": {
-        "idScheme": "UID",
-        "identifier": "QfUVllTs6cS"
-      },
-      "orgUnitName": "Mbokie CHP",
-      "enrolledAt": "2021-03-28T12:05:00.000",
-      "occurredAt": "2021-03-28T12:05:00.000",
-      "followUp": false,
-      "deleted": false,
-      "events": [],
-      "relationships": [],
-      "attributes": [],
-      "notes": []
+      "enrollment": "TvctPPhpD8u"
     }
   ],
   "events": [],


### PR DESCRIPTION
First step to fix https://dhis2.atlassian.net/browse/DHIS2-17402 was to clean up integration test json files used to delete entities and remove all the fields except the entity uid.
This step revealed a potential NPE in the [preprocessor](https://github.com/dhis2/dhis2-core/blob/6be24e962adb654e354bd0a8c77857a91e2097c7/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preprocess/EventProgramPreProcessor.java#L54) and showed that we do not really need to run most of the preprocessor when the `importStrategy` is `DELETE`