### PR TITLE
fix: api filter support sharing object[DHIS2-17688-42]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
@@ -118,7 +118,7 @@ public final class QueryUtils {
       if (enumValue != null) {
         return enumValue;
       }
-    } else if (Collection.class.isAssignableFrom(klass)) {
+    } else if (Collection.class.isAssignableFrom(klass) || Map.class.isAssignableFrom(klass)) {
       if (!value.startsWith("[") || !value.endsWith("]")) {
         try {
           return (T) Integer.valueOf(value);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Type.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Type.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.query;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import lombok.Getter;
 import lombok.ToString;
@@ -64,6 +65,8 @@ public final class Type {
 
   private final boolean isCollection;
 
+  private final boolean isMap;
+
   private final boolean isList;
 
   private final boolean isSet;
@@ -83,6 +86,7 @@ public final class Type {
     isEnum = object instanceof Enum;
     isDate = object instanceof Date;
     isCollection = object instanceof Collection;
+    isMap = object instanceof Map;
     isList = object instanceof List;
     isSet = object instanceof Set;
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/EmptyOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/EmptyOperator.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.query.operators;
 
 import java.util.Collection;
+import java.util.Map;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
@@ -66,6 +67,10 @@ public class EmptyOperator<T extends Comparable<? super T>> extends Operator<T> 
     if (type.isCollection()) {
       Collection<?> collection = (Collection<?>) value;
       return collection.isEmpty();
+    }
+    if (type.isMap()) {
+      Map<?, ?> map = (Map<?, ?>) value;
+      return map.isEmpty();
     }
 
     return false;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/EqualOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/EqualOperator.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.query.operators;
 
 import java.util.Collection;
 import java.util.Date;
+import java.util.Map;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
@@ -125,6 +126,12 @@ public class EqualOperator<T extends Comparable<? super T>> extends Operator<T> 
       Integer size = getValue(Integer.class);
 
       return size != null && collection.size() == size;
+    }
+    if (type.isMap()) {
+      Map<?, ?> map = (Map<?, ?>) value;
+      Integer size = getValue(Integer.class);
+
+      return size != null && map.size() == size;
     }
     if (type.isDate()) {
       Date s1 = getValue(Date.class);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/GreaterEqualOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/GreaterEqualOperator.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.query.operators;
 
 import java.util.Collection;
 import java.util.Date;
+import java.util.Map;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
@@ -122,6 +123,12 @@ public class GreaterEqualOperator<T extends Comparable<? super T>> extends Opera
       Integer size = getValue(Integer.class);
 
       return size != null && collection.size() >= size;
+    }
+    if (type.isMap()) {
+      Map<?, ?> map = (Map<?, ?>) value;
+      Integer size = getValue(Integer.class);
+
+      return size != null && map.size() >= size;
     }
 
     return false;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/GreaterThanOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/GreaterThanOperator.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.query.operators;
 
 import java.util.Collection;
 import java.util.Date;
+import java.util.Map;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
@@ -122,6 +123,12 @@ public class GreaterThanOperator<T extends Comparable<? super T>> extends Operat
       Integer size = getValue(Integer.class);
 
       return size != null && collection.size() > size;
+    }
+    if (type.isMap()) {
+      Map<?, ?> map = (Map<?, ?>) value;
+      Integer size = getValue(Integer.class);
+
+      return size != null && map.size() > size;
     }
 
     return false;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/LessEqualOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/LessEqualOperator.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.query.operators;
 
 import java.util.Collection;
 import java.util.Date;
+import java.util.Map;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
@@ -122,6 +123,12 @@ public class LessEqualOperator<T extends Comparable<? super T>> extends Operator
       Integer size = getValue(Integer.class);
 
       return size != null && collection.size() <= size;
+    }
+    if (type.isMap()) {
+      Map<?, ?> map = (Map<?, ?>) value;
+      Integer size = getValue(Integer.class);
+
+      return size != null && map.size() <= size;
     }
 
     return false;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/LessThanOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/LessThanOperator.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.query.operators;
 
 import java.util.Collection;
 import java.util.Date;
+import java.util.Map;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
@@ -122,6 +123,12 @@ public class LessThanOperator<T extends Comparable<? super T>> extends Operator<
       Integer size = getValue(Integer.class);
 
       return size != null && collection.size() < size;
+    }
+    if (type.isMap()) {
+      Map<?, ?> map = (Map<?, ?>) value;
+      Integer size = getValue(Integer.class);
+
+      return size != null && map.size() < size;
     }
 
     return false;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/OperatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/OperatorTest.java
@@ -34,7 +34,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Map;
 import org.hisp.dhis.query.operators.BetweenOperator;
+import org.hisp.dhis.query.operators.EmptyOperator;
 import org.hisp.dhis.query.operators.EqualOperator;
 import org.hisp.dhis.query.operators.GreaterEqualOperator;
 import org.hisp.dhis.query.operators.GreaterThanOperator;
@@ -407,5 +409,47 @@ class OperatorTest {
     assertFalse(operator.test("operator"));
     assertFalse(operator.test("OPERATOR"));
     assertTrue(operator.test("abc"));
+  }
+
+  @Test
+  void testEqualMap() {
+    EqualOperator<Integer> operator = new EqualOperator<>(0);
+    assertFalse(operator.test(Map.of("key", "value")));
+    assertTrue(operator.test(Map.of()));
+  }
+
+  @Test
+  void testGteMap() {
+    GreaterEqualOperator<Integer> operator = new GreaterEqualOperator<>(1);
+    assertTrue(operator.test(Map.of("key", "value")));
+    assertFalse(operator.test(Map.of()));
+  }
+
+  @Test
+  void testGtMap() {
+    GreaterThanOperator<Integer> operator = new GreaterThanOperator<>(0);
+    assertTrue(operator.test(Map.of("key", "value")));
+    assertFalse(operator.test(Map.of()));
+  }
+
+  @Test
+  void testLtMap() {
+    LessThanOperator<Integer> operator = new LessThanOperator<>(1);
+    assertFalse(operator.test(Map.of("key", "value")));
+    assertTrue(operator.test(Map.of()));
+  }
+
+  @Test
+  void testLteMap() {
+    LessEqualOperator<Integer> operator = new LessEqualOperator<>(1);
+    assertTrue(operator.test(Map.of("key", "value")));
+    assertFalse(operator.test(Map.of("key", "value", "key2", "value2")));
+  }
+
+  @Test
+  void testEmptyMap() {
+    EmptyOperator operator = new EmptyOperator();
+    assertTrue(operator.test(Map.of()));
+    assertFalse(operator.test(Map.of("key", "value")));
   }
 }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
@@ -41,9 +41,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Map;
 import java.util.Set;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeValue;
+import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementGroup;
 import org.hisp.dhis.dataset.DataSet;
@@ -1101,6 +1103,107 @@ class AbstractCrudControllerTest extends DhisControllerConvenienceTest {
                 .formatted(dataElementGroup.getUid()))
             .content();
     assertFalse(response.getArray("dataElements").isEmpty());
+  }
+
+  @Test
+  void testFilterSharingEmptyTrue() {
+    String userId = getCurrentUser().getUid();
+    String programId =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/programs/",
+                "{'name':'test', 'shortName':'test', 'programType':'WITHOUT_REGISTRATION'}"));
+    String sharing =
+        TextUtils.replace(
+            """
+      {'owner':'${userId}', 'public':'rwrw----', 'external': true,'users':{},'userGroups':{}}}""",
+            Map.of("userId", userId));
+    assertStatus(HttpStatus.NO_CONTENT, PUT("/programs/" + programId + "/sharing", sharing));
+    JsonObject programs =
+        GET("/programs?filter=sharing.users:empty", programId).content().as(JsonObject.class);
+
+    assertFalse(programs.get("programs").as(JsonArray.class).isEmpty());
+  }
+
+  @Test
+  void testFilterSharingEmptyFalse() {
+    String userId = getCurrentUser().getUid();
+    String programId =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/programs/",
+                "{'name':'test', 'shortName':'test', 'programType':'WITHOUT_REGISTRATION'}"));
+    String sharing =
+        TextUtils.replace(
+            """
+      {'owner':'${userId}', 'public':'rwrw----', 'external': true,'users':{'${userId}':{'id':'${userId}','access':'rw------'}},'userGroups':{}}}""",
+            Map.of("userId", userId));
+    assertStatus(HttpStatus.NO_CONTENT, PUT("/programs/" + programId + "/sharing", sharing));
+    JsonObject programs =
+        GET("/programs?filter=sharing.users:empty", programId).content().as(JsonObject.class);
+    assertTrue(programs.get("programs").as(JsonArray.class).isEmpty());
+  }
+
+  @Test
+  void testFilterSharingEqTrue() {
+    String userId = getCurrentUser().getUid();
+    String programId =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/programs/",
+                "{'name':'test', 'shortName':'test', 'programType':'WITHOUT_REGISTRATION'}"));
+    String sharing =
+        TextUtils.replace(
+            """
+      {'owner':'${userId}', 'public':'rwrw----', 'external': true,'users':{'${userId}':{'id':'${userId}','access':'rw------'}},'userGroups':{}}}""",
+            Map.of("userId", userId));
+    assertStatus(HttpStatus.NO_CONTENT, PUT("/programs/" + programId + "/sharing", sharing));
+    JsonObject programs =
+        GET("/programs?filter=sharing.users:eq:2", programId).content().as(JsonObject.class);
+    assertTrue(programs.get("programs").as(JsonArray.class).isEmpty());
+  }
+
+  @Test
+  void testFilterSharingGt() {
+    String userId = getCurrentUser().getUid();
+    String programId =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/programs/",
+                "{'name':'test', 'shortName':'test', 'programType':'WITHOUT_REGISTRATION'}"));
+    String sharing =
+        TextUtils.replace(
+            """
+      {'owner':'${userId}', 'public':'rwrw----', 'external': true,'users':{'${userId}':{'id':'${userId}','access':'rw------'}},'userGroups':{}}}""",
+            Map.of("userId", userId));
+    assertStatus(HttpStatus.NO_CONTENT, PUT("/programs/" + programId + "/sharing", sharing));
+    JsonObject programs =
+        GET("/programs?filter=sharing.users:gt:0", programId).content().as(JsonObject.class);
+    assertEquals(1, programs.get("programs").as(JsonArray.class).size());
+  }
+
+  @Test
+  void testFilterSharingLt() {
+    String userId = getCurrentUser().getUid();
+    String programId =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/programs/",
+                "{'name':'test', 'shortName':'test', 'programType':'WITHOUT_REGISTRATION'}"));
+    String sharing =
+        TextUtils.replace(
+            """
+      {'owner':'${userId}', 'public':'rwrw----', 'external': true,'users':{'${userId}':{'id':'${userId}','access':'rw------'}},'userGroups':{}}}""",
+            Map.of("userId", userId));
+    assertStatus(HttpStatus.NO_CONTENT, PUT("/programs/" + programId + "/sharing", sharing));
+    JsonObject programs =
+        GET("/programs?filter=sharing.users:lt:2", programId).content().as(JsonObject.class);
+    assertEquals(1, programs.get("programs").as(JsonArray.class).size());
   }
 
   private void assertUserGroupHasOnlyUser(String groupId, String userId) {


### PR DESCRIPTION
[DHIS2-17688-42](https://dhis2.atlassian.net/browse/DHIS2-17688)

- The api request api/dataSets?filter=userAccesses:empty doesn’t work in 2.41 because the legacy accesses object have been removed.
- User should be able to use sharing like below, but currently this is also not working.
```
api/dataSets?filter=sharing.users:empty 
api/dataSets?filter=sharing.userGroups:empty
```

- This PR add supports for handling sharing property in API filter.