### PR TITLE
fix: Validate mandatory data values also on UPDATE [DHIS2-17560]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/StatusUpdateValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/validation/validator/event/StatusUpdateValidator.java
@@ -54,7 +54,6 @@ class StatusUpdateValidator implements Validator<Event> {
       case VISITED, ACTIVE, COMPLETED ->
           EventStatus.STATUSES_WITHOUT_DATA_VALUES.contains(toStatus);
         // An event can transition from a STATUSES_WITHOUT_DATA_VALUES to any status
-        // TODO: Is OVERDUE a read-only status?
       case OVERDUE, SKIPPED, SCHEDULE -> false;
     };
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/executor/event/SetMandatoryFieldExecutorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/executor/event/SetMandatoryFieldExecutorTest.java
@@ -190,9 +190,9 @@ class SetMandatoryFieldExecutorTest extends DhisConvenienceTest {
     when(preheat.getIdSchemes()).thenReturn(TrackerIdSchemeParams.builder().build());
     when(preheat.getDataElement(DATA_ELEMENT_UID.getValue())).thenReturn(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStage))).thenReturn(programStage);
-    Event event = getEventWithMandatoryValueNOTSet(savedStatus);
+    Event event = getEventWithMandatoryValueNOTSet(newStatus);
     when(preheat.getEvent(event.getUid()))
-        .thenReturn(eventWithMandatoryValue(event.getUid(), newStatus));
+        .thenReturn(eventWithMandatoryValue(event.getUid(), savedStatus));
     bundle.setEvents(List.of(event));
     bundle.setStrategy(event, TrackerImportStrategy.UPDATE);
     Optional<ProgramRuleIssue> error = executor.executeRuleAction(bundle, event);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/executor/event/SetMandatoryFieldExecutorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/programrule/executor/event/SetMandatoryFieldExecutorTest.java
@@ -43,6 +43,7 @@ import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.common.UID;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
+import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.program.ValidationStrategy;
@@ -184,13 +185,14 @@ class SetMandatoryFieldExecutorTest extends DhisConvenienceTest {
 
   @ParameterizedTest
   @MethodSource("transactionsNotCreatingDataValues")
-  void shouldPassValidationWhenMandatoryFieldIsNotPresentAndStrategyIsUpdate(
+  void shouldPassValidationWhenMandatoryFieldIsNotPresentInPayloadButPresentInDB(
       EventStatus savedStatus, EventStatus newStatus) {
     when(preheat.getIdSchemes()).thenReturn(TrackerIdSchemeParams.builder().build());
     when(preheat.getDataElement(DATA_ELEMENT_UID.getValue())).thenReturn(dataElement);
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStage))).thenReturn(programStage);
     Event event = getEventWithMandatoryValueNOTSet(savedStatus);
-    when(preheat.getEvent(event.getUid())).thenReturn(event(event.getUid(), newStatus));
+    when(preheat.getEvent(event.getUid()))
+        .thenReturn(eventWithMandatoryValue(event.getUid(), newStatus));
     bundle.setEvents(List.of(event));
     bundle.setStrategy(event, TrackerImportStrategy.UPDATE);
     Optional<ProgramRuleIssue> error = executor.executeRuleAction(bundle, event);
@@ -247,6 +249,15 @@ class SetMandatoryFieldExecutorTest extends DhisConvenienceTest {
 
     assertFalse(error.isEmpty());
     assertEquals(error(RULE_UID, E1301, dataElement.getUid()), error.get());
+  }
+
+  private org.hisp.dhis.program.Event eventWithMandatoryValue(String uid, EventStatus status) {
+    org.hisp.dhis.program.Event event = new org.hisp.dhis.program.Event();
+    event.setUid(uid);
+    event.setStatus(status);
+    event.setEventDataValues(
+        Set.of(new EventDataValue(DATA_ELEMENT_UID.getValue(), DATA_ELEMENT_VALUE)));
+    return event;
   }
 
   private org.hisp.dhis.program.Event event(String uid, EventStatus status) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/imports/validation/validator/event/DataValuesValidatorTest.java
@@ -34,11 +34,13 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
+import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionSet;
@@ -243,7 +245,6 @@ class DataValuesValidatorTest {
             .dataValues(Set.of(dataValue()))
             .build();
 
-    when(bundle.getStrategy(event)).thenReturn(TrackerImportStrategy.CREATE);
     validator.validate(reporter, bundle, event);
 
     assertHasError(reporter, event, ValidationCode.E1303);
@@ -285,7 +286,7 @@ class DataValuesValidatorTest {
 
   @ParameterizedTest
   @MethodSource("transactionsNotCreatingDataValues")
-  void shouldPassValidationWhenAMandatoryDataElementIsMissingAndDataValuesAreNotCreated(
+  void shouldPassValidationWhenAMandatoryDataElementIsMissingAndDataValueIsAlreadyPresentInDB(
       EventStatus savedStatus, EventStatus newStatus) {
     DataElement dataElement = dataElement();
     String eventUid = CodeGenerator.generateUid();
@@ -307,7 +308,8 @@ class DataValuesValidatorTest {
     programStage.setProgramStageDataElements(
         Set.of(mandatoryStageElement1, mandatoryStageElement2));
     when(preheat.getProgramStage(MetadataIdentifier.ofUid(programStage))).thenReturn(programStage);
-    when(preheat.getEvent(eventUid)).thenReturn(event(eventUid, savedStatus));
+    when(preheat.getEvent(eventUid))
+        .thenReturn(event(eventUid, savedStatus, Set.of("MANDATORY_DE", dataElementUid)));
 
     Event event =
         Event.builder()
@@ -317,7 +319,6 @@ class DataValuesValidatorTest {
             .dataValues(Set.of(dataValue()))
             .build();
 
-    when(bundle.getStrategy(event)).thenReturn(TrackerImportStrategy.UPDATE);
     validator.validate(reporter, bundle, event);
 
     assertNoErrors(reporter);
@@ -357,7 +358,6 @@ class DataValuesValidatorTest {
             .dataValues(Set.of(dataValue()))
             .build();
 
-    when(bundle.getStrategy(event)).thenReturn(TrackerImportStrategy.UPDATE);
     validator.validate(reporter, bundle, event);
 
     assertHasError(reporter, event, ValidationCode.E1303);
@@ -392,7 +392,6 @@ class DataValuesValidatorTest {
             .dataValues(Set.of(dataValue))
             .build();
 
-    when(bundle.getStrategy(event)).thenReturn(TrackerImportStrategy.CREATE);
     validator.validate(reporter, bundle, event);
 
     assertIsEmpty(reporter.getErrors());
@@ -515,7 +514,6 @@ class DataValuesValidatorTest {
             .dataValues(Set.of(validDataValue))
             .build();
 
-    when(bundle.getStrategy(event)).thenReturn(TrackerImportStrategy.CREATE);
     validator.validate(reporter, bundle, event);
 
     assertIsEmpty(reporter.getErrors());
@@ -541,7 +539,6 @@ class DataValuesValidatorTest {
             .dataValues(Set.of(validDataValue))
             .build();
 
-    when(bundle.getStrategy(event)).thenReturn(TrackerImportStrategy.CREATE);
     validator.validate(reporter, bundle, event);
 
     assertHasError(reporter, event, ValidationCode.E1076);
@@ -568,7 +565,6 @@ class DataValuesValidatorTest {
             .dataValues(Set.of(validDataValue))
             .build();
 
-    when(bundle.getStrategy(event)).thenReturn(TrackerImportStrategy.CREATE);
     validator.validate(reporter, bundle, event);
 
     assertHasError(reporter, event, ValidationCode.E1076);
@@ -597,7 +593,6 @@ class DataValuesValidatorTest {
             .dataValues(Set.of(validDataValue))
             .build();
 
-    when(bundle.getStrategy(event)).thenReturn(TrackerImportStrategy.UPDATE);
     validator.validate(reporter, bundle, event);
 
     assertHasError(reporter, event, ValidationCode.E1076);
@@ -624,7 +619,6 @@ class DataValuesValidatorTest {
             .dataValues(Set.of(validDataValue))
             .build();
 
-    when(bundle.getStrategy(event)).thenReturn(TrackerImportStrategy.CREATE);
     validator.validate(reporter, bundle, event);
 
     assertHasError(reporter, event, ValidationCode.E1076);
@@ -676,7 +670,6 @@ class DataValuesValidatorTest {
             .dataValues(Set.of(validDataValue))
             .build();
 
-    when(bundle.getStrategy(event)).thenReturn(TrackerImportStrategy.CREATE);
     validator.validate(reporter, bundle, event);
 
     assertHasError(reporter, event, ValidationCode.E1076);
@@ -776,7 +769,6 @@ class DataValuesValidatorTest {
             .dataValues(Set.of(validDataValue))
             .build();
 
-    when(bundle.getStrategy(event)).thenReturn(TrackerImportStrategy.CREATE);
     validator.validate(reporter, bundle, event);
 
     assertIsEmpty(reporter.getErrors());
@@ -1094,6 +1086,18 @@ class DataValuesValidatorTest {
     validator.validate(reporter, bundle, event);
 
     assertHasError(reporter, event, ValidationCode.E1302);
+  }
+
+  private org.hisp.dhis.program.Event event(
+      String uid, EventStatus status, Set<String> dataElements) {
+    org.hisp.dhis.program.Event event = new org.hisp.dhis.program.Event();
+    event.setUid(uid);
+    event.setStatus(status);
+    event.setEventDataValues(
+        dataElements.stream()
+            .map(de -> new EventDataValue(de, "value"))
+            .collect(Collectors.toSet()));
+    return event;
   }
 
   private org.hisp.dhis.program.Event event(String uid, EventStatus status) {


### PR DESCRIPTION
We were validating mandatory data values when creating or when transitioning from a status that does not allow to define data values to one that allows it. This is an issue in some cases:
- When a program rule is evaluated to true based on some temporal factor. A data value could then be not mandatory at the moment of creation/transition, but become mandatory at a later stage.
- When metadata is changed. A DataElement is now mandatory.
- When the programStage validation strategy is `ON_COMPLETE` and the status was `ACTIVE` and become `COMPLETE`. Becasue it is not a `CREATE` we were skipping validation here. This is a really common use case that we were missing.

The solution is to not consider anymore if the import is a CREATE or an UPDATE but always validate mandatory data values (when data values need to be validated, based on the status and the programStage validation strategy) based on all the data values (DB + payload).