### PR TITLE
feat: add a brute force protection on the 2fa/disable endpoint

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/CacheProvider.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/CacheProvider.java
@@ -65,6 +65,8 @@ public interface CacheProvider {
 
   <V> Cache<V> createUserFailedLoginAttemptCache(V defaultValue);
 
+  <V> Cache<V> createDisable2FAFailedAttemptCache(V defaultValue);
+
   <V> Cache<V> createUserAccountRecoverAttemptCache(V defaultValue);
 
   <V> Cache<V> createProgramOwnerCache();

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -216,6 +216,7 @@ public enum ErrorCode {
   E3032("User `{0}` does not have access to user role"),
   E3040("Could not resolve JwsAlgorithm from the JWK. Can not write a valid JWKSet"),
   E3041("User `{0}` is not allowed to change a user having the ALL authority"),
+  E3042("Too many failed disable attempts. Please try again later"),
 
   /* Metadata Validation */
   E4000("Missing required property `{0}`"),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -561,6 +561,30 @@ public interface UserService {
   void disableTwoFa(User user, String code);
 
   /**
+   * Register a failed 2FA disable attempt for the given user account.
+   *
+   * @param username
+   */
+  void registerFailed2FADisableAttempt(String username);
+
+  /**
+   * If the user has a failed 2FA disable attempt more than 4 times in the last 15 minutes, return
+   * true.
+   *
+   * @param username
+   * @return
+   */
+  boolean twoFaDisableIsLocked(String username);
+
+  /**
+   * Register a successful 2FA disable attempt for the given user account, this will reset the
+   * attempt cache.
+   *
+   * @param username
+   */
+  void registerSuccess2FADisable(String username);
+
+  /**
    * If the user has a role with the 2FA authentication required restriction, return true.
    *
    * @param userDetails The user object that is being checked for the role.

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
@@ -95,6 +95,7 @@ public class DefaultCacheProvider implements CacheProvider {
     periodIdCache,
     userAccountRecoverAttempt,
     userFailedLoginAttempt,
+    twoFaDisableFailedAttempt,
     programOwner,
     programTempOwner,
     userIdCache,
@@ -290,6 +291,15 @@ public class DefaultCacheProvider implements CacheProvider {
     return registerCache(
         this.<V>newBuilder()
             .forRegion(Region.userFailedLoginAttempt.name())
+            .expireAfterWrite(15, MINUTES)
+            .withDefaultValue(defaultValue));
+  }
+
+  @Override
+  public <V> Cache<V> createDisable2FAFailedAttemptCache(V defaultValue) {
+    return registerCache(
+        this.<V>newBuilder()
+            .forRegion(Region.twoFaDisableFailedAttempt.name())
             .expireAfterWrite(15, MINUTES)
             .withDefaultValue(defaultValue));
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/TwoFactorControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/TwoFactorControllerTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.test.web.WebClientUtils.assertStatus;
+import static org.hisp.dhis.test.webapi.Assertions.assertWebMessage;
 import static org.hisp.dhis.user.UserService.TWO_FACTOR_CODE_APPROVAL_PREFIX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -128,6 +129,37 @@ class TwoFactorControllerTest extends H2ControllerIntegrationTestBase {
         POST("/2fa/disabled", "{'code':'wrong'}")
             .error(HttpStatus.Series.CLIENT_ERROR)
             .getMessage());
+  }
+
+  @Test
+  void testDisable2FaTooManyTimes() {
+    User user = makeUser("X", List.of("TEST"));
+    user.setEmail("valid.x@email.com");
+    userService.addUser(user);
+    userService.generateTwoFactorOtpSecretForApproval(user);
+
+    switchToNewUser(user);
+
+    String code = getCode(user);
+    assertStatus(HttpStatus.OK, POST("/2fa/enabled", "{'code':'" + code + "'}"));
+
+    assertStatus(HttpStatus.UNAUTHORIZED, POST("/2fa/disabled", "{'code':'333333'}"));
+
+    for (int i = 0; i < 3; i++) {
+      assertWebMessage(
+          "Unauthorized",
+          401,
+          "ERROR",
+          "Invalid 2FA code",
+          POST("/2fa/disabled", "{'code':'333333'}").content(HttpStatus.UNAUTHORIZED));
+    }
+
+    assertWebMessage(
+        "Conflict",
+        409,
+        "ERROR",
+        "Too many failed disable attempts. Please try again later",
+        POST("/2fa/disabled", "{'code':'333333'}").content(HttpStatus.CONFLICT));
   }
 
   private static String replaceApprovalPartOfTheSecret(User user) {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/TwoFactorController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/TwoFactorController.java
@@ -195,7 +195,12 @@ public class TwoFactorController {
       throw new WebMessageException(conflict(ErrorCode.E3031.getMessage(), ErrorCode.E3031));
     }
 
+    if (defaultUserService.twoFaDisableIsLocked(currentUser.getUsername())) {
+      throw new WebMessageException(conflict(ErrorCode.E3042.getMessage(), ErrorCode.E3042));
+    }
+
     if (!verifyCode(code, currentUser)) {
+      defaultUserService.registerFailed2FADisableAttempt(currentUser.getUsername());
       return unauthorized(ErrorCode.E3023.getMessage());
     }
 


### PR DESCRIPTION
## Summary
Adds a simple brute force protection on the 2fa/disable endpoint.
After 4 failed attempts the endpoint will be disabled for the next 15 minutes.

### Automatic test
TwoFactorControllerTest#testDisable2FaTooManyTimes()

### Manual test
1. Log in and go to account app.
2. Enable 2FA as instructed.
3. Try to disable the 2FA on the same page with a random code
4. Observe that on the 5th attempt with a wrong code you get this response: `Too many failed disable attempts. Please try again later`