### PR TITLE
test: log4j2 is configured via xml DHIS2-16557

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-test/pom.xml
@@ -127,14 +127,6 @@
       <artifactId>joda-time</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
     </dependency>

--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/log4j2-test.xml
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/log4j2-test.xml
@@ -22,7 +22,7 @@
             we use due to for example misconfigurations or so. If you want to increase the verbosity of specific
             packages use a logger like shown below. -->
             <AppenderRef ref="console" level="error"/>
-            <!-- Used to upload test logs during CI in case a test step fails. Verbosity is a bit higher so we have more
+            <!-- Used to upload test logs during CI in case a test step fails. Verbosity is a bit higher, so we have more
              information when debugging failed tests. -->
             <AppenderRef ref="file" level="warn"/>
         </Root>

--- a/dhis-2/dhis-test-integration/src/test/resources/log4j2-test.xml
+++ b/dhis-2/dhis-test-integration/src/test/resources/log4j2-test.xml
@@ -19,7 +19,7 @@
             we use due to for example misconfigurations or so. If you want to increase the verbosity of specific
             packages use a logger like shown below. -->
             <AppenderRef ref="console" level="error"/>
-            <!-- Used to upload test logs during CI in case a test step fails. Verbosity is a bit higher so we have more
+            <!-- Used to upload test logs during CI in case a test step fails. Verbosity is a bit higher, so we have more
              information when debugging failed tests. -->
             <AppenderRef ref="file" level="warn"/>
         </Root>
@@ -28,9 +28,8 @@
         Adding an AppenderRef is necessary to overrule the log level we have set on the Root AppenderRefs.
         Once you add an AppenderRef to a Logger you need to set additivity to false otherwise logs might appear twice
         as they propagate up from the Logger to its parent which is the Root.
-        Check the log4j2 config documentation for more details. Uncommend the various loggers to debug the tests. -->
-        
-        
+        Check the log4j2 config documentation for more details. Uncomment the various loggers to debug the tests. -->
+
         <!-- DHIS2 -->
         <!--        
         <Logger name="org.hisp.dhis.migration" level="info" additivity="false">

--- a/dhis-2/dhis-test-web-api/pom.xml
+++ b/dhis-2/dhis-test-web-api/pom.xml
@@ -317,16 +317,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-jdbc</artifactId>
       <scope>test</scope>

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/DhisControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/DhisControllerIntegrationTest.java
@@ -30,14 +30,11 @@ package org.hisp.dhis.webapi;
 import java.time.Duration;
 import java.util.Date;
 import java.util.function.BooleanSupplier;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.core.config.Configurator;
 import org.hisp.dhis.IntegrationTest;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.config.TestContainerPostgresConfig;
 import org.hisp.dhis.dbms.DbmsManager;
-import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
@@ -71,8 +68,6 @@ import org.springframework.web.context.WebApplicationContext;
 @IntegrationTest
 @Transactional
 public class DhisControllerIntegrationTest extends DhisControllerTestBase {
-  public static final String ORG_HISP_DHIS_DATASOURCE_QUERY = "org.hisp.dhis.datasource.query";
-
   @Autowired private WebApplicationContext webApplicationContext;
 
   @Autowired private UserService _userService;
@@ -101,8 +96,6 @@ public class DhisControllerIntegrationTest extends DhisControllerTestBase {
     currentUser = superUser;
 
     TestUtils.executeStartupRoutines(webApplicationContext);
-
-    integrationTestBefore();
 
     dbmsManager.flushSession();
     dbmsManager.clearSession();
@@ -143,17 +136,6 @@ public class DhisControllerIntegrationTest extends DhisControllerTestBase {
     lookUpInjectUserSecurityContext(user);
 
     return user;
-  }
-
-  protected void integrationTestBefore() {
-    boolean enableQueryLogging =
-        dhisConfigurationProvider.isEnabled(ConfigurationKey.ENABLE_QUERY_LOGGING);
-    // Enable to query logger to log only what's happening inside the test
-    // method
-    if (enableQueryLogging) {
-      Configurator.setLevel(ORG_HISP_DHIS_DATASOURCE_QUERY, Level.INFO);
-      Configurator.setRootLevel(Level.INFO);
-    }
   }
 
   protected static boolean await(Duration timeout, BooleanSupplier test)


### PR DESCRIPTION
These configs are responsible for configuring log4j2 during test execution

- https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-test-integration/src/test/resources/log4j2-test.xml
- https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-support/dhis-support-test/src/main/resources/log4j2-test.xml

For example if you add

```xml
        <Logger name="org.hisp.dhis.datasource" level="debug" additivity="false">
            <AppenderRef ref="console"/>
        </Logger>
```

into https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-test-integration/src/test/resources/log4j2-test.xml

and run an integration test in `dhis-test-integration` you will see debug logs like

```
12:56:24.642 [main] INFO  org.hisp.dhis.datasource.DatabasePoolUtils - Database pool type value is 'C3P0'
12:57:14.670 [main] ERROR org.hisp.dhis.external.location.DefaultLocationManager - No Home directory set, and /opt/dhis2 is not a directory
12:57:17.801 [main] DEBUG org.hisp.dhis.datasource.ReadOnlyDataSourceManager - Searching read-only data source with connection URL key: 'read1.connection.url'
12:57:17.802 [main] DEBUG org.hisp.dhis.datasource.ReadOnlyDataSourceManager - Searching read-only data source with connection URL key: 'read2.connection.url'
12:57:17.802 [main] DEBUG org.hisp.dhis.datasource.ReadOnlyDataSourceManager - Searching read-only data source with connection URL key: 'read3.connection.url'
12:57:17.802 [main] DEBUG org.hisp.dhis.datasource.ReadOnlyDataSourceManager - Searching read-only data source with connection URL key: 'read4.connection.url'
```

which you do not by default as the root logger is configured with a level of `warn`.