### PR TITLE
fix: Adds missing translations for new integrity checks

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
@@ -2093,6 +2093,13 @@ data_integrity.dashboards_not_viewed_one_year.name=Dashboards which have not bee
 data_integrity.maps_not_viewed_one_year.name=Maps which have not been viewed in the past 12 months
 data_integrity.visualizations_not_viewed_one_year.name=Visualizations which have not been viewed in the past 12 months
 data_integrity.users_with_invalid_usernames.name = Users with invalid usernames
+data_integrity.users_capture_ou_not_in_data_view_ou.name=Users with capture org unit not in data view org unit
+data_integrity.users_capture_ou_not_in_tei_search_ou.name=Users with capture org unit not in TEI search org unit
+data_integrity.users_with_no_user_role.name=Users with no user role
+data_integrity.user_roles_no_authorities.name=User roles with no authorities
+data_integrity.user_roles_with_no_users.name=User roles with no users
+data_integrity.option_groups_empty.users=Option groups with no options
+data_integrity.push_analysis_no_recipients.name=Push analyses without recipients
 
 # -- End Data Integrity Checks--------------------------------------------#
 


### PR DESCRIPTION
We were missing a few translations for some data integrity checks which have been added recently
