### PR TITLE
chore: remove dhis-api EventService.get by UID DHIS2-17638

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventService.java
@@ -65,14 +65,6 @@ public interface EventService {
   Event getEvent(String uid);
 
   /**
-   * Gets the number of events added since the given number of days.
-   *
-   * @param days number of days.
-   * @return the number of events.
-   */
-  long getEventCount(int days);
-
-  /**
    * Validates EventDataValues, handles files for File EventDataValues and creates audit logs for
    * the upcoming create/save changes. DOES PERSIST the changes to the Event object.
    *

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventStore.java
@@ -38,14 +38,6 @@ import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
 public interface EventStore extends IdentifiableObjectStore<Event> {
 
   /**
-   * Get the number of events updates since the given Date.
-   *
-   * @param time the time.
-   * @return the number of events.
-   */
-  long getEventCountLastUpdatedAfter(Date time);
-
-  /**
    * Checks for the existence of an event by UID. The deleted events are not taken into account.
    *
    * @param uid event UID to check for

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventService.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.program;
 
 import static org.hisp.dhis.external.conf.ConfigurationKey.CHANGELOG_TRACKER;
 
-import java.util.Calendar;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -44,7 +43,6 @@ import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.fileresource.FileResourceService;
-import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.system.util.ValidationUtils;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueChangeLog;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueChangeLogService;
@@ -89,15 +87,6 @@ public class DefaultEventService implements EventService {
   @Transactional(readOnly = true)
   public boolean eventExistsIncludingDeleted(String uid) {
     return eventStore.existsIncludingDeleted(uid);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public long getEventCount(int days) {
-    Calendar cal = PeriodType.createCalendarInstance();
-    cal.add(Calendar.DAY_OF_YEAR, (days * -1));
-
-    return eventStore.getEventCountLastUpdatedAfter(cal.getTime());
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventStore.java
@@ -73,17 +73,6 @@ public class HibernateEventStore extends SoftDeleteHibernateObjectStore<Event>
   }
 
   @Override
-  public long getEventCountLastUpdatedAfter(Date time) {
-    CriteriaBuilder builder = getCriteriaBuilder();
-
-    return getCount(
-        builder,
-        newJpaParameters()
-            .addPredicate(root -> builder.greaterThanOrEqualTo(root.get("lastUpdated"), time))
-            .count(builder::countDistinct));
-  }
-
-  @Override
   public boolean exists(String uid) {
     if (uid == null) {
       return false;

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
@@ -44,7 +44,8 @@ import org.hisp.dhis.datasummary.DataSummary;
 import org.hisp.dhis.datavalue.DataValueService;
 import org.hisp.dhis.eventvisualization.EventVisualizationStore;
 import org.hisp.dhis.indicator.Indicator;
-import org.hisp.dhis.program.EventService;
+import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.program.Event;
 import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.statistics.StatisticsProvider;
 import org.hisp.dhis.system.SystemInfo;
@@ -77,8 +78,6 @@ public class DefaultDataStatisticsService implements DataStatisticsService {
   private final DataValueService dataValueService;
 
   private final StatisticsProvider statisticsProvider;
-
-  private final EventService eventService;
 
   private final EventVisualizationStore eventVisualizationStore;
 
@@ -229,29 +228,30 @@ public class DefaultDataStatisticsService implements DataStatisticsService {
 
     statistics.setUserInvitations(userInvitations);
 
-    // Data values
     Map<Integer, Integer> dataValueCount = new HashMap<>();
-
     dataValueCount.put(0, dataValueService.getDataValueCount(0));
     dataValueCount.put(1, dataValueService.getDataValueCount(1));
     dataValueCount.put(7, dataValueService.getDataValueCount(7));
     dataValueCount.put(30, dataValueService.getDataValueCount(30));
-
     statistics.setDataValueCount(dataValueCount);
 
-    // Events
     Map<Integer, Long> eventCount = new HashMap<>();
-
-    eventCount.put(0, eventService.getEventCount(0));
-    eventCount.put(1, eventService.getEventCount(1));
-    eventCount.put(7, eventService.getEventCount(7));
-    eventCount.put(30, eventService.getEventCount(30));
-
+    eventCount.put(0, (long) idObjectManager.getCountByLastUpdated(Event.class, todayMinusDays(0)));
+    eventCount.put(1, (long) idObjectManager.getCountByLastUpdated(Event.class, todayMinusDays(1)));
+    eventCount.put(7, (long) idObjectManager.getCountByLastUpdated(Event.class, todayMinusDays(7)));
+    eventCount.put(
+        30, (long) idObjectManager.getCountByLastUpdated(Event.class, todayMinusDays(30)));
     statistics.setEventCount(eventCount);
 
     statistics.setSystem(getDhis2Info());
 
     return statistics;
+  }
+
+  private static Date todayMinusDays(int days) {
+    Calendar cal = PeriodType.createCalendarInstance();
+    cal.add(Calendar.DAY_OF_YEAR, (days * -1));
+    return cal.getTime();
   }
 
   private Date getStartDate(Date day) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventServiceTest.java
@@ -243,9 +243,9 @@ class EventServiceTest extends TransactionalIntegrationTest {
      * Prepare data for EventDataValues manipulation tests
      */
     manager.save(eventA);
-    // Check that there are no EventDataValues assigned to PSI
-    Event tempPsiA = eventService.getEvent(eventA.getUid());
-    assertEquals(0, tempPsiA.getEventDataValues().size());
+    // Check that there are no EventDataValues assigned to the event
+    Event tempEventA = manager.get(Event.class, eventA.getUid());
+    assertEquals(0, tempEventA.getEventDataValues().size());
     // Prepare EventDataValues to manipulate with
     dataElementMap.put(dataElementA.getUid(), dataElementA);
     dataElementMap.put(dataElementB.getUid(), dataElementB);
@@ -297,8 +297,8 @@ class EventServiceTest extends TransactionalIntegrationTest {
     long idB = eventB.getId();
     assertEquals(eventA, getEvent(idA));
     assertEquals(eventB, getEvent(idB));
-    assertEquals(eventA, eventService.getEvent("UID-A"));
-    assertEquals(eventB, eventService.getEvent("UID-B"));
+    assertEquals(eventA, manager.get(Event.class, "UID-A"));
+    assertEquals(eventB, manager.get(Event.class, "UID-B"));
   }
 
   @Test
@@ -316,11 +316,11 @@ class EventServiceTest extends TransactionalIntegrationTest {
 
     manager.save(event);
 
-    assertNotNull(eventService.getEvent(event.getUid()));
+    assertNotNull(manager.get(Event.class, event.getUid()));
 
     eventService.deleteEvent(event);
 
-    assertNull(eventService.getEvent(event.getUid()));
+    assertNull(manager.get(Event.class, event.getUid()));
     assertTrue(noteService.noteExists(note.getUid()));
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventDataValueTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventDataValueTest.java
@@ -40,7 +40,6 @@ import java.util.stream.Collectors;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
@@ -61,7 +60,6 @@ class EventDataValueTest extends TrackerTest {
 
   @Autowired private IdentifiableObjectManager manager;
 
-  @Autowired private EventService eventService;
   @Autowired protected UserService _userService;
 
   @Override
@@ -121,10 +119,10 @@ class EventDataValueTest extends TrackerTest {
     assertNoErrors(importReport);
     List<Event> updatedEvents = manager.getAll(Event.class);
     assertEquals(1, updatedEvents.size());
-    Event updatedPsi = eventService.getEvent(updatedEvents.get(0).getUid());
-    assertEquals(3, updatedPsi.getEventDataValues().size());
+    Event updatedEvent = manager.get(Event.class, updatedEvents.get(0).getUid());
+    assertEquals(3, updatedEvent.getEventDataValues().size());
     List<String> values =
-        updatedPsi.getEventDataValues().stream()
+        updatedEvent.getEventDataValues().stream()
             .map(EventDataValue::getValue)
             .collect(Collectors.toList());
     assertThat(values, hasItem("First"));
@@ -135,7 +133,7 @@ class EventDataValueTest extends TrackerTest {
         eventDataValues.stream()
             .collect(Collectors.toMap(EventDataValue::getDataElement, ev -> ev));
     Map<String, EventDataValue> updatedDataValueMap =
-        updatedPsi.getEventDataValues().stream()
+        updatedEvent.getEventDataValues().stream()
             .collect(Collectors.toMap(EventDataValue::getDataElement, ev -> ev));
 
     String updatedDataElementId = "DATAEL00004";

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
@@ -376,7 +376,7 @@ class EventImportValidationTest extends TrackerTest {
   private void testDeletedEventFails(TrackerImportStrategy importStrategy) {
     // Given -> Creates an event
     createEvent("tracker/validations/events-with-notes-data.json");
-    Event event = programStageServiceInstance.getEvent("uLxFbxfYDQE");
+    Event event = manager.get(Event.class, "uLxFbxfYDQE");
     assertNotNull(event);
     // When -> Soft-delete the event
     programStageServiceInstance.deleteEvent(event);
@@ -436,6 +436,6 @@ class EventImportValidationTest extends TrackerTest {
     final Map<TrackerType, TrackerTypeReport> typeReportMap =
         importReport.getPersistenceReport().getTypeReportMap();
     String newEvent = typeReportMap.get(TrackerType.EVENT).getEntityReport().get(0).getUid();
-    return programStageServiceInstance.getEvent(newEvent);
+    return manager.get(Event.class, newEvent);
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventSecurityImportValidationTest.java
@@ -46,7 +46,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
@@ -78,8 +77,6 @@ class EventSecurityImportValidationTest extends TrackerTest {
   @Autowired protected TrackedEntityService trackedEntityService;
 
   @Autowired private TrackerImportService trackerImportService;
-
-  @Autowired private EventService programStageServiceInstance;
 
   @Autowired private TrackedEntityProgramOwnerService trackedEntityProgramOwnerService;
 
@@ -242,7 +239,7 @@ class EventSecurityImportValidationTest extends TrackerTest {
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
     assertNoErrors(importReport);
     // Change just inserted Event to status COMPLETED...
-    Event zwwuwNp6gVd = programStageServiceInstance.getEvent("ZwwuwNp6gVd");
+    Event zwwuwNp6gVd = manager.get(Event.class, "ZwwuwNp6gVd");
     zwwuwNp6gVd.setStatus(EventStatus.COMPLETED);
     manager.update(zwwuwNp6gVd);
     programA.setPublicAccess(AccessStringHelper.FULL);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceController.java
@@ -36,13 +36,17 @@ import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.EnrollmentService;
-import org.hisp.dhis.program.EventService;
+import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.notification.ProgramNotificationInstance;
 import org.hisp.dhis.program.notification.ProgramNotificationInstanceParam;
 import org.hisp.dhis.program.notification.ProgramNotificationInstanceService;
 import org.hisp.dhis.schema.descriptors.ProgramNotificationInstanceSchemaDescriptor;
 import org.hisp.dhis.security.RequiresAuthority;
+import org.hisp.dhis.tracker.export.event.EventParams;
+import org.hisp.dhis.tracker.export.event.EventService;
 import org.hisp.dhis.webapi.controller.tracker.view.Page;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.stereotype.Controller;
@@ -90,7 +94,7 @@ public class ProgramNotificationInstanceController {
       @RequestParam(required = false) Boolean paging,
       @RequestParam(required = false, defaultValue = "1") int page,
       @RequestParam(required = false, defaultValue = "50") int pageSize)
-      throws BadRequestException {
+      throws BadRequestException, ForbiddenException, NotFoundException {
     if (paging != null && skipPaging != null && paging.equals(skipPaging)) {
       throw new BadRequestException(
           "Paging can either be enabled or disabled. Prefer 'paging' as 'skipPaging' will be removed.");
@@ -102,12 +106,17 @@ public class ProgramNotificationInstanceController {
     UID eventUid =
         validateDeprecatedParameter("programStageInstance", programStageInstance, "event", event);
 
+    // TODO(ivo) expose this as getEvent(UID)
+    Event event1 = null;
+    if (eventUid != null) {
+      event1 = eventService.getEvent(eventUid.getValue(), EventParams.FALSE);
+    }
     ProgramNotificationInstanceParam params =
         ProgramNotificationInstanceParam.builder()
             .enrollment(
                 enrollmentService.getEnrollment(
                     enrollmentUid == null ? null : enrollmentUid.getValue()))
-            .event(eventService.getEvent(eventUid == null ? null : eventUid.getValue()))
+            .event(event1)
             .skipPaging(!isPaged)
             .page(page)
             .pageSize(pageSize)


### PR DESCRIPTION
## Big picture

Tracker has multiple services for each entity like tracked entity, enrollment and event. One is in dhis-api and one in dhis-service-tracker. Our goal is to provide one API (service) per entity that is part of the tracker domain/team.

Trackers architecture splits read/write into exporter services and an importer. So if you want to get data you use an exporter. If you want to insert, update or delete you have to go through the importer. Only then can we ensure integrity of tracker data.

Another goal is that code that provides tracker functionality and is thus owned by the tracker team lives in ideally one maven module (We can settle on a name later on maybe `dhis-service-tracker` or `dhis-tracker`).

This is a **big** task that we are going to implement in many small steps.

## This PR

Tests can use the manager and production code should depend on the tracker exporter service.