### PR TITLE
chore: remove dhis-api EventService.addEvent DHIS2-17677

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventService.java
@@ -37,14 +37,6 @@ import org.hisp.dhis.eventdatavalue.EventDataValue;
 public interface EventService {
   String ID = EventService.class.getName();
 
-  /**
-   * Adds an {@link Event}
-   *
-   * @param event The Event to add.
-   * @return A generated unique id of the added {@link Event}.
-   */
-  long addEvent(Event event);
-
   /** Soft deletes an {@link Event}. */
   void deleteEvent(Event event);
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventService.java
@@ -69,20 +69,6 @@ public class DefaultEventService implements EventService {
 
   @Override
   @Transactional
-  public long addEvent(Event event) {
-    event.setAutoFields();
-
-    if (!event.hasAttributeOptionCombo()) {
-      CategoryOptionCombo aoc = categoryService.getDefaultCategoryOptionCombo();
-      event.setAttributeOptionCombo(aoc);
-    }
-
-    eventStore.save(event);
-    return event.getId();
-  }
-
-  @Override
-  @Transactional
   public void deleteEvent(Event event) {
     eventStore.delete(event);
   }
@@ -121,7 +107,13 @@ public class DefaultEventService implements EventService {
     validateEventDataValues(dataElementEventDataValueMap);
     Set<EventDataValue> eventDataValues = new HashSet<>(dataElementEventDataValueMap.values());
     event.setEventDataValues(eventDataValues);
-    addEvent(event);
+
+    event.setAutoFields();
+    if (!event.hasAttributeOptionCombo()) {
+      CategoryOptionCombo aoc = categoryService.getDefaultCategoryOptionCombo();
+      event.setAttributeOptionCombo(aoc);
+    }
+    eventStore.save(event);
 
     for (Map.Entry<DataElement, EventDataValue> entry : dataElementEventDataValueMap.entrySet()) {
       entry.getValue().setAutoFields();
@@ -129,14 +121,6 @@ public class DefaultEventService implements EventService {
       handleFileDataValueSave(entry.getValue(), entry.getKey());
     }
   }
-
-  // -------------------------------------------------------------------------
-  // Supportive methods
-  // -------------------------------------------------------------------------
-
-  // -------------------------------------------------------------------------
-  // Validation
-  // -------------------------------------------------------------------------
 
   private String validateEventDataValue(DataElement dataElement, EventDataValue eventDataValue) {
 
@@ -173,10 +157,6 @@ public class DefaultEventService implements EventService {
     }
   }
 
-  // -------------------------------------------------------------------------
-  // Audit
-  // -------------------------------------------------------------------------
-
   private void createAndAddAudit(
       EventDataValue dataValue, DataElement dataElement, Event event, ChangeLogType changeLogType) {
     if (!config.isEnabled(CHANGELOG_TRACKER) || dataElement == null) {
@@ -194,10 +174,6 @@ public class DefaultEventService implements EventService {
 
     dataValueAuditService.addTrackedEntityDataValueChangeLog(dataValueAudit);
   }
-
-  // -------------------------------------------------------------------------
-  // File data values
-  // -------------------------------------------------------------------------
 
   /** Update FileResource with 'assigned' status. */
   private void handleFileDataValueSave(EventDataValue dataValue, DataElement dataElement) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
@@ -119,7 +119,7 @@ class MaintenanceServiceTest extends IntegrationTestBase {
 
   @Autowired private IdentifiableObjectManager manager;
 
-  private Date incidenDate;
+  private Date occurredDate;
 
   private Date enrollmentDate;
 
@@ -181,15 +181,15 @@ class MaintenanceServiceTest extends IntegrationTestBase {
     DateTime testDate1 = DateTime.now();
     testDate1.withTimeAtStartOfDay();
     testDate1 = testDate1.minusDays(70);
-    incidenDate = testDate1.toDate();
+    occurredDate = testDate1.toDate();
     DateTime testDate2 = DateTime.now();
     testDate2.withTimeAtStartOfDay();
     enrollmentDate = testDate2.toDate();
-    enrollment = new Enrollment(enrollmentDate, incidenDate, trackedEntity, program);
+    enrollment = new Enrollment(enrollmentDate, occurredDate, trackedEntity, program);
     enrollment.setUid("UID-A");
     enrollment.setOrganisationUnit(organisationUnit);
     enrollmentWithTeAssociation =
-        new Enrollment(enrollmentDate, incidenDate, trackedEntityWithAssociations, program);
+        new Enrollment(enrollmentDate, occurredDate, trackedEntityWithAssociations, program);
     enrollmentWithTeAssociation.setUid("UID-B");
     enrollmentWithTeAssociation.setOrganisationUnit(organisationUnit);
     trackedEntityService.addTrackedEntity(trackedEntityWithAssociations);
@@ -207,7 +207,7 @@ class MaintenanceServiceTest extends IntegrationTestBase {
     eventWithTeAssociation.setEnrollment(enrollmentWithTeAssociation);
     eventWithTeAssociation.setOccurredDate(new Date());
     eventWithTeAssociation.setAttributeOptionCombo(coA);
-    eventService.addEvent(eventWithTeAssociation);
+    manager.save(eventWithTeAssociation);
     relationshipType = createPersonToPersonRelationshipType('A', program, trackedEntityType, false);
     relationshipTypeService.addRelationshipType(relationshipType);
   }
@@ -286,7 +286,8 @@ class MaintenanceServiceTest extends IntegrationTestBase {
             .deliveryChannels(Sets.newHashSet(DeliveryChannel.EMAIL))
             .event(event)
             .build();
-    long idA = eventService.addEvent(event);
+    manager.save(event);
+    long idA = event.getId();
     programMessageService.saveProgramMessage(message);
     assertNotNull(getEvent(idA));
     eventService.deleteEvent(event);
@@ -332,7 +333,7 @@ class MaintenanceServiceTest extends IntegrationTestBase {
     eventA.setScheduledDate(enrollmentDate);
     eventA.setUid("UID-A");
     eventA.setAttributeOptionCombo(coA);
-    eventService.addEvent(eventA);
+    manager.save(eventA);
     TrackedEntityDataValueChangeLog trackedEntityDataValueChangeLog =
         new TrackedEntityDataValueChangeLog(
             dataElement, eventA, "value", "modifiedBy", false, ChangeLogType.UPDATE);
@@ -362,7 +363,8 @@ class MaintenanceServiceTest extends IntegrationTestBase {
     eventA.setScheduledDate(enrollmentDate);
     eventA.setUid("UID-A");
     eventA.setAttributeOptionCombo(coA);
-    long idA = eventService.addEvent(eventA);
+    manager.save(eventA);
+    long idA = eventA.getId();
     Relationship r = new Relationship();
     RelationshipItem rItem1 = new RelationshipItem();
     rItem1.setEvent(eventA);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/merge/orgunit/handler/TrackerOrgUnitMergeHandlerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/merge/orgunit/handler/TrackerOrgUnitMergeHandlerTest.java
@@ -32,13 +32,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.google.common.collect.Sets;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.merge.orgunit.OrgUnitMergeRequest;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
@@ -54,11 +54,11 @@ class TrackerOrgUnitMergeHandlerTest extends SingleSetupIntegrationTestBase {
 
   @Autowired private TrackedEntityService trackedEntityService;
 
-  @Autowired private EnrollmentService piService;
+  @Autowired private EnrollmentService enrollmentService;
 
-  @Autowired private EventService eventService;
+  @Autowired private CategoryService categoryService;
 
-  @Autowired private IdentifiableObjectManager idObjectManager;
+  @Autowired private IdentifiableObjectManager manager;
 
   @Autowired private TrackerOrgUnitMergeHandler mergeHandler;
 
@@ -95,15 +95,15 @@ class TrackerOrgUnitMergeHandlerTest extends SingleSetupIntegrationTestBase {
   @Override
   public void setUpTest() {
     prA = createProgram('A', Sets.newHashSet(), ouA);
-    idObjectManager.save(prA);
+    manager.save(prA);
     psA = createProgramStage('A', prA);
-    idObjectManager.save(psA);
+    manager.save(psA);
     ouA = createOrganisationUnit('A');
     ouB = createOrganisationUnit('B');
     ouC = createOrganisationUnit('C');
-    idObjectManager.save(ouA);
-    idObjectManager.save(ouB);
-    idObjectManager.save(ouC);
+    manager.save(ouA);
+    manager.save(ouB);
+    manager.save(ouC);
     trackedEntityA = createTrackedEntity('A', ouA);
     trackedEntityB = createTrackedEntity('B', ouB);
     trackedEntityC = createTrackedEntity('C', ouC);
@@ -113,15 +113,15 @@ class TrackerOrgUnitMergeHandlerTest extends SingleSetupIntegrationTestBase {
     enrollmentA = createEnrollment(prA, trackedEntityA, ouA);
     enrollmentB = createEnrollment(prA, trackedEntityB, ouB);
     enrollmentC = createEnrollment(prA, trackedEntityC, ouA);
-    piService.addEnrollment(enrollmentA);
-    piService.addEnrollment(enrollmentB);
-    piService.addEnrollment(enrollmentC);
-    eventA = new Event(enrollmentA, psA, ouA);
-    eventB = new Event(enrollmentB, psA, ouB);
-    eventC = new Event(enrollmentC, psA, ouA);
-    eventService.addEvent(eventA);
-    eventService.addEvent(eventB);
-    eventService.addEvent(eventC);
+    enrollmentService.addEnrollment(enrollmentA);
+    enrollmentService.addEnrollment(enrollmentB);
+    enrollmentService.addEnrollment(enrollmentC);
+    eventA = createEvent(psA, enrollmentA, ouA);
+    eventB = createEvent(psA, enrollmentB, ouB);
+    eventC = createEvent(psA, enrollmentC, ouA);
+    manager.save(eventA);
+    manager.save(eventB);
+    manager.save(eventC);
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/notification/ProgramNotificationMessageRendererTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/notification/ProgramNotificationMessageRendererTest.java
@@ -35,8 +35,10 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import org.hisp.dhis.analytics.AggregationType;
+import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DeliveryChannel;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementDomain;
@@ -47,7 +49,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
@@ -143,8 +144,6 @@ class ProgramNotificationMessageRendererTest extends TransactionalIntegrationTes
 
   @Autowired private EnrollmentService enrollmentService;
 
-  @Autowired private EventService eventService;
-
   @Autowired private ProgramNotificationTemplateStore programNotificationTemplateStore;
 
   @Autowired private OrganisationUnitService organisationUnitService;
@@ -153,6 +152,10 @@ class ProgramNotificationMessageRendererTest extends TransactionalIntegrationTes
 
   @Autowired
   private ProgramStageNotificationMessageRenderer programStageNotificationMessageRenderer;
+
+  @Autowired private CategoryService categoryService;
+
+  @Autowired private IdentifiableObjectManager manager;
 
   @Override
   protected void setUpTest() throws Exception {
@@ -218,8 +221,7 @@ class ProgramNotificationMessageRendererTest extends TransactionalIntegrationTes
     enrollmentA.setUid(enrollmentUid);
     enrollmentService.updateEnrollment(enrollmentA);
     // Event to be provided in message renderer
-    eventA = new Event(enrollmentA, programStageA);
-    eventA.setOrganisationUnit(organisationUnitA);
+    eventA = createEvent(programStageA, enrollmentA, organisationUnitA);
     eventA.setScheduledDate(enrollmentDate);
     eventA.setOccurredDate(new Date());
     eventA.setUid("PSI-UID");
@@ -232,7 +234,7 @@ class ProgramNotificationMessageRendererTest extends TransactionalIntegrationTes
     eventDataValueB.setAutoFields();
     eventDataValueB.setValue("dataElementB-Text");
     eventA.setEventDataValues(Sets.newHashSet(eventDataValueA, eventDataValueB));
-    eventService.addEvent(eventA);
+    manager.save(eventA);
     enrollmentA.getEvents().add(eventA);
     enrollmentService.updateEnrollment(enrollmentA);
     programNotificationTemplate = new ProgramNotificationTemplate();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
@@ -69,8 +69,6 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
 
   @Autowired private ProgramStageService programStageService;
 
-  @Autowired private EventService eventService;
-
   @Autowired protected UserService _userService;
 
   @Autowired private NoteService noteService;
@@ -201,7 +199,8 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
   @Test
   void testSoftDeleteEnrollmentAndLinkedEvent() {
     long idA = enrollmentService.addEnrollment(enrollmentA);
-    long eventIdA = eventService.addEvent(eventA);
+    manager.save(eventA);
+    long eventIdA = eventA.getId();
     enrollmentA.setEvents(Sets.newHashSet(eventA));
     enrollmentService.updateEnrollment(enrollmentA);
     assertNotNull(enrollmentService.getEnrollment(idA));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventServiceTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.TestCache;
+import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
@@ -86,6 +87,8 @@ class EventServiceTest extends TransactionalIntegrationTest {
   @Autowired private NoteService noteService;
 
   @Autowired private IdentifiableObjectManager manager;
+
+  @Autowired private CategoryService categoryService;
 
   private OrganisationUnit organisationUnitA;
 
@@ -221,25 +224,25 @@ class EventServiceTest extends TransactionalIntegrationTest {
     enrollmentService.addEnrollment(enrollmentA);
     enrollmentB = new Enrollment(enrollmentDate, incidenDate, trackedEntityB, programB);
     enrollmentService.addEnrollment(enrollmentB);
-    eventA = new Event(enrollmentA, stageA);
+    eventA = createEvent(stageA, enrollmentA, organisationUnitA);
     eventA.setScheduledDate(enrollmentDate);
     eventA.setUid("UID-A");
-    eventB = new Event(enrollmentA, stageB);
+    eventB = createEvent(stageB, enrollmentA, organisationUnitA);
     eventB.setScheduledDate(enrollmentDate);
     eventB.setUid("UID-B");
-    eventC = new Event(enrollmentB, stageC);
+    eventC = createEvent(stageC, enrollmentB, organisationUnitB);
     eventC.setScheduledDate(enrollmentDate);
     eventC.setUid("UID-C");
-    eventD1 = new Event(enrollmentB, stageD);
+    eventD1 = createEvent(stageD, enrollmentB, organisationUnitB);
     eventD1.setScheduledDate(enrollmentDate);
     eventD1.setUid("UID-D1");
-    eventD2 = new Event(enrollmentB, stageD);
+    eventD2 = createEvent(stageD, enrollmentB, organisationUnitB);
     eventD2.setScheduledDate(enrollmentDate);
     eventD2.setUid("UID-D2");
     /*
      * Prepare data for EventDataValues manipulation tests
      */
-    eventService.addEvent(eventA);
+    manager.save(eventA);
     // Check that there are no EventDataValues assigned to PSI
     Event tempPsiA = eventService.getEvent(eventA.getUid());
     assertEquals(0, tempPsiA.getEventDataValues().size());
@@ -252,16 +255,20 @@ class EventServiceTest extends TransactionalIntegrationTest {
 
   @Test
   void testAddEvent() {
-    long idA = eventService.addEvent(eventA);
-    long idB = eventService.addEvent(eventB);
+    manager.save(eventA);
+    long idA = eventA.getId();
+    manager.save(eventB);
+    long idB = eventB.getId();
     assertNotNull(getEvent(idA));
     assertNotNull(getEvent(idB));
   }
 
   @Test
   void testDeleteEvent() {
-    long idA = eventService.addEvent(eventA);
-    long idB = eventService.addEvent(eventB);
+    manager.save(eventA);
+    long idA = eventA.getId();
+    manager.save(eventB);
+    long idB = eventB.getId();
     assertNotNull(getEvent(idA));
     assertNotNull(getEvent(idB));
     eventService.deleteEvent(eventA);
@@ -274,16 +281,20 @@ class EventServiceTest extends TransactionalIntegrationTest {
 
   @Test
   void testGetEventById() {
-    long idA = eventService.addEvent(eventA);
-    long idB = eventService.addEvent(eventB);
+    manager.save(eventA);
+    long idA = eventA.getId();
+    manager.save(eventB);
+    long idB = eventB.getId();
     assertEquals(eventA, getEvent(idA));
     assertEquals(eventB, getEvent(idB));
   }
 
   @Test
   void testGetEventByUid() {
-    long idA = eventService.addEvent(eventA);
-    long idB = eventService.addEvent(eventB);
+    manager.save(eventA);
+    long idA = eventA.getId();
+    manager.save(eventB);
+    long idB = eventB.getId();
     assertEquals(eventA, getEvent(idA));
     assertEquals(eventB, getEvent(idB));
     assertEquals(eventA, eventService.getEvent("UID-A"));
@@ -292,8 +303,7 @@ class EventServiceTest extends TransactionalIntegrationTest {
 
   @Test
   void shouldNoteDeleteNoteWhenDeletingEvent() {
-
-    Event event = new Event(enrollmentA, stageA);
+    Event event = createEvent(stageA, enrollmentA, organisationUnitA);
     event.setScheduledDate(enrollmentDate);
     event.setUid(CodeGenerator.generateUid());
 
@@ -304,7 +314,7 @@ class EventServiceTest extends TransactionalIntegrationTest {
 
     event.setNotes(List.of(note));
 
-    eventService.addEvent(event);
+    manager.save(event);
 
     assertNotNull(eventService.getEvent(event.getUid()));
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramMessageStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramMessageStoreTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.program;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -36,8 +37,10 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DeliveryChannel;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.message.ProgramMessage;
@@ -69,23 +72,15 @@ class ProgramMessageStoreTest extends TransactionalIntegrationTest {
 
   @Autowired private ProgramStageService programStageService;
 
-  @Autowired private EventService eventService;
+  @Autowired private IdentifiableObjectManager manager;
 
-  private OrganisationUnit ouA;
-
-  private OrganisationUnit ouB;
-
-  private Program programA;
+  @Autowired private CategoryService categoryService;
 
   private Enrollment enrollmentA;
 
-  private TrackedEntity trackedEntityA;
+  private final ProgramMessageStatus messageStatus = ProgramMessageStatus.SENT;
 
-  private TrackedEntity trackedEntityB;
-
-  private ProgramMessageStatus messageStatus = ProgramMessageStatus.SENT;
-
-  private Set<DeliveryChannel> channels = new HashSet<>();
+  private final Set<DeliveryChannel> channels = new HashSet<>();
 
   private ProgramMessageQueryParams params;
 
@@ -97,38 +92,15 @@ class ProgramMessageStoreTest extends TransactionalIntegrationTest {
 
   private ProgramMessage pmsgC;
 
-  private ProgramMessageRecipients recipientsA;
+  private final String notificationTemplate = CodeGenerator.generateUid();
 
-  private ProgramMessageRecipients recipientsB;
-
-  private ProgramMessageRecipients recipientsC;
-
-  private String uidA;
-
-  private String uidB;
-
-  private String uidC;
-
-  private String text = "Hi";
-
-  private String msisdn = "4740332255";
-
-  private String notificationTemplate = CodeGenerator.generateUid();
-
-  private Date incidentDate;
-
-  private Date enrollmentDate;
-
-  // -------------------------------------------------------------------------
-  // Prerequisite
-  // -------------------------------------------------------------------------
   @Override
   public void setUpTest() {
-    ouA = createOrganisationUnit('A');
-    ouB = createOrganisationUnit('B');
-    orgUnitService.addOrganisationUnit(ouA);
-    orgUnitService.addOrganisationUnit(ouB);
-    programA = createProgram('A', new HashSet<>(), ouA);
+    OrganisationUnit orgUnitA = createOrganisationUnit('A');
+    OrganisationUnit orgUnitB = createOrganisationUnit('B');
+    orgUnitService.addOrganisationUnit(orgUnitA);
+    orgUnitService.addOrganisationUnit(orgUnitB);
+    Program programA = createProgram('A', new HashSet<>(), orgUnitA);
     programService.addProgram(programA);
     ProgramStage stageA = new ProgramStage("StageA", programA);
     stageA.setSortOrder(1);
@@ -137,37 +109,35 @@ class ProgramMessageStoreTest extends TransactionalIntegrationTest {
     programStages.add(stageA);
     programA.setProgramStages(programStages);
     programService.updateProgram(programA);
-    trackedEntityB = createTrackedEntity(ouA);
+    TrackedEntity trackedEntityB = createTrackedEntity(orgUnitA);
     trackedEntityService.addTrackedEntity(trackedEntityB);
     DateTime testDate1 = DateTime.now();
     testDate1.withTimeAtStartOfDay();
     testDate1 = testDate1.minusDays(70);
-    incidentDate = testDate1.toDate();
+    Date incidentDate = testDate1.toDate();
     DateTime testDate2 = DateTime.now();
     testDate2.withTimeAtStartOfDay();
-    enrollmentDate = testDate2.toDate();
+    Date enrollmentDate = testDate2.toDate();
     enrollmentA = new Enrollment(enrollmentDate, incidentDate, trackedEntityB, programA);
     enrollmentA.setUid("UID-A");
-    eventA = new Event(enrollmentA, stageA);
+    eventA = createEvent(stageA, enrollmentA, orgUnitA);
     eventA.setScheduledDate(enrollmentDate);
     eventA.setUid("UID-A");
-    Set<OrganisationUnit> ouSet = new HashSet<>();
-    ouSet.add(ouA);
-    Set<String> ouUids = new HashSet<>();
-    ouUids.add(ouA.getUid());
-    // ouSet.add( ouB );
-    trackedEntityA = createTrackedEntity(ouA);
+    Set<String> orgUnits = new HashSet<>();
+    orgUnits.add(orgUnitA.getUid());
+    TrackedEntity trackedEntityA = createTrackedEntity(orgUnitA);
     trackedEntityService.addTrackedEntity(trackedEntityA);
-    recipientsA = new ProgramMessageRecipients();
-    recipientsA.setOrganisationUnit(ouA);
+    ProgramMessageRecipients recipientsA = new ProgramMessageRecipients();
+    recipientsA.setOrganisationUnit(orgUnitA);
     recipientsA.setTrackedEntity(trackedEntityA);
-    recipientsB = new ProgramMessageRecipients();
-    recipientsB.setOrganisationUnit(ouA);
+    ProgramMessageRecipients recipientsB = new ProgramMessageRecipients();
+    recipientsB.setOrganisationUnit(orgUnitA);
     recipientsB.setTrackedEntity(trackedEntityA);
-    recipientsC = new ProgramMessageRecipients();
-    recipientsC.setOrganisationUnit(ouA);
+    ProgramMessageRecipients recipientsC = new ProgramMessageRecipients();
+    recipientsC.setOrganisationUnit(orgUnitA);
     recipientsC.setTrackedEntity(trackedEntityA);
     Set<String> phoneNumberListA = new HashSet<>();
+    String msisdn = "4740332255";
     phoneNumberListA.add(msisdn);
     recipientsA.setPhoneNumbers(phoneNumberListA);
     Set<String> phoneNumberListB = new HashSet<>();
@@ -177,6 +147,7 @@ class ProgramMessageStoreTest extends TransactionalIntegrationTest {
     phoneNumberListC.add(msisdn);
     recipientsC.setPhoneNumbers(phoneNumberListC);
     channels.add(DeliveryChannel.SMS);
+    String text = "Hi";
     pmsgA =
         ProgramMessage.builder()
             .subject(text)
@@ -204,19 +175,16 @@ class ProgramMessageStoreTest extends TransactionalIntegrationTest {
             .deliveryChannels(channels)
             .notificationTemplate(notificationTemplate)
             .build();
-    uidA = CodeGenerator.generateCode(10);
-    uidB = CodeGenerator.generateCode(10);
-    uidC = CodeGenerator.generateCode(10);
+    String uidA = CodeGenerator.generateCode(10);
+    String uidB = CodeGenerator.generateCode(10);
+    String uidC = CodeGenerator.generateCode(10);
     pmsgA.setUid(uidA);
     pmsgB.setUid(uidB);
     pmsgC.setUid(uidC);
     params = new ProgramMessageQueryParams();
-    params.setOrganisationUnit(ouUids);
+    params.setOrganisationUnit(orgUnits);
   }
 
-  // -------------------------------------------------------------------------
-  // Tests
-  // -------------------------------------------------------------------------
   @Test
   void testGetProgramMessage() {
     programMessageStore.save(pmsgA);
@@ -224,7 +192,7 @@ class ProgramMessageStoreTest extends TransactionalIntegrationTest {
     ProgramMessage actual = programMessageStore.get(id.intValue());
     assertNotNull(id);
     assertNotNull(actual);
-    assertTrue(actual.equals(pmsgA));
+    assertEquals(actual, pmsgA);
   }
 
   @Test
@@ -264,14 +232,14 @@ class ProgramMessageStoreTest extends TransactionalIntegrationTest {
     List<ProgramMessage> programMessages = programMessageStore.getProgramMessages(params);
     assertNotNull(programMessages);
     assertTrue(equals(programMessages, pmsgA, pmsgB));
-    assertTrue(channels.equals(programMessages.get(0).getDeliveryChannels()));
-    assertTrue(enrollmentA.equals(programMessages.get(0).getEnrollment()));
+    assertEquals(channels, programMessages.get(0).getDeliveryChannels());
+    assertEquals(enrollmentA, programMessages.get(0).getEnrollment());
   }
 
   @Test
   void testGetProgramMessageByEvent() {
     enrollmentStore.save(enrollmentA);
-    eventService.addEvent(eventA);
+    manager.save(eventA);
     pmsgA.setEvent(eventA);
     pmsgB.setEvent(eventA);
     programMessageStore.save(pmsgA);
@@ -280,8 +248,8 @@ class ProgramMessageStoreTest extends TransactionalIntegrationTest {
     List<ProgramMessage> programMessages = programMessageStore.getProgramMessages(params);
     assertNotNull(programMessages);
     assertTrue(equals(programMessages, pmsgA, pmsgB));
-    assertTrue(channels.equals(programMessages.get(0).getDeliveryChannels()));
-    assertTrue(eventA.equals(programMessages.get(0).getEvent()));
+    assertEquals(channels, programMessages.get(0).getDeliveryChannels());
+    assertEquals(eventA, programMessages.get(0).getEvent());
   }
 
   @Test
@@ -292,8 +260,8 @@ class ProgramMessageStoreTest extends TransactionalIntegrationTest {
     List<ProgramMessage> programMessages = programMessageStore.getProgramMessages(params);
     assertNotNull(programMessages);
     assertTrue(equals(programMessages, pmsgA, pmsgB));
-    assertTrue(channels.equals(programMessages.get(0).getDeliveryChannels()));
-    assertTrue(messageStatus.equals(programMessages.get(0).getMessageStatus()));
+    assertEquals(channels, programMessages.get(0).getDeliveryChannels());
+    assertEquals(messageStatus, programMessages.get(0).getMessageStatus());
   }
 
   @Test
@@ -308,7 +276,7 @@ class ProgramMessageStoreTest extends TransactionalIntegrationTest {
     List<ProgramMessage> programMessages = programMessageStore.getProgramMessages(params);
     assertNotNull(programMessages);
     assertTrue(equals(programMessages, pmsgA, pmsgB));
-    assertTrue(channels.equals(programMessages.get(0).getDeliveryChannels()));
-    assertTrue(enrollmentA.equals(programMessages.get(0).getEnrollment()));
+    assertEquals(channels, programMessages.get(0).getDeliveryChannels());
+    assertEquals(enrollmentA, programMessages.get(0).getEnrollment());
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/relationship/hibernate/RelationshipStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/relationship/hibernate/RelationshipStoreTest.java
@@ -37,6 +37,8 @@ import java.util.Optional;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeService;
 import org.hisp.dhis.attribute.AttributeValue;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.commons.util.RelationshipUtils;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -45,7 +47,6 @@ import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
@@ -70,8 +71,6 @@ class RelationshipStoreTest extends TransactionalIntegrationTest {
 
   @Autowired private OrganisationUnitService organisationUnitService;
 
-  @Autowired private EventService eventService;
-
   @Autowired private ProgramService programService;
 
   @Autowired private EnrollmentService enrollmentService;
@@ -80,9 +79,11 @@ class RelationshipStoreTest extends TransactionalIntegrationTest {
 
   @Autowired private AttributeService attributeService;
 
-  private TrackedEntity trackedEntityA;
+  @Autowired private IdentifiableObjectManager manager;
 
-  private TrackedEntity trackedEntityB;
+  @Autowired private CategoryService categoryService;
+
+  private TrackedEntity trackedEntityA;
 
   private RelationshipType relationshipType;
 
@@ -115,7 +116,8 @@ class RelationshipStoreTest extends TransactionalIntegrationTest {
 
     ProgramStage programStageA = addProgramStage(programA);
 
-    Event event = addEvent(enrollment, programStageA);
+    Event event = createEvent(programStageA, enrollment, organisationUnit);
+    manager.save(event);
 
     trackedEntityA = createTrackedEntity(organisationUnit);
     trackedEntityService.addTrackedEntity(trackedEntityA);
@@ -188,7 +190,7 @@ class RelationshipStoreTest extends TransactionalIntegrationTest {
 
   private Relationship addTeToTeRelationship() {
     trackedEntityA = createTrackedEntity(organisationUnit);
-    trackedEntityB = createTrackedEntity(organisationUnit);
+    TrackedEntity trackedEntityB = createTrackedEntity(organisationUnit);
 
     trackedEntityService.addTrackedEntity(trackedEntityA);
     trackedEntityService.addTrackedEntity(trackedEntityB);
@@ -243,17 +245,6 @@ class RelationshipStoreTest extends TransactionalIntegrationTest {
 
     relationshipService.addRelationship(relationshipA);
     return relationshipA;
-  }
-
-  private Event addEvent(Enrollment enrollment, ProgramStage programStageA) {
-    Event event = new Event();
-    event.setOrganisationUnit(organisationUnit);
-    event.setProgramStage(programStageA);
-    event.setEnrollment(enrollment);
-    event.setAutoFields();
-
-    eventService.addEvent(event);
-    return event;
   }
 
   private ProgramStage addProgramStage(Program programA) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityDataValueChangeLogStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityDataValueChangeLogStoreTest.java
@@ -38,6 +38,7 @@ import org.hisp.dhis.audit.UserInfoTestHelper;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.changelog.ChangeLogType;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
@@ -47,7 +48,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
@@ -81,9 +81,9 @@ class TrackedEntityDataValueChangeLogStoreTest extends SingleSetupIntegrationTes
 
   @Autowired private EnrollmentService enrollmentService;
 
-  @Autowired private EventService eventService;
-
   @Autowired private CategoryService categoryService;
+
+  @Autowired private IdentifiableObjectManager manager;
 
   private CategoryOptionCombo coc;
 
@@ -175,11 +175,11 @@ class TrackedEntityDataValueChangeLogStoreTest extends SingleSetupIntegrationTes
     eventC = createEvent(enrollmentA, psA, ouC, Set.of(dvA, dvB));
     eventD = createEvent(enrollmentA, psB, ouD, Set.of(dvC, dvD));
     eventE = createEvent(enrollmentA, psA, ouE, Set.of(dvA, dvE));
-    eventService.addEvent(eventA);
-    eventService.addEvent(eventB);
-    eventService.addEvent(eventC);
-    eventService.addEvent(eventD);
-    eventService.addEvent(eventE);
+    manager.save(eventA);
+    manager.save(eventB);
+    manager.save(eventC);
+    manager.save(eventD);
+    manager.save(eventE);
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramMessageControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramMessageControllerTest.java
@@ -82,7 +82,7 @@ class ProgramMessageControllerTest extends DhisControllerConvenienceTest {
     enrollmentA = createEnrollment(prA, trackedEntityA, ouA);
     enrollmentService.addEnrollment(enrollmentA);
     eventA = createEvent(psA, enrollmentA, ouA);
-    eventService.addEvent(eventA);
+    manager.save(eventA);
   }
 
   @Test

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceControllerTest.java
@@ -102,7 +102,7 @@ class ProgramNotificationInstanceControllerTest extends DhisControllerConvenienc
     programNotificationInstanceService.save(enrollmentNotification2);
 
     event = createEvent(psA, enrollment, ouA);
-    eventService.addEvent(event);
+    manager.save(event);
     eventNotification = new ProgramNotificationInstance();
     eventNotification.setName("event A notification");
     eventNotification.setEvent(event);


### PR DESCRIPTION
Follow up to https://github.com/dhis2/dhis2-core/pull/17916

## Big picture

Tracker has multiple services for each entity like tracked entity, enrollment and event. One is in dhis-api and one in dhis-service-tracker. Our goal is to provide one API (service) per entity that is part of the tracker domain/team.

Trackers architecture splits read/write into exporter services and an importer. So if you want to get data you use an exporter. If you want to insert, update or delete you have to go through the importer. Only then can we ensure integrity of tracker data.

Another goal is that code that provides tracker functionality and is thus owned by the tracker team lives in ideally one maven module (We can settle on a name later on maybe `dhis-service-tracker` or `dhis-tracker`).

This is a **big** task that we are going to implement in many small steps.

## This PR

`EventService.addEvent` was only used in the EventService itself (inlined) and tests. `DhisConvenienceTest` base class already has a `createEvent` that fulfilled most of what the tests relied on.

Store the event via the `IdentifiableObjectManager` as we do for many other test
fixtures.