### PR TITLE
feat: Add integrity check for user roles with no authorities/users

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
@@ -74,3 +74,4 @@ checks:
   - users/users_capture_ou_not_in_tei_search_ou.yaml
   - users/users_with_no_user_role.yaml
   - users/user_roles_no_authorities.yaml
+  - users/user_roles_with_no_users.yaml

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
@@ -73,3 +73,4 @@ checks:
   - users/users_capture_ou_not_in_data_view_ou.yaml
   - users/users_capture_ou_not_in_tei_search_ou.yaml
   - users/users_with_no_user_role.yaml
+  - users/user_roles_no_authorities.yaml

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/user_roles_no_authorities.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/user_roles_no_authorities.yaml
@@ -1,0 +1,51 @@
+# Copyright (c) 2004-2022, University of Oslo
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# Neither the name of the HISP project nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+---
+name: user_roles_no_authorities
+description: User roles which have no authorities assigned.
+section: Users
+section_order: 4
+summary_sql: >-
+    SELECT COUNT(*) as value, 
+    100.0 * COUNT(*) / NULLIF((SELECT COUNT(*) FROM userrole), 0) as percent
+    FROM userrole
+    WHERE userroleid NOT IN (SELECT userroleid FROM userroleauthorities);
+details_sql: >-
+    SELECT uid, name FROM userrole
+    WHERE userroleid NOT IN (SELECT userroleid FROM userroleauthorities);
+details_id_type: userRoles
+severity: SEVERE
+introduction: >
+  User roles should generally have some authorities assigned to them. A valid case for a user role with
+  no authorities would be for users which need to be restricted from accessing any data or functionality.
+  It is also possible that user roles may have been created without any authorities assigned by mistake.
+  Another possibility is that due to changes in the system, authorities may have been removed automatically.
+recommendation: >
+  Using the details provided, review the user roles which have no authorities assigned and consider whether
+    they should have authorities assigned. If they should have authorities assigned, assign the appropriate
+    authorities to the user roles. If they should not have authorities assigned, consider whether the user roles
+    are necessary and if not, delete them.

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/user_roles_with_no_users.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/user_roles_with_no_users.yaml
@@ -25,18 +25,18 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 ---
-name: user_roles_no_authorities
-description: User roles which have no authorities assigned.
+name: user_roles_with_no_users
+description: User roles which have no users assigned.
 section: Users
-section_order: 4
+section_order: 5
 summary_sql: >-
     SELECT COUNT(*) as value, 
     100.0 * COUNT(*) / NULLIF((SELECT COUNT(*) FROM userrole), 0) as percent
     FROM userrole
-    WHERE userroleid NOT IN (SELECT userroleid FROM userroleauthorities);
+    WHERE userroleid NOT IN (SELECT userroleid FROM userrolemembers);
 details_sql: >-
-    SELECT uid, name FROM userrole
-    WHERE userroleid NOT IN (SELECT userroleid FROM userroleauthorities);
+  SELECT uid, name FROM userrole
+  WHERE userroleid NOT IN (SELECT userroleid FROM userrolemembers);
 details_id_type: userRoles
 severity: WARNING
 introduction: >

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/user_roles_with_no_users.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/user_roles_with_no_users.yaml
@@ -40,12 +40,12 @@ details_sql: >-
 details_id_type: userRoles
 severity: WARNING
 introduction: >
-  User roles should generally have some authorities assigned to them. A valid case for a user role with
-  no authorities would be for users which need to be restricted from accessing any data or functionality.
-  It is also possible that user roles may have been created without any authorities assigned by mistake.
-  Another possibility is that due to changes in the system, authorities may have been removed automatically.
+    User roles should generally have some users assigned to them. A valid case for a user role with
+    no users would be for user roles which are newly created and have not yet been assigned to any users.
+    It is also possible that user roles may have been created without any users assigned by mistake.
+    Some user roles may have also been in use at some point in time, but are no longer in use.
 recommendation: >
-  Using the details provided, review the user roles which have no authorities assigned and consider whether
-    they should have authorities assigned. If they should have authorities assigned, assign the appropriate
-    authorities to the user roles. If they should not have authorities assigned, consider whether the user roles
+    Using the details provided, review the user roles which have no users assigned and consider whether
+    they should have users assigned. If they should have users assigned, assign the appropriate
+    users to the user roles. If they should not have users assigned, consider whether the user roles
     are necessary and if not, delete them.

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
@@ -56,7 +56,7 @@ class DataIntegrityYamlReaderTest {
 
     List<DataIntegrityCheck> checks = new ArrayList<>();
     readYaml(checks, "data-integrity-checks.yaml", "data-integrity-checks", CLASS_PATH);
-    assertEquals(74, checks.size());
+    assertEquals(75, checks.size());
 
     // Names should be unique
     List<String> allNames = checks.stream().map(DataIntegrityCheck::getName).toList();

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
@@ -56,7 +56,7 @@ class DataIntegrityYamlReaderTest {
 
     List<DataIntegrityCheck> checks = new ArrayList<>();
     readYaml(checks, "data-integrity-checks.yaml", "data-integrity-checks", CLASS_PATH);
-    assertEquals(75, checks.size());
+    assertEquals(76, checks.size());
 
     // Names should be unique
     List<String> allNames = checks.stream().map(DataIntegrityCheck::getName).toList();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUserRolesNoAuthorities.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUserRolesNoAuthorities.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.dataintegrity;
+
+import static org.hisp.dhis.web.WebClientUtils.assertStatus;
+
+import org.hisp.dhis.web.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+class DataIntegrityUserRolesNoAuthorities extends AbstractDataIntegrityIntegrationTest {
+
+  private static final String CHECK_NAME = "user_roles_no_authorities";
+
+  private static final String DETAILS_ID_TYPE = "userRoles";
+
+  private String userRoleUid;
+
+  @Test
+  void testUserRolesNoAuthorities() {
+    userRoleUid =
+        assertStatus(
+            HttpStatus.CREATED, POST("/userRoles", "{ 'name': 'Empty role', 'authorities': [] }"));
+    assertStatus(
+        HttpStatus.CREATED,
+        POST("/userRoles", "{ 'name': 'Good role', 'authorities': ['F_DATAVALUE_ADD'] }"));
+    // Note that two user roles already exist due to the setup in the
+    // AbstractDataIntegrityIntegrationTest class
+    // Thus there should be 4 roles total. Only the Empty role should be flagged.
+    assertHasDataIntegrityIssues(
+        DETAILS_ID_TYPE, CHECK_NAME, 25, userRoleUid, "Empty role", null, true);
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUserRolesNoUsers.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUserRolesNoUsers.java
@@ -1,0 +1,30 @@
+package org.hisp.dhis.webapi.controller.dataintegrity;
+
+import org.hisp.dhis.web.HttpStatus;
+import org.hisp.dhis.webapi.json.domain.JsonDataIntegritySummary;
+import org.junit.jupiter.api.Test;
+
+import static org.hisp.dhis.web.WebClientUtils.assertStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DataIntegrityUserRolesNoUsers extends AbstractDataIntegrityIntegrationTest
+{
+    private static final String CHECK_NAME = "user_roles_with_no_users";
+
+    private static final String DETAILS_ID_TYPE = "userRoles";
+
+    private String userRoleUid;
+
+    @Test
+    void testUserRolesNoUsers() {
+        userRoleUid = assertStatus(
+            HttpStatus.CREATED, POST("/userRoles", "{ 'name': 'Test role', 'authorities': ['F_DATAVALUE_ADD'] }"));
+        //Note that two user roles already exist as part of the setup in the AbstractDataIntegrityIntegrationTest class
+        //Thus, there should be three roles in total, two of which are valid since they already have users associated with them.
+        postSummary(CHECK_NAME);
+
+        JsonDataIntegritySummary summary = getSummary(CHECK_NAME);
+        assertEquals(1, summary.getCount());
+        assertHasDataIntegrityIssues(DETAILS_ID_TYPE, CHECK_NAME, 33, userRoleUid, "Test role", null, true);
+    }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUserRolesNoUsers.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUserRolesNoUsers.java
@@ -1,30 +1,61 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.webapi.controller.dataintegrity;
+
+import static org.hisp.dhis.web.WebClientUtils.assertStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.json.domain.JsonDataIntegritySummary;
 import org.junit.jupiter.api.Test;
 
-import static org.hisp.dhis.web.WebClientUtils.assertStatus;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+class DataIntegrityUserRolesNoUsers extends AbstractDataIntegrityIntegrationTest {
+  private static final String CHECK_NAME = "user_roles_with_no_users";
 
-class DataIntegrityUserRolesNoUsers extends AbstractDataIntegrityIntegrationTest
-{
-    private static final String CHECK_NAME = "user_roles_with_no_users";
+  private static final String DETAILS_ID_TYPE = "userRoles";
 
-    private static final String DETAILS_ID_TYPE = "userRoles";
+  private String userRoleUid;
 
-    private String userRoleUid;
+  @Test
+  void testUserRolesNoUsers() {
+    userRoleUid =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST("/userRoles", "{ 'name': 'Test role', 'authorities': ['F_DATAVALUE_ADD'] }"));
+    // Note that two user roles already exist as part of the setup in the
+    // AbstractDataIntegrityIntegrationTest class
+    // Thus, there should be three roles in total, two of which are valid since they already have
+    // users associated with them.
+    postSummary(CHECK_NAME);
 
-    @Test
-    void testUserRolesNoUsers() {
-        userRoleUid = assertStatus(
-            HttpStatus.CREATED, POST("/userRoles", "{ 'name': 'Test role', 'authorities': ['F_DATAVALUE_ADD'] }"));
-        //Note that two user roles already exist as part of the setup in the AbstractDataIntegrityIntegrationTest class
-        //Thus, there should be three roles in total, two of which are valid since they already have users associated with them.
-        postSummary(CHECK_NAME);
-
-        JsonDataIntegritySummary summary = getSummary(CHECK_NAME);
-        assertEquals(1, summary.getCount());
-        assertHasDataIntegrityIssues(DETAILS_ID_TYPE, CHECK_NAME, 33, userRoleUid, "Test role", null, true);
-    }
+    JsonDataIntegritySummary summary = getSummary(CHECK_NAME);
+    assertEquals(1, summary.getCount());
+    assertHasDataIntegrityIssues(
+        DETAILS_ID_TYPE, CHECK_NAME, 33, userRoleUid, "Test role", null, true);
+  }
 }


### PR DESCRIPTION
User roles should normally have some authority associated with them. This integrity check identifies user roles with no authorities. 

We also add a check for user roles with no users. 