### PR TITLE
chore: remove dhis-api EnrollmentService.get(id) [DHIS2-17712]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
@@ -67,14 +67,6 @@ public interface EnrollmentService {
   void updateEnrollment(Enrollment enrollment);
 
   /**
-   * Returns a {@link Enrollment}.
-   *
-   * @param id the id of the Enrollment to return.
-   * @return the Enrollment with the given id
-   */
-  Enrollment getEnrollment(long id);
-
-  /**
    * Returns the {@link Enrollment} with the given UID.
    *
    * @param uid the UID.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
@@ -81,12 +81,6 @@ public class DefaultEnrollmentService implements EnrollmentService {
 
   @Override
   @Transactional(readOnly = true)
-  public Enrollment getEnrollment(long id) {
-    return enrollmentStore.get(id);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
   public Enrollment getEnrollment(String uid) {
     return enrollmentStore.getByUid(uid);
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
@@ -253,9 +253,9 @@ class MaintenanceServiceTest extends IntegrationTestBase {
             .build();
     long idA = enrollmentService.addEnrollment(enrollment);
     programMessageService.saveProgramMessage(message);
-    assertNotNull(enrollmentService.getEnrollment(idA));
+    assertNotNull(manager.get(Enrollment.class, idA));
     enrollmentService.deleteEnrollment(enrollment);
-    assertNull(enrollmentService.getEnrollment(idA));
+    assertNull(manager.get(Enrollment.class, idA));
     assertTrue(enrollmentService.enrollmentExistsIncludingDeleted(enrollment.getUid()));
 
     maintenanceService.deleteSoftDeletedEnrollments();
@@ -331,9 +331,9 @@ class MaintenanceServiceTest extends IntegrationTestBase {
     trackedEntityDataValueAuditService.addTrackedEntityDataValueChangeLog(
         trackedEntityDataValueChangeLog);
     long idA = enrollmentService.addEnrollment(enrollment);
-    assertNotNull(enrollmentService.getEnrollment(idA));
+    assertNotNull(manager.get(Enrollment.class, idA));
     enrollmentService.deleteEnrollment(enrollment);
-    assertNull(enrollmentService.getEnrollment(idA));
+    assertNull(manager.get(Enrollment.class, idA));
     assertTrue(enrollmentService.enrollmentExistsIncludingDeleted(enrollment.getUid()));
 
     maintenanceService.deleteSoftDeletedEnrollments();
@@ -400,10 +400,10 @@ class MaintenanceServiceTest extends IntegrationTestBase {
     r.setKey(RelationshipUtils.generateRelationshipKey(r));
     r.setInvertedKey(RelationshipUtils.generateRelationshipInvertedKey(r));
     relationshipService.addRelationship(r);
-    assertNotNull(enrollmentService.getEnrollment(enrollment.getId()));
+    assertNotNull(manager.get(Enrollment.class, enrollment.getId()));
     assertNotNull(relationshipService.getRelationship(r.getId()));
     enrollmentService.deleteEnrollment(enrollment);
-    assertNull(enrollmentService.getEnrollment(enrollment.getId()));
+    assertNull(manager.get(Enrollment.class, enrollment.getId()));
     assertNull(relationshipService.getRelationship(r.getId()));
     assertTrue(enrollmentService.enrollmentExistsIncludingDeleted(enrollment.getUid()));
     assertTrue(relationshipService.relationshipExistsIncludingDeleted(r.getUid()));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
@@ -178,22 +178,22 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
   void testAddEnrollment() {
     long idA = enrollmentService.addEnrollment(enrollmentA);
     long idB = enrollmentService.addEnrollment(enrollmentB);
-    assertNotNull(enrollmentService.getEnrollment(idA));
-    assertNotNull(enrollmentService.getEnrollment(idB));
+    assertNotNull(manager.get(Enrollment.class, idA));
+    assertNotNull(manager.get(Enrollment.class, idB));
   }
 
   @Test
   void testDeleteEnrollment() {
     long idA = enrollmentService.addEnrollment(enrollmentA);
     long idB = enrollmentService.addEnrollment(enrollmentB);
-    assertNotNull(enrollmentService.getEnrollment(idA));
-    assertNotNull(enrollmentService.getEnrollment(idB));
+    assertNotNull(manager.get(Enrollment.class, idA));
+    assertNotNull(manager.get(Enrollment.class, idB));
     enrollmentService.deleteEnrollment(enrollmentA);
-    assertNull(enrollmentService.getEnrollment(idA));
-    assertNotNull(enrollmentService.getEnrollment(idB));
+    assertNull(manager.get(Enrollment.class, idA));
+    assertNotNull(manager.get(Enrollment.class, idB));
     enrollmentService.deleteEnrollment(enrollmentB);
-    assertNull(enrollmentService.getEnrollment(idA));
-    assertNull(enrollmentService.getEnrollment(idB));
+    assertNull(manager.get(Enrollment.class, idA));
+    assertNull(manager.get(Enrollment.class, idB));
   }
 
   @Test
@@ -203,38 +203,38 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
     long eventIdA = eventA.getId();
     enrollmentA.setEvents(Sets.newHashSet(eventA));
     enrollmentService.updateEnrollment(enrollmentA);
-    assertNotNull(enrollmentService.getEnrollment(idA));
+    assertNotNull(manager.get(Enrollment.class, idA));
     assertNotNull(manager.get(Event.class, eventIdA));
 
     enrollmentService.deleteEnrollment(enrollmentA);
 
-    assertNull(enrollmentService.getEnrollment(idA));
+    assertNull(manager.get(Enrollment.class, idA));
     assertNull(manager.get(Event.class, eventIdA));
   }
 
   @Test
   void testUpdateEnrollment() {
     long idA = enrollmentService.addEnrollment(enrollmentA);
-    assertNotNull(enrollmentService.getEnrollment(idA));
+    assertNotNull(manager.get(Enrollment.class, idA));
     enrollmentA.setOccurredDate(enrollmentDate);
     enrollmentService.updateEnrollment(enrollmentA);
-    assertEquals(enrollmentDate, enrollmentService.getEnrollment(idA).getOccurredDate());
+    assertEquals(enrollmentDate, manager.get(Enrollment.class, idA).getOccurredDate());
   }
 
   @Test
   void testGetEnrollmentById() {
     long idA = enrollmentService.addEnrollment(enrollmentA);
     long idB = enrollmentService.addEnrollment(enrollmentB);
-    assertEquals(enrollmentA, enrollmentService.getEnrollment(idA));
-    assertEquals(enrollmentB, enrollmentService.getEnrollment(idB));
+    assertEquals(enrollmentA, manager.get(Enrollment.class, idA));
+    assertEquals(enrollmentB, manager.get(Enrollment.class, idB));
   }
 
   @Test
   void testGetEnrollmentByUid() {
     enrollmentService.addEnrollment(enrollmentA);
     enrollmentService.addEnrollment(enrollmentB);
-    assertEquals("UID-A", enrollmentService.getEnrollment("UID-A").getUid());
-    assertEquals("UID-B", enrollmentService.getEnrollment("UID-B").getUid());
+    assertEquals("UID-A", manager.get(Enrollment.class, "UID-A").getUid());
+    assertEquals("UID-B", manager.get(Enrollment.class, "UID-B").getUid());
   }
 
   @Test
@@ -280,7 +280,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
     Enrollment enrollment =
         enrollmentService.enrollTrackedEntity(
             trackedEntityA, programB, enrollmentDate, incidentDate, organisationUnitA);
-    assertNotNull(enrollmentService.getEnrollment(enrollment.getId()));
+    assertNotNull(manager.get(Enrollment.class, enrollment.getId()));
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityServiceTest.java
@@ -207,14 +207,14 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     enrollmentService.updateEnrollment(enrollment);
     trackedEntityService.updateTrackedEntity(trackedEntityA1);
     TrackedEntity trackedEntityA = trackedEntityService.getTrackedEntity(idA);
-    Enrollment psA = enrollmentService.getEnrollment(psIdA);
+    Enrollment psA = manager.get(Enrollment.class, psIdA);
     Event eventA = manager.get(Event.class, eventIdA);
     assertNotNull(trackedEntityA);
     assertNotNull(psA);
     assertNotNull(eventA);
     trackedEntityService.deleteTrackedEntity(trackedEntityA1);
     assertNull(trackedEntityService.getTrackedEntity(trackedEntityA.getUid()));
-    assertNull(enrollmentService.getEnrollment(psIdA));
+    assertNull(manager.get(Enrollment.class, psIdA));
     assertNull(manager.get(Event.class, eventIdA));
   }
 


### PR DESCRIPTION
###  Big picture

Tracker has multiple services for each entity like tracked entity, enrollment and event. One is in dhis-api and one in dhis-service-tracker. Our goal is to provide one API (service) per entity that is part of the tracker domain/team.

Trackers architecture splits read/write into exporter services and an importer. So if you want to get data you use an exporter. If you want to insert, update or delete you have to go through the importer. Only then can we ensure integrity of tracker data.

Another goal is that code that provides tracker functionality and is thus owned by the tracker team lives in ideally one maven module (We can settle on a name later on maybe dhis-service-tracker or dhis-tracker).

This is a big task that we are going to implement in many small steps.

### This PR

Finding an enrollment by an internal DB id is only used in tests. We do not want to expose it in our tracker exporter services. We therefore remove it from the dhis-api service.
