### PR TITLE
fix: Deprecate old change log endpoints [DHIS2-16741]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChangeLogController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ChangeLogController.java
@@ -253,6 +253,10 @@ public class ChangeLogController {
     return rootNode;
   }
 
+  /**
+   * @deprecated use EventsExportController#getEventChangeLogsByUid instead
+   */
+  @Deprecated(forRemoval = true, since = "2.42")
   @GetMapping("trackedEntityDataValue")
   public RootNode getTrackedEntityDataValueChangeLog(
       @OpenApi.Param({UID[].class, DataElement.class}) @RequestParam(required = false)
@@ -335,6 +339,10 @@ public class ChangeLogController {
     return rootNode;
   }
 
+  /**
+   * @deprecated use TrackedEntitiesExportController#getTrackedEntityAttributeChangeLog instead
+   */
+  @Deprecated(forRemoval = true, since = "2.42")
   @GetMapping("trackedEntityAttributeValue")
   public RootNode getTrackedEntityAttributeValueChangeLog(
       @OpenApi.Param({UID[].class, TrackedEntityAttribute.class}) @RequestParam(required = false)


### PR DESCRIPTION
Following up on the work done in [change logs](https://github.com/dhis2/dhis2-core/pull/16628), we need to deprecate the old endpoints in favor of the new ones.