### PR TITLE
chore: Disable e2e test to see if jenkins passes

### DIFF
--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/DataElementMergeTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/DataElementMergeTest.java
@@ -43,9 +43,11 @@ import org.hisp.dhis.actions.UserActions;
 import org.hisp.dhis.dto.ApiResponse;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@Disabled
 class DataElementMergeTest extends ApiTest {
 
   private RestApiActions dataElementApiActions;


### PR DESCRIPTION
temporarily disable the last e2e test to see if the Jenkins builds passes.
GitHub e2e tests are passing fine.