### PR TITLE
test: Change recaptcha API tests to unit tests

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserAccountServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserAccountServiceTest.java
@@ -1,0 +1,88 @@
+package org.hisp.dhis.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.List;
+import org.hisp.dhis.common.auth.RegistrationParams;
+import org.hisp.dhis.common.auth.UserRegistrationParams;
+import org.hisp.dhis.configuration.ConfigurationService;
+import org.hisp.dhis.feedback.BadRequestException;
+import org.hisp.dhis.security.spring2fa.TwoFactorAuthenticationProvider;
+import org.hisp.dhis.setting.SystemSettingManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserAccountServiceTest {
+
+  private UserAccountService userAccountService;
+  @Mock private UserService userService;
+  @Mock private ConfigurationService configService;
+  @Mock private TwoFactorAuthenticationProvider twoFactorAuthProvider;
+  @Mock private SystemSettingManager systemSettingManager;
+  @Mock private PasswordValidationService passwordValidationService;
+
+  @BeforeEach
+  public void init() {
+    userAccountService =
+        new DefaultUserAccountService(
+            userService,
+            configService,
+            twoFactorAuthProvider,
+            systemSettingManager,
+            passwordValidationService);
+  }
+
+  @Test
+  @DisplayName("Failed recaptcha response during user registration throws an exception")
+  void failedRecaptchaResponseUserRegTest() throws IOException {
+    // given
+    RegistrationParams regParams = UserRegistrationParams.builder().build();
+    regParams.setRecaptchaResponse("invalid-key");
+
+    RecaptchaResponse recaptchaResponse = new RecaptchaResponse();
+    recaptchaResponse.setSuccess(false);
+    recaptchaResponse.setErrorCodes(List.of("invalid challenge received"));
+
+    when(systemSettingManager.selfRegistrationNoRecaptcha()).thenReturn(false);
+    when(userService.verifyRecaptcha("invalid-key", "ip1")).thenReturn(recaptchaResponse);
+
+    // then
+    BadRequestException exception =
+        assertThrows(
+            BadRequestException.class,
+            () -> userAccountService.validateUserRegistration(regParams, "ip1"));
+    assertEquals(
+        "Recaptcha validation failed: [invalid challenge received]", exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("Failed recaptcha response during user invite throws an exception")
+  void failedRecaptchaResponseUserInviteTest() throws IOException {
+    // given
+    RegistrationParams regParams = UserRegistrationParams.builder().build();
+    regParams.setRecaptchaResponse("invalid-key");
+
+    RecaptchaResponse recaptchaResponse = new RecaptchaResponse();
+    recaptchaResponse.setSuccess(false);
+    recaptchaResponse.setErrorCodes(List.of("invalid challenge received"));
+
+    when(systemSettingManager.selfRegistrationNoRecaptcha()).thenReturn(false);
+    when(userService.verifyRecaptcha("invalid-key", "ip1")).thenReturn(recaptchaResponse);
+
+    // then
+    BadRequestException exception =
+        assertThrows(
+            BadRequestException.class,
+            () -> userAccountService.validateInvitedUser(regParams, "ip1"));
+    assertEquals(
+        "Recaptcha validation failed: [invalid challenge received]", exception.getMessage());
+  }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserAccountServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserAccountServiceTest.java
@@ -1,3 +1,30 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.user;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserAccountControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserAccountControllerTest.java
@@ -54,7 +54,6 @@ import org.hisp.dhis.test.message.FakeMessageSender;
 import org.hisp.dhis.test.web.HttpStatus;
 import org.hisp.dhis.test.webapi.H2ControllerIntegrationTestBase;
 import org.hisp.dhis.test.webapi.json.domain.JsonUser;
-import org.hisp.dhis.test.webapi.json.domain.JsonWebMessage;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -407,23 +406,6 @@ class UserAccountControllerTest extends H2ControllerIntegrationTestBase {
   }
 
   @Test
-  @DisplayName("Self registration error when invalid recaptcha input")
-  void selfRegInvalidRecaptchaInput() {
-    systemSettingManager.saveSystemSetting(
-        SettingKey.SELF_REGISTRATION_NO_RECAPTCHA, Boolean.FALSE);
-
-    JsonWebMessage response =
-        POST(
-                "/auth/registration",
-                renderService.toJsonAsString(getRegParamsWithRecaptcha("secret", RegType.SELF_REG)))
-            .content(HttpStatus.BAD_REQUEST)
-            .as(JsonWebMessage.class);
-
-    assertTrue(response.getMessage().contains("Recaptcha validation failed"));
-    assertEquals("ERROR", response.getStatus());
-  }
-
-  @Test
   @DisplayName("Self registration error when recaptcha enabled and null input")
   void selfRegRecaptcha() {
     systemSettingManager.saveSystemSetting(
@@ -550,23 +532,6 @@ class UserAccountControllerTest extends H2ControllerIntegrationTestBase {
                 "/auth/invite",
                 renderService.toJsonAsString(getRegParamsWithPassword(password, RegType.INVITE)))
             .content(HttpStatus.BAD_REQUEST));
-  }
-
-  @Test
-  @DisplayName("Invite registration error when invalid recaptcha input")
-  void inviteRegInvalidRecaptchaInput() {
-    systemSettingManager.saveSystemSetting(
-        SettingKey.SELF_REGISTRATION_NO_RECAPTCHA, Boolean.FALSE);
-
-    JsonWebMessage response =
-        POST(
-                "/auth/invite",
-                renderService.toJsonAsString(getRegParamsWithRecaptcha("secret", RegType.INVITE)))
-            .content(HttpStatus.BAD_REQUEST)
-            .as(JsonWebMessage.class);
-
-    assertTrue(response.getMessage().contains("Recaptcha validation failed"));
-    assertEquals("ERROR", response.getStatus());
   }
 
   @Test


### PR DESCRIPTION
Change 2 recaptcha web API tests to unit tests.
This is required so we don't rely on any external calls in our tests.

The 2 API tests were calling Google to verify the recaptcha string.