### PR TITLE
chore: Backport new data integrity checks from master

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
@@ -71,3 +71,4 @@ checks:
   - groups/group_size_category_option_group_sets.yaml
   - groups/group_size_user_groups.yaml
   - users/users_capture_ou_not_in_data_view_ou.yaml
+  - users/users_capture_ou_not_in_tei_search_ou.yaml

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
@@ -70,3 +70,4 @@ checks:
   - groups/group_size_category_option_groups.yaml
   - groups/group_size_category_option_group_sets.yaml
   - groups/group_size_user_groups.yaml
+  - users/users_capture_ou_not_in_data_view_ou.yaml

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
@@ -73,3 +73,5 @@ checks:
   - users/users_capture_ou_not_in_data_view_ou.yaml
   - users/users_capture_ou_not_in_tei_search_ou.yaml
   - users/users_with_no_user_role.yaml
+  - users/user_roles_no_authorities.yaml
+  - users/user_roles_with_no_users.yaml

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
@@ -72,3 +72,4 @@ checks:
   - groups/group_size_user_groups.yaml
   - users/users_capture_ou_not_in_data_view_ou.yaml
   - users/users_capture_ou_not_in_tei_search_ou.yaml
+  - users/users_with_no_user_role.yaml

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/user_roles_no_authorities.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/user_roles_no_authorities.yaml
@@ -1,0 +1,51 @@
+# Copyright (c) 2004-2022, University of Oslo
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# Neither the name of the HISP project nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+---
+name: user_roles_no_authorities
+description: User roles which have no authorities assigned.
+section: Users
+section_order: 4
+summary_sql: >-
+    SELECT COUNT(*) as value, 
+    100.0 * COUNT(*) / NULLIF((SELECT COUNT(*) FROM userrole), 0) as percent
+    FROM userrole
+    WHERE userroleid NOT IN (SELECT userroleid FROM userroleauthorities);
+details_sql: >-
+    SELECT uid, name FROM userrole
+    WHERE userroleid NOT IN (SELECT userroleid FROM userroleauthorities);
+details_id_type: userRoles
+severity: WARNING
+introduction: >
+  User roles should generally have some authorities assigned to them. A valid case for a user role with
+  no authorities would be for users which need to be restricted from accessing any data or functionality.
+  It is also possible that user roles may have been created without any authorities assigned by mistake.
+  Another possibility is that due to changes in the system, authorities may have been removed automatically.
+recommendation: >
+  Using the details provided, review the user roles which have no authorities assigned and consider whether
+    they should have authorities assigned. If they should have authorities assigned, assign the appropriate
+    authorities to the user roles. If they should not have authorities assigned, consider whether the user roles
+    are necessary and if not, delete them.

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/user_roles_with_no_users.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/user_roles_with_no_users.yaml
@@ -1,0 +1,51 @@
+# Copyright (c) 2004-2022, University of Oslo
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# Neither the name of the HISP project nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+---
+name: user_roles_with_no_users
+description: User roles which have no users assigned.
+section: Users
+section_order: 5
+summary_sql: >-
+    SELECT COUNT(*) as value, 
+    100.0 * COUNT(*) / NULLIF((SELECT COUNT(*) FROM userrole), 0) as percent
+    FROM userrole
+    WHERE userroleid NOT IN (SELECT userroleid FROM userrolemembers);
+details_sql: >-
+  SELECT uid, name FROM userrole
+  WHERE userroleid NOT IN (SELECT userroleid FROM userrolemembers);
+details_id_type: userRoles
+severity: WARNING
+introduction: >
+    User roles should generally have some users assigned to them. A valid case for a user role with
+    no users would be for user roles which are newly created and have not yet been assigned to any users.
+    It is also possible that user roles may have been created without any users assigned by mistake.
+    Some user roles may have also been in use at some point in time, but are no longer in use.
+recommendation: >
+    Using the details provided, review the user roles which have no users assigned and consider whether
+    they should have users assigned. If they should have users assigned, assign the appropriate
+    users to the user roles. If they should not have users assigned, consider whether the user roles
+    are necessary and if not, delete them.

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/users_capture_ou_not_in_data_view_ou.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/users_capture_ou_not_in_data_view_ou.yaml
@@ -1,0 +1,121 @@
+# Copyright (c) 2004-2022, University of Oslo
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# Neither the name of the HISP project nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+---
+name: users_capture_ou_not_in_data_view_ou
+description: Users who have a data capture organisation unit which is not in their data view organisation unit hierarchy.
+section: Users
+section_order: 1
+summary_sql: >-
+  WITH user_data_orgunits AS (
+      SELECT userinfoid, array_agg(path) AS data_orgunits_paths
+      FROM organisationunit
+      JOIN usermembership ON organisationunit.organisationunitid = usermembership.organisationunitid
+      WHERE path IS NOT NULL
+      GROUP BY userinfoid
+  ),
+  user_view_orgunits AS (
+      SELECT userinfoid, array_agg(path) AS view_orgunit_paths
+      FROM organisationunit
+      JOIN userdatavieworgunits ON organisationunit.organisationunitid = userdatavieworgunits.organisationunitid
+      WHERE path IS NOT NULL
+      GROUP BY userinfoid
+  ),
+  usercount as (
+      SELECT COUNT(*) as usercount FROM userinfo
+  )
+  SELECT COUNT(ui.uid) as value, 
+  100.0 * COUNT(ui.uid) / NULLIF(usercount.usercount, 0) as percent
+  FROM userinfo ui
+  INNER JOIN (
+  SELECT u.userinfoid, ARRAY_AGG(dop) FILTER (WHERE dop IS NOT NULL) AS invalid_data_orgunits
+  FROM user_data_orgunits u
+  INNER JOIN user_view_orgunits v ON u.userinfoid = v.userinfoid
+  LEFT JOIN LATERAL (
+      SELECT path AS dop
+      FROM unnest(u.data_orgunits_paths) AS path
+      WHERE NOT EXISTS (
+          SELECT 1
+          FROM unnest(COALESCE(v.view_orgunit_paths, '{}')) AS view_path
+          WHERE path LIKE view_path || '%'
+      )
+  ) invalid_paths ON true
+  GROUP BY u.userinfoid
+  HAVING array_length(ARRAY_AGG(dop) FILTER (WHERE dop IS NOT NULL), 1) > 0
+  ) x on x.userinfoid = ui.userinfoid
+  INNER JOIN organisationunit ou on ou.path = any(x.invalid_data_orgunits)
+  JOIN usercount on true
+  GROUP BY usercount.usercount;
+details_sql: >-
+  WITH user_data_orgunits AS (
+      SELECT userinfoid, array_agg(path) AS data_orgunits_paths
+      FROM organisationunit 
+      JOIN usermembership ON organisationunit.organisationunitid = usermembership.organisationunitid
+      WHERE organisationunit.path IS NOT NULL
+      GROUP BY userinfoid
+  ),
+  user_view_orgunits AS (
+      SELECT userinfoid, array_agg(path) AS view_orgunit_paths
+      FROM organisationunit
+      JOIN userdatavieworgunits ON organisationunit.organisationunitid = userdatavieworgunits.organisationunitid
+      WHERE path IS NOT NULL
+      GROUP BY userinfoid
+  )
+  SELECT ui.uid, 
+  ui.username as name,
+  NULL as comment,
+  array_agg(ou.name) as refs
+  FROM userinfo ui
+  INNER JOIN (
+  SELECT u.userinfoid, ARRAY_AGG(dop) FILTER (WHERE dop IS NOT NULL) AS invalid_data_orgunits
+  FROM user_data_orgunits u
+  INNER JOIN user_view_orgunits v ON u.userinfoid = v.userinfoid
+  LEFT JOIN LATERAL (
+      SELECT path AS dop
+      FROM unnest(u.data_orgunits_paths) AS path
+      WHERE NOT EXISTS (
+          SELECT 1
+          FROM unnest(COALESCE(v.view_orgunit_paths, '{}')) AS view_path
+          WHERE path LIKE view_path || '%'
+      )
+  ) invalid_paths ON true
+  GROUP BY u.userinfoid
+  HAVING array_length(ARRAY_AGG(dop) FILTER (WHERE dop IS NOT NULL), 1) > 0
+  ) x on x.userinfoid = ui.userinfoid
+  INNER JOIN organisationunit ou on ou.path = any(x.invalid_data_orgunits)
+  GROUP BY ui.uid, ui.username;
+details_id_type: users
+severity: SEVERE
+introduction: >
+  Users who can enter data should be able to view their own data. This situation occurs when a user has 
+  a data capture organisation unit which is not within the data view organisation unit hierarchy.
+  This can lead to a situation where a user can enter data, but cannot view the data that they have entered.
+recommendation: >
+  Users should at least have access to view the data that they have entered. Using the results
+  of the details SQL view, identify the affected users and the organisation units where they
+  have access to enter data. The user should have at least all of their data capture organisation units
+  specified in their data view organisation units. Alternatively, you can set the data view organisation units
+  to be at a higher level in the hierarchy.

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/users_capture_ou_not_in_tei_search_ou.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/users_capture_ou_not_in_tei_search_ou.yaml
@@ -1,0 +1,120 @@
+# Copyright (c) 2004-2022, University of Oslo
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# Neither the name of the HISP project nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+---
+name: users_capture_ou_not_in_tei_search_ou
+description: Users who have a data capture organisation unit which is not within their tracked entity search organisation unit hierarchy.
+section: Users
+section_order: 2
+summary_sql: >-
+  WITH user_data_orgunits AS (
+      SELECT userinfoid, array_agg(path) AS data_orgunits_paths
+      FROM organisationunit
+      JOIN usermembership ON organisationunit.organisationunitid = usermembership.organisationunitid
+      WHERE path IS NOT NULL
+      GROUP BY userinfoid
+  ),
+  user_view_orgunits AS (
+      SELECT userinfoid, array_agg(path) AS view_orgunit_paths
+      FROM organisationunit
+      JOIN userteisearchorgunits ON organisationunit.organisationunitid = userteisearchorgunits.organisationunitid
+      WHERE path IS NOT NULL
+      GROUP BY userinfoid
+  ),
+  usercount as (
+      SELECT COUNT(*) as usercount FROM userinfo
+  )
+  SELECT COUNT(ui.uid) as value, 
+  100.0 * COUNT(ui.uid) / NULLIF(usercount.usercount, 0) as percent
+  FROM userinfo ui
+  INNER JOIN (
+  SELECT u.userinfoid, ARRAY_AGG(dop) FILTER (WHERE dop IS NOT NULL) AS invalid_data_orgunits
+  FROM user_data_orgunits u
+  INNER JOIN user_view_orgunits v ON u.userinfoid = v.userinfoid
+  LEFT JOIN LATERAL (
+      SELECT path AS dop
+      FROM unnest(u.data_orgunits_paths) AS path
+      WHERE NOT EXISTS (
+          SELECT 1
+          FROM unnest(COALESCE(v.view_orgunit_paths, '{}')) AS view_path
+          WHERE path LIKE view_path || '%'
+      )
+  ) invalid_paths ON true
+  GROUP BY u.userinfoid
+  HAVING array_length(ARRAY_AGG(dop) FILTER (WHERE dop IS NOT NULL), 1) > 0
+  ) x on x.userinfoid = ui.userinfoid
+  INNER JOIN organisationunit ou on ou.path = any(x.invalid_data_orgunits)
+  JOIN usercount on true
+  GROUP BY usercount.usercount;
+details_sql: >-
+  WITH user_data_orgunits AS (
+      SELECT userinfoid, array_agg(path) AS data_orgunits_paths
+      FROM organisationunit 
+      JOIN usermembership ON organisationunit.organisationunitid = usermembership.organisationunitid
+      WHERE organisationunit.path IS NOT NULL
+      GROUP BY userinfoid
+  ),
+  user_view_orgunits AS (
+      SELECT userinfoid, array_agg(path) AS view_orgunit_paths
+      FROM organisationunit
+      JOIN userteisearchorgunits ON organisationunit.organisationunitid = userteisearchorgunits.organisationunitid
+      WHERE path IS NOT NULL
+      GROUP BY userinfoid
+  )
+  SELECT ui.uid, 
+  ui.username as name,
+  NULL as comment,
+  array_agg(ou.name) as refs
+  FROM userinfo ui
+  INNER JOIN (
+  SELECT u.userinfoid, ARRAY_AGG(dop) FILTER (WHERE dop IS NOT NULL) AS invalid_data_orgunits
+  FROM user_data_orgunits u
+  INNER JOIN user_view_orgunits v ON u.userinfoid = v.userinfoid
+  LEFT JOIN LATERAL (
+      SELECT path AS dop
+      FROM unnest(u.data_orgunits_paths) AS path
+      WHERE NOT EXISTS (
+          SELECT 1
+          FROM unnest(COALESCE(v.view_orgunit_paths, '{}')) AS view_path
+          WHERE path LIKE view_path || '%'
+      )
+  ) invalid_paths ON true
+  GROUP BY u.userinfoid
+  HAVING array_length(ARRAY_AGG(dop) FILTER (WHERE dop IS NOT NULL), 1) > 0
+  ) x on x.userinfoid = ui.userinfoid
+  INNER JOIN organisationunit ou on ou.path = any(x.invalid_data_orgunits)
+  GROUP BY ui.uid, ui.username;
+details_id_type: users
+severity: WARNING
+introduction: >
+  Users who can enter tracker data should also be able to search for tracked entities. If a users 
+  data capture organisation unit is not within their tracked entity search organisation unit hierarchy,
+  they may not be able to search for all tracked entities that they have entered data for.
+recommendation: >
+  Users should be able to search for all tracked entities that they have entered data for. Using the results
+  of the details query, adjust either the users capture organisation unit so that it is within the tracked entity
+    search organisation unit hierarchy. Alternatively, you can consider to adjust the tracked entity search organisation
+    unit hierarchy so that it includes the data capture organisation unit.

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/users_with_no_user_role.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/users_with_no_user_role.yaml
@@ -1,0 +1,50 @@
+# Copyright (c) 2004-2022, University of Oslo
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# Neither the name of the HISP project nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+---
+name: users_with_no_user_role
+description: Users who have no user role assigned.
+section: Users
+section_order: 3
+summary_sql: >-
+  SELECT COUNT(*) as value,
+    100.0 * COUNT(*) / NULLIF((SELECT COUNT(*) FROM userinfo), 0) as percent
+    FROM userinfo
+    WHERE userinfoid NOT IN (SELECT DISTINCT userid FROM userrolemembers);
+details_sql: >
+  SELECT uid, 
+  username as name,
+  'disabled:' || disabled as comment
+  from userinfo
+  WHERE userinfoid NOT IN (SELECT DISTINCT userid FROM userrolemembers);
+details_id_type: users
+severity: SEVERE
+introduction: >
+  All users should have at least one use role associated with their account. If a user does not have a role, 
+  they will not be able to perform any actions in the system.
+recommendation: >
+  Using the list of users provided by the details query, either assign a user role or roles to the user
+  or alternatively, delete the user if they are no longer active in the system.

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
@@ -56,7 +56,7 @@ class DataIntegrityYamlReaderTest {
 
     List<DataIntegrityCheck> checks = new ArrayList<>();
     readYaml(checks, "data-integrity-checks.yaml", "data-integrity-checks", CLASS_PATH);
-    assertEquals(73, checks.size());
+    assertEquals(74, checks.size());
 
     // Names should be unique
     List<String> allNames = checks.stream().map(DataIntegrityCheck::getName).toList();

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
@@ -56,7 +56,7 @@ class DataIntegrityYamlReaderTest {
 
     List<DataIntegrityCheck> checks = new ArrayList<>();
     readYaml(checks, "data-integrity-checks.yaml", "data-integrity-checks", CLASS_PATH);
-    assertEquals(72, checks.size());
+    assertEquals(73, checks.size());
 
     // Names should be unique
     List<String> allNames = checks.stream().map(DataIntegrityCheck::getName).toList();

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
@@ -56,7 +56,7 @@ class DataIntegrityYamlReaderTest {
 
     List<DataIntegrityCheck> checks = new ArrayList<>();
     readYaml(checks, "data-integrity-checks.yaml", "data-integrity-checks", CLASS_PATH);
-    assertEquals(74, checks.size());
+    assertEquals(76, checks.size());
 
     // Names should be unique
     List<String> allNames = checks.stream().map(DataIntegrityCheck::getName).toList();

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
@@ -56,7 +56,7 @@ class DataIntegrityYamlReaderTest {
 
     List<DataIntegrityCheck> checks = new ArrayList<>();
     readYaml(checks, "data-integrity-checks.yaml", "data-integrity-checks", CLASS_PATH);
-    assertEquals(71, checks.size());
+    assertEquals(72, checks.size());
 
     // Names should be unique
     List<String> allNames = checks.stream().map(DataIntegrityCheck::getName).toList();

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUserRolesNoAuthorities.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUserRolesNoAuthorities.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.dataintegrity;
+
+import static org.hisp.dhis.web.WebClientUtils.assertStatus;
+
+import org.hisp.dhis.web.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+class DataIntegrityUserRolesNoAuthorities extends AbstractDataIntegrityIntegrationTest {
+
+  private static final String CHECK_NAME = "user_roles_no_authorities";
+
+  private static final String DETAILS_ID_TYPE = "userRoles";
+
+  private String userRoleUid;
+
+  @Test
+  void testUserRolesNoAuthorities() {
+    userRoleUid =
+        assertStatus(
+            HttpStatus.CREATED, POST("/userRoles", "{ 'name': 'Empty role', 'authorities': [] }"));
+    assertStatus(
+        HttpStatus.CREATED,
+        POST("/userRoles", "{ 'name': 'Good role', 'authorities': ['F_DATAVALUE_ADD'] }"));
+    // Note that two user roles already exist due to the setup in the
+    // AbstractDataIntegrityIntegrationTest class
+    // Thus there should be 4 roles total. Only the Empty role should be flagged.
+    assertHasDataIntegrityIssues(
+        DETAILS_ID_TYPE, CHECK_NAME, 25, userRoleUid, "Empty role", null, true);
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUserRolesNoUsers.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUserRolesNoUsers.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.dataintegrity;
+
+import static org.hisp.dhis.web.WebClientUtils.assertStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.hisp.dhis.web.HttpStatus;
+import org.hisp.dhis.webapi.json.domain.JsonDataIntegritySummary;
+import org.junit.jupiter.api.Test;
+
+class DataIntegrityUserRolesNoUsers extends AbstractDataIntegrityIntegrationTest {
+  private static final String CHECK_NAME = "user_roles_with_no_users";
+
+  private static final String DETAILS_ID_TYPE = "userRoles";
+
+  private String userRoleUid;
+
+  @Test
+  void testUserRolesNoUsers() {
+    userRoleUid =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST("/userRoles", "{ 'name': 'Test role', 'authorities': ['F_DATAVALUE_ADD'] }"));
+    // Note that two user roles already exist as part of the setup in the
+    // AbstractDataIntegrityIntegrationTest class
+    // Thus, there should be three roles in total, two of which are valid since they already have
+    // users associated with them.
+    postSummary(CHECK_NAME);
+
+    JsonDataIntegritySummary summary = getSummary(CHECK_NAME);
+    assertEquals(1, summary.getCount());
+    assertHasDataIntegrityIssues(
+        DETAILS_ID_TYPE, CHECK_NAME, 33, userRoleUid, "Test role", null, true);
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersCaptureOrgUnitNotInTeiSearchHierarchy.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersCaptureOrgUnitNotInTeiSearchHierarchy.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.dataintegrity;
+
+import static java.util.stream.Collectors.toUnmodifiableSet;
+import static org.hisp.dhis.web.WebClientUtils.assertStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.jsontree.JsonString;
+import org.hisp.dhis.web.HttpStatus;
+import org.hisp.dhis.webapi.json.domain.JsonDataIntegrityDetails;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integrity check to identify users who have a data view organisation unit, but who cannot access
+ * data which they have possibly entered at a higher level of the hierarchy. {@see
+ * dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/users_capture_ou_not_in_data_view_ou.yaml}
+ *
+ * @author Jason P. Pickering
+ */
+class DataIntegrityUsersCaptureOrgUnitNotInTeiSearchHierarchy
+    extends AbstractDataIntegrityIntegrationTest {
+
+  private static final String CHECK_NAME = "users_capture_ou_not_in_tei_search_ou";
+
+  private static final String DETAILS_ID_TYPE = "users";
+
+  private String orgunitAUid;
+  private String orgunitBUid;
+
+  private String userBUid;
+
+  private String userRoleUid;
+
+  @Test
+  void testDataCaptureUnitInDataViewHierarchy() {
+
+    orgunitAUid =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/organisationUnits",
+                "{ 'name': 'Fish District', 'shortName': 'Fish District', 'openingDate' : '2022-01-01'}"));
+
+    orgunitBUid =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/organisationUnits",
+                "{ 'name': 'Pizza District', 'shortName': 'Pizza District', 'openingDate' : '2022-01-01'}"));
+
+    userRoleUid =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST("/userRoles", "{ 'name': 'Test role', 'authorities': ['F_DATAVALUE_ADD'] }"));
+
+    assertStatus(
+        HttpStatus.CREATED,
+        POST(
+            "/users",
+            "{ 'username': 'bobbytables' , 'password': 'District123+', 'firstName': 'Bobby', 'surname': 'Tables', 'organisationUnits' : [{'id' : '"
+                + orgunitAUid
+                + "'}], 'teiSearchOrganisationUnits' : [{'id' : '"
+                + orgunitAUid
+                + "'}], 'userRoles' : [{'id' : '"
+                + userRoleUid
+                + "'}]}"));
+
+    userBUid =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/users",
+                "{ 'username': 'janedoe' , 'password': 'District123+', 'firstName': 'Jane', 'surname': 'Doe', 'organisationUnits' : [{'id' : '"
+                    + orgunitAUid
+                    + "'}], 'teiSearchOrganisationUnits' : [{'id' : '"
+                    + orgunitBUid
+                    + "'}], 'userRoles' : [{'id' : '"
+                    + userRoleUid
+                    + "'}]}"));
+
+    assertStatus(
+        HttpStatus.CREATED,
+        POST(
+            "/users",
+            "{ 'username': 'tommytables' , 'password': 'District123+', 'firstName': 'Tommy', 'surname': 'Tables', 'organisationUnits' : [{'id' : '"
+                + orgunitAUid
+                + "'}],  'userRoles' : [{'id' : '"
+                + userRoleUid
+                + "'}]}"));
+
+    // Note that there are already two users which exist due to the overall test setup, thus, five
+    // users in total. Only userB should be flagged.
+    assertHasDataIntegrityIssues(DETAILS_ID_TYPE, CHECK_NAME, 20, userBUid, "janedoe", null, true);
+
+    JsonDataIntegrityDetails details = getDetails(CHECK_NAME);
+    JsonList<JsonDataIntegrityDetails.JsonDataIntegrityIssue> issues = details.getIssues();
+    assertEquals(1, issues.size());
+
+    Set<String> detailsRefs =
+        issues.stream()
+            .flatMap(issue -> issue.getRefs().stream())
+            .map(JsonString::string)
+            .collect(toUnmodifiableSet());
+
+    assertTrue(detailsRefs.contains("Fish District"));
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersCaptureOrgunitNotInDataView.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersCaptureOrgunitNotInDataView.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.dataintegrity;
+
+import static java.util.stream.Collectors.toUnmodifiableSet;
+import static org.hisp.dhis.web.WebClientUtils.assertStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.jsontree.JsonString;
+import org.hisp.dhis.web.HttpStatus;
+import org.hisp.dhis.webapi.json.domain.JsonDataIntegrityDetails;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integrity check to identify users who have a data view organisation unit, but who cannot access
+ * data which they have possibly entered at a higher level of the hierarchy. {@see
+ * dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/users_capture_ou_not_in_data_view_ou.yaml}
+ *
+ * @author Jason P. Pickering
+ */
+class DataIntegrityUsersCaptureOrgunitNotInDataView extends AbstractDataIntegrityIntegrationTest {
+
+  private static final String CHECK_NAME = "users_capture_ou_not_in_data_view_ou";
+
+  private static final String DETAILS_ID_TYPE = "users";
+
+  private String orgunitAUid;
+  private String orgunitBUid;
+
+  private String userBUid;
+
+  private String userRoleUid;
+
+  @Test
+  void testDataCaptureUnitInDataViewHierarchy() {
+
+    orgunitAUid =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/organisationUnits",
+                "{ 'name': 'Fish District', 'shortName': 'Fish District', 'openingDate' : '2022-01-01'}"));
+
+    orgunitBUid =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/organisationUnits",
+                "{ 'name': 'Pizza District', 'shortName': 'Pizza District', 'openingDate' : '2022-01-01'}"));
+
+    userRoleUid =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST("/userRoles", "{ 'name': 'Test role', 'authorities': ['F_DATAVALUE_ADD'] }"));
+
+    assertStatus(
+        HttpStatus.CREATED,
+        POST(
+            "/users",
+            "{ 'username': 'bobbytables' , 'password': 'District123+', 'firstName': 'Bobby', 'surname': 'Tables', 'organisationUnits' : [{'id' : '"
+                + orgunitAUid
+                + "'}], 'dataViewOrganisationUnits' : [{'id' : '"
+                + orgunitAUid
+                + "'}], 'userRoles' : [{'id' : '"
+                + userRoleUid
+                + "'}]}"));
+
+    userBUid =
+        assertStatus(
+            HttpStatus.CREATED,
+            POST(
+                "/users",
+                "{ 'username': 'janedoe' , 'password': 'District123+', 'firstName': 'Jane', 'surname': 'Doe', 'organisationUnits' : [{'id' : '"
+                    + orgunitAUid
+                    + "'}], 'dataViewOrganisationUnits' : [{'id' : '"
+                    + orgunitBUid
+                    + "'}], 'userRoles' : [{'id' : '"
+                    + userRoleUid
+                    + "'}]}"));
+
+    assertStatus(
+        HttpStatus.CREATED,
+        POST(
+            "/users",
+            "{ 'username': 'tommytables' , 'password': 'District123+', 'firstName': 'Tommy', 'surname': 'Tables', 'organisationUnits' : [{'id' : '"
+                + orgunitAUid
+                + "'}],  'userRoles' : [{'id' : '"
+                + userRoleUid
+                + "'}]}"));
+
+    // Note that there are already two users which exist due to the overall test setup, thus, five
+    // users in total. Only userB should be flagged.
+    assertHasDataIntegrityIssues(DETAILS_ID_TYPE, CHECK_NAME, 20, userBUid, "janedoe", null, true);
+
+    JsonDataIntegrityDetails details = getDetails(CHECK_NAME);
+    JsonList<JsonDataIntegrityDetails.JsonDataIntegrityIssue> issues = details.getIssues();
+    assertEquals(1, issues.size());
+
+    Set<String> detailsRefs =
+        issues.stream()
+            .flatMap(issue -> issue.getRefs().stream())
+            .map(JsonString::string)
+            .collect(toUnmodifiableSet());
+
+    assertTrue(detailsRefs.contains("Fish District"));
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersWithNoRoleControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityUsersWithNoRoleControllerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.dataintegrity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Date;
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.webapi.json.domain.JsonDataIntegrityDetails;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integrity check to identify users who have no user role associated with their user. {@see
+ * dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/users/users_with_no_user_role.yaml}
+ *
+ * @author Jason P. Pickering
+ */
+class DataIntegrityUsersWithNoRoleControllerTest extends AbstractDataIntegrityIntegrationTest {
+
+  private static final String CHECK_NAME = "users_with_no_user_role";
+
+  private static final String DETAILS_ID_TYPE = "users";
+
+  @Test
+  void testCanFlagUserWithNoRoles() {
+
+    // Use the service layer, as the API will refuse to create a user with no role.
+    User user = new User();
+    user.setUid(CodeGenerator.generateUid());
+    user.setFirstName("Bobby");
+    user.setSurname("Tables");
+    user.setUsername(DEFAULT_USERNAME + "_no_role_" + CodeGenerator.generateUid());
+    user.setPassword(DEFAULT_ADMIN_PASSWORD);
+    user.setLastUpdated(new Date());
+    user.setCreated(new Date());
+    manager.persist(user);
+    dbmsManager.clearSession();
+
+    // Note that there are already two users which exist due to the overall test setup, thus, three
+    // users in total.
+    assertHasDataIntegrityIssues(
+        DETAILS_ID_TYPE, CHECK_NAME, 33, user.getUid(), user.getUsername(), "disabled:false", true);
+
+    JsonDataIntegrityDetails details = getDetails(CHECK_NAME);
+    JsonList<JsonDataIntegrityDetails.JsonDataIntegrityIssue> issues = details.getIssues();
+    assertEquals(1, issues.size());
+  }
+
+  @Test
+  void testDoNotFlagUsersWithRoles() {
+
+    assertHasNoDataIntegrityIssues(DETAILS_ID_TYPE, CHECK_NAME, true);
+  }
+}


### PR DESCRIPTION
Adding the following integrity checks to this version: 
-Users capture OU within data view OU

-Users capture OU within TEI search OU

-Users with no roles

-User roles with no users

-User roles with no authorities