### PR TITLE
chore: Remove getEnrollments(List<String>) [DHIS2-17712]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.program;
 
 import java.util.Date;
 import java.util.List;
-import javax.annotation.Nonnull;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 
@@ -65,14 +64,6 @@ public interface EnrollmentService {
    * @param enrollment the Enrollment to update.
    */
   void updateEnrollment(Enrollment enrollment);
-
-  /**
-   * Returns a list of existing Enrollments from the provided UIDs
-   *
-   * @param uids Event UIDs to check
-   * @return Enrollment list
-   */
-  List<Enrollment> getEnrollments(@Nonnull List<String> uids);
 
   /** Get enrollments into a program. */
   List<Enrollment> getEnrollments(Program program);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.program;
 
 import java.util.Date;
 import java.util.List;
-import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.CodeGenerator;
@@ -77,12 +76,6 @@ public class DefaultEnrollmentService implements EnrollmentService {
   @Transactional
   public void hardDeleteEnrollment(Enrollment enrollment) {
     enrollmentStore.hardDelete(enrollment);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public List<Enrollment> getEnrollments(@Nonnull List<String> uids) {
-    return enrollmentStore.getByUid(uids);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelper.java
@@ -283,8 +283,7 @@ public class DeduplicationHelper {
       return "Missing data write access to one or more Relationship Types.";
     }
 
-    List<Enrollment> enrollments =
-        enrollmentService.getEnrollments(mergeObject.getEnrollments(), currentUserDetails);
+    List<Enrollment> enrollments = enrollmentService.getEnrollments(mergeObject.getEnrollments());
 
     if (enrollments.stream()
         .anyMatch(e -> !aclService.canDataWrite(currentUserDetails, e.getProgram()))) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DeduplicationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DeduplicationService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.tracker.deduplication;
 
 import java.util.List;
+import org.hisp.dhis.feedback.ForbiddenException;
 
 public interface DeduplicationService {
   PotentialDuplicate getPotentialDuplicateById(long id);
@@ -46,8 +47,12 @@ public interface DeduplicationService {
   void updatePotentialDuplicate(PotentialDuplicate potentialDuplicate);
 
   void autoMerge(DeduplicationMergeParams deduplicationRequest)
-      throws PotentialDuplicateConflictException, PotentialDuplicateForbiddenException;
+      throws PotentialDuplicateConflictException,
+          PotentialDuplicateForbiddenException,
+          ForbiddenException;
 
   void manualMerge(DeduplicationMergeParams deduplicationRequest)
-      throws PotentialDuplicateConflictException, PotentialDuplicateForbiddenException;
+      throws PotentialDuplicateConflictException,
+          PotentialDuplicateForbiddenException,
+          ForbiddenException;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DefaultDeduplicationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DefaultDeduplicationService.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.trackedentity.TrackedEntity;
@@ -92,7 +93,9 @@ public class DefaultDeduplicationService implements DeduplicationService {
   @Override
   @Transactional
   public void autoMerge(DeduplicationMergeParams params)
-      throws PotentialDuplicateConflictException, PotentialDuplicateForbiddenException {
+      throws PotentialDuplicateConflictException,
+          PotentialDuplicateForbiddenException,
+          ForbiddenException {
     String autoMergeConflicts =
         getAutoMergeConflictErrors(params.getOriginal(), params.getDuplicate());
 
@@ -110,7 +113,9 @@ public class DefaultDeduplicationService implements DeduplicationService {
   @Override
   @Transactional
   public void manualMerge(DeduplicationMergeParams deduplicationMergeParams)
-      throws PotentialDuplicateConflictException, PotentialDuplicateForbiddenException {
+      throws PotentialDuplicateConflictException,
+          PotentialDuplicateForbiddenException,
+          ForbiddenException {
     String invalidReference =
         deduplicationHelper.getInvalidReferenceErrors(deduplicationMergeParams);
     if (invalidReference != null) {
@@ -145,7 +150,8 @@ public class DefaultDeduplicationService implements DeduplicationService {
     return null;
   }
 
-  private void merge(DeduplicationMergeParams params) throws PotentialDuplicateForbiddenException {
+  private void merge(DeduplicationMergeParams params)
+      throws PotentialDuplicateForbiddenException, ForbiddenException {
     TrackedEntity original = params.getOriginal();
     TrackedEntity duplicate = params.getDuplicate();
     MergeObject mergeObject = params.getMergeObject();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -52,6 +52,7 @@ import org.hisp.dhis.trackedentity.TrackerOwnershipManager;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
+import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -220,13 +221,13 @@ class DefaultEnrollmentService implements EnrollmentService {
   }
 
   @Override
-  public List<Enrollment> getEnrollments(@Nonnull List<String> uids, UserDetails currentUser)
-      throws ForbiddenException {
+  public List<Enrollment> getEnrollments(@Nonnull List<String> uids) throws ForbiddenException {
     List<Enrollment> enrollments = enrollmentStore.getByUid(uids);
+    UserDetails user = CurrentUserUtil.getCurrentUserDetails();
 
     List<String> errors =
         enrollments.stream()
-            .flatMap(e -> trackerAccessManager.canRead(currentUser, e, false).stream())
+            .flatMap(e -> trackerAccessManager.canRead(user, e, false).stream())
             .toList();
 
     if (!errors.isEmpty()) {
@@ -234,7 +235,7 @@ class DefaultEnrollmentService implements EnrollmentService {
     }
 
     return enrollments.stream()
-        .map(e -> getEnrollment(e, EnrollmentParams.FALSE, false, currentUser))
+        .map(e -> getEnrollment(e, EnrollmentParams.FALSE, false, user))
         .toList();
   }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/DefaultEnrollmentService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.tracker.export.enrollment;
 
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.ALL;
+import static org.hisp.dhis.user.CurrentUserUtil.getCurrentUserDetails;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -51,7 +52,6 @@ import org.hisp.dhis.trackedentity.TrackerOwnershipManager;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.export.Page;
 import org.hisp.dhis.tracker.export.PageParams;
-import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -84,7 +84,7 @@ class DefaultEnrollmentService implements EnrollmentService {
   @Override
   public Enrollment getEnrollment(String uid, EnrollmentParams params, boolean includeDeleted)
       throws NotFoundException, ForbiddenException {
-    return getEnrollment(uid, params, includeDeleted, CurrentUserUtil.getCurrentUserDetails());
+    return getEnrollment(uid, params, includeDeleted, getCurrentUserDetails());
   }
 
   private Enrollment getEnrollment(
@@ -165,7 +165,7 @@ class DefaultEnrollmentService implements EnrollmentService {
       throw new NotFoundException(Enrollment.class, uid);
     }
 
-    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
+    UserDetails currentUser = getCurrentUserDetails();
     List<String> errors = trackerAccessManager.canRead(currentUser, enrollment, false);
     if (!errors.isEmpty()) {
       return null;
@@ -220,6 +220,25 @@ class DefaultEnrollmentService implements EnrollmentService {
   }
 
   @Override
+  public List<Enrollment> getEnrollments(@Nonnull List<String> uids, UserDetails currentUser)
+      throws ForbiddenException {
+    List<Enrollment> enrollments = enrollmentStore.getByUid(uids);
+
+    List<String> errors =
+        enrollments.stream()
+            .flatMap(e -> trackerAccessManager.canRead(currentUser, e, false).stream())
+            .toList();
+
+    if (!errors.isEmpty()) {
+      throw new ForbiddenException(errors.toString());
+    }
+
+    return enrollments.stream()
+        .map(e -> getEnrollment(e, EnrollmentParams.FALSE, false, currentUser))
+        .toList();
+  }
+
+  @Override
   public List<Enrollment> getEnrollments(EnrollmentOperationParams params)
       throws ForbiddenException, BadRequestException {
     EnrollmentQueryParams queryParams = paramsMapper.map(params);
@@ -252,7 +271,7 @@ class DefaultEnrollmentService implements EnrollmentService {
       boolean includeDeleted,
       OrganisationUnitSelectionMode orgUnitMode) {
     List<Enrollment> enrollmentList = new ArrayList<>();
-    UserDetails currentUser = CurrentUserUtil.getCurrentUserDetails();
+    UserDetails currentUser = getCurrentUserDetails();
 
     for (Enrollment enrollment : enrollments) {
       if (enrollment != null

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.tracker.export.enrollment;
 
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
@@ -57,6 +58,15 @@ public interface EnrollmentService {
   /** Get a page of enrollments matching given params. */
   Page<Enrollment> getEnrollments(EnrollmentOperationParams params, PageParams pageParams)
       throws BadRequestException, ForbiddenException;
+
+  /**
+   * Returns a list of existing Enrollments from the provided UIDs
+   *
+   * @param uids Enrollment UIDs to check
+   * @return Enrollment list
+   */
+  List<Enrollment> getEnrollments(@Nonnull List<String> uids, UserDetails currentUser)
+      throws ForbiddenException;
 
   /**
    * Fields the {@link #getEnrollments(EnrollmentOperationParams)} can order enrollments by.

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentService.java
@@ -60,13 +60,10 @@ public interface EnrollmentService {
       throws BadRequestException, ForbiddenException;
 
   /**
-   * Returns a list of existing Enrollments from the provided UIDs
-   *
-   * @param uids Enrollment UIDs to check
-   * @return Enrollment list
+   * Get event matching given {@code UID} under the privileges the user in the context. This method
+   * does not get the events relationships.
    */
-  List<Enrollment> getEnrollments(@Nonnull List<String> uids, UserDetails currentUser)
-      throws ForbiddenException;
+  List<Enrollment> getEnrollments(@Nonnull List<String> uids) throws ForbiddenException;
 
   /**
    * Fields the {@link #getEnrollments(EnrollmentOperationParams)} can order enrollments by.

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelperTest.java
@@ -138,8 +138,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest {
     when(aclService.canDataWrite(currentUserDetails, enrollment.getProgram())).thenReturn(true);
 
     when(relationshipService.getRelationships(relationshipUids)).thenReturn(getRelationships());
-    when(enrollmentService.getEnrollments(enrollmentUids, currentUserDetails))
-        .thenReturn(getEnrollments());
+    when(enrollmentService.getEnrollments(enrollmentUids)).thenReturn(getEnrollments());
     when(organisationUnitService.isInUserHierarchyCached(user, organisationUnitA)).thenReturn(true);
     when(organisationUnitService.isInUserHierarchyCached(user, organisationUnitB)).thenReturn(true);
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelperTest.java
@@ -39,10 +39,10 @@ import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.hisp.dhis.DhisConvenienceTest;
+import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.relationship.RelationshipItem;
@@ -53,6 +53,7 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
@@ -76,6 +77,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest {
   @Mock private OrganisationUnitService organisationUnitService;
 
   @Mock private EnrollmentService enrollmentService;
+
   @Mock private UserService userService;
 
   private OrganisationUnit organisationUnitA;
@@ -101,7 +103,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest {
   private UserDetails currentUserDetails;
 
   @BeforeEach
-  public void setUp() {
+  public void setUp() throws ForbiddenException {
     List<String> relationshipUids = Lists.newArrayList("REL_A", "REL_B");
     List<String> attributeUids = Lists.newArrayList("ATTR_A", "ATTR_B");
     List<String> enrollmentUids = Lists.newArrayList("PI_A", "PI_B");
@@ -136,13 +138,14 @@ class DeduplicationHelperTest extends DhisConvenienceTest {
     when(aclService.canDataWrite(currentUserDetails, enrollment.getProgram())).thenReturn(true);
 
     when(relationshipService.getRelationships(relationshipUids)).thenReturn(getRelationships());
-    when(enrollmentService.getEnrollments(enrollmentUids)).thenReturn(getEnrollments());
+    when(enrollmentService.getEnrollments(enrollmentUids, currentUserDetails))
+        .thenReturn(getEnrollments());
     when(organisationUnitService.isInUserHierarchyCached(user, organisationUnitA)).thenReturn(true);
     when(organisationUnitService.isInUserHierarchyCached(user, organisationUnitB)).thenReturn(true);
   }
 
   @Test
-  void shouldHasUserAccess() {
+  void shouldHaveUserAccess() throws ForbiddenException {
     when(userService.getUserByUsername(user.getUsername())).thenReturn(user);
 
     String hasUserAccess =
@@ -153,7 +156,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldNotHasUserAccessWhenUserIsNull() {
+  void shouldNotHaveUserAccessWhenUserIsNull() throws ForbiddenException {
     clearSecurityContext();
 
     String hasUserAccess =
@@ -165,7 +168,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldNotHasUserAccessWhenUserHasNoMergeRoles() {
+  void shouldNotHaveUserAccessWhenUserHasNoMergeRoles() throws ForbiddenException {
     injectSecurityContext(UserDetails.fromUser(getNoMergeAuthsUser()));
 
     String hasUserAccess =
@@ -177,7 +180,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldNotHasUserAccessWhenUserHasNoAccessToOriginalTEType() {
+  void shouldNotHaveUserAccessWhenUserHasNoAccessToOriginalTEType() throws ForbiddenException {
     when(aclService.canDataWrite(currentUserDetails, trackedEntityTypeA)).thenReturn(false);
 
     String hasUserAccess =
@@ -189,7 +192,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldNotHasUserAccessWhenUserHasNoAccessToDuplicateTEType() {
+  void shouldNotHaveUserAccessWhenUserHasNoAccessToDuplicateTEType() throws ForbiddenException {
 
     when(aclService.canDataWrite(currentUserDetails, trackedEntityTypeB)).thenReturn(false);
     when(userService.getUserByUsername(user.getUsername())).thenReturn(user);
@@ -203,7 +206,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldNotHasUserAccessWhenUserHasNoAccessToRelationshipType() {
+  void shouldNotHaveUserAccessWhenUserHasNoAccessToRelationshipType() throws ForbiddenException {
     when(aclService.canDataWrite(currentUserDetails, relationshipType)).thenReturn(false);
 
     String hasUserAccess =
@@ -215,7 +218,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldNotHasUserAccessWhenUserHasNoAccessToEnrollment() {
+  void shouldNotHaveUserAccessWhenUserHasNoWriteAccessToEnrollment() throws ForbiddenException {
     when(aclService.canDataWrite(currentUserDetails, enrollment.getProgram())).thenReturn(false);
 
     String hasUserAccess =
@@ -227,7 +230,8 @@ class DeduplicationHelperTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldNotHasUserAccessWhenUserHasNoCaptureScopeAccessToOriginalOrgUnit() {
+  void shouldNotHaveUserAccessWhenUserHasNoCaptureScopeAccessToOriginalOrgUnit()
+      throws ForbiddenException {
     when(organisationUnitService.isInUserHierarchyCached(user, organisationUnitA))
         .thenReturn(false);
 
@@ -240,7 +244,8 @@ class DeduplicationHelperTest extends DhisConvenienceTest {
   }
 
   @Test
-  void shouldNotHasUserAccessWhenUserHasNoCaptureScopeAccessToDuplicateOrgUnit() {
+  void shouldNotHaveUserAccessWhenUserHasNoCaptureScopeAccessToDuplicateOrgUnit()
+      throws ForbiddenException {
     when(organisationUnitService.isInUserHierarchyCached(user, organisationUnitB))
         .thenReturn(false);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceTest.java
@@ -39,6 +39,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.trackedentity.TrackedEntity;
@@ -68,6 +69,7 @@ class DeduplicationServiceTest {
   @Mock private Enrollment enrollmentA;
 
   @Mock private Enrollment enrollmentB;
+
   @Mock private UserService userService;
 
   @Mock private DeduplicationHelper deduplicationHelper;
@@ -89,7 +91,7 @@ class DeduplicationServiceTest {
   private static final String teavSexFirstName = "John";
 
   @BeforeEach
-  void setUp() {
+  void setUp() throws ForbiddenException {
     PotentialDuplicate potentialDuplicate = new PotentialDuplicate("original", "duplicate");
     deduplicationMergeParams =
         DeduplicationMergeParams.builder()
@@ -146,7 +148,9 @@ class DeduplicationServiceTest {
 
   @Test
   void shouldBeAutoMergeable()
-      throws PotentialDuplicateConflictException, PotentialDuplicateForbiddenException {
+      throws PotentialDuplicateConflictException,
+          PotentialDuplicateForbiddenException,
+          ForbiddenException {
     MergeObject mergeObject = MergeObject.builder().build();
     when(deduplicationHelper.generateMergeObject(trackedEntityA, trackedEntityB))
         .thenReturn(mergeObject);
@@ -252,7 +256,9 @@ class DeduplicationServiceTest {
 
   @Test
   void shouldNotBeAutoMergeableNoUserAccess()
-      throws PotentialDuplicateConflictException, PotentialDuplicateForbiddenException {
+      throws PotentialDuplicateConflictException,
+          PotentialDuplicateForbiddenException,
+          ForbiddenException {
     MergeObject mergeObject = MergeObject.builder().build();
     when(deduplicationHelper.generateMergeObject(trackedEntityA, trackedEntityB))
         .thenReturn(mergeObject);
@@ -269,7 +275,9 @@ class DeduplicationServiceTest {
 
   @Test
   void shouldtBeAutoMergeableAttributeValuesIsEmpty()
-      throws PotentialDuplicateConflictException, PotentialDuplicateForbiddenException {
+      throws PotentialDuplicateConflictException,
+          PotentialDuplicateForbiddenException,
+          ForbiddenException {
     when(trackedEntityB.getTrackedEntityAttributeValues()).thenReturn(new HashSet<>());
     MergeObject mergeObject = MergeObject.builder().build();
     when(deduplicationHelper.generateMergeObject(trackedEntityA, trackedEntityB))
@@ -288,7 +296,9 @@ class DeduplicationServiceTest {
 
   @Test
   void shouldBeManualMergeable()
-      throws PotentialDuplicateConflictException, PotentialDuplicateForbiddenException {
+      throws PotentialDuplicateConflictException,
+          PotentialDuplicateForbiddenException,
+          ForbiddenException {
     deduplicationService.manualMerge(deduplicationMergeParams);
     verify(deduplicationHelper, times(1)).getInvalidReferenceErrors(deduplicationMergeParams);
     verify(deduplicationHelper, times(0)).generateMergeObject(trackedEntityA, trackedEntityB);
@@ -311,7 +321,9 @@ class DeduplicationServiceTest {
 
   @Test
   void shouldThrowManualMergeableHasInvalidReference()
-      throws PotentialDuplicateConflictException, PotentialDuplicateForbiddenException {
+      throws PotentialDuplicateConflictException,
+          PotentialDuplicateForbiddenException,
+          ForbiddenException {
     when(deduplicationHelper.getInvalidReferenceErrors(deduplicationMergeParams))
         .thenReturn("Error");
     assertThrows(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceMergeIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceMergeIntegrationTest.java
@@ -35,6 +35,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
@@ -78,7 +79,9 @@ class DeduplicationServiceMergeIntegrationTest extends IntegrationTestBase {
 
   @Test
   void shouldManualMergeWithAuthorityAll()
-      throws PotentialDuplicateConflictException, PotentialDuplicateForbiddenException {
+      throws PotentialDuplicateConflictException,
+          PotentialDuplicateForbiddenException,
+          ForbiddenException {
     OrganisationUnit ou = createOrganisationUnit("OU_A");
     organisationUnitService.addOrganisationUnit(ou);
     User user =
@@ -127,7 +130,9 @@ class DeduplicationServiceMergeIntegrationTest extends IntegrationTestBase {
 
   @Test
   void shouldManualMergeWithUserGroupOfProgram()
-      throws PotentialDuplicateConflictException, PotentialDuplicateForbiddenException {
+      throws PotentialDuplicateConflictException,
+          PotentialDuplicateForbiddenException,
+          ForbiddenException {
     OrganisationUnit ou = createOrganisationUnit("OU_A");
     organisationUnitService.addOrganisationUnit(ou);
     User user = createAndAddUser(true, "userB", ou, "F_TRACKED_ENTITY_MERGE");

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -73,8 +73,8 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -675,9 +675,9 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
         EnrollmentOperationParams.builder().orgUnitMode(ALL).build();
 
     BadRequestException exception =
-        Assertions.assertThrows(
+        assertThrows(
             BadRequestException.class, () -> enrollmentService.getEnrollments(operationParams));
-    Assertions.assertEquals(
+    assertEquals(
         "Current user is not authorized to query across all organisation units",
         exception.getMessage());
   }
@@ -693,9 +693,9 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
             .build();
 
     ForbiddenException exception =
-        Assertions.assertThrows(
+        assertThrows(
             ForbiddenException.class, () -> enrollmentService.getEnrollments(operationParams));
-    Assertions.assertEquals(
+    assertEquals(
         String.format("Organisation unit is not part of the search scope: %s", orgUnitA.getUid()),
         exception.getMessage());
   }
@@ -773,6 +773,24 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
     assertContainsOnly(
         List.of(enrollmentA.getUid(), enrollmentChildA.getUid(), enrollmentGrandchildA.getUid()),
         uids(enrollments));
+  }
+
+  @Test
+  void shouldFailWhenRequestingListOfEnrollmentsAndAtLeastOneNotAccessible() {
+    injectSecurityContextUser(admin);
+    programA.getSharing().setPublicAccess("rw------");
+    manager.update(programA);
+
+    ForbiddenException exception =
+        assertThrows(
+            ForbiddenException.class,
+            () ->
+                enrollmentService.getEnrollments(
+                    List.of(enrollmentA.getUid(), enrollmentB.getUid()),
+                    UserDetails.fromUser(authorizedUser)));
+    assertContains(
+        String.format("User has no data read access to program: %s", programA.getUid()),
+        exception.getMessage());
   }
 
   private static List<String> attributeUids(Enrollment enrollment) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/enrollment/EnrollmentServiceTest.java
@@ -73,7 +73,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -781,13 +780,13 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
     programA.getSharing().setPublicAccess("rw------");
     manager.update(programA);
 
+    injectSecurityContextUser(authorizedUser);
     ForbiddenException exception =
         assertThrows(
             ForbiddenException.class,
             () ->
                 enrollmentService.getEnrollments(
-                    List.of(enrollmentA.getUid(), enrollmentB.getUid()),
-                    UserDetails.fromUser(authorizedUser)));
+                    List.of(enrollmentA.getUid(), enrollmentB.getUid())));
     assertContains(
         String.format("User has no data read access to program: %s", programA.getUid()),
         exception.getMessage());

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/deduplication/DeduplicationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/deduplication/DeduplicationController.java
@@ -161,7 +161,8 @@ public class DeduplicationController {
       @RequestBody(required = false) MergeObject mergeObject)
       throws NotFoundException,
           PotentialDuplicateConflictException,
-          PotentialDuplicateForbiddenException {
+          PotentialDuplicateForbiddenException,
+          ForbiddenException {
     PotentialDuplicate potentialDuplicate = getPotentialDuplicateBy(id);
 
     if (potentialDuplicate.getOriginal() == null || potentialDuplicate.getDuplicate() == null) {


### PR DESCRIPTION
### Big picture

Tracker has multiple services for each entity like tracked entity, enrollment and event. One is in dhis-api and one in dhis-service-tracker. Our goal is to provide one API (service) per entity that is part of the tracker domain/team.

Trackers architecture splits read/write into exporter services and an importer. So if you want to get data you use an exporter. If you want to insert, update or delete you have to go through the importer. Only then can we ensure integrity of tracker data.

Another goal is that code that provides tracker functionality and is thus owned by the tracker team lives in ideally one maven module (We can settle on a name later on maybe dhis-service-tracker or dhis-tracker).

This is a big task that we are going to implement in many small steps.

### This PR

Moves the method `getEnrollments(List<String>)` from the api module, to the service-tracker module. This method is just used by the deduplication service.
