### PR TITLE
fix: Return specific message when user can break glass [DHIS2-17477]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerOwnershipManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerOwnershipManager.java
@@ -107,4 +107,11 @@ public interface TrackerOwnershipManager {
    * @return true if ownership check can be skipped.
    */
   boolean canSkipOwnershipCheck(UserDetails user, ProgramType programType);
+
+  /**
+   * Checks whether the owner of the TE/program pair resides within the user search scope.
+   *
+   * @return true if the owner is in the search scope, false otherwise
+   */
+  boolean isOwnerInUserSearchScope(UserDetails user, TrackedEntity trackedEntity, Program program);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
@@ -519,7 +519,7 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
     List<String> errors = new ArrayList<>();
     if (program.isWithoutRegistration()) {
       OrganisationUnit ou = event.getOrganisationUnit();
-      if (ou != null && !user.isInUserDataHierarchy(ou.getPath())) {
+      if (ou != null && !user.isInUserHierarchy(ou.getPath())) {
         errors.add("User has no delete access to organisation unit: " + ou.getUid());
       }
 
@@ -747,7 +747,9 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager {
       UserDetails user, TrackedEntity trackedEntity, Program program, boolean skipOwnershipCheck) {
     if (!skipOwnershipCheck && !ownershipAccessManager.hasAccess(user, trackedEntity, program)) {
       if (program.isProtected()) {
-        return OWNERSHIP_ACCESS_DENIED;
+        return ownershipAccessManager.isOwnerInUserSearchScope(user, trackedEntity, program)
+            ? OWNERSHIP_ACCESS_DENIED
+            : NO_READ_ACCESS_TO_ORG_UNIT;
       }
 
       if (program.isClosed()) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerOwnershipManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerOwnershipManager.java
@@ -263,6 +263,13 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager {
     return user == null || user.isSuper() || ProgramType.WITHOUT_REGISTRATION == programType;
   }
 
+  @Override
+  public boolean isOwnerInUserSearchScope(
+      UserDetails user, TrackedEntity trackedEntity, Program program) {
+    return user.isInUserSearchHierarchy(
+        getOwner(trackedEntity.getId(), program, trackedEntity::getOrganisationUnit).getPath());
+  }
+
   // -------------------------------------------------------------------------
   // Private Helper Methods
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/trackedentity/DefaultTrackedEntityService.java
@@ -452,8 +452,7 @@ class DefaultTrackedEntityService implements TrackedEntityService {
     }
     UserDetails currentUser = getCurrentUserDetails();
 
-    List<String> errors = trackerAccessManager.canRead(currentUser, trackedEntity);
-    if (!errors.isEmpty()) {
+    if (!trackerAccessManager.canRead(currentUser, trackedEntity).isEmpty()) {
       return null;
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/SecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/enrollment/SecurityOwnershipValidator.java
@@ -175,7 +175,7 @@ class SecurityOwnershipValidator implements Validator<Enrollment> {
     }
   }
 
-  private void checkTeiTypeAndTeiProgramAccess(
+  private void checkTeTypeAndTeProgramAccess(
       Reporter reporter,
       TrackerDto dto,
       UserDetails user,
@@ -204,8 +204,7 @@ class SecurityOwnershipValidator implements Validator<Enrollment> {
 
     checkProgramWriteAccess(reporter, enrollment, user, program);
 
-    checkTeiTypeAndTeiProgramAccess(
-        reporter, enrollment, user, trackedEntity, ownerOrgUnit, program);
+    checkTeTypeAndTeProgramAccess(reporter, enrollment, user, trackedEntity, ownerOrgUnit, program);
   }
 
   private void checkProgramWriteAccess(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/SecurityOwnershipValidator.java
@@ -332,7 +332,7 @@ class SecurityOwnershipValidator implements Validator<org.hisp.dhis.tracker.impo
       log.warn(ORG_UNIT_NO_USER_ASSIGNED, event.getUid());
     } else if (isCreatableInSearchScope
         ? !user.isInUserSearchHierarchy(eventOrgUnit.getPath())
-        : !user.isInUserDataHierarchy(eventOrgUnit.getPath())) {
+        : !user.isInUserHierarchy(eventOrgUnit.getPath())) {
       reporter.addError(event, ValidationCode.E1000, user, eventOrgUnit);
     }
   }


### PR DESCRIPTION
When there's a request to an inaccessible TE and the program is protected, we always return `OWNERSHIP_ACCESS_DENIED`, regardless of whether the owner is in the user search scope. This PR aims to fix that by verifying if the owner is in the correct scope and returning a different error message if they are not. It's important to get this error message right because it's the one used to determine on the FE side if the user can break the glass or not.

While I am at it, I'm also fixing a couple of typos and two errors that arose after the transition from `User` to `UserDetails`. They validate the user access by comparing to the data org units when they should be using the capture scope org units.

Ticket: https://dhis2.atlassian.net/browse/DHIS2-17477