### PR TITLE
feat: datastore namespace protection - independent read and write authorities

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastore/DatastoreNamespaceProtection.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastore/DatastoreNamespaceProtection.java
@@ -27,10 +27,13 @@
  */
 package org.hisp.dhis.datastore;
 
-import static java.util.Arrays.asList;
+import static com.fasterxml.jackson.annotation.JsonProperty.Access.READ_ONLY;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.HashSet;
 import java.util.Set;
+import javax.annotation.Nonnull;
+import lombok.Value;
 
 /**
  * The {@link DatastoreNamespaceProtection} is a configuration for a particular namespace and the
@@ -40,11 +43,11 @@ import java.util.Set;
  *
  * @author Jan Bernitt
  */
+@Value
 public class DatastoreNamespaceProtection {
 
   /**
-   * Protection rules apply to users that do not have at least one of the required {@link
-   * #authorities}.
+   * Protection rules apply to users that do not have at least one of the required authorities.
    *
    * <p>All superusers always have read and write access.
    */
@@ -65,55 +68,61 @@ public class DatastoreNamespaceProtection {
     RESTRICTED
   }
 
-  private final String namespace;
+  @JsonProperty(access = READ_ONLY)
+  @Nonnull
+  String namespace;
 
-  private final ProtectionType reads;
+  @JsonProperty(access = READ_ONLY)
+  @Nonnull
+  ProtectionType reads;
 
-  private final ProtectionType writes;
+  @JsonProperty(access = READ_ONLY)
+  @Nonnull
+  ProtectionType writes;
 
-  private final Set<String> authorities;
+  @JsonProperty(access = READ_ONLY)
+  @Nonnull
+  Set<String> readAuthorities;
+
+  @JsonProperty(access = READ_ONLY)
+  @Nonnull
+  Set<String> writeAuthorities;
 
   public DatastoreNamespaceProtection(
-      String namespace, ProtectionType readWrite, String... authorities) {
+      @Nonnull String namespace,
+      @Nonnull ProtectionType readWrite,
+      @Nonnull String... authorities) {
     this(namespace, readWrite, readWrite, authorities);
   }
 
   public DatastoreNamespaceProtection(
-      String namespace, ProtectionType reads, ProtectionType writes, String... authorities) {
-    this(namespace, reads, writes, new HashSet<>(asList(authorities)));
+      @Nonnull String namespace,
+      @Nonnull ProtectionType reads,
+      @Nonnull ProtectionType writes,
+      @Nonnull String... authorities) {
+    this(namespace, reads, Set.of(authorities), writes, Set.of(authorities));
   }
 
   public DatastoreNamespaceProtection(
-      String namespace, ProtectionType reads, ProtectionType writes, Set<String> authorities) {
+      @Nonnull String namespace,
+      @Nonnull ProtectionType reads,
+      @Nonnull Set<String> readAuthorities,
+      @Nonnull ProtectionType writes,
+      @Nonnull Set<String> writeAuthorities) {
     this.namespace = namespace;
-    this.reads = reads;
-    this.writes = writes;
-    this.authorities = authorities;
+    this.reads = readAuthorities.isEmpty() ? ProtectionType.NONE : reads;
+    this.writes = writeAuthorities.isEmpty() ? ProtectionType.NONE : writes;
+    this.readAuthorities = readAuthorities;
+    this.writeAuthorities = writeAuthorities;
   }
 
-  public String getNamespace() {
-    return namespace;
-  }
-
-  /**
-   * @return true when the {@link org.hisp.dhis.user.sharing.Sharing} of a {@link DatastoreEntry}
-   *     should be checked in addition to authority based checks, else false.
-   */
-  public Set<String> getAuthorities() {
-    return authorities;
-  }
-
-  public ProtectionType getReads() {
-    return reads;
-  }
-
-  public ProtectionType getWrites() {
-    return writes;
-  }
-
-  @Override
-  public String toString() {
-    return String.format(
-        "KeyJsonNamespaceProtection{%s r:%s w:%s [%s]}", namespace, reads, writes, authorities);
+  @Nonnull
+  public Set<String> getAllAuthorities() {
+    if (readAuthorities.isEmpty()) return writeAuthorities;
+    if (writeAuthorities.isEmpty()) return readAuthorities;
+    Set<String> all = new HashSet<>();
+    all.addAll(readAuthorities);
+    all.addAll(writeAuthorities);
+    return all;
   }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastore/DatastoreService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastore/DatastoreService.java
@@ -50,6 +50,20 @@ import org.springframework.security.access.AccessDeniedException;
  * @author Jan Bernitt (advanced namespace protection)
  */
 public interface DatastoreService {
+
+  /**
+   * @param namespace to check
+   * @return the protection used or {@null} when unprotected
+   */
+  @CheckForNull
+  DatastoreNamespaceProtection getProtection(@Nonnull String namespace);
+
+  /**
+   * @return a list of the active namespace protections sorted by namespace name
+   */
+  @Nonnull
+  List<DatastoreNamespaceProtection> getProtections();
+
   /**
    * Applies the configuration for the provided protection so it is considered by this service in
    * future requests.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datastore/DefaultDatastoreService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datastore/DefaultDatastoreService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.datastore;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static java.util.Comparator.comparing;
 
 import java.util.Date;
 import java.util.List;
@@ -41,6 +42,7 @@ import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.common.NonTransactional;
 import org.hisp.dhis.datastore.DatastoreNamespaceProtection.ProtectionType;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ConflictException;
@@ -69,11 +71,28 @@ public class DefaultDatastoreService implements DatastoreService {
   private final AclService aclService;
 
   @Override
+  @NonTransactional
+  public DatastoreNamespaceProtection getProtection(@Nonnull String namespace) {
+    return protectionByNamespace.get(namespace);
+  }
+
+  @Nonnull
+  @Override
+  @NonTransactional
+  public List<DatastoreNamespaceProtection> getProtections() {
+    return protectionByNamespace.values().stream()
+        .sorted(comparing(DatastoreNamespaceProtection::getNamespace))
+        .toList();
+  }
+
+  @Override
+  @NonTransactional
   public void addProtection(DatastoreNamespaceProtection protection) {
     protectionByNamespace.put(protection.getNamespace(), protection);
   }
 
   @Override
+  @NonTransactional
   public void removeProtection(String namespace) {
     protectionByNamespace.remove(namespace);
   }
@@ -212,13 +231,13 @@ public class DefaultDatastoreService implements DatastoreService {
   private boolean userHasNamespaceReadAccess(DatastoreNamespaceProtection protection) {
     return protection == null
         || protection.getReads() == ProtectionType.NONE
-        || currentUserHasAuthority(protection.getAuthorities());
+        || currentUserHasAuthority(protection.getReadAuthorities());
   }
 
   private boolean userHasNamespaceWriteAccess(DatastoreNamespaceProtection protection) {
     return protection == null
         || protection.getWrites() == ProtectionType.NONE
-        || currentUserHasAuthority(protection.getAuthorities());
+        || currentUserHasAuthority(protection.getWriteAuthorities());
   }
 
   /**
@@ -271,7 +290,7 @@ public class DefaultDatastoreService implements DatastoreService {
     DatastoreNamespaceProtection protection = protectionByNamespace.get(namespace);
     return protection == null
         || protection.getReads() != ProtectionType.HIDDEN
-        || currentUserHasAuthority(protection.getAuthorities());
+        || currentUserHasAuthority(protection.getReadAuthorities());
   }
 
   private boolean currentUserHasAuthority(Set<String> authorities) {


### PR DESCRIPTION
This is a fully manual backport of #17740 where only the part adding independent read and write authorities to the datastore is backported by checking out the 2.42 version of the files into 2.41. The only adjustment needed then was to approximate the set `union` function used and which isn't available in 2.41.