### PR TITLE
chore: remove dhis-api EventStore getIncludingDeleted DHIS2-17701

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventStore.java
@@ -54,14 +54,6 @@ public interface EventStore extends IdentifiableObjectStore<Event> {
   boolean existsIncludingDeleted(String uid);
 
   /**
-   * Fetches Event matching the given list of UIDs
-   *
-   * @param uids a List of UID
-   * @return a List containing the Event matching the given parameters list
-   */
-  List<Event> getIncludingDeleted(List<String> uids);
-
-  /**
    * Get all events which have notifications with the given. ProgramNotificationTemplate scheduled
    * on the given date.
    *

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventStore.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.program.hibernate;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -57,7 +56,6 @@ import org.springframework.stereotype.Repository;
 @Repository("org.hisp.dhis.program.EventStore")
 public class HibernateEventStore extends SoftDeleteHibernateObjectStore<Event>
     implements EventStore {
-  private static final String EVENT_HQL_BY_UIDS = "from Event as ev where ev.uid in (:uids)";
 
   private static final Set<NotificationTrigger> SCHEDULED_EVENT_TRIGGERS =
       Sets.intersection(
@@ -96,24 +94,6 @@ public class HibernateEventStore extends SoftDeleteHibernateObjectStore<Event>
     query.setParameter("uid", uid);
 
     return ((Boolean) query.getSingleResult()).booleanValue();
-  }
-
-  @Override
-  public List<Event> getIncludingDeleted(List<String> uids) {
-    List<Event> events = new ArrayList<>();
-    List<List<String>> uidsPartitions = Lists.partition(Lists.newArrayList(uids), 20000);
-
-    for (List<String> uidsPartition : uidsPartitions) {
-      if (!uidsPartition.isEmpty()) {
-        events.addAll(
-            getSession()
-                .createQuery(EVENT_HQL_BY_UIDS, Event.class)
-                .setParameter("uids", uidsPartition)
-                .list());
-      }
-    }
-
-    return events;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/strategy/EventStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/strategy/EventStrategy.java
@@ -27,32 +27,55 @@
  */
 package org.hisp.dhis.tracker.imports.preheat.supplier.strategy;
 
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Nonnull;
-import lombok.RequiredArgsConstructor;
+import javax.persistence.EntityManager;
+import org.hisp.dhis.hibernate.HibernateGenericStore;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventStore;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.preheat.mappers.EventMapper;
 import org.hisp.dhis.tracker.imports.preheat.supplier.DetachUtils;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Luciano Fiandesio
  */
-@RequiredArgsConstructor
 @Component
 @StrategyFor(value = org.hisp.dhis.tracker.imports.domain.Event.class, mapper = EventMapper.class)
-public class EventStrategy implements ClassBasedSupplierStrategy {
-  @Nonnull private final EventStore eventStore;
+public class EventStrategy extends HibernateGenericStore<Event>
+    implements ClassBasedSupplierStrategy {
+  public EventStrategy(
+      EntityManager entityManager, JdbcTemplate jdbcTemplate, ApplicationEventPublisher publisher) {
+    super(entityManager, jdbcTemplate, publisher, Event.class, false);
+  }
 
   @Override
   public void add(List<List<String>> splitList, TrackerPreheat preheat) {
     for (List<String> ids : splitList) {
-      List<Event> events = eventStore.getIncludingDeleted(ids);
+      List<Event> events = getIncludingDeleted(ids);
 
       preheat.putEvents(
           DetachUtils.detach(this.getClass().getAnnotation(StrategyFor.class).mapper(), events));
     }
+  }
+
+  private List<Event> getIncludingDeleted(List<String> uids) {
+    List<Event> events = new ArrayList<>();
+    List<List<String>> uidsPartitions = Lists.partition(Lists.newArrayList(uids), 20000);
+
+    for (List<String> uidsPartition : uidsPartitions) {
+      if (!uidsPartition.isEmpty()) {
+        events.addAll(
+            getSession()
+                .createQuery("from Event as ev where ev.uid in (:uids)", Event.class)
+                .setParameter("uids", uidsPartition)
+                .list());
+      }
+    }
+
+    return events;
   }
 }


### PR DESCRIPTION
`getIncludingDeleted` is only used in the `EventStrategy`.

Soft-deletion is only present so Android can tell what was deleted. Soft-deleted entities should otherwise not be exposed. We want to find a more reliable synching mechanism for Android. Its therefore important that we do not expose this in our public API service unless we absolutely have to. This will then make it easier to move to another mechanism.

So this is a pragmatic change that violates our usual layered architecture in service of the above. 