### PR TITLE
fix: [DHIS2-14139] check fileResource null reference (2.40)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/shared/postprocess/EventFileResourcePostProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/shared/postprocess/EventFileResourcePostProcessor.java
@@ -51,7 +51,8 @@ public class EventFileResourcePostProcessor implements Processor {
       if (dataElement.isFileType()) {
         FileResource fileResource = fileResourceService.getFileResource(dataValue.getValue());
 
-        if (!fileResource.isAssigned() || fileResource.getFileResourceOwner() == null) {
+        if (fileResource != null
+            && (!fileResource.isAssigned() || fileResource.getFileResourceOwner() == null)) {
           fileResource.setAssigned(true);
           fileResource.setFileResourceOwner(event.getEvent());
           fileResourceService.updateFileResource(fileResource);


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-14139

**Problem:** When trying to delete a file (data element of type `FILE_RESOURCE`) in Tracker Capture, the event PUT request fails with a `NullPointerException`. 

**Solution:** Check if the object is `null` before accessing it.