### PR TITLE
chore: Remove getEnrollments(Program) from store [DHIS2-17712]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EnrollmentStore.java
@@ -39,9 +39,6 @@ import org.hisp.dhis.trackedentity.TrackedEntity;
 public interface EnrollmentStore extends IdentifiableObjectStore<Enrollment> {
   String ID = EnrollmentStore.class.getName();
 
-  /** Get enrollments into a program. */
-  List<Enrollment> get(Program program);
-
   /** Get enrollments into a program that are in given status. */
   List<Enrollment> get(Program program, EnrollmentStatus status);
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEnrollmentStore.java
@@ -74,15 +74,6 @@ public class HibernateEnrollmentStore extends SoftDeleteHibernateObjectStore<Enr
   }
 
   @Override
-  public List<Enrollment> get(Program program) {
-    CriteriaBuilder builder = getCriteriaBuilder();
-
-    return getList(
-        builder,
-        newJpaParameters().addPredicate(root -> builder.equal(root.get("program"), program)));
-  }
-
-  @Override
   public List<Enrollment> get(Program program, EnrollmentStatus status) {
     CriteriaBuilder builder = getCriteriaBuilder();
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EnrollmentStoreTest.java
@@ -166,20 +166,6 @@ class EnrollmentStoreTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  void testGetEnrollmentsByProgram() {
-    enrollmentStore.save(enrollmentA);
-    enrollmentStore.save(enrollmentB);
-    enrollmentStore.save(enrollmentD);
-    List<Enrollment> enrollments = enrollmentStore.get(programA);
-    assertEquals(2, enrollments.size());
-    assertTrue(enrollments.contains(enrollmentA));
-    assertTrue(enrollments.contains(enrollmentD));
-    enrollments = enrollmentStore.get(programB);
-    assertEquals(1, enrollments.size());
-    assertTrue(enrollments.contains(enrollmentB));
-  }
-
-  @Test
   void testGetEnrollmentsByTrackedEntityProgramAndEnrollmentStatus() {
     enrollmentStore.save(enrollmentA);
     enrollmentStore.save(enrollmentB);


### PR DESCRIPTION
This PR continues the work of moving tracker-related code out of the API module. Specifically, it:
- Removes the `getEnrollments(Program)` from the api module `enrollmentStore`, which is just used in one test, and this test is already covered in `EventProgramEnrollmentServiceTest`