### PR TITLE
chore: Remove method enrollmentExistIncludingDeleted [DHIS2-17712]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
@@ -74,14 +74,6 @@ public interface EnrollmentService {
    */
   List<Enrollment> getEnrollments(@Nonnull List<String> uids);
 
-  /**
-   * Checks for the existence of an enrollment by UID. Takes into account also the deleted values.
-   *
-   * @param uid Event UID to check for
-   * @return true/false depending on result
-   */
-  boolean enrollmentExistsIncludingDeleted(String uid);
-
   /** Get enrollments into a program. */
   List<Enrollment> getEnrollments(Program program);
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentStore.java
@@ -49,15 +49,6 @@ public interface EnrollmentStore extends IdentifiableObjectStore<Enrollment> {
   List<Enrollment> get(TrackedEntity trackedEntity, Program program, EnrollmentStatus status);
 
   /**
-   * Checks for the existence of an enrollment by UID. Takes into account also the deleted
-   * enrollments.
-   *
-   * @param uid Event UID to check for
-   * @return true/false depending on result
-   */
-  boolean existsIncludingDeleted(String uid);
-
-  /**
    * Fetches enrollments matching the given list of UIDs
    *
    * @param uids a List of UID

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
@@ -86,12 +86,6 @@ public class DefaultEnrollmentService implements EnrollmentService {
   }
 
   @Override
-  @Transactional(readOnly = true)
-  public boolean enrollmentExistsIncludingDeleted(String uid) {
-    return enrollmentStore.existsIncludingDeleted(uid);
-  }
-
-  @Override
   @Transactional
   public void updateEnrollment(Enrollment enrollment) {
     enrollmentStore.update(enrollment);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEnrollmentStore.java
@@ -39,7 +39,6 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import org.apache.commons.lang3.time.DateUtils;
-import org.hibernate.query.Query;
 import org.hisp.dhis.common.ObjectDeletionRequestedEvent;
 import org.hisp.dhis.common.hibernate.SoftDeleteHibernateObjectStore;
 import org.hisp.dhis.program.Enrollment;
@@ -109,19 +108,6 @@ public class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enr
             .addPredicate(root -> builder.equal(root.get("trackedEntity"), trackedEntity))
             .addPredicate(root -> builder.equal(root.get("program"), program))
             .addPredicate(root -> builder.equal(root.get(STATUS), status)));
-  }
-
-  @Override
-  public boolean existsIncludingDeleted(String uid) {
-    if (uid == null) {
-      return false;
-    }
-
-    Query<?> query =
-        nativeSynchronizedQuery("select exists(select 1 from enrollment where uid=:uid)");
-    query.setParameter("uid", uid);
-
-    return ((Boolean) query.getSingleResult()).booleanValue();
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListener.java
@@ -138,7 +138,7 @@ public class EnrollmentSMSListener extends EventSavingSMSListener {
     EnrollmentSmsSubmission subm = (EnrollmentSmsSubmission) submission;
 
     Date enrollmentDate = subm.getEnrollmentDate();
-    Date incidentDate = subm.getIncidentDate();
+    Date occurredDate = subm.getIncidentDate();
     Uid teUid = subm.getTrackedEntityInstance();
     Uid progid = subm.getTrackerProgram();
     Uid tetid = subm.getTrackedEntityType();
@@ -193,7 +193,7 @@ public class EnrollmentSMSListener extends EventSavingSMSListener {
       enrollment =
           enrollmentService.getEnrollment(enrollmentid.getUid(), UserDetails.fromUser(user));
       enrollment.setEnrollmentDate(enrollmentDate);
-      enrollment.setOccurredDate(incidentDate);
+      enrollment.setOccurredDate(occurredDate);
     } catch (ForbiddenException e) {
       throw new SMSProcessingException(SmsResponse.INVALID_ENROLL.set(enrollmentid.getUid()));
     } catch (NotFoundException e) {
@@ -205,7 +205,7 @@ public class EnrollmentSMSListener extends EventSavingSMSListener {
     if (enrollment == null) {
       enrollment =
           apiEnrollmentService.enrollTrackedEntity(
-              te, program, enrollmentDate, incidentDate, orgUnit, enrollmentid.getUid());
+              te, program, enrollmentDate, occurredDate, orgUnit, enrollmentid.getUid());
 
       if (enrollment == null) {
         throw new SMSProcessingException(SmsResponse.ENROLL_FAILED.set(teUid, progid));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.maintenance;
 
+import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ALL;
+import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
+import static org.hisp.dhis.utils.Assertions.assertNotEmpty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -52,10 +55,11 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.commons.util.RelationshipUtils;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
+import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
@@ -77,6 +81,8 @@ import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueChangeLog;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueChangeLogService;
+import org.hisp.dhis.tracker.export.enrollment.EnrollmentOperationParams;
+import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -87,6 +93,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
  * @author Enrico Colasante
  */
 class MaintenanceServiceTest extends IntegrationTestBase {
+  @Autowired private org.hisp.dhis.program.EnrollmentService apiEnrollmentService;
+
   @Autowired private EnrollmentService enrollmentService;
 
   @Autowired private ProgramMessageService programMessageService;
@@ -181,8 +189,8 @@ class MaintenanceServiceTest extends IntegrationTestBase {
     enrollmentWithTeAssociation.setUid("UID-B");
     enrollmentWithTeAssociation.setOrganisationUnit(organisationUnit);
     trackedEntityService.addTrackedEntity(trackedEntityWithAssociations);
-    enrollmentService.addEnrollment(enrollmentWithTeAssociation);
-    enrollmentService.addEnrollment(enrollment);
+    apiEnrollmentService.addEnrollment(enrollmentWithTeAssociation);
+    apiEnrollmentService.addEnrollment(enrollment);
     event = new Event(enrollment, stageA);
     event.setUid("PSUID-B");
     event.setOrganisationUnit(organisationUnit);
@@ -234,7 +242,8 @@ class MaintenanceServiceTest extends IntegrationTestBase {
   }
 
   @Test
-  void testDeleteSoftDeletedEnrollmentWithAProgramMessage() {
+  void testDeleteSoftDeletedEnrollmentWithAProgramMessage()
+      throws ForbiddenException, BadRequestException {
     ProgramMessageRecipients programMessageRecipients = new ProgramMessageRecipients();
     programMessageRecipients.setEmailAddresses(Sets.newHashSet("testemail"));
     programMessageRecipients.setPhoneNumbers(Sets.newHashSet("testphone"));
@@ -248,16 +257,17 @@ class MaintenanceServiceTest extends IntegrationTestBase {
             .deliveryChannels(Sets.newHashSet(DeliveryChannel.EMAIL))
             .enrollment(enrollment)
             .build();
-    long idA = enrollmentService.addEnrollment(enrollment);
+    long idA = apiEnrollmentService.addEnrollment(enrollment);
     programMessageService.saveProgramMessage(message);
     assertNotNull(manager.get(Enrollment.class, idA));
-    enrollmentService.deleteEnrollment(enrollment);
+    apiEnrollmentService.deleteEnrollment(enrollment);
     assertNull(manager.get(Enrollment.class, idA));
-    assertTrue(enrollmentService.enrollmentExistsIncludingDeleted(enrollment.getUid()));
+    EnrollmentOperationParams params = createEnrollmentParamsIncludingDeleted(enrollment.getUid());
+    assertNotEmpty(enrollmentService.getEnrollments(params));
 
     maintenanceService.deleteSoftDeletedEnrollments();
 
-    assertFalse(enrollmentService.enrollmentExistsIncludingDeleted(enrollment.getUid()));
+    assertIsEmpty(enrollmentService.getEnrollments(params));
   }
 
   @Test
@@ -314,7 +324,8 @@ class MaintenanceServiceTest extends IntegrationTestBase {
   }
 
   @Test
-  void testDeleteSoftDeletedEnrollmentLinkedToATrackedEntityDataValueAudit() {
+  void testDeleteSoftDeletedEnrollmentLinkedToATrackedEntityDataValueAudit()
+      throws ForbiddenException, BadRequestException {
     DataElement dataElement = createDataElement('A');
     dataElementService.addDataElement(dataElement);
     Event eventA = new Event(enrollment, program.getProgramStageByStage(1));
@@ -327,15 +338,19 @@ class MaintenanceServiceTest extends IntegrationTestBase {
             dataElement, eventA, "value", "modifiedBy", false, ChangeLogType.UPDATE);
     trackedEntityDataValueAuditService.addTrackedEntityDataValueChangeLog(
         trackedEntityDataValueChangeLog);
-    long idA = enrollmentService.addEnrollment(enrollment);
+    long idA = apiEnrollmentService.addEnrollment(enrollment);
     assertNotNull(manager.get(Enrollment.class, idA));
-    enrollmentService.deleteEnrollment(enrollment);
+    apiEnrollmentService.deleteEnrollment(enrollment);
     assertNull(manager.get(Enrollment.class, idA));
-    assertTrue(enrollmentService.enrollmentExistsIncludingDeleted(enrollment.getUid()));
+    assertNotEmpty(
+        enrollmentService.getEnrollments(
+            createEnrollmentParamsIncludingDeleted(enrollment.getUid())));
 
     maintenanceService.deleteSoftDeletedEnrollments();
 
-    assertFalse(enrollmentService.enrollmentExistsIncludingDeleted(enrollment.getUid()));
+    assertIsEmpty(
+        enrollmentService.getEnrollments(
+            createEnrollmentParamsIncludingDeleted(enrollment.getUid())));
   }
 
   @Test
@@ -379,7 +394,8 @@ class MaintenanceServiceTest extends IntegrationTestBase {
   }
 
   @Test
-  void testDeleteSoftDeletedEnrollmentLinkedToARelationshipItem() {
+  void testDeleteSoftDeletedEnrollmentLinkedToARelationshipItem()
+      throws ForbiddenException, BadRequestException {
     RelationshipType rType = createRelationshipType('A');
     rType.getFromConstraint().setRelationshipEntity(RelationshipEntity.PROGRAM_INSTANCE);
     rType.getFromConstraint().setProgram(program);
@@ -399,15 +415,19 @@ class MaintenanceServiceTest extends IntegrationTestBase {
     relationshipService.addRelationship(r);
     assertNotNull(manager.get(Enrollment.class, enrollment.getId()));
     assertNotNull(relationshipService.getRelationship(r.getId()));
-    enrollmentService.deleteEnrollment(enrollment);
+    apiEnrollmentService.deleteEnrollment(enrollment);
     assertNull(manager.get(Enrollment.class, enrollment.getId()));
     assertNull(relationshipService.getRelationship(r.getId()));
-    assertTrue(enrollmentService.enrollmentExistsIncludingDeleted(enrollment.getUid()));
+    assertNotEmpty(
+        enrollmentService.getEnrollments(
+            createEnrollmentParamsIncludingDeleted(enrollment.getUid())));
     assertTrue(relationshipService.relationshipExistsIncludingDeleted(r.getUid()));
 
     maintenanceService.deleteSoftDeletedEnrollments();
 
-    assertFalse(enrollmentService.enrollmentExistsIncludingDeleted(enrollment.getUid()));
+    assertIsEmpty(
+        enrollmentService.getEnrollments(
+            createEnrollmentParamsIncludingDeleted(enrollment.getUid())));
     assertFalse(relationshipService.relationshipExistsIncludingDeleted(r.getUid()));
   }
 
@@ -465,5 +485,13 @@ class MaintenanceServiceTest extends IntegrationTestBase {
     return Boolean.TRUE.equals(
         jdbcTemplate.queryForObject(
             "select exists(select 1 from event where uid=?)", Boolean.class, uid));
+  }
+
+  private EnrollmentOperationParams createEnrollmentParamsIncludingDeleted(String enrollmentUid) {
+    return EnrollmentOperationParams.builder()
+        .enrollmentUids(Set.of(enrollmentUid))
+        .orgUnitMode(ALL)
+        .includeDeleted(true)
+        .build();
   }
 }


### PR DESCRIPTION
### Big picture

Tracker has multiple services for each entity like tracked entity, enrollment and event. One is in dhis-api and one in dhis-service-tracker. Our goal is to provide one API (service) per entity that is part of the tracker domain/team.

Trackers architecture splits read/write into exporter services and an importer. So if you want to get data you use an exporter. If you want to insert, update or delete you have to go through the importer. Only then can we ensure integrity of tracker data.

Another goal is that code that provides tracker functionality and is thus owned by the tracker team lives in ideally one maven module (We can settle on a name later on maybe dhis-service-tracker or dhis-tracker).

This is a big task that we are going to implement in many small steps.

### This PR

Removes the method enrollmentExistsIncludingDeleted(uid) from the api module, since it's only used in tests and we can achieve the same result by using the method getEnrollments from the service tracker module.