### PR TITLE
chore: Remove maven debug logs in pipeline dev build

### DIFF
--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -37,7 +37,7 @@ pipeline {
                     gitHelper.setCommitStatus("${env.DHIS2_COMMIT_SHA}", "${env.DHIS2_REPO_URL}")
 
                     withMaven(options: [artifactsPublisher(disabled: true)]) {
-                        sh 'mvn -X -T 4 --batch-mode --no-transfer-progress clean install -f dhis-2/pom.xml -P -default --update-snapshots -pl -dhis-test-coverage'
+                        sh 'mvn -T 4 --batch-mode --no-transfer-progress clean install -f dhis-2/pom.xml -P -default --update-snapshots -pl -dhis-test-coverage'
                     }
                 }
             }


### PR DESCRIPTION
The debug option for the maven build was [added 3 years ago](https://github.com/dhis2/dhis2-core/pull/8476) to debug an issue. It was never removed.
This PR removes the debug log option in the dev build to reduce unnecessary noise in the build logs.

If debugging the build is necessary, it would be nice to have a `build with parameters` option in Jenkins to request a debug build on demand (without needing a code change).