### PR TITLE
chore: Remove get by uids from RelationshipService [DHIS2-17713]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipService.java
@@ -28,8 +28,6 @@
 package org.hisp.dhis.relationship;
 
 import java.util.List;
-import java.util.Optional;
-import javax.annotation.Nonnull;
 
 /**
  * @author Abyot Asalefew
@@ -44,18 +42,6 @@ public interface RelationshipService {
    * @return id of the added relationship.
    */
   long addRelationship(Relationship relationship);
-
-  /**
-   * Fetches a {@link Relationship} based on a relationship identifying attributes:
-   *
-   * <p>- relationship type - from - to
-   *
-   * @param relationship A valid Relationship
-   * @return an Optional Relationship
-   */
-  Optional<Relationship> getRelationshipByRelationship(Relationship relationship);
-
-  List<Relationship> getRelationships(@Nonnull List<String> uids);
 
   List<Relationship> getRelationshipsByRelationshipType(RelationshipType relationshipType);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipStore.java
@@ -38,16 +38,6 @@ public interface RelationshipStore extends IdentifiableObjectStore<Relationship>
 
   List<Relationship> getByRelationshipType(RelationshipType relationshipType);
 
-  /**
-   * Fetches a {@link Relationship} based on a relationship identifying attributes: - relationship
-   * type - from - to
-   *
-   * @param relationship A valid Relationship
-   * @return a {@link Relationship} or null if no Relationship is found matching the identifying
-   *     criterias
-   */
-  Relationship getByRelationship(Relationship relationship);
-
   List<String> getUidsByRelationshipKeys(List<String> relationshipKeyList);
 
   List<Relationship> getByUidsIncludeDeleted(List<String> uids);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/DefaultRelationshipService.java
@@ -27,11 +27,7 @@
  */
 package org.hisp.dhis.relationship;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.List;
-import java.util.Optional;
-import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -59,23 +55,7 @@ public class DefaultRelationshipService implements RelationshipService {
 
   @Override
   @Transactional(readOnly = true)
-  public List<Relationship> getRelationships(@Nonnull List<String> uids) {
-    return relationshipStore.getByUid(uids);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
   public List<Relationship> getRelationshipsByRelationshipType(RelationshipType relationshipType) {
     return relationshipStore.getByRelationshipType(relationshipType);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public Optional<Relationship> getRelationshipByRelationship(Relationship relationship) {
-    checkNotNull(relationship.getFrom());
-    checkNotNull(relationship.getTo());
-    checkNotNull(relationship.getRelationshipType());
-
-    return Optional.ofNullable(relationshipStore.getByRelationship(relationship));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelper.java
@@ -39,11 +39,11 @@ import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.commons.collection.ListUtils;
 import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.relationship.RelationshipItem;
-import org.hisp.dhis.relationship.RelationshipService;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.security.acl.AclService;
@@ -51,6 +51,7 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
+import org.hisp.dhis.tracker.export.relationship.RelationshipService;
 import org.hisp.dhis.user.CurrentUserUtil;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
@@ -255,7 +256,7 @@ public class DeduplicationHelper {
 
   public String getUserAccessErrors(
       TrackedEntity original, TrackedEntity duplicate, MergeObject mergeObject)
-      throws ForbiddenException {
+      throws ForbiddenException, NotFoundException {
 
     UserDetails currentUserDetails = CurrentUserUtil.getCurrentUserDetails();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DeduplicationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DeduplicationService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.tracker.deduplication;
 
 import java.util.List;
 import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.feedback.NotFoundException;
 
 public interface DeduplicationService {
   PotentialDuplicate getPotentialDuplicateById(long id);
@@ -49,10 +50,12 @@ public interface DeduplicationService {
   void autoMerge(DeduplicationMergeParams deduplicationRequest)
       throws PotentialDuplicateConflictException,
           PotentialDuplicateForbiddenException,
-          ForbiddenException;
+          ForbiddenException,
+          NotFoundException;
 
   void manualMerge(DeduplicationMergeParams deduplicationRequest)
       throws PotentialDuplicateConflictException,
           PotentialDuplicateForbiddenException,
-          ForbiddenException;
+          ForbiddenException,
+          NotFoundException;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DefaultDeduplicationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/deduplication/DefaultDeduplicationService.java
@@ -99,7 +99,8 @@ public class DefaultDeduplicationService implements DeduplicationService {
   public void autoMerge(DeduplicationMergeParams params)
       throws PotentialDuplicateConflictException,
           PotentialDuplicateForbiddenException,
-          ForbiddenException {
+          ForbiddenException,
+          NotFoundException {
     String autoMergeConflicts =
         getAutoMergeConflictErrors(params.getOriginal(), params.getDuplicate());
 
@@ -119,7 +120,8 @@ public class DefaultDeduplicationService implements DeduplicationService {
   public void manualMerge(DeduplicationMergeParams deduplicationMergeParams)
       throws PotentialDuplicateConflictException,
           PotentialDuplicateForbiddenException,
-          ForbiddenException {
+          ForbiddenException,
+          NotFoundException {
     String invalidReference =
         deduplicationHelper.getInvalidReferenceErrors(deduplicationMergeParams);
     if (invalidReference != null) {
@@ -155,7 +157,7 @@ public class DefaultDeduplicationService implements DeduplicationService {
   }
 
   private void merge(DeduplicationMergeParams params)
-      throws PotentialDuplicateForbiddenException, ForbiddenException {
+      throws PotentialDuplicateForbiddenException, ForbiddenException, NotFoundException {
     TrackedEntity original = params.getOriginal();
     TrackedEntity duplicate = params.getDuplicate();
     MergeObject mergeObject = params.getMergeObject();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/DefaultRelationshipService.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.tracker.export.relationship;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
@@ -88,6 +89,16 @@ public class DefaultRelationshipService implements RelationshipService {
     }
 
     return map(relationship);
+  }
+
+  @Override
+  public List<Relationship> getRelationships(@Nonnull List<String> uids)
+      throws ForbiddenException, NotFoundException {
+    List<Relationship> relationships = new ArrayList<>();
+    for (String uid : uids) {
+      relationships.add(getRelationship(uid));
+    }
+    return relationships;
   }
 
   private List<Relationship> getRelationshipsByTrackedEntity(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/export/relationship/RelationshipService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.tracker.export.relationship;
 
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.relationship.Relationship;
@@ -54,4 +55,11 @@ public interface RelationshipService {
   Set<String> getOrderableFields();
 
   Relationship getRelationship(String id) throws ForbiddenException, NotFoundException;
+
+  /**
+   * Get relationships matching given {@code UID}s under the privileges of the currently
+   * authenticated user.
+   */
+  List<Relationship> getRelationships(@Nonnull List<String> uids)
+      throws ForbiddenException, NotFoundException;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationHelperTest.java
@@ -39,13 +39,13 @@ import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.relationship.RelationshipItem;
-import org.hisp.dhis.relationship.RelationshipService;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.test.TestBase;
@@ -54,6 +54,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
+import org.hisp.dhis.tracker.export.relationship.RelationshipService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
@@ -103,7 +104,7 @@ class DeduplicationHelperTest extends TestBase {
   private UserDetails currentUserDetails;
 
   @BeforeEach
-  public void setUp() throws ForbiddenException {
+  public void setUp() throws ForbiddenException, NotFoundException {
     List<String> relationshipUids = Lists.newArrayList("REL_A", "REL_B");
     List<String> attributeUids = Lists.newArrayList("ATTR_A", "ATTR_B");
     List<String> enrollmentUids = Lists.newArrayList("PI_A", "PI_B");
@@ -144,7 +145,7 @@ class DeduplicationHelperTest extends TestBase {
   }
 
   @Test
-  void shouldHaveUserAccess() throws ForbiddenException {
+  void shouldHaveUserAccess() throws ForbiddenException, NotFoundException {
     when(userService.getUserByUsername(user.getUsername())).thenReturn(user);
 
     String hasUserAccess =
@@ -155,7 +156,7 @@ class DeduplicationHelperTest extends TestBase {
   }
 
   @Test
-  void shouldNotHaveUserAccessWhenUserIsNull() throws ForbiddenException {
+  void shouldNotHaveUserAccessWhenUserIsNull() throws ForbiddenException, NotFoundException {
     clearSecurityContext();
 
     String hasUserAccess =
@@ -167,7 +168,8 @@ class DeduplicationHelperTest extends TestBase {
   }
 
   @Test
-  void shouldNotHaveUserAccessWhenUserHasNoMergeRoles() throws ForbiddenException {
+  void shouldNotHaveUserAccessWhenUserHasNoMergeRoles()
+      throws ForbiddenException, NotFoundException {
     injectSecurityContext(UserDetails.fromUser(getNoMergeAuthsUser()));
 
     String hasUserAccess =
@@ -179,7 +181,8 @@ class DeduplicationHelperTest extends TestBase {
   }
 
   @Test
-  void shouldNotHaveUserAccessWhenUserHasNoAccessToOriginalTEType() throws ForbiddenException {
+  void shouldNotHaveUserAccessWhenUserHasNoAccessToOriginalTEType()
+      throws ForbiddenException, NotFoundException {
     when(aclService.canDataWrite(currentUserDetails, trackedEntityTypeA)).thenReturn(false);
 
     String hasUserAccess =
@@ -191,7 +194,8 @@ class DeduplicationHelperTest extends TestBase {
   }
 
   @Test
-  void shouldNotHaveUserAccessWhenUserHasNoAccessToDuplicateTEType() throws ForbiddenException {
+  void shouldNotHaveUserAccessWhenUserHasNoAccessToDuplicateTEType()
+      throws ForbiddenException, NotFoundException {
 
     when(aclService.canDataWrite(currentUserDetails, trackedEntityTypeB)).thenReturn(false);
     when(userService.getUserByUsername(user.getUsername())).thenReturn(user);
@@ -205,7 +209,8 @@ class DeduplicationHelperTest extends TestBase {
   }
 
   @Test
-  void shouldNotHaveUserAccessWhenUserHasNoAccessToRelationshipType() throws ForbiddenException {
+  void shouldNotHaveUserAccessWhenUserHasNoAccessToRelationshipType()
+      throws ForbiddenException, NotFoundException {
     when(aclService.canDataWrite(currentUserDetails, relationshipType)).thenReturn(false);
 
     String hasUserAccess =
@@ -217,7 +222,8 @@ class DeduplicationHelperTest extends TestBase {
   }
 
   @Test
-  void shouldNotHaveUserAccessWhenUserHasNoWriteAccessToEnrollment() throws ForbiddenException {
+  void shouldNotHaveUserAccessWhenUserHasNoWriteAccessToEnrollment()
+      throws ForbiddenException, NotFoundException {
     when(aclService.canDataWrite(currentUserDetails, enrollment.getProgram())).thenReturn(false);
 
     String hasUserAccess =
@@ -230,7 +236,7 @@ class DeduplicationHelperTest extends TestBase {
 
   @Test
   void shouldNotHaveUserAccessWhenUserHasNoCaptureScopeAccessToOriginalOrgUnit()
-      throws ForbiddenException {
+      throws ForbiddenException, NotFoundException {
     when(organisationUnitService.isInUserHierarchyCached(user, organisationUnitA))
         .thenReturn(false);
 
@@ -244,7 +250,7 @@ class DeduplicationHelperTest extends TestBase {
 
   @Test
   void shouldNotHaveUserAccessWhenUserHasNoCaptureScopeAccessToDuplicateOrgUnit()
-      throws ForbiddenException {
+      throws ForbiddenException, NotFoundException {
     when(organisationUnitService.isInUserHierarchyCached(user, organisationUnitB))
         .thenReturn(false);
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceTest.java
@@ -100,7 +100,7 @@ class DeduplicationServiceTest {
   private static final String teavSexFirstName = "John";
 
   @BeforeEach
-  void setUp() throws ForbiddenException {
+  void setUp() throws ForbiddenException, NotFoundException {
     PotentialDuplicate potentialDuplicate = new PotentialDuplicate("original", "duplicate");
     deduplicationMergeParams =
         DeduplicationMergeParams.builder()
@@ -270,7 +270,8 @@ class DeduplicationServiceTest {
   void shouldNotBeAutoMergeableNoUserAccess()
       throws PotentialDuplicateConflictException,
           PotentialDuplicateForbiddenException,
-          ForbiddenException {
+          ForbiddenException,
+          NotFoundException {
     MergeObject mergeObject = MergeObject.builder().build();
     when(deduplicationHelper.generateMergeObject(trackedEntityA, trackedEntityB))
         .thenReturn(mergeObject);
@@ -337,7 +338,8 @@ class DeduplicationServiceTest {
   void shouldThrowManualMergeableHasInvalidReference()
       throws PotentialDuplicateConflictException,
           PotentialDuplicateForbiddenException,
-          ForbiddenException {
+          ForbiddenException,
+          NotFoundException {
     when(deduplicationHelper.getInvalidReferenceErrors(deduplicationMergeParams))
         .thenReturn("Error");
     assertThrows(

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/relationship/hibernate/RelationshipStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/relationship/hibernate/RelationshipStoreTest.java
@@ -31,7 +31,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
-import java.util.Optional;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeService;
 import org.hisp.dhis.attribute.AttributeValue;
@@ -99,16 +98,6 @@ class RelationshipStoreTest extends PostgresIntegrationTestBase {
 
     assertEquals(1, relationshipList.size());
     assertTrue(relationshipList.contains(teRelationship));
-  }
-
-  @Test
-  void testGetByRelationship() {
-    Relationship teRelationship = addTeToTeRelationship();
-
-    Optional<Relationship> existing =
-        relationshipService.getRelationshipByRelationship(teRelationship);
-
-    assertTrue(existing.isPresent());
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceMergeIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceMergeIntegrationTest.java
@@ -37,6 +37,7 @@ import java.util.HashSet;
 import java.util.Map;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Enrollment;
@@ -74,7 +75,8 @@ class DeduplicationServiceMergeIntegrationTest extends PostgresIntegrationTestBa
   void shouldManualMergeWithAuthorityAll()
       throws PotentialDuplicateConflictException,
           PotentialDuplicateForbiddenException,
-          ForbiddenException {
+          ForbiddenException,
+          NotFoundException {
     OrganisationUnit ou = createOrganisationUnit("OU_A");
     organisationUnitService.addOrganisationUnit(ou);
     User user =
@@ -125,7 +127,8 @@ class DeduplicationServiceMergeIntegrationTest extends PostgresIntegrationTestBa
   void shouldManualMergeWithUserGroupOfProgram()
       throws PotentialDuplicateConflictException,
           PotentialDuplicateForbiddenException,
-          ForbiddenException {
+          ForbiddenException,
+          NotFoundException {
     OrganisationUnit ou = createOrganisationUnit("OU_A");
     organisationUnitService.addOrganisationUnit(ou);
     User user = createAndAddUser(true, "userB", ou, "F_TRACKED_ENTITY_MERGE");


### PR DESCRIPTION
## Big picture

Tracker has multiple services for each entity like tracked entity, enrollment, event and relationship. One is in dhis-api and one in dhis-service-tracker. Our goal is to provide one API (service) per entity that is part of the tracker domain/team.

Trackers architecture splits read/write into exporter services and an importer. So if you want to get data you use an exporter. If you want to insert, update or delete you have to go through the importer. Only then can we ensure integrity of tracker data.

Another goal is that code that provides tracker functionality and is thus owned by the tracker team lives in ideally one maven module (We can settle on a name later on maybe `dhis-service-tracker` or `dhis-tracker`).

This is a **big** task that we are going to implement in many small steps.

## This PR

Remove `Optional<Relationship> getRelationshipByRelationship(Relationship relationship);
` as it was not used anymore.
Move `List<Relationship> getRelationships(@Nonnull List<String> uids);` to tracker.
  