### PR TITLE
chore: remove unused AppType.TRACKER_DASHBOARD_WIDGET DHIS2-17723

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppType.java
@@ -38,8 +38,5 @@ public enum AppType {
   RESOURCE,
 
   /** Dashboard widget, can be placed on the main system dashboard as 'widgets' (portlets). */
-  DASHBOARD_WIDGET,
-
-  /** Tracker dashboard widget, used for tracker capture dashboard. */
-  TRACKER_DASHBOARD_WIDGET
+  DASHBOARD_WIDGET
 }


### PR DESCRIPTION
now that tracker capture app has been removed from v42.

@eirikhaugstulen pointed out that this removal should be safe. There are no apps on the app hub with this type https://apps.dhis2.org/?page=1&types=TRACKER_DASHBOARD_WIDGET. Furthermore, tracker capture is not supported from v42 forward.