### PR TITLE
chore: make sms base classes independent of tracker DHIS2-17638

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListener.java
@@ -48,7 +48,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
@@ -86,7 +85,6 @@ public class AggregateDataSetSMSListener extends CompressionSMSListener {
       OrganisationUnitService organisationUnitService,
       CategoryService categoryService,
       DataElementService dataElementService,
-      EventService eventService,
       DataSetService dataSetService,
       DataValueService dataValueService,
       CompleteDataSetRegistrationService registrationService,
@@ -101,9 +99,7 @@ public class AggregateDataSetSMSListener extends CompressionSMSListener {
         organisationUnitService,
         categoryService,
         dataElementService,
-        eventService,
         identifiableObjectManager);
-
     this.dataSetService = dataSetService;
     this.dataValueService = dataValueService;
     this.registrationService = registrationService;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
@@ -248,7 +248,6 @@ public abstract class CompressionSMSListener extends BaseSMSListener {
       OrganisationUnit orgUnit,
       ProgramStage programStage,
       Enrollment enrollment,
-      IncomingSms sms,
       CategoryOptionCombo aoc,
       User user,
       List<SmsDataValue> values,

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/CompressionSMSListener.java
@@ -31,14 +31,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.IdentifiableObject;
@@ -46,29 +42,18 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dataset.DataSet;
-import org.hisp.dhis.event.EventStatus;
-import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
-import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.EnrollmentStatus;
-import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
-import org.hisp.dhis.smscompression.SmsConsts.SmsEnrollmentStatus;
-import org.hisp.dhis.smscompression.SmsConsts.SmsEventStatus;
 import org.hisp.dhis.smscompression.SmsConsts.SubmissionType;
 import org.hisp.dhis.smscompression.SmsResponse;
 import org.hisp.dhis.smscompression.SmsSubmissionReader;
-import org.hisp.dhis.smscompression.models.GeoPoint;
-import org.hisp.dhis.smscompression.models.SmsDataValue;
 import org.hisp.dhis.smscompression.models.SmsMetadata;
 import org.hisp.dhis.smscompression.models.SmsSubmission;
 import org.hisp.dhis.smscompression.models.SmsSubmissionHeader;
@@ -79,11 +64,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.GeometryFactory;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
@@ -108,8 +89,6 @@ public abstract class CompressionSMSListener extends BaseSMSListener {
 
   protected final DataElementService dataElementService;
 
-  protected final EventService eventService;
-
   protected final IdentifiableObjectManager identifiableObjectManager;
 
   public CompressionSMSListener(
@@ -122,10 +101,8 @@ public abstract class CompressionSMSListener extends BaseSMSListener {
       OrganisationUnitService organisationUnitService,
       CategoryService categoryService,
       DataElementService dataElementService,
-      EventService eventService,
       IdentifiableObjectManager identifiableObjectManager) {
     super(incomingSmsService, smsSender);
-
     checkNotNull(userService);
     checkNotNull(trackedEntityTypeService);
     checkNotNull(trackedEntityAttributeService);
@@ -133,8 +110,6 @@ public abstract class CompressionSMSListener extends BaseSMSListener {
     checkNotNull(organisationUnitService);
     checkNotNull(categoryService);
     checkNotNull(dataElementService);
-    checkNotNull(eventService);
-
     this.userService = userService;
     this.trackedEntityTypeService = trackedEntityTypeService;
     this.trackedEntityAttributeService = trackedEntityAttributeService;
@@ -142,7 +117,6 @@ public abstract class CompressionSMSListener extends BaseSMSListener {
     this.organisationUnitService = organisationUnitService;
     this.categoryService = categoryService;
     this.dataElementService = dataElementService;
-    this.eventService = eventService;
     this.identifiableObjectManager = identifiableObjectManager;
   }
 
@@ -241,130 +215,5 @@ public abstract class CompressionSMSListener extends BaseSMSListener {
     return identifiableObjectManager.getUidsCreatedBefore(klass, lastSyncDate).stream()
         .map(o -> new SmsMetadata.Id(o))
         .collect(Collectors.toList());
-  }
-
-  protected List<Object> saveNewEvent(
-      String eventUid,
-      OrganisationUnit orgUnit,
-      ProgramStage programStage,
-      Enrollment enrollment,
-      CategoryOptionCombo aoc,
-      User user,
-      List<SmsDataValue> values,
-      SmsEventStatus eventStatus,
-      Date eventDate,
-      Date dueDate,
-      GeoPoint coordinates) {
-    ArrayList<Object> errorUids = new ArrayList<>();
-    Event event;
-    // If we aren't given a Uid for the event, it will be auto-generated
-
-    if (eventService.eventExists(eventUid)) {
-      event = eventService.getEvent(eventUid);
-    } else {
-      event = new Event();
-      event.setUid(eventUid);
-    }
-
-    event.setOrganisationUnit(orgUnit);
-    event.setProgramStage(programStage);
-    event.setEnrollment(enrollment);
-    event.setOccurredDate(eventDate);
-    event.setScheduledDate(dueDate);
-    event.setAttributeOptionCombo(aoc);
-    event.setStoredBy(user.getUsername());
-
-    UserDetails currentUserDetails = UserDetails.fromUser(user);
-    UserInfoSnapshot currentUserInfo = UserInfoSnapshot.from(currentUserDetails);
-
-    event.setCreatedByUserInfo(currentUserInfo);
-    event.setLastUpdatedByUserInfo(currentUserInfo);
-
-    event.setStatus(getCoreEventStatus(eventStatus));
-    event.setGeometry(convertGeoPointToGeometry(coordinates));
-
-    if (eventStatus.equals(SmsEventStatus.COMPLETED)) {
-      event.setCompletedBy(user.getUsername());
-      event.setCompletedDate(new Date());
-    }
-
-    Map<DataElement, EventDataValue> dataElementsAndEventDataValues = new HashMap<>();
-    if (values != null) {
-      for (SmsDataValue dv : values) {
-        Uid deid = dv.getDataElement();
-        String val = dv.getValue();
-
-        DataElement de = dataElementService.getDataElement(deid.getUid());
-
-        // TODO: Is this the correct way of handling errors here?
-        if (de == null) {
-          log.warn(
-              String.format(
-                  "Given data element [%s] could not be found. Continuing with submission...",
-                  deid));
-          errorUids.add(deid);
-
-          continue;
-        } else if (val == null || StringUtils.isEmpty(val)) {
-          log.warn(
-              String.format(
-                  "Value for atttribute [%s] is null or empty. Continuing with submission...",
-                  deid));
-          continue;
-        }
-
-        EventDataValue eventDataValue =
-            new EventDataValue(deid.getUid(), dv.getValue(), currentUserInfo);
-        eventDataValue.setAutoFields();
-        dataElementsAndEventDataValues.put(de, eventDataValue);
-      }
-    }
-
-    eventService.saveEventDataValuesAndSaveEvent(event, dataElementsAndEventDataValues);
-
-    return errorUids;
-  }
-
-  private EventStatus getCoreEventStatus(SmsEventStatus eventStatus) {
-    switch (eventStatus) {
-      case ACTIVE:
-        return EventStatus.ACTIVE;
-      case COMPLETED:
-        return EventStatus.COMPLETED;
-      case VISITED:
-        return EventStatus.VISITED;
-      case SCHEDULE:
-        return EventStatus.SCHEDULE;
-      case OVERDUE:
-        return EventStatus.OVERDUE;
-      case SKIPPED:
-        return EventStatus.SKIPPED;
-      default:
-        return null;
-    }
-  }
-
-  protected EnrollmentStatus getCoreEnrollmentStatus(SmsEnrollmentStatus enrollmentStatus) {
-    switch (enrollmentStatus) {
-      case ACTIVE:
-        return EnrollmentStatus.ACTIVE;
-      case COMPLETED:
-        return EnrollmentStatus.COMPLETED;
-      case CANCELLED:
-        return EnrollmentStatus.CANCELLED;
-      default:
-        return null;
-    }
-  }
-
-  protected Geometry convertGeoPointToGeometry(GeoPoint coordinates) {
-    if (coordinates == null) {
-      return null;
-    }
-
-    GeometryFactory gf = new GeometryFactory();
-    Coordinate co = new Coordinate(coordinates.getLongitude(), coordinates.getLatitude());
-
-    return gf.createPoint(co);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DataValueSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DataValueSMSListener.java
@@ -51,8 +51,6 @@ import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
-import org.hisp.dhis.program.EnrollmentService;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.sms.command.CompletenessMethod;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
@@ -94,9 +92,7 @@ public class DataValueSMSListener extends CommandSMSListener {
   private final DataElementService dataElementService;
 
   public DataValueSMSListener(
-      EnrollmentService enrollmentService,
       CategoryService dataElementCategoryService,
-      EventService eventService,
       UserService userService,
       IncomingSmsService incomingSmsService,
       @Qualifier("smsMessageSender") MessageSender smsSender,
@@ -106,14 +102,7 @@ public class DataValueSMSListener extends CommandSMSListener {
       SMSCommandService smsCommandService,
       DataSetService dataSetService,
       DataElementService dataElementService) {
-    super(
-        enrollmentService,
-        dataElementCategoryService,
-        eventService,
-        userService,
-        incomingSmsService,
-        smsSender);
-
+    super(dataElementCategoryService, userService, incomingSmsService, smsSender);
     this.registrationService = registrationService;
     this.dataValueService = dataValueService;
     this.dataElementCategoryService = dataElementCategoryService1;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DeleteEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DeleteEventSMSListener.java
@@ -52,6 +52,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Component("org.hisp.dhis.sms.listener.DeleteEventSMSListener")
 @Transactional
 public class DeleteEventSMSListener extends CompressionSMSListener {
+  private final EventService eventService;
+
   public DeleteEventSMSListener(
       IncomingSmsService incomingSmsService,
       @Qualifier("smsMessageSender") MessageSender smsSender,
@@ -62,8 +64,8 @@ public class DeleteEventSMSListener extends CompressionSMSListener {
       OrganisationUnitService organisationUnitService,
       CategoryService categoryService,
       DataElementService dataElementService,
-      EventService eventService,
-      IdentifiableObjectManager identifiableObjectManager) {
+      IdentifiableObjectManager identifiableObjectManager,
+      EventService eventService) {
     super(
         incomingSmsService,
         smsSender,
@@ -74,8 +76,8 @@ public class DeleteEventSMSListener extends CompressionSMSListener {
         organisationUnitService,
         categoryService,
         dataElementService,
-        eventService,
         identifiableObjectManager);
+    this.eventService = eventService;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DhisMessageAlertListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/DhisMessageAlertListener.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.sms.listener;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -41,8 +39,6 @@ import org.hisp.dhis.message.MessageConversationParams;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.message.MessageType;
-import org.hisp.dhis.program.EnrollmentService;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
@@ -67,25 +63,13 @@ public class DhisMessageAlertListener extends CommandSMSListener {
   private final MessageService messageService;
 
   public DhisMessageAlertListener(
-      EnrollmentService enrollmentService,
       CategoryService dataElementCategoryService,
-      EventService eventService,
       UserService userService,
       IncomingSmsService incomingSmsService,
       @Qualifier("smsMessageSender") MessageSender smsSender,
       SMSCommandService smsCommandService,
       MessageService messageService) {
-    super(
-        enrollmentService,
-        dataElementCategoryService,
-        eventService,
-        userService,
-        incomingSmsService,
-        smsSender);
-
-    checkNotNull(smsCommandService);
-    checkNotNull(messageService);
-
+    super(dataElementCategoryService, userService, incomingSmsService, smsSender);
     this.smsCommandService = smsCommandService;
     this.messageService = messageService;
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
@@ -73,7 +73,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Component("org.hisp.dhis.sms.listener.EnrollmentSMSListener")
 @Transactional
-public class EnrollmentSMSListener extends CompressionSMSListener {
+public class EnrollmentSMSListener extends TrackerSMSListener {
   private final TrackedEntityService teService;
 
   private final EnrollmentService enrollmentService;
@@ -110,9 +110,8 @@ public class EnrollmentSMSListener extends CompressionSMSListener {
         organisationUnitService,
         categoryService,
         dataElementService,
-        eventService,
-        identifiableObjectManager);
-
+        identifiableObjectManager,
+        eventService);
     this.teService = teService;
     this.programStageService = programStageService;
     this.enrollmentService = enrollmentService;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
@@ -202,7 +202,7 @@ public class EnrollmentSMSListener extends CompressionSMSListener {
     List<Object> errorUIDs = new ArrayList<>();
     if (subm.getEvents() != null) {
       for (SmsEvent event : subm.getEvents()) {
-        errorUIDs.addAll(processEvent(event, user, enrollment, sms));
+        errorUIDs.addAll(processEvent(event, user, enrollment));
       }
     }
     enrollment.setStatus(getCoreEnrollmentStatus(subm.getEnrollmentStatus()));
@@ -289,8 +289,7 @@ public class EnrollmentSMSListener extends CompressionSMSListener {
     return trackedEntityAttributeValue;
   }
 
-  protected List<Object> processEvent(
-      SmsEvent event, User user, Enrollment enrollment, IncomingSms sms) {
+  protected List<Object> processEvent(SmsEvent event, User user, Enrollment enrollment) {
     Uid stageid = event.getProgramStage();
     Uid aocid = event.getAttributeOptionCombo();
     Uid orgunitid = event.getOrgUnit();
@@ -316,7 +315,6 @@ public class EnrollmentSMSListener extends CompressionSMSListener {
             orgUnit,
             programStage,
             enrollment,
-            sms,
             aoc,
             user,
             event.getValues(),

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EnrollmentSMSListener.java
@@ -73,7 +73,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Component("org.hisp.dhis.sms.listener.EnrollmentSMSListener")
 @Transactional
-public class EnrollmentSMSListener extends TrackerSMSListener {
+public class EnrollmentSMSListener extends EventSavingSMSListener {
   private final TrackedEntityService teService;
 
   private final EnrollmentService enrollmentService;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EventSavingSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/EventSavingSMSListener.java
@@ -69,11 +69,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Transactional
-public abstract class TrackerSMSListener extends CompressionSMSListener {
+public abstract class EventSavingSMSListener extends CompressionSMSListener {
 
   protected final EventService eventService;
 
-  public TrackerSMSListener(
+  protected EventSavingSMSListener(
       IncomingSmsService incomingSmsService,
       MessageSender smsSender,
       UserService userService,
@@ -182,35 +182,22 @@ public abstract class TrackerSMSListener extends CompressionSMSListener {
   }
 
   private EventStatus getCoreEventStatus(SmsEventStatus eventStatus) {
-    switch (eventStatus) {
-      case ACTIVE:
-        return EventStatus.ACTIVE;
-      case COMPLETED:
-        return EventStatus.COMPLETED;
-      case VISITED:
-        return EventStatus.VISITED;
-      case SCHEDULE:
-        return EventStatus.SCHEDULE;
-      case OVERDUE:
-        return EventStatus.OVERDUE;
-      case SKIPPED:
-        return EventStatus.SKIPPED;
-      default:
-        return null;
-    }
+    return switch (eventStatus) {
+      case ACTIVE -> EventStatus.ACTIVE;
+      case COMPLETED -> EventStatus.COMPLETED;
+      case VISITED -> EventStatus.VISITED;
+      case SCHEDULE -> EventStatus.SCHEDULE;
+      case OVERDUE -> EventStatus.OVERDUE;
+      case SKIPPED -> EventStatus.SKIPPED;
+    };
   }
 
   protected EnrollmentStatus getCoreEnrollmentStatus(SmsEnrollmentStatus enrollmentStatus) {
-    switch (enrollmentStatus) {
-      case ACTIVE:
-        return EnrollmentStatus.ACTIVE;
-      case COMPLETED:
-        return EnrollmentStatus.COMPLETED;
-      case CANCELLED:
-        return EnrollmentStatus.CANCELLED;
-      default:
-        return null;
-    }
+    return switch (enrollmentStatus) {
+      case ACTIVE -> EnrollmentStatus.ACTIVE;
+      case COMPLETED -> EnrollmentStatus.COMPLETED;
+      case CANCELLED -> EnrollmentStatus.CANCELLED;
+    };
   }
 
   protected Geometry convertGeoPointToGeometry(GeoPoint coordinates) {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/ProgramStageDataEntrySMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/ProgramStageDataEntrySMSListener.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.sms.listener;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -65,7 +63,7 @@ import org.springframework.transaction.annotation.Transactional;
 /** Created by zubair@dhis2.org on 11.08.17. */
 @Component("org.hisp.dhis.sms.listener.ProgramStageDataEntrySMSListener")
 @Transactional
-public class ProgramStageDataEntrySMSListener extends CommandSMSListener {
+public class ProgramStageDataEntrySMSListener extends RegisterSMSListener {
   private static final String MORE_THAN_ONE_TE =
       "More than one tracked entity found for given phone number";
 
@@ -80,35 +78,26 @@ public class ProgramStageDataEntrySMSListener extends CommandSMSListener {
   private final SMSCommandService smsCommandService;
 
   public ProgramStageDataEntrySMSListener(
-      EnrollmentService enrollmentService,
       CategoryService dataElementCategoryService,
-      EventService eventService,
       UserService userService,
       IncomingSmsService incomingSmsService,
       @Qualifier("smsMessageSender") MessageSender smsSender,
+      EventService eventService,
+      EnrollmentService enrollmentService,
       TrackedEntityService trackedEntityService,
       TrackedEntityAttributeService trackedEntityAttributeService,
       SMSCommandService smsCommandService) {
     super(
-        enrollmentService,
         dataElementCategoryService,
-        eventService,
         userService,
         incomingSmsService,
-        smsSender);
-
-    checkNotNull(trackedEntityAttributeService);
-    checkNotNull(trackedEntityService);
-    checkNotNull(smsCommandService);
-
+        smsSender,
+        eventService,
+        enrollmentService);
     this.trackedEntityService = trackedEntityService;
     this.trackedEntityAttributeService = trackedEntityAttributeService;
     this.smsCommandService = smsCommandService;
   }
-
-  // -------------------------------------------------------------------------
-  // IncomingSmsListener implementation
-  // -------------------------------------------------------------------------
 
   @Override
   public void postProcess(

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/RegisterSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/RegisterSMSListener.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.sms.listener;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.eventdatavalue.EventDataValue;
+import org.hisp.dhis.message.MessageSender;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
+import org.hisp.dhis.program.EnrollmentStatus;
+import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
+import org.hisp.dhis.program.UserInfoSnapshot;
+import org.hisp.dhis.sms.command.SMSCommand;
+import org.hisp.dhis.sms.command.code.SMSCode;
+import org.hisp.dhis.sms.incoming.IncomingSms;
+import org.hisp.dhis.sms.incoming.IncomingSmsService;
+import org.hisp.dhis.sms.incoming.SmsMessageStatus;
+import org.hisp.dhis.user.CurrentUserUtil;
+import org.hisp.dhis.user.UserService;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Transactional
+public abstract class RegisterSMSListener extends CommandSMSListener {
+
+  protected final EventService eventService;
+
+  protected final EnrollmentService enrollmentService;
+
+  protected RegisterSMSListener(
+      CategoryService dataElementCategoryService,
+      UserService userService,
+      IncomingSmsService incomingSmsService,
+      MessageSender smsSender,
+      EventService eventService,
+      EnrollmentService enrollmentService) {
+    super(dataElementCategoryService, userService, incomingSmsService, smsSender);
+    this.eventService = eventService;
+    this.enrollmentService = enrollmentService;
+  }
+
+  protected void register(
+      List<Enrollment> enrollments,
+      Map<String, String> commandValuePairs,
+      SMSCommand smsCommand,
+      IncomingSms sms,
+      Set<OrganisationUnit> ous) {
+    if (enrollments.isEmpty()) {
+      Enrollment enrollment = new Enrollment();
+      enrollment.setEnrollmentDate(new Date());
+      enrollment.setOccurredDate(new Date());
+      enrollment.setProgram(smsCommand.getProgram());
+      enrollment.setStatus(EnrollmentStatus.ACTIVE);
+
+      enrollmentService.addEnrollment(enrollment);
+
+      enrollments.add(enrollment);
+    } else if (enrollments.size() > 1) {
+      update(sms, SmsMessageStatus.FAILED, false);
+
+      sendFeedback(
+          "Multiple active Enrollments exists for program: " + smsCommand.getProgram().getUid(),
+          sms.getOriginator(),
+          ERROR);
+
+      return;
+    }
+
+    Enrollment enrollment = enrollments.get(0);
+
+    UserInfoSnapshot currentUserInfo =
+        UserInfoSnapshot.from(CurrentUserUtil.getCurrentUserDetails());
+
+    Event event = new Event();
+    event.setOrganisationUnit(ous.iterator().next());
+    event.setProgramStage(smsCommand.getProgramStage());
+    event.setEnrollment(enrollment);
+    event.setOccurredDate(sms.getSentDate());
+    event.setScheduledDate(sms.getSentDate());
+    event.setAttributeOptionCombo(dataElementCategoryService.getDefaultCategoryOptionCombo());
+    event.setCompletedBy("DHIS 2");
+    event.setStoredBy(currentUserInfo.getUsername());
+    event.setCreatedByUserInfo(currentUserInfo);
+    event.setLastUpdatedByUserInfo(currentUserInfo);
+
+    Map<DataElement, EventDataValue> dataElementsAndEventDataValues = new HashMap<>();
+    for (SMSCode smsCode : smsCommand.getCodes()) {
+      EventDataValue eventDataValue =
+          new EventDataValue(
+              smsCode.getDataElement().getUid(),
+              commandValuePairs.get(smsCode.getCode()),
+              currentUserInfo);
+      eventDataValue.setAutoFields();
+
+      // Filter empty values out -> this is "adding/saving/creating",
+      // therefore, empty values are ignored
+      if (!StringUtils.isEmpty(eventDataValue.getValue())) {
+        dataElementsAndEventDataValues.put(smsCode.getDataElement(), eventDataValue);
+      }
+    }
+
+    eventService.saveEventDataValuesAndSaveEvent(event, dataElementsAndEventDataValues);
+
+    update(sms, SmsMessageStatus.PROCESSED, true);
+
+    sendFeedback(
+        StringUtils.defaultIfEmpty(smsCommand.getSuccessMessage(), SMSCommand.SUCCESS_MESSAGE),
+        sms.getOriginator(),
+        INFO);
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/RelationshipSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/RelationshipSMSListener.java
@@ -68,6 +68,8 @@ public class RelationshipSMSListener extends CompressionSMSListener {
     TO;
   }
 
+  private final EventService eventService;
+
   private final RelationshipService relationshipService;
 
   private final RelationshipTypeService relationshipTypeService;
@@ -86,12 +88,12 @@ public class RelationshipSMSListener extends CompressionSMSListener {
       OrganisationUnitService organisationUnitService,
       CategoryService categoryService,
       DataElementService dataElementService,
+      IdentifiableObjectManager identifiableObjectManager,
       EventService eventService,
       RelationshipService relationshipService,
       RelationshipTypeService relationshipTypeService,
       TrackedEntityService trackedEntityService,
-      EnrollmentService enrollmentService,
-      IdentifiableObjectManager identifiableObjectManager) {
+      EnrollmentService enrollmentService) {
     super(
         incomingSmsService,
         smsSender,
@@ -102,13 +104,12 @@ public class RelationshipSMSListener extends CompressionSMSListener {
         organisationUnitService,
         categoryService,
         dataElementService,
-        eventService,
         identifiableObjectManager);
-
     this.relationshipService = relationshipService;
     this.relationshipTypeService = relationshipTypeService;
     this.trackedEntityService = trackedEntityService;
     this.enrollmentService = enrollmentService;
+    this.eventService = eventService;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
@@ -62,7 +62,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component("org.hisp.dhis.sms.listener.SimpleEventSMSListener")
 @Transactional
-public class SimpleEventSMSListener extends TrackerSMSListener {
+public class SimpleEventSMSListener extends EventSavingSMSListener {
   private final EnrollmentService enrollmentService;
 
   public SimpleEventSMSListener(

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
@@ -155,7 +155,6 @@ public class SimpleEventSMSListener extends CompressionSMSListener {
             orgUnit,
             programStage,
             enrollment,
-            sms,
             aoc,
             user,
             subm.getValues(),

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SimpleEventSMSListener.java
@@ -62,7 +62,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component("org.hisp.dhis.sms.listener.SimpleEventSMSListener")
 @Transactional
-public class SimpleEventSMSListener extends CompressionSMSListener {
+public class SimpleEventSMSListener extends TrackerSMSListener {
   private final EnrollmentService enrollmentService;
 
   public SimpleEventSMSListener(
@@ -88,9 +88,8 @@ public class SimpleEventSMSListener extends CompressionSMSListener {
         organisationUnitService,
         categoryService,
         dataElementService,
-        eventService,
-        identifiableObjectManager);
-
+        identifiableObjectManager,
+        eventService);
     this.enrollmentService = enrollmentService;
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SingleEventListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/SingleEventListener.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.sms.listener;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -54,33 +52,26 @@ import org.springframework.transaction.annotation.Transactional;
 /** Zubair <rajazubair.asghar@gmail.com> */
 @Component("org.hisp.dhis.sms.listener.SingleEventListener")
 @Transactional
-public class SingleEventListener extends CommandSMSListener {
+public class SingleEventListener extends RegisterSMSListener {
   private final SMSCommandService smsCommandService;
 
   public SingleEventListener(
-      EnrollmentService enrollmentService,
       CategoryService dataElementCategoryService,
-      EventService eventService,
       UserService userService,
       IncomingSmsService incomingSmsService,
       @Qualifier("smsMessageSender") MessageSender smsSender,
+      EventService eventService,
+      EnrollmentService enrollmentService,
       SMSCommandService smsCommandService) {
     super(
-        enrollmentService,
         dataElementCategoryService,
-        eventService,
         userService,
         incomingSmsService,
-        smsSender);
-
-    checkNotNull(smsCommandService);
-
+        smsSender,
+        eventService,
+        enrollmentService);
     this.smsCommandService = smsCommandService;
   }
-
-  // -------------------------------------------------------------------------
-  // Implementation
-  // -------------------------------------------------------------------------
 
   @Override
   protected SMSCommand getSMSCommand(IncomingSms sms) {
@@ -95,10 +86,6 @@ public class SingleEventListener extends CommandSMSListener {
 
     registerEvent(parsedMessage, smsCommand, sms, ous);
   }
-
-  // -------------------------------------------------------------------------
-  // Supportive Methods
-  // -------------------------------------------------------------------------
 
   private void registerEvent(
       Map<String, String> commandValuePairs,

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationSMSListener.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.sms.listener;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
@@ -39,7 +37,6 @@ import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.EnrollmentService;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.sms.command.SMSCommand;
@@ -66,10 +63,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class TrackedEntityRegistrationSMSListener extends CommandSMSListener {
   private static final String SUCCESS_MESSAGE = "Tracked Entity Registered Successfully with uid. ";
 
-  // -------------------------------------------------------------------------
-  // Dependencies
-  // -------------------------------------------------------------------------
-
   private final SMSCommandService smsCommandService;
 
   private final TrackedEntityTypeService trackedEntityTypeService;
@@ -78,38 +71,25 @@ public class TrackedEntityRegistrationSMSListener extends CommandSMSListener {
 
   private final ProgramService programService;
 
+  private final EnrollmentService enrollmentService;
+
   public TrackedEntityRegistrationSMSListener(
       ProgramService programService,
-      EnrollmentService enrollmentService,
       CategoryService dataElementCategoryService,
-      EventService eventService,
       UserService userService,
       IncomingSmsService incomingSmsService,
       @Qualifier("smsMessageSender") MessageSender smsSender,
       SMSCommandService smsCommandService,
       TrackedEntityTypeService trackedEntityTypeService,
-      TrackedEntityService trackedEntityService) {
-    super(
-        enrollmentService,
-        dataElementCategoryService,
-        eventService,
-        userService,
-        incomingSmsService,
-        smsSender);
-
-    checkNotNull(smsCommandService);
-    checkNotNull(trackedEntityTypeService);
-    checkNotNull(trackedEntityService);
-
+      TrackedEntityService trackedEntityService,
+      EnrollmentService enrollmentService) {
+    super(dataElementCategoryService, userService, incomingSmsService, smsSender);
     this.smsCommandService = smsCommandService;
     this.trackedEntityTypeService = trackedEntityTypeService;
     this.trackedEntityService = trackedEntityService;
     this.programService = programService;
+    this.enrollmentService = enrollmentService;
   }
-
-  // -------------------------------------------------------------------------
-  // IncomingSmsListener implementation
-  // -------------------------------------------------------------------------
 
   @Override
   protected void postProcess(

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackerEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackerEventSMSListener.java
@@ -131,7 +131,6 @@ public class TrackerEventSMSListener extends CompressionSMSListener {
             orgUnit,
             programStage,
             enrollment,
-            sms,
             aoc,
             user,
             subm.getValues(),

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackerEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackerEventSMSListener.java
@@ -58,7 +58,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component("org.hisp.dhis.sms.listener.TrackerEventSMSListener")
 @Transactional
-public class TrackerEventSMSListener extends TrackerSMSListener {
+public class TrackerEventSMSListener extends EventSavingSMSListener {
   private final ProgramStageService programStageService;
 
   private final EnrollmentService enrollmentService;
@@ -73,10 +73,10 @@ public class TrackerEventSMSListener extends TrackerSMSListener {
       OrganisationUnitService organisationUnitService,
       CategoryService categoryService,
       DataElementService dataElementService,
+      IdentifiableObjectManager identifiableObjectManager,
       EventService eventService,
       ProgramStageService programStageService,
-      EnrollmentService enrollmentService,
-      IdentifiableObjectManager identifiableObjectManager) {
+      EnrollmentService enrollmentService) {
     super(
         incomingSmsService,
         smsSender,

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackerEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackerEventSMSListener.java
@@ -58,7 +58,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component("org.hisp.dhis.sms.listener.TrackerEventSMSListener")
 @Transactional
-public class TrackerEventSMSListener extends CompressionSMSListener {
+public class TrackerEventSMSListener extends TrackerSMSListener {
   private final ProgramStageService programStageService;
 
   private final EnrollmentService enrollmentService;
@@ -87,9 +87,8 @@ public class TrackerEventSMSListener extends CompressionSMSListener {
         organisationUnitService,
         categoryService,
         dataElementService,
-        eventService,
-        identifiableObjectManager);
-
+        identifiableObjectManager,
+        eventService);
     this.programStageService = programStageService;
     this.enrollmentService = enrollmentService;
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackerSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/TrackerSMSListener.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.sms.listener;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataelement.DataElementService;
+import org.hisp.dhis.event.EventStatus;
+import org.hisp.dhis.eventdatavalue.EventDataValue;
+import org.hisp.dhis.message.MessageSender;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentStatus;
+import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.EventService;
+import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.UserInfoSnapshot;
+import org.hisp.dhis.sms.incoming.IncomingSmsService;
+import org.hisp.dhis.smscompression.SmsConsts.SmsEnrollmentStatus;
+import org.hisp.dhis.smscompression.SmsConsts.SmsEventStatus;
+import org.hisp.dhis.smscompression.models.GeoPoint;
+import org.hisp.dhis.smscompression.models.SmsDataValue;
+import org.hisp.dhis.smscompression.models.Uid;
+import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
+import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
+import org.hisp.dhis.user.UserService;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Transactional
+public abstract class TrackerSMSListener extends CompressionSMSListener {
+
+  protected final EventService eventService;
+
+  public TrackerSMSListener(
+      IncomingSmsService incomingSmsService,
+      MessageSender smsSender,
+      UserService userService,
+      TrackedEntityTypeService trackedEntityTypeService,
+      TrackedEntityAttributeService trackedEntityAttributeService,
+      ProgramService programService,
+      OrganisationUnitService organisationUnitService,
+      CategoryService categoryService,
+      DataElementService dataElementService,
+      IdentifiableObjectManager identifiableObjectManager,
+      EventService eventService) {
+    super(
+        incomingSmsService,
+        smsSender,
+        userService,
+        trackedEntityTypeService,
+        trackedEntityAttributeService,
+        programService,
+        organisationUnitService,
+        categoryService,
+        dataElementService,
+        identifiableObjectManager);
+    this.eventService = eventService;
+  }
+
+  protected List<Object> saveNewEvent(
+      String eventUid,
+      OrganisationUnit orgUnit,
+      ProgramStage programStage,
+      Enrollment enrollment,
+      CategoryOptionCombo aoc,
+      User user,
+      List<SmsDataValue> values,
+      SmsEventStatus eventStatus,
+      Date eventDate,
+      Date dueDate,
+      GeoPoint coordinates) {
+    ArrayList<Object> errorUids = new ArrayList<>();
+    Event event;
+    // If we aren't given a Uid for the event, it will be auto-generated
+
+    if (eventService.eventExists(eventUid)) {
+      event = eventService.getEvent(eventUid);
+    } else {
+      event = new Event();
+      event.setUid(eventUid);
+    }
+
+    event.setOrganisationUnit(orgUnit);
+    event.setProgramStage(programStage);
+    event.setEnrollment(enrollment);
+    event.setOccurredDate(eventDate);
+    event.setScheduledDate(dueDate);
+    event.setAttributeOptionCombo(aoc);
+    event.setStoredBy(user.getUsername());
+
+    UserDetails currentUserDetails = UserDetails.fromUser(user);
+    UserInfoSnapshot currentUserInfo = UserInfoSnapshot.from(currentUserDetails);
+
+    event.setCreatedByUserInfo(currentUserInfo);
+    event.setLastUpdatedByUserInfo(currentUserInfo);
+
+    event.setStatus(getCoreEventStatus(eventStatus));
+    event.setGeometry(convertGeoPointToGeometry(coordinates));
+
+    if (eventStatus.equals(SmsEventStatus.COMPLETED)) {
+      event.setCompletedBy(user.getUsername());
+      event.setCompletedDate(new Date());
+    }
+
+    Map<DataElement, EventDataValue> dataElementsAndEventDataValues = new HashMap<>();
+    if (values != null) {
+      for (SmsDataValue dv : values) {
+        Uid deid = dv.getDataElement();
+        String val = dv.getValue();
+
+        DataElement de = dataElementService.getDataElement(deid.getUid());
+
+        // TODO: Is this the correct way of handling errors here?
+        if (de == null) {
+          log.warn(
+              String.format(
+                  "Given data element [%s] could not be found. Continuing with submission...",
+                  deid));
+          errorUids.add(deid);
+
+          continue;
+        } else if (val == null || StringUtils.isEmpty(val)) {
+          log.warn(
+              String.format(
+                  "Value for atttribute [%s] is null or empty. Continuing with submission...",
+                  deid));
+          continue;
+        }
+
+        EventDataValue eventDataValue =
+            new EventDataValue(deid.getUid(), dv.getValue(), currentUserInfo);
+        eventDataValue.setAutoFields();
+        dataElementsAndEventDataValues.put(de, eventDataValue);
+      }
+    }
+
+    eventService.saveEventDataValuesAndSaveEvent(event, dataElementsAndEventDataValues);
+
+    return errorUids;
+  }
+
+  private EventStatus getCoreEventStatus(SmsEventStatus eventStatus) {
+    switch (eventStatus) {
+      case ACTIVE:
+        return EventStatus.ACTIVE;
+      case COMPLETED:
+        return EventStatus.COMPLETED;
+      case VISITED:
+        return EventStatus.VISITED;
+      case SCHEDULE:
+        return EventStatus.SCHEDULE;
+      case OVERDUE:
+        return EventStatus.OVERDUE;
+      case SKIPPED:
+        return EventStatus.SKIPPED;
+      default:
+        return null;
+    }
+  }
+
+  protected EnrollmentStatus getCoreEnrollmentStatus(SmsEnrollmentStatus enrollmentStatus) {
+    switch (enrollmentStatus) {
+      case ACTIVE:
+        return EnrollmentStatus.ACTIVE;
+      case COMPLETED:
+        return EnrollmentStatus.COMPLETED;
+      case CANCELLED:
+        return EnrollmentStatus.CANCELLED;
+      default:
+        return null;
+    }
+  }
+
+  protected Geometry convertGeoPointToGeometry(GeoPoint coordinates) {
+    if (coordinates == null) {
+      return null;
+    }
+
+    GeometryFactory gf = new GeometryFactory();
+    Coordinate co = new Coordinate(coordinates.getLongitude(), coordinates.getLatitude());
+
+    return gf.createPoint(co);
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/UnregisteredSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/UnregisteredSMSListener.java
@@ -27,16 +27,12 @@
  */
 package org.hisp.dhis.sms.listener;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.Map;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.message.MessageConversationParams;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.message.MessageType;
-import org.hisp.dhis.program.EnrollmentService;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
@@ -61,35 +57,18 @@ public class UnregisteredSMSListener extends CommandSMSListener {
   private final MessageService messageService;
 
   public UnregisteredSMSListener(
-      EnrollmentService enrollmentService,
       CategoryService dataElementCategoryService,
-      EventService eventService,
       UserService userService,
       IncomingSmsService incomingSmsService,
       @Qualifier("smsMessageSender") MessageSender smsSender,
       SMSCommandService smsCommandService,
       UserService userService1,
       MessageService messageService) {
-    super(
-        enrollmentService,
-        dataElementCategoryService,
-        eventService,
-        userService,
-        incomingSmsService,
-        smsSender);
-
-    checkNotNull(smsCommandService);
-    checkNotNull(userService);
-    checkNotNull(messageService);
-
+    super(dataElementCategoryService, userService, incomingSmsService, smsSender);
     this.smsCommandService = smsCommandService;
     this.userService = userService1;
     this.messageService = messageService;
   }
-
-  // -------------------------------------------------------------------------
-  // IncomingSmsListener implementation
-  // -------------------------------------------------------------------------
 
   @Override
   protected SMSCommand getSMSCommand(IncomingSms sms) {

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListenerTest.java
@@ -53,7 +53,6 @@ import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
@@ -93,8 +92,6 @@ class AggregateDataSetSMSListenerTest extends CompressionSMSListenerTest {
   @Mock private OrganisationUnitService organisationUnitService;
 
   @Mock private CategoryService categoryService;
-
-  @Mock private EventService eventService;
 
   // Needed for this test
 
@@ -145,7 +142,6 @@ class AggregateDataSetSMSListenerTest extends CompressionSMSListenerTest {
             organisationUnitService,
             categoryService,
             dataElementService,
-            eventService,
             dataSetService,
             dataValueService,
             registrationService,

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/DataValueListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/DataValueListenerTest.java
@@ -63,7 +63,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.program.EnrollmentService;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.sms.command.SMSCommand;
 import org.hisp.dhis.sms.command.SMSCommandService;
 import org.hisp.dhis.sms.command.SMSSpecialCharacter;
@@ -118,8 +117,6 @@ class DataValueListenerTest extends DhisConvenienceTest {
   @Mock private EnrollmentService enrollmentService;
 
   @Mock private CategoryService dataElementCategoryService;
-
-  @Mock private EventService eventService;
 
   @Mock private UserService userService;
 
@@ -201,9 +198,7 @@ class DataValueListenerTest extends DhisConvenienceTest {
   public void initTest() {
     subject =
         new DataValueSMSListener(
-            enrollmentService,
             dataElementCategoryService,
-            eventService,
             userService,
             incomingSmsService,
             smsSender,

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/DeleteEventSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/DeleteEventSMSListenerTest.java
@@ -114,8 +114,8 @@ class DeleteEventSMSListenerTest extends CompressionSMSListenerTest {
             organisationUnitService,
             categoryService,
             dataElementService,
-            eventService,
-            identifiableObjectManager);
+            identifiableObjectManager,
+            eventService);
 
     setUpInstances();
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/RelationshipSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/RelationshipSMSListenerTest.java
@@ -131,12 +131,12 @@ class RelationshipSMSListenerTest extends CompressionSMSListenerTest {
             organisationUnitService,
             categoryService,
             dataElementService,
+            identifiableObjectManager,
             eventService,
             relationshipService,
             relationshipTypeService,
             trackedEntityService,
-            enrollmentService,
-            identifiableObjectManager);
+            enrollmentService);
 
     setUpInstances();
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationListenerTest.java
@@ -143,15 +143,14 @@ class TrackedEntityRegistrationListenerTest extends DhisConvenienceTest {
     subject =
         new TrackedEntityRegistrationSMSListener(
             programService,
-            enrollmentService,
             dataElementCategoryService,
-            eventService,
             userService,
             incomingSmsService,
             smsSender,
             smsCommandService,
             trackedEntityTypeService,
-            trackedEntityService);
+            trackedEntityService,
+            enrollmentService);
 
     setUpInstances();
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackerEventSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackerEventSMSListenerTest.java
@@ -152,10 +152,10 @@ class TrackerEventSMSListenerTest extends CompressionSMSListenerTest {
             organisationUnitService,
             categoryService,
             dataElementService,
+            identifiableObjectManager,
             eventService,
             programStageService,
-            enrollmentService,
-            identifiableObjectManager);
+            enrollmentService);
 
     setUpInstances();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventChangeLogService.java
@@ -27,17 +27,13 @@
  */
 package org.hisp.dhis.tracker.export.event;
 
-import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
-import org.hisp.dhis.program.Event;
-import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
-import org.hisp.dhis.user.CurrentUserUtil;
-import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,26 +42,16 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DefaultEventChangeLogService implements EventChangeLogService {
 
-  private final org.hisp.dhis.program.EventService eventService;
+  private final EventService eventService;
 
   private final JdbcEventChangeLogStore jdbcEventChangeLogStore;
-
-  private final TrackerAccessManager trackerAccessManager;
 
   @Override
   public Page<EventChangeLog> getEventChangeLog(
       UID eventUid, EventChangeLogOperationParams operationParams, PageParams pageParams)
-      throws NotFoundException {
-    Event event = eventService.getEvent(eventUid.getValue());
-    if (event == null) {
-      throw new NotFoundException(Event.class, eventUid.getValue());
-    }
-
-    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
-    List<String> errors = trackerAccessManager.canRead(currentUser, event, false);
-    if (!errors.isEmpty()) {
-      throw new NotFoundException(Event.class, eventUid.getValue());
-    }
+      throws NotFoundException, ForbiddenException {
+    // check existence and access
+    eventService.getEvent(eventUid);
 
     return jdbcEventChangeLogStore.getEventChangeLog(
         eventUid, operationParams.getOrder(), pageParams);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLogService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventChangeLogService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.tracker.export.event;
 
 import java.util.Set;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
@@ -42,7 +43,7 @@ public interface EventChangeLogService {
    */
   Page<EventChangeLog> getEventChangeLog(
       UID event, EventChangeLogOperationParams operationParams, PageParams pageParams)
-      throws NotFoundException;
+      throws NotFoundException, ForbiddenException;
 
   /**
    * Fields the {@link #getEventChangeLog(UID, EventChangeLogOperationParams, PageParams)} can order

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
@@ -45,11 +45,18 @@ import org.hisp.dhis.tracker.export.PageParams;
  */
 public interface EventService {
   /** Get a file for an events' data element. */
-  FileResourceStream getFileResource(UID event, UID dataElement) throws NotFoundException;
+  FileResourceStream getFileResource(UID event, UID dataElement)
+      throws NotFoundException, ForbiddenException;
 
   /** Get an image for an events' data element in the given dimension. */
   FileResourceStream getFileResourceImage(UID event, UID dataElement, ImageFileDimension dimension)
-      throws NotFoundException;
+      throws NotFoundException, ForbiddenException;
+
+  /**
+   * Get event matching given {@code UID}. Use {@link #getEvent(String, EventParams)} instead to
+   * also get the events relationships.
+   */
+  Event getEvent(UID uid) throws NotFoundException, ForbiddenException;
 
   /** Get event matching given {@code UID} and params. */
   Event getEvent(String uid, EventParams eventParams) throws NotFoundException, ForbiddenException;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapper.java
@@ -30,15 +30,15 @@ package org.hisp.dhis.tracker.export.relationship;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentService;
-import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
+import org.hisp.dhis.tracker.export.event.EventService;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Component;
@@ -67,7 +67,7 @@ class RelationshipOperationParamsMapper {
         switch (params.getType()) {
           case TRACKED_ENTITY -> validateTrackedEntity(currentUser, params.getIdentifier());
           case ENROLLMENT -> validateEnrollment(currentUser, params.getIdentifier());
-          case EVENT -> validateEvent(currentUser, params.getIdentifier());
+          case EVENT -> eventService.getEvent(UID.of(params.getIdentifier()));
           case RELATIONSHIP -> throw new IllegalArgumentException("Unsupported type");
         };
 
@@ -106,20 +106,5 @@ class RelationshipOperationParamsMapper {
     }
 
     return enrollment;
-  }
-
-  private Event validateEvent(UserDetails user, String uid)
-      throws NotFoundException, ForbiddenException {
-    Event event = eventService.getEvent(uid);
-    if (event == null) {
-      throw new NotFoundException(Event.class, uid);
-    }
-
-    List<String> errors = accessManager.canRead(user, event, false);
-    if (!errors.isEmpty()) {
-      throw new ForbiddenException(Event.class, uid);
-    }
-
-    return event;
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/DefaultTrackerObjectsDeletionService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/DefaultTrackerObjectsDeletionService.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.tracker.imports.bundle.persister;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
@@ -55,6 +56,8 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
   private final EnrollmentService enrollmentService;
 
   private final TrackedEntityService teService;
+
+  private final IdentifiableObjectManager manager;
 
   private final EventService eventService;
 
@@ -116,7 +119,7 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
 
       Entity objectReport = new Entity(TrackerType.EVENT, uid);
 
-      Event event = eventService.getEvent(uid);
+      Event event = manager.get(Event.class, uid);
       event.setLastUpdatedByUserInfo(bundle.getUserInfo());
 
       eventService.deleteEvent(event);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipOperationParamsMapperTest.java
@@ -39,19 +39,20 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.common.SortDirection;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.tracker.export.Order;
+import org.hisp.dhis.tracker.export.event.EventService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
@@ -178,8 +179,7 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
 
   @Test
   void shouldMapEventWhenAEventIsPassed() throws NotFoundException, ForbiddenException {
-    when(eventService.getEvent(EV_UID)).thenReturn(event);
-    when(accessManager.canRead(user, event, false)).thenReturn(List.of());
+    when(eventService.getEvent(UID.of(EV_UID))).thenReturn(event);
     RelationshipOperationParams params =
         RelationshipOperationParams.builder().type(EVENT).identifier(EV_UID).build();
 
@@ -187,25 +187,6 @@ class RelationshipOperationParamsMapperTest extends DhisConvenienceTest {
 
     assertInstanceOf(Event.class, queryParams.getEntity());
     assertEquals(EV_UID, queryParams.getEntity().getUid());
-  }
-
-  @Test
-  void shouldThrowWhenEventIsNotFound() {
-    when(eventService.getEvent(EV_UID)).thenReturn(null);
-    RelationshipOperationParams params =
-        RelationshipOperationParams.builder().type(EVENT).identifier(EV_UID).build();
-
-    assertThrows(NotFoundException.class, () -> mapper.map(params));
-  }
-
-  @Test
-  void shouldThrowWhenUserHasNoAccessToEvent() {
-    when(eventService.getEvent(EV_UID)).thenReturn(event);
-    when(accessManager.canRead(user, event, false)).thenReturn(List.of("error"));
-    RelationshipOperationParams params =
-        RelationshipOperationParams.builder().type(EVENT).identifier(EV_UID).build();
-
-    assertThrows(ForbiddenException.class, () -> mapper.map(params));
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventServiceTest.java
@@ -243,9 +243,9 @@ class EventServiceTest extends TransactionalIntegrationTest {
      * Prepare data for EventDataValues manipulation tests
      */
     manager.save(eventA);
-    // Check that there are no EventDataValues assigned to PSI
-    Event tempPsiA = eventService.getEvent(eventA.getUid());
-    assertEquals(0, tempPsiA.getEventDataValues().size());
+    // Check that there are no EventDataValues assigned to the event
+    Event tempEventA = manager.get(Event.class, eventA.getUid());
+    assertEquals(0, tempEventA.getEventDataValues().size());
     // Prepare EventDataValues to manipulate with
     dataElementMap.put(dataElementA.getUid(), dataElementA);
     dataElementMap.put(dataElementB.getUid(), dataElementB);
@@ -297,8 +297,8 @@ class EventServiceTest extends TransactionalIntegrationTest {
     long idB = eventB.getId();
     assertEquals(eventA, getEvent(idA));
     assertEquals(eventB, getEvent(idB));
-    assertEquals(eventA, eventService.getEvent("UID-A"));
-    assertEquals(eventB, eventService.getEvent("UID-B"));
+    assertEquals(eventA, manager.get(Event.class, "UID-A"));
+    assertEquals(eventB, manager.get(Event.class, "UID-B"));
   }
 
   @Test
@@ -316,11 +316,11 @@ class EventServiceTest extends TransactionalIntegrationTest {
 
     manager.save(event);
 
-    assertNotNull(eventService.getEvent(event.getUid()));
+    assertNotNull(manager.get(Event.class, event.getUid()));
 
     eventService.deleteEvent(event);
 
-    assertNull(eventService.getEvent(event.getUid()));
+    assertNull(manager.get(Event.class, event.getUid()));
     assertTrue(noteService.noteExists(note.getUid()));
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/event/EventChangeLogServiceTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.UID;
+import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.tracker.TrackerTest;
@@ -95,7 +96,7 @@ class EventChangeLogServiceTest extends TrackerTest {
     testAsUser("o1HMTIzBGo7");
 
     assertThrows(
-        NotFoundException.class,
+        ForbiddenException.class,
         () -> eventChangeLogService.getEventChangeLog(UID.of("D9PbzJY8bJM"), null, null));
   }
 
@@ -104,7 +105,7 @@ class EventChangeLogServiceTest extends TrackerTest {
     testAsUser("o1HMTIzBGo7");
 
     assertThrows(
-        NotFoundException.class,
+        ForbiddenException.class,
         () -> eventChangeLogService.getEventChangeLog(UID.of("G9PbzJY8bJG"), null, null));
   }
 
@@ -113,7 +114,7 @@ class EventChangeLogServiceTest extends TrackerTest {
     testAsUser("FIgVWzUCkpw");
 
     assertThrows(
-        NotFoundException.class,
+        ForbiddenException.class,
         () -> eventChangeLogService.getEventChangeLog(UID.of("H0PbzJY8bJG"), null, null));
   }
 
@@ -122,12 +123,12 @@ class EventChangeLogServiceTest extends TrackerTest {
     testAsUser("o1HMTIzBGo7");
 
     assertThrows(
-        NotFoundException.class,
+        ForbiddenException.class,
         () -> eventChangeLogService.getEventChangeLog(UID.of("G9PbzJY8bJG"), null, null));
   }
 
   @Test
-  void shouldReturnChangeLogsWhenDataValueIsCreated() throws NotFoundException {
+  void shouldReturnChangeLogsWhenDataValueIsCreated() throws NotFoundException, ForbiddenException {
     testAsUser("M5zQapPyTZI");
     Event event = getEvent("QRYjLTiJTrA");
     String dataElementUid = event.getEventDataValues().iterator().next().getDataElement();
@@ -141,7 +142,8 @@ class EventChangeLogServiceTest extends TrackerTest {
   }
 
   @Test
-  void shouldReturnChangeLogsWhenDataValueIsDeleted() throws NotFoundException, IOException {
+  void shouldReturnChangeLogsWhenDataValueIsDeleted()
+      throws NotFoundException, IOException, ForbiddenException {
     testAsUser("M5zQapPyTZI");
 
     Event event = getEvent("QRYjLTiJTrA");
@@ -163,7 +165,7 @@ class EventChangeLogServiceTest extends TrackerTest {
 
   @Test
   void shouldNotUpdateChangeLogsWhenDataValueIsDeletedTwiceInARow()
-      throws NotFoundException, IOException {
+      throws NotFoundException, IOException, ForbiddenException {
     testAsUser("M5zQapPyTZI");
 
     Event event = getEvent("QRYjLTiJTrA");
@@ -186,7 +188,8 @@ class EventChangeLogServiceTest extends TrackerTest {
   }
 
   @Test
-  void shouldReturnChangeLogsWhenDataValueIsUpdated() throws NotFoundException, IOException {
+  void shouldReturnChangeLogsWhenDataValueIsUpdated()
+      throws NotFoundException, IOException, ForbiddenException {
     testAsUser("M5zQapPyTZI");
 
     Event event = getEvent("QRYjLTiJTrA");
@@ -208,7 +211,7 @@ class EventChangeLogServiceTest extends TrackerTest {
 
   @Test
   void shouldReturnChangeLogsWhenDataValueIsUpdatedTwiceInARow()
-      throws NotFoundException, IOException {
+      throws NotFoundException, IOException, ForbiddenException {
     testAsUser("M5zQapPyTZI");
 
     Event event = getEvent("QRYjLTiJTrA");
@@ -233,7 +236,7 @@ class EventChangeLogServiceTest extends TrackerTest {
 
   @Test
   void shouldReturnChangeLogsWhenDataValueIsCreatedUpdatedAndDeleted()
-      throws IOException, NotFoundException {
+      throws IOException, NotFoundException, ForbiddenException {
     testAsUser("M5zQapPyTZI");
 
     Event event = getEvent("QRYjLTiJTrA");

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventDataValueTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/EventDataValueTest.java
@@ -40,7 +40,6 @@ import java.util.stream.Collectors;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
@@ -61,7 +60,6 @@ class EventDataValueTest extends TrackerTest {
 
   @Autowired private IdentifiableObjectManager manager;
 
-  @Autowired private EventService eventService;
   @Autowired protected UserService _userService;
 
   @Override
@@ -121,10 +119,10 @@ class EventDataValueTest extends TrackerTest {
     assertNoErrors(importReport);
     List<Event> updatedEvents = manager.getAll(Event.class);
     assertEquals(1, updatedEvents.size());
-    Event updatedPsi = eventService.getEvent(updatedEvents.get(0).getUid());
-    assertEquals(3, updatedPsi.getEventDataValues().size());
+    Event updatedEvent = manager.get(Event.class, updatedEvents.get(0).getUid());
+    assertEquals(3, updatedEvent.getEventDataValues().size());
     List<String> values =
-        updatedPsi.getEventDataValues().stream()
+        updatedEvent.getEventDataValues().stream()
             .map(EventDataValue::getValue)
             .collect(Collectors.toList());
     assertThat(values, hasItem("First"));
@@ -135,7 +133,7 @@ class EventDataValueTest extends TrackerTest {
         eventDataValues.stream()
             .collect(Collectors.toMap(EventDataValue::getDataElement, ev -> ev));
     Map<String, EventDataValue> updatedDataValueMap =
-        updatedPsi.getEventDataValues().stream()
+        updatedEvent.getEventDataValues().stream()
             .collect(Collectors.toMap(EventDataValue::getDataElement, ev -> ev));
 
     String updatedDataElementId = "DATAEL00004";

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventImportValidationTest.java
@@ -376,7 +376,7 @@ class EventImportValidationTest extends TrackerTest {
   private void testDeletedEventFails(TrackerImportStrategy importStrategy) {
     // Given -> Creates an event
     createEvent("tracker/validations/events-with-notes-data.json");
-    Event event = programStageServiceInstance.getEvent("uLxFbxfYDQE");
+    Event event = manager.get(Event.class, "uLxFbxfYDQE");
     assertNotNull(event);
     // When -> Soft-delete the event
     programStageServiceInstance.deleteEvent(event);
@@ -436,6 +436,6 @@ class EventImportValidationTest extends TrackerTest {
     final Map<TrackerType, TrackerTypeReport> typeReportMap =
         importReport.getPersistenceReport().getTypeReportMap();
     String newEvent = typeReportMap.get(TrackerType.EVENT).getEntityReport().get(0).getUid();
-    return programStageServiceInstance.getEvent(newEvent);
+    return manager.get(Event.class, newEvent);
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventSecurityImportValidationTest.java
@@ -46,7 +46,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
@@ -78,8 +77,6 @@ class EventSecurityImportValidationTest extends TrackerTest {
   @Autowired protected TrackedEntityService trackedEntityService;
 
   @Autowired private TrackerImportService trackerImportService;
-
-  @Autowired private EventService programStageServiceInstance;
 
   @Autowired private TrackedEntityProgramOwnerService trackedEntityProgramOwnerService;
 
@@ -242,7 +239,7 @@ class EventSecurityImportValidationTest extends TrackerTest {
     ImportReport importReport = trackerImportService.importTracker(params, trackerObjects);
     assertNoErrors(importReport);
     // Change just inserted Event to status COMPLETED...
-    Event zwwuwNp6gVd = programStageServiceInstance.getEvent("ZwwuwNp6gVd");
+    Event zwwuwNp6gVd = manager.get(Event.class, "ZwwuwNp6gVd");
     zwwuwNp6gVd.setStatus(EventStatus.COMPLETED);
     manager.update(zwwuwNp6gVd);
     programA.setPublicAccess(AccessStringHelper.FULL);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerByIdTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportControllerByIdTest.java
@@ -557,7 +557,7 @@ class EventsExportControllerByIdTest extends DhisControllerConvenienceTest {
     this.switchContextToUser(user);
 
     GET("/tracker/events/{eventUid}/dataValues/{dataElementUid}/file", event.getUid(), de.getUid())
-        .error(HttpStatus.NOT_FOUND);
+        .error(HttpStatus.FORBIDDEN);
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -301,7 +301,7 @@ class EventsExportController {
       @OpenApi.Param({UID.class, Event.class}) @PathVariable UID event,
       @OpenApi.Param({UID.class, DataElement.class}) @PathVariable UID dataElement,
       HttpServletRequest request)
-      throws NotFoundException, ConflictException, BadRequestException {
+      throws NotFoundException, ConflictException, BadRequestException, ForbiddenException {
     validateUnsupportedParameter(
         request,
         "dimension",
@@ -317,7 +317,7 @@ class EventsExportController {
       @OpenApi.Param({UID.class, DataElement.class}) @PathVariable UID dataElement,
       @RequestParam(required = false) ImageFileDimension dimension,
       HttpServletRequest request)
-      throws NotFoundException, ConflictException, BadRequestException {
+      throws NotFoundException, ConflictException, BadRequestException, ForbiddenException {
     return fileResourceRequestHandler.handle(
         request, eventService.getFileResourceImage(event, dataElement, dimension));
   }
@@ -327,7 +327,7 @@ class EventsExportController {
       @OpenApi.Param({UID.class, Event.class}) @PathVariable UID event,
       ChangeLogRequestParams requestParams,
       HttpServletRequest request)
-      throws NotFoundException, BadRequestException {
+      throws NotFoundException, BadRequestException, ForbiddenException {
     EventChangeLogOperationParams operationParams =
         ChangeLogRequestParamsMapper.map(eventChangeLogService.getOrderableFields(), requestParams);
     PageParams pageParams =


### PR DESCRIPTION
## This PR

* Base class `CompressionSMSListener` only depended on tracker because of its `saveNewEvent` method that was only used by tracker subclasses. Create tracker specific subclass `EventSavingSMSListener` to make `CompressionSMSListener` tracker independent.
* Base class `CommandSMSListener` only depended on tracker because of its `register` method that was only used by tracker subclasses. Create tracker specific subclass `RegisterSMSListener` to make `CommandSMSListener` tracker independent.

The sms code could use some refactoring as these class hierarchies and large number of dependencies are wild. This is out of scope for this epic though 😅 

Next PR move tracker specific sms code into `dhis-service-tracker`. This allows us to use tracker exporter and importer services.

## Big picture

Tracker has multiple services for each entity like tracked entity, enrollment and event. One is in dhis-api and one in dhis-service-tracker. Our goal is to provide one API (service) per entity that is part of the tracker domain/team.

Trackers architecture splits read/write into exporter services and an importer. So if you want to get data you use an exporter. If you want to insert, update or delete you have to go through the importer. Only then can we ensure integrity of tracker data.

Another goal is that code that provides tracker functionality and is thus owned by the tracker team lives in ideally one maven module (We can settle on a name later on maybe `dhis-service-tracker` or `dhis-tracker`).

This is a **big** task that we are going to implement in many small steps.
