### PR TITLE
chore: Remove updateEnrollment(Enrollment) [DHIS2-17712]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
@@ -60,13 +60,6 @@ public interface EnrollmentService {
   void hardDeleteEnrollment(Enrollment enrollment);
 
   /**
-   * Updates an {@link Enrollment}.
-   *
-   * @param enrollment the Enrollment to update.
-   */
-  void updateEnrollment(Enrollment enrollment);
-
-  /**
    * Returns a list of existing Enrollments from the provided UIDs
    *
    * @param uids Event UIDs to check

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
@@ -33,6 +33,7 @@ import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.notification.event.ProgramEnrollmentNotificationEvent;
@@ -57,6 +58,8 @@ public class DefaultEnrollmentService implements EnrollmentService {
   private final ApplicationEventPublisher eventPublisher;
 
   private final TrackerOwnershipManager trackerOwnershipAccessManager;
+
+  private final IdentifiableObjectManager manager;
 
   @Override
   @Transactional
@@ -83,12 +86,6 @@ public class DefaultEnrollmentService implements EnrollmentService {
   @Transactional(readOnly = true)
   public List<Enrollment> getEnrollments(@Nonnull List<String> uids) {
     return enrollmentStore.getByUid(uids);
-  }
-
-  @Override
-  @Transactional
-  public void updateEnrollment(Enrollment enrollment) {
-    enrollmentStore.update(enrollment);
   }
 
   @Override
@@ -178,7 +175,7 @@ public class DefaultEnrollmentService implements EnrollmentService {
     trackerOwnershipAccessManager.assignOwnership(
         trackedEntity, program, organisationUnit, true, true);
     eventPublisher.publishEvent(new ProgramEnrollmentNotificationEvent(this, enrollment.getId()));
-    updateEnrollment(enrollment);
+    manager.update(enrollment);
     trackedEntityService.updateTrackedEntity(trackedEntity);
     return enrollment;
   }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/DefaultTrackerObjectsDeletionService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/DefaultTrackerObjectsDeletionService.java
@@ -134,7 +134,7 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
         enrollment.setLastUpdatedByUserInfo(bundle.getUserInfo());
 
         enrollment.getEvents().remove(event);
-        apiEnrollmentService.updateEnrollment(enrollment);
+        manager.update(enrollment);
       }
 
       typeReport.getStats().incDeleted();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListener.java
@@ -214,7 +214,7 @@ public class EnrollmentSMSListener extends EventSavingSMSListener {
 
     enrollment.setStatus(getCoreEnrollmentStatus(subm.getEnrollmentStatus()));
     enrollment.setGeometry(convertGeoPointToGeometry(subm.getCoordinates()));
-    apiEnrollmentService.updateEnrollment(enrollment);
+    identifiableObjectManager.update(enrollment);
 
     // We now check if the enrollment has events to process
     List<Object> errorUIDs = new ArrayList<>();
@@ -225,7 +225,7 @@ public class EnrollmentSMSListener extends EventSavingSMSListener {
     }
     enrollment.setStatus(getCoreEnrollmentStatus(subm.getEnrollmentStatus()));
     enrollment.setGeometry(convertGeoPointToGeometry(subm.getCoordinates()));
-    apiEnrollmentService.updateEnrollment(enrollment);
+    identifiableObjectManager.update(enrollment);
 
     if (!errorUIDs.isEmpty()) {
       return SmsResponse.WARN_DVERR.setList(errorUIDs);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/notification/ProgramNotificationMessageRendererTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/notification/ProgramNotificationMessageRendererTest.java
@@ -219,7 +219,7 @@ class ProgramNotificationMessageRendererTest extends TransactionalIntegrationTes
         enrollmentService.enrollTrackedEntity(
             trackedEntityA, programA, enrollmentDate, incidentDate, organisationUnitA);
     enrollmentA.setUid(enrollmentUid);
-    enrollmentService.updateEnrollment(enrollmentA);
+    manager.save(enrollmentA);
     // Event to be provided in message renderer
     eventA = createEvent(programStageA, enrollmentA, organisationUnitA);
     eventA.setScheduledDate(enrollmentDate);
@@ -236,7 +236,7 @@ class ProgramNotificationMessageRendererTest extends TransactionalIntegrationTes
     eventA.setEventDataValues(Sets.newHashSet(eventDataValueA, eventDataValueB));
     manager.save(eventA);
     enrollmentA.getEvents().add(eventA);
-    enrollmentService.updateEnrollment(enrollmentA);
+    manager.save(enrollmentA);
     programNotificationTemplate = new ProgramNotificationTemplate();
     programNotificationTemplate.setName("Test-PNT");
     programNotificationTemplate.setMessageTemplate("message_template");

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
@@ -209,7 +209,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
     manager.save(eventA);
     long eventIdA = eventA.getId();
     enrollmentA.setEvents(Sets.newHashSet(eventA));
-    apiEnrollmentService.updateEnrollment(enrollmentA);
+    manager.update(enrollmentA);
     assertNotNull(manager.get(Enrollment.class, idA));
     assertNotNull(manager.get(Event.class, eventIdA));
 
@@ -224,7 +224,7 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
     long idA = apiEnrollmentService.addEnrollment(enrollmentA);
     assertNotNull(manager.get(Enrollment.class, idA));
     enrollmentA.setOccurredDate(enrollmentDate);
-    apiEnrollmentService.updateEnrollment(enrollmentA);
+    manager.update(enrollmentA);
     assertEquals(enrollmentDate, manager.get(Enrollment.class, idA).getOccurredDate());
   }
 
@@ -265,12 +265,12 @@ class EnrollmentServiceTest extends TransactionalIntegrationTest {
         apiEnrollmentService.enrollTrackedEntity(
             trackedEntityA, programA, enrollmentDate, incidentDate, organisationUnitA);
     enrollment1.setStatus(EnrollmentStatus.COMPLETED);
-    apiEnrollmentService.updateEnrollment(enrollment1);
+    manager.update(enrollment1);
     Enrollment enrollment2 =
         apiEnrollmentService.enrollTrackedEntity(
             trackedEntityA, programA, enrollmentDate, incidentDate, organisationUnitA);
     enrollment2.setStatus(EnrollmentStatus.COMPLETED);
-    apiEnrollmentService.updateEnrollment(enrollment2);
+    manager.update(enrollment2);
     List<Enrollment> enrollments =
         apiEnrollmentService.getEnrollments(trackedEntityA, programA, EnrollmentStatus.COMPLETED);
     assertEquals(2, enrollments.size());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityServiceTest.java
@@ -204,7 +204,7 @@ class TrackedEntityServiceTest extends IntegrationTestBase {
     long eventIdA = event.getId();
     enrollment.setEvents(of(event));
     trackedEntityA1.setEnrollments(of(enrollment));
-    enrollmentService.updateEnrollment(enrollment);
+    manager.update(enrollment);
     trackedEntityService.updateTrackedEntity(trackedEntityA1);
     TrackedEntity trackedEntityA = trackedEntityService.getTrackedEntity(idA);
     Enrollment psA = manager.get(Enrollment.class, psIdA);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceMergeIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceMergeIntegrationTest.java
@@ -35,6 +35,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
@@ -70,6 +71,8 @@ class DeduplicationServiceMergeIntegrationTest extends IntegrationTestBase {
   @Autowired private TrackedEntityService trackedEntityService;
 
   @Autowired private ProgramService programService;
+
+  @Autowired private IdentifiableObjectManager manager;
 
   @Override
   public void setUpTest() {
@@ -153,8 +156,8 @@ class DeduplicationServiceMergeIntegrationTest extends IntegrationTestBase {
     Enrollment enrollment2 = createEnrollment(program1, duplicate, ou);
     enrollmentService.addEnrollment(enrollment1);
     enrollmentService.addEnrollment(enrollment2);
-    enrollmentService.updateEnrollment(enrollment1);
-    enrollmentService.updateEnrollment(enrollment2);
+    manager.update(enrollment1);
+    manager.update(enrollment2);
     original.getEnrollments().add(enrollment1);
     duplicate.getEnrollments().add(enrollment2);
     trackedEntityService.updateTrackedEntity(original);


### PR DESCRIPTION
Continuing with the work on removing the enrollment service from the API module, this PR removes the `updateEnrollment()` method. Instead, the manager will handle enrollment updates until the importer is ready for use.