### PR TITLE
fix: revert deprecated OAuth security config

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/LoginTests.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/LoginTests.java
@@ -40,7 +40,6 @@ import org.hisp.dhis.helpers.QueryParamsBuilder;
 import org.hisp.dhis.helpers.ResponseValidationHelper;
 import org.hisp.dhis.utils.DataGenerator;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -78,7 +77,6 @@ public class LoginTests extends ApiTest {
   }
 
   @Test
-  @Disabled
   public void shouldBeAbleToLoginWithOAuth2() {
 
     loginActions.addAuthenticationHeader(oauthClientId, secret);
@@ -109,7 +107,6 @@ public class LoginTests extends ApiTest {
   }
 
   @Test
-  @Disabled
   public void shouldBeAbleToGetRefreshToken() {
     loginActions.addAuthenticationHeader(oauthClientId, secret);
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/DhisWebApiWebSecurityConfig.java
@@ -42,6 +42,8 @@ import org.hisp.dhis.security.basic.HttpBasicWebAuthenticationDetailsSource;
 import org.hisp.dhis.security.jwt.Dhis2JwtAuthenticationManagerResolver;
 import org.hisp.dhis.security.jwt.DhisBearerJwtTokenAuthenticationEntryPoint;
 import org.hisp.dhis.security.ldap.authentication.CustomLdapAuthenticationProvider;
+import org.hisp.dhis.security.oauth2.DefaultClientDetailsService;
+import org.hisp.dhis.security.oauth2.OAuth2AuthorizationServerEnabledCondition;
 import org.hisp.dhis.security.oidc.DhisAuthorizationCodeTokenResponseClient;
 import org.hisp.dhis.security.oidc.DhisCustomAuthorizationRequestResolver;
 import org.hisp.dhis.security.oidc.DhisOidcLogoutSuccessHandler;
@@ -54,6 +56,7 @@ import org.hisp.dhis.webapi.controller.security.AuthenticationController;
 import org.hisp.dhis.webapi.filter.CorsFilter;
 import org.hisp.dhis.webapi.filter.CspFilter;
 import org.hisp.dhis.webapi.filter.CustomAuthenticationFilter;
+import org.hisp.dhis.webapi.oprovider.DhisOauthAuthenticationProvider;
 import org.hisp.dhis.webapi.security.ExternalAccessVoter;
 import org.hisp.dhis.webapi.security.FormLoginBasicAuthenticationEntryPoint;
 import org.hisp.dhis.webapi.security.apikey.ApiTokenAuthManager;
@@ -66,6 +69,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.access.AccessDecisionManager;
@@ -74,8 +78,11 @@ import org.springframework.security.access.vote.UnanimousBased;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
+import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.ObjectPostProcessor;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.authentication.configurers.userdetails.DaoAuthenticationConfigurer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer;
@@ -83,8 +90,27 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.security.core.session.SessionRegistryImpl;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.oauth2.config.annotation.configurers.ClientDetailsServiceConfigurer;
+import org.springframework.security.oauth2.config.annotation.web.configuration.AuthorizationServerConfigurer;
+import org.springframework.security.oauth2.config.annotation.web.configuration.AuthorizationServerEndpointsConfiguration;
+import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerEndpointsConfigurer;
+import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerSecurityConfigurer;
+import org.springframework.security.oauth2.provider.approval.DefaultUserApprovalHandler;
+import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationManager;
+import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationProcessingFilter;
+import org.springframework.security.oauth2.provider.code.JdbcAuthorizationCodeServices;
+import org.springframework.security.oauth2.provider.endpoint.FrameworkEndpointHandlerMapping;
+import org.springframework.security.oauth2.provider.error.OAuth2AccessDeniedHandler;
+import org.springframework.security.oauth2.provider.error.OAuth2AuthenticationEntryPoint;
+import org.springframework.security.oauth2.provider.expression.OAuth2WebSecurityExpressionHandler;
+import org.springframework.security.oauth2.provider.token.DefaultTokenServices;
+import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
+import org.springframework.security.oauth2.provider.token.TokenStore;
+import org.springframework.security.oauth2.provider.token.store.JdbcTokenStore;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationFilter;
 import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.DefaultSecurityFilterChain;
 import org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler;
 import org.springframework.security.web.access.expression.WebExpressionVoter;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -127,6 +153,126 @@ public class DhisWebApiWebSecurityConfig {
   @Bean
   public RequestCache requestCache() {
     return new HttpSessionRequestCache();
+  }
+
+  /**
+   * This configuration class is responsible for setting up the OAuth2 /token endpoint and
+   * /authorize endpoint. This config is a modification of the config that is automatically enabled
+   * by using the @EnableAuthorizationServer annotation. The spring-security-oauth2 project is
+   * deprecated, but as of August 19, 2020; there is still no other viable alternative available.
+   */
+  @Configuration
+  @Order(1001)
+  @Import({AuthorizationServerEndpointsConfiguration.class})
+  @Conditional(value = OAuth2AuthorizationServerEnabledCondition.class)
+  public class OAuth2SecurityConfig extends WebSecurityConfigurerAdapter
+      implements AuthorizationServerConfigurer {
+    @Autowired private TwoFactorAuthenticationProvider twoFactorAuthenticationProvider;
+
+    @Autowired
+    @Qualifier("customLdapAuthenticationProvider")
+    private CustomLdapAuthenticationProvider customLdapAuthenticationProvider;
+
+    @Autowired private AuthorizationServerEndpointsConfiguration endpoints;
+
+    @Autowired private DhisOauthAuthenticationProvider dhisOauthAuthenticationProvider;
+
+    @Autowired private DefaultAuthenticationEventPublisher authenticationEventPublisher;
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+      AuthorizationServerSecurityConfigurer configurer =
+          new AuthorizationServerSecurityConfigurer();
+      FrameworkEndpointHandlerMapping handlerMapping = endpoints.oauth2EndpointHandlerMapping();
+      http.setSharedObject(FrameworkEndpointHandlerMapping.class, handlerMapping);
+
+      endpoints.authorizationEndpoint().setUserApprovalPage("forward:/uaa/oauth/confirm_access");
+      endpoints.authorizationEndpoint().setErrorPage("forward:/uaa/oauth/error");
+
+      configure(configurer);
+      http.apply(configurer);
+
+      String tokenEndpointPath = handlerMapping.getServletPath("/oauth/token");
+
+      http.authorizeRequests()
+          .antMatchers(tokenEndpointPath)
+          .fullyAuthenticated()
+          .and()
+          .requestMatchers()
+          .antMatchers(tokenEndpointPath)
+          .and()
+          .sessionManagement()
+          .sessionCreationPolicy(SessionCreationPolicy.NEVER);
+
+      http.apply(new AuthorizationServerAuthenticationManagerConfigurer());
+
+      setHttpHeaders(http);
+    }
+
+    private class AuthorizationServerAuthenticationManagerConfigurer
+        extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+      @Override
+      @SuppressWarnings("unchecked")
+      public void init(HttpSecurity builder) {
+        // This is a quirk to remove the default
+        // DaoAuthenticationConfigurer,
+        // that gets automatically assigned in the
+        // AuthorizationServerSecurityConfigurer.
+        // We only want ONE authentication provider (our own...)
+        AuthenticationManagerBuilder authBuilder =
+            builder.getSharedObject(AuthenticationManagerBuilder.class);
+        authBuilder.removeConfigurer(DaoAuthenticationConfigurer.class);
+        authBuilder.authenticationProvider(dhisOauthAuthenticationProvider);
+      }
+    }
+
+    @Override
+    public void configure(AuthorizationServerSecurityConfigurer security) {
+      // Intentionally empty
+    }
+
+    @Override
+    public void configure(ClientDetailsServiceConfigurer configurer) {
+      // Intentionally empty
+    }
+
+    @Bean("authorizationCodeServices")
+    public JdbcAuthorizationCodeServices jdbcAuthorizationCodeServices() {
+      return new JdbcAuthorizationCodeServices(dataSource);
+    }
+
+    @Override
+    public void configure(final AuthorizationServerEndpointsConfigurer endpoints) {
+      ProviderManager providerManager =
+          new ProviderManager(
+              List.of(twoFactorAuthenticationProvider, customLdapAuthenticationProvider));
+
+      if (authenticationEventPublisher != null) {
+        providerManager.setAuthenticationEventPublisher(authenticationEventPublisher);
+      }
+
+      endpoints
+          .prefix("/uaa")
+          .userApprovalHandler(new DefaultUserApprovalHandler())
+          .authorizationCodeServices(jdbcAuthorizationCodeServices())
+          .tokenStore(tokenStore())
+          .authenticationManager(providerManager);
+    }
+  }
+
+  @Bean
+  public TokenStore tokenStore() {
+    return new JdbcTokenStore(dataSource);
+  }
+
+  @Bean("defaultTokenService")
+  @Primary
+  public DefaultTokenServices tokenServices() {
+    final DefaultTokenServices defaultTokenServices = new DefaultTokenServices();
+    defaultTokenServices.setTokenStore(tokenStore());
+    defaultTokenServices.setSupportRefreshToken(true);
+    defaultTokenServices.setRefreshTokenValiditySeconds(Integer.MAX_VALUE);
+    return defaultTokenServices;
   }
 
   /** This class is configuring the OIDC login endpoints */
@@ -194,6 +340,14 @@ public class DhisWebApiWebSecurityConfig {
     @Qualifier("customLdapAuthenticationProvider")
     private CustomLdapAuthenticationProvider customLdapAuthenticationProvider;
 
+    @Autowired
+    @Qualifier("defaultTokenService")
+    private ResourceServerTokenServices tokenServices;
+
+    @Autowired
+    @Qualifier("defaultClientDetailsService")
+    private DefaultClientDetailsService clientDetailsService;
+
     @Autowired private DefaultAuthenticationEventPublisher authenticationEventPublisher;
 
     @Autowired private Dhis2JwtAuthenticationManagerResolver dhis2JwtAuthenticationManagerResolver;
@@ -241,10 +395,29 @@ public class DhisWebApiWebSecurityConfig {
       return super.authenticationManagerBean();
     }
 
+    /**
+     * This AuthenticationManager is responsible for authorizing access, refresh and code OAuth2
+     * tokens from the /token and /authorize endpoints. It is used only by the
+     * OAuth2AuthenticationProcessingFilter.
+     */
+    private AuthenticationManager oauthAuthenticationManager() {
+      OAuth2AuthenticationManager oauthAuthenticationManager = new OAuth2AuthenticationManager();
+      oauthAuthenticationManager.setResourceId("oauth2-resource");
+      oauthAuthenticationManager.setTokenServices(tokenServices);
+      oauthAuthenticationManager.setClientDetailsService(clientDetailsService);
+
+      return oauthAuthenticationManager;
+    }
+
     public WebExpressionVoter apiWebExpressionVoter() {
       WebExpressionVoter voter = new WebExpressionVoter();
 
-      DefaultWebSecurityExpressionHandler handler = new DefaultWebSecurityExpressionHandler();
+      DefaultWebSecurityExpressionHandler handler;
+      if (dhisConfig.isEnabled(ConfigurationKey.ENABLE_OAUTH2_AUTHORIZATION_SERVER)) {
+        handler = new OAuth2WebSecurityExpressionHandler();
+      } else {
+        handler = new DefaultWebSecurityExpressionHandler();
+      }
       handler.setDefaultRolePrefix("");
 
       voter.setExpressionHandler(handler);
@@ -266,6 +439,11 @@ public class DhisWebApiWebSecurityConfig {
     private void configureAccessRestrictions(
         ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry
             authorize) {
+
+      if (dhisConfig.isEnabled(ConfigurationKey.ENABLE_OAUTH2_AUTHORIZATION_SERVER)) {
+        authorize.expressionHandler(new OAuth2WebSecurityExpressionHandler());
+      }
+
       authorize
           .antMatchers("/impersonate")
           .hasAnyAuthority("ALL", "F_IMPERSONATE_USER")
@@ -325,6 +503,7 @@ public class DhisWebApiWebSecurityConfig {
       http.requestCache().requestCache(requestCache);
 
       configureMatchers(http);
+      configureOAuthAuthorizationServer(http);
       configureCspFilter(http, dhisConfig, configurationService);
       configureCorsFilter(http);
       configureMobileAuthFilter(http);
@@ -387,6 +566,12 @@ public class DhisWebApiWebSecurityConfig {
       }
     }
 
+    private void configureOAuthAuthorizationServer(HttpSecurity http) throws Exception {
+      if (dhisConfig.isEnabled(ConfigurationKey.ENABLE_OAUTH2_AUTHORIZATION_SERVER)) {
+        http.exceptionHandling().accessDeniedHandler(new OAuth2AccessDeniedHandler());
+      }
+    }
+
     private void configureCspFilter(
         HttpSecurity http,
         DhisConfigurationProvider dhisConfig,
@@ -423,10 +608,30 @@ public class DhisWebApiWebSecurityConfig {
      * @param http HttpSecurity config
      */
     private void configureOAuthTokenFilters(HttpSecurity http) {
-      if (dhisConfig.isEnabled(ConfigurationKey.ENABLE_JWT_OIDC_TOKEN_AUTHENTICATION)) {
+      if (dhisConfig.isEnabled(ConfigurationKey.ENABLE_OAUTH2_AUTHORIZATION_SERVER)) {
+        http.addFilterAfter(getOAuthAuthorizationServerFilter(), BasicAuthenticationFilter.class);
+      } else if (dhisConfig.isEnabled(ConfigurationKey.ENABLE_JWT_OIDC_TOKEN_AUTHENTICATION)) {
         http.addFilterAfter(
             getJwtBearerTokenAuthenticationFilter(), BasicAuthenticationFilter.class);
       }
+    }
+
+    /**
+     * This is the "deprecated" OAuth2 authorization server. It is deprecated by Spring, but we
+     * still use it since there is no alternative yet. An experimental authorization server is in
+     * the makings, and will hopefully replace this in the future.
+     *
+     * @return OAuth2AuthenticationProcessingFilter to be added to filter chain
+     */
+    private OAuth2AuthenticationProcessingFilter getOAuthAuthorizationServerFilter() {
+      AuthenticationEntryPoint authenticationEntryPoint = new OAuth2AuthenticationEntryPoint();
+
+      OAuth2AuthenticationProcessingFilter filter = new OAuth2AuthenticationProcessingFilter();
+      filter.setAuthenticationEntryPoint(authenticationEntryPoint);
+      filter.setAuthenticationManager(oauthAuthenticationManager());
+      filter.setStateless(false);
+
+      return filter;
     }
 
     /**


### PR DESCRIPTION
## Summary
Regression in OAuth configuration is resulting in non functional deprecated OAuth functionality.

During reversion of the Struts removal and Spring 6 updated security config before 2.41 release, the deprecated OAuth functionality configuration was not properly reverted.   

JIRA: [DHIS2-17612](https://dhis2.atlassian.net/browse/DHIS2-17612)

[DHIS2-17612]: https://dhis2.atlassian.net/browse/DHIS2-17612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ