### PR TITLE
chore: Remove addEnrollment(Enrollment enrollment) [DHIS2-17712]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
@@ -37,13 +37,6 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
  * @author Abyot Asalefew
  */
 public interface EnrollmentService {
-  /**
-   * Adds an {@link Enrollment}
-   *
-   * @param enrollment The to Enrollment add.
-   * @return A generated unique id of the added {@link Enrollment}.
-   */
-  long addEnrollment(Enrollment enrollment);
 
   /**
    * Soft deletes a {@link Enrollment}.

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/copy/CopyService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/copy/CopyService.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.Enrollment;
@@ -93,6 +94,7 @@ public class CopyService {
   private final EnrollmentService enrollmentService;
 
   private final AclService aclService;
+  private final IdentifiableObjectManager identifiableObjectManager;
 
   /**
    * Method to copy a {@link Program} from a UID
@@ -208,7 +210,7 @@ public class CopyService {
   private void copyEnrollments(Program original, Program copy) {
     List<Enrollment> enrollments =
         copyList(copy, enrollmentService.getEnrollments(original), Enrollment.copyOf);
-    enrollments.forEach(enrollmentService::addEnrollment);
+    enrollments.forEach(identifiableObjectManager::save);
   }
 
   /**

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/copy/CopyService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/copy/CopyService.java
@@ -94,6 +94,7 @@ public class CopyService {
   private final EnrollmentService enrollmentService;
 
   private final AclService aclService;
+
   private final IdentifiableObjectManager identifiableObjectManager;
 
   /**

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
@@ -33,6 +33,7 @@ import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.notification.event.ProgramEnrollmentNotificationEvent;
@@ -58,12 +59,7 @@ public class DefaultEnrollmentService implements EnrollmentService {
 
   private final TrackerOwnershipManager trackerOwnershipAccessManager;
 
-  @Override
-  @Transactional
-  public long addEnrollment(Enrollment enrollment) {
-    enrollmentStore.save(enrollment);
-    return enrollment.getId();
-  }
+  private final IdentifiableObjectManager identifiableObjectManager;
 
   @Override
   @Transactional
@@ -174,7 +170,7 @@ public class DefaultEnrollmentService implements EnrollmentService {
     Enrollment enrollment =
         prepareEnrollment(
             trackedEntity, program, enrollmentDate, occurredDate, organisationUnit, uid);
-    addEnrollment(enrollment);
+    identifiableObjectManager.save(enrollment);
     trackerOwnershipAccessManager.assignOwnership(
         trackedEntity, program, organisationUnit, true, true);
     eventPublisher.publishEvent(new ProgramEnrollmentNotificationEvent(this, enrollment.getId()));

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/copy/CopyServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/copy/CopyServiceTest.java
@@ -49,6 +49,7 @@ import java.util.stream.Collectors;
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.common.AccessLevel;
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ObjectStyle;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataentryform.DataEntryForm;
@@ -109,6 +110,8 @@ class CopyServiceTest extends DhisConvenienceTest {
 
   @Mock private AclService aclService;
 
+  @Mock private IdentifiableObjectManager identifiableObjectManager;
+
   @InjectMocks private CopyService copyService;
 
   private static final String VALID_PROGRAM_UID = "abcdefghijk";
@@ -152,7 +155,7 @@ class CopyServiceTest extends DhisConvenienceTest {
     verify(programRuleVariableService, times(1))
         .addProgramRuleVariable(any(ProgramRuleVariable.class));
     verify(programSectionService, times(1)).addProgramSection(any(ProgramSection.class));
-    verify(enrollmentService, times(1)).addEnrollment(any(Enrollment.class));
+    verify(identifiableObjectManager, times(1)).save(any(Enrollment.class));
   }
 
   @Test
@@ -311,7 +314,7 @@ class CopyServiceTest extends DhisConvenienceTest {
 
     assertNotEquals(original.getUid(), programCopy.getUid());
     assertTrue(CodeGenerator.isValidUid(programCopy.getUid()));
-    verify(enrollmentService, never()).addEnrollment(any(Enrollment.class));
+    verify(identifiableObjectManager, never()).save(any(Enrollment.class));
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHook.java
@@ -31,6 +31,7 @@ import java.util.Date;
 import java.util.Objects;
 import java.util.function.Consumer;
 import lombok.AllArgsConstructor;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
@@ -58,6 +59,8 @@ public class ProgramObjectBundleHook extends AbstractObjectBundleHook<Program> {
   private final ProgramStageService programStageService;
 
   private final AclService aclService;
+
+  private final IdentifiableObjectManager identifiableObjectManager;
 
   @Override
   public void postCreate(Program object, ObjectBundle bundle) {
@@ -131,7 +134,7 @@ public class ProgramObjectBundleHook extends AbstractObjectBundleHook<Program> {
       enrollment.setStatus(EnrollmentStatus.ACTIVE);
       enrollment.setStoredBy("system-process");
 
-      this.enrollmentService.addEnrollment(enrollment);
+      identifiableObjectManager.save(enrollment);
     }
   }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHookTest.java
@@ -42,13 +42,13 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
 import java.util.List;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.program.ProgramType;
@@ -69,17 +69,19 @@ class ProgramObjectBundleHookTest {
 
   @Mock private EnrollmentService enrollmentService;
 
-  @Mock private ProgramService programService;
-
   @Mock private ProgramStageService programStageService;
 
   @Mock private AclService aclService;
+
+  @Mock private IdentifiableObjectManager identifiableObjectManager;
 
   private Program programA;
 
   @BeforeEach
   public void setUp() {
-    this.subject = new ProgramObjectBundleHook(enrollmentService, programStageService, aclService);
+    this.subject =
+        new ProgramObjectBundleHook(
+            enrollmentService, programStageService, aclService, identifiableObjectManager);
 
     programA = createProgram('A');
     programA.setId(100);
@@ -106,7 +108,7 @@ class ProgramObjectBundleHookTest {
     programA.setProgramType(ProgramType.WITHOUT_REGISTRATION);
     subject.postCreate(programA, null);
 
-    verify(enrollmentService).addEnrollment(argument.capture());
+    verify(identifiableObjectManager).save(argument.capture());
 
     assertThat(argument.getValue().getEnrollmentDate(), is(notNullValue()));
     assertThat(argument.getValue().getOccurredDate(), is(notNullValue()));
@@ -122,7 +124,7 @@ class ProgramObjectBundleHookTest {
     programA.setProgramType(ProgramType.WITH_REGISTRATION);
     subject.postCreate(programA, null);
 
-    verify(enrollmentService, times(0)).addEnrollment(argument.capture());
+    verify(identifiableObjectManager, times(0)).save(argument.capture());
   }
 
   @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/RegisterSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/RegisterSMSListener.java
@@ -110,7 +110,7 @@ public abstract class RegisterSMSListener extends CommandSMSListener {
       enrollment.setProgram(smsCommand.getProgram());
       enrollment.setStatus(EnrollmentStatus.ACTIVE);
 
-      enrollmentService.addEnrollment(enrollment);
+      identifiableObjectManager.save(enrollment);
 
       enrollments.add(enrollment);
     } else if (enrollments.size() > 1) {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/SimpleEventSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/SimpleEventSMSListener.java
@@ -142,7 +142,7 @@ public class SimpleEventSMSListener extends EventSavingSMSListener {
       enrollment.setProgram(program);
       enrollment.setStatus(EnrollmentStatus.ACTIVE);
 
-      enrollmentService.addEnrollment(enrollment);
+      identifiableObjectManager.save(enrollment);
 
       enrollments.add(enrollment);
     } else if (enrollments.size() > 1) {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
@@ -159,7 +159,7 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
 
   @Autowired private TrackedEntityAttributeValueService attributeValueService;
 
-  @Autowired private IdentifiableObjectManager idObjectManager;
+  @Autowired private IdentifiableObjectManager manager;
 
   @Autowired private ProgramOwnershipHistoryService programOwnershipHistoryService;
 
@@ -284,20 +284,20 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
     ouM = createOrganisationUnit('M', ouC);
     ouN = createOrganisationUnit('N', ouC);
 
-    idObjectManager.save(ouA);
-    idObjectManager.save(ouB);
-    idObjectManager.save(ouC);
-    idObjectManager.save(ouD);
-    idObjectManager.save(ouE);
-    idObjectManager.save(ouF);
-    idObjectManager.save(ouG);
-    idObjectManager.save(ouH);
-    idObjectManager.save(ouI);
-    idObjectManager.save(ouJ);
-    idObjectManager.save(ouK);
-    idObjectManager.save(ouL);
-    idObjectManager.save(ouM);
-    idObjectManager.save(ouN);
+    manager.save(ouA);
+    manager.save(ouB);
+    manager.save(ouC);
+    manager.save(ouD);
+    manager.save(ouE);
+    manager.save(ouF);
+    manager.save(ouG);
+    manager.save(ouH);
+    manager.save(ouI);
+    manager.save(ouJ);
+    manager.save(ouK);
+    manager.save(ouL);
+    manager.save(ouM);
+    manager.save(ouN);
 
     level3Ous = organisationUnitService.getOrganisationUnitsAtLevel(3);
 
@@ -308,9 +308,9 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
     ou2.getSharing().setPublicAccess("--------");
     OrganisationUnitLevel ou3 = new OrganisationUnitLevel(3, "Ou Level 3");
     ou3.getSharing().setPublicAccess("--------");
-    idObjectManager.save(ou1);
-    idObjectManager.save(ou2);
-    idObjectManager.save(ou3);
+    manager.save(ou1);
+    manager.save(ou2);
+    manager.save(ou3);
 
     // Category Options
     coA = createCategoryOption('A');
@@ -393,47 +393,47 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
     psA.setUid("progrStageA");
     psA.addDataElement(deA, 1);
     psA.addDataElement(deU, 2);
-    idObjectManager.save(psA);
+    manager.save(psA);
 
     ProgramStage psB = createProgramStage('B', 0);
     psB.setUid("progrStageB");
     psB.addDataElement(deA, 1);
     psB.addDataElement(deB, 2);
     psB.addDataElement(deM, 3);
-    idObjectManager.save(psB);
+    manager.save(psB);
 
     // Programs
     programA = createProgram('A');
     programA.getProgramStages().add(psA);
     programA.getOrganisationUnits().addAll(level3Ous);
     programA.setUid("programA123");
-    idObjectManager.save(programA);
+    manager.save(programA);
 
     programB = createProgram('B');
     programB.getProgramStages().add(psB);
     programB.getOrganisationUnits().addAll(level3Ous);
     programB.setUid("programB123");
     programB.setCategoryCombo(ccA);
-    idObjectManager.save(programB);
+    manager.save(programB);
 
     // Tracked Entity Attributes
     atU = createTrackedEntityAttribute('U', ORGANISATION_UNIT);
     atU.setUid("teaAttribuU");
-    idObjectManager.save(atU);
+    manager.save(atU);
 
     ProgramTrackedEntityAttribute pTea = createProgramTrackedEntityAttribute(programA, atU);
     programA.getProgramAttributes().add(pTea);
-    idObjectManager.update(programA);
+    manager.update(programA);
 
     // Tracked Entity Types
     TrackedEntityType trackedEntityType = createTrackedEntityType('A');
-    idObjectManager.save(trackedEntityType);
+    manager.save(trackedEntityType);
 
     // Tracked Entity Instances (Registrations)
     TrackedEntity teiA = createTrackedEntity(ouD);
     teiA.setUid("trackEntInA");
     teiA.setTrackedEntityType(trackedEntityType);
-    idObjectManager.save(teiA);
+    manager.save(teiA);
 
     // Tracked Entity Attribute Values
     TrackedEntityAttributeValue atv = createTrackedEntityAttributeValue('A', teiA, atU);
@@ -444,12 +444,12 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
     Enrollment piA = enrollmentService.enrollTrackedEntity(teiA, programA, jan1, jan1, ouE);
     piA.setEnrollmentDate(jan1);
     piA.setOccurredDate(jan1);
-    enrollmentService.addEnrollment(piA);
+    manager.save(piA);
 
     Enrollment piB = enrollmentService.enrollTrackedEntity(teiA, programB, jan1, jan1, ouE);
     piB.setEnrollmentDate(jan1);
     piB.setOccurredDate(jan1);
-    enrollmentService.addEnrollment(piB);
+    manager.save(piB);
 
     // Change programA / teiA ownership through time:
     // Jan 1 (enrollment) - Jan 15: ouE
@@ -560,9 +560,9 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
     eventM1.setUid("event0000M1");
     eventM1.setEventDataValues(Set.of(new EventDataValue(deM.getUid(), "abc,def,ghi,jkl")));
     eventM1.setAttributeOptionCombo(cocDefault);
-    idObjectManager.save(eventA2);
+    manager.save(eventA2);
 
-    idObjectManager.save(
+    manager.save(
         List.of(
             eventA1, eventA2, eventA3, eventB1, eventB2, eventB3, eventB4, eventB5, eventB6,
             eventB7, eventB8, eventM1));
@@ -573,7 +573,7 @@ class EventAnalyticsServiceTest extends SingleSetupIntegrationTestBase {
     userService.addUser(userA);
     enableDataSharing(userA, programA, AccessStringHelper.DATA_READ_WRITE);
     enableDataSharing(userA, programB, AccessStringHelper.DATA_READ_WRITE);
-    idObjectManager.update(userA);
+    manager.update(userA);
 
     // Wait for one second. This is needed because last updated time for
     // the data we just created is stored to milliseconds, hh:mm:ss.SSS.

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
@@ -187,8 +187,8 @@ class MaintenanceServiceTest extends IntegrationTestBase {
     enrollmentWithTeAssociation.setUid("UID-B");
     enrollmentWithTeAssociation.setOrganisationUnit(organisationUnit);
     trackedEntityService.addTrackedEntity(trackedEntityWithAssociations);
-    apiEnrollmentService.addEnrollment(enrollmentWithTeAssociation);
-    apiEnrollmentService.addEnrollment(enrollment);
+    manager.save(enrollmentWithTeAssociation);
+    manager.save(enrollment);
     event = new Event(enrollment, stageA);
     event.setUid("PSUID-B");
     event.setOrganisationUnit(organisationUnit);
@@ -255,11 +255,11 @@ class MaintenanceServiceTest extends IntegrationTestBase {
             .deliveryChannels(Sets.newHashSet(DeliveryChannel.EMAIL))
             .enrollment(enrollment)
             .build();
-    long idA = apiEnrollmentService.addEnrollment(enrollment);
+    manager.save(enrollment);
     programMessageService.saveProgramMessage(message);
-    assertNotNull(manager.get(Enrollment.class, idA));
+    assertNotNull(manager.get(Enrollment.class, enrollment.getUid()));
     apiEnrollmentService.deleteEnrollment(enrollment);
-    assertNull(manager.get(Enrollment.class, idA));
+    assertNull(manager.get(Enrollment.class, enrollment.getUid()));
     assertTrue(enrollmentExistsIncludingDeleted(enrollment));
 
     maintenanceService.deleteSoftDeletedEnrollments();
@@ -335,10 +335,10 @@ class MaintenanceServiceTest extends IntegrationTestBase {
             dataElement, eventA, "value", "modifiedBy", false, ChangeLogType.UPDATE);
     trackedEntityDataValueAuditService.addTrackedEntityDataValueChangeLog(
         trackedEntityDataValueChangeLog);
-    long idA = apiEnrollmentService.addEnrollment(enrollment);
-    assertNotNull(manager.get(Enrollment.class, idA));
+    manager.save(enrollment);
+    assertNotNull(manager.get(Enrollment.class, enrollment.getUid()));
     apiEnrollmentService.deleteEnrollment(enrollment);
-    assertNull(manager.get(Enrollment.class, idA));
+    assertNull(manager.get(Enrollment.class, enrollment.getUid()));
     assertTrue(enrollmentExistsIncludingDeleted(enrollment));
 
     maintenanceService.deleteSoftDeletedEnrollments();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/merge/orgunit/handler/TrackerOrgUnitMergeHandlerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/merge/orgunit/handler/TrackerOrgUnitMergeHandlerTest.java
@@ -37,7 +37,6 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.merge.orgunit.OrgUnitMergeRequest;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
@@ -53,8 +52,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 class TrackerOrgUnitMergeHandlerTest extends SingleSetupIntegrationTestBase {
 
   @Autowired private TrackedEntityService trackedEntityService;
-
-  @Autowired private EnrollmentService enrollmentService;
 
   @Autowired private CategoryService categoryService;
 
@@ -113,9 +110,9 @@ class TrackerOrgUnitMergeHandlerTest extends SingleSetupIntegrationTestBase {
     enrollmentA = createEnrollment(prA, trackedEntityA, ouA);
     enrollmentB = createEnrollment(prA, trackedEntityB, ouB);
     enrollmentC = createEnrollment(prA, trackedEntityC, ouA);
-    enrollmentService.addEnrollment(enrollmentA);
-    enrollmentService.addEnrollment(enrollmentB);
-    enrollmentService.addEnrollment(enrollmentC);
+    manager.save(enrollmentA);
+    manager.save(enrollmentB);
+    manager.save(enrollmentC);
     eventA = createEvent(psA, enrollmentA, ouA);
     eventB = createEvent(psA, enrollmentB, ouB);
     eventC = createEvent(psA, enrollmentC, ouA);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/EventPredictionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/EventPredictionServiceTest.java
@@ -256,7 +256,7 @@ class EventPredictionServiceTest extends IntegrationTestBase {
     Enrollment enrollment =
         enrollmentService.enrollTrackedEntity(
             trackedEntity, program, dateMar20, dateMar20, orgUnitA);
-    enrollmentService.addEnrollment(enrollment);
+    manager.save(enrollment);
     Event eventA = createEvent(stageA, enrollment, orgUnitA);
     eventA.setOccurredDate(dateMar20);
     manager.save(eventA);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
@@ -183,72 +183,73 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
 
   @Test
   void testAddEnrollment() {
-    long idA = apiEnrollmentService.addEnrollment(enrollmentA);
-    long idB = apiEnrollmentService.addEnrollment(enrollmentB);
-    assertNotNull(manager.get(Enrollment.class, idA));
-    assertNotNull(manager.get(Enrollment.class, idB));
+    manager.save(enrollmentA);
+    manager.save(enrollmentB);
+    assertNotNull(manager.get(Enrollment.class, enrollmentA.getUid()));
+    assertNotNull(manager.get(Enrollment.class, enrollmentB.getUid()));
   }
 
   @Test
   void testDeleteEnrollment() {
-    long idA = apiEnrollmentService.addEnrollment(enrollmentA);
-    long idB = apiEnrollmentService.addEnrollment(enrollmentB);
-    assertNotNull(manager.get(Enrollment.class, idA));
-    assertNotNull(manager.get(Enrollment.class, idB));
+    manager.save(enrollmentA);
+    manager.save(enrollmentB);
+    assertNotNull(manager.get(Enrollment.class, enrollmentA.getUid()));
+    assertNotNull(manager.get(Enrollment.class, enrollmentB.getUid()));
     apiEnrollmentService.deleteEnrollment(enrollmentA);
-    assertNull(manager.get(Enrollment.class, idA));
-    assertNotNull(manager.get(Enrollment.class, idB));
+    assertNull(manager.get(Enrollment.class, enrollmentA.getUid()));
+    assertNotNull(manager.get(Enrollment.class, enrollmentB.getUid()));
     apiEnrollmentService.deleteEnrollment(enrollmentB);
-    assertNull(manager.get(Enrollment.class, idA));
-    assertNull(manager.get(Enrollment.class, idB));
+    assertNull(manager.get(Enrollment.class, enrollmentA.getUid()));
+    assertNull(manager.get(Enrollment.class, enrollmentB.getUid()));
   }
 
   @Test
   void testSoftDeleteEnrollmentAndLinkedEvent() {
-    long idA = apiEnrollmentService.addEnrollment(enrollmentA);
+    manager.save(enrollmentA);
     manager.save(eventA);
     long eventIdA = eventA.getId();
     enrollmentA.setEvents(Sets.newHashSet(eventA));
     apiEnrollmentService.updateEnrollment(enrollmentA);
-    assertNotNull(manager.get(Enrollment.class, idA));
+    assertNotNull(manager.get(Enrollment.class, enrollmentA.getUid()));
     assertNotNull(manager.get(Event.class, eventIdA));
 
     apiEnrollmentService.deleteEnrollment(enrollmentA);
 
-    assertNull(manager.get(Enrollment.class, idA));
+    assertNull(manager.get(Enrollment.class, enrollmentA.getUid()));
     assertNull(manager.get(Event.class, eventIdA));
   }
 
   @Test
   void testUpdateEnrollment() {
-    long idA = apiEnrollmentService.addEnrollment(enrollmentA);
-    assertNotNull(manager.get(Enrollment.class, idA));
+    manager.save(enrollmentA);
+    assertNotNull(manager.get(Enrollment.class, enrollmentA.getUid()));
     enrollmentA.setOccurredDate(enrollmentDate);
     apiEnrollmentService.updateEnrollment(enrollmentA);
-    assertEquals(enrollmentDate, manager.get(Enrollment.class, idA).getOccurredDate());
+    assertEquals(
+        enrollmentDate, manager.get(Enrollment.class, enrollmentA.getUid()).getOccurredDate());
   }
 
   @Test
   void testGetEnrollmentById() {
-    long idA = apiEnrollmentService.addEnrollment(enrollmentA);
-    long idB = apiEnrollmentService.addEnrollment(enrollmentB);
-    assertEquals(enrollmentA, manager.get(Enrollment.class, idA));
-    assertEquals(enrollmentB, manager.get(Enrollment.class, idB));
+    manager.save(enrollmentA);
+    manager.save(enrollmentB);
+    assertEquals(enrollmentA, manager.get(Enrollment.class, enrollmentA.getUid()));
+    assertEquals(enrollmentB, manager.get(Enrollment.class, enrollmentB.getUid()));
   }
 
   @Test
   void testGetEnrollmentByUid() {
-    apiEnrollmentService.addEnrollment(enrollmentA);
-    apiEnrollmentService.addEnrollment(enrollmentB);
+    manager.save(enrollmentA);
+    manager.save(enrollmentB);
     assertEquals("UID-A", manager.get(Enrollment.class, "UID-A").getUid());
     assertEquals("UID-B", manager.get(Enrollment.class, "UID-B").getUid());
   }
 
   @Test
   void testGetEnrollmentsByProgram() {
-    apiEnrollmentService.addEnrollment(enrollmentA);
-    apiEnrollmentService.addEnrollment(enrollmentB);
-    apiEnrollmentService.addEnrollment(enrollmentD);
+    manager.save(enrollmentA);
+    manager.save(enrollmentB);
+    manager.save(enrollmentD);
     List<Enrollment> enrollments = apiEnrollmentService.getEnrollments(programA);
     assertEquals(2, enrollments.size());
     assertTrue(enrollments.contains(enrollmentA));
@@ -260,7 +261,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
 
   @Test
   void testGetEnrollmentsByTrackedEntityProgramAndEnrollmentStatus() {
-    apiEnrollmentService.addEnrollment(enrollmentA);
+    manager.save(enrollmentA);
     Enrollment enrollment1 =
         apiEnrollmentService.enrollTrackedEntity(
             trackedEntityA, programA, enrollmentDate, incidentDate, organisationUnitA);
@@ -300,7 +301,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
 
     enrollmentA.setNotes(List.of(note));
 
-    apiEnrollmentService.addEnrollment(enrollmentA);
+    manager.save(enrollmentA);
 
     assertNotNull(enrollmentService.getEnrollment(enrollmentA.getUid()));
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramMessageServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramMessageServiceTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Set;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DeliveryChannel;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.message.ProgramMessage;
@@ -111,7 +112,7 @@ class ProgramMessageServiceTest extends TransactionalIntegrationTest {
 
   @Autowired private TrackedEntityService trackedEntityService;
 
-  @Autowired private EnrollmentService enrollmentService;
+  @Autowired private IdentifiableObjectManager manager;
 
   @Autowired private ProgramService programService;
 
@@ -140,7 +141,7 @@ class ProgramMessageServiceTest extends TransactionalIntegrationTest {
     enrollmentA.setName("enrollmentA");
     enrollmentA.setEnrollmentDate(new Date());
     enrollmentA.setAutoFields();
-    enrollmentService.addEnrollment(enrollmentA);
+    manager.save(enrollmentA);
     Set<OrganisationUnit> ouSet = new HashSet<>();
     ouSet.add(ouA);
     Set<String> ouUids = new HashSet<>();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/notification/ProgramNotificationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/notification/ProgramNotificationServiceTest.java
@@ -48,7 +48,6 @@ import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.EventStore;
 import org.hisp.dhis.program.Program;
@@ -82,8 +81,6 @@ class ProgramNotificationServiceTest extends TransactionalIntegrationTest {
   @Autowired private ProgramStageService programStageService;
 
   @Autowired private TrackedEntityService trackedEntityService;
-
-  @Autowired private EnrollmentService enrollmentService;
 
   @Autowired private CategoryService categoryService;
 
@@ -168,9 +165,9 @@ class ProgramNotificationServiceTest extends TransactionalIntegrationTest {
     Date enrollmentDate = testDate2.toDate();
     enrollmentA = new Enrollment(enrollmentDate, incidenDate, trackedEntityA, programA);
     enrollmentA.setUid("UID-PIA");
-    enrollmentService.addEnrollment(enrollmentA);
+    manager.save(enrollmentA);
     enrollmentB = new Enrollment(enrollmentDate, incidenDate, trackedEntityB, programB);
-    enrollmentService.addEnrollment(enrollmentB);
+    manager.save(enrollmentB);
     Event eventA = new Event(enrollmentA, stageA);
     eventA.setScheduledDate(enrollmentDate);
     eventA.setUid("UID-A");

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/relationship/hibernate/RelationshipStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/relationship/hibernate/RelationshipStoreTest.java
@@ -44,7 +44,6 @@ import org.hisp.dhis.commons.util.RelationshipUtils;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.EnrollmentStatus;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
@@ -72,8 +71,6 @@ class RelationshipStoreTest extends TransactionalIntegrationTest {
   @Autowired private OrganisationUnitService organisationUnitService;
 
   @Autowired private ProgramService programService;
-
-  @Autowired private EnrollmentService enrollmentService;
 
   @Autowired private ProgramStageService programStageService;
 
@@ -262,7 +259,7 @@ class RelationshipStoreTest extends TransactionalIntegrationTest {
     enrollment.setEnrollmentDate(new Date());
     enrollment.setOccurredDate(new Date());
     enrollment.setStatus(EnrollmentStatus.ACTIVE);
-    enrollmentService.addEnrollment(enrollment);
+    manager.save(enrollment);
     return enrollment;
   }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityQueryLimitTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityQueryLimitTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -69,6 +70,8 @@ class TrackedEntityQueryLimitTest extends SingleSetupIntegrationTestBase {
   @Autowired private SystemSettingManager systemSettingManager;
 
   @Autowired private UserService _userService;
+
+  @Autowired private IdentifiableObjectManager manager;
 
   private OrganisationUnit orgUnitA;
 
@@ -127,10 +130,10 @@ class TrackedEntityQueryLimitTest extends SingleSetupIntegrationTestBase {
     enrollment3 = createEnrollment(program, trackedEntity3, orgUnitA);
     enrollment4 = createEnrollment(program, trackedEntity4, orgUnitA);
 
-    enrollmentService.addEnrollment(enrollment1);
-    enrollmentService.addEnrollment(enrollment2);
-    enrollmentService.addEnrollment(enrollment3);
-    enrollmentService.addEnrollment(enrollment4);
+    manager.save(enrollment1);
+    manager.save(enrollment2);
+    manager.save(enrollment3);
+    manager.save(enrollment4);
 
     enrollmentService.enrollTrackedEntity(
         trackedEntity1, program, new Date(), new Date(), orgUnitA);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityServiceTest.java
@@ -199,7 +199,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
   @Test
   void testDeleteTrackedEntityAndLinkedEnrollmentsAndEvents() {
     long idA = trackedEntityService.addTrackedEntity(trackedEntityA1);
-    long psIdA = enrollmentService.addEnrollment(enrollment);
+    manager.save(enrollment);
     manager.save(event);
     long eventIdA = event.getId();
     enrollment.setEvents(of(event));
@@ -207,14 +207,14 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     enrollmentService.updateEnrollment(enrollment);
     trackedEntityService.updateTrackedEntity(trackedEntityA1);
     TrackedEntity trackedEntityA = trackedEntityService.getTrackedEntity(idA);
-    Enrollment psA = manager.get(Enrollment.class, psIdA);
+    Enrollment psA = manager.get(Enrollment.class, enrollment.getUid());
     Event eventA = manager.get(Event.class, eventIdA);
     assertNotNull(trackedEntityA);
     assertNotNull(psA);
     assertNotNull(eventA);
     trackedEntityService.deleteTrackedEntity(trackedEntityA1);
     assertNull(trackedEntityService.getTrackedEntity(trackedEntityA.getUid()));
-    assertNull(manager.get(Enrollment.class, psIdA));
+    assertNull(manager.get(Enrollment.class, enrollment.getUid()));
     assertNull(manager.get(Event.class, eventIdA));
   }
 
@@ -476,7 +476,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     injectSecurityContextUser(superUser);
 
     addEntityInstances();
-    enrollmentService.addEnrollment(enrollment);
+    manager.save(enrollment);
     addEnrollment(trackedEntityB1, DateTime.now().plusDays(2).toDate(), 'B');
     addEnrollment(trackedEntityC1, DateTime.now().minusDays(2).toDate(), 'C');
     addEnrollment(trackedEntityD1, DateTime.now().plusDays(1).toDate(), 'D');
@@ -506,7 +506,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     trackedEntityD1.setInactive(false);
     addEntityInstances();
 
-    enrollmentService.addEnrollment(enrollment);
+    manager.save(enrollment);
     addEnrollment(trackedEntityB1, DateTime.now().plusDays(2).toDate(), 'B');
     addEnrollment(trackedEntityC1, DateTime.now().minusDays(2).toDate(), 'C');
     addEnrollment(trackedEntityD1, DateTime.now().plusDays(1).toDate(), 'D');
@@ -687,7 +687,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     enrollment.setUid("UID-PSI-" + programStage);
     enrollment.setOrganisationUnit(organisationUnit);
 
-    enrollmentService.addEnrollment(enrollment);
+    manager.save(enrollment);
   }
 
   private void addEntityInstances() {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackerOwnershipManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackerOwnershipManagerTest.java
@@ -40,13 +40,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.hisp.dhis.common.AccessLevel;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.security.Authorities;
@@ -84,7 +84,7 @@ class TrackerOwnershipManagerTest extends IntegrationTestBase {
 
   @Autowired private ProgramService programService;
 
-  @Autowired private EnrollmentService enrollmentService;
+  @Autowired private IdentifiableObjectManager manager;
 
   @Autowired private TrackedEntityTypeService trackedEntityTypeService;
 
@@ -163,7 +163,7 @@ class TrackerOwnershipManagerTest extends IntegrationTestBase {
 
     Enrollment trackedEntityA1Enrollment =
         createEnrollment(programA, trackedEntityA1, organisationUnitA);
-    enrollmentService.addEnrollment(trackedEntityA1Enrollment);
+    manager.save(trackedEntityA1Enrollment);
 
     defaultParams =
         new TrackedEntityParams(false, TrackedEntityEnrollmentParams.FALSE, false, false);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceMergeIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceMergeIntegrationTest.java
@@ -35,6 +35,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
@@ -71,6 +72,8 @@ class DeduplicationServiceMergeIntegrationTest extends IntegrationTestBase {
 
   @Autowired private ProgramService programService;
 
+  @Autowired private IdentifiableObjectManager manager;
+
   @Override
   public void setUpTest() {
     super.userService = this.userService;
@@ -99,8 +102,8 @@ class DeduplicationServiceMergeIntegrationTest extends IntegrationTestBase {
     programService.addProgram(program1);
     Enrollment enrollment1 = createEnrollment(program, original, ou);
     Enrollment enrollment2 = createEnrollment(program1, duplicate, ou);
-    enrollmentService.addEnrollment(enrollment1);
-    enrollmentService.addEnrollment(enrollment2);
+    manager.save(enrollment1);
+    manager.save(enrollment2);
     original.getEnrollments().add(enrollment1);
     duplicate.getEnrollments().add(enrollment2);
     trackedEntityService.updateTrackedEntity(original);
@@ -151,8 +154,8 @@ class DeduplicationServiceMergeIntegrationTest extends IntegrationTestBase {
     program1.setSharing(sharing);
     Enrollment enrollment1 = createEnrollment(program, original, ou);
     Enrollment enrollment2 = createEnrollment(program1, duplicate, ou);
-    enrollmentService.addEnrollment(enrollment1);
-    enrollmentService.addEnrollment(enrollment2);
+    manager.save(enrollment1);
+    manager.save(enrollment2);
     enrollmentService.updateEnrollment(enrollment1);
     enrollmentService.updateEnrollment(enrollment2);
     original.getEnrollments().add(enrollment1);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateRemoveTrackedEntityTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateRemoveTrackedEntityTest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -68,7 +69,7 @@ class PotentialDuplicateRemoveTrackedEntityTest extends TransactionalIntegration
 
   @Autowired private TrackedEntityAttributeValueService trackedEntityAttributeValueService;
 
-  @Autowired private org.hisp.dhis.program.EnrollmentService apiEnrollmentService;
+  @Autowired private IdentifiableObjectManager manager;
 
   @Autowired private EnrollmentService enrollmentService;
 
@@ -155,10 +156,10 @@ class PotentialDuplicateRemoveTrackedEntityTest extends TransactionalIntegration
     Enrollment enrollment2 = createEnrollment(program, duplicate, ou);
     Enrollment enrollment3 = createEnrollment(program, control1, ou);
     Enrollment enrollment4 = createEnrollment(program, control2, ou);
-    apiEnrollmentService.addEnrollment(enrollment1);
-    apiEnrollmentService.addEnrollment(enrollment2);
-    apiEnrollmentService.addEnrollment(enrollment3);
-    apiEnrollmentService.addEnrollment(enrollment4);
+    manager.save(enrollment1);
+    manager.save(enrollment2);
+    manager.save(enrollment3);
+    manager.save(enrollment4);
     original.getEnrollments().add(enrollment1);
     duplicate.getEnrollments().add(enrollment2);
     control1.getEnrollments().add(enrollment3);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/export/relationship/RelationshipServiceTest.java
@@ -299,7 +299,7 @@ class RelationshipServiceTest extends SingleSetupIntegrationTestBase {
     trackedEntityFrom.setTrackedEntityType(trackedEntityType);
     manager.save(trackedEntityFrom);
 
-    enrollmentService.addEnrollment(createEnrollment(program, trackedEntityFrom, orgUnitA));
+    manager.save(createEnrollment(program, trackedEntityFrom, orgUnitA));
 
     trackerOwnershipAccessManager.assignOwnership(
         trackedEntityFrom, program, orgUnitA, false, true);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/imports/validation/EventSecurityImportValidationTest.java
@@ -198,7 +198,7 @@ class EventSecurityImportValidationTest extends TrackerTest {
     Enrollment enrollment =
         enrollmentService.enrollTrackedEntity(
             maleA, programA, dateMar20, dateApr10, organisationUnitA, "MNWZ6hnuhSX");
-    enrollmentService.addEnrollment(enrollment);
+    manager.save(enrollment);
     trackedEntityProgramOwnerService.updateTrackedEntityProgramOwner(
         maleA.getUid(), programA.getUid(), organisationUnitA.getUid());
     manager.update(programA);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/AnalyticsValidationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/AnalyticsValidationServiceTest.java
@@ -227,7 +227,7 @@ class AnalyticsValidationServiceTest extends TransactionalIntegrationTest {
     Enrollment enrollment =
         enrollmentService.enrollTrackedEntity(
             trackedEntity, program, dateMar20, dateMar20, orgUnitA);
-    enrollmentService.addEnrollment(enrollment);
+    manager.save(enrollment);
     Event eventA = createEvent(stageA, enrollment, orgUnitA);
     eventA.setOccurredDate(dateMar20);
     manager.save(eventA);

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramMessageControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramMessageControllerTest.java
@@ -31,12 +31,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Sets;
-import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
@@ -58,10 +56,6 @@ class ProgramMessageControllerTest extends DhisControllerConvenienceTest {
 
   @Autowired private TrackedEntityService trackedEntityService;
 
-  @Autowired private EnrollmentService enrollmentService;
-
-  @Autowired private IdentifiableObjectManager idObjectManager;
-
   private Enrollment enrollmentA;
 
   private Event eventA;
@@ -69,15 +63,15 @@ class ProgramMessageControllerTest extends DhisControllerConvenienceTest {
   @BeforeEach
   void setUp() {
     OrganisationUnit ouA = createOrganisationUnit('A');
-    idObjectManager.save(ouA);
+    manager.save(ouA);
     Program prA = createProgram('A', Sets.newHashSet(), ouA);
-    idObjectManager.save(prA);
+    manager.save(prA);
     ProgramStage psA = createProgramStage('A', prA);
-    idObjectManager.save(psA);
+    manager.save(psA);
     TrackedEntity trackedEntityA = createTrackedEntity('A', ouA);
     trackedEntityService.addTrackedEntity(trackedEntityA);
     enrollmentA = createEnrollment(prA, trackedEntityA, ouA);
-    enrollmentService.addEnrollment(enrollmentA);
+    manager.save(enrollmentA);
     eventA = createEvent(psA, enrollmentA, ouA);
     manager.save(eventA);
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/ProgramNotificationInstanceControllerTest.java
@@ -34,11 +34,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.Sets;
 import java.util.List;
-import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.EnrollmentService;
 import org.hisp.dhis.program.Event;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
@@ -58,11 +56,7 @@ class ProgramNotificationInstanceControllerTest extends DhisControllerConvenienc
 
   @Autowired private ProgramNotificationInstanceService programNotificationInstanceService;
 
-  @Autowired private EnrollmentService enrollmentService;
-
   @Autowired private TrackedEntityService trackedEntityService;
-
-  @Autowired private IdentifiableObjectManager idObjectManager;
 
   private Enrollment enrollment;
 
@@ -77,16 +71,16 @@ class ProgramNotificationInstanceControllerTest extends DhisControllerConvenienc
   @BeforeEach
   void setUp() {
     OrganisationUnit ouA = createOrganisationUnit('A');
-    idObjectManager.save(ouA);
+    manager.save(ouA);
 
     Program prA = createProgram('A', Sets.newHashSet(), ouA);
-    idObjectManager.save(prA);
+    manager.save(prA);
     ProgramStage psA = createProgramStage('A', prA);
-    idObjectManager.save(psA);
+    manager.save(psA);
     TrackedEntity trackedEntityA = createTrackedEntity('A', ouA);
     trackedEntityService.addTrackedEntity(trackedEntityA);
     enrollment = createEnrollment(prA, trackedEntityA, ouA);
-    enrollmentService.addEnrollment(enrollment);
+    manager.save(enrollment);
 
     enrollmentNotification1 = new ProgramNotificationInstance();
     enrollmentNotification1.setName("enrollment A notification 1");


### PR DESCRIPTION
Continuing with the work on removing the enrollment service from the API module, this PR removes the addEnrollment() method. Instead, the manager will handle enrollments until the importer is ready for use.