### PR TITLE
[DRAFT] Value type org unit in an attribute [2.40-DHIS2-17772]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -58,6 +58,7 @@ import org.hisp.dhis.analytics.common.ProgramIndicatorSubqueryBuilder;
 import org.hisp.dhis.analytics.event.EnrollmentAnalyticsManager;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.common.DimensionItemType;
 import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
@@ -629,6 +630,8 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
           + " "
           + LIMIT_1
           + " )";
+    } else if (isOrganizationUnitProgramAttribute(item)) {
+      return quoteAlias(colName + suffix);
     } else {
       return quoteAlias(colName);
     }
@@ -642,6 +645,16 @@ public class JdbcEnrollmentAnalyticsManager extends AbstractJdbcEventAnalyticsMa
   @Override
   protected String getColumn(QueryItem item) {
     return getColumn(item, "");
+  }
+
+  /**
+   * Returns true if the item is a program attribute and the value type is an organizational unit.
+   *
+   * @param item the {@link QueryItem}.
+   */
+  private boolean isOrganizationUnitProgramAttribute(QueryItem item) {
+    return item.getValueType() == ValueType.ORGANISATION_UNIT
+        && item.getItem().getDimensionItemType() == DimensionItemType.PROGRAM_ATTRIBUTE;
   }
 
   /**


### PR DESCRIPTION
When a user selects the value type "Org Unit" for an attribute, the line listing currently displays the UID of the organizational unit instead of its name. This behavior needs to be corrected so that the line listing shows the name of the organizational unit for better readability and usability.