### PR TITLE
fix: getOptionCodePropertyMap now returns translated value if necessary [DHIS2-16208][2.39]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionSet.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionSet.java
@@ -171,7 +171,7 @@ public class OptionSet extends BaseIdentifiableObject implements VersionedObject
   public Map<String, String> getOptionCodePropertyMap(IdScheme idScheme) {
     return options.stream()
         .filter(Objects::nonNull)
-        .collect(Collectors.toMap(Option::getCode, o -> o.getPropertyValue(idScheme)));
+        .collect(Collectors.toMap(Option::getCode, o -> o.getDisplayPropertyValue(idScheme)));
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
Backport for DHIS2-16208