### PR TITLE
test: move NoOpFlywayConfiguration into dhis-support-test DHIS2-16557

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/config/FlywayConfig.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/config/FlywayConfig.java
@@ -34,7 +34,6 @@ import javax.sql.DataSource;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.Location;
 import org.flywaydb.core.api.configuration.ClassicConfiguration;
-import org.hisp.dhis.db.migration.helper.NoOpFlyway;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -49,7 +48,7 @@ public class FlywayConfig {
 
   private static final String FLYWAY_MIGRATION_FOLDER = "org/hisp/dhis/db/migration";
 
-  @Bean(value = "flyway", initMethod = "migrate")
+  @Bean(initMethod = "migrate")
   @Profile("!test-h2")
   @DependsOn("dataSource")
   public Flyway flyway(DhisConfigurationProvider configurationProvider, DataSource dataSource) {
@@ -66,11 +65,5 @@ public class FlywayConfig {
 
     return new DhisFlyway(
         classicConfiguration, configurationProvider.isEnabled(FLYWAY_REPAIR_BEFORE_MIGRATION));
-  }
-
-  @Bean("flyway")
-  @Profile("test-h2")
-  public NoOpFlyway noFlyway() {
-    return new NoOpFlyway();
   }
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/config/NoOpFlywayConfiguration.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/config/NoOpFlywayConfiguration.java
@@ -25,11 +25,24 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.db.migration.helper;
+package org.hisp.dhis.test.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 /**
- * A no operation flyway that is used for unit tests. Disabling flyway migrations during unit tests.
- *
- * @author Ameen Mohamed
+ * Creates a no operation flyway bean that can be used to disable flyway migrations when running
+ * tests.
  */
-public class NoOpFlyway {}
+@Profile("test-h2")
+@Configuration
+public class NoOpFlywayConfiguration {
+
+  public static class NoOpFlyway {}
+
+  @Bean
+  public NoOpFlyway flyway() {
+    return new NoOpFlyway();
+  }
+}

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/test/webapi/WebTestConfiguration.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/test/webapi/WebTestConfiguration.java
@@ -52,6 +52,7 @@ import org.hisp.dhis.jdbc.config.JdbcConfig;
 import org.hisp.dhis.leader.election.LeaderElectionConfiguration;
 import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.security.SystemAuthoritiesProvider;
+import org.hisp.dhis.test.config.NoOpFlywayConfiguration;
 import org.hisp.dhis.test.h2.H2SqlFunction;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -96,6 +97,7 @@ import org.springframework.transaction.annotation.Transactional;
   DataSourceConfig.class,
   AnalyticsDataSourceConfig.class,
   JdbcConfig.class,
+  NoOpFlywayConfiguration.class,
   FlywayConfig.class,
   HibernateEncryptionConfig.class,
   ServiceConfig.class,


### PR DESCRIPTION
so we do not include it into the dhis.war and risk using it in production.

No need to specify the bean name if the method has the expected name.