### PR TITLE
chore: Remove getEnrollments(Program) [DHIS2-17712]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentService.java
@@ -37,9 +37,6 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
  */
 public interface EnrollmentService {
 
-  /** Get enrollments into a program. */
-  List<Enrollment> getEnrollments(Program program);
-
   /** Get enrollments into a program that are in given status. */
   List<Enrollment> getEnrollments(Program program, EnrollmentStatus status);
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventProgramEnrollmentService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventProgramEnrollmentService.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.program;
+
+import java.util.List;
+
+/**
+ * This service is intended as a temporary solution until we separate event programs from tracker
+ * programs. Once they become distinct entities and event programs no longer require a placeholder
+ * enrollment, this service should be discontinued.
+ */
+public interface EventProgramEnrollmentService {
+
+  /** Returns a list of enrollments in the given program. */
+  List<Enrollment> getEnrollments(Program program);
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventProgramEnrollmentStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventProgramEnrollmentStore.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.program;
+
+import java.util.List;
+
+/**
+ * This store is intended as a temporary solution until we separate event programs from tracker
+ * programs. Once they become distinct entities and event programs no longer require a placeholder
+ * enrollment, this store should be discontinued.
+ */
+public interface EventProgramEnrollmentStore {
+
+  List<Enrollment> get(Program program);
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/copy/CopyService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/copy/CopyService.java
@@ -42,7 +42,7 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
 import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.EnrollmentService;
+import org.hisp.dhis.program.EventProgramEnrollmentService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramIndicatorService;
@@ -91,7 +91,7 @@ public class CopyService {
 
   private final ProgramRuleVariableService programRuleVariableService;
 
-  private final EnrollmentService enrollmentService;
+  private final EventProgramEnrollmentService eventProgramEnrollmentService;
 
   private final AclService aclService;
 
@@ -210,7 +210,7 @@ public class CopyService {
 
   private void copyEnrollments(Program original, Program copy) {
     List<Enrollment> enrollments =
-        copyList(copy, enrollmentService.getEnrollments(original), Enrollment.copyOf);
+        copyList(copy, eventProgramEnrollmentService.getEnrollments(original), Enrollment.copyOf);
     enrollments.forEach(identifiableObjectManager::save);
   }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEnrollmentService.java
@@ -62,12 +62,6 @@ public class DefaultEnrollmentService implements EnrollmentService {
 
   @Override
   @Transactional(readOnly = true)
-  public List<Enrollment> getEnrollments(Program program) {
-    return enrollmentStore.get(program);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
   public List<Enrollment> getEnrollments(Program program, EnrollmentStatus status) {
     return enrollmentStore.get(program, status);
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventProgramEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventProgramEnrollmentService.java
@@ -38,7 +38,8 @@ public class DefaultEventProgramEnrollmentService implements EventProgramEnrollm
   private final EventProgramEnrollmentStore eventProgramEnrollmentStore;
 
   @Override
-  // TODO The CopyService is currently copying enrollments from tracker programs. We need to discuss
+  // TODO(tracker) The CopyService is currently copying enrollments from tracker programs. We need
+  // to discuss
   // if that's correct. Seems to make more sense to copy enrollments from event programs only.
   public List<Enrollment> getEnrollments(Program program) {
     return eventProgramEnrollmentStore.get(program);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventProgramEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventProgramEnrollmentService.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.program;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service("org.hisp.dhis.program.DefaultEventProgramEnrollmentService")
+public class DefaultEventProgramEnrollmentService implements EventProgramEnrollmentService {
+
+  private final EventProgramEnrollmentStore eventProgramEnrollmentStore;
+
+  @Override
+  // TODO The CopyService is currently copying enrollments from tracker programs. We need to discuss
+  // if that's correct. Seems to make more sense to copy enrollments from event programs only.
+  public List<Enrollment> getEnrollments(Program program) {
+    return eventProgramEnrollmentStore.get(program);
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventProgramEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventProgramEnrollmentStore.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.program.hibernate;
+
+import java.util.List;
+import javax.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.Session;
+import org.hisp.dhis.program.Enrollment;
+import org.hisp.dhis.program.EventProgramEnrollmentStore;
+import org.hisp.dhis.program.Program;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository("org.hisp.dhis.program.EventProgramEnrollmentStore")
+public class HibernateEventProgramEnrollmentStore implements EventProgramEnrollmentStore {
+
+  private final EntityManager entityManager;
+
+  @Override
+  public List<Enrollment> get(Program program) {
+    try (Session session = entityManager.unwrap(Session.class)) {
+
+      return session
+          .createQuery("from Enrollment e where e.program.uid = :programUid", Enrollment.class)
+          .setParameter("programUid", program.getUid())
+          .list();
+    }
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/copy/CopyServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/copy/CopyServiceTest.java
@@ -59,7 +59,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.period.PeriodTypeEnum;
 import org.hisp.dhis.program.Enrollment;
-import org.hisp.dhis.program.EnrollmentService;
+import org.hisp.dhis.program.EventProgramEnrollmentService;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramIndicatorService;
@@ -106,7 +106,7 @@ class CopyServiceTest extends TestBase {
 
   @Mock private ProgramRuleVariableService programRuleVariableService;
 
-  @Mock private EnrollmentService enrollmentService;
+  @Mock private EventProgramEnrollmentService eventProgramEnrollmentService;
 
   @Mock private AclService aclService;
 
@@ -139,7 +139,7 @@ class CopyServiceTest extends TestBase {
     when(aclService.canWrite(UserDetails.fromUser(user), original)).thenReturn(true);
     injectSecurityContext(UserDetails.fromUser(user));
 
-    when(enrollmentService.getEnrollments(original)).thenReturn(originalEnrollments);
+    when(eventProgramEnrollmentService.getEnrollments(original)).thenReturn(originalEnrollments);
 
     Program programCopy = copyService.copyProgram(VALID_PROGRAM_UID, Map.of());
 
@@ -305,7 +305,7 @@ class CopyServiceTest extends TestBase {
   void testCopyProgramFromUidWithValidProgramAndNullEnrollments()
       throws NotFoundException, ForbiddenException {
     when(programService.getProgram(VALID_PROGRAM_UID)).thenReturn(original);
-    when(enrollmentService.getEnrollments(original)).thenReturn(null);
+    when(eventProgramEnrollmentService.getEnrollments(original)).thenReturn(null);
 
     when(aclService.canWrite(UserDetails.fromUser(user), original)).thenReturn(true);
     injectSecurityContext(UserDetails.fromUser(user));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
@@ -74,6 +74,8 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
   @Autowired private org.hisp.dhis.program.EnrollmentService apiEnrollmentService;
 
+  @Autowired private EventProgramEnrollmentService eventProgramEnrollmentService;
+
   @Autowired private EnrollmentService enrollmentService;
 
   @Autowired private TrackedEntityService trackedEntityService;
@@ -242,11 +244,11 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
     manager.save(enrollmentA);
     manager.save(enrollmentB);
     manager.save(enrollmentD);
-    List<Enrollment> enrollments = apiEnrollmentService.getEnrollments(programA);
+    List<Enrollment> enrollments = eventProgramEnrollmentService.getEnrollments(programA);
     assertEquals(2, enrollments.size());
     assertTrue(enrollments.contains(enrollmentA));
     assertTrue(enrollments.contains(enrollmentD));
-    enrollments = apiEnrollmentService.getEnrollments(programB);
+    enrollments = eventProgramEnrollmentService.getEnrollments(programB);
     assertEquals(1, enrollments.size());
     assertTrue(enrollments.contains(enrollmentB));
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentServiceTest.java
@@ -74,8 +74,6 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
 
   @Autowired private org.hisp.dhis.program.EnrollmentService apiEnrollmentService;
 
-  @Autowired private EventProgramEnrollmentService eventProgramEnrollmentService;
-
   @Autowired private EnrollmentService enrollmentService;
 
   @Autowired private TrackedEntityService trackedEntityService;
@@ -237,20 +235,6 @@ class EnrollmentServiceTest extends PostgresIntegrationTestBase {
     manager.save(enrollmentB);
     assertEquals(ENROLLMENT_A_UID, manager.get(Enrollment.class, ENROLLMENT_A_UID).getUid());
     assertEquals(ENROLLMENT_B_UID, manager.get(Enrollment.class, ENROLLMENT_B_UID).getUid());
-  }
-
-  @Test
-  void testGetEnrollmentsByProgram() {
-    manager.save(enrollmentA);
-    manager.save(enrollmentB);
-    manager.save(enrollmentD);
-    List<Enrollment> enrollments = eventProgramEnrollmentService.getEnrollments(programA);
-    assertEquals(2, enrollments.size());
-    assertTrue(enrollments.contains(enrollmentA));
-    assertTrue(enrollments.contains(enrollmentD));
-    enrollments = eventProgramEnrollmentService.getEnrollments(programB);
-    assertEquals(1, enrollments.size());
-    assertTrue(enrollments.contains(enrollmentB));
   }
 
   @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventProgramEnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventProgramEnrollmentServiceTest.java
@@ -27,8 +27,7 @@
  */
 package org.hisp.dhis.program;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 
 import java.util.HashSet;
 import java.util.List;
@@ -110,12 +109,9 @@ class EventProgramEnrollmentServiceTest extends PostgresIntegrationTestBase {
   @Test
   void testGetEnrollmentsByProgram() {
     List<Enrollment> enrollments = eventProgramEnrollmentService.getEnrollments(programA);
-    assertEquals(2, enrollments.size());
-    assertTrue(enrollments.contains(enrollmentA));
-    assertTrue(enrollments.contains(enrollmentC));
+    assertContainsOnly(List.of(enrollmentA, enrollmentC), enrollments);
 
     enrollments = eventProgramEnrollmentService.getEnrollments(programB);
-    assertEquals(1, enrollments.size());
-    assertTrue(enrollments.contains(enrollmentB));
+    assertContainsOnly(List.of(enrollmentB), enrollments);
   }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventProgramEnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventProgramEnrollmentServiceTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.program;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.test.integration.PostgresIntegrationTestBase;
+import org.hisp.dhis.trackedentity.TrackedEntity;
+import org.hisp.dhis.trackedentity.TrackedEntityService;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.sharing.Sharing;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public class EventProgramEnrollmentServiceTest extends PostgresIntegrationTestBase {
+
+  @Autowired private IdentifiableObjectManager manager;
+
+  @Autowired private EventProgramEnrollmentService eventProgramEnrollmentService;
+
+  @Autowired private ProgramService programService;
+
+  @Autowired private OrganisationUnitService organisationUnitService;
+
+  @Autowired private TrackedEntityService trackedEntityService;
+
+  private Program programA;
+
+  private Program programB;
+
+  private Enrollment enrollmentA;
+
+  private Enrollment enrollmentB;
+
+  private Enrollment enrollmentC;
+
+  @BeforeEach
+  void setUp() {
+    OrganisationUnit organisationUnitA = createOrganisationUnit('A');
+    organisationUnitService.addOrganisationUnit(organisationUnitA);
+    OrganisationUnit organisationUnitB = createOrganisationUnit('B');
+    organisationUnitService.addOrganisationUnit(organisationUnitB);
+
+    TrackedEntity trackedEntityA = createTrackedEntity(organisationUnitA);
+    trackedEntityService.addTrackedEntity(trackedEntityA);
+    TrackedEntity trackedEntityB = createTrackedEntity(organisationUnitB);
+    trackedEntityService.addTrackedEntity(trackedEntityB);
+
+    programA = createProgram('A', new HashSet<>(), organisationUnitA);
+    programService.addProgram(programA);
+    programA.setSharing(Sharing.builder().publicAccess("rwrw----").build());
+    programService.updateProgram(programA);
+
+    programB = createProgram('B', new HashSet<>(), organisationUnitA);
+    programService.addProgram(programB);
+
+    enrollmentA = createEnrollment(programA, trackedEntityA, organisationUnitA);
+    manager.save(enrollmentA);
+
+    enrollmentB = createEnrollment(programB, trackedEntityA, organisationUnitB);
+    manager.save(enrollmentB);
+
+    enrollmentC = createEnrollment(programA, trackedEntityA, organisationUnitB);
+    manager.save(enrollmentC);
+
+    User user =
+        createAndAddUser(
+            false, "user", Set.of(organisationUnitA), Set.of(organisationUnitA), "F_EXPORT_DATA");
+    user.setTeiSearchOrganisationUnits(Set.of(organisationUnitA, organisationUnitB));
+    user.setOrganisationUnits(Set.of(organisationUnitA));
+
+    injectSecurityContextUser(user);
+  }
+
+  @Test
+  void testGetEnrollmentsByProgram() {
+    List<Enrollment> enrollments = eventProgramEnrollmentService.getEnrollments(programA);
+    assertEquals(2, enrollments.size());
+    assertTrue(enrollments.contains(enrollmentA));
+    assertTrue(enrollments.contains(enrollmentC));
+
+    enrollments = eventProgramEnrollmentService.getEnrollments(programB);
+    assertEquals(1, enrollments.size());
+    assertTrue(enrollments.contains(enrollmentB));
+  }
+}

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventProgramEnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventProgramEnrollmentServiceTest.java
@@ -47,7 +47,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-public class EventProgramEnrollmentServiceTest extends PostgresIntegrationTestBase {
+class EventProgramEnrollmentServiceTest extends PostgresIntegrationTestBase {
 
   @Autowired private IdentifiableObjectManager manager;
 


### PR DESCRIPTION
This PR continues the work of moving tracker-related code out of the API module. Specifically, it:

- Removes the getEnrollments(Program) method from the `EnrollmentService`.
- Creates a new service and store to deal with event programs enrollments. These two are meant to be used as a temporary solution until event programs are completely separated from tracker programs. At that point, both classes should be removed.

As a side note, we've found out the `CopyService` is actually copying enrollments from tracker programs. For now, we don't change its logic, but that's something worth of a discussion when the appropriate people are back from holidays.

