### PR TITLE
chore: refactor embedded Jetty main class, remove deprecated features

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
@@ -63,8 +63,6 @@ import org.hisp.dhis.hibernate.exception.ReadAccessDeniedException;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.security.RequiresAuthority;
-import org.hisp.dhis.user.CurrentUserUtil;
-import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.hisp.dhis.webapi.utils.ContextUtils;
@@ -73,10 +71,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.context.SecurityContextImpl;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -117,32 +111,8 @@ public class AppController {
 
   @GetMapping(value = "/menu", produces = ContextUtils.CONTENT_TYPE_JSON)
   public @ResponseBody Map<String, List<WebModule>> getWebModules(HttpServletRequest request) {
-    checkForEmbeddedJettyRuntime(request);
-
     String contextPath = HttpServletRequestPaths.getContextPath(request);
     return Map.of("modules", getAccessibleAppMenu(contextPath));
-  }
-
-  /**
-   * Checks if we are running in embedded Jetty mode. If so, we need to set the SecurityContext
-   * manually from the session object SPRING_SECURITY_CONTEXT. This is done for compatibility with
-   * the old Struts action, which is not 100% ported yet. To be removed when application is ported
-   * away from Struts
-   */
-  private static void checkForEmbeddedJettyRuntime(HttpServletRequest request) {
-    Object springSecurityContext = request.getSession().getAttribute("SPRING_SECURITY_CONTEXT");
-    if (springSecurityContext != null) {
-      SecurityContextImpl context = (SecurityContextImpl) springSecurityContext;
-      Authentication authentication = context.getAuthentication();
-
-      UserDetails currentUserDetails = CurrentUserUtil.getCurrentUserDetails();
-
-      if (authentication != null && currentUserDetails == null) {
-        SecurityContext newContext = SecurityContextHolder.createEmptyContext();
-        newContext.setAuthentication(authentication);
-        SecurityContextHolder.setContext(context);
-      }
-    }
   }
 
   private List<WebModule> getAccessibleAppMenu(String contextPath) {

--- a/dhis-2/dhis-web-server/src/main/java/org/hisp/dhis/web/jetty/JettyStartupTimerSpringConfiguration.java
+++ b/dhis-2/dhis-web-server/src/main/java/org/hisp/dhis/web/jetty/JettyStartupTimerSpringConfiguration.java
@@ -27,29 +27,20 @@
  */
 package org.hisp.dhis.web.jetty;
 
-import org.hisp.dhis.security.Authorities;
-import org.hisp.dhis.security.SystemAuthoritiesProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
-import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 
 /**
+ * Configuration class for a simple startup timer for embedded Jetty.
+ *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 @Configuration
 @Order(100)
 @ComponentScan(basePackages = {"org.hisp.dhis"})
-@Profile("embeddedJetty")
-public class SpringConfiguration {
-
-  @Primary
-  @Bean("org.hisp.dhis.security.SystemAuthoritiesProvider")
-  public SystemAuthoritiesProvider systemAuthoritiesProvider() {
-    return Authorities::getAllAuthorities;
-  }
+public class JettyStartupTimerSpringConfiguration {
 
   @Bean("org.hisp.dhis.web.embeddedjetty.StartupFinishedRoutine")
   public StartupFinishedRoutine startupFinishedRoutine() {

--- a/dhis-2/dhis-web-server/src/main/java/org/hisp/dhis/web/jetty/Main.java
+++ b/dhis-2/dhis-web-server/src/main/java/org/hisp/dhis/web/jetty/Main.java
@@ -49,14 +49,13 @@ import org.springframework.web.filter.DelegatingFilterProxy;
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-public class JettyEmbeddedCoreWeb extends EmbeddedJettyBase {
+public class Main extends EmbeddedJettyBase {
+
   private static final int DEFAULT_HTTP_PORT = 9090;
-
   private static final String SERVER_HOSTNAME_OR_IP = "localhost";
-
   private static final Long ELAPSED_SINCE_START = System.currentTimeMillis();
 
-  public JettyEmbeddedCoreWeb() {
+  public Main() {
     super();
   }
 
@@ -68,15 +67,7 @@ public class JettyEmbeddedCoreWeb extends EmbeddedJettyBase {
     setDefaultPropertyValue("jetty.host", SERVER_HOSTNAME_OR_IP);
     setDefaultPropertyValue("jetty.http.port", String.valueOf(DEFAULT_HTTP_PORT));
 
-    /*
-     * This property is very import, this will instruct Spring to use
-     * special Spring config classes adapted to running in embedded Jetty.
-     *
-     * @see org.hisp.dhis.web.embeddedjetty.SpringConfiguration
-     */
-    setDefaultPropertyValue("spring.profiles.active", "embeddedJetty");
-
-    JettyEmbeddedCoreWeb jettyEmbeddedCoreWeb = new JettyEmbeddedCoreWeb();
+    Main jettyEmbeddedCoreWeb = new Main();
     jettyEmbeddedCoreWeb.printBanner("DHIS2 API Server");
     jettyEmbeddedCoreWeb.startJetty();
   }
@@ -111,7 +102,7 @@ public class JettyEmbeddedCoreWeb extends EmbeddedJettyBase {
 
   private static AnnotationConfigWebApplicationContext getWebApplicationContext() {
     AnnotationConfigWebApplicationContext context = new AnnotationConfigWebApplicationContext();
-    context.register(SpringConfiguration.class);
+    context.register(JettyStartupTimerSpringConfiguration.class);
     return context;
   }
 

--- a/dhis-2/dhis-web-server/src/main/java/org/hisp/dhis/web/jetty/StartupFinishedRoutine.java
+++ b/dhis-2/dhis-web-server/src/main/java/org/hisp/dhis/web/jetty/StartupFinishedRoutine.java
@@ -40,7 +40,6 @@ public class StartupFinishedRoutine extends AbstractStartupRoutine {
     log.info(
         String.format(
             "DHIS2 API Server Startup Finished In %s Seconds! Running on port: %s",
-            (JettyEmbeddedCoreWeb.getElapsedMsSinceStart() / 1000),
-            System.getProperty("jetty.http.port")));
+            (Main.getElapsedMsSinceStart() / 1000), System.getProperty("jetty.http.port")));
   }
 }

--- a/dhis-2/dhis-web-server/src/main/java/org/hisp/dhis/web/tomcat/Main.java
+++ b/dhis-2/dhis-web-server/src/main/java/org/hisp/dhis/web/tomcat/Main.java
@@ -65,7 +65,8 @@ import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 
 /**
- * This code is a modified version of the original code from Spring Boot project.
+ * This code is a modified version of the original code from Spring Boot project. It serves as the
+ * main entry point for the embedded server. It starts an embedded Tomcat server
  *
  * @author Phillip Webb
  * @author Andy Wilkinson

--- a/dhis-2/dhis-web-server/src/test/java/org/hisp/dhis/auth/AuthTest.java
+++ b/dhis-2/dhis-web-server/src/test/java/org/hisp/dhis/auth/AuthTest.java
@@ -39,7 +39,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.system.util.HttpHeadersBuilder;
-import org.hisp.dhis.web.jetty.JettyEmbeddedCoreWeb;
+import org.hisp.dhis.web.jetty.Main;
 import org.hisp.dhis.webapi.controller.security.LoginRequest;
 import org.hisp.dhis.webapi.controller.security.LoginResponse;
 import org.junit.jupiter.api.BeforeAll;
@@ -98,7 +98,7 @@ class AuthTest {
         new Thread(
             () -> {
               try {
-                JettyEmbeddedCoreWeb.main(null);
+                Main.main(null);
               } catch (InterruptedException ignored) {
               } catch (Exception e) {
                 throw new RuntimeException(e);


### PR DESCRIPTION
## Summary
Renames the embedded Jetty main class to Main, same as the embedded Tomcat main class to unify the naming.
Also removed unused code that was necessary for embedded Jetty before the transition to a Struts less server.