### PR TITLE
chore: Remove getters by entity from RelationshipService [DHIS2-17713]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipService.java
@@ -30,10 +30,6 @@ package org.hisp.dhis.relationship;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
-import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.Event;
-import org.hisp.dhis.trackedentity.TrackedEntity;
-import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
 
 /**
  * @author Abyot Asalefew
@@ -60,35 +56,6 @@ public interface RelationshipService {
   Optional<Relationship> getRelationshipByRelationship(Relationship relationship);
 
   List<Relationship> getRelationships(@Nonnull List<String> uids);
-
-  default List<Relationship> getRelationshipsByTrackedEntity(
-      TrackedEntity trackedEntity, boolean includeDeleted) {
-    return getRelationshipsByTrackedEntity(trackedEntity, null, includeDeleted);
-  }
-
-  List<Relationship> getRelationshipsByTrackedEntity(
-      TrackedEntity te,
-      PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean includeDeleted);
-
-  default List<Relationship> getRelationshipsByEnrollment(
-      Enrollment enrollment, boolean includeDeleted) {
-    return getRelationshipsByEnrollment(enrollment, null, includeDeleted);
-  }
-
-  List<Relationship> getRelationshipsByEnrollment(
-      Enrollment enrollment,
-      PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean includeDeleted);
-
-  default List<Relationship> getRelationshipsByEvent(Event event, boolean includeDeleted) {
-    return getRelationshipsByEvent(event, null, includeDeleted);
-  }
-
-  List<Relationship> getRelationshipsByEvent(
-      Event event,
-      PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean includeDeleted);
 
   List<Relationship> getRelationshipsByRelationshipType(RelationshipType relationshipType);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipStore.java
@@ -29,31 +29,12 @@ package org.hisp.dhis.relationship;
 
 import java.util.List;
 import org.hisp.dhis.common.IdentifiableObjectStore;
-import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.Event;
-import org.hisp.dhis.trackedentity.TrackedEntity;
-import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
 
 /**
  * @author Abyot Asalefew
  */
 public interface RelationshipStore extends IdentifiableObjectStore<Relationship> {
   String ID = RelationshipStore.class.getName();
-
-  List<Relationship> getByTrackedEntity(
-      TrackedEntity te,
-      PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean includeDeleted);
-
-  List<Relationship> getByEnrollment(
-      Enrollment enrollment,
-      PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean includeDeleted);
-
-  List<Relationship> getByEvent(
-      Event event,
-      PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean includeDeleted);
 
   List<Relationship> getByRelationshipType(RelationshipType relationshipType);
 
@@ -66,14 +47,6 @@ public interface RelationshipStore extends IdentifiableObjectStore<Relationship>
    *     criterias
    */
   Relationship getByRelationship(Relationship relationship);
-
-  /**
-   * Checks if relationship for given UID exists (including deleted relationships).
-   *
-   * @param uid Relationship UID to check for.
-   * @return return true if relationship exists, false otherwise.
-   */
-  boolean existsIncludingDeleted(String uid);
 
   List<String> getUidsByRelationshipKeys(List<String> relationshipKeyList);
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/DefaultRelationshipService.java
@@ -33,10 +33,6 @@ import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
-import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.Event;
-import org.hisp.dhis.trackedentity.TrackedEntity;
-import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -65,35 +61,6 @@ public class DefaultRelationshipService implements RelationshipService {
   @Transactional(readOnly = true)
   public List<Relationship> getRelationships(@Nonnull List<String> uids) {
     return relationshipStore.getByUid(uids);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public List<Relationship> getRelationshipsByTrackedEntity(
-      TrackedEntity te,
-      PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean includeDeleted) {
-    return relationshipStore.getByTrackedEntity(
-        te, pagingAndSortingCriteriaAdapter, includeDeleted);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public List<Relationship> getRelationshipsByEnrollment(
-      Enrollment enrollment,
-      PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean includeDeleted) {
-    return relationshipStore.getByEnrollment(
-        enrollment, pagingAndSortingCriteriaAdapter, includeDeleted);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public List<Relationship> getRelationshipsByEvent(
-      Event event,
-      PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean includeDeleted) {
-    return relationshipStore.getByEvent(event, pagingAndSortingCriteriaAdapter, includeDeleted);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/hibernate/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/hibernate/HibernateRelationshipStore.java
@@ -27,35 +27,23 @@
  */
 package org.hisp.dhis.relationship.hibernate;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
-import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
-import javax.persistence.criteria.Subquery;
 import org.apache.commons.collections4.CollectionUtils;
-import org.hibernate.query.Query;
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.hibernate.SoftDeleteHibernateObjectStore;
-import org.hisp.dhis.hibernate.JpaQueryParameters;
-import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.Event;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.relationship.RelationshipItem;
 import org.hisp.dhis.relationship.RelationshipStore;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.security.acl.AclService;
-import org.hisp.dhis.trackedentity.TrackedEntity;
-import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
-import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -81,132 +69,6 @@ public class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<R
   }
 
   @Override
-  public List<Relationship> getByTrackedEntity(
-      TrackedEntity trackedEntity,
-      PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean includeDeleted) {
-    TypedQuery<Relationship> relationshipTypedQuery =
-        getRelationshipTypedQuery(trackedEntity, pagingAndSortingCriteriaAdapter, includeDeleted);
-
-    return getList(relationshipTypedQuery);
-  }
-
-  @Override
-  public List<Relationship> getByEnrollment(
-      Enrollment enrollment,
-      PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean includeDeleted) {
-    TypedQuery<Relationship> relationshipTypedQuery =
-        getRelationshipTypedQuery(enrollment, pagingAndSortingCriteriaAdapter, includeDeleted);
-
-    return getList(relationshipTypedQuery);
-  }
-
-  @Override
-  public List<Relationship> getByEvent(
-      Event event,
-      PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean includeDeleted) {
-    TypedQuery<Relationship> relationshipTypedQuery =
-        getRelationshipTypedQuery(event, pagingAndSortingCriteriaAdapter, includeDeleted);
-
-    return getList(relationshipTypedQuery);
-  }
-
-  private <T extends IdentifiableObject> TypedQuery<Relationship> getRelationshipTypedQuery(
-      T entity,
-      PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      boolean includeDeleted) {
-    CriteriaBuilder builder = getCriteriaBuilder();
-
-    CriteriaQuery<Relationship> relationshipItemCriteriaQuery =
-        builder.createQuery(Relationship.class);
-    Root<Relationship> root = relationshipItemCriteriaQuery.from(Relationship.class);
-
-    setRelationshipItemCriteriaQueryExistsCondition(
-        entity, builder, relationshipItemCriteriaQuery, root, includeDeleted);
-
-    return getRelationshipTypedQuery(
-        pagingAndSortingCriteriaAdapter, builder, relationshipItemCriteriaQuery, root);
-  }
-
-  private <T extends IdentifiableObject> void setRelationshipItemCriteriaQueryExistsCondition(
-      T entity,
-      CriteriaBuilder builder,
-      CriteriaQuery<Relationship> relationshipItemCriteriaQuery,
-      Root<Relationship> root,
-      boolean includeDeleted) {
-    Subquery<RelationshipItem> fromSubQuery =
-        relationshipItemCriteriaQuery.subquery(RelationshipItem.class);
-    Root<RelationshipItem> fromRoot = fromSubQuery.from(RelationshipItem.class);
-
-    String relationshipEntityType = getRelationshipEntityType(entity);
-
-    fromSubQuery.where(
-        builder.equal(root.get("from"), fromRoot.get("id")),
-        builder.equal(fromRoot.get(relationshipEntityType), entity.getId()));
-
-    fromSubQuery.select(fromRoot.get("id"));
-
-    Subquery<RelationshipItem> toSubQuery =
-        relationshipItemCriteriaQuery.subquery(RelationshipItem.class);
-    Root<RelationshipItem> toRoot = toSubQuery.from(RelationshipItem.class);
-
-    toSubQuery.where(
-        builder.equal(root.get("to"), toRoot.get("id")),
-        builder.equal(toRoot.get(relationshipEntityType), entity.getId()));
-
-    toSubQuery.select(toRoot.get("id"));
-
-    List<Predicate> predicates = new ArrayList<>();
-    predicates.add(builder.or(builder.exists(fromSubQuery), builder.exists(toSubQuery)));
-
-    if (!includeDeleted) {
-      predicates.add(builder.equal(root.get("deleted"), false));
-    }
-
-    relationshipItemCriteriaQuery.where(predicates.toArray(Predicate[]::new));
-
-    relationshipItemCriteriaQuery.select(root);
-  }
-
-  private <T extends IdentifiableObject> String getRelationshipEntityType(T entity) {
-    if (entity instanceof TrackedEntity) return TRACKED_ENTITY;
-    else if (entity instanceof Enrollment) return ENROLLMENT;
-    else if (entity instanceof Event) return EVENT;
-    else
-      throw new IllegalArgumentException(
-          entity.getClass().getSimpleName() + " not supported in relationship");
-  }
-
-  private TypedQuery<Relationship> getRelationshipTypedQuery(
-      PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      CriteriaBuilder builder,
-      CriteriaQuery<Relationship> relationshipItemCriteriaQuery,
-      Root<Relationship> root) {
-    JpaQueryParameters<Relationship> jpaQueryParameters =
-        newJpaParameters(pagingAndSortingCriteriaAdapter, builder);
-
-    relationshipItemCriteriaQuery.orderBy(
-        jpaQueryParameters.getOrders().stream()
-            .map(o -> o.apply(root))
-            .collect(Collectors.toList()));
-
-    TypedQuery<Relationship> relationshipTypedQuery =
-        getSession().createQuery(relationshipItemCriteriaQuery);
-
-    if (jpaQueryParameters.hasFirstResult()) {
-      relationshipTypedQuery.setFirstResult(jpaQueryParameters.getFirstResult());
-    }
-
-    if (jpaQueryParameters.hasMaxResult()) {
-      relationshipTypedQuery.setMaxResults(jpaQueryParameters.getMaxResults());
-    }
-
-    return relationshipTypedQuery;
-  }
-
-  @Override
   public List<Relationship> getByRelationshipType(RelationshipType relationshipType) {
     CriteriaBuilder builder = getCriteriaBuilder();
 
@@ -214,49 +76,6 @@ public class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<R
         builder,
         newJpaParameters()
             .addPredicate(root -> builder.equal(root.join("relationshipType"), relationshipType)));
-  }
-
-  @Override
-  @SuppressWarnings("unchecked")
-  public boolean existsIncludingDeleted(String uid) {
-    Query<String> query =
-        nativeSynchronizedQuery("select uid from relationship where uid=:uid limit 1;");
-    query.setParameter("uid", uid);
-
-    return !query.list().isEmpty();
-  }
-
-  private JpaQueryParameters<Relationship> newJpaParameters(
-      PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter,
-      CriteriaBuilder criteriaBuilder) {
-
-    JpaQueryParameters<Relationship> jpaQueryParameters = newJpaParameters();
-
-    if (Objects.nonNull(pagingAndSortingCriteriaAdapter)) {
-      if (pagingAndSortingCriteriaAdapter.isSortingRequest()) {
-        pagingAndSortingCriteriaAdapter
-            .getOrder()
-            .forEach(orderCriteria -> addOrder(jpaQueryParameters, orderCriteria, criteriaBuilder));
-      }
-
-      if (pagingAndSortingCriteriaAdapter.isPagingRequest()) {
-        jpaQueryParameters.setFirstResult(pagingAndSortingCriteriaAdapter.getFirstResult());
-        jpaQueryParameters.setMaxResults(pagingAndSortingCriteriaAdapter.getPageSize() + 1);
-      }
-    }
-
-    return jpaQueryParameters;
-  }
-
-  private void addOrder(
-      JpaQueryParameters<Relationship> jpaQueryParameters,
-      OrderCriteria orderCriteria,
-      CriteriaBuilder builder) {
-    jpaQueryParameters.addOrder(
-        relationshipRoot ->
-            orderCriteria.getDirection().isAscending()
-                ? builder.asc(relationshipRoot.get(orderCriteria.getField()))
-                : builder.desc(relationshipRoot.get(orderCriteria.getField())));
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipQueryParams.java
@@ -35,10 +35,10 @@ import org.hisp.dhis.tracker.export.Order;
 
 @Getter
 @Builder(toBuilder = true)
-class RelationshipQueryParams {
+public class RelationshipQueryParams {
   private final IdentifiableObject entity;
 
-  private List<Order> order;
+  @Builder.Default private List<Order> order = List.of();
 
   private boolean includeDeleted;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/DefaultTrackerObjectsDeletionService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/DefaultTrackerObjectsDeletionService.java
@@ -41,13 +41,14 @@ import org.hisp.dhis.program.notification.ProgramNotificationInstance;
 import org.hisp.dhis.program.notification.ProgramNotificationInstanceParam;
 import org.hisp.dhis.program.notification.ProgramNotificationInstanceService;
 import org.hisp.dhis.relationship.Relationship;
-import org.hisp.dhis.relationship.RelationshipService;
 import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackedEntityService;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueChangeLogService;
 import org.hisp.dhis.tracker.TrackerType;
+import org.hisp.dhis.tracker.export.relationship.RelationshipQueryParams;
+import org.hisp.dhis.tracker.export.relationship.RelationshipStore;
 import org.hisp.dhis.tracker.imports.report.Entity;
 import org.hisp.dhis.tracker.imports.report.TrackerTypeReport;
 import org.hisp.dhis.user.CurrentUserUtil;
@@ -65,7 +66,7 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
 
   private final IdentifiableObjectManager manager;
 
-  private final RelationshipService relationshipService;
+  private final RelationshipStore relationshipStore;
 
   private final TrackedEntityAttributeValueService attributeValueService;
 
@@ -95,8 +96,9 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
               .toList();
       deleteEvents(events);
 
+      RelationshipQueryParams params = RelationshipQueryParams.builder().entity(enrollment).build();
       List<String> relationships =
-          relationshipService.getRelationshipsByEnrollment(enrollment, false).stream()
+          relationshipStore.getByEnrollment(enrollment, params).stream()
               .map(BaseIdentifiableObject::getUid)
               .toList();
 
@@ -132,8 +134,9 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
       Event event = manager.get(Event.class, uid);
       event.setLastUpdatedByUserInfo(userInfoSnapshot);
 
+      RelationshipQueryParams params = RelationshipQueryParams.builder().entity(event).build();
       List<String> relationships =
-          relationshipService.getRelationshipsByEvent(event, false).stream()
+          relationshipStore.getByEvent(event, params).stream()
               .map(BaseIdentifiableObject::getUid)
               .toList();
 
@@ -189,10 +192,12 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
               .toList();
       deleteEnrollments(enrollments);
 
+      RelationshipQueryParams params = RelationshipQueryParams.builder().entity(entity).build();
       List<String> relationships =
-          relationshipService.getRelationshipsByTrackedEntity(entity, false).stream()
+          relationshipStore.getByTrackedEntity(entity, params).stream()
               .map(BaseIdentifiableObject::getUid)
               .toList();
+
       deleteRelationships(relationships);
 
       Collection<TrackedEntityAttributeValue> attributeValues =

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.note.Note;
@@ -65,6 +66,11 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Transactional
 class EnrollmentServiceTest extends PostgresIntegrationTestBase {
+  private static final UID ENROLLMENT_A_UID = UID.of(CodeGenerator.generateUid());
+  private static final UID ENROLLMENT_B_UID = UID.of(CodeGenerator.generateUid());
+  private static final UID ENROLLMENT_C_UID = UID.of(CodeGenerator.generateUid());
+  private static final UID ENROLLMENT_D_UID = UID.of(CodeGenerator.generateUid());
+  private static final UID EVENT_UID = UID.of(CodeGenerator.generateUid());
 
   @Autowired private EnrollmentService apiEnrollmentService;
 
@@ -161,21 +167,21 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
     testDate2.withTimeAtStartOfDay();
     enrollmentDate = testDate2.toDate();
     enrollmentA = new Enrollment(enrollmentDate, incidentDate, trackedEntityA, programA);
-    enrollmentA.setUid("UID-A");
+    enrollmentA.setUid(ENROLLMENT_A_UID.getValue());
     enrollmentA.setOrganisationUnit(organisationUnitA);
     enrollmentB = new Enrollment(enrollmentDate, incidentDate, trackedEntityA, programB);
-    enrollmentB.setUid("UID-B");
+    enrollmentB.setUid(ENROLLMENT_B_UID.getValue());
     enrollmentB.setStatus(EnrollmentStatus.CANCELLED);
     enrollmentB.setOrganisationUnit(organisationUnitB);
     enrollmentC = new Enrollment(enrollmentDate, incidentDate, trackedEntityA, programC);
-    enrollmentC.setUid("UID-C");
+    enrollmentC.setUid(ENROLLMENT_C_UID.getValue());
     enrollmentC.setStatus(EnrollmentStatus.COMPLETED);
     enrollmentC.setOrganisationUnit(organisationUnitA);
     enrollmentD = new Enrollment(enrollmentDate, incidentDate, trackedEntityB, programA);
-    enrollmentD.setUid("UID-D");
+    enrollmentD.setUid(ENROLLMENT_D_UID.getValue());
     enrollmentD.setOrganisationUnit(organisationUnitB);
     eventA = new Event(enrollmentA, stageA);
-    eventA.setUid("UID-PSI-A");
+    eventA.setUid(EVENT_UID.getValue());
     eventA.setOrganisationUnit(organisationUnitA);
     eventA.setAttributeOptionCombo(coA);
 
@@ -242,8 +248,12 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
   void testGetEnrollmentByUid() {
     manager.save(enrollmentA);
     manager.save(enrollmentB);
-    assertEquals("UID-A", manager.get(Enrollment.class, "UID-A").getUid());
-    assertEquals("UID-B", manager.get(Enrollment.class, "UID-B").getUid());
+    assertEquals(
+        ENROLLMENT_A_UID.getValue(),
+        manager.get(Enrollment.class, ENROLLMENT_A_UID.getValue()).getUid());
+    assertEquals(
+        ENROLLMENT_B_UID.getValue(),
+        manager.get(Enrollment.class, ENROLLMENT_B_UID.getValue()).getUid());
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
@@ -66,11 +66,11 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Transactional
 class EnrollmentServiceTest extends PostgresIntegrationTestBase {
-  private static final UID ENROLLMENT_A_UID = UID.of(CodeGenerator.generateUid());
-  private static final UID ENROLLMENT_B_UID = UID.of(CodeGenerator.generateUid());
-  private static final UID ENROLLMENT_C_UID = UID.of(CodeGenerator.generateUid());
-  private static final UID ENROLLMENT_D_UID = UID.of(CodeGenerator.generateUid());
-  private static final UID EVENT_UID = UID.of(CodeGenerator.generateUid());
+  private static final String ENROLLMENT_A_UID = UID.of(CodeGenerator.generateUid()).getValue();
+  private static final String ENROLLMENT_B_UID = UID.of(CodeGenerator.generateUid()).getValue();
+  private static final String ENROLLMENT_C_UID = UID.of(CodeGenerator.generateUid()).getValue();
+  private static final String ENROLLMENT_D_UID = UID.of(CodeGenerator.generateUid()).getValue();
+  private static final String EVENT_UID = UID.of(CodeGenerator.generateUid()).getValue();
 
   @Autowired private EnrollmentService apiEnrollmentService;
 
@@ -167,21 +167,21 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
     testDate2.withTimeAtStartOfDay();
     enrollmentDate = testDate2.toDate();
     enrollmentA = new Enrollment(enrollmentDate, incidentDate, trackedEntityA, programA);
-    enrollmentA.setUid(ENROLLMENT_A_UID.getValue());
+    enrollmentA.setUid(ENROLLMENT_A_UID);
     enrollmentA.setOrganisationUnit(organisationUnitA);
     enrollmentB = new Enrollment(enrollmentDate, incidentDate, trackedEntityA, programB);
-    enrollmentB.setUid(ENROLLMENT_B_UID.getValue());
+    enrollmentB.setUid(ENROLLMENT_B_UID);
     enrollmentB.setStatus(EnrollmentStatus.CANCELLED);
     enrollmentB.setOrganisationUnit(organisationUnitB);
     enrollmentC = new Enrollment(enrollmentDate, incidentDate, trackedEntityA, programC);
-    enrollmentC.setUid(ENROLLMENT_C_UID.getValue());
+    enrollmentC.setUid(ENROLLMENT_C_UID);
     enrollmentC.setStatus(EnrollmentStatus.COMPLETED);
     enrollmentC.setOrganisationUnit(organisationUnitA);
     enrollmentD = new Enrollment(enrollmentDate, incidentDate, trackedEntityB, programA);
-    enrollmentD.setUid(ENROLLMENT_D_UID.getValue());
+    enrollmentD.setUid(ENROLLMENT_D_UID);
     enrollmentD.setOrganisationUnit(organisationUnitB);
     eventA = new Event(enrollmentA, stageA);
-    eventA.setUid(EVENT_UID.getValue());
+    eventA.setUid(EVENT_UID);
     eventA.setOrganisationUnit(organisationUnitA);
     eventA.setAttributeOptionCombo(coA);
 
@@ -248,12 +248,8 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
   void testGetEnrollmentByUid() {
     manager.save(enrollmentA);
     manager.save(enrollmentB);
-    assertEquals(
-        ENROLLMENT_A_UID.getValue(),
-        manager.get(Enrollment.class, ENROLLMENT_A_UID.getValue()).getUid());
-    assertEquals(
-        ENROLLMENT_B_UID.getValue(),
-        manager.get(Enrollment.class, ENROLLMENT_B_UID.getValue()).getUid());
+    assertEquals(ENROLLMENT_A_UID, manager.get(Enrollment.class, ENROLLMENT_A_UID).getUid());
+    assertEquals(ENROLLMENT_B_UID, manager.get(Enrollment.class, ENROLLMENT_B_UID).getUid());
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/relationship/hibernate/RelationshipStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/relationship/hibernate/RelationshipStoreTest.java
@@ -30,8 +30,6 @@ package org.hisp.dhis.relationship.hibernate;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import org.hisp.dhis.attribute.Attribute;
@@ -43,12 +41,7 @@ import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.commons.util.RelationshipUtils;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
-import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.EnrollmentStatus;
-import org.hisp.dhis.program.Event;
-import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
-import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.relationship.RelationshipItem;
@@ -95,61 +88,6 @@ class RelationshipStoreTest extends PostgresIntegrationTestBase {
     relationshipTypeService.addRelationshipType(relationshipType);
     organisationUnit = createOrganisationUnit("testOU");
     organisationUnitService.addOrganisationUnit(organisationUnit);
-  }
-
-  @Test
-  void testGetByTrackedEntity() {
-    Relationship teRelationship = addTeToTeRelationship();
-
-    List<Relationship> relationshipList =
-        relationshipService.getRelationshipsByTrackedEntity(trackedEntityA, false);
-
-    assertEquals(1, relationshipList.size());
-    assertTrue(relationshipList.contains(teRelationship));
-  }
-
-  @Test
-  void testGetByEvent() {
-    Program programA = addProgram();
-
-    Enrollment enrollment = addEnrollment(programA);
-
-    ProgramStage programStageA = addProgramStage(programA);
-
-    Event event = createEvent(programStageA, enrollment, organisationUnit);
-    manager.save(event);
-
-    trackedEntityA = createTrackedEntity(organisationUnit);
-    trackedEntityService.addTrackedEntity(trackedEntityA);
-
-    Relationship relationshipA = addTeToEventRelationship(trackedEntityA, event);
-
-    List<Relationship> relationshipList = relationshipService.getRelationshipsByEvent(event, false);
-
-    assertEquals(1, relationshipList.size());
-    assertTrue(relationshipList.contains(relationshipA));
-
-    assertTrue(relationshipService.getRelationshipByRelationship(relationshipA).isPresent());
-  }
-
-  @Test
-  void testGetByEnrollment() {
-    trackedEntityA = createTrackedEntity(organisationUnit);
-    trackedEntityService.addTrackedEntity(trackedEntityA);
-
-    Program programA = addProgram();
-
-    Enrollment enrollment = addEnrollment(programA);
-
-    Relationship relationshipA = addTeToEnrollmentRelationship(trackedEntityA, enrollment);
-
-    List<Relationship> relationshipList =
-        relationshipService.getRelationshipsByEnrollment(enrollment, false);
-
-    assertEquals(1, relationshipList.size());
-    assertTrue(relationshipList.contains(relationshipA));
-
-    assertTrue(relationshipService.getRelationshipByRelationship(relationshipA).isPresent());
   }
 
   @Test
@@ -210,65 +148,5 @@ class RelationshipStoreTest extends PostgresIntegrationTestBase {
         RelationshipUtils.generateRelationshipInvertedKey(teRelationship));
     relationshipService.addRelationship(teRelationship);
     return teRelationship;
-  }
-
-  private Relationship addTeToEventRelationship(TrackedEntity trackedEntity, Event event) {
-    RelationshipItem relationshipItemFrom = new RelationshipItem();
-    relationshipItemFrom.setTrackedEntity(trackedEntity);
-    RelationshipItem relationshipItemTo = new RelationshipItem();
-    relationshipItemTo.setEvent(event);
-
-    Relationship relationshipA = new Relationship();
-    relationshipA.setRelationshipType(relationshipType);
-    relationshipA.setFrom(relationshipItemFrom);
-    relationshipA.setTo(relationshipItemTo);
-    relationshipA.setKey(RelationshipUtils.generateRelationshipKey(relationshipA));
-    relationshipA.setInvertedKey(RelationshipUtils.generateRelationshipInvertedKey(relationshipA));
-
-    relationshipService.addRelationship(relationshipA);
-    return relationshipA;
-  }
-
-  private Relationship addTeToEnrollmentRelationship(
-      TrackedEntity trackedEntity, Enrollment enrollment) {
-    RelationshipItem relationshipItemFrom = new RelationshipItem();
-    relationshipItemFrom.setTrackedEntity(trackedEntity);
-    RelationshipItem relationshipItemTo = new RelationshipItem();
-    relationshipItemTo.setEnrollment(enrollment);
-
-    Relationship relationshipA = new Relationship();
-    relationshipA.setRelationshipType(relationshipType);
-    relationshipA.setFrom(relationshipItemFrom);
-    relationshipA.setTo(relationshipItemTo);
-    relationshipA.setKey(RelationshipUtils.generateRelationshipKey(relationshipA));
-    relationshipA.setInvertedKey(RelationshipUtils.generateRelationshipInvertedKey(relationshipA));
-
-    relationshipService.addRelationship(relationshipA);
-    return relationshipA;
-  }
-
-  private ProgramStage addProgramStage(Program programA) {
-    ProgramStage programStageA = createProgramStage('S', programA);
-    programStageA.setProgram(programA);
-    programStageService.saveProgramStage(programStageA);
-    programA.getProgramStages().add(programStageA);
-    return programStageA;
-  }
-
-  private Enrollment addEnrollment(Program programA) {
-    Enrollment enrollment = new Enrollment();
-    enrollment.setProgram(programA);
-    enrollment.setAutoFields();
-    enrollment.setEnrollmentDate(new Date());
-    enrollment.setOccurredDate(new Date());
-    enrollment.setStatus(EnrollmentStatus.ACTIVE);
-    manager.save(enrollment);
-    return enrollment;
-  }
-
-  private Program addProgram() {
-    Program programA = createProgram('A', new HashSet<>(), organisationUnit);
-    programService.addProgram(programA);
-    return programA;
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityServiceTest.java
@@ -35,9 +35,11 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.SortDirection;
+import org.hisp.dhis.common.UID;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
@@ -63,6 +65,13 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @author Chau Thu Tran
  */
 class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
+  private static final UID TE_A_UID = uidWithPrefix('A');
+  private static final UID TE_B_UID = uidWithPrefix('B');
+  private static final UID TE_C_UID = uidWithPrefix('C');
+  private static final UID TE_D_UID = uidWithPrefix('D');
+  private static final UID ENROLLMENT_A_UID = UID.of(CodeGenerator.generateUid());
+  private static final UID EVENT_A_UID = UID.of(CodeGenerator.generateUid());
+
   @Autowired private TrackedEntityService trackedEntityService;
 
   @Autowired private OrganisationUnitService organisationUnitService;
@@ -131,10 +140,10 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     trackedEntityB1 = createTrackedEntity(organisationUnit);
     trackedEntityC1 = createTrackedEntity(organisationUnit);
     trackedEntityD1 = createTrackedEntity(organisationUnit);
-    trackedEntityA1.setUid("UID-A1");
-    trackedEntityB1.setUid("UID-B1");
-    trackedEntityC1.setUid("UID-C1");
-    trackedEntityD1.setUid("UID-D1");
+    trackedEntityA1.setUid(TE_A_UID.getValue());
+    trackedEntityB1.setUid(TE_B_UID.getValue());
+    trackedEntityC1.setUid(TE_C_UID.getValue());
+    trackedEntityD1.setUid(TE_D_UID.getValue());
     program = createProgram('A', new HashSet<>(), organisationUnit);
     programService.addProgram(program);
     ProgramStage stageA = createProgramStage('A', program);
@@ -151,10 +160,10 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     incidentDate.withTimeAtStartOfDay();
     enrollment =
         new Enrollment(enrollmentDate.toDate(), incidentDate.toDate(), trackedEntityA1, program);
-    enrollment.setUid("UID-A");
+    enrollment.setUid(ENROLLMENT_A_UID.getValue());
     enrollment.setOrganisationUnit(organisationUnit);
     event = createEvent(stageA, enrollment, organisationUnit);
-    event.setUid("UID-Event-A");
+    event.setUid(EVENT_A_UID.getValue());
 
     trackedEntityType.setPublicAccess(AccessStringHelper.FULL);
     trackedEntityTypeService.addTrackedEntityType(trackedEntityType);
@@ -677,10 +686,10 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     programService.updateProgram(program);
 
     enrollment = new Enrollment(enrollmentDate, DateTime.now().toDate(), trackedEntity, program);
-    enrollment.setUid("UID-" + programStage);
+    enrollment.setUid(uidWithPrefix(programStage).getValue());
     enrollment.setOrganisationUnit(organisationUnit);
     event = new Event(enrollment, stage);
-    enrollment.setUid("UID-PSI-" + programStage);
+    enrollment.setUid(uidWithPrefix(programStage).getValue());
     enrollment.setOrganisationUnit(organisationUnit);
 
     manager.save(enrollment);
@@ -724,5 +733,10 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     trackedEntityAttributeValueA1.setValue(value);
 
     attributeValueService.addTrackedEntityAttributeValue(trackedEntityAttributeValueA1);
+  }
+
+  private static UID uidWithPrefix(char prefix) {
+    String value = prefix + CodeGenerator.generateUid().substring(0, 10);
+    return UID.of(value);
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityServiceTest.java
@@ -65,12 +65,12 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @author Chau Thu Tran
  */
 class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
-  private static final UID TE_A_UID = uidWithPrefix('A');
-  private static final UID TE_B_UID = uidWithPrefix('B');
-  private static final UID TE_C_UID = uidWithPrefix('C');
-  private static final UID TE_D_UID = uidWithPrefix('D');
-  private static final UID ENROLLMENT_A_UID = UID.of(CodeGenerator.generateUid());
-  private static final UID EVENT_A_UID = UID.of(CodeGenerator.generateUid());
+  private static final String TE_A_UID = uidWithPrefix('A');
+  private static final String TE_B_UID = uidWithPrefix('B');
+  private static final String TE_C_UID = uidWithPrefix('C');
+  private static final String TE_D_UID = uidWithPrefix('D');
+  private static final String ENROLLMENT_A_UID = UID.of(CodeGenerator.generateUid()).getValue();
+  private static final String EVENT_A_UID = UID.of(CodeGenerator.generateUid()).getValue();
 
   @Autowired private TrackedEntityService trackedEntityService;
 
@@ -140,10 +140,10 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     trackedEntityB1 = createTrackedEntity(organisationUnit);
     trackedEntityC1 = createTrackedEntity(organisationUnit);
     trackedEntityD1 = createTrackedEntity(organisationUnit);
-    trackedEntityA1.setUid(TE_A_UID.getValue());
-    trackedEntityB1.setUid(TE_B_UID.getValue());
-    trackedEntityC1.setUid(TE_C_UID.getValue());
-    trackedEntityD1.setUid(TE_D_UID.getValue());
+    trackedEntityA1.setUid(TE_A_UID);
+    trackedEntityB1.setUid(TE_B_UID);
+    trackedEntityC1.setUid(TE_C_UID);
+    trackedEntityD1.setUid(TE_D_UID);
     program = createProgram('A', new HashSet<>(), organisationUnit);
     programService.addProgram(program);
     ProgramStage stageA = createProgramStage('A', program);
@@ -160,10 +160,10 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     incidentDate.withTimeAtStartOfDay();
     enrollment =
         new Enrollment(enrollmentDate.toDate(), incidentDate.toDate(), trackedEntityA1, program);
-    enrollment.setUid(ENROLLMENT_A_UID.getValue());
+    enrollment.setUid(ENROLLMENT_A_UID);
     enrollment.setOrganisationUnit(organisationUnit);
     event = createEvent(stageA, enrollment, organisationUnit);
-    event.setUid(EVENT_A_UID.getValue());
+    event.setUid(EVENT_A_UID);
 
     trackedEntityType.setPublicAccess(AccessStringHelper.FULL);
     trackedEntityTypeService.addTrackedEntityType(trackedEntityType);
@@ -686,10 +686,10 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     programService.updateProgram(program);
 
     enrollment = new Enrollment(enrollmentDate, DateTime.now().toDate(), trackedEntity, program);
-    enrollment.setUid(uidWithPrefix(programStage).getValue());
+    enrollment.setUid(uidWithPrefix(programStage));
     enrollment.setOrganisationUnit(organisationUnit);
     event = new Event(enrollment, stage);
-    enrollment.setUid(uidWithPrefix(programStage).getValue());
+    enrollment.setUid(uidWithPrefix(programStage));
     enrollment.setOrganisationUnit(organisationUnit);
 
     manager.save(enrollment);
@@ -735,8 +735,8 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     attributeValueService.addTrackedEntityAttributeValue(trackedEntityAttributeValueA1);
   }
 
-  private static UID uidWithPrefix(char prefix) {
+  private static String uidWithPrefix(char prefix) {
     String value = prefix + CodeGenerator.generateUid().substring(0, 10);
-    return UID.of(value);
+    return UID.of(value).getValue();
   }
 }


### PR DESCRIPTION
## Big picture

Tracker has multiple services for each entity like tracked entity, enrollment, event and relationship. One is in dhis-api and one in dhis-service-tracker. Our goal is to provide one API (service) per entity that is part of the tracker domain/team.

Trackers architecture splits read/write into exporter services and an importer. So if you want to get data you use an exporter. If you want to insert, update or delete you have to go through the importer. Only then can we ensure integrity of tracker data.

Another goal is that code that provides tracker functionality and is thus owned by the tracker team lives in ideally one maven module (We can settle on a name later on maybe `dhis-service-tracker` or `dhis-tracker`).

This is a **big** task that we are going to implement in many small steps.

## This PR
Remove `getRelationshipBy` getters from `RelationshipService` that were used in tests and in `TrackerObjectDeletionService`, use `RelationshipStore` from tracker instead.
We cannot use relationship exporter here as we need to get and delete relationships that can potentially be inaccessible to the user. In the importer there is a validation to check the `CASCADE` authority that allows to delete everything under the entity being deleted.