### PR TITLE
fix: runStage null to non-null or cancel via exception

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
@@ -238,6 +238,24 @@ public interface JobProgress {
   void startingStage(@Nonnull String description, int workItems, @Nonnull FailurePolicy onFailure)
       throws CancellationException;
 
+  /**
+   * Should be called after a {@link #runStage(Callable)} or {@link #runStage(Object, Callable)} or
+   * on of the other variants in case the returned value may be null but never should be null in
+   * order to be able to continue the process.
+   *
+   * @param value a value returned by a {@code runStage} method that might be null
+   * @return the same value but only if it is non-null
+   * @param <T> type of the checked value
+   * @throws CancellationException in case the value is null, this is similar to starting the
+   *     cancellation based exception that would occur by starting the next stage except that it
+   *     also has a message indicating that a failed post condition was the cause
+   */
+  @Nonnull
+  default <T> T nonNullStagePostCondition(@CheckForNull T value) throws CancellationException {
+    if (value == null) throw new CancellationException("Post-condition was null");
+    return value;
+  }
+
   default void startingStage(@Nonnull String description, int workItems) {
     startingStage(description, workItems, FailurePolicy.PARENT);
   }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/dataset/tasks/ImportCompleteDataSetRegistrationsJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/dataset/tasks/ImportCompleteDataSetRegistrationsJob.java
@@ -66,7 +66,8 @@ public class ImportCompleteDataSetRegistrationsJob implements Job {
 
     progress.startingStage("Loading file resource");
     FileResource data =
-        progress.runStage(() -> fileResourceService.getFileResource(jobConfig.getUid()));
+        progress.nonNullStagePostCondition(
+            progress.runStage(() -> fileResourceService.getFileResource(jobConfig.getUid())));
 
     progress.startingStage("Loading file content");
     try (InputStream input =

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/tasks/DataValueSetImportJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/tasks/DataValueSetImportJob.java
@@ -66,7 +66,8 @@ public class DataValueSetImportJob implements Job {
     ImportOptions options = (ImportOptions) jobId.getJobParameters();
     progress.startingStage("Loading file resource");
     FileResource data =
-        progress.runStage(() -> fileResourceService.getFileResource(jobId.getUid()));
+        progress.nonNullStagePostCondition(
+            progress.runStage(() -> fileResourceService.getFileResource(jobId.getUid())));
     progress.startingStage("Loading file content");
     try (InputStream input =
         progress.runStage(() -> fileResourceService.getFileResourceContent(data))) {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataImportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataImportService.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.dxf2.metadata.objectbundle.EventReportCompatibilityG
 import com.google.common.base.Enums;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -99,14 +100,17 @@ public class DefaultMetadataImportService implements MetadataImportService {
     handleDeprecationIfEventReport(bundleParams);
 
     progress.startingStage("Creating bundle");
-    ObjectBundle bundle = progress.runStage(() -> objectBundleService.create(bundleParams));
+    ObjectBundle bundle =
+        progress.nonNullStagePostCondition(
+            progress.runStage(() -> objectBundleService.create(bundleParams)));
 
     progress.startingStage("Running postCreateBundle");
     progress.runStage(() -> postCreateBundle(bundle, bundleParams));
 
     progress.startingStage("Validating bundle");
     ObjectBundleValidationReport validationReport =
-        progress.runStage(() -> objectBundleValidationService.validate(bundle));
+        progress.nonNullStagePostCondition(
+            progress.runStage(() -> objectBundleValidationService.validate(bundle)));
     ImportReport report = new ImportReport();
     report.setImportParams(params);
     report.setStatus(Status.OK);
@@ -241,7 +245,7 @@ public class DefaultMetadataImportService implements MetadataImportService {
 
     String value = String.valueOf(parameters.get(key).get(0));
 
-    return "true".equals(value.toLowerCase());
+    return "true".equalsIgnoreCase(value);
   }
 
   private <T extends Enum<T>> T getEnumWithDefault(
@@ -276,8 +280,8 @@ public class DefaultMetadataImportService implements MetadataImportService {
     object.setLastUpdatedBy(params.getUser());
   }
 
-  private void postCreateBundle(ObjectBundle bundle, ObjectBundleParams params) {
-    if (bundle.getUser() == null) {
+  private void postCreateBundle(@CheckForNull ObjectBundle bundle, ObjectBundleParams params) {
+    if (bundle == null || bundle.getUser() == null) {
       return;
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/DefaultTrackerImportService.java
@@ -83,17 +83,21 @@ public class DefaultTrackerImportService implements TrackerImportService {
 
     jobProgress.startingStage("Running PreHeat");
     TrackerBundle trackerBundle =
-        jobProgress.runStage(() -> trackerBundleService.create(params, trackerObjects, user));
+        jobProgress.nonNullStagePostCondition(
+            jobProgress.runStage(() -> trackerBundleService.create(params, trackerObjects, user)));
 
     jobProgress.startingStage("Calculating Payload Size");
     Map<TrackerType, Integer> bundleSize =
-        jobProgress.runStage(() -> calculatePayloadSize(trackerBundle));
+        jobProgress.nonNullStagePostCondition(
+            jobProgress.runStage(() -> calculatePayloadSize(trackerBundle)));
 
     jobProgress.startingStage("Running PreProcess");
     jobProgress.runStage(() -> trackerPreprocessService.preprocess(trackerBundle));
 
     jobProgress.startingStage("Running Validation");
-    ValidationResult validationResult = jobProgress.runStage(() -> validateBundle(trackerBundle));
+    ValidationResult validationResult =
+        jobProgress.nonNullStagePostCondition(
+            jobProgress.runStage(() -> validateBundle(trackerBundle)));
 
     ValidationReport validationReport = ValidationReport.fromResult(validationResult);
 
@@ -103,7 +107,8 @@ public class DefaultTrackerImportService implements TrackerImportService {
 
       jobProgress.startingStage("Running Rule Engine Validation");
       ValidationResult result =
-          jobProgress.runStage(() -> validationService.validateRuleEngine(trackerBundle));
+          jobProgress.nonNullStagePostCondition(
+              jobProgress.runStage(() -> validationService.validateRuleEngine(trackerBundle)));
       trackerBundle.setTrackedEntities(result.getTrackedEntities());
       trackerBundle.setEnrollments(result.getEnrollments());
       trackerBundle.setEvents(result.getEvents());
@@ -118,7 +123,9 @@ public class DefaultTrackerImportService implements TrackerImportService {
     }
 
     jobProgress.startingStage("Commit Transaction");
-    PersistenceReport persistenceReport = jobProgress.runStage(() -> commit(params, trackerBundle));
+    PersistenceReport persistenceReport =
+        jobProgress.nonNullStagePostCondition(
+            jobProgress.runStage(() -> commit(params, trackerBundle)));
 
     jobProgress.startingStage("PostCommit");
     jobProgress.runStage(() -> trackerBundleService.postCommit(trackerBundle));

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportJob.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportJob.java
@@ -82,7 +82,8 @@ public class MetadataImportJob implements Job {
     MetadataImportParams params = (MetadataImportParams) config.getJobParameters();
     progress.startingStage("Loading file resource");
     FileResource data =
-        progress.runStage(() -> fileResourceService.getExistingFileResource(config.getUid()));
+        progress.nonNullStagePostCondition(
+            progress.runStage(() -> fileResourceService.getExistingFileResource(config.getUid())));
     progress.startingStage("Loading file content");
     try (InputStream input =
         progress.runStage(() -> fileResourceService.getFileResourceContent(data))) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportJob.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportJob.java
@@ -69,7 +69,8 @@ public class TrackerImportJob implements Job {
     TrackerImportParams params = (TrackerImportParams) config.getJobParameters();
     progress.startingStage("Loading file resource");
     FileResource data =
-        progress.runStage(() -> fileResourceService.getExistingFileResource(config.getUid()));
+        progress.nonNullStagePostCondition(
+            progress.runStage(() -> fileResourceService.getExistingFileResource(config.getUid())));
     progress.startingStage("Loading file content");
     try (InputStream input =
         progress.runStage(() -> fileResourceService.getFileResourceContent(data))) {


### PR DESCRIPTION
### Summary
The `runStage` method that would run a `Callable` could return `null` either from that `Callable` or from the `errorValue` given.
This potential NPE was not handled in many places. Often enough it also wasn't an issue as the usage of the returned value was below the next `startingStage` which would fail if the `null` was due to an error so the code would never proceed to use the variable. 

With the `JobProgress` not having nullness annotations the nullness analysis would warn about potential NPEs from the return values of `runStage`. To transition the value into a known non-null while keeping the error behaviour of throwing a cancellation exception on next use of progress after a failed stage a new method was added to confirm post run assumptions:

The `nonNullStagePostCondition` method takes a potential null value and simply returns it when non-null or throws an exception when it is null. 

I checked the callers of the `runStage` method and added `nonNullStagePostCondition` where the nullness analysis indicated potential NPEs