### PR TITLE
chore: remove dhis-api EventService.get by UID part 2 DHIS2-17638-7

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -144,10 +144,6 @@
       <artifactId>commons-beanutils</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.locationtech.jts</groupId>
-      <artifactId>jts-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.jasypt</groupId>
       <artifactId>jasypt</artifactId>
     </dependency>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListener.java
@@ -106,7 +106,7 @@ public class AggregateDataSetSMSListener extends CompressionSMSListener {
   }
 
   @Override
-  protected SmsResponse postProcess(IncomingSms sms, SmsSubmission submission)
+  protected SmsResponse postProcess(IncomingSms sms, SmsSubmission submission, User user)
       throws SMSProcessingException {
     AggregateDatasetSmsSubmission subm = (AggregateDatasetSmsSubmission) submission;
 
@@ -116,10 +116,8 @@ public class AggregateDataSetSMSListener extends CompressionSMSListener {
     Uid aocid = subm.getAttributeOptionCombo();
 
     OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit(ouid.getUid());
-    User user = userService.getUser(subm.getUserId().getUid());
 
     DataSet dataSet = dataSetService.getDataSet(dsid.getUid());
-
     if (dataSet == null) {
       throw new SMSProcessingException(SmsResponse.INVALID_DATASET.set(dsid));
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-tracker/pom.xml
@@ -66,6 +66,10 @@
       <artifactId>kotlinx-datetime-jvm</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.github.dhis2</groupId>
+      <artifactId>sms-compression</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-jdbc</artifactId>
     </dependency>

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/DefaultEventService.java
@@ -132,25 +132,35 @@ class DefaultEventService implements EventService {
   }
 
   @Override
-  public Event getEvent(UID uid) throws ForbiddenException, NotFoundException {
-    return getEvent(uid.getValue(), EventParams.FALSE);
+  public Event getEvent(@Nonnull UID event) throws ForbiddenException, NotFoundException {
+    return getEvent(event, EventParams.FALSE, CurrentUserUtil.getCurrentUserDetails());
   }
 
   @Override
-  public Event getEvent(String uid, EventParams eventParams)
+  public Event getEvent(@Nonnull UID event, UserDetails user)
+      throws ForbiddenException, NotFoundException {
+    return getEvent(event, EventParams.FALSE, user);
+  }
+
+  @Override
+  public Event getEvent(@Nonnull UID event, EventParams eventParams)
+      throws ForbiddenException, NotFoundException {
+    return getEvent(event, eventParams, CurrentUserUtil.getCurrentUserDetails());
+  }
+
+  public Event getEvent(@Nonnull UID eventUid, EventParams eventParams, UserDetails user)
       throws NotFoundException, ForbiddenException {
-    Event event = manager.get(Event.class, uid);
+    Event event = manager.get(Event.class, eventUid.getValue());
     if (event == null) {
-      throw new NotFoundException(Event.class, uid);
+      throw new NotFoundException(Event.class, eventUid.getValue());
     }
 
-    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
-    List<String> errors = trackerAccessManager.canRead(currentUser, event, false);
+    List<String> errors = trackerAccessManager.canRead(user, event, false);
     if (!errors.isEmpty()) {
       throw new ForbiddenException(errors.toString());
     }
 
-    return getEvent(event, eventParams, currentUser);
+    return getEvent(event, eventParams, user);
   }
 
   private Event getEvent(@Nonnull Event event, EventParams eventParams, UserDetails currentUser) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/event/EventService.java
@@ -39,37 +39,58 @@ import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.tracker.export.FileResourceStream;
 import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
+import org.hisp.dhis.user.UserDetails;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 public interface EventService {
-  /** Get a file for an events' data element. */
+  /**
+   * Get a file for an events' data element under the privileges of the currently authenticated
+   * user.
+   */
   FileResourceStream getFileResource(UID event, UID dataElement)
       throws NotFoundException, ForbiddenException;
 
-  /** Get an image for an events' data element in the given dimension. */
+  /**
+   * Get an image for an events' data element in the given dimension under the privileges of the
+   * currently authenticated user.
+   */
   FileResourceStream getFileResourceImage(UID event, UID dataElement, ImageFileDimension dimension)
       throws NotFoundException, ForbiddenException;
 
   /**
-   * Get event matching given {@code UID}. Use {@link #getEvent(String, EventParams)} instead to
-   * also get the events relationships.
+   * Get event matching given {@code UID} under the privileges of the currently authenticated user.
+   * Use {@link #getEvent(UID, EventParams)} instead to also get the events relationships.
    */
   Event getEvent(UID uid) throws NotFoundException, ForbiddenException;
 
-  /** Get event matching given {@code UID} and params. */
-  Event getEvent(String uid, EventParams eventParams) throws NotFoundException, ForbiddenException;
+  /**
+   * Get event matching given {@code UID} under the privileges of given user. This method does not
+   * get the events relationships.
+   */
+  Event getEvent(UID uid, UserDetails user) throws NotFoundException, ForbiddenException;
 
-  /** Get all events matching given params. */
+  /**
+   * Get event matching given {@code UID} and params under the privileges of the currently
+   * authenticated user.
+   */
+  Event getEvent(UID uid, EventParams eventParams) throws NotFoundException, ForbiddenException;
+
+  /**
+   * Get all events matching given params under the privileges of the currently authenticated user.
+   */
   List<Event> getEvents(EventOperationParams params) throws BadRequestException, ForbiddenException;
 
-  /** Get a page of events matching given params. */
+  /**
+   * Get a page of events matching given params under the privileges of the currently authenticated
+   * user.
+   */
   Page<Event> getEvents(EventOperationParams params, PageParams pageParams)
       throws BadRequestException, ForbiddenException;
 
   RelationshipItem getEventInRelationshipItem(String uid, EventParams eventParams)
-      throws NotFoundException, ForbiddenException;
+      throws NotFoundException;
 
   /**
    * Fields the {@link #getEvents(EventOperationParams)} and {@link #getEvents(EventOperationParams,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/ProgramStageDataEntrySMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/ProgramStageDataEntrySMSListener.java
@@ -25,13 +25,12 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.sms.listener;
+package org.hisp.dhis.tracker.imports.sms;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
@@ -61,7 +60,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 /** Created by zubair@dhis2.org on 11.08.17. */
-@Component("org.hisp.dhis.sms.listener.ProgramStageDataEntrySMSListener")
+@Component("org.hisp.dhis.tracker.sms.ProgramStageDataEntrySMSListener")
 @Transactional
 public class ProgramStageDataEntrySMSListener extends RegisterSMSListener {
   private static final String MORE_THAN_ONE_TE =
@@ -137,7 +136,7 @@ public class ProgramStageDataEntrySMSListener extends RegisterSMSListener {
     List<TrackedEntityAttribute> attributes =
         trackedEntityAttributeService.getAllTrackedEntityAttributes().stream()
             .filter(attr -> attr.getValueType().equals(ValueType.PHONE_NUMBER))
-            .collect(Collectors.toList());
+            .toList();
 
     List<TrackedEntity> trackedEntities = new ArrayList<>();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/RegisterSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/RegisterSMSListener.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.sms.listener;
+package org.hisp.dhis.tracker.imports.sms;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -50,12 +50,11 @@ import org.hisp.dhis.sms.command.code.SMSCode;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
 import org.hisp.dhis.sms.incoming.SmsMessageStatus;
+import org.hisp.dhis.sms.listener.CommandSMSListener;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.UserService;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
-@Transactional
 public abstract class RegisterSMSListener extends CommandSMSListener {
 
   protected final EventService eventService;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/SingleEventListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/SingleEventListener.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.sms.listener;
+package org.hisp.dhis.tracker.imports.sms;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,7 +50,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 /** Zubair <rajazubair.asghar@gmail.com> */
-@Component("org.hisp.dhis.sms.listener.SingleEventListener")
+@Component("org.hisp.dhis.tracker.sms.SingleEventListener")
 @Transactional
 public class SingleEventListener extends RegisterSMSListener {
   private final SMSCommandService smsCommandService;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/TrackedEntityRegistrationSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/TrackedEntityRegistrationSMSListener.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.sms.listener;
+package org.hisp.dhis.tracker.imports.sms;
 
 import java.util.Collection;
 import java.util.Date;
@@ -45,6 +45,7 @@ import org.hisp.dhis.sms.command.code.SMSCode;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
 import org.hisp.dhis.sms.incoming.SmsMessageStatus;
+import org.hisp.dhis.sms.listener.CommandSMSListener;
 import org.hisp.dhis.sms.parse.ParserType;
 import org.hisp.dhis.sms.parse.SMSParserException;
 import org.hisp.dhis.system.util.SmsUtils;
@@ -58,7 +59,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-@Component("org.hisp.dhis.sms.listener.TrackedEntityRegistrationSMSListener")
+@Component("org.hisp.dhis.tracker.sms.TrackedEntityRegistrationSMSListener")
 @Transactional
 public class TrackedEntityRegistrationSMSListener extends CommandSMSListener {
   private static final String SUCCESS_MESSAGE = "Tracked Entity Registered Successfully with uid. ";
@@ -127,7 +128,7 @@ public class TrackedEntityRegistrationSMSListener extends CommandSMSListener {
             });
 
     long trackedEntityId = 0;
-    if (patientAttributeValues.size() > 0) {
+    if (!patientAttributeValues.isEmpty()) {
       trackedEntityId =
           trackedEntityService.createTrackedEntity(trackedEntity, patientAttributeValues);
     } else {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/sms/CompressionSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/sms/CompressionSMSListenerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.imports.sms;
+
+import java.util.Base64;
+import java.util.Date;
+import org.hisp.dhis.DhisConvenienceTest;
+import org.hisp.dhis.sms.incoming.IncomingSms;
+import org.hisp.dhis.smscompression.SmsCompressionException;
+import org.hisp.dhis.smscompression.SmsSubmissionWriter;
+import org.hisp.dhis.smscompression.models.SmsMetadata;
+import org.hisp.dhis.smscompression.models.SmsSubmission;
+import org.hisp.dhis.user.User;
+
+abstract class CompressionSMSListenerTest extends DhisConvenienceTest {
+  protected static final String SUCCESS_MESSAGE = "1:0::Submission has been processed successfully";
+
+  protected static final String NOVALUES_MESSAGE =
+      "1:2::The submission did not include any data values";
+
+  protected static final String NOATTRIBS_MESSAGE =
+      "1:3::The submission did not include any attribute values";
+
+  protected static final String ORIGINATOR = "47400000";
+
+  protected static final String ATTRIBUTE_VALUE = "TEST";
+
+  protected IncomingSms createSMSFromSubmission(SmsSubmission subm) throws SmsCompressionException {
+    User user = makeUser("U");
+    SmsMetadata meta = new SmsMetadata();
+    meta.lastSyncDate = new Date();
+    SmsSubmissionWriter writer = new SmsSubmissionWriter(meta);
+    String smsText = Base64.getEncoder().encodeToString(writer.compress(subm));
+
+    IncomingSms incomingSms = new IncomingSms();
+    incomingSms.setText(smsText);
+    incomingSms.setOriginator(ORIGINATOR);
+    incomingSms.setCreatedBy(user);
+
+    return incomingSms;
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/sms/DeleteEventSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/sms/DeleteEventSMSListenerTest.java
@@ -25,48 +25,39 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.sms.listener;
+package org.hisp.dhis.tracker.imports.sms;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.Sets;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashSet;
-import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataelement.DataElementService;
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.message.MessageSender;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
-import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventService;
-import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
 import org.hisp.dhis.smscompression.SmsCompressionException;
-import org.hisp.dhis.smscompression.SmsConsts.SmsEventStatus;
-import org.hisp.dhis.smscompression.models.GeoPoint;
-import org.hisp.dhis.smscompression.models.SimpleEventSmsSubmission;
-import org.hisp.dhis.smscompression.models.SmsDataValue;
+import org.hisp.dhis.smscompression.models.DeleteSmsSubmission;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
+import org.hisp.dhis.tracker.export.event.EventService;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -75,7 +66,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class SimpleEventSMSListenerTest extends CompressionSMSListenerTest {
+class DeleteEventSMSListenerTest extends CompressionSMSListenerTest {
 
   @Mock private UserService userService;
 
@@ -95,13 +86,15 @@ class SimpleEventSMSListenerTest extends CompressionSMSListenerTest {
 
   @Mock private CategoryService categoryService;
 
+  @Mock private org.hisp.dhis.program.EventService apiEventService;
+
   @Mock private EventService eventService;
 
   @Mock private IdentifiableObjectManager identifiableObjectManager;
 
   private User user;
 
-  private OutboundMessageResponse response = new OutboundMessageResponse();
+  private final OutboundMessageResponse response = new OutboundMessageResponse();
 
   private IncomingSms updatedIncomingSms;
 
@@ -109,30 +102,16 @@ class SimpleEventSMSListenerTest extends CompressionSMSListenerTest {
 
   // Needed for this test
 
-  @Mock private EnrollmentService enrollmentService;
+  DeleteEventSMSListener subject;
 
-  private SimpleEventSMSListener subject;
-
-  private IncomingSms incomingSmsSimpleEvent;
-
-  private IncomingSms incomingSmsSimpleEventWithNulls;
-
-  private IncomingSms incomingSmsSimpleEventNoValues;
-
-  private OrganisationUnit organisationUnit;
-
-  private CategoryOptionCombo categoryOptionCombo;
-
-  private DataElement dataElement;
-
-  private Program program;
+  private IncomingSms incomingSmsDelete;
 
   private Event event;
 
   @BeforeEach
-  public void initTest() throws SmsCompressionException {
+  public void initTest() throws SmsCompressionException, ForbiddenException, NotFoundException {
     subject =
-        new SimpleEventSMSListener(
+        new DeleteEventSMSListener(
             incomingSmsService,
             smsSender,
             userService,
@@ -142,9 +121,9 @@ class SimpleEventSMSListenerTest extends CompressionSMSListenerTest {
             organisationUnitService,
             categoryService,
             dataElementService,
-            eventService,
-            enrollmentService,
-            identifiableObjectManager);
+            identifiableObjectManager,
+            apiEventService,
+            eventService);
 
     setUpInstances();
 
@@ -156,11 +135,8 @@ class SimpleEventSMSListenerTest extends CompressionSMSListenerTest {
               message = (String) invocation.getArguments()[1];
               return response;
             });
-
-    when(organisationUnitService.getOrganisationUnit(anyString())).thenReturn(organisationUnit);
-    when(programService.getProgram(anyString())).thenReturn(program);
-    lenient().when(dataElementService.getDataElement(anyString())).thenReturn(dataElement);
-    when(categoryService.getCategoryOptionCombo(anyString())).thenReturn(categoryOptionCombo);
+    when(eventService.getEvent(eq(UID.of(event.getUid())), any(UserDetails.class)))
+        .thenReturn(event);
 
     doAnswer(
             invocation -> {
@@ -169,115 +145,35 @@ class SimpleEventSMSListenerTest extends CompressionSMSListenerTest {
             })
         .when(incomingSmsService)
         .update(any());
-
-    when(programService.hasOrgUnit(any(Program.class), any(OrganisationUnit.class)))
-        .thenReturn(true);
   }
 
   @Test
-  void testSimpleEvent() {
-    subject.receive(incomingSmsSimpleEvent);
+  void testDeleteEvent() {
+    subject.receive(incomingSmsDelete);
 
     assertNotNull(updatedIncomingSms);
     assertTrue(updatedIncomingSms.isParsed());
     assertEquals(SUCCESS_MESSAGE, message);
-
-    verify(incomingSmsService, times(1)).update(any());
-  }
-
-  @Test
-  void testSimpleEventRepeat() {
-    subject.receive(incomingSmsSimpleEvent);
-    subject.receive(incomingSmsSimpleEvent);
-
-    assertNotNull(updatedIncomingSms);
-    assertTrue(updatedIncomingSms.isParsed());
-    assertEquals(SUCCESS_MESSAGE, message);
-
-    verify(incomingSmsService, times(2)).update(any());
-  }
-
-  @Test
-  void testSimpleEventWithNulls() {
-    subject.receive(incomingSmsSimpleEventWithNulls);
-
-    assertNotNull(updatedIncomingSms);
-    assertTrue(updatedIncomingSms.isParsed());
-    assertEquals(SUCCESS_MESSAGE, message);
-
-    verify(incomingSmsService, times(1)).update(any());
-  }
-
-  @Test
-  void testSimpleEventNoValues() {
-    subject.receive(incomingSmsSimpleEventNoValues);
-
-    assertNotNull(updatedIncomingSms);
-    assertTrue(updatedIncomingSms.isParsed());
-    assertEquals(NOVALUES_MESSAGE, message);
 
     verify(incomingSmsService, times(1)).update(any());
   }
 
   private void setUpInstances() throws SmsCompressionException {
-    organisationUnit = createOrganisationUnit('O');
-    program = createProgram('P');
-    ProgramStage programStage = createProgramStage('S', program);
-
     user = makeUser("U");
     user.setPhoneNumber(ORIGINATOR);
-    user.setOrganisationUnits(Sets.newHashSet(organisationUnit));
-
-    categoryOptionCombo = createCategoryOptionCombo('C');
-    dataElement = createDataElement('D');
-
-    program.getOrganisationUnits().add(organisationUnit);
-    HashSet<ProgramStage> stages = new HashSet<>();
-    stages.add(programStage);
-    program.setProgramStages(stages);
 
     event = new Event();
     event.setAutoFields();
 
-    incomingSmsSimpleEvent = createSMSFromSubmission(createSimpleEventSubmission());
-    incomingSmsSimpleEventWithNulls =
-        createSMSFromSubmission(createSimpleEventSubmissionWithNulls());
-    incomingSmsSimpleEventNoValues = createSMSFromSubmission(createSimpleEventSubmissionNoValues());
+    incomingSmsDelete = createSMSFromSubmission(createDeleteSubmission());
   }
 
-  private SimpleEventSmsSubmission createSimpleEventSubmission() {
-    SimpleEventSmsSubmission subm = new SimpleEventSmsSubmission();
+  private DeleteSmsSubmission createDeleteSubmission() {
+    DeleteSmsSubmission subm = new DeleteSmsSubmission();
 
     subm.setUserId(user.getUid());
-    subm.setOrgUnit(organisationUnit.getUid());
-    subm.setEventProgram(program.getUid());
-    subm.setAttributeOptionCombo(categoryOptionCombo.getUid());
     subm.setEvent(event.getUid());
-    subm.setEventStatus(SmsEventStatus.COMPLETED);
-    subm.setEventDate(new Date());
-    subm.setDueDate(new Date());
-    subm.setCoordinates(new GeoPoint(59.9399586f, 10.7195609f));
-
-    ArrayList<SmsDataValue> values = new ArrayList<>();
-    values.add(new SmsDataValue(categoryOptionCombo.getUid(), dataElement.getUid(), "true"));
-    subm.setValues(values);
     subm.setSubmissionId(1);
-
-    return subm;
-  }
-
-  private SimpleEventSmsSubmission createSimpleEventSubmissionWithNulls() {
-    SimpleEventSmsSubmission subm = createSimpleEventSubmission();
-    subm.setEventDate(null);
-    subm.setDueDate(null);
-    subm.setCoordinates(null);
-
-    return subm;
-  }
-
-  private SimpleEventSmsSubmission createSimpleEventSubmissionNoValues() {
-    SimpleEventSmsSubmission subm = createSimpleEventSubmission();
-    subm.setValues(null);
 
     return subm;
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListenerTest.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.sms.listener;
+package org.hisp.dhis.tracker.imports.sms;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -54,7 +54,6 @@ import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
@@ -78,6 +77,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
+import org.hisp.dhis.tracker.export.event.EventService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.BeforeEach;
@@ -109,6 +109,7 @@ class EnrollmentSMSListenerTest extends CompressionSMSListenerTest {
 
   @Mock private ProgramStageService programStageService;
 
+  @Mock private org.hisp.dhis.program.EventService apiEventService;
   @Mock private EventService eventService;
 
   // Needed for this test
@@ -127,7 +128,7 @@ class EnrollmentSMSListenerTest extends CompressionSMSListenerTest {
 
   private User user;
 
-  private OutboundMessageResponse response = new OutboundMessageResponse();
+  private final OutboundMessageResponse response = new OutboundMessageResponse();
 
   private IncomingSms updatedIncomingSms;
 
@@ -183,6 +184,7 @@ class EnrollmentSMSListenerTest extends CompressionSMSListenerTest {
             categoryService,
             dataElementService,
             programStageService,
+            apiEventService,
             eventService,
             attributeValueService,
             trackedEntityService,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/sms/RelationshipSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/sms/RelationshipSMSListenerTest.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.sms.listener;
+package org.hisp.dhis.tracker.imports.sms;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -45,7 +45,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentService;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.relationship.RelationshipConstraint;
 import org.hisp.dhis.relationship.RelationshipEntity;
@@ -59,6 +58,7 @@ import org.hisp.dhis.smscompression.models.RelationshipSmsSubmission;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
+import org.hisp.dhis.tracker.export.event.EventService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.BeforeEach;
@@ -94,7 +94,7 @@ class RelationshipSMSListenerTest extends CompressionSMSListenerTest {
 
   private User user;
 
-  private OutboundMessageResponse response = new OutboundMessageResponse();
+  private final OutboundMessageResponse response = new OutboundMessageResponse();
 
   private IncomingSms updatedIncomingSms;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/sms/TrackedEntityRegistrationListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/sms/TrackedEntityRegistrationListenerTest.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.sms.listener;
+package org.hisp.dhis.tracker.imports.sms;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/sms/TrackerEventSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/sms/TrackerEventSMSListenerTest.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.sms.listener;
+package org.hisp.dhis.tracker.imports.sms;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -53,7 +53,6 @@ import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
@@ -67,6 +66,7 @@ import org.hisp.dhis.smscompression.models.SmsDataValue;
 import org.hisp.dhis.smscompression.models.TrackerEventSmsSubmission;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
+import org.hisp.dhis.tracker.export.event.EventService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.BeforeEach;
@@ -99,13 +99,14 @@ class TrackerEventSMSListenerTest extends CompressionSMSListenerTest {
 
   @Mock private CategoryService categoryService;
 
+  @Mock private org.hisp.dhis.program.EventService apiEventService;
   @Mock private EventService eventService;
 
   @Mock private IdentifiableObjectManager identifiableObjectManager;
 
   private User user;
 
-  private OutboundMessageResponse response = new OutboundMessageResponse();
+  private final OutboundMessageResponse response = new OutboundMessageResponse();
 
   private IncomingSms updatedIncomingSms;
 
@@ -131,8 +132,6 @@ class TrackerEventSMSListenerTest extends CompressionSMSListenerTest {
 
   private DataElement dataElement;
 
-  private Program program;
-
   private ProgramStage programStage;
 
   private Enrollment enrollment;
@@ -153,6 +152,7 @@ class TrackerEventSMSListenerTest extends CompressionSMSListenerTest {
             categoryService,
             dataElementService,
             identifiableObjectManager,
+            apiEventService,
             eventService,
             programStageService,
             enrollmentService);
@@ -230,7 +230,7 @@ class TrackerEventSMSListenerTest extends CompressionSMSListenerTest {
 
   private void setUpInstances() throws SmsCompressionException {
     organisationUnit = createOrganisationUnit('O');
-    program = createProgram('P');
+    Program program = createProgram('P');
     programStage = createProgramStage('S', program);
 
     user = makeUser("U");

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/event/EventsExportController.java
@@ -291,7 +291,7 @@ class EventsExportController {
       throws NotFoundException, ForbiddenException {
     EventParams eventParams = eventsMapper.map(fields);
     org.hisp.dhis.webapi.controller.tracker.view.Event event =
-        EVENTS_MAPPER.from(eventService.getEvent(uid.getValue(), eventParams));
+        EVENTS_MAPPER.from(eventService.getEvent(uid, eventParams));
 
     return ResponseEntity.ok(fieldFilterService.toObjectNode(event, fields));
   }


### PR DESCRIPTION
follow up to https://github.com/dhis2/dhis2-core/pull/17970 and https://github.com/dhis2/dhis2-core/pull/17952

Move tracker specific SMS classes into the `tracker.imports.sms` package in the `dhis-service-tracker` as these classes import tracker data. As discussed we will revisit the internal tracker package structure once we have finished the epic and consolidated to one maven module.

Some of the SMS classes still depend on `org.hisp.dhis.program.EventService` for CRUD operations. This will be fixed in the next PRs.

We need to run operations in the context of the user sending the SMS. The tracker event exporter therefore gets `getEvent` methods for passing in a `UserDetails`.
