### PR TITLE
chore: Remove getters from RelationshipService [DHIS2-17713]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipService.java
@@ -50,22 +50,6 @@ public interface RelationshipService {
   long addRelationship(Relationship relationship);
 
   /**
-   * Returns a {@link Relationship}.
-   *
-   * @param id the id of the relationship to return.
-   * @return the relationship with the given identifier.
-   */
-  Relationship getRelationship(long id);
-
-  /**
-   * Checks if relationship for given UID exists (including deleted relationships).
-   *
-   * @param uid Relationship UID to check for.
-   * @return return true if relationship exists, false otherwise.
-   */
-  boolean relationshipExistsIncludingDeleted(String uid);
-
-  /**
    * Fetches a {@link Relationship} based on a relationship identifying attributes:
    *
    * <p>- relationship type - from - to
@@ -74,10 +58,6 @@ public interface RelationshipService {
    * @return an Optional Relationship
    */
   Optional<Relationship> getRelationshipByRelationship(Relationship relationship);
-
-  Relationship getRelationship(String uid);
-
-  Relationship getRelationshipIncludeDeleted(String uid);
 
   List<Relationship> getRelationships(@Nonnull List<String> uids);
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/DefaultRelationshipService.java
@@ -51,19 +51,6 @@ public class DefaultRelationshipService implements RelationshipService {
   // -------------------------------------------------------------------------
   // Implementation methods
   // -------------------------------------------------------------------------
-
-  @Override
-  @Transactional(readOnly = true)
-  public Relationship getRelationship(long id) {
-    return relationshipStore.get(id);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public boolean relationshipExistsIncludingDeleted(String uid) {
-    return relationshipStore.existsIncludingDeleted(uid);
-  }
-
   @Override
   @Transactional
   public long addRelationship(Relationship relationship) {
@@ -72,18 +59,6 @@ public class DefaultRelationshipService implements RelationshipService {
     relationshipStore.save(relationship);
 
     return relationship.getId();
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public Relationship getRelationship(String uid) {
-    return relationshipStore.getByUid(uid);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public Relationship getRelationshipIncludeDeleted(String uid) {
-    return relationshipStore.getByUidsIncludeDeleted(List.of(uid)).stream().findAny().orElse(null);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/DefaultTrackerObjectsDeletionService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/DefaultTrackerObjectsDeletionService.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.program.notification.ProgramNotificationInstance;
 import org.hisp.dhis.program.notification.ProgramNotificationInstanceParam;
 import org.hisp.dhis.program.notification.ProgramNotificationInstanceService;
+import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.relationship.RelationshipService;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
@@ -217,8 +218,7 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
     for (String uid : relationships) {
       Entity objectReport = new Entity(TrackerType.RELATIONSHIP, uid);
 
-      org.hisp.dhis.relationship.Relationship relationship =
-          relationshipService.getRelationship(uid);
+      Relationship relationship = manager.get(Relationship.class, uid);
 
       manager.delete(relationship);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/DefaultTrackerObjectsDeletionService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/DefaultTrackerObjectsDeletionService.java
@@ -122,7 +122,7 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
   }
 
   @Override
-  public TrackerTypeReport deleteEvents(List<String> events) {
+  public TrackerTypeReport deleteEvents(List<String> events) throws NotFoundException {
     UserInfoSnapshot userInfoSnapshot =
         UserInfoSnapshot.from(CurrentUserUtil.getCurrentUserDetails());
     TrackerTypeReport typeReport = new TrackerTypeReport(TrackerType.EVENT);
@@ -212,14 +212,17 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
   }
 
   @Override
-  public TrackerTypeReport deleteRelationships(List<String> relationships) {
+  public TrackerTypeReport deleteRelationships(List<String> relationships)
+      throws NotFoundException {
     TrackerTypeReport typeReport = new TrackerTypeReport(TrackerType.RELATIONSHIP);
 
     for (String uid : relationships) {
       Entity objectReport = new Entity(TrackerType.RELATIONSHIP, uid);
 
       Relationship relationship = manager.get(Relationship.class, uid);
-
+      if (relationship == null) {
+        throw new NotFoundException(Relationship.class, uid);
+      }
       manager.delete(relationship);
 
       typeReport.getStats().incDeleted();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerObjectDeletionService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/TrackerObjectDeletionService.java
@@ -39,7 +39,7 @@ public interface TrackerObjectDeletionService {
 
   TrackerTypeReport deleteEnrollments(List<String> enrollments) throws NotFoundException;
 
-  TrackerTypeReport deleteEvents(List<String> events);
+  TrackerTypeReport deleteEvents(List<String> events) throws NotFoundException;
 
-  TrackerTypeReport deleteRelationships(List<String> relationships);
+  TrackerTypeReport deleteRelationships(List<String> relationships) throws NotFoundException;
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/maintenance/MaintenanceServiceTest.java
@@ -226,18 +226,18 @@ class MaintenanceServiceTest extends IntegrationTestBase {
     r.setInvertedKey(RelationshipUtils.generateRelationshipInvertedKey(r));
     relationshipService.addRelationship(r);
     assertNotNull(trackedEntityService.getTrackedEntity(trackedEntity.getId()));
-    assertNotNull(relationshipService.getRelationship(r.getId()));
+    assertNotNull(getRelationship(r.getId()));
     trackedEntityService.deleteTrackedEntity(trackedEntity);
     assertNull(trackedEntityService.getTrackedEntity(trackedEntity.getId()));
     manager.delete(r);
-    assertNull(relationshipService.getRelationship(r.getId()));
+    assertNull(getRelationship(r.getId()));
     assertTrue(trackedEntityService.trackedEntityExistsIncludingDeleted(trackedEntity.getUid()));
-    assertTrue(relationshipService.relationshipExistsIncludingDeleted(r.getUid()));
+    assertTrue(relationshipExistsIncludingDeleted(r.getUid()));
 
     maintenanceService.deleteSoftDeletedTrackedEntities();
 
     assertFalse(trackedEntityService.trackedEntityExistsIncludingDeleted(trackedEntity.getUid()));
-    assertFalse(relationshipService.relationshipExistsIncludingDeleted(r.getUid()));
+    assertFalse(relationshipExistsIncludingDeleted(r.getUid()));
   }
 
   @Test
@@ -374,18 +374,18 @@ class MaintenanceServiceTest extends IntegrationTestBase {
     r.setInvertedKey(RelationshipUtils.generateRelationshipInvertedKey(r));
     relationshipService.addRelationship(r);
     assertNotNull(getEvent(idA));
-    assertNotNull(relationshipService.getRelationship(r.getId()));
+    assertNotNull(getRelationship(r.getId()));
     manager.delete(eventA);
     assertNull(getEvent(idA));
     manager.delete(r);
-    assertNull(relationshipService.getRelationship(r.getId()));
+    assertNull(getRelationship(r.getId()));
     assertTrue(eventExistsIncludingDeleted(eventA.getUid()));
-    assertTrue(relationshipService.relationshipExistsIncludingDeleted(r.getUid()));
+    assertTrue(relationshipExistsIncludingDeleted(r.getUid()));
 
     maintenanceService.deleteSoftDeletedEvents();
 
     assertFalse(eventExistsIncludingDeleted(eventA.getUid()));
-    assertFalse(relationshipService.relationshipExistsIncludingDeleted(r.getUid()));
+    assertFalse(relationshipExistsIncludingDeleted(r.getUid()));
   }
 
   @Test
@@ -409,18 +409,18 @@ class MaintenanceServiceTest extends IntegrationTestBase {
     r.setInvertedKey(RelationshipUtils.generateRelationshipInvertedKey(r));
     relationshipService.addRelationship(r);
     assertNotNull(manager.get(Enrollment.class, enrollment.getId()));
-    assertNotNull(relationshipService.getRelationship(r.getId()));
+    assertNotNull(getRelationship(r.getId()));
     apiEnrollmentService.deleteEnrollment(enrollment);
     assertNull(manager.get(Enrollment.class, enrollment.getId()));
     manager.delete(r);
-    assertNull(relationshipService.getRelationship(r.getId()));
+    assertNull(getRelationship(r.getId()));
     assertTrue(enrollmentExistsIncludingDeleted(enrollment));
-    assertTrue(relationshipService.relationshipExistsIncludingDeleted(r.getUid()));
+    assertTrue(relationshipExistsIncludingDeleted(r.getUid()));
 
     maintenanceService.deleteSoftDeletedEnrollments();
 
     assertFalse(enrollmentExistsIncludingDeleted(enrollment));
-    assertFalse(relationshipService.relationshipExistsIncludingDeleted(r.getUid()));
+    assertFalse(relationshipExistsIncludingDeleted(r.getUid()));
   }
 
   @Test
@@ -459,24 +459,38 @@ class MaintenanceServiceTest extends IntegrationTestBase {
     Relationship relationship =
         createTeToTeRelationship(trackedEntity, trackedEntityB, relationshipType);
     relationshipService.addRelationship(relationship);
-    assertNotNull(relationshipService.getRelationship(relationship.getUid()));
+    assertNotNull(getRelationship(relationship.getUid()));
 
     manager.delete(relationship);
-    assertNull(relationshipService.getRelationship(relationship.getUid()));
-    assertNotNull(relationshipService.getRelationshipIncludeDeleted(relationship.getUid()));
+    assertNull(getRelationship(relationship.getUid()));
+    assertTrue(relationshipExistsIncludingDeleted(relationship.getUid()));
 
     maintenanceService.deleteSoftDeletedRelationships();
-    assertNull(relationshipService.getRelationshipIncludeDeleted(relationship.getUid()));
+    assertFalse(relationshipExistsIncludingDeleted(relationship.getUid()));
   }
 
   private Event getEvent(long id) {
     return manager.get(Event.class, id);
   }
 
+  private Relationship getRelationship(String uid) {
+    return manager.get(Relationship.class, uid);
+  }
+
+  private Relationship getRelationship(long id) {
+    return manager.get(Relationship.class, id);
+  }
+
   private boolean eventExistsIncludingDeleted(String uid) {
     return Boolean.TRUE.equals(
         jdbcTemplate.queryForObject(
             "select exists(select 1 from event where uid=?)", Boolean.class, uid));
+  }
+
+  private boolean relationshipExistsIncludingDeleted(String uid) {
+    return Boolean.TRUE.equals(
+        jdbcTemplate.queryForObject(
+            "select exists(select 1 from relationship where uid=?)", Boolean.class, uid));
   }
 
   private boolean enrollmentExistsIncludingDeleted(Enrollment enrollment)

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateRemoveTrackedEntityTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateRemoveTrackedEntityTest.java
@@ -133,11 +133,11 @@ class PotentialDuplicateRemoveTrackedEntityTest extends TransactionalIntegration
     assertNotNull(trackedEntityService.getTrackedEntity(control2.getUid()));
     dbmsManager.clearSession();
     removeTrackedEntity(duplicate);
-    assertNull(relationshipService.getRelationship(relationShip3));
-    assertNull(relationshipService.getRelationship(relationShip4));
-    assertNotNull(relationshipService.getRelationship(relationShip1));
-    assertNotNull(relationshipService.getRelationship(relationShip2));
-    assertNotNull(relationshipService.getRelationship(relationShip5));
+    assertNull(getRelationship(relationShip3));
+    assertNull(getRelationship(relationShip4));
+    assertNotNull(getRelationship(relationShip1));
+    assertNotNull(getRelationship(relationShip2));
+    assertNotNull(getRelationship(relationShip5));
     assertNull(trackedEntityService.getTrackedEntity(duplicate.getUid()));
   }
 
@@ -194,5 +194,9 @@ class PotentialDuplicateRemoveTrackedEntityTest extends TransactionalIntegration
 
   private void removeTrackedEntity(TrackedEntity trackedEntity) throws NotFoundException {
     trackerObjectDeletionService.deleteTrackedEntities(List.of(trackedEntity.getUid()));
+  }
+
+  private Relationship getRelationship(long id) {
+    return manager.get(Relationship.class, id);
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateStoreRelationshipTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateStoreRelationshipTest.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.google.common.collect.Lists;
 import java.util.List;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.relationship.Relationship;
@@ -59,6 +60,8 @@ class PotentialDuplicateStoreRelationshipTest extends IntegrationTestBase {
   @Autowired private RelationshipTypeService relationshipTypeService;
 
   @Autowired private OrganisationUnitService organisationUnitService;
+
+  @Autowired private IdentifiableObjectManager manager;
 
   private TrackedEntity original;
 
@@ -111,10 +114,10 @@ class PotentialDuplicateStoreRelationshipTest extends IntegrationTestBase {
     transactionTemplate.execute(
         status -> {
           dbmsManager.clearSession();
-          Relationship _bi1 = relationshipService.getRelationship(bi1.getUid());
-          Relationship _bi2 = relationshipService.getRelationship(bi2.getUid());
-          Relationship _bi3 = relationshipService.getRelationship(bi3.getUid());
-          Relationship _bi4 = relationshipService.getRelationship(bi4.getUid());
+          Relationship _bi1 = getRelationship(bi1.getUid());
+          Relationship _bi2 = getRelationship(bi2.getUid());
+          Relationship _bi3 = getRelationship(bi3.getUid());
+          Relationship _bi4 = getRelationship(bi4.getUid());
           assertNotNull(_bi1);
           assertEquals(original.getUid(), _bi1.getFrom().getTrackedEntity().getUid());
           assertEquals(extra2.getUid(), _bi1.getTo().getTrackedEntity().getUid());
@@ -147,10 +150,10 @@ class PotentialDuplicateStoreRelationshipTest extends IntegrationTestBase {
     potentialDuplicateStore.moveRelationships(original, duplicate, relationships);
     trackedEntityService.updateTrackedEntity(original);
     trackedEntityService.updateTrackedEntity(duplicate);
-    Relationship _uni1 = relationshipService.getRelationship(uni1.getUid());
-    Relationship _uni2 = relationshipService.getRelationship(uni2.getUid());
-    Relationship _uni3 = relationshipService.getRelationship(uni3.getUid());
-    Relationship _uni4 = relationshipService.getRelationship(uni4.getUid());
+    Relationship _uni1 = getRelationship(uni1.getUid());
+    Relationship _uni2 = getRelationship(uni2.getUid());
+    Relationship _uni3 = getRelationship(uni3.getUid());
+    Relationship _uni4 = getRelationship(uni4.getUid());
     assertNotNull(_uni1);
     assertEquals(original.getUid(), _uni1.getFrom().getTrackedEntity().getUid());
     assertEquals(extra2.getUid(), _uni1.getTo().getTrackedEntity().getUid());
@@ -184,10 +187,10 @@ class PotentialDuplicateStoreRelationshipTest extends IntegrationTestBase {
     transactionTemplate.execute(
         status -> {
           dbmsManager.clearSession();
-          Relationship _uni1 = relationshipService.getRelationship(uni1.getUid());
-          Relationship _uni2 = relationshipService.getRelationship(uni2.getUid());
-          Relationship _bi1 = relationshipService.getRelationship(bi1.getUid());
-          Relationship _bi2 = relationshipService.getRelationship(bi2.getUid());
+          Relationship _uni1 = getRelationship(uni1.getUid());
+          Relationship _uni2 = getRelationship(uni2.getUid());
+          Relationship _bi1 = getRelationship(bi1.getUid());
+          Relationship _bi2 = getRelationship(bi2.getUid());
           assertNotNull(_uni1);
           assertEquals(original.getUid(), _uni1.getFrom().getTrackedEntity().getUid());
           assertEquals(extra2.getUid(), _uni1.getTo().getTrackedEntity().getUid());
@@ -202,5 +205,9 @@ class PotentialDuplicateStoreRelationshipTest extends IntegrationTestBase {
           assertEquals(extra2.getUid(), _bi2.getTo().getTrackedEntity().getUid());
           return null;
         });
+  }
+
+  private Relationship getRelationship(String uid) {
+    return manager.get(Relationship.class, uid);
   }
 }


### PR DESCRIPTION
## Big picture

Tracker has multiple services for each entity like tracked entity, enrollment, event and relationship. One is in dhis-api and one in dhis-service-tracker. Our goal is to provide one API (service) per entity that is part of the tracker domain/team.

Trackers architecture splits read/write into exporter services and an importer. So if you want to get data you use an exporter. If you want to insert, update or delete you have to go through the importer. Only then can we ensure integrity of tracker data.

Another goal is that code that provides tracker functionality and is thus owned by the tracker team lives in ideally one maven module (We can settle on a name later on maybe `dhis-service-tracker` or `dhis-tracker`).

This is a **big** task that we are going to implement in many small steps.

## This PR

`RelationshipService` getters were used in tests and in `TrackerObjectDeletionService`.
`relationshipExistsIncludingDeleted` was only used in one test so now it is implemented in `MaintenanceServiceTest`.
`getRelationshipIncludeDeleted` was just removed and we are using `relationshipExistsIncludingDeleted` instead.
`getRelationship` by id and by uid are now implemented using `IdentifiableObjectManager`.