### PR TITLE
fix: Return PAs when TE found [DHIS2-14300][2.40] (#17954)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/AbstractTrackedEntityInstanceService.java
@@ -286,7 +286,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
     }
 
     Set<TrackedEntityAttribute> readableAttributes =
-        new HashSet<>(daoTrackedEntityInstance.getTrackedEntityType().getTrackedEntityAttributes());
+        trackedEntityAttributeService.getAllUserReadableTrackedEntityAttributes(user);
 
     return getTei(daoTrackedEntityInstance, readableAttributes, params, user, null);
   }
@@ -305,7 +305,7 @@ public abstract class AbstractTrackedEntityInstanceService implements TrackedEnt
     User user = currentUserService.getCurrentUser();
 
     Set<TrackedEntityAttribute> readableAttributes =
-        new HashSet<>(daoTrackedEntityInstance.getTrackedEntityType().getTrackedEntityAttributes());
+        trackedEntityAttributeService.getAllUserReadableTrackedEntityAttributes(user);
     readableAttributes.addAll(program.getTrackedEntityAttributes());
 
     return getTei(daoTrackedEntityInstance, readableAttributes, params, user, program);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/TrackedEntityInstanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/TrackedEntityInstanceServiceTest.java
@@ -838,26 +838,12 @@ class TrackedEntityInstanceServiceTest extends TransactionalIntegrationTest {
   }
 
   @Test
-  void
-      shouldReturnTrackedEntityTypeAttributesWhenSingleTERequestedAndProgramSpecifiedButItHasNoProgramAttributes() {
-    TrackedEntityInstance trackedEntityInstance =
-        trackedEntityInstanceService.getTrackedEntityInstanceExcludingACL(
-            maleA.getUid(), new Program(), TrackedEntityInstanceParams.TRUE);
-
-    assertContainsOnly(
-        List.of(uniqueIdAttribute.getUid()),
-        trackedEntityInstance.getAttributes().stream()
-            .map(Attribute::getAttribute)
-            .collect(Collectors.toList()));
-  }
-
-  @Test
   void shouldReturnTrackedEntityTypeAttributesWhenSingleTERequestedAndNoProgramSpecified() {
     TrackedEntityInstance trackedEntityInstance =
         trackedEntityInstanceService.getTrackedEntityInstance(maleA);
 
     assertContainsOnly(
-        List.of(uniqueIdAttribute.getUid()),
+        List.of(programAttribute.getUid(), uniqueIdAttribute.getUid()),
         trackedEntityInstance.getAttributes().stream()
             .map(Attribute::getAttribute)
             .collect(Collectors.toList()));


### PR DESCRIPTION
We inadvertently introduced a but that causes a request to fetch a single tracked entity will return only tracked entity type attributes even if the program is provided.
This fix aims to solve the issue by returning program attributes too.