### PR TITLE
fix: Validate no datavalues for some event statuses [DHIS2-17658]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/tracker/imports/validation/ValidationCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/tracker/imports/validation/ValidationCode.java
@@ -157,6 +157,7 @@ public enum ValidationCode {
   E1312("Referral events need to have both sides of a relationship."),
   E1313(
       "Event {0} of an enrollment does not point to an existing tracked entity. The data in your system might be corrupted"),
+  E1315("Status`{0}` does not allow to define data values."),
   E1316("No event can transition from status `{0}` to status `{1}.`"),
 
   /* Relationship */

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/ValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/ValidationUtils.java
@@ -120,8 +120,7 @@ public class ValidationUtils {
   }
 
   public static boolean needsToValidateDataValues(Event event, ProgramStage programStage) {
-    if (event.getStatus().equals(EventStatus.SCHEDULE)
-        || event.getStatus().equals(EventStatus.SKIPPED)) {
+    if (EventStatus.STATUSES_WITHOUT_DATA_VALUES.contains(event.getStatus())) {
       return false;
     } else if (programStage.getValidationStrategy().equals(ValidationStrategy.ON_COMPLETE)
         && event.getStatus().equals(EventStatus.COMPLETED)) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidator.java
@@ -42,6 +42,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
@@ -80,8 +81,18 @@ class DataValuesValidator implements Validator<Event> {
       validateDataValue(reporter, bundle, dataElement, dataValue, programStage, event);
     }
 
+    if (EventStatus.STATUSES_WITHOUT_DATA_VALUES.contains(event.getStatus())) {
+      validateNoDataValuesArePresent(reporter, event);
+    }
+
     validateMandatoryDataValues(reporter, bundle, event);
     validateDataValueDataElementIsConnectedToProgramStage(reporter, bundle, event, programStage);
+  }
+
+  private void validateNoDataValuesArePresent(Reporter reporter, Event event) {
+    if (!event.getDataValues().isEmpty()) {
+      reporter.addError(event, ValidationCode.E1315, event.getStatus());
+    }
   }
 
   private void validateMandatoryDataValues(Reporter reporter, TrackerBundle bundle, Event event) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidatorTest.java
@@ -106,7 +106,7 @@ class DataValuesValidatorTest {
     Event event =
         Event.builder()
             .programStage(idSchemes.toMetadataIdentifier(programStage))
-            .status(EventStatus.SKIPPED)
+            .status(EventStatus.ACTIVE)
             .dataValues(Set.of(dataValue()))
             .build();
 
@@ -129,7 +129,7 @@ class DataValuesValidatorTest {
     Event event =
         Event.builder()
             .programStage(idSchemes.toMetadataIdentifier(programStage))
-            .status(EventStatus.SKIPPED)
+            .status(EventStatus.ACTIVE)
             .dataValues(Set.of(validDataValue))
             .build();
 
@@ -152,7 +152,7 @@ class DataValuesValidatorTest {
     Event event =
         Event.builder()
             .programStage(idSchemes.toMetadataIdentifier(programStage))
-            .status(EventStatus.SKIPPED)
+            .status(EventStatus.ACTIVE)
             .dataValues(Set.of(validDataValue))
             .build();
 
@@ -558,7 +558,7 @@ class DataValuesValidatorTest {
   }
 
   @Test
-  void succeedsOnScheduledEventWithDataElementValueIsNullAndEventStatusSkippedOrScheduled() {
+  void shouldFailWhenScheduledEventHasDataValueDefined() {
     DataElement validDataElement = dataElement();
     when(preheat.getDataElement(MetadataIdentifier.ofUid(dataElementUid)))
         .thenReturn(validDataElement);
@@ -568,9 +568,10 @@ class DataValuesValidatorTest {
         .thenReturn(programStage);
 
     DataValue validDataValue = dataValue();
-    validDataValue.setValue(null);
+    validDataValue.setValue("1");
     Event event =
         Event.builder()
+            .event(CodeGenerator.generateUid())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.SCHEDULE)
             .dataValues(Set.of(validDataValue))
@@ -578,11 +579,11 @@ class DataValuesValidatorTest {
 
     validator.validate(reporter, bundle, event);
 
-    assertIsEmpty(reporter.getErrors());
+    assertHasError(reporter, event, ValidationCode.E1315);
   }
 
   @Test
-  void succeedsOnSkippedEventWithDataElementValueIsNullAndEventStatusSkippedOrScheduled() {
+  void shouldFailValidationWhenSkippedEventHasDataValueDefined() {
     DataElement validDataElement = dataElement();
     when(preheat.getDataElement(MetadataIdentifier.ofUid(dataElementUid)))
         .thenReturn(validDataElement);
@@ -592,9 +593,10 @@ class DataValuesValidatorTest {
         .thenReturn(programStage);
 
     DataValue validDataValue = dataValue();
-    validDataValue.setValue(null);
+    validDataValue.setValue("1");
     Event event =
         Event.builder()
+            .event(CodeGenerator.generateUid())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
             .status(EventStatus.SKIPPED)
             .dataValues(Set.of(validDataValue))
@@ -602,7 +604,32 @@ class DataValuesValidatorTest {
 
     validator.validate(reporter, bundle, event);
 
-    assertIsEmpty(reporter.getErrors());
+    assertHasError(reporter, event, ValidationCode.E1315);
+  }
+
+  @Test
+  void shouldFailValidationWhenOverdueEventHasDataValueDefined() {
+    DataElement validDataElement = dataElement();
+    when(preheat.getDataElement(MetadataIdentifier.ofUid(dataElementUid)))
+        .thenReturn(validDataElement);
+
+    ProgramStage programStage = programStage(validDataElement, true);
+    when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStageUid)))
+        .thenReturn(programStage);
+
+    DataValue validDataValue = dataValue();
+    validDataValue.setValue("1");
+    Event event =
+        Event.builder()
+            .event(CodeGenerator.generateUid())
+            .programStage(idSchemes.toMetadataIdentifier(programStage))
+            .status(EventStatus.OVERDUE)
+            .dataValues(Set.of(validDataValue))
+            .build();
+
+    validator.validate(reporter, bundle, event);
+
+    assertHasError(reporter, event, ValidationCode.E1315);
   }
 
   @Test
@@ -647,7 +674,7 @@ class DataValuesValidatorTest {
         Event.builder()
             .event(CodeGenerator.generateUid())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
-            .status(EventStatus.SKIPPED)
+            .status(EventStatus.ACTIVE)
             .dataValues(Set.of(validDataValue))
             .build();
 
@@ -684,7 +711,7 @@ class DataValuesValidatorTest {
         Event.builder()
             .event(CodeGenerator.generateUid())
             .programStage(idSchemes.toMetadataIdentifier(programStage))
-            .status(EventStatus.SKIPPED)
+            .status(EventStatus.ACTIVE)
             .dataValues(Set.of(validDataValue))
             .build();
 
@@ -757,7 +784,7 @@ class DataValuesValidatorTest {
     Event event =
         Event.builder()
             .programStage(idSchemes.toMetadataIdentifier(programStage))
-            .status(EventStatus.SKIPPED)
+            .status(EventStatus.ACTIVE)
             .dataValues(Set.of(validDataValue, nullDataValue))
             .build();
 
@@ -822,7 +849,7 @@ class DataValuesValidatorTest {
     Event event =
         Event.builder()
             .programStage(idSchemes.toMetadataIdentifier(programStage))
-            .status(EventStatus.SKIPPED)
+            .status(EventStatus.ACTIVE)
             .dataValues(Set.of(validDataValue, nullDataValue))
             .build();
 


### PR DESCRIPTION
Following on https://github.com/dhis2/dhis2-core/pull/17890.
Event statuses `OVERDUE`, `SKIPPED` and `SCHEDULE` do not allow to define data values. This PR is adding a validation to verify this.