### PR TITLE
feat: add max upload file size validation

### DIFF
--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -658,7 +658,9 @@ public enum ConfigurationKey {
   LINKED_ACCOUNTS_RELOGIN_URL("linked_accounts.relogin_url", "", false),
   SWITCH_USER_FEATURE_ENABLED("switch_user_feature.enabled", Constants.OFF, false),
   SWITCH_USER_ALLOW_LISTED_IPS(
-      "switch_user_allow_listed_ips", "localhost,127.0.0.1,[0:0:0:0:0:0:0:1]", false);
+      "switch_user_allow_listed_ips", "localhost,127.0.0.1,[0:0:0:0:0:0:0:1]", false),
+
+  MAX_FILE_UPLOAD_SIZE_BYTES("max.file_upload_size", Integer.toString(10_000_000), false);
 
   private final String key;
 

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/FileResourceControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/FileResourceControllerTest.java
@@ -45,6 +45,17 @@ import org.springframework.mock.web.MockMultipartFile;
 class FileResourceControllerTest extends DhisControllerConvenienceTest {
 
   @Test
+  void testSaveTooBigFileSize() {
+    byte[] bytes = new byte[3_000_001];
+    MockMultipartFile image =
+        new MockMultipartFile("file", "OU_profile_image.png", "image/png", bytes);
+    HttpResponse response = POST_MULTIPART("/fileResources?domain=USER_AVATAR", image);
+    JsonString errorMessage = response.content(HttpStatus.CONFLICT).getString("message");
+    assertEquals(
+        "File size can't be bigger than 3000000, current file size 3000001", errorMessage.string());
+  }
+
+  @Test
   void testSaveBadAvatarImageData() {
     MockMultipartFile image =
         new MockMultipartFile(

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/FileResourceControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/FileResourceControllerTest.java
@@ -46,13 +46,14 @@ class FileResourceControllerTest extends DhisControllerConvenienceTest {
 
   @Test
   void testSaveTooBigFileSize() {
-    byte[] bytes = new byte[3_000_001];
+    byte[] bytes = new byte[10_000_001];
     MockMultipartFile image =
         new MockMultipartFile("file", "OU_profile_image.png", "image/png", bytes);
     HttpResponse response = POST_MULTIPART("/fileResources?domain=USER_AVATAR", image);
     JsonString errorMessage = response.content(HttpStatus.CONFLICT).getString("message");
     assertEquals(
-        "File size can't be bigger than 3000000, current file size 3000001", errorMessage.string());
+        "File size can't be bigger than 10000000, current file size 10000001",
+        errorMessage.string());
   }
 
   @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
+import static org.hisp.dhis.webapi.utils.FileResourceUtils.MAX_FILE_UPLOAD_SIZE_BYTES;
 import static org.hisp.dhis.webapi.utils.FileResourceUtils.resizeAvatarToDefaultSize;
 import static org.hisp.dhis.webapi.utils.FileResourceUtils.resizeIconToDefaultSize;
 import static org.hisp.dhis.webapi.utils.FileResourceUtils.validateCustomIconFile;
@@ -167,8 +168,10 @@ public class FileResourceController extends AbstractFullReadOnlyController<FileR
       @RequestParam(defaultValue = "DATA_VALUE") FileResourceDomain domain,
       @RequestParam(required = false) String uid)
       throws IOException, ConflictException {
-    FileResource fileResource;
 
+    FileResourceUtils.validateFileSize(file, MAX_FILE_UPLOAD_SIZE_BYTES);
+
+    FileResource fileResource;
     if (domain.equals(FileResourceDomain.ICON)) {
       validateCustomIconFile(file);
       fileResource = fileResourceUtils.saveFileResource(uid, resizeIconToDefaultSize(file), domain);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
-import static org.hisp.dhis.webapi.utils.FileResourceUtils.MAX_FILE_UPLOAD_SIZE_BYTES;
 import static org.hisp.dhis.webapi.utils.FileResourceUtils.resizeAvatarToDefaultSize;
 import static org.hisp.dhis.webapi.utils.FileResourceUtils.resizeIconToDefaultSize;
 import static org.hisp.dhis.webapi.utils.FileResourceUtils.validateCustomIconFile;
@@ -169,7 +168,8 @@ public class FileResourceController extends AbstractFullReadOnlyController<FileR
       @RequestParam(required = false) String uid)
       throws IOException, ConflictException {
 
-    FileResourceUtils.validateFileSize(file, MAX_FILE_UPLOAD_SIZE_BYTES);
+    FileResourceUtils.validateFileSize(
+        file, Long.parseLong(dhisConfig.getProperty(ConfigurationKey.MAX_FILE_UPLOAD_SIZE_BYTES)));
 
     FileResource fileResource;
     if (domain.equals(FileResourceDomain.ICON)) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FileResourceUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FileResourceUtils.java
@@ -83,8 +83,6 @@ public class FileResourceUtils {
   @Autowired private final JobRunner jobRunner;
   @Autowired private final FileResourceService fileResourceService;
 
-  public static final long MAX_FILE_UPLOAD_SIZE_BYTES = 3_000_000;
-
   private static final List<String> CUSTOM_ICON_VALID_ICON_EXTENSIONS = List.of("png");
 
   private static final long CUSTOM_ICON_FILE_SIZE_LIMIT_IN_BYTES = 25_000_000;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FileResourceUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FileResourceUtils.java
@@ -83,6 +83,8 @@ public class FileResourceUtils {
   @Autowired private final JobRunner jobRunner;
   @Autowired private final FileResourceService fileResourceService;
 
+  public static final long MAX_FILE_UPLOAD_SIZE_BYTES = 3_000_000;
+
   private static final List<String> CUSTOM_ICON_VALID_ICON_EXTENSIONS = List.of("png");
 
   private static final long CUSTOM_ICON_FILE_SIZE_LIMIT_IN_BYTES = 25_000_000;
@@ -282,7 +284,7 @@ public class FileResourceUtils {
     }
   }
 
-  private static void validateFileSize(@Nonnull MultipartFile file, long maxFileSizeInBytes) {
+  public static void validateFileSize(@Nonnull MultipartFile file, long maxFileSizeInBytes) {
     if (file.getSize() > maxFileSizeInBytes) {
       throw new IllegalQueryException(
           String.format(


### PR DESCRIPTION
## Summary
This PR adds a upload file size hard limit. There is a 2MB limit enforced in the UI, this adds the limit check to the back-end too. The new limit can be configured in dhis.conf with the `max.file_upload_size` setting. The default is 10MB.

### Automatic tests
FileResourceControllerTest

### Manual test
* Try to upload a file bigger than 3MB
* Observe you are not allowed to upload