### PR TITLE
fix: incorrect schema.owner value base on inverse attribute

### DIFF
--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/HibernatePropertyIntrospector.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/HibernatePropertyIntrospector.java
@@ -229,9 +229,11 @@ public class HibernatePropertyIntrospector implements PropertyIntrospector {
       MetamodelImplementor metamodelImplementor, Property property, CollectionType type) {
     CollectionPersister persister = metamodelImplementor.collectionPersister(type.getRole());
 
-    property.setOwner(!persister.isInverse());
     property.setManyToMany(persister.isManyToMany());
     property.setOneToMany(persister.isOneToMany());
+    if ((property.isManyToMany() || property.isOneToMany()) && persister.isInverse()) {
+      property.setOwner(false);
+    }
 
     property.setMin(0d);
     property.setMax(Double.MAX_VALUE);


### PR DESCRIPTION
```
curl -X PATCH -H "Content-Type: application/json-patch+json" -d '[{ "op": "add", "path": "/categoryOptions/-", "value": {"id": "K4gwuiVvW3z"} }]' 'http://localhost:8080/api/categories/gtuVl6NbXQV' -u admin:district
{"httpStatus":"Conflict","httpStatusCode":409,"status":"ERROR","message":"org.hibernate.PropertyValueException: not-null property references a null or transient value : org.hisp.dhis.category.Category.uid"}%      
```