### PR TITLE
chore: Create event program service and store [DHIS2-17712]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
@@ -44,13 +44,6 @@ public interface EnrollmentService {
    */
   void deleteEnrollment(Enrollment enrollment);
 
-  /**
-   * Hard deletes a {@link Enrollment}.
-   *
-   * @param enrollment the Enrollment to delete.
-   */
-  void hardDeleteEnrollment(Enrollment enrollment);
-
   /** Get enrollments into a program. */
   List<Enrollment> getEnrollments(Program program);
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventProgramService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventProgramService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2024, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,43 +27,8 @@
  */
 package org.hisp.dhis.program;
 
-import java.util.Date;
-import java.util.List;
-import org.hisp.dhis.common.IdentifiableObjectStore;
-import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
-import org.hisp.dhis.trackedentity.TrackedEntity;
+public interface EventProgramService {
 
-/**
- * @author Abyot Asalefew
- */
-public interface EnrollmentStore extends IdentifiableObjectStore<Enrollment> {
-  String ID = EnrollmentStore.class.getName();
-
-  /** Get enrollments into a program. */
-  List<Enrollment> get(Program program);
-
-  /** Get enrollments into a program that are in given status. */
-  List<Enrollment> get(Program program, EnrollmentStatus status);
-
-  /** Get a tracked entities enrollments into a program that are in given status. */
-  List<Enrollment> get(TrackedEntity trackedEntity, Program program, EnrollmentStatus status);
-
-  /**
-   * Fetches enrollments matching the given list of UIDs
-   *
-   * @param uids a List of UID
-   * @return a List containing the enrollments matching the given parameters list
-   */
-  List<Enrollment> getIncludingDeleted(List<String> uids);
-
-  /**
-   * Get all enrollments which have notifications with the given ProgramNotificationTemplate
-   * scheduled on the given date.
-   *
-   * @param template the template.
-   * @param notificationDate the Date for which the notification is scheduled.
-   * @return a list of enrollments.
-   */
-  List<Enrollment> getWithScheduledNotifications(
-      ProgramNotificationTemplate template, Date notificationDate);
+  /** Hard deletes a {@link Enrollment}. */
+  void hardDeleteEnrollment(Enrollment enrollment);
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventProgramStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventProgramStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2024, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,43 +27,10 @@
  */
 package org.hisp.dhis.program;
 
-import java.util.Date;
-import java.util.List;
 import org.hisp.dhis.common.IdentifiableObjectStore;
-import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
-import org.hisp.dhis.trackedentity.TrackedEntity;
 
-/**
- * @author Abyot Asalefew
- */
-public interface EnrollmentStore extends IdentifiableObjectStore<Enrollment> {
-  String ID = EnrollmentStore.class.getName();
+public interface EventProgramStore extends IdentifiableObjectStore<Enrollment> {
 
-  /** Get enrollments into a program. */
-  List<Enrollment> get(Program program);
-
-  /** Get enrollments into a program that are in given status. */
-  List<Enrollment> get(Program program, EnrollmentStatus status);
-
-  /** Get a tracked entities enrollments into a program that are in given status. */
-  List<Enrollment> get(TrackedEntity trackedEntity, Program program, EnrollmentStatus status);
-
-  /**
-   * Fetches enrollments matching the given list of UIDs
-   *
-   * @param uids a List of UID
-   * @return a List containing the enrollments matching the given parameters list
-   */
-  List<Enrollment> getIncludingDeleted(List<String> uids);
-
-  /**
-   * Get all enrollments which have notifications with the given ProgramNotificationTemplate
-   * scheduled on the given date.
-   *
-   * @param template the template.
-   * @param notificationDate the Date for which the notification is scheduled.
-   * @return a list of enrollments.
-   */
-  List<Enrollment> getWithScheduledNotifications(
-      ProgramNotificationTemplate template, Date notificationDate);
+  /** Hard deletes a {@link Enrollment}. */
+  void hardDelete(Enrollment enrollment);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
@@ -69,12 +69,6 @@ public class DefaultEnrollmentService implements EnrollmentService {
   }
 
   @Override
-  @Transactional
-  public void hardDeleteEnrollment(Enrollment enrollment) {
-    enrollmentStore.hardDelete(enrollment);
-  }
-
-  @Override
   @Transactional(readOnly = true)
   public List<Enrollment> getEnrollments(Program program) {
     return enrollmentStore.get(program);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventProgramService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventProgramService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2024, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,48 +27,16 @@
  */
 package org.hisp.dhis.program;
 
-import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
-
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-/**
- * @author Quang Nguyen
- */
-@Component
 @RequiredArgsConstructor
-public class EnrollmentDeletionHandler extends IdObjectDeletionHandler<Enrollment> {
-  private final EnrollmentService enrollmentService;
+@Service("org.hisp.dhis.program.EventProgramService")
+public class DefaultEventProgramService implements EventProgramService {
+  private final EventProgramStore eventProgramStore;
 
   @Override
-  protected void registerHandler() {
-    whenVetoing(Program.class, this::allowDeleteProgram);
-    whenDeleting(Program.class, this::deleteProgram);
-  }
-
-  private DeletionVeto allowDeleteProgram(Program program) {
-    if (program.isWithoutRegistration()) {
-      return ACCEPT;
-    }
-    String sql = "select 1 from enrollment where programid = :id limit 1";
-    return vetoIfExists(VETO, sql, Map.of("id", program.getId()));
-  }
-
-  private void deleteProgram(Program program) {
-    Collection<Enrollment> enrollments = enrollmentService.getEnrollments(program);
-
-    if (enrollments != null) {
-      Iterator<Enrollment> iterator = enrollments.iterator();
-      while (iterator.hasNext()) {
-        Enrollment enrollment = iterator.next();
-        iterator.remove();
-        enrollmentService.hardDeleteEnrollment(enrollment);
-      }
-    }
+  public void hardDeleteEnrollment(Enrollment enrollment) {
+    eventProgramStore.hardDelete(enrollment);
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEnrollmentStore.java
@@ -161,11 +161,6 @@ public class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enr
         .list();
   }
 
-  @Override
-  public void hardDelete(Enrollment enrollment) {
-    getSession().delete(enrollment);
-  }
-
   private String toDateProperty(NotificationTrigger trigger) {
     if (trigger == NotificationTrigger.SCHEDULED_DAYS_ENROLLMENT_DATE) {
       return "enrollmentDate";

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventProgramStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventProgramStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022, University of Oslo
+ * Copyright (c) 2004-2024, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -25,45 +25,31 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.program;
+package org.hisp.dhis.program.hibernate;
 
-import java.util.Date;
-import java.util.List;
-import org.hisp.dhis.common.IdentifiableObjectStore;
-import org.hisp.dhis.program.notification.ProgramNotificationTemplate;
-import org.hisp.dhis.trackedentity.TrackedEntity;
+import javax.persistence.EntityManager;
+import org.hisp.dhis.common.hibernate.SoftDeleteHibernateObjectStore;
+import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EventProgramStore;
+import org.hisp.dhis.security.acl.AclService;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.jdbc.core.JdbcTemplate;
 
-/**
- * @author Abyot Asalefew
- */
-public interface EnrollmentStore extends IdentifiableObjectStore<Enrollment> {
-  String ID = EnrollmentStore.class.getName();
+public class HibernateEventProgramStore extends SoftDeleteHibernateObjectStore<Enrollment>
+    implements EventProgramStore {
 
-  /** Get enrollments into a program. */
-  List<Enrollment> get(Program program);
+  public HibernateEventProgramStore(
+      EntityManager entityManager,
+      JdbcTemplate jdbcTemplate,
+      ApplicationEventPublisher publisher,
+      Class<Enrollment> clazz,
+      AclService aclService,
+      boolean cacheable) {
+    super(entityManager, jdbcTemplate, publisher, clazz, aclService, cacheable);
+  }
 
-  /** Get enrollments into a program that are in given status. */
-  List<Enrollment> get(Program program, EnrollmentStatus status);
-
-  /** Get a tracked entities enrollments into a program that are in given status. */
-  List<Enrollment> get(TrackedEntity trackedEntity, Program program, EnrollmentStatus status);
-
-  /**
-   * Fetches enrollments matching the given list of UIDs
-   *
-   * @param uids a List of UID
-   * @return a List containing the enrollments matching the given parameters list
-   */
-  List<Enrollment> getIncludingDeleted(List<String> uids);
-
-  /**
-   * Get all enrollments which have notifications with the given ProgramNotificationTemplate
-   * scheduled on the given date.
-   *
-   * @param template the template.
-   * @param notificationDate the Date for which the notification is scheduled.
-   * @return a list of enrollments.
-   */
-  List<Enrollment> getWithScheduledNotifications(
-      ProgramNotificationTemplate template, Date notificationDate);
+  @Override
+  public void hardDelete(Enrollment enrollment) {
+    getSession().delete(enrollment);
+  }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventProgramStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventProgramStore.java
@@ -34,7 +34,9 @@ import org.hisp.dhis.program.EventProgramStore;
 import org.hisp.dhis.security.acl.AclService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
 
+@Service("org.hisp.dhis.program.hibernate.HibernateEventProgramStore")
 public class HibernateEventProgramStore extends SoftDeleteHibernateObjectStore<Enrollment>
     implements EventProgramStore {
 
@@ -42,10 +44,8 @@ public class HibernateEventProgramStore extends SoftDeleteHibernateObjectStore<E
       EntityManager entityManager,
       JdbcTemplate jdbcTemplate,
       ApplicationEventPublisher publisher,
-      Class<Enrollment> clazz,
-      AclService aclService,
-      boolean cacheable) {
-    super(entityManager, jdbcTemplate, publisher, clazz, aclService, cacheable);
+      AclService aclService) {
+    super(entityManager, jdbcTemplate, publisher, Enrollment.class, aclService, true);
   }
 
   @Override

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventProgramEnrollmentDeletionHandlerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventProgramEnrollmentDeletionHandlerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.program;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.hisp.dhis.common.DeleteNotAllowedException;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.feedback.ForbiddenException;
+import org.hisp.dhis.feedback.NotFoundException;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
+import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.tracker.export.enrollment.EnrollmentService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class EventProgramEnrollmentDeletionHandlerTest extends PostgresIntegrationTestBase {
+  @Autowired ProgramService programService;
+  @Autowired EnrollmentService enrollmentService;
+  @Autowired IdentifiableObjectManager manager;
+
+  private OrganisationUnit orgUnit;
+  private TrackedEntity trackedEntity;
+
+  @BeforeEach
+  void setUp() {
+    orgUnit = createOrganisationUnit('O');
+    manager.save(orgUnit);
+    trackedEntity = createTrackedEntity(orgUnit);
+    manager.save(trackedEntity);
+  }
+
+  @Test
+  void shouldDeleteEnrollmentsWhenDeletingEventProgram()
+      throws ForbiddenException, NotFoundException {
+    Program program = createProgramWithoutRegistration('P');
+    programService.addProgram(program);
+    Enrollment enrollment = createEnrollment(program);
+
+    assertNotNull(enrollmentService.getEnrollment(enrollment.getUid()));
+
+    programService.deleteProgram(program);
+
+    assertThrows(
+        NotFoundException.class, () -> enrollmentService.getEnrollment(enrollment.getUid()));
+  }
+
+  @Test
+  void shouldNotDeleteEnrollmentsWhenDeletingTrackerProgram()
+      throws ForbiddenException, NotFoundException {
+    Program program = createProgram('P');
+    programService.addProgram(program);
+    Enrollment enrollment = createEnrollment(program);
+
+    assertNotNull(enrollmentService.getEnrollment(enrollment.getUid()));
+    assertThrows(DeleteNotAllowedException.class, () -> programService.deleteProgram(program));
+  }
+
+  private Enrollment createEnrollment(Program program) {
+    Enrollment enrollment = createEnrollment(program, trackedEntity, orgUnit);
+    manager.save(enrollment);
+
+    return enrollment;
+  }
+}


### PR DESCRIPTION
This PR continues the work of moving tracker-related code out of the API module. Specifically, it:

- Removes the `hardDeleteEnrollment` method from `EnrollmentService` and `EnrollmentStore`.
- Creates a new service and store called `EventProgramService` and `EventProgramStore`, respectively. Their goal is to handle CRUD operations on event programs.
- Ensures that `EventProgramEnrollmentDeletionHandler` deletes enrollments of event programs only.

