### PR TITLE
chore: Remove delete relationship from service [DHIS2-17713]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipService.java
@@ -52,13 +52,6 @@ public interface RelationshipService {
   /**
    * Returns a {@link Relationship}.
    *
-   * @param relationship the relationship.
-   */
-  void deleteRelationship(Relationship relationship);
-
-  /**
-   * Returns a {@link Relationship}.
-   *
    * @param id the id of the relationship to return.
    * @return the relationship with the given identifier.
    */

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/DefaultRelationshipService.java
@@ -53,12 +53,6 @@ public class DefaultRelationshipService implements RelationshipService {
   // -------------------------------------------------------------------------
 
   @Override
-  @Transactional
-  public void deleteRelationship(Relationship relationship) {
-    relationshipStore.delete(relationship);
-  }
-
-  @Override
   @Transactional(readOnly = true)
   public Relationship getRelationship(long id) {
     return relationshipStore.get(id);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/DefaultTrackerObjectsDeletionService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/DefaultTrackerObjectsDeletionService.java
@@ -220,7 +220,7 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
       org.hisp.dhis.relationship.Relationship relationship =
           relationshipService.getRelationship(uid);
 
-      relationshipService.deleteRelationship(relationship);
+      manager.delete(relationship);
 
       typeReport.getStats().incDeleted();
       typeReport.addEntity(objectReport);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
@@ -461,7 +461,7 @@ class MaintenanceServiceTest extends IntegrationTestBase {
     relationshipService.addRelationship(relationship);
     assertNotNull(relationshipService.getRelationship(relationship.getUid()));
 
-    relationshipService.deleteRelationship(relationship);
+    manager.delete(relationship);
     assertNull(relationshipService.getRelationship(relationship.getUid()));
     assertNotNull(relationshipService.getRelationshipIncludeDeleted(relationship.getUid()));
 


### PR DESCRIPTION
## Big picture

Tracker has multiple services for each entity like tracked entity, enrollment, event and relationship. One is in dhis-api and one in dhis-service-tracker. Our goal is to provide one API (service) per entity that is part of the tracker domain/team.

Trackers architecture splits read/write into exporter services and an importer. So if you want to get data you use an exporter. If you want to insert, update or delete you have to go through the importer. Only then can we ensure integrity of tracker data.

Another goal is that code that provides tracker functionality and is thus owned by the tracker team lives in ideally one maven module (We can settle on a name later on maybe `dhis-service-tracker` or `dhis-tracker`).

This is a **big** task that we are going to implement in many small steps.

## This PR

`RelationshipService.deleteRelationship` was used in tests and in `TrackerObjectDeletionService`. We are now using `IdentifiableObjectManager` to delete.