### PR TITLE
fix: add name for default ehcache

### DIFF
--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
@@ -42,6 +42,8 @@ import javax.sql.DataSource;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ArrayUtils;
 import org.hibernate.SessionFactory;
+import org.hibernate.cache.ehcache.ConfigSettings;
+import org.hibernate.cache.ehcache.MissingCacheStrategy;
 import org.hibernate.cache.ehcache.internal.EhcacheRegionFactory;
 import org.hibernate.cfg.AvailableSettings;
 import org.hisp.dhis.cache.DefaultHibernateCacheManager;
@@ -153,6 +155,7 @@ public class HibernateConfig {
       properties.put(AvailableSettings.USE_SECOND_LEVEL_CACHE, "true");
       properties.put(AvailableSettings.CACHE_REGION_FACTORY, EhcacheRegionFactory.class.getName());
       properties.put(AvailableSettings.USE_QUERY_CACHE, dhisConfig.getProperty(USE_QUERY_CACHE));
+      properties.put(ConfigSettings.MISSING_CACHE_STRATEGY, MissingCacheStrategy.CREATE);
     }
 
     // TODO: this is anti-pattern and should be turn off

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/ehcache.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ehcache>
 
-  <!-- Default cache -->
-  
+<!-- Default cache -->
   <!-- 
     Ensure that default cache has less frequent expiration than query cache
     to avoid individual select queries per entity.
@@ -13,12 +12,12 @@
     eternal="false" 
     timeToIdleSeconds="21600" 
     timeToLiveSeconds="21600"
-    overflowToDisk="false" 
+    overflowToDisk="false"
     diskPersistent="false" />
 
   <!-- Hibernate query cache -->
 
-  <cache name="org.hibernate.cache.internal.StandardQueryCache"
+  <cache name="default-query-results-region"
     maxElementsInMemory="1000000" 
     eternal="false" 
     timeToIdleSeconds="21600" 
@@ -26,6 +25,7 @@
     overflowToDisk="false" 
     diskPersistent="false" />
 
-  <cache name="org.hibernate.cache.spi.UpdateTimestampsCache" 
+  <cache name="default-update-timestamps-region" 
     maxElementsInMemory="5000" />
+
 </ehcache>


### PR DESCRIPTION
- This is to fix hibernate warnings like below

```
core-web-1      | WARN  org.hibernate.orm.cache [main] HHH90001007: Using legacy cache name [org.hibernate.cache.spi.UpdateTimestampsCache] because configuration could not be found for cache [default-update-timestamps-region]. Update your configuration to rename cache [org.hibernate.cache.spi.UpdateTimestampsCache] to [default-update-timestamps-region].
core-web-1      | WARN  org.hibernate.orm.cache [main] HHH90001007: Using legacy cache name [org.hibernate.cache.internal.StandardQueryCache] because configuration could not be found for cache [default-query-results-region]. Update your configuration to rename cache [org.hibernate.cache.internal.StandardQueryCache] to [default-query-results-region].
core-web-1      | WARN  org.hibernate.orm.cache [main] HHH90001006: Missing cache[org.hisp.dhis.version.Version] was created on-the-fly. The created cache will use a provider-specific default configuration: make sure you defined one. You can disable this warning by setting 'hibernate.cache.ehcache.missing_cache_strategy' to 'create'.
```
### Test
- This change only affects hibernate second level cache function which is covered in `HibernateQueryCacheTest`.