### PR TITLE
chore: Re-enable disabled test and use existing metadata import method in E2E test

### DIFF
--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/metadata/MetadataActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/metadata/MetadataActions.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.actions.metadata;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import java.io.File;
 import org.hisp.dhis.actions.RestApiActions;
@@ -38,6 +39,13 @@ import org.hisp.dhis.dto.MetadataApiResponse;
 import org.hisp.dhis.helpers.QueryParamsBuilder;
 
 /**
+ * An important point to note about this class in relation to test data clean-up is that the
+ * implemented methods in this class use the query param `importReportMode=FULL`. This param is
+ * paramount if the metadata created needs to be deleted after a test completes. By passing this
+ * param, `objectReports` are returned in the response, which contain UIDs which allow the test
+ * framework to track what has been created, which then allows deletion of said objects after each
+ * test.
+ *
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */
 public class MetadataActions extends RestApiActions {
@@ -67,6 +75,12 @@ public class MetadataActions extends RestApiActions {
     return new MetadataApiResponse(response);
   }
 
+  public MetadataApiResponse importMetadata(String metadata) {
+    JsonObject json = new Gson().fromJson(metadata, JsonObject.class);
+    ApiResponse response = importMetadata(json);
+    return new MetadataApiResponse(response);
+  }
+
   public MetadataApiResponse importAndValidateMetadata(JsonObject object, String... queryParams) {
     ApiResponse response = importMetadata(object, queryParams);
 
@@ -85,18 +99,5 @@ public class MetadataActions extends RestApiActions {
         .body("response.stats.ignored", not(equalTo(response.extract("response.stats.total"))));
 
     return new MetadataApiResponse(response);
-  }
-
-  /**
-   * Override to make default behaviour of Metadata POST queries return full object reports
-   *
-   * @param object Body of request
-   * @return
-   */
-  @Override
-  public ApiResponse post(Object object) {
-    QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder();
-    queryParamsBuilder.addAll("importReportMode=FULL");
-    return super.post(object, queryParamsBuilder);
   }
 }

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/metadata/MetadataActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/metadata/MetadataActions.java
@@ -44,7 +44,7 @@ import org.hisp.dhis.helpers.QueryParamsBuilder;
  * paramount if the metadata created needs to be deleted after a test completes. By passing this
  * param, `objectReports` are returned in the response, which contain UIDs which allow the test
  * framework to track what has been created, which then allows deletion of said objects after each
- * test.
+ * test. See {@link RestApiActions#saveCreatedObjects(ApiResponse)} for more info.
  *
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */

--- a/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/metadata/MetadataActions.java
+++ b/dhis-2/dhis-test-e2e/src/main/java/org/hisp/dhis/actions/metadata/MetadataActions.java
@@ -86,4 +86,17 @@ public class MetadataActions extends RestApiActions {
 
     return new MetadataApiResponse(response);
   }
+
+  /**
+   * Override to make default behaviour of Metadata POST queries return full object reports
+   *
+   * @param object Body of request
+   * @return
+   */
+  @Override
+  public ApiResponse post(Object object) {
+    QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder();
+    queryParamsBuilder.addAll("importReportMode=FULL");
+    return super.post(object, queryParamsBuilder);
+  }
 }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/DataElementMergeTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/DataElementMergeTest.java
@@ -318,12 +318,12 @@ class DataElementMergeTest extends ApiTest {
   private void setupProgramStageDataElements(
       String sourceUid1, String sourceUid2, String targetUid) {
     metadataApiActions
-        .post(programWithStageAndDataElements(sourceUid1, sourceUid2, targetUid))
+        .importMetadata(programWithStageAndDataElements(sourceUid1, sourceUid2, targetUid))
         .validateStatus(200);
   }
 
   private void setupMinMaxDataElements(String sourceUid1, String sourceUid2, String targetUid) {
-    metadataApiActions.post(metadata()).validateStatus(200);
+    metadataApiActions.importMetadata(metadata()).validateStatus(200);
     minMaxActions.post(minMaxDataElements("OrgUnit0001", sourceUid1, "CatOptCom01"));
     minMaxActions.post(minMaxDataElements("OrgUnit0001", sourceUid2, "CatOptCom01"));
     minMaxActions.post(minMaxDataElements("OrgUnit0001", targetUid, "CatOptCom01"));

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/DataElementMergeTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/DataElementMergeTest.java
@@ -40,19 +40,18 @@ import org.hisp.dhis.ApiTest;
 import org.hisp.dhis.actions.LoginActions;
 import org.hisp.dhis.actions.RestApiActions;
 import org.hisp.dhis.actions.UserActions;
+import org.hisp.dhis.actions.metadata.MetadataActions;
 import org.hisp.dhis.dto.ApiResponse;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@Disabled
 class DataElementMergeTest extends ApiTest {
 
   private RestApiActions dataElementApiActions;
   private RestApiActions datasetApiActions;
-  private RestApiActions metadataApiActions;
+  private MetadataActions metadataApiActions;
   private RestApiActions minMaxActions;
   private UserActions userActions;
   private LoginActions loginActions;
@@ -66,7 +65,7 @@ class DataElementMergeTest extends ApiTest {
     loginActions = new LoginActions();
     dataElementApiActions = new RestApiActions("dataElements");
     datasetApiActions = new RestApiActions("dataSets");
-    metadataApiActions = new RestApiActions("metadata");
+    metadataApiActions = new MetadataActions();
     minMaxActions = new RestApiActions("minMaxDataElements");
     loginActions.loginAsSuperUser();
 


### PR DESCRIPTION
# Summary
[This test](https://github.com/dhis2/dhis2-core/blob/2b1b76cfe10a053a20db38a5b0ba8f26d5fae08d/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/merge/DataElementMergeTest.java#L183) in [this PR](https://github.com/dhis2/dhis2-core/pull/17288) introduced a potential scenario whereby unrelated existing tests could fail depending on the order in which the tests were run (it was observed that tests were passing in GitHub but failing in Jenkins).

# Cause
The newly-added test creates a `Program` which is never cleaned-up by the E2E test framework after the test is finished. This `Program` then causes `NullPointerException`s when Tracker logic is invoked to check write  permissions here `org.hisp.dhis.trackedentity.DefaultTrackerAccessManager.canWrite`.  

If the `Progam` does not have a `TrackedEntity` then a `NPE` is thrown here: `org.hisp.dhis.trackedentity.TrackedEntityType.getUid()`. This is when other tests would fail, bombing out. (the tests were retrieving all `Program`s and executing logic against all)

# Change
1. Use the `MetadataActions` class method instead, (in E2E module) which uses the query param `importReportMode=FULL`. The E2E framework relies on this param to track creation/deletion of entities/metadata.

2. Re-enable disabled test

# Info
The E2E framework requires `objectReports` in responses in order to track changes, using the `UID` in the response.
The [default behaviour for metadata import report mode](https://github.com/dhis2/dhis2-core/blob/2b1b76cfe10a053a20db38a5b0ba8f26d5fae08d/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dxf2/metadata/MetadataImportParams.java#L96) is `ERRORS`, which will not include object reports, which was the reason why the test/`Program` was not being cleaned up correctly.

`MetadataActions` does already have some existing methods which include some query params already, but they are easily missed when using the ApiActions classes in a simple manner e.g.
- create `RestApiActions` with path e.g. `/metadata`
- call `POST` with metadata string