### PR TITLE
chore: Remove getIncludingDeleted [DHIS-17712]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentStore.java
@@ -49,14 +49,6 @@ public interface EnrollmentStore extends IdentifiableObjectStore<Enrollment> {
   List<Enrollment> get(TrackedEntity trackedEntity, Program program, EnrollmentStatus status);
 
   /**
-   * Fetches enrollments matching the given list of UIDs
-   *
-   * @param uids a List of UID
-   * @return a List containing the enrollments matching the given parameters list
-   */
-  List<Enrollment> getIncludingDeleted(List<String> uids);
-
-  /**
    * Get all enrollments which have notifications with the given ProgramNotificationTemplate
    * scheduled on the given date.
    *

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEnrollmentStore.java
@@ -58,8 +58,6 @@ import org.springframework.stereotype.Repository;
 @Repository("org.hisp.dhis.program.EnrollmentStore")
 public class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enrollment>
     implements EnrollmentStore {
-  private static final String PI_HQL_BY_UIDS = "from Enrollment as en where en.uid in (:uids)";
-
   private static final String STATUS = "status";
 
   private static final Set<NotificationTrigger> SCHEDULED_ENROLLMENT_TRIGGERS =

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEnrollmentStore.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.program.hibernate;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -107,24 +106,6 @@ public class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enr
             .addPredicate(root -> builder.equal(root.get("trackedEntity"), trackedEntity))
             .addPredicate(root -> builder.equal(root.get("program"), program))
             .addPredicate(root -> builder.equal(root.get(STATUS), status)));
-  }
-
-  @Override
-  public List<Enrollment> getIncludingDeleted(List<String> uids) {
-    List<Enrollment> enrollments = new ArrayList<>();
-    List<List<String>> uidsPartitions = Lists.partition(Lists.newArrayList(uids), 20000);
-
-    for (List<String> uidsPartition : uidsPartitions) {
-      if (!uidsPartition.isEmpty()) {
-        enrollments.addAll(
-            getSession()
-                .createQuery(PI_HQL_BY_UIDS, Enrollment.class)
-                .setParameter("uids", uidsPartition)
-                .list());
-      }
-    }
-
-    return enrollments;
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/strategy/EnrollmentStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/strategy/EnrollmentStrategy.java
@@ -33,7 +33,6 @@ import java.util.List;
 import javax.persistence.EntityManager;
 import org.hisp.dhis.hibernate.HibernateGenericStore;
 import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.Event;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.preheat.mappers.EnrollmentMapper;
 import org.hisp.dhis.tracker.imports.preheat.supplier.DetachUtils;
@@ -48,16 +47,12 @@ import org.springframework.stereotype.Component;
 @StrategyFor(
     value = org.hisp.dhis.tracker.imports.domain.Enrollment.class,
     mapper = EnrollmentMapper.class)
-public class EnrollmentStrategy extends HibernateGenericStore<Event>
+public class EnrollmentStrategy extends HibernateGenericStore<Enrollment>
     implements ClassBasedSupplierStrategy {
 
   public EnrollmentStrategy(
-      EntityManager entityManager,
-      JdbcTemplate jdbcTemplate,
-      ApplicationEventPublisher publisher,
-      Class<Event> clazz,
-      boolean cacheable) {
-    super(entityManager, jdbcTemplate, publisher, clazz, cacheable);
+      EntityManager entityManager, JdbcTemplate jdbcTemplate, ApplicationEventPublisher publisher) {
+    super(entityManager, jdbcTemplate, publisher, Enrollment.class, false);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/strategy/EnrollmentStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/preheat/supplier/strategy/EnrollmentStrategy.java
@@ -27,35 +27,64 @@
  */
 package org.hisp.dhis.tracker.imports.preheat.supplier.strategy;
 
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Nonnull;
-import lombok.RequiredArgsConstructor;
+import javax.persistence.EntityManager;
+import org.hisp.dhis.hibernate.HibernateGenericStore;
 import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.EnrollmentStore;
+import org.hisp.dhis.program.Event;
 import org.hisp.dhis.tracker.imports.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.imports.preheat.mappers.EnrollmentMapper;
 import org.hisp.dhis.tracker.imports.preheat.supplier.DetachUtils;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Luciano Fiandesio
  */
-@RequiredArgsConstructor
 @Component
 @StrategyFor(
     value = org.hisp.dhis.tracker.imports.domain.Enrollment.class,
     mapper = EnrollmentMapper.class)
-public class EnrollmentStrategy implements ClassBasedSupplierStrategy {
-  @Nonnull private final EnrollmentStore enrollmentStore;
+public class EnrollmentStrategy extends HibernateGenericStore<Event>
+    implements ClassBasedSupplierStrategy {
+
+  public EnrollmentStrategy(
+      EntityManager entityManager,
+      JdbcTemplate jdbcTemplate,
+      ApplicationEventPublisher publisher,
+      Class<Event> clazz,
+      boolean cacheable) {
+    super(entityManager, jdbcTemplate, publisher, clazz, cacheable);
+  }
 
   @Override
   public void add(List<List<String>> splitList, TrackerPreheat preheat) {
     for (List<String> ids : splitList) {
-      List<Enrollment> enrollments = enrollmentStore.getIncludingDeleted(ids);
+      List<Enrollment> enrollments = getIncludingDeleted(ids);
 
       preheat.putEnrollments(
           DetachUtils.detach(
               this.getClass().getAnnotation(StrategyFor.class).mapper(), enrollments));
     }
+  }
+
+  private List<Enrollment> getIncludingDeleted(List<String> uids) {
+    List<Enrollment> enrollments = new ArrayList<>();
+    List<List<String>> uidsPartitions = Lists.partition(Lists.newArrayList(uids), 20000);
+
+    for (List<String> uidsPartition : uidsPartitions) {
+      if (!uidsPartition.isEmpty()) {
+        enrollments.addAll(
+            getSession()
+                .createQuery("from Enrollment as e where e.uid in (:uids)", Enrollment.class)
+                .setParameter("uids", uidsPartition)
+                .list());
+      }
+    }
+
+    return enrollments;
   }
 }


### PR DESCRIPTION
This PR continues the work of moving tracker-related code out of the API module. Specifically, it:

- Removes the `getIncludingDeleted` method from `EnrollmentStore`. It's used just in `EnrollmentStrategy`, and a sql query will be triggered directly from there.
