### PR TITLE
chore: remove unneeded code DHIS2-17821

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/association/jdbc/JdbcOrgUnitAssociationStoreConfiguration.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/association/jdbc/JdbcOrgUnitAssociationStoreConfiguration.java
@@ -40,13 +40,9 @@ import org.springframework.jdbc.core.JdbcTemplate;
 @Configuration
 @RequiredArgsConstructor
 public class JdbcOrgUnitAssociationStoreConfiguration {
-  private final CacheProvider cacheProvider;
-
-  private final UserService userService;
-
-  @Bean("jdbcProgramOrgUnitAssociationsStore")
-  public JdbcOrgUnitAssociationsStore jdbcProgramOrgUnitAssociationStore(
-      JdbcTemplate jdbcTemplate) {
+  @Bean
+  public JdbcOrgUnitAssociationsStore jdbcProgramOrgUnitAssociationsStore(
+      JdbcTemplate jdbcTemplate, CacheProvider cacheProvider, UserService userService) {
     return new JdbcOrgUnitAssociationsStore(
         jdbcTemplate,
         new ProgramOrganisationUnitAssociationsQueryBuilder(),
@@ -54,9 +50,9 @@ public class JdbcOrgUnitAssociationStoreConfiguration {
         userService);
   }
 
-  @Bean("jdbcCategoryOptionOrgUnitAssociationsStore")
-  public JdbcOrgUnitAssociationsStore jdbcCategoryOptionOrgUnitAssociationStore(
-      JdbcTemplate jdbcTemplate) {
+  @Bean
+  public JdbcOrgUnitAssociationsStore jdbcCategoryOptionOrgUnitAssociationsStore(
+      JdbcTemplate jdbcTemplate, CacheProvider cacheProvider, UserService userService) {
     return new JdbcOrgUnitAssociationsStore(
         jdbcTemplate,
         new CategoryOptionOrganisationUnitAssociationsQueryBuilder(),
@@ -64,9 +60,9 @@ public class JdbcOrgUnitAssociationStoreConfiguration {
         userService);
   }
 
-  @Bean("jdbcDataSetOrgUnitAssociationsStore")
-  public JdbcOrgUnitAssociationsStore jdbcDataSetOrgUnitAssociationStore(
-      JdbcTemplate jdbcTemplate) {
+  @Bean
+  public JdbcOrgUnitAssociationsStore jdbcDataSetOrgUnitAssociationsStore(
+      JdbcTemplate jdbcTemplate, CacheProvider cacheProvider, UserService userService) {
     return new JdbcOrgUnitAssociationsStore(
         jdbcTemplate,
         new DataSetOrganisationUnitAssociationsQueryBuilder(),

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/config/ServiceConfig.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/config/ServiceConfig.java
@@ -95,7 +95,7 @@ public class ServiceConfig {
         .collect(Collectors.toMap(e -> (Class<? extends T>) e.getClass(), Functions.identity()));
   }
 
-  @Bean("retryTemplate")
+  @Bean
   public RetryTemplate retryTemplate() {
     ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();
 

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/config/ServiceConfig.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/config/ServiceConfig.java
@@ -40,7 +40,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration("validationServiceConfig")
 public class ServiceConfig {
-  @Bean("dataAnalysisServiceProvider")
+  @Bean
   public ServiceProvider<DataAnalysisService> dataAnalysisServiceProvider(
       StdDevOutlierAnalysisService stdDevOutlierAnalysisService,
       MinMaxOutlierAnalysisService minMaxOutlierAnalysisService) {

--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/jackson/config/JacksonObjectMapperConfig.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/jackson/config/JacksonObjectMapperConfig.java
@@ -88,12 +88,12 @@ public class JacksonObjectMapperConfig {
   public static final CsvMapper csvMapper = configureCsvMapper(new CsvMapper());
 
   @Primary
-  @Bean("jsonMapper")
+  @Bean
   public ObjectMapper jsonMapper() {
     return jsonMapper;
   }
 
-  @Bean("hibernateAwareJsonMapper")
+  @Bean
   public ObjectMapper hibernateAwareJsonMapper() {
     Hibernate5Module hibernate5Module = new Hibernate5Module();
     hibernate5Module.enable(
@@ -102,7 +102,7 @@ public class JacksonObjectMapperConfig {
     return hibernateAwareJsonMapper;
   }
 
-  @Bean("dataValueJsonMapper")
+  @Bean
   public ObjectMapper dataValueJsonMapper() {
     return dataValueJsonMapper;
   }

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/config/FlywayConfig.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/config/FlywayConfig.java
@@ -37,7 +37,6 @@ import org.flywaydb.core.api.configuration.ClassicConfiguration;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Profile;
 
 /**
@@ -50,7 +49,6 @@ public class FlywayConfig {
 
   @Bean(initMethod = "migrate")
   @Profile("!test-h2")
-  @DependsOn("dataSource")
   public Flyway flyway(DhisConfigurationProvider configurationProvider, DataSource dataSource) {
     ClassicConfiguration classicConfiguration = new ClassicConfiguration();
 

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/config/ServiceConfig.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/config/ServiceConfig.java
@@ -51,17 +51,17 @@ public class ServiceConfig {
     return DefaultLocationManager.getDefault();
   }
 
-  @Bean("maxAttempts")
+  @Bean
   public ConfigurationPropertyFactoryBean maxAttempts() {
     return new ConfigurationPropertyFactoryBean(META_DATA_SYNC_RETRY);
   }
 
-  @Bean("initialInterval")
+  @Bean
   public ConfigurationPropertyFactoryBean initialInterval() {
     return new ConfigurationPropertyFactoryBean(META_DATA_SYNC_RETRY_TIME_FREQUENCY_MILLISEC);
   }
 
-  @Bean("sessionTimeout")
+  @Bean
   public ConfigurationPropertyFactoryBean sessionTimeout() {
     return new ConfigurationPropertyFactoryBean(SYSTEM_SESSION_TIMEOUT);
   }

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateConfig.java
@@ -52,7 +52,6 @@ import org.hisp.dhis.dbms.HibernateDbmsManager;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.hibernate.EntityManagerBeanDefinitionRegistrarPostProcessor;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -81,23 +80,18 @@ public class HibernateConfig {
     return new PersistenceExceptionTranslationPostProcessor();
   }
 
-  @Bean("jpaTransactionManager")
-  @DependsOn("entityManagerFactory")
-  public JpaTransactionManager jpaTransactionManager(
-      @Qualifier("entityManagerFactory") EntityManagerFactory emf) {
-    return new JpaTransactionManager(emf);
+  @Bean
+  public JpaTransactionManager jpaTransactionManager(EntityManagerFactory entityManagerFactory) {
+    return new JpaTransactionManager(entityManagerFactory);
   }
 
-  @Bean("transactionTemplate")
-  @DependsOn("jpaTransactionManager")
-  public TransactionTemplate transactionTemplate(
-      @Qualifier("jpaTransactionManager") JpaTransactionManager transactionManager) {
+  @Bean
+  public TransactionTemplate transactionTemplate(JpaTransactionManager transactionManager) {
     return new TransactionTemplate(transactionManager);
   }
 
   @Bean
-  public DefaultHibernateCacheManager cacheManager(
-      @Qualifier("entityManagerFactory") EntityManagerFactory emf) {
+  public DefaultHibernateCacheManager cacheManager(EntityManagerFactory emf) {
     DefaultHibernateCacheManager cacheManager = new DefaultHibernateCacheManager();
     cacheManager.setSessionFactory(emf.unwrap(SessionFactory.class));
 
@@ -121,9 +115,9 @@ public class HibernateConfig {
     return new EntityManagerBeanDefinitionRegistrarPostProcessor();
   }
 
-  @Bean("entityManagerFactory")
+  @Bean
   @DependsOn({"flyway"})
-  public EntityManagerFactory entityManagerFactoryBean(
+  public EntityManagerFactory entityManagerFactory(
       DhisConfigurationProvider dhisConfig, DataSource dataSource) {
     HibernateJpaVendorAdapter adapter = new HibernateJpaVendorAdapter();
     adapter.setDatabasePlatform(dhisConfig.getProperty(ConfigurationKey.CONNECTION_DIALECT));

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateEncryptionConfig.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/config/HibernateEncryptionConfig.java
@@ -86,7 +86,7 @@ public class HibernateEncryptionConfig {
     return encryptor;
   }
 
-  @Bean("hibernateEncryptors")
+  @Bean
   public HibernateEncryptorRegistry hibernateEncryptors() {
     HibernateEncryptorRegistry registry = HibernateEncryptorRegistry.getInstance();
     registry.setEncryptors(Map.of(AES_128_STRING_ENCRYPTOR, aes128StringEncryptor()));

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/DefaultSessionConfiguration.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/DefaultSessionConfiguration.java
@@ -52,7 +52,7 @@ public class DefaultSessionConfiguration {
    *
    * @return a {@link CharacterEncodingFilter} without specifying encoding.
    */
-  @Bean("springSessionRepositoryFilter")
+  @Bean
   public Filter springSessionRepositoryFilter() {
     return new CharacterEncodingFilter();
   }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java
@@ -156,7 +156,7 @@ public class WebMvcConfig extends DelegatingWebMvcConfiguration {
         .addResolver(new IndexFallbackResourceResolver());
   }
 
-  @Bean("multipartResolver")
+  @Bean
   public MultipartResolver multipartResolver() {
     return new CommonsMultipartResolver();
   }


### PR DESCRIPTION
* `@DependsOn` is not needed if the dependency is explicit via the code like a parameter to a bean annotated method
* Setting the bean name is not necessary if the method has the same name
* Use one mechanism to wire up the bean: either parameters (which I prefer) or fields
