### PR TITLE
refactor: remove unused notification service methods [DHIS2-17827]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationTemplateService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationTemplateService.java
@@ -28,8 +28,6 @@
 package org.hisp.dhis.program.notification;
 
 import java.util.List;
-import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramStage;
 
 /**
  * @author Zubair Asghar
@@ -44,32 +42,6 @@ public interface ProgramNotificationTemplateService {
   void update(ProgramNotificationTemplate programNotificationTemplate);
 
   void delete(ProgramNotificationTemplate programNotificationTemplate);
-
-  List<ProgramNotificationTemplate> getProgramNotificationByTriggerType(
-      NotificationTrigger trigger);
-
-  /**
-   * Method is used to check if {@link Program} is associated with any web hook notification
-   * template.
-   *
-   * @param program {@link Program} to check for association.
-   * @return true if {@link Program} is associated, otherwise false.
-   */
-  boolean isProgramLinkedToWebHookNotification(Program program);
-
-  /**
-   * Method is used to check if {@link ProgramStage} is associated with any web hook notification
-   * template.
-   *
-   * @param programStage {@link ProgramStage} to check for association.
-   * @return true if {@link ProgramStage} is associated, otherwise false.
-   */
-  boolean isProgramStageLinkedToWebHookNotification(ProgramStage programStage);
-
-  List<ProgramNotificationTemplate> getProgramLinkedToWebHookNotifications(Program program);
-
-  List<ProgramNotificationTemplate> getProgramStageLinkedToWebHookNotifications(
-      ProgramStage programStage);
 
   int countProgramNotificationTemplates(
       ProgramNotificationTemplateParam programNotificationTemplateParam);

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationTemplateStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationTemplateStore.java
@@ -31,25 +31,11 @@ import java.util.Collection;
 import java.util.List;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramStage;
 
 /** Created by zubair@dhis2.org on 16.11.17. */
 public interface ProgramNotificationTemplateStore
     extends IdentifiableObjectStore<ProgramNotificationTemplate> {
   String ID = ProgramNotificationTemplate.class.getName();
-
-  List<ProgramNotificationTemplate> getProgramNotificationByTriggerType(
-      NotificationTrigger triggers);
-
-  boolean isProgramLinkedToWebHookNotification(Long pId);
-
-  boolean isProgramStageLinkedToWebHookNotification(Long psId);
-
-  List<ProgramNotificationTemplate> getProgramLinkedToWebHookNotifications(Program program);
-
-  List<ProgramNotificationTemplate> getProgramStageLinkedToWebHookNotifications(
-      ProgramStage programStage);
 
   int countProgramNotificationTemplates(ProgramNotificationTemplateParam param);
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationTemplateService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationTemplateService.java
@@ -28,10 +28,6 @@
 package org.hisp.dhis.program.notification;
 
 import java.util.List;
-import org.hisp.dhis.cache.Cache;
-import org.hisp.dhis.cache.CacheProvider;
-import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramStage;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,17 +39,8 @@ public class DefaultProgramNotificationTemplateService
     implements ProgramNotificationTemplateService {
   private final ProgramNotificationTemplateStore store;
 
-  private final Cache<Boolean> programWebHookNotificationCache;
-
-  private final Cache<Boolean> programStageWebHookNotificationCache;
-
-  public DefaultProgramNotificationTemplateService(
-      ProgramNotificationTemplateStore store, CacheProvider cacheProvider) {
+  public DefaultProgramNotificationTemplateService(ProgramNotificationTemplateStore store) {
     this.store = store;
-    this.programWebHookNotificationCache =
-        cacheProvider.createProgramWebHookNotificationTemplateCache();
-    this.programStageWebHookNotificationCache =
-        cacheProvider.createProgramStageWebHookNotificationTemplateCache();
   }
 
   @Override
@@ -84,41 +71,6 @@ public class DefaultProgramNotificationTemplateService
   @Transactional
   public void delete(ProgramNotificationTemplate programNotificationTemplate) {
     store.delete(programNotificationTemplate);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public List<ProgramNotificationTemplate> getProgramNotificationByTriggerType(
-      NotificationTrigger trigger) {
-    return store.getProgramNotificationByTriggerType(trigger);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public boolean isProgramLinkedToWebHookNotification(Program program) {
-    return programWebHookNotificationCache.get(
-        program.getUid(), uid -> store.isProgramLinkedToWebHookNotification(program.getId()));
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public boolean isProgramStageLinkedToWebHookNotification(ProgramStage programStage) {
-    return programStageWebHookNotificationCache.get(
-        programStage.getUid(),
-        uid -> store.isProgramStageLinkedToWebHookNotification(programStage.getId()));
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public List<ProgramNotificationTemplate> getProgramLinkedToWebHookNotifications(Program program) {
-    return store.getProgramLinkedToWebHookNotifications(program);
-  }
-
-  @Override
-  @Transactional(readOnly = true)
-  public List<ProgramNotificationTemplate> getProgramStageLinkedToWebHookNotifications(
-      ProgramStage programStage) {
-    return store.getProgramStageLinkedToWebHookNotifications(programStage);
   }
 
   @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationTemplateStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationTemplateStore.java
@@ -27,17 +27,13 @@
  */
 package org.hisp.dhis.program.notification;
 
-import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
-import javax.persistence.criteria.CriteriaBuilder;
 import org.hibernate.query.NativeQuery;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
 import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.security.acl.AclService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -48,8 +44,6 @@ import org.springframework.stereotype.Repository;
 public class DefaultProgramNotificationTemplateStore
     extends HibernateIdentifiableObjectStore<ProgramNotificationTemplate>
     implements ProgramNotificationTemplateStore {
-  private static final String NOTIFICATION_RECIPIENT = "recipient";
-
   private static final String PROGRAM_ID = "pid";
 
   private static final String PROGRAM_STAGE_ID = "psid";
@@ -66,62 +60,6 @@ public class DefaultProgramNotificationTemplateStore
         ProgramNotificationTemplate.class,
         aclService,
         true);
-  }
-
-  @Override
-  public List<ProgramNotificationTemplate> getProgramNotificationByTriggerType(
-      NotificationTrigger trigger) {
-    CriteriaBuilder builder = getCriteriaBuilder();
-
-    return getList(
-        builder,
-        newJpaParameters()
-            .addPredicate(root -> builder.equal(root.get("notificationtrigger"), trigger)));
-  }
-
-  @Override
-  public boolean isProgramLinkedToWebHookNotification(Long pId) {
-    NativeQuery<BigInteger> query =
-        nativeSynchronizedQuery(
-            "select count(*) from programnotificationtemplate where programid = :pid and notificationrecipienttype = :recipient");
-    query.setParameter(PROGRAM_ID, pId);
-    query.setParameter(NOTIFICATION_RECIPIENT, ProgramNotificationRecipient.WEB_HOOK.name());
-
-    return query.getSingleResult().longValue() > 0;
-  }
-
-  @Override
-  public boolean isProgramStageLinkedToWebHookNotification(Long psId) {
-    NativeQuery<BigInteger> query =
-        nativeSynchronizedQuery(
-            "select count(*) from programnotificationtemplate where programstageid = :psid and notificationrecipienttype = :recipient");
-    query.setParameter(PROGRAM_STAGE_ID, psId);
-    query.setParameter(NOTIFICATION_RECIPIENT, ProgramNotificationRecipient.WEB_HOOK.name());
-
-    return query.getSingleResult().longValue() > 0;
-  }
-
-  @Override
-  public List<ProgramNotificationTemplate> getProgramLinkedToWebHookNotifications(Program program) {
-    NativeQuery<ProgramNotificationTemplate> query =
-        nativeSynchronizedTypedQuery(
-            "select * from programnotificationtemplate where programid = :pid and notificationrecipienttype = :recipient");
-    query.setParameter(PROGRAM_ID, program.getId());
-    query.setParameter(NOTIFICATION_RECIPIENT, ProgramNotificationRecipient.WEB_HOOK.name());
-
-    return query.getResultList();
-  }
-
-  @Override
-  public List<ProgramNotificationTemplate> getProgramStageLinkedToWebHookNotifications(
-      ProgramStage programStage) {
-    NativeQuery<ProgramNotificationTemplate> query =
-        nativeSynchronizedTypedQuery(
-            "select * from programnotificationtemplate where programstageid = :psid and notificationrecipienttype = :recipient");
-    query.setParameter(PROGRAM_STAGE_ID, programStage.getId());
-    query.setParameter(NOTIFICATION_RECIPIENT, ProgramNotificationRecipient.WEB_HOOK.name());
-
-    return query.getResultList();
   }
 
   @Override


### PR DESCRIPTION
[DHIS2-17827](https://dhis2.atlassian.net/browse/DHIS2-17827)
- Removes unused methods of `ProgramNotificationService` and `ProgramNotificationTemplateStore`


[DHIS2-17827]: https://dhis2.atlassian.net/browse/DHIS2-17827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ