### PR TITLE
fix: throws exception for invalid dates [DHIS2-17539] [2.41] (#17823)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProducer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DimensionalObjectProducer.java
@@ -58,6 +58,7 @@ import static org.hisp.dhis.common.IdentifiableProperty.UID;
 import static org.hisp.dhis.commons.collection.ListUtils.sort;
 import static org.hisp.dhis.feedback.ErrorCode.E7124;
 import static org.hisp.dhis.feedback.ErrorCode.E7143;
+import static org.hisp.dhis.feedback.ErrorCode.E7611;
 import static org.hisp.dhis.hibernate.HibernateProxyUtils.getRealClass;
 import static org.hisp.dhis.organisationunit.OrganisationUnit.KEY_LEVEL;
 import static org.hisp.dhis.organisationunit.OrganisationUnit.KEY_ORGUNIT_GROUP;
@@ -89,6 +90,7 @@ import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.DisplayProperty;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.dataelement.DataElementGroup;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.i18n.I18nFormat;
@@ -255,7 +257,9 @@ public class DimensionalObjectProducer {
       dimensionalKeywords.addKeyword(
           isoPeriodHolder.getIsoPeriod(), join(" - ", startDate, endDate));
       periods.add(periodToAdd);
+      return;
     }
+    throw new IllegalQueryException(E7611, isoPeriodHolder.getIsoPeriod());
   }
 
   /**

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TrackedEntityQueryTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/analytics/tei/TrackedEntityQueryTest.java
@@ -3238,6 +3238,48 @@ public class TrackedEntityQueryTest extends AnalyticsApiTest {
     metaCustomLabels.forEach(this::testMetaCustomLabel);
   }
 
+  @Test
+  public void testInvalidProgram() {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder()
+            .add("dimension=HpHINAT79UW.A03MvHHogjR.a3kGcGDCuk6:IN:2;5")
+            .add("headers=HpHINAT79UW.A03MvHHogjR.a3kGcGDCuk6")
+            .add("pageSize=1");
+
+    // When
+    ApiResponse response = analyticsTeiActions.query().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(400)
+        .body("status", equalTo("ERROR"))
+        .body("httpStatusCode", equalTo(400))
+        .body("httpStatus", equalTo("Bad Request"))
+        .body("message", equalTo("Specified program HpHINAT79UW does not exist"));
+  }
+
+  @Test
+  public void testInvalidPeriod() {
+    // Given
+    QueryParamsBuilder params =
+        new QueryParamsBuilder().add("headers=created").add("created=INVALID_PERIOD");
+
+    // When
+    ApiResponse response = analyticsTeiActions.query().get("nEenWmSyUEp", JSON, JSON, params);
+
+    // Then
+    response
+        .validate()
+        .statusCode(409)
+        .body("status", equalTo("ERROR"))
+        .body("httpStatusCode", equalTo(409))
+        .body("httpStatus", equalTo("Conflict"))
+        .body("errorCode", equalTo("E7611"))
+        .body("message", equalTo("Period not valid: `INVALID_PERIOD`"));
+  }
+
   private void testMetaCustomLabel(String header, String expected) {
     // Given
     QueryParamsBuilder params = new QueryParamsBuilder().add("headers=" + header).add("pageSize=0");


### PR DESCRIPTION
* fix: throws exception for invalid dates [DHIS2-17539]

* fix: throws exception for invalid dates [DHIS2-17539]

* fix: throws exception for invalid dates [DHIS2-17539]

(cherry picked from commit e1ef2a6b3e498d35400a6726c673cbb2c157a63b)

[DHIS2-17539]: https://dhis2.atlassian.net/browse/DHIS2-17539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-17539]: https://dhis2.atlassian.net/browse/DHIS2-17539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-17539]: https://dhis2.atlassian.net/browse/DHIS2-17539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ