### PR TITLE
feat: Add integrity check for users with no user roles

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
@@ -71,3 +71,4 @@ checks:
   - groups/group_size_category_option_group_sets.yaml
   - groups/group_size_user_groups.yaml
   - users/users_capture_ou_not_in_data_view_ou.yaml
+  - users/users_with_no_user_role.yaml

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/users_with_no_user_role.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/users_with_no_user_role.yaml
@@ -1,0 +1,50 @@
+# Copyright (c) 2004-2022, University of Oslo
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# Neither the name of the HISP project nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+---
+name: users_with_no_user_role
+description: Users who have no user role assigned.
+section: Users
+section_order: 3
+summary_sql: >-
+  SELECT COUNT(*) as value,
+    100.0 * COUNT(*) / NULLIF((SELECT COUNT(*) FROM userinfo), 0) as percent
+    FROM userinfo
+    WHERE userinfoid NOT IN (SELECT DISTINCT userid FROM userrolemembers);
+details_sql: >
+  SELECT uid, 
+  username as name,
+  'disabled:' || disabled as comment
+  from userinfo
+  WHERE userinfoid NOT IN (SELECT DISTINCT userid FROM userrolemembers);
+details_id_type: users
+severity: SEVERE
+introduction: >
+  All users should have at least one use role associated with their account. If a user does not have a role, 
+  they will not be able to perform any actions in the system.
+recommendation: >
+  Using the list of users provided by the details query, either assign a user role or roles to the user
+  or alternatively, delete the user if they are no longer active in the system.

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
@@ -56,7 +56,7 @@ class DataIntegrityYamlReaderTest {
 
     List<DataIntegrityCheck> checks = new ArrayList<>();
     readYaml(checks, "data-integrity-checks.yaml", "data-integrity-checks", CLASS_PATH);
-    assertEquals(73, checks.size());
+    assertEquals(74, checks.size());
 
     // Names should be unique
     List<String> allNames = checks.stream().map(DataIntegrityCheck::getName).toList();

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
@@ -56,7 +56,7 @@ class DataIntegrityYamlReaderTest {
 
     List<DataIntegrityCheck> checks = new ArrayList<>();
     readYaml(checks, "data-integrity-checks.yaml", "data-integrity-checks", CLASS_PATH);
-    assertEquals(72, checks.size());
+    assertEquals(73, checks.size());
 
     // Names should be unique
     List<String> allNames = checks.stream().map(DataIntegrityCheck::getName).toList();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersWithNoRoleControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersWithNoRoleControllerTest.java
@@ -37,9 +37,8 @@ import org.hisp.dhis.webapi.json.domain.JsonDataIntegrityDetails;
 import org.junit.jupiter.api.Test;
 
 /**
- * Integrity check to identify users who have a data view organisation unit, but who cannot access
- * data which they have possibly entered at a higher level of the hierarchy. {@see
- * dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/users_capture_ou_not_in_data_view_ou.yaml}
+ * Integrity check to identify users who have no user role associated with their user. {@see
+ * dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/users_with_no_user_role.yaml}
  *
  * @author Jason P. Pickering
  */

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersWithNoRoleControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersWithNoRoleControllerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.dataintegrity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Date;
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.webapi.json.domain.JsonDataIntegrityDetails;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integrity check to identify users who have a data view organisation unit, but who cannot access
+ * data which they have possibly entered at a higher level of the hierarchy. {@see
+ * dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/users_capture_ou_not_in_data_view_ou.yaml}
+ *
+ * @author Jason P. Pickering
+ */
+class DataIntegrityUsersWithNoRoleControllerTest extends AbstractDataIntegrityIntegrationTest {
+
+  private static final String CHECK_NAME = "users_with_no_user_role";
+
+  private static final String DETAILS_ID_TYPE = "users";
+
+  private String userRoleUid;
+
+  @Test
+  void testCanFlagUserWithNoRoles() {
+
+    // Use the service layer, as the API will refuse to create a user with no role.
+    User user = new User();
+    user.setUid(CodeGenerator.generateUid());
+    user.setFirstName("Bobby");
+    user.setSurname("Tables");
+    user.setUsername(DEFAULT_USERNAME + "_no_role_" + CodeGenerator.generateUid());
+    user.setPassword(DEFAULT_ADMIN_PASSWORD);
+    user.setLastUpdated(new Date());
+    user.setCreated(new Date());
+    manager.persist(user);
+    dbmsManager.clearSession();
+
+    // Note that there are already two users which exist due to the overall test setup, thus, three
+    // users in total.
+    assertHasDataIntegrityIssues(
+        DETAILS_ID_TYPE, CHECK_NAME, 33, user.getUid(), user.getUsername(), "disabled:false", true);
+
+    JsonDataIntegrityDetails details = getDetails(CHECK_NAME);
+    JsonList<JsonDataIntegrityDetails.JsonDataIntegrityIssue> issues = details.getIssues();
+    assertEquals(1, issues.size());
+  }
+
+  @Test
+  void testDoNotFlagUsersWithRoles() {
+
+    assertHasNoDataIntegrityIssues(DETAILS_ID_TYPE, CHECK_NAME, true);
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersWithNoRoleControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersWithNoRoleControllerTest.java
@@ -48,8 +48,6 @@ class DataIntegrityUsersWithNoRoleControllerTest extends AbstractDataIntegrityIn
 
   private static final String DETAILS_ID_TYPE = "users";
 
-  private String userRoleUid;
-
   @Test
   void testCanFlagUserWithNoRoles() {
 


### PR DESCRIPTION
The API actively forces users to have a role and should prevent removing roles which are associated with a user. When looking at some old databases, it was observed however that there are users with no roles. Likely this resulted from changes in the API over time, and at some point, users were left abandoned without roles. This integrity check will help to identify them. 