### PR TITLE
test: document why we need to emptyDB DHIS2-16557

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/junit/SpringIntegrationTestExtension.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/test/junit/SpringIntegrationTestExtension.java
@@ -148,6 +148,11 @@ public class SpringIntegrationTestExtension
   private void tearDown(ExtensionContext context) {
     clearSecurityContext();
 
+    // https://docs.spring.io/spring-framework/reference/testing/testcontext-framework/tx.html#testcontext-tx-attribute-support
+    // > methods annotated with JUnit @BeforeAll or @AfterAll are not run within a test-managed
+    // transaction
+    // This means we need to empty the DB even if a test class is annotated with @Transactional if
+    // its test lifecycle is set to class
     if (isTestLifecyclePerClass(context) || !isAnnotatedWithTransactional(context)) {
       unbindSession(context);
       emptyDatabase(context);


### PR DESCRIPTION
I wanted to document the current behavior as I always have to remember why we are doing it that way.

An example is

https://github.com/dhis2/dhis2-core/blob/4cb87482cd1241e83ab3924b1064ef6ff30e3a21/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/relationship/RelationshipDeletionHandlerTest.java#L44-L46

## To discuss

We can discuss this in the backend meeting. I wonder if annotating a test with

```java
@Transactional
@TestInstance(TestInstance.Lifecycle.PER_CLASS)
```

even makes sense. Can you even write a test class like this with a `@BeforeEach` method that changes the DB and with multiple test methods?
