### PR TITLE
chore: remove dhis-api EventStore.getWithScheduledNotifications DHIS2-17638

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventStore.java
@@ -27,24 +27,9 @@
  */
 package org.hisp.dhis.program;
 
-import java.util.Date;
-import java.util.List;
 import org.hisp.dhis.common.IdentifiableObjectStore;
-import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
 
 /**
  * @author Abyot Asalefew
  */
-public interface EventStore extends IdentifiableObjectStore<Event> {
-
-  /**
-   * Get all events which have notifications with the given. ProgramNotificationTemplate scheduled
-   * on the given date.
-   *
-   * @param template the template.
-   * @param notificationDate the Date for which the notification is scheduled.
-   * @return a list of Event.
-   */
-  List<Event> getWithScheduledNotifications(
-      ProgramNotificationTemplate template, Date notificationDate);
-}
+public interface EventStore extends IdentifiableObjectStore<Event> {}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageDataElementStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageDataElementStore.java
@@ -36,7 +36,7 @@ import org.hisp.dhis.dataelement.DataElement;
  */
 public interface ProgramStageDataElementStore
     extends IdentifiableObjectStore<ProgramStageDataElement> {
-  String ID = EventStore.class.getName();
+  String ID = ProgramStageDataElementStore.class.getName();
 
   /**
    * Retrieve ProgramStageDataElement list on a program stage and a data element

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.program.notification;
 
 import java.util.Date;
+import java.util.List;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.scheduling.JobProgress;
@@ -106,4 +107,16 @@ public interface ProgramNotificationService {
    * @param enrollment the Enrollment id.
    */
   void sendEnrollmentNotifications(long enrollment);
+
+  /**
+   * Get all events which have notifications with the given. ProgramNotificationTemplate scheduled
+   * on the given date.
+   *
+   * @param template the template.
+   * @param notificationDate the Date for which the notification is scheduled.
+   * @return a list of Event.
+   */
+  @Deprecated
+  List<Event> getWithScheduledNotifications(
+      ProgramNotificationTemplate template, Date notificationDate);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventService.java
@@ -37,6 +37,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.changelog.ChangeLogType;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
@@ -55,7 +56,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Service("org.hisp.dhis.program.EventService")
 public class DefaultEventService implements EventService {
-  private final EventStore eventStore;
+  private final IdentifiableObjectManager manager;
 
   private final CategoryService categoryService;
 
@@ -78,7 +79,7 @@ public class DefaultEventService implements EventService {
       CategoryOptionCombo aoc = categoryService.getDefaultCategoryOptionCombo();
       event.setAttributeOptionCombo(aoc);
     }
-    eventStore.save(event);
+    manager.save(event);
 
     for (Map.Entry<DataElement, EventDataValue> entry : dataElementEventDataValueMap.entrySet()) {
       entry.getValue().setAutoFields();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationService.java
@@ -41,20 +41,24 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.persistence.EntityManager;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Root;
 import lombok.Builder;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.DeliveryChannel;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
+import org.hisp.dhis.hibernate.HibernateGenericStore;
 import org.hisp.dhis.message.MessageConversationParams;
 import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.message.MessageType;
@@ -65,7 +69,6 @@ import org.hisp.dhis.outboundmessage.BatchResponseStatus;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentStore;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventStore;
 import org.hisp.dhis.program.message.ProgramMessage;
 import org.hisp.dhis.program.message.ProgramMessageRecipients;
 import org.hisp.dhis.program.message.ProgramMessageService;
@@ -76,6 +79,8 @@ import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.util.DateUtils;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -83,9 +88,9 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Halvdan Hoem Grelland
  */
 @Slf4j
-@RequiredArgsConstructor
 @Service("org.hisp.dhis.program.notification.ProgramNotificationService")
-public class DefaultProgramNotificationService implements ProgramNotificationService {
+public class DefaultProgramNotificationService extends HibernateGenericStore<Event>
+    implements ProgramNotificationService {
   private static final Predicate<NotificationInstanceWithTemplate> IS_SCHEDULED_BY_PROGRAM_RULE =
       (iwt) ->
           Objects.nonNull(iwt.getProgramNotificationInstance())
@@ -93,31 +98,49 @@ public class DefaultProgramNotificationService implements ProgramNotificationSer
               && iwt.getProgramNotificationInstance().getScheduledAt() != null
               && DateUtils.isToday(iwt.getProgramNotificationInstance().getScheduledAt());
 
-  // -------------------------------------------------------------------------
-  // Dependencies
-  // -------------------------------------------------------------------------
+  private static final Set<NotificationTrigger> SCHEDULED_EVENT_TRIGGERS =
+      Sets.intersection(
+          NotificationTrigger.getAllApplicableToEvent(),
+          NotificationTrigger.getAllScheduledTriggers());
 
-  @Nonnull private final ProgramMessageService programMessageService;
+  private final ProgramMessageService programMessageService;
 
-  @Nonnull private final MessageService messageService;
+  private final MessageService messageService;
 
-  @Nonnull private final EnrollmentStore enrollmentStore;
+  private final EnrollmentStore enrollmentStore;
 
-  @Nonnull private final EventStore eventStore;
+  private final IdentifiableObjectManager identifiableObjectManager;
 
-  @Nonnull private final IdentifiableObjectManager identifiableObjectManager;
+  private final NotificationMessageRenderer<Enrollment> programNotificationRenderer;
 
-  @Nonnull private final NotificationMessageRenderer<Enrollment> programNotificationRenderer;
+  private final NotificationMessageRenderer<Event> programStageNotificationRenderer;
 
-  @Nonnull private final NotificationMessageRenderer<Event> programStageNotificationRenderer;
+  private final ProgramNotificationTemplateService notificationTemplateService;
 
-  @Nonnull private final ProgramNotificationTemplateService notificationTemplateService;
+  private final NotificationTemplateMapper notificationTemplateMapper;
 
-  @Nonnull private final NotificationTemplateMapper notificationTemplateMapper;
-
-  // -------------------------------------------------------------------------
-  // ProgramStageNotificationService implementation
-  // -------------------------------------------------------------------------
+  public DefaultProgramNotificationService(
+      ProgramMessageService programMessageService,
+      MessageService messageService,
+      EnrollmentStore enrollmentStore,
+      IdentifiableObjectManager identifiableObjectManager,
+      NotificationMessageRenderer<Enrollment> programNotificationRenderer,
+      NotificationMessageRenderer<Event> programStageNotificationRenderer,
+      ProgramNotificationTemplateService notificationTemplateService,
+      NotificationTemplateMapper notificationTemplateMapper,
+      EntityManager entityManager,
+      JdbcTemplate jdbcTemplate,
+      ApplicationEventPublisher publisher) {
+    super(entityManager, jdbcTemplate, publisher, Event.class, false);
+    this.programMessageService = programMessageService;
+    this.messageService = messageService;
+    this.enrollmentStore = enrollmentStore;
+    this.identifiableObjectManager = identifiableObjectManager;
+    this.programNotificationRenderer = programNotificationRenderer;
+    this.programStageNotificationRenderer = programStageNotificationRenderer;
+    this.notificationTemplateService = notificationTemplateService;
+    this.notificationTemplateMapper = notificationTemplateMapper;
+  }
 
   @Override
   @Transactional
@@ -222,9 +245,8 @@ public class DefaultProgramNotificationService implements ProgramNotificationSer
   private boolean hasTemplate(NotificationInstanceWithTemplate instanceWithTemplate) {
     if (Objects.isNull(instanceWithTemplate.getProgramNotificationTemplate())) {
       log.warn(
-          "Cannot process scheduled notification with id: "
-              + instanceWithTemplate.getProgramNotificationInstance().getId()
-              + " since it has no associated templates");
+          "Cannot process scheduled notification with id: {} since it has no associated templates",
+          instanceWithTemplate.getProgramNotificationInstance().getId());
       return false;
     }
     return true;
@@ -265,7 +287,7 @@ public class DefaultProgramNotificationService implements ProgramNotificationSer
   @Override
   @Transactional
   public void sendEventCompletionNotifications(long eventId) {
-    sendEventNotifications(eventStore.get(eventId), NotificationTrigger.COMPLETION);
+    sendEventNotifications(identifiableObjectManager.get(Event.class, eventId));
   }
 
   @Override
@@ -297,13 +319,54 @@ public class DefaultProgramNotificationService implements ProgramNotificationSer
     sendAll(messageBatch);
   }
 
-  // -------------------------------------------------------------------------
-  // Supportive methods
-  // -------------------------------------------------------------------------
+  @Override
+  public List<Event> getWithScheduledNotifications(
+      ProgramNotificationTemplate template, Date notificationDate) {
+    if (notificationDate == null
+        || !SCHEDULED_EVENT_TRIGGERS.contains(template.getNotificationTrigger())) {
+      return List.of();
+    }
+
+    if (template.getRelativeScheduledDays() == null) {
+      return List.of();
+    }
+
+    Date targetDate =
+        org.apache.commons.lang3.time.DateUtils.addDays(
+            notificationDate, template.getRelativeScheduledDays() * -1);
+
+    String hql =
+        "select distinct ev from Event as ev "
+            + "inner join ev.programStage as ps "
+            + "where :notificationTemplate in elements(ps.notificationTemplates) "
+            + "and ev.scheduledDate is not null "
+            + "and ev.occurredDate is null "
+            + "and ev.status != :skippedEventStatus "
+            + "and cast(:targetDate as date) = ev.scheduledDate "
+            + "and ev.deleted is false";
+
+    return getQuery(hql)
+        .setParameter("notificationTemplate", template)
+        .setParameter("skippedEventStatus", EventStatus.SKIPPED)
+        .setParameter("targetDate", targetDate)
+        .list();
+  }
+
+  @Override
+  protected void preProcessPredicates(
+      CriteriaBuilder builder,
+      List<Function<Root<Event>, javax.persistence.criteria.Predicate>> predicates) {
+    predicates.add(root -> builder.equal(root.get("deleted"), false));
+  }
+
+  @Override
+  protected Event postProcessObject(Event event) {
+    return (event == null || event.isDeleted()) ? null : event;
+  }
 
   private MessageBatch createScheduledMessageBatchForDay(
       ProgramNotificationTemplate template, Date day) {
-    List<Event> events = eventStore.getWithScheduledNotifications(template, day);
+    List<Event> events = getWithScheduledNotifications(template, day);
 
     List<Enrollment> enrollments = enrollmentStore.getWithScheduledNotifications(template, day);
 
@@ -319,12 +382,12 @@ public class DefaultProgramNotificationService implements ProgramNotificationSer
         .collect(toList());
   }
 
-  private void sendEventNotifications(Event event, NotificationTrigger trigger) {
+  private void sendEventNotifications(Event event) {
     if (event == null) {
       return;
     }
 
-    Set<ProgramNotificationTemplate> templates = resolveTemplates(event, trigger);
+    Set<ProgramNotificationTemplate> templates = resolveTemplates(event);
 
     if (templates.isEmpty()) {
       return;
@@ -490,7 +553,7 @@ public class DefaultProgramNotificationService implements ProgramNotificationSer
           event.getEventDataValues().stream()
               .filter(dv -> template.getRecipientDataElement().getUid().equals(dv.getDataElement()))
               .map(EventDataValue::getValue)
-              .collect(toList());
+              .toList();
 
       if (template.getDeliveryChannels().contains(DeliveryChannel.SMS)) {
         recipients.getPhoneNumbers().addAll(recipientList);
@@ -530,7 +593,7 @@ public class DefaultProgramNotificationService implements ProgramNotificationSer
                           .getUid()
                           .equals(av.getAttribute().getUid()))
               .map(TrackedEntityAttributeValue::getPlainValue)
-              .collect(toList());
+              .toList();
 
       if (template.getDeliveryChannels().contains(DeliveryChannel.SMS)) {
         recipients.getPhoneNumbers().addAll(recipientList);
@@ -549,10 +612,9 @@ public class DefaultProgramNotificationService implements ProgramNotificationSer
         .collect(Collectors.toSet());
   }
 
-  private Set<ProgramNotificationTemplate> resolveTemplates(
-      Event event, final NotificationTrigger trigger) {
+  private Set<ProgramNotificationTemplate> resolveTemplates(Event event) {
     return event.getProgramStage().getNotificationTemplates().stream()
-        .filter(t -> t.getNotificationTrigger() == trigger)
+        .filter(t -> t.getNotificationTrigger() == NotificationTrigger.COMPLETION)
         .collect(Collectors.toSet());
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/ProgramNotificationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/ProgramNotificationServiceTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.program.notification;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.anyLong;
@@ -44,6 +45,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import javax.persistence.EntityManager;
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DeliveryChannel;
@@ -60,7 +62,6 @@ import org.hisp.dhis.outboundmessage.BatchResponseStatus;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentStore;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventStore;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
@@ -78,6 +79,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
  * @author Zubair Asghar.
@@ -102,15 +105,13 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest {
 
   private static final String ATT_EMAIL = "attr@test.org";
 
-  private String notificationTemplate = CodeGenerator.generateUid();
+  private final String notificationTemplate = CodeGenerator.generateUid();
 
   @Mock private ProgramMessageService programMessageService;
 
   @Mock private MessageService messageService;
 
   @Mock private EnrollmentStore enrollmentStore;
-
-  @Mock private EventStore eventStore;
 
   @Mock private IdentifiableObjectManager manager;
 
@@ -120,17 +121,24 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest {
 
   @Mock private ProgramNotificationTemplateService notificationTemplateService;
 
-  private NotificationTemplateMapper notificationTemplateMapper = new NotificationTemplateMapper();
+  @Mock private EntityManager entityManager;
+
+  @Mock private JdbcTemplate jdbcTemplate;
+
+  @Mock private ApplicationEventPublisher applicationEventPublisher;
+
+  private final NotificationTemplateMapper notificationTemplateMapper =
+      new NotificationTemplateMapper();
 
   private DefaultProgramNotificationService programNotificationService;
 
-  private Set<Enrollment> enrollments = new HashSet<>();
+  private final Set<Enrollment> enrollments = new HashSet<>();
 
-  private Set<Event> events = new HashSet<>();
+  private final Set<Event> events = new HashSet<>();
 
-  private List<ProgramMessage> sentProgramMessages = new ArrayList<>();
+  private final List<ProgramMessage> sentProgramMessages = new ArrayList<>();
 
-  private List<MockMessage> sentInternalMessages = new ArrayList<>();
+  private final List<MockMessage> sentInternalMessages = new ArrayList<>();
 
   private User userA;
 
@@ -152,15 +160,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest {
 
   private UserGroup userGroupBasedOnParent;
 
-  private OrganisationUnit root;
-
-  private OrganisationUnit lvlOneLeft;
-
-  private OrganisationUnit lvlOneRight;
-
   private OrganisationUnit lvlTwoLeftLeft;
-
-  private OrganisationUnit lvlTwoLeftRight;
 
   private TrackedEntity te;
 
@@ -170,21 +170,11 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest {
 
   private TrackedEntityAttribute trackedEntityAttribute;
 
-  private TrackedEntityAttribute trackedEntityAttributeEmail;
-
   private ProgramTrackedEntityAttribute programTrackedEntityAttribute;
-
-  private ProgramTrackedEntityAttribute programTrackedEntityAttributeEmail;
-
-  private TrackedEntityAttributeValue attributeValue;
-
-  private TrackedEntityAttributeValue attributeValueEmail;
 
   private NotificationMessage notificationMessage;
 
   private ProgramNotificationTemplate programNotificationTemplate;
-
-  private ProgramNotificationTemplate programNotificationTemplateForToday;
 
   private ProgramNotificationInstance programNotificationInstaceForToday;
 
@@ -195,12 +185,14 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest {
             this.programMessageService,
             this.messageService,
             this.enrollmentStore,
-            this.eventStore,
             this.manager,
             this.programNotificationRenderer,
             this.programStageNotificationRenderer,
             notificationTemplateService,
-            notificationTemplateMapper);
+            notificationTemplateMapper,
+            entityManager,
+            jdbcTemplate,
+            applicationEventPublisher);
 
     setUpInstances();
   }
@@ -222,7 +214,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest {
 
   @Test
   void testIfEventIsNull() {
-    when(eventStore.get(anyLong())).thenReturn(null);
+    when(manager.get(eq(Event.class), anyLong())).thenReturn(null);
 
     programNotificationService.sendEventCompletionNotifications(0);
 
@@ -399,7 +391,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest {
 
   @Test
   void testDataElementRecipientWithSMS() {
-    when(eventStore.get(anyLong())).thenReturn(events.iterator().next());
+    when(manager.get(eq(Event.class), anyLong())).thenReturn(events.iterator().next());
 
     when(programMessageService.sendMessages(anyList()))
         .thenAnswer(
@@ -432,7 +424,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest {
 
   @Test
   void testDataElementRecipientWithEmail() {
-    when(eventStore.get(anyLong())).thenReturn(events.iterator().next());
+    when(manager.get(eq(Event.class), anyLong())).thenReturn(events.iterator().next());
 
     when(programMessageService.sendMessages(anyList()))
         .thenAnswer(
@@ -465,7 +457,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest {
 
   @Test
   void testDataElementRecipientWithInternalRecipients() {
-    when(eventStore.get(anyLong())).thenReturn(events.iterator().next());
+    when(manager.get(eq(Event.class), anyLong())).thenReturn(events.iterator().next());
 
     when(messageService.sendMessage(any()))
         .thenAnswer(
@@ -500,7 +492,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest {
 
   @Test
   void testSendToParent() {
-    when(eventStore.get(anyLong())).thenReturn(events.iterator().next());
+    when(manager.get(eq(Event.class), anyLong())).thenReturn(events.iterator().next());
 
     when(messageService.sendMessage(any()))
         .thenAnswer(
@@ -532,7 +524,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest {
 
   @Test
   void testSendToHierarchy() {
-    when(eventStore.get(anyLong())).thenReturn(events.iterator().next());
+    when(manager.get(eq(Event.class), anyLong())).thenReturn(events.iterator().next());
 
     when(messageService.sendMessage(any()))
         .thenAnswer(
@@ -570,7 +562,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest {
 
   @Test
   void testSendToUsersAtOu() {
-    when(eventStore.get(anyLong())).thenReturn(events.iterator().next());
+    when(manager.get(eq(Event.class), anyLong())).thenReturn(events.iterator().next());
 
     when(messageService.sendMessage(any()))
         .thenAnswer(
@@ -651,7 +643,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest {
     Date today = cal.getTime();
     cal.add(java.util.Calendar.DATE, -1);
 
-    programNotificationTemplateForToday =
+    ProgramNotificationTemplate programNotificationTemplateForToday =
         createProgramNotificationTemplate(
             TEMPLATE_NAME,
             0,
@@ -667,12 +659,12 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest {
     programNotificationInstaceForToday.setAutoFields();
     programNotificationInstaceForToday.setScheduledAt(today);
 
-    root = createOrganisationUnit('R');
-    lvlOneLeft = createOrganisationUnit('1');
-    lvlOneRight = createOrganisationUnit('2');
+    OrganisationUnit root = createOrganisationUnit('R');
+    OrganisationUnit lvlOneLeft = createOrganisationUnit('1');
+    OrganisationUnit lvlOneRight = createOrganisationUnit('2');
     lvlTwoLeftLeft = createOrganisationUnit('3');
     lvlTwoLeftLeft.setPhoneNumber(OU_PHONE_NUMBER);
-    lvlTwoLeftRight = createOrganisationUnit('4');
+    OrganisationUnit lvlTwoLeftRight = createOrganisationUnit('4');
 
     configureHierarchy(root, lvlOneLeft, lvlOneRight, lvlTwoLeftLeft, lvlTwoLeftRight);
 
@@ -732,12 +724,12 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest {
     programA.getProgramAttributes().add(programTrackedEntityAttribute);
 
     trackedEntityAttribute = createTrackedEntityAttribute('T');
-    trackedEntityAttributeEmail = createTrackedEntityAttribute('E');
+    TrackedEntityAttribute trackedEntityAttributeEmail = createTrackedEntityAttribute('E');
     trackedEntityAttribute.setValueType(ValueType.PHONE_NUMBER);
     trackedEntityAttribute.setValueType(ValueType.EMAIL);
     programTrackedEntityAttribute =
         createProgramTrackedEntityAttribute(programA, trackedEntityAttribute);
-    programTrackedEntityAttributeEmail =
+    ProgramTrackedEntityAttribute programTrackedEntityAttributeEmail =
         createProgramTrackedEntityAttribute(programA, trackedEntityAttributeEmail);
     programTrackedEntityAttribute.setAttribute(trackedEntityAttribute);
     programTrackedEntityAttributeEmail.setAttribute(trackedEntityAttributeEmail);
@@ -755,8 +747,10 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest {
     te.setAutoFields();
     te.setOrganisationUnit(lvlTwoLeftLeft);
 
-    attributeValue = createTrackedEntityAttributeValue('P', te, trackedEntityAttribute);
-    attributeValueEmail = createTrackedEntityAttributeValue('E', te, trackedEntityAttribute);
+    TrackedEntityAttributeValue attributeValue =
+        createTrackedEntityAttributeValue('P', te, trackedEntityAttribute);
+    TrackedEntityAttributeValue attributeValueEmail =
+        createTrackedEntityAttributeValue('E', te, trackedEntityAttribute);
     attributeValue.setValue(ATT_PHONE_NUMBER);
     attributeValueEmail.setValue(ATT_EMAIL);
     te.getTrackedEntityAttributeValues().add(attributeValue);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/notification/ProgramNotificationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/notification/ProgramNotificationServiceTest.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.program;
+package org.hisp.dhis.program.notification;
 
 import static org.hisp.dhis.program.notification.NotificationTrigger.SCHEDULED_DAYS_DUE_DATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -42,11 +42,17 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
-import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.PeriodType;
-import org.hisp.dhis.program.notification.ProgramNotificationRecipient;
-import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
+import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EnrollmentService;
+import org.hisp.dhis.program.Event;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramStageDataElement;
+import org.hisp.dhis.program.ProgramStageDataElementStore;
+import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
@@ -58,9 +64,9 @@ import org.springframework.beans.factory.annotation.Qualifier;
 /**
  * @author Chau Thu Tran
  */
-class EventStoreTest extends TransactionalIntegrationTest {
+class ProgramNotificationServiceTest extends TransactionalIntegrationTest {
 
-  @Autowired private EventStore eventStore;
+  @Autowired private IdentifiableObjectManager manager;
 
   @Autowired private ProgramStageDataElementStore programStageDataElementStore;
 
@@ -72,11 +78,7 @@ class EventStoreTest extends TransactionalIntegrationTest {
 
   @Autowired private TrackedEntityService trackedEntityService;
 
-  @Autowired private DbmsManager dbmsManager;
-
   @Autowired private EnrollmentService enrollmentService;
-
-  @Autowired private IdentifiableObjectManager idObjectManager;
 
   @Autowired private CategoryService categoryService;
 
@@ -84,11 +86,9 @@ class EventStoreTest extends TransactionalIntegrationTest {
   @Qualifier("org.hisp.dhis.program.notification.ProgramNotificationStore")
   private IdentifiableObjectStore<ProgramNotificationTemplate> programNotificationStore;
 
+  @Autowired private ProgramNotificationService programNotificationService;
+
   private CategoryOptionCombo coA;
-
-  private OrganisationUnit organisationUnitA;
-
-  private OrganisationUnit organisationUnitB;
 
   private ProgramStage stageA;
 
@@ -96,56 +96,22 @@ class EventStoreTest extends TransactionalIntegrationTest {
 
   private ProgramStage stageC;
 
-  private ProgramStage stageD;
-
-  private DataElement dataElementA;
-
-  private DataElement dataElementB;
-
-  private ProgramStageDataElement stageDataElementA;
-
-  private ProgramStageDataElement stageDataElementB;
-
-  private ProgramStageDataElement stageDataElementC;
-
-  private ProgramStageDataElement stageDataElementD;
-
-  private Date incidenDate;
-
-  private Date enrollmentDate;
-
   private Enrollment enrollmentA;
 
   private Enrollment enrollmentB;
 
-  private Event eventA;
-
-  private Event eventB;
-
-  private Event eventC;
-
-  private Event eventD1;
-
-  private Event eventD2;
-
-  private TrackedEntity trackedEntityA;
-
-  private TrackedEntity trackedEntityB;
-
-  private Program programA;
-
   @Override
   public void setUpTest() {
     coA = categoryService.getDefaultCategoryOptionCombo();
-    organisationUnitA = createOrganisationUnit('A');
-    organisationUnitB = createOrganisationUnit('B');
-    idObjectManager.save(organisationUnitA);
-    idObjectManager.save(organisationUnitB);
-    trackedEntityA = createTrackedEntity(organisationUnitA);
+    OrganisationUnit organisationUnitA = createOrganisationUnit('A');
+    OrganisationUnit organisationUnitB = createOrganisationUnit('B');
+    manager.save(organisationUnitA);
+    manager.save(organisationUnitB);
+    TrackedEntity trackedEntityA = createTrackedEntity(organisationUnitA);
     trackedEntityService.addTrackedEntity(trackedEntityA);
-    trackedEntityB = createTrackedEntity(organisationUnitB);
+    TrackedEntity trackedEntityB = createTrackedEntity(organisationUnitB);
     trackedEntityService.addTrackedEntity(trackedEntityB);
-    programA = createProgram('A', new HashSet<>(), organisationUnitA);
+    Program programA = createProgram('A', new HashSet<>(), organisationUnitA);
     programService.addProgram(programA);
     stageA = new ProgramStage("A", programA);
     programStageService.saveProgramStage(stageA);
@@ -156,25 +122,28 @@ class EventStoreTest extends TransactionalIntegrationTest {
     programStages.add(stageB);
     programA.getProgramStages().addAll(programStages);
     programService.updateProgram(programA);
-    dataElementA = createDataElement('A');
-    dataElementB = createDataElement('B');
+    DataElement dataElementA = createDataElement('A');
+    DataElement dataElementB = createDataElement('B');
     dataElementService.addDataElement(dataElementA);
     dataElementService.addDataElement(dataElementB);
-    stageDataElementA = createProgramStageDataElement(stageA, dataElementA, 1);
-    stageDataElementB = createProgramStageDataElement(stageA, dataElementB, 2);
-    stageDataElementC = createProgramStageDataElement(stageB, dataElementA, 1);
-    stageDataElementD = createProgramStageDataElement(stageB, dataElementB, 2);
+    ProgramStageDataElement stageDataElementA =
+        createProgramStageDataElement(stageA, dataElementA, 1);
+    ProgramStageDataElement stageDataElementB =
+        createProgramStageDataElement(stageA, dataElementB, 2);
+    ProgramStageDataElement stageDataElementC =
+        createProgramStageDataElement(stageB, dataElementA, 1);
+    ProgramStageDataElement stageDataElementD =
+        createProgramStageDataElement(stageB, dataElementB, 2);
     programStageDataElementStore.save(stageDataElementA);
     programStageDataElementStore.save(stageDataElementB);
     programStageDataElementStore.save(stageDataElementC);
     programStageDataElementStore.save(stageDataElementD);
-    /** Program B */
     Program programB = createProgram('B', new HashSet<>(), organisationUnitB);
     programService.addProgram(programB);
     stageC = createProgramStage('C', 0);
     stageC.setProgram(programB);
     programStageService.saveProgramStage(stageC);
-    stageD = createProgramStage('D', 0);
+    ProgramStage stageD = createProgramStage('D', 0);
     stageD.setProgram(programB);
     stageC.setRepeatable(true);
     programStageService.saveProgramStage(stageD);
@@ -183,36 +152,35 @@ class EventStoreTest extends TransactionalIntegrationTest {
     programStages.add(stageD);
     programB.getProgramStages().addAll(programStages);
     programService.updateProgram(programB);
-    /** Enrollment and event */
     DateTime testDate1 = DateTime.now();
     testDate1.withTimeAtStartOfDay();
     testDate1 = testDate1.minusDays(70);
-    incidenDate = testDate1.toDate();
+    Date incidenDate = testDate1.toDate();
     DateTime testDate2 = DateTime.now();
     testDate2.withTimeAtStartOfDay();
-    enrollmentDate = testDate2.toDate();
+    Date enrollmentDate = testDate2.toDate();
     enrollmentA = new Enrollment(enrollmentDate, incidenDate, trackedEntityA, programA);
     enrollmentA.setUid("UID-PIA");
     enrollmentService.addEnrollment(enrollmentA);
     enrollmentB = new Enrollment(enrollmentDate, incidenDate, trackedEntityB, programB);
     enrollmentService.addEnrollment(enrollmentB);
-    eventA = new Event(enrollmentA, stageA);
+    Event eventA = new Event(enrollmentA, stageA);
     eventA.setScheduledDate(enrollmentDate);
     eventA.setUid("UID-A");
     eventA.setAttributeOptionCombo(coA);
-    eventB = new Event(enrollmentA, stageB);
+    Event eventB = new Event(enrollmentA, stageB);
     eventB.setScheduledDate(enrollmentDate);
     eventB.setUid("UID-B");
     eventB.setAttributeOptionCombo(coA);
-    eventC = new Event(enrollmentB, stageC);
+    Event eventC = new Event(enrollmentB, stageC);
     eventC.setScheduledDate(enrollmentDate);
     eventC.setUid("UID-C");
     eventC.setAttributeOptionCombo(coA);
-    eventD1 = new Event(enrollmentB, stageD);
+    Event eventD1 = new Event(enrollmentB, stageD);
     eventD1.setScheduledDate(enrollmentDate);
     eventD1.setUid("UID-D1");
     eventD1.setAttributeOptionCombo(coA);
-    eventD2 = new Event(enrollmentB, stageD);
+    Event eventD2 = new Event(enrollmentB, stageD);
     eventD2.setScheduledDate(enrollmentDate);
     eventD2.setUid("UID-D2");
     eventD2.setAttributeOptionCombo(coA);
@@ -306,38 +274,38 @@ class EventStoreTest extends TransactionalIntegrationTest {
     Event eventA = new Event(enrollmentA, stageA);
     eventA.setScheduledDate(tomorrow);
     eventA.setAttributeOptionCombo(coA);
-    eventStore.save(eventA);
+    manager.save(eventA);
     Event eventB = new Event(enrollmentB, stageB);
     eventB.setScheduledDate(today);
     eventB.setAttributeOptionCombo(coA);
-    eventStore.save(eventB);
+    manager.save(eventB);
     Event eventC = new Event(enrollmentB, stageC);
     eventC.setScheduledDate(yesterday);
     eventC.setAttributeOptionCombo(coA);
-    eventStore.save(eventC);
+    manager.save(eventC);
     // Queries
     List<Event> results;
     // A
-    results = eventStore.getWithScheduledNotifications(a1, today);
+    results = programNotificationService.getWithScheduledNotifications(a1, today);
     assertEquals(1, results.size());
     assertEquals(eventA, results.get(0));
-    results = eventStore.getWithScheduledNotifications(a2, today);
+    results = programNotificationService.getWithScheduledNotifications(a2, today);
     assertEquals(0, results.size());
-    results = eventStore.getWithScheduledNotifications(a3, today);
+    results = programNotificationService.getWithScheduledNotifications(a3, today);
     assertEquals(0, results.size());
     // B
-    results = eventStore.getWithScheduledNotifications(b1, today);
+    results = programNotificationService.getWithScheduledNotifications(b1, today);
     assertEquals(0, results.size());
-    results = eventStore.getWithScheduledNotifications(b2, today);
+    results = programNotificationService.getWithScheduledNotifications(b2, today);
     assertEquals(0, results.size());
-    results = eventStore.getWithScheduledNotifications(b3, today);
+    results = programNotificationService.getWithScheduledNotifications(b3, today);
     assertEquals(0, results.size());
     // C
-    results = eventStore.getWithScheduledNotifications(c1, today);
+    results = programNotificationService.getWithScheduledNotifications(c1, today);
     assertEquals(0, results.size());
-    results = eventStore.getWithScheduledNotifications(c2, today);
+    results = programNotificationService.getWithScheduledNotifications(c2, today);
     assertEquals(0, results.size());
-    results = eventStore.getWithScheduledNotifications(c3, today);
+    results = programNotificationService.getWithScheduledNotifications(c3, today);
     assertEquals(1, results.size());
     assertEquals(eventC, results.get(0));
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerEventBundleServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/bundle/TrackerEventBundleServiceTest.java
@@ -33,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.IOException;
 import java.util.List;
 import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.EventStore;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.imports.TrackerImportParams;
 import org.hisp.dhis.tracker.imports.TrackerImportService;
@@ -50,7 +49,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 class TrackerEventBundleServiceTest extends TrackerTest {
   @Autowired private TrackerImportService trackerImportService;
 
-  @Autowired private EventStore eventStore;
   @Autowired protected UserService _userService;
 
   @Override
@@ -68,7 +66,7 @@ class TrackerEventBundleServiceTest extends TrackerTest {
         trackerImportService.importTracker(new TrackerImportParams(), trackerObjects);
     assertNoErrors(importReport);
 
-    List<Event> events = eventStore.getAll();
+    List<Event> events = manager.getAll(Event.class);
     assertEquals(8, events.size());
   }
 
@@ -80,11 +78,11 @@ class TrackerEventBundleServiceTest extends TrackerTest {
     ImportReport importReport =
         trackerImportService.importTracker(trackerImportParams, trackerObjects);
     assertNoErrors(importReport);
-    assertEquals(8, eventStore.getAll().size());
+    assertEquals(8, manager.getAll(Event.class).size());
 
     importReport = trackerImportService.importTracker(trackerImportParams, trackerObjects);
     assertNoErrors(importReport);
 
-    assertEquals(8, eventStore.getAll().size());
+    assertEquals(8, manager.getAll(Event.class).size());
   }
 }


### PR DESCRIPTION
As in https://github.com/dhis2/dhis2-core/pull/17992 this is a pragmatic change that violates our usual layered architecture in service of the achieving one tracker event exporter service. Inlined the code used in one place.

How notifications are sent will change soon as the platform team is working on it. So we will get an opportunity to refactor this code.