### PR TITLE
chore: remove dhis-api EventService.get(id) DHIS2-17677

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventService.java
@@ -67,14 +67,6 @@ public interface EventService {
   boolean eventExistsIncludingDeleted(String uid);
 
   /**
-   * Returns an {@link Event}.
-   *
-   * @param id the id of the Event to return.
-   * @return the Event with the given id.
-   */
-  Event getEvent(long id);
-
-  /**
    * Returns the {@link Event} with the given UID.
    *
    * @param uid the UID.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventService.java
@@ -97,12 +97,6 @@ public class DefaultEventService implements EventService {
 
   @Override
   @Transactional(readOnly = true)
-  public Event getEvent(long id) {
-    return eventStore.get(id);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
   public Event getEvent(String uid) {
     return eventStore.getByUid(uid);
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
@@ -48,6 +48,7 @@ import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.changelog.ChangeLogType;
 import org.hisp.dhis.common.DeliveryChannel;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.commons.util.RelationshipUtils;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
@@ -115,6 +116,8 @@ class MaintenanceServiceTest extends IntegrationTestBase {
   @Autowired private AuditService auditService;
 
   @Autowired private CategoryService categoryService;
+
+  @Autowired private IdentifiableObjectManager manager;
 
   private Date incidenDate;
 
@@ -235,7 +238,9 @@ class MaintenanceServiceTest extends IntegrationTestBase {
     assertNull(relationshipService.getRelationship(r.getId()));
     assertTrue(trackedEntityService.trackedEntityExistsIncludingDeleted(trackedEntity.getUid()));
     assertTrue(relationshipService.relationshipExistsIncludingDeleted(r.getUid()));
+
     maintenanceService.deleteSoftDeletedTrackedEntities();
+
     assertFalse(trackedEntityService.trackedEntityExistsIncludingDeleted(trackedEntity.getUid()));
     assertFalse(relationshipService.relationshipExistsIncludingDeleted(r.getUid()));
   }
@@ -261,7 +266,9 @@ class MaintenanceServiceTest extends IntegrationTestBase {
     enrollmentService.deleteEnrollment(enrollment);
     assertNull(enrollmentService.getEnrollment(idA));
     assertTrue(enrollmentService.enrollmentExistsIncludingDeleted(enrollment.getUid()));
+
     maintenanceService.deleteSoftDeletedEnrollments();
+
     assertFalse(enrollmentService.enrollmentExistsIncludingDeleted(enrollment.getUid()));
   }
 
@@ -281,11 +288,13 @@ class MaintenanceServiceTest extends IntegrationTestBase {
             .build();
     long idA = eventService.addEvent(event);
     programMessageService.saveProgramMessage(message);
-    assertNotNull(eventService.getEvent(idA));
+    assertNotNull(getEvent(idA));
     eventService.deleteEvent(event);
-    assertNull(eventService.getEvent(idA));
+    assertNull(getEvent(idA));
     assertTrue(eventService.eventExistsIncludingDeleted(event.getUid()));
+
     maintenanceService.deleteSoftDeletedEvents();
+
     assertFalse(eventService.eventExistsIncludingDeleted(event.getUid()));
   }
 
@@ -309,7 +318,9 @@ class MaintenanceServiceTest extends IntegrationTestBase {
     trackedEntityService.deleteTrackedEntity(trackedEntityB);
     assertNull(trackedEntityService.getTrackedEntity(idA));
     assertTrue(trackedEntityService.trackedEntityExistsIncludingDeleted(trackedEntityB.getUid()));
+
     maintenanceService.deleteSoftDeletedTrackedEntities();
+
     assertFalse(trackedEntityService.trackedEntityExistsIncludingDeleted(trackedEntityB.getUid()));
   }
 
@@ -332,7 +343,9 @@ class MaintenanceServiceTest extends IntegrationTestBase {
     enrollmentService.deleteEnrollment(enrollment);
     assertNull(enrollmentService.getEnrollment(idA));
     assertTrue(enrollmentService.enrollmentExistsIncludingDeleted(enrollment.getUid()));
+
     maintenanceService.deleteSoftDeletedEnrollments();
+
     assertFalse(enrollmentService.enrollmentExistsIncludingDeleted(enrollment.getUid()));
   }
 
@@ -361,14 +374,16 @@ class MaintenanceServiceTest extends IntegrationTestBase {
     r.setKey(RelationshipUtils.generateRelationshipKey(r));
     r.setInvertedKey(RelationshipUtils.generateRelationshipInvertedKey(r));
     relationshipService.addRelationship(r);
-    assertNotNull(eventService.getEvent(idA));
+    assertNotNull(getEvent(idA));
     assertNotNull(relationshipService.getRelationship(r.getId()));
     eventService.deleteEvent(eventA);
-    assertNull(eventService.getEvent(idA));
+    assertNull(getEvent(idA));
     assertNull(relationshipService.getRelationship(r.getId()));
     assertTrue(eventService.eventExistsIncludingDeleted(eventA.getUid()));
     assertTrue(relationshipService.relationshipExistsIncludingDeleted(r.getUid()));
+
     maintenanceService.deleteSoftDeletedEvents();
+
     assertFalse(eventService.eventExistsIncludingDeleted(eventA.getUid()));
     assertFalse(relationshipService.relationshipExistsIncludingDeleted(r.getUid()));
   }
@@ -399,7 +414,9 @@ class MaintenanceServiceTest extends IntegrationTestBase {
     assertNull(relationshipService.getRelationship(r.getId()));
     assertTrue(enrollmentService.enrollmentExistsIncludingDeleted(enrollment.getUid()));
     assertTrue(relationshipService.relationshipExistsIncludingDeleted(r.getUid()));
+
     maintenanceService.deleteSoftDeletedEnrollments();
+
     assertFalse(enrollmentService.enrollmentExistsIncludingDeleted(enrollment.getUid()));
     assertFalse(relationshipService.relationshipExistsIncludingDeleted(r.getUid()));
   }
@@ -448,5 +465,9 @@ class MaintenanceServiceTest extends IntegrationTestBase {
 
     maintenanceService.deleteSoftDeletedRelationships();
     assertNull(relationshipService.getRelationshipIncludeDeleted(relationship.getUid()));
+  }
+
+  private Event getEvent(long id) {
+    return manager.get(Event.class, id);
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
@@ -40,6 +40,7 @@ import java.util.Set;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.note.Note;
 import org.hisp.dhis.note.NoteService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -75,6 +76,8 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
   @Autowired private NoteService noteService;
 
   @Autowired private CategoryService categoryService;
+
+  @Autowired private IdentifiableObjectManager manager;
 
   private Date incidentDate;
 
@@ -202,10 +205,12 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
     enrollmentA.setEvents(Sets.newHashSet(eventA));
     enrollmentService.updateEnrollment(enrollmentA);
     assertNotNull(enrollmentService.getEnrollment(idA));
-    assertNotNull(eventService.getEvent(eventIdA));
+    assertNotNull(manager.get(Event.class, eventIdA));
+
     enrollmentService.deleteEnrollment(enrollmentA);
+
     assertNull(enrollmentService.getEnrollment(idA));
-    assertNull(eventService.getEvent(eventIdA));
+    assertNull(manager.get(Event.class, eventIdA));
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventServiceTest.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.TestCache;
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
@@ -83,6 +84,8 @@ class EventServiceTest extends TransactionalIntegrationTest {
   @Autowired private TrackedEntityAttributeValueService attributeValueService;
 
   @Autowired private NoteService noteService;
+
+  @Autowired private IdentifiableObjectManager manager;
 
   private OrganisationUnit organisationUnitA;
 
@@ -251,38 +254,38 @@ class EventServiceTest extends TransactionalIntegrationTest {
   void testAddEvent() {
     long idA = eventService.addEvent(eventA);
     long idB = eventService.addEvent(eventB);
-    assertNotNull(eventService.getEvent(idA));
-    assertNotNull(eventService.getEvent(idB));
+    assertNotNull(getEvent(idA));
+    assertNotNull(getEvent(idB));
   }
 
   @Test
   void testDeleteEvent() {
     long idA = eventService.addEvent(eventA);
     long idB = eventService.addEvent(eventB);
-    assertNotNull(eventService.getEvent(idA));
-    assertNotNull(eventService.getEvent(idB));
+    assertNotNull(getEvent(idA));
+    assertNotNull(getEvent(idB));
     eventService.deleteEvent(eventA);
-    assertNull(eventService.getEvent(idA));
-    assertNotNull(eventService.getEvent(idB));
+    assertNull(getEvent(idA));
+    assertNotNull(getEvent(idB));
     eventService.deleteEvent(eventB);
-    assertNull(eventService.getEvent(idA));
-    assertNull(eventService.getEvent(idB));
+    assertNull(getEvent(idA));
+    assertNull(getEvent(idB));
   }
 
   @Test
   void testGetEventById() {
     long idA = eventService.addEvent(eventA);
     long idB = eventService.addEvent(eventB);
-    assertEquals(eventA, eventService.getEvent(idA));
-    assertEquals(eventB, eventService.getEvent(idB));
+    assertEquals(eventA, getEvent(idA));
+    assertEquals(eventB, getEvent(idB));
   }
 
   @Test
   void testGetEventByUid() {
     long idA = eventService.addEvent(eventA);
     long idB = eventService.addEvent(eventB);
-    assertEquals(eventA, eventService.getEvent(idA));
-    assertEquals(eventB, eventService.getEvent(idB));
+    assertEquals(eventA, getEvent(idA));
+    assertEquals(eventB, getEvent(idB));
     assertEquals(eventA, eventService.getEvent("UID-A"));
     assertEquals(eventB, eventService.getEvent("UID-B"));
   }
@@ -309,5 +312,9 @@ class EventServiceTest extends TransactionalIntegrationTest {
 
     assertNull(eventService.getEvent(event.getUid()));
     assertTrue(noteService.noteExists(note.getUid()));
+  }
+
+  private Event getEvent(long id) {
+    return manager.get(Event.class, id);
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityServiceTest.java
@@ -35,6 +35,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.SortDirection;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -80,6 +81,8 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
   @Autowired private TrackedEntityTypeService trackedEntityTypeService;
 
   @Autowired private TrackedEntityAttributeService trackedEntityAttributeService;
+
+  @Autowired private IdentifiableObjectManager manager;
 
   private Event event;
 
@@ -204,14 +207,14 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     trackedEntityService.updateTrackedEntity(trackedEntityA1);
     TrackedEntity trackedEntityA = trackedEntityService.getTrackedEntity(idA);
     Enrollment psA = enrollmentService.getEnrollment(psIdA);
-    Event eventA = eventService.getEvent(eventIdA);
+    Event eventA = manager.get(Event.class, eventIdA);
     assertNotNull(trackedEntityA);
     assertNotNull(psA);
     assertNotNull(eventA);
     trackedEntityService.deleteTrackedEntity(trackedEntityA1);
     assertNull(trackedEntityService.getTrackedEntity(trackedEntityA.getUid()));
     assertNull(enrollmentService.getEnrollment(psIdA));
-    assertNull(eventService.getEvent(eventIdA));
+    assertNull(manager.get(Event.class, eventIdA));
   }
 
   @Test


### PR DESCRIPTION
## Big picture

Tracker has multiple services for each entity like tracked entity, enrollment and event. One is in dhis-api and one in dhis-service-tracker. Our goal is to provide one API (service) per entity that is part of the tracker domain/team.

Trackers architecture splits read/write into exporter services and an importer. So if you want to get data you use an exporter. If you want to insert, update or delete you have to go through the importer. Only then can we ensure integrity of tracker data.

Another goal is that code that provides tracker functionality and is thus owned by the tracker team lives in ideally one maven module (We can settle on a name later on maybe `dhis-service-tracker` or `dhis-tracker`).

This is a **big** task that we are going to implement in many small steps.

## This PR

Finding an event by an internal DB id is only used in tests. We do not
want to expose it in our tracker exporter services. We therefore remove it from the dhis-api service.