### PR TITLE
chore: remove dhis-api EventService.createEvent DHIS2-17677

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventService.java
@@ -27,11 +27,9 @@
  */
 package org.hisp.dhis.program;
 
-import java.util.Date;
 import java.util.Map;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
 
 /**
  * @author Abyot Asalefew
@@ -81,23 +79,6 @@ public interface EventService {
    * @return the number of events.
    */
   long getEventCount(int days);
-
-  /**
-   * Creates and saves an event.
-   *
-   * @param enrollment the Enrollment.
-   * @param programStage the ProgramStage.
-   * @param enrollmentDate the enrollment date.
-   * @param incidentDate date of the incident.
-   * @param organisationUnit the OrganisationUnit where the event took place.
-   * @return Event the Event which was created.
-   */
-  Event createEvent(
-      Enrollment enrollment,
-      ProgramStage programStage,
-      Date enrollmentDate,
-      Date incidentDate,
-      OrganisationUnit organisationUnit);
 
   /**
    * Validates EventDataValues, handles files for File EventDataValues and creates audit logs for

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -1653,10 +1653,12 @@ public abstract class DhisConvenienceTest {
       ProgramStage programStage, Enrollment enrollment, OrganisationUnit organisationUnit) {
     Event event = new Event();
     event.setAutoFields();
-
     event.setProgramStage(programStage);
     event.setEnrollment(enrollment);
     event.setOrganisationUnit(organisationUnit);
+    if (categoryService != null) {
+      event.setAttributeOptionCombo(categoryService.getDefaultCategoryOptionCombo());
+    }
     return event;
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/EventPredictionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/EventPredictionServiceTest.java
@@ -64,7 +64,6 @@ import org.hisp.dhis.program.AnalyticsType;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramIndicatorService;
@@ -109,8 +108,6 @@ class EventPredictionServiceTest extends IntegrationTestBase {
   @Autowired private ProgramStageService programStageService;
 
   @Autowired private ProgramIndicatorService programIndicatorService;
-
-  @Autowired private EventService eventService;
 
   @Autowired private OrganisationUnitService organisationUnitService;
 
@@ -260,13 +257,13 @@ class EventPredictionServiceTest extends IntegrationTestBase {
         enrollmentService.enrollTrackedEntity(
             trackedEntity, program, dateMar20, dateMar20, orgUnitA);
     enrollmentService.addEnrollment(enrollment);
-    Event stageInstanceA = createEvent(stageA, enrollment, orgUnitA);
-    stageInstanceA.setOccurredDate(dateMar20);
-    manager.save(stageInstanceA);
-    Event stageInstanceB = createEvent(stageA, enrollment, orgUnitA);
-    stageInstanceB.setOccurredDate(dateApr10);
-    stageInstanceB.setAttributeOptionCombo(defaultCombo);
-    manager.save(stageInstanceB);
+    Event eventA = createEvent(stageA, enrollment, orgUnitA);
+    eventA.setOccurredDate(dateMar20);
+    manager.save(eventA);
+    Event eventB = createEvent(stageA, enrollment, orgUnitA);
+    eventB.setOccurredDate(dateApr10);
+    eventB.setAttributeOptionCombo(defaultCombo);
+    manager.save(eventB);
     categoryManager.addAndPruneAllOptionCombos();
     Expression expressionA = new Expression(EXPRESSION_A, "ProgramTrackedEntityAttribute");
     Expression expressionD = new Expression(EXPRESSION_D, "ProgramDataElement");

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/EventPredictionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/EventPredictionServiceTest.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementDomain;
@@ -124,6 +125,8 @@ class EventPredictionServiceTest extends IntegrationTestBase {
   @Autowired private CategoryManager categoryManager;
 
   @Autowired private UserService _userService;
+
+  @Autowired private IdentifiableObjectManager manager;
 
   private CategoryOptionCombo defaultCombo;
 
@@ -257,16 +260,13 @@ class EventPredictionServiceTest extends IntegrationTestBase {
         enrollmentService.enrollTrackedEntity(
             trackedEntity, program, dateMar20, dateMar20, orgUnitA);
     enrollmentService.addEnrollment(enrollment);
-    Event stageInstanceA =
-        eventService.createEvent(enrollment, stageA, dateMar20, dateMar20, orgUnitA);
-    Event stageInstanceB =
-        eventService.createEvent(enrollment, stageA, dateApr10, dateApr10, orgUnitA);
+    Event stageInstanceA = createEvent(stageA, enrollment, orgUnitA);
     stageInstanceA.setOccurredDate(dateMar20);
+    manager.save(stageInstanceA);
+    Event stageInstanceB = createEvent(stageA, enrollment, orgUnitA);
     stageInstanceB.setOccurredDate(dateApr10);
-    stageInstanceA.setAttributeOptionCombo(defaultCombo);
     stageInstanceB.setAttributeOptionCombo(defaultCombo);
-    eventService.addEvent(stageInstanceA);
-    eventService.addEvent(stageInstanceB);
+    manager.save(stageInstanceB);
     categoryManager.addAndPruneAllOptionCombos();
     Expression expressionA = new Expression(EXPRESSION_A, "ProgramTrackedEntityAttribute");
     Expression expressionD = new Expression(EXPRESSION_D, "ProgramDataElement");

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceTest.java
@@ -46,6 +46,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.constant.ConstantService;
@@ -92,11 +93,11 @@ class ProgramIndicatorServiceTest extends TransactionalIntegrationTest {
 
   @Autowired private TrackedEntityAttributeValueService attributeValueService;
 
-  @Autowired private EventService eventService;
-
   @Autowired private ConstantService constantService;
 
-  private Date incidentDate;
+  @Autowired private IdentifiableObjectManager manager;
+
+  private Date occurredDate;
 
   private Date enrollmentDate;
 
@@ -236,16 +237,16 @@ class ProgramIndicatorServiceTest extends TransactionalIntegrationTest {
     // ---------------------------------------------------------------------
     TrackedEntity trackedEntity = createTrackedEntity(organisationUnit);
     trackedEntityService.addTrackedEntity(trackedEntity);
-    incidentDate = DateUtils.toMediumDate("2014-10-22");
+    occurredDate = DateUtils.toMediumDate("2014-10-22");
     enrollmentDate = DateUtils.toMediumDate("2014-12-31");
     enrollment =
         enrollmentService.enrollTrackedEntity(
-            trackedEntity, programA, enrollmentDate, incidentDate, organisationUnit);
-    incidentDate = DateUtils.toMediumDate("2014-10-22");
+            trackedEntity, programA, enrollmentDate, occurredDate, organisationUnit);
+    occurredDate = DateUtils.toMediumDate("2014-10-22");
     enrollmentDate = DateUtils.toMediumDate("2014-12-31");
     enrollment =
         enrollmentService.enrollTrackedEntity(
-            trackedEntity, programA, enrollmentDate, incidentDate, organisationUnit);
+            trackedEntity, programA, enrollmentDate, occurredDate, organisationUnit);
     // TODO enroll twice?
     // ---------------------------------------------------------------------
     // TrackedEntityAttribute
@@ -265,13 +266,13 @@ class ProgramIndicatorServiceTest extends TransactionalIntegrationTest {
     // ---------------------------------------------------------------------
     // TrackedEntityDataValue
     // ---------------------------------------------------------------------
-    Event eventA =
-        eventService.createEvent(enrollment, psA, enrollmentDate, incidentDate, organisationUnit);
-    Event eventB =
-        eventService.createEvent(enrollment, psB, enrollmentDate, incidentDate, organisationUnit);
+    Event eventA = createEvent(psA, enrollment, organisationUnit);
+    eventA.setOccurredDate(occurredDate);
+    manager.save(eventA);
+    Event eventB = createEvent(psB, enrollment, organisationUnit);
+    eventB.setOccurredDate(occurredDate);
+    manager.save(eventB);
     Set<Event> events = new HashSet<>();
-    events.add(eventA);
-    events.add(eventB);
     enrollment.setEvents(events);
     enrollment.setProgram(programA);
     // ---------------------------------------------------------------------

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -60,7 +60,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramType;
@@ -88,13 +87,9 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
 
   @Autowired private EnrollmentService apiEnrollmentService;
 
-  @Autowired private EventService eventService;
-
   @Autowired private IdentifiableObjectManager manager;
 
-  private Date incidentDate = new Date();
-
-  private Date enrollmentDate = new Date();
+  private final Date incidentDate = new Date();
 
   private User admin;
 
@@ -259,9 +254,9 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
     enrollmentA =
         apiEnrollmentService.enrollTrackedEntity(
             trackedEntityA, programA, new Date(), new Date(), orgUnitA);
-    eventA =
-        eventService.createEvent(
-            enrollmentA, programStageA, enrollmentDate, incidentDate, orgUnitA);
+    eventA = createEvent(programStageA, enrollmentA, orgUnitA);
+    eventA.setOccurredDate(incidentDate);
+    manager.save(eventA);
     enrollmentA.setEvents(Set.of(eventA));
     enrollmentA.setRelationshipItems(Set.of(from, to));
     manager.save(enrollmentA, false);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipServiceTest.java
@@ -166,15 +166,15 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase {
     enrollmentA =
         enrollmentService.enrollTrackedEntity(
             teA, program, enrollmentDate, enrollmentDate, orgUnitA);
-    eventA =
-        eventService.createEvent(
-            enrollmentA, programStage, enrollmentDate, enrollmentDate, orgUnitA);
+    eventA = createEvent(programStage, enrollmentA, orgUnitA);
+    eventA.setOccurredDate(enrollmentDate);
+    manager.save(eventA);
 
     Enrollment enrollmentB =
         enrollmentService.enrollTrackedEntity(teB, program, new Date(), new Date(), orgUnitA);
-    inaccessibleEvent =
-        eventService.createEvent(
-            enrollmentB, inaccessibleProgramStage, enrollmentDate, enrollmentDate, orgUnitA);
+    inaccessibleEvent = createEvent(inaccessibleProgramStage, enrollmentB, orgUnitA);
+    inaccessibleEvent.setOccurredDate(enrollmentDate);
+    manager.save(inaccessibleEvent);
 
     teToTeType
         .getFromConstraint()

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/AnalyticsValidationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/AnalyticsValidationServiceTest.java
@@ -56,6 +56,7 @@ import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataanalysis.ValidationRuleExpressionDetails;
 import org.hisp.dhis.dataelement.DataElement;
@@ -73,7 +74,6 @@ import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramIndicatorService;
@@ -113,8 +113,6 @@ class AnalyticsValidationServiceTest extends TransactionalIntegrationTest {
 
   @Autowired private ProgramIndicatorService programIndicatorService;
 
-  @Autowired private EventService eventService;
-
   @Autowired private OrganisationUnitService organisationUnitService;
 
   @Autowired private PeriodService periodService;
@@ -134,6 +132,8 @@ class AnalyticsValidationServiceTest extends TransactionalIntegrationTest {
   @Autowired private DataValidationRunner runner;
 
   @Autowired private UserService _userService;
+
+  @Autowired private IdentifiableObjectManager manager;
 
   private CategoryOptionCombo defaultCombo;
 
@@ -228,16 +228,12 @@ class AnalyticsValidationServiceTest extends TransactionalIntegrationTest {
         enrollmentService.enrollTrackedEntity(
             trackedEntity, program, dateMar20, dateMar20, orgUnitA);
     enrollmentService.addEnrollment(enrollment);
-    Event stageInstanceA =
-        eventService.createEvent(enrollment, stageA, dateMar20, dateMar20, orgUnitA);
-    Event stageInstanceB =
-        eventService.createEvent(enrollment, stageA, dateApr10, dateApr10, orgUnitA);
-    stageInstanceA.setOccurredDate(dateMar20);
-    stageInstanceB.setOccurredDate(dateApr10);
-    stageInstanceA.setAttributeOptionCombo(defaultCombo);
-    stageInstanceB.setAttributeOptionCombo(defaultCombo);
-    eventService.addEvent(stageInstanceA);
-    eventService.addEvent(stageInstanceB);
+    Event eventA = createEvent(stageA, enrollment, orgUnitA);
+    eventA.setOccurredDate(dateMar20);
+    manager.save(eventA);
+    Event eventB = createEvent(stageA, enrollment, orgUnitA);
+    eventB.setOccurredDate(dateApr10);
+    manager.save(eventB);
     categoryManager.addAndPruneAllOptionCombos();
     Expression expressionA = new Expression(EXPRESSION_A, "ProgramTrackedEntityAttribute");
     Expression expressionD = new Expression(EXPRESSION_D, "ProgramDataElement");


### PR DESCRIPTION
follow up after https://github.com/dhis2/dhis2-core/pull/17873

## Big picture

Tracker has multiple services for each entity like tracked entity, enrollment and event. One is in dhis-api and one in dhis-service-tracker. Our goal is to provide one API (service) per entity that is part of the tracker domain/team.

Trackers architecture splits read/write into exporter services and an importer. So if you want to get data you use an exporter. If you want to insert, update or delete you have to go through the importer. Only then can we ensure integrity of tracker data.

Another goal is that code that provides tracker functionality and is thus owned by the tracker team lives in ideally one maven module (We can settle on a name later on maybe `dhis-service-tracker` or `dhis-tracker`).

This is a **big** task that we are going to implement in many small steps.

## This PR

`EventService.createEvent` was only used in tests and thus belongs in a test helper. `DhisConvenienceTest` base class already has a `createEvent` that fulfilled most of what the tests relied on.

The

`programStage.getGeneratedByEnrollmentDate()`

was always `false` so the param `enrollmentDate` was never used.

Set the default category option combo in the `DhisConvenienceTest`. Store
the event via the `IdentifiableObjectManager` as we do for many other test
fixtures created via the `DhisConvenienceTest` methods.
