### PR TITLE
chore: Remove enrollmentService.enrollmentExists [DHIS2-17712-3]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
@@ -75,14 +75,6 @@ public interface EnrollmentService {
   List<Enrollment> getEnrollments(@Nonnull List<String> uids);
 
   /**
-   * Checks for the existence of an enrollment by UID. Deleted values are not taken into account.
-   *
-   * @param uid Event UID to check for
-   * @return true/false depending on result
-   */
-  boolean enrollmentExists(String uid);
-
-  /**
    * Checks for the existence of an enrollment by UID. Takes into account also the deleted values.
    *
    * @param uid Event UID to check for

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentStore.java
@@ -49,15 +49,6 @@ public interface EnrollmentStore extends IdentifiableObjectStore<Enrollment> {
   List<Enrollment> get(TrackedEntity trackedEntity, Program program, EnrollmentStatus status);
 
   /**
-   * Checks for the existence of an enrollment by UID, Deleted enrollments are not taken into
-   * account.
-   *
-   * @param uid Event UID to check for
-   * @return true/false depending on result
-   */
-  boolean exists(String uid);
-
-  /**
    * Checks for the existence of an enrollment by UID. Takes into account also the deleted
    * enrollments.
    *

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
@@ -87,12 +87,6 @@ public class DefaultEnrollmentService implements EnrollmentService {
 
   @Override
   @Transactional(readOnly = true)
-  public boolean enrollmentExists(String uid) {
-    return enrollmentStore.exists(uid);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
   public boolean enrollmentExistsIncludingDeleted(String uid) {
     return enrollmentStore.existsIncludingDeleted(uid);
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEnrollmentStore.java
@@ -112,20 +112,6 @@ public class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enr
   }
 
   @Override
-  public boolean exists(String uid) {
-    if (uid == null) {
-      return false;
-    }
-
-    Query<?> query =
-        nativeSynchronizedQuery(
-            "select exists(select 1 from enrollment where uid=:uid and deleted is false)");
-    query.setParameter("uid", uid);
-
-    return ((Boolean) query.getSingleResult()).booleanValue();
-  }
-
-  @Override
   public boolean existsIncludingDeleted(String uid) {
     if (uid == null) {
       return false;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -105,8 +105,7 @@ class DefaultEnrollmentService implements EnrollmentService {
     return getEnrollment(enrollment, params, includeDeleted, currentUser);
   }
 
-  @Override
-  public Enrollment getEnrollment(
+  private Enrollment getEnrollment(
       @Nonnull Enrollment enrollment,
       EnrollmentParams params,
       boolean includeDeleted,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
@@ -47,10 +47,6 @@ public interface EnrollmentService {
   Enrollment getEnrollment(String uid, EnrollmentParams params, boolean includeDeleted)
       throws NotFoundException, ForbiddenException;
 
-  Enrollment getEnrollment(
-      Enrollment enrollment, EnrollmentParams params, boolean includeDeleted, UserDetails user)
-      throws ForbiddenException;
-
   RelationshipItem getEnrollmentInRelationshipItem(
       String uid, EnrollmentParams params, boolean includeDeleted) throws NotFoundException;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListenerTest.java
@@ -48,6 +48,8 @@ import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.fileresource.FileResourceService;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -82,6 +84,7 @@ import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueChangeLogServi
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
 import org.hisp.dhis.tracker.export.event.EventService;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -181,7 +184,7 @@ class EnrollmentSMSListenerTest extends CompressionSMSListenerTest {
   private DataElement dataElement;
 
   @BeforeEach
-  public void initTest() throws SmsCompressionException {
+  public void initTest() throws SmsCompressionException, ForbiddenException, NotFoundException {
     subject =
         new EnrollmentSMSListener(
             incomingSmsService,
@@ -222,6 +225,8 @@ class EnrollmentSMSListenerTest extends CompressionSMSListenerTest {
         .thenReturn(enrollment);
     when(programService.hasOrgUnit(any(Program.class), any(OrganisationUnit.class)))
         .thenReturn(true);
+    when(enrollmentService.getEnrollment(anyString(), any(UserDetails.class)))
+        .thenThrow(NotFoundException.class);
 
     doAnswer(
             invocation -> {
@@ -296,7 +301,7 @@ class EnrollmentSMSListenerTest extends CompressionSMSListenerTest {
   }
 
   @Test
-  void testEnrollmentNoAttribs() {
+  void testEnrollmentNoAttribs() throws ForbiddenException, NotFoundException {
     subject.receive(incomingSmsEnrollmentNoAttribs);
 
     assertNotNull(updatedIncomingSms);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListenerTest.java
@@ -301,7 +301,7 @@ class EnrollmentSMSListenerTest extends CompressionSMSListenerTest {
   }
 
   @Test
-  void testEnrollmentNoAttribs() throws ForbiddenException, NotFoundException {
+  void testEnrollmentNoAttribs() {
     subject.receive(incomingSmsEnrollmentNoAttribs);
 
     assertNotNull(updatedIncomingSms);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentStoreTest.java
@@ -30,7 +30,8 @@ package org.hisp.dhis.program;
 import static org.hisp.dhis.program.notification.NotificationTrigger.SCHEDULED_DAYS_ENROLLMENT_DATE;
 import static org.hisp.dhis.program.notification.NotificationTrigger.SCHEDULED_DAYS_INCIDENT_DATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Sets;
@@ -156,10 +157,9 @@ class EnrollmentStoreTest extends TransactionalIntegrationTest {
     enrollmentStore.save(enrollmentA);
     enrollmentStore.save(enrollmentB);
     dbmsManager.flushSession();
-    assertTrue(enrollmentStore.exists(enrollmentA.getUid()));
-    assertTrue(enrollmentStore.exists(enrollmentB.getUid()));
-    assertFalse(enrollmentStore.exists("aaaabbbbccc"));
-    assertFalse(enrollmentStore.exists(null));
+    assertNotNull(enrollmentStore.get(enrollmentA.getId()));
+    assertNotNull(enrollmentStore.get(enrollmentB.getId()));
+    assertNull(enrollmentStore.get(99999));
   }
 
   @Test


### PR DESCRIPTION
### Big picture

Tracker has multiple services for each entity like tracked entity, enrollment and event. One is in dhis-api and one in dhis-service-tracker. Our goal is to provide one API (service) per entity that is part of the tracker domain/team.

Trackers architecture splits read/write into exporter services and an importer. So if you want to get data you use an exporter. If you want to insert, update or delete you have to go through the importer. Only then can we ensure integrity of tracker data.

Another goal is that code that provides tracker functionality and is thus owned by the tracker team lives in ideally one maven module (We can settle on a name later on maybe dhis-service-tracker or dhis-tracker).

This is a big task that we are going to implement in many small steps.

### This PR

Removes the method `enrollmentExists(uid)` from the api module as we can achieve the same result by using the method `getEnrollment` from the service tracker module.

We need to discuss how to deal with not found enrollments, since it might be because the enrollment truly doesn't exist, or because the user has no metadata access to it. Depending on the reason, we'll need to react differently (I guess).