### PR TITLE
chore: Remove getIncludingDeleted from RelationshipStore [DHIS2-17713]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipStore.java
@@ -37,6 +37,4 @@ public interface RelationshipStore extends IdentifiableObjectStore<Relationship>
   String ID = RelationshipStore.class.getName();
 
   List<String> getUidsByRelationshipKeys(List<String> relationshipKeyList);
-
-  List<Relationship> getByUidsIncludeDeleted(List<String> uids);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/hibernate/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/hibernate/HibernateRelationshipStore.java
@@ -32,9 +32,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
-import javax.persistence.NoResultException;
 import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import org.apache.commons.collections4.CollectionUtils;
@@ -84,23 +82,6 @@ public class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<R
             .getResultList();
 
     return c.stream().map(String::valueOf).collect(Collectors.toList());
-  }
-
-  @Override
-  public List<Relationship> getByUidsIncludeDeleted(List<String> uids) {
-    CriteriaBuilder criteriaBuilder = getCriteriaBuilder();
-
-    CriteriaQuery<Relationship> query = criteriaBuilder.createQuery(Relationship.class);
-
-    Root<Relationship> root = query.from(Relationship.class);
-
-    query.where(criteriaBuilder.in(root.get("uid")).value(uids));
-
-    try {
-      return getSession().createQuery(query).getResultList();
-    } catch (NoResultException nre) {
-      return null;
-    }
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/strategy/RelationshipStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/strategy/RelationshipStrategy.java
@@ -52,12 +52,8 @@ public class RelationshipStrategy extends HibernateGenericStore<Relationship>
     implements ClassBasedSupplierStrategy {
 
   public RelationshipStrategy(
-      EntityManager entityManager,
-      JdbcTemplate jdbcTemplate,
-      ApplicationEventPublisher publisher,
-      Class<Relationship> clazz,
-      boolean cacheable) {
-    super(entityManager, jdbcTemplate, publisher, clazz, cacheable);
+      EntityManager entityManager, JdbcTemplate jdbcTemplate, ApplicationEventPublisher publisher) {
+    super(entityManager, jdbcTemplate, publisher, Relationship.class, false);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/strategy/RelationshipStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/strategy/RelationshipStrategy.java
@@ -27,30 +27,42 @@
  */
 package org.hisp.dhis.tracker.imports.preheat.supplier.strategy;
 
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
-import lombok.RequiredArgsConstructor;
+import javax.persistence.EntityManager;
 import org.hisp.dhis.common.CodeGenerator;
-import org.hisp.dhis.relationship.RelationshipStore;
-import org.hisp.dhis.tracker.imports.domain.Relationship;
+import org.hisp.dhis.hibernate.HibernateGenericStore;
+import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.preheat.mappers.RelationshipMapper;
 import org.hisp.dhis.tracker.imports.preheat.supplier.DetachUtils;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Luciano Fiandesio
  */
-@RequiredArgsConstructor
 @Component
-@StrategyFor(value = Relationship.class, mapper = RelationshipMapper.class)
-public class RelationshipStrategy implements ClassBasedSupplierStrategy {
-  @Nonnull private final RelationshipStore relationshipStore;
+@StrategyFor(
+    value = org.hisp.dhis.tracker.imports.domain.Relationship.class,
+    mapper = RelationshipMapper.class)
+public class RelationshipStrategy extends HibernateGenericStore<Relationship>
+    implements ClassBasedSupplierStrategy {
+
+  public RelationshipStrategy(
+      EntityManager entityManager,
+      JdbcTemplate jdbcTemplate,
+      ApplicationEventPublisher publisher,
+      Class<Relationship> clazz,
+      boolean cacheable) {
+    super(entityManager, jdbcTemplate, publisher, clazz, cacheable);
+  }
 
   @Override
   public void add(List<List<String>> splitList, TrackerPreheat preheat) {
-    List<org.hisp.dhis.relationship.Relationship> relationships = retrieveRelationships(splitList);
+    List<Relationship> relationships = retrieveRelationships(splitList);
 
     preheat.putRelationships(
         DetachUtils.detach(
@@ -60,11 +72,25 @@ public class RelationshipStrategy implements ClassBasedSupplierStrategy {
   private List<org.hisp.dhis.relationship.Relationship> retrieveRelationships(
       List<List<String>> splitList) {
     List<String> uids =
-        splitList.stream()
-            .flatMap(List::stream)
-            .filter(CodeGenerator::isValidUid)
-            .collect(Collectors.toList());
+        splitList.stream().flatMap(List::stream).filter(CodeGenerator::isValidUid).toList();
 
-    return relationshipStore.getByUidsIncludeDeleted(uids);
+    return getIncludingDeleted(uids);
+  }
+
+  private List<Relationship> getIncludingDeleted(List<String> uids) {
+    List<Relationship> relationships = new ArrayList<>();
+    List<List<String>> uidsPartitions = Lists.partition(Lists.newArrayList(uids), 20000);
+
+    for (List<String> uidsPartition : uidsPartitions) {
+      if (!uidsPartition.isEmpty()) {
+        relationships.addAll(
+            getSession()
+                .createQuery("from Relationship as r where r.uid in (:uids)", Relationship.class)
+                .setParameter("uids", uidsPartition)
+                .list());
+      }
+    }
+
+    return relationships;
   }
 }


### PR DESCRIPTION
## Big picture

Tracker has multiple services for each entity like tracked entity, enrollment, event and relationship. One is in dhis-api and one in dhis-service-tracker. Our goal is to provide one API (service) per entity that is part of the tracker domain/team.

Trackers architecture splits read/write into exporter services and an importer. So if you want to get data you use an exporter. If you want to insert, update or delete you have to go through the importer. Only then can we ensure integrity of tracker data.

Another goal is that code that provides tracker functionality and is thus owned by the tracker team lives in ideally one maven module (We can settle on a name later on maybe `dhis-service-tracker` or `dhis-tracker`).

This is a **big** task that we are going to implement in many small steps.

## This PR

Implement `getByUidsIncludeDeleted` directly in `RelationshipStrategy`