### PR TITLE
fix: embedded Jetty failing to start

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/network/PortUtil.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/network/PortUtil.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.common.network;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.Random;
+
+public class PortUtil {
+  private static final int MIN_PORT = 49152;
+  private static final int MAX_PORT = 65535;
+  private static final Random random = new Random();
+
+  public static int findAvailablePort() {
+    int port;
+    do {
+      port = pickRandomPort();
+    } while (!isPortAvailable(port));
+    return port;
+  }
+
+  private static int pickRandomPort() {
+    return random.nextInt(MAX_PORT - MIN_PORT + 1) + MIN_PORT;
+  }
+
+  private static boolean isPortAvailable(int port) {
+    try (ServerSocket serverSocket = new ServerSocket(port)) {
+      serverSocket.setReuseAddress(true);
+      return true;
+    } catch (IOException e) {
+      return false;
+    }
+  }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/servlet/DhisWebApiWebAppInitializer.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/servlet/DhisWebApiWebAppInitializer.java
@@ -100,6 +100,9 @@ public class DhisWebApiWebAppInitializer implements WebApplicationInitializer {
     dispatcher.setLoadOnStartup(1);
     dispatcher.addMapping("/*");
 
+    //    RequestContextListener requestContextListener = new RequestContextListener();
+    //    context.addListener(requestContextListener);
+
     context
         .addServlet("TempGetAppMenuServlet", TempGetAppMenuServlet.class)
         .addMapping("/dhis-web-commons/menu/getModules.action");
@@ -141,7 +144,10 @@ public class DhisWebApiWebAppInitializer implements WebApplicationInitializer {
 
     context.addServlet("RootPageServlet", LoginFallbackServlet.class).addMapping("/login.html");
 
-    RequestContextListener requestContextListener = new RequestContextListener();
-    context.addListener(requestContextListener);
+    String profile = System.getProperty("spring.profiles.active");
+    if (profile == null || !profile.equals("embeddedJetty")) {
+      RequestContextListener requestContextListener = new RequestContextListener();
+      context.addListener(requestContextListener);
+    }
   }
 }

--- a/dhis-2/dhis-web-server/src/main/java/org/hisp/dhis/web/jetty/Main.java
+++ b/dhis-2/dhis-web-server/src/main/java/org/hisp/dhis/web/jetty/Main.java
@@ -39,6 +39,7 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.hisp.dhis.system.startup.StartupListener;
 import org.springframework.security.web.session.HttpSessionEventPublisher;
 import org.springframework.web.context.ContextLoaderListener;
+import org.springframework.web.context.request.RequestContextListener;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 import org.springframework.web.filter.DelegatingFilterProxy;
 
@@ -66,6 +67,8 @@ public class Main extends EmbeddedJettyBase {
     setDefaultPropertyValue("jetty.host", SERVER_HOSTNAME_OR_IP);
     setDefaultPropertyValue("jetty.http.port", String.valueOf(DEFAULT_HTTP_PORT));
 
+    setDefaultPropertyValue("spring.profiles.active", "embeddedJetty");
+
     Main jettyEmbeddedCoreWeb = new Main();
     jettyEmbeddedCoreWeb.printBanner("DHIS2 API Server");
     jettyEmbeddedCoreWeb.startJetty();
@@ -75,6 +78,9 @@ public class Main extends EmbeddedJettyBase {
     ServletContextHandler contextHandler =
         new ServletContextHandler(ServletContextHandler.SESSIONS);
     contextHandler.setErrorHandler(null);
+
+    RequestContextListener requestContextListener = new RequestContextListener();
+    contextHandler.addEventListener(requestContextListener);
 
     AnnotationConfigWebApplicationContext webApplicationContext = getWebApplicationContext();
     contextHandler.addEventListener(new ContextLoaderListener(webApplicationContext));


### PR DESCRIPTION
## Summary
Fixes a regression that caused the embedded Jetty to fail during startup.
A profile is applied when starting Jetty to selectively add the request event listener.

### Automatic test
AuthTest (will start embedded Jetty on an available port and run login tests)

### Manual test
* Start the embedded Jetty server
* Observe you can log in 