### PR TITLE
fix: can not update users after OpenID field is set (#16723)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
@@ -107,6 +107,14 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook<User> {
               .setErrorProperty(USERNAME));
     }
 
+    User existingUserWithMatchingOpenID = userService.getUserByOpenId(user.getOpenId());
+    if (existingUserWithMatchingOpenID != null
+        && !existingUserWithMatchingOpenID.getUid().equals(user.getUid())) {
+      addReports.accept(
+          new ErrorReport(User.class, ErrorCode.E4054, "OIDC mapping value", user.getOpenId())
+              .setErrorProperty(USERNAME));
+    }
+
     if (user.getUserRoles() == null || user.getUserRoles().isEmpty()) {
       addReports.accept(
           new ErrorReport(User.class, ErrorCode.E4055, USERNAME, user.getUsername())

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -79,6 +79,7 @@ import org.hisp.dhis.webapi.json.domain.JsonUser;
 import org.hisp.dhis.webapi.json.domain.JsonUserGroup;
 import org.hisp.dhis.webapi.json.domain.JsonWebMessage;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.session.SessionRegistry;
@@ -167,6 +168,28 @@ class UserControllerTest extends DhisControllerConvenienceTest {
     User user = userService.getUser(peter.getUid());
     assertEquals("mapping value", user.getOpenId());
     assertEquals("mapping value", user.getUserCredentials().getOpenId());
+  }
+
+  @Test
+  @DisplayName(
+      "Make sure an update after first setting OpenID works, has special handling logic in UserObjectBundleHook.")
+  void testSetOpenIdThenUpdate() {
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/users/{id}",
+            peter.getUid() + "?importReportMode=ERRORS",
+            Body("[{'op': 'add', 'path': '/openId', 'value': 'mapping value'}]")));
+
+    User user = userService.getUser(peter.getUid());
+    assertEquals("mapping value", user.getOpenId());
+
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/users/{id}",
+            peter.getUid() + "?importReportMode=ERRORS",
+            Body("[{'op': 'add', 'path': '/openId', 'value': 'mapping value'}]")));
   }
 
   /**


### PR DESCRIPTION
(cherry picked from commit 6eafbbf816ba4d284f0927075abcecc7bc6910c2)
Signed-off-by: Morten Svanaes <msvanaes@dhis2.org>