### PR TITLE
chore: Remove method hardDeleteEnrollment [DHIS2-17721]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
@@ -44,13 +44,6 @@ public interface EnrollmentService {
    */
   void deleteEnrollment(Enrollment enrollment);
 
-  /**
-   * Hard deletes a {@link Enrollment}.
-   *
-   * @param enrollment the Enrollment to delete.
-   */
-  void hardDeleteEnrollment(Enrollment enrollment);
-
   /** Get enrollments into a program. */
   List<Enrollment> getEnrollments(Program program);
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentStore.java
@@ -58,11 +58,4 @@ public interface EnrollmentStore extends IdentifiableObjectStore<Enrollment> {
    */
   List<Enrollment> getWithScheduledNotifications(
       ProgramNotificationTemplate template, Date notificationDate);
-
-  /**
-   * Hard deletes a {@link Enrollment}.
-   *
-   * @param enrollment the enrollment to delete.
-   */
-  void hardDelete(Enrollment enrollment);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
@@ -69,12 +69,6 @@ public class DefaultEnrollmentService implements EnrollmentService {
   }
 
   @Override
-  @Transactional
-  public void hardDeleteEnrollment(Enrollment enrollment) {
-    enrollmentStore.hardDelete(enrollment);
-  }
-
-  @Override
   @Transactional(readOnly = true)
   public List<Enrollment> getEnrollments(Program program) {
     return enrollmentStore.get(program);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/EnrollmentDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/EnrollmentDeletionHandler.java
@@ -60,6 +60,10 @@ public class EnrollmentDeletionHandler extends IdObjectDeletionHandler<Enrollmen
   }
 
   private void deleteProgram(Program program) {
+    if (program.isRegistration()) {
+      return;
+    }
+
     Collection<Enrollment> enrollments = enrollmentService.getEnrollments(program);
 
     if (enrollments != null) {
@@ -67,7 +71,7 @@ public class EnrollmentDeletionHandler extends IdObjectDeletionHandler<Enrollmen
       while (iterator.hasNext()) {
         Enrollment enrollment = iterator.next();
         iterator.remove();
-        enrollmentService.hardDeleteEnrollment(enrollment);
+        idObjectManager.delete(enrollment);
       }
     }
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/EnrollmentDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/EnrollmentDeletionHandler.java
@@ -29,8 +29,6 @@ package org.hisp.dhis.program;
 
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.system.deletion.DeletionVeto;
@@ -64,15 +62,6 @@ public class EnrollmentDeletionHandler extends IdObjectDeletionHandler<Enrollmen
       return;
     }
 
-    Collection<Enrollment> enrollments = enrollmentService.getEnrollments(program);
-
-    if (enrollments != null) {
-      Iterator<Enrollment> iterator = enrollments.iterator();
-      while (iterator.hasNext()) {
-        Enrollment enrollment = iterator.next();
-        iterator.remove();
-        idObjectManager.delete(enrollment);
-      }
-    }
+    delete("delete from enrollment where programid = :id", Map.of("id", program.getId()));
   }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEnrollmentStore.java
@@ -140,11 +140,6 @@ public class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enr
         .list();
   }
 
-  @Override
-  public void hardDelete(Enrollment enrollment) {
-    getSession().delete(enrollment);
-  }
-
   private String toDateProperty(NotificationTrigger trigger) {
     if (trigger == NotificationTrigger.SCHEDULED_DAYS_ENROLLMENT_DATE) {
       return "enrollmentDate";


### PR DESCRIPTION
This PR continues the work of moving tracker-related code out of the API module. Specifically, it:

- Removes the hardDeleteEnrollment method from EnrollmentService and EnrollmentStore.
- Removes the ceremony around deleting an event program enrollment.

