### PR TITLE
feat: add more ACL checks to SMS inbound/outbound

### DIFF
--- a/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
+++ b/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
@@ -380,9 +380,13 @@ public class DefaultAclService implements AclService {
   @Override
   public <T extends IdentifiableObject> boolean canRead(UserDetails userDetails, Class<T> klass) {
     Schema schema = schemaService.getSchema(klass);
-    return schema == null
-        || schema.getAuthorityByType(AuthorityType.READ) == null
-        || canAccess(userDetails, schema.getAuthorityByType(AuthorityType.READ));
+    Schema schema1 = schema;
+    if (schema == null) return true;
+
+    List<String> authorityByType = schema.getAuthorityByType(AuthorityType.READ);
+    List<String> authorityByType1 = schema.getAuthorityByType(AuthorityType.READ);
+    boolean canAccess = canAccess(userDetails, authorityByType1);
+    return authorityByType == null || canAccess;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
+++ b/dhis-2/dhis-services/dhis-service-acl/src/main/java/org/hisp/dhis/security/acl/DefaultAclService.java
@@ -380,13 +380,9 @@ public class DefaultAclService implements AclService {
   @Override
   public <T extends IdentifiableObject> boolean canRead(UserDetails userDetails, Class<T> klass) {
     Schema schema = schemaService.getSchema(klass);
-    Schema schema1 = schema;
-    if (schema == null) return true;
-
-    List<String> authorityByType = schema.getAuthorityByType(AuthorityType.READ);
-    List<String> authorityByType1 = schema.getAuthorityByType(AuthorityType.READ);
-    boolean canAccess = canAccess(userDetails, authorityByType1);
-    return authorityByType == null || canAccess;
+    return schema == null
+        || schema.getAuthorityByType(AuthorityType.READ) == null
+        || canAccess(userDetails, schema.getAuthorityByType(AuthorityType.READ));
   }
 
   @Override

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SmsCommandControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SmsCommandControllerTest.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.test.webapi.Assertions.assertWebMessage;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.hisp.dhis.jsontree.JsonMixed;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SmsInboundControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SmsInboundControllerTest.java
@@ -33,6 +33,7 @@ import org.hisp.dhis.sms.incoming.IncomingSms;
 import org.hisp.dhis.sms.incoming.IncomingSmsService;
 import org.hisp.dhis.test.web.HttpStatus;
 import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
+import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -45,6 +46,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 class SmsInboundControllerTest extends H2ControllerIntegrationTestBase {
 
   @Autowired private IncomingSmsService incomingSMSService;
+
+  @Test
+  void testGetInboundSMSMessage() {
+    User guestUser = createUserWithAuth("guestuser", "NONE");
+    injectSecurityContextUser(guestUser);
+
+    assertWebMessage(
+        "Forbidden",
+        403,
+        "ERROR",
+        "Access is denied, requires one Authority from [F_MOBILE_SENDSMS]",
+        GET("/sms/inbound").content(HttpStatus.FORBIDDEN));
+  }
 
   @Test
   void testReceiveSMSMessage() {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SmsOutboundControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/SmsOutboundControllerTest.java
@@ -33,6 +33,7 @@ import org.hisp.dhis.sms.outbound.OutboundSms;
 import org.hisp.dhis.sms.outbound.OutboundSmsService;
 import org.hisp.dhis.test.web.HttpStatus;
 import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
+import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -45,6 +46,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 class SmsOutboundControllerTest extends H2ControllerIntegrationTestBase {
 
   @Autowired private OutboundSmsService outboundSmsService;
+
+  @Test
+  void testGetOutboundSMSMessage() {
+    User guestUser = createUserWithAuth("guestuser", "NONE");
+    injectSecurityContextUser(guestUser);
+
+    assertWebMessage(
+        "Forbidden",
+        403,
+        "ERROR",
+        "Access is denied, requires one Authority from [F_MOBILE_SENDSMS]",
+        GET("/sms/outbound").content(HttpStatus.FORBIDDEN));
+  }
 
   @Test
   void testSendSMSMessage() {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsInboundController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsInboundController.java
@@ -86,6 +86,7 @@ public class SmsInboundController extends AbstractCrudController<IncomingSms> {
 
   private final UserService userService;
 
+  @Override
   @RequiresAuthority(anyOf = F_MOBILE_SENDSMS)
   @GetMapping
   public @ResponseBody ResponseEntity<StreamingJsonRoot<IncomingSms>> getObjectList(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsInboundController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsInboundController.java
@@ -30,17 +30,23 @@ package org.hisp.dhis.webapi.controller.sms;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+import static org.hisp.dhis.security.Authorities.F_MOBILE_SENDSMS;
 import static org.hisp.dhis.security.Authorities.F_MOBILE_SETTINGS;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.io.IOException;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.dxf2.common.OrderParams;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
+import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.sms.command.SMSCommand;
@@ -51,10 +57,14 @@ import org.hisp.dhis.sms.parse.ParserType;
 import org.hisp.dhis.system.util.SmsUtils;
 import org.hisp.dhis.user.CurrentUser;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
+import org.hisp.dhis.webapi.webdomain.StreamingJsonRoot;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -75,6 +85,18 @@ public class SmsInboundController extends AbstractCrudController<IncomingSms> {
   private final SMSCommandService smsCommandService;
 
   private final UserService userService;
+
+  @RequiresAuthority(anyOf = F_MOBILE_SENDSMS)
+  @GetMapping
+  public @ResponseBody ResponseEntity<StreamingJsonRoot<IncomingSms>> getObjectList(
+      @RequestParam Map<String, String> rpParameters,
+      OrderParams orderParams,
+      HttpServletResponse response,
+      @CurrentUser UserDetails currentUser)
+      throws ForbiddenException, BadRequestException {
+    return getObjectList(
+        rpParameters, orderParams, response, currentUser, !rpParameters.containsKey("query"), null);
+  }
 
   // -------------------------------------------------------------------------
   // POST

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsOutboundController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsOutboundController.java
@@ -37,19 +37,29 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.dxf2.common.OrderParams;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
+import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.security.RequiresAuthority;
 import org.hisp.dhis.sms.outbound.OutboundSms;
 import org.hisp.dhis.sms.outbound.OutboundSmsService;
+import org.hisp.dhis.user.CurrentUser;
+import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
+import org.hisp.dhis.webapi.webdomain.StreamingJsonRoot;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -77,6 +87,18 @@ public class SmsOutboundController extends AbstractCrudController<OutboundSms> {
     this.smsSender = smsSender;
     this.renderService = renderService;
     this.outboundSmsService = outboundSmsService;
+  }
+
+  @RequiresAuthority(anyOf = F_MOBILE_SENDSMS)
+  @GetMapping
+  public @ResponseBody ResponseEntity<StreamingJsonRoot<OutboundSms>> getObjectList(
+      @RequestParam Map<String, String> rpParameters,
+      OrderParams orderParams,
+      HttpServletResponse response,
+      @CurrentUser UserDetails currentUser)
+      throws ForbiddenException, BadRequestException {
+    return getObjectList(
+        rpParameters, orderParams, response, currentUser, !rpParameters.containsKey("query"), null);
   }
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsOutboundController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/sms/SmsOutboundController.java
@@ -89,6 +89,7 @@ public class SmsOutboundController extends AbstractCrudController<OutboundSms> {
     this.outboundSmsService = outboundSmsService;
   }
 
+  @Override
   @RequiresAuthority(anyOf = F_MOBILE_SENDSMS)
   @GetMapping
   public @ResponseBody ResponseEntity<StreamingJsonRoot<OutboundSms>> getObjectList(


### PR DESCRIPTION
## Summary
Adds more ACL checks to inbound and outbound SMS messages.

### Automatic tests
SmsCommandControllerTest
SmsOutboundControllerTest
SmsInboundControllerTest

### Manual tests
1. Create a guest user account, with no authorities
2. Call GET /api/sms/outbound, observe 403 response
3. Call GET /api/sms/inbound, observe 403 response
4. Call GET /api/smsCommands, observe 403 response