### PR TITLE
chore: compute event statistics using IdentifiableObjectManager DHIS2-17638

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventService.java
@@ -65,14 +65,6 @@ public interface EventService {
   Event getEvent(String uid);
 
   /**
-   * Gets the number of events added since the given number of days.
-   *
-   * @param days number of days.
-   * @return the number of events.
-   */
-  long getEventCount(int days);
-
-  /**
    * Validates EventDataValues, handles files for File EventDataValues and creates audit logs for
    * the upcoming create/save changes. DOES PERSIST the changes to the Event object.
    *

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventStore.java
@@ -38,14 +38,6 @@ import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
 public interface EventStore extends IdentifiableObjectStore<Event> {
 
   /**
-   * Get the number of events updates since the given Date.
-   *
-   * @param time the time.
-   * @return the number of events.
-   */
-  long getEventCountLastUpdatedAfter(Date time);
-
-  /**
    * Checks for the existence of an event by UID. The deleted events are not taken into account.
    *
    * @param uid event UID to check for

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventService.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.program;
 
 import static org.hisp.dhis.external.conf.ConfigurationKey.CHANGELOG_TRACKER;
 
-import java.util.Calendar;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -44,7 +43,6 @@ import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.fileresource.FileResourceService;
-import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.system.util.ValidationUtils;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueChangeLog;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueChangeLogService;
@@ -89,15 +87,6 @@ public class DefaultEventService implements EventService {
   @Transactional(readOnly = true)
   public boolean eventExistsIncludingDeleted(String uid) {
     return eventStore.existsIncludingDeleted(uid);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public long getEventCount(int days) {
-    Calendar cal = PeriodType.createCalendarInstance();
-    cal.add(Calendar.DAY_OF_YEAR, (days * -1));
-
-    return eventStore.getEventCountLastUpdatedAfter(cal.getTime());
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventStore.java
@@ -73,17 +73,6 @@ public class HibernateEventStore extends SoftDeleteHibernateObjectStore<Event>
   }
 
   @Override
-  public long getEventCountLastUpdatedAfter(Date time) {
-    CriteriaBuilder builder = getCriteriaBuilder();
-
-    return getCount(
-        builder,
-        newJpaParameters()
-            .addPredicate(root -> builder.greaterThanOrEqualTo(root.get("lastUpdated"), time))
-            .count(builder::countDistinct));
-  }
-
-  @Override
   public boolean exists(String uid) {
     if (uid == null) {
       return false;

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
@@ -44,7 +44,8 @@ import org.hisp.dhis.datasummary.DataSummary;
 import org.hisp.dhis.datavalue.DataValueService;
 import org.hisp.dhis.eventvisualization.EventVisualizationStore;
 import org.hisp.dhis.indicator.Indicator;
-import org.hisp.dhis.program.EventService;
+import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.program.Event;
 import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.statistics.StatisticsProvider;
 import org.hisp.dhis.system.SystemInfo;
@@ -77,8 +78,6 @@ public class DefaultDataStatisticsService implements DataStatisticsService {
   private final DataValueService dataValueService;
 
   private final StatisticsProvider statisticsProvider;
-
-  private final EventService eventService;
 
   private final EventVisualizationStore eventVisualizationStore;
 
@@ -229,29 +228,30 @@ public class DefaultDataStatisticsService implements DataStatisticsService {
 
     statistics.setUserInvitations(userInvitations);
 
-    // Data values
     Map<Integer, Integer> dataValueCount = new HashMap<>();
-
     dataValueCount.put(0, dataValueService.getDataValueCount(0));
     dataValueCount.put(1, dataValueService.getDataValueCount(1));
     dataValueCount.put(7, dataValueService.getDataValueCount(7));
     dataValueCount.put(30, dataValueService.getDataValueCount(30));
-
     statistics.setDataValueCount(dataValueCount);
 
-    // Events
     Map<Integer, Long> eventCount = new HashMap<>();
-
-    eventCount.put(0, eventService.getEventCount(0));
-    eventCount.put(1, eventService.getEventCount(1));
-    eventCount.put(7, eventService.getEventCount(7));
-    eventCount.put(30, eventService.getEventCount(30));
-
+    eventCount.put(0, (long) idObjectManager.getCountByLastUpdated(Event.class, todayMinusDays(0)));
+    eventCount.put(1, (long) idObjectManager.getCountByLastUpdated(Event.class, todayMinusDays(1)));
+    eventCount.put(7, (long) idObjectManager.getCountByLastUpdated(Event.class, todayMinusDays(7)));
+    eventCount.put(
+        30, (long) idObjectManager.getCountByLastUpdated(Event.class, todayMinusDays(30)));
     statistics.setEventCount(eventCount);
 
     statistics.setSystem(getDhis2Info());
 
     return statistics;
+  }
+
+  private static Date todayMinusDays(int days) {
+    Calendar cal = PeriodType.createCalendarInstance();
+    cal.add(Calendar.DAY_OF_YEAR, (days * -1));
+    return cal.getTime();
   }
 
   private Date getStartDate(Date day) {


### PR DESCRIPTION
## Big picture

Tracker has multiple services for each entity like tracked entity, enrollment and event. One is in dhis-api and one in dhis-service-tracker. Our goal is to provide one API (service) per entity that is part of the tracker domain/team.

Trackers architecture splits read/write into exporter services and an importer. So if you want to get data you use an exporter. If you want to insert, update or delete you have to go through the importer. Only then can we ensure integrity of tracker data.

Another goal is that code that provides tracker functionality and is thus owned by the tracker team lives in ideally one maven module (We can settle on a name later on maybe `dhis-service-tracker` or `dhis-tracker`).

This is a **big** task that we are going to implement in many small steps.

## This PR

There are a couple of issues with how the event/data value statistics are computed in the backend and shown in the data management app. There is a lengthy discussion on it in https://dhis2.slack.com/archives/CPGUFVC56/p1719906006918859. We could not settle on a way forward. We will discuss this in a dedicated meeting.

This PR keeps the behavior as is while getting us closer to our big picture described above. We can/will adapt once we come to an agreement with the platform team.

The logic of computing the last updated dates is extracted from

https://github.com/dhis2/dhis2-core/blob/51d18bd8dbfa632b3ca1c52021d1d50ad7d9be54/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventService.java#L97-L100

(It is also the same for the [data value counts](https://github.com/dhis2/dhis2-core/blob/51d18bd8dbfa632b3ca1c52021d1d50ad7d9be54/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java#L327-L330))

The query that was previously part of our dhis-service-core HibernateEventStore

https://github.com/dhis2/dhis2-core/blob/51d18bd8dbfa632b3ca1c52021d1d50ad7d9be54/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventStore.java#L76-L84

is replaced by

https://github.com/dhis2/dhis2-core/blob/1be8198fdcc59ae6dcbdc1aa7f630497082fd21b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java#L633-L644
