### PR TITLE
fix: throws exception for invalid dates [DHIS2-17539]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -446,7 +446,6 @@ public enum ErrorCode {
       "Query failed because a referenced table does not exist. Please ensure analytics job was run"),
   E7145("Query failed because of a syntax error"),
   E7146("A {0} date was not specified in periods, dimensions, filters"),
-  E7147("Invalid period: {0}"),
 
   /* Analytics outliers */
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -446,6 +446,7 @@ public enum ErrorCode {
       "Query failed because a referenced table does not exist. Please ensure analytics job was run"),
   E7145("Query failed because of a syntax error"),
   E7146("A {0} date was not specified in periods, dimensions, filters"),
+  E7147("Invalid period: {0}"),
 
   /* Analytics outliers */
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProducer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProducer.java
@@ -59,6 +59,7 @@ import static org.hisp.dhis.common.IdentifiableProperty.UID;
 import static org.hisp.dhis.commons.collection.ListUtils.sort;
 import static org.hisp.dhis.feedback.ErrorCode.E7124;
 import static org.hisp.dhis.feedback.ErrorCode.E7143;
+import static org.hisp.dhis.feedback.ErrorCode.E7147;
 import static org.hisp.dhis.hibernate.HibernateProxyUtils.getRealClass;
 import static org.hisp.dhis.organisationunit.OrganisationUnit.KEY_DATASET;
 import static org.hisp.dhis.organisationunit.OrganisationUnit.KEY_LEVEL;
@@ -261,7 +262,7 @@ public class DimensionalObjectProducer {
       periods.add(periodToAdd);
       return;
     }
-    throw new IllegalQueryException("Invalid period: " + isoPeriodHolder.getIsoPeriod());
+    throw new IllegalQueryException(E7147, isoPeriodHolder.getIsoPeriod());
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProducer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProducer.java
@@ -59,7 +59,7 @@ import static org.hisp.dhis.common.IdentifiableProperty.UID;
 import static org.hisp.dhis.commons.collection.ListUtils.sort;
 import static org.hisp.dhis.feedback.ErrorCode.E7124;
 import static org.hisp.dhis.feedback.ErrorCode.E7143;
-import static org.hisp.dhis.feedback.ErrorCode.E7147;
+import static org.hisp.dhis.feedback.ErrorCode.E7611;
 import static org.hisp.dhis.hibernate.HibernateProxyUtils.getRealClass;
 import static org.hisp.dhis.organisationunit.OrganisationUnit.KEY_DATASET;
 import static org.hisp.dhis.organisationunit.OrganisationUnit.KEY_LEVEL;
@@ -262,7 +262,7 @@ public class DimensionalObjectProducer {
       periods.add(periodToAdd);
       return;
     }
-    throw new IllegalQueryException(E7147, isoPeriodHolder.getIsoPeriod());
+    throw new IllegalQueryException(E7611, isoPeriodHolder.getIsoPeriod());
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProducer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProducer.java
@@ -93,6 +93,7 @@ import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.DisplayProperty;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.dataelement.DataElementGroup;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.i18n.I18nFormat;
@@ -258,7 +259,9 @@ public class DimensionalObjectProducer {
       dimensionalKeywords.addKeyword(
           isoPeriodHolder.getIsoPeriod(), join(" - ", startDate, endDate));
       periods.add(periodToAdd);
+      return;
     }
+    throw new IllegalQueryException("Invalid period: " + isoPeriodHolder.getIsoPeriod());
   }
 
   /**

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TrackedEntityQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TrackedEntityQueryTest.java
@@ -3274,8 +3274,8 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
         .body("status", equalTo("ERROR"))
         .body("httpStatusCode", equalTo(409))
         .body("httpStatus", equalTo("Conflict"))
-        .body("errorCode", equalTo("E7147"))
-        .body("message", equalTo("Invalid period: INVALID_PERIOD"));
+        .body("errorCode", equalTo("E7611"))
+        .body("message", equalTo("Period not valid: `INVALID_PERIOD`"));
   }
 
   private void testMetaCustomLabel(String header, String expected) {

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TrackedEntityQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TrackedEntityQueryTest.java
@@ -3274,6 +3274,7 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
         .body("status", equalTo("ERROR"))
         .body("httpStatusCode", equalTo(409))
         .body("httpStatus", equalTo("Conflict"))
+        .body("errorCode", equalTo("E7147"))
         .body("message", equalTo("Invalid period: INVALID_PERIOD"));
   }
 

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TrackedEntityQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TrackedEntityQueryTest.java
@@ -3258,6 +3258,25 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
         .body("message", equalTo("Specified program HpHINAT79UW does not exist"));
   }
 
+  @Test
+  public void testInvalidPeriod() {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder().add("headers=created").add("created=INVALID_PERIOD");
+
+    // When
+    ApiResponse response = analyticsTeiActions.query().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(409)
+        .body("status", equalTo("ERROR"))
+        .body("httpStatusCode", equalTo(409))
+        .body("httpStatus", equalTo("Conflict"))
+        .body("message", equalTo("Invalid period: INVALID_PERIOD"));
+  }
+
   private void testMetaCustomLabel(String header, String expected) {
     // Given
     QueryParamsBuilder params = new QueryParamsBuilder().add("headers=" + header).add("pageSize=0");


### PR DESCRIPTION
Before this PR, a request containing an invalid date could pass through and get processed anyway.
This PR changes this behavior, returning an error when an invalid date is passed.