### PR TITLE
chore: Remove updateTrackedEntity [DHIS2-17714]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityService.java
@@ -112,13 +112,6 @@ public interface TrackedEntityService {
       boolean skipAccessValidation,
       boolean skipSearchScopeValidation);
 
-  /**
-   * Updates a {@link TrackedEntity}.
-   *
-   * @param trackedEntity the TrackedEntity to update.
-   */
-  void updateTrackedEntity(TrackedEntity trackedEntity);
-
   /** */
   void updateTrackedEntityLastUpdated(
       Set<String> trackedEntityUIDs, Date lastUpdated, String userInfoSnapshot);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityService.java
@@ -45,6 +45,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.changelog.ChangeLogType;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -85,6 +86,8 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
 
   private final UserService userService;
 
+  private final IdentifiableObjectManager manager;
+
   public DefaultTrackedEntityService(
       UserService userService,
       TrackedEntityStore trackedEntityStore,
@@ -94,7 +97,8 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
       OrganisationUnitService organisationUnitService,
       AclService aclService,
       TrackedEntityChangeLogService trackedEntityChangeLogService,
-      TrackedEntityAttributeValueChangeLogService attributeValueAuditService) {
+      TrackedEntityAttributeValueChangeLogService attributeValueAuditService,
+      IdentifiableObjectManager manager) {
     checkNotNull(trackedEntityStore);
     checkNotNull(attributeValueService);
     checkNotNull(attributeService);
@@ -112,6 +116,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
     this.organisationUnitService = organisationUnitService;
     this.aclService = aclService;
     this.trackedEntityChangeLogService = trackedEntityChangeLogService;
+    this.manager = manager;
   }
 
   @Override
@@ -477,7 +482,7 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
       trackedEntity.getTrackedEntityAttributeValues().add(pav);
     }
 
-    updateTrackedEntity(trackedEntity); // Update associations
+    manager.update(trackedEntity);
 
     return id;
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityService.java
@@ -489,12 +489,6 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
 
   @Override
   @Transactional
-  public void updateTrackedEntity(TrackedEntity trackedEntity) {
-    trackedEntityStore.update(trackedEntity);
-  }
-
-  @Override
-  @Transactional
   public void updateTrackedEntityLastUpdated(
       Set<String> trackedEntityUIDs, Date lastUpdated, String userInfoSnapshot) {
     trackedEntityStore.updateTrackedEntityLastUpdated(

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityServiceTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
 import java.util.Set;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -76,6 +77,8 @@ class DefaultTrackedEntityServiceTest {
 
   @Mock private TrackedEntityAttributeValueChangeLogService attributeValueAuditService;
 
+  @Mock private IdentifiableObjectManager manager;
+
   private TrackedEntityQueryParams params;
 
   private DefaultTrackedEntityService trackedEntityService;
@@ -94,7 +97,8 @@ class DefaultTrackedEntityServiceTest {
             organisationUnitService,
             aclService,
             trackedEntityChangeLogService,
-            attributeValueAuditService);
+            attributeValueAuditService,
+            manager);
 
     User user = new User();
     user.setUsername("test");

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/DefaultTrackerObjectsDeletionService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/bundle/persister/DefaultTrackerObjectsDeletionService.java
@@ -116,7 +116,7 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
 
       manager.delete(enrollment);
 
-      teService.updateTrackedEntity(te);
+      manager.update(te);
 
       typeReport.getStats().incDeleted();
       typeReport.addEntity(objectReport);
@@ -160,7 +160,7 @@ public class DefaultTrackerObjectsDeletionService implements TrackerObjectDeleti
         TrackedEntity entity = event.getEnrollment().getTrackedEntity();
         entity.setLastUpdatedByUserInfo(userInfoSnapshot);
 
-        teService.updateTrackedEntity(entity);
+        manager.update(entity);
 
         Enrollment enrollment = event.getEnrollment();
         enrollment.setLastUpdatedByUserInfo(userInfoSnapshot);

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListener.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/EnrollmentSMSListener.java
@@ -91,6 +91,8 @@ public class EnrollmentSMSListener extends EventSavingSMSListener {
 
   private final SMSEnrollmentService smsEnrollmentService;
 
+  private final IdentifiableObjectManager manager;
+
   public EnrollmentSMSListener(
       IncomingSmsService incomingSmsService,
       @Qualifier("smsMessageSender") MessageSender smsSender,
@@ -131,6 +133,7 @@ public class EnrollmentSMSListener extends EventSavingSMSListener {
     this.enrollmentService = enrollmentService;
     this.attributeValueService = attributeValueService;
     this.smsEnrollmentService = smsEnrollmentService;
+    this.manager = manager;
   }
 
   @Override
@@ -182,7 +185,7 @@ public class EnrollmentSMSListener extends EventSavingSMSListener {
     if (teExists) {
       updateAttributeValues(attributeValues, trackedEntity.getTrackedEntityAttributeValues());
       trackedEntity.setTrackedEntityAttributeValues(attributeValues);
-      teService.updateTrackedEntity(trackedEntity);
+      manager.update(trackedEntity);
     } else {
       teService.createTrackedEntity(trackedEntity, attributeValues);
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/SMSEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/imports/sms/SMSEnrollmentService.java
@@ -78,7 +78,7 @@ public class SMSEnrollmentService {
         trackedEntity, program, organisationUnit, true, true);
     eventPublisher.publishEvent(new ProgramEnrollmentNotificationEvent(this, enrollment.getId()));
     manager.update(enrollment);
-    trackedEntityService.updateTrackedEntity(trackedEntity);
+    manager.update(trackedEntity);
 
     return enrollment;
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/notification/ProgramNotificationMessageRendererTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/notification/ProgramNotificationMessageRendererTest.java
@@ -210,7 +210,7 @@ class ProgramNotificationMessageRendererTest extends PostgresIntegrationTestBase
         new TrackedEntityAttributeValue(trackedEntityAttributeA, trackedEntityA, "attribute-test");
     trackedEntityAttributeValueService.addTrackedEntityAttributeValue(trackedEntityAttributeValueA);
     trackedEntityA.setTrackedEntityAttributeValues(Sets.newHashSet(trackedEntityAttributeValueA));
-    trackedEntityService.updateTrackedEntity(trackedEntityA);
+    manager.update(trackedEntityA);
 
     // Enrollment to be provided in message renderer
     enrollmentA = createEnrollment(programA, trackedEntityA, organisationUnitA);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/EventPredictionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/EventPredictionServiceTest.java
@@ -226,7 +226,7 @@ class EventPredictionServiceTest extends PostgresIntegrationTestBase {
     trackedEntityAttributeValue.setValue("123");
     entityAttributeValueService.addTrackedEntityAttributeValue(trackedEntityAttributeValue);
     trackedEntity.setTrackedEntityAttributeValues(Sets.newHashSet(trackedEntityAttributeValue));
-    trackedEntityService.updateTrackedEntity(trackedEntity);
+    manager.update(trackedEntity);
     Program program = createProgram('A', null, Sets.newHashSet(entityAttribute), orgUnitASet, null);
     program.setUid(PROGRAM_UID);
     programService.addProgram(program);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityServiceTest.java
@@ -206,7 +206,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     enrollment.setEvents(Set.of(event));
     trackedEntityA1.setEnrollments(Set.of(enrollment));
     manager.update(enrollment);
-    trackedEntityService.updateTrackedEntity(trackedEntityA1);
+    manager.update(trackedEntityA1);
     TrackedEntity trackedEntityA = trackedEntityService.getTrackedEntity(trackedEntityA1.getUid());
     Enrollment psA = manager.get(Enrollment.class, enrollment.getUid());
     Event eventA = manager.get(Event.class, eventIdA);
@@ -224,7 +224,7 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     manager.save(trackedEntityA1);
     assertNotNull(trackedEntityService.getTrackedEntity(trackedEntityA1.getUid()));
     trackedEntityA1.setName("B");
-    trackedEntityService.updateTrackedEntity(trackedEntityA1);
+    manager.update(trackedEntityA1);
     assertEquals("B", trackedEntityService.getTrackedEntity(trackedEntityA1.getUid()).getName());
   }
 
@@ -369,13 +369,13 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     // lastupdated is automatically set by the store; update entities in a certain order and
     //   expect
     // that to be returned
-    trackedEntityService.updateTrackedEntity(trackedEntityD1);
+    manager.update(trackedEntityD1);
     Thread.sleep(1000);
-    trackedEntityService.updateTrackedEntity(trackedEntityB1);
+    manager.update(trackedEntityB1);
     Thread.sleep(1000);
-    trackedEntityService.updateTrackedEntity(trackedEntityC1);
+    manager.update(trackedEntityC1);
     Thread.sleep(1000);
-    trackedEntityService.updateTrackedEntity(trackedEntityA1);
+    manager.update(trackedEntityA1);
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
     params.setOrgUnits(Set.of(organisationUnit));
@@ -400,13 +400,13 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     // lastupdated is automatically set by the store; update entities in a certain order and
     //   expect
     // that to be returned
-    trackedEntityService.updateTrackedEntity(trackedEntityD1);
+    manager.update(trackedEntityD1);
     Thread.sleep(1000);
-    trackedEntityService.updateTrackedEntity(trackedEntityB1);
+    manager.update(trackedEntityB1);
     Thread.sleep(1000);
-    trackedEntityService.updateTrackedEntity(trackedEntityC1);
+    manager.update(trackedEntityC1);
     Thread.sleep(1000);
-    trackedEntityService.updateTrackedEntity(trackedEntityA1);
+    manager.update(trackedEntityA1);
 
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceMergeIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/DeduplicationServiceMergeIntegrationTest.java
@@ -101,8 +101,8 @@ class DeduplicationServiceMergeIntegrationTest extends PostgresIntegrationTestBa
     manager.save(enrollment2);
     original.getEnrollments().add(enrollment1);
     duplicate.getEnrollments().add(enrollment2);
-    trackedEntityService.updateTrackedEntity(original);
-    trackedEntityService.updateTrackedEntity(duplicate);
+    manager.update(original);
+    manager.update(duplicate);
     PotentialDuplicate potentialDuplicate =
         new PotentialDuplicate(original.getUid(), duplicate.getUid());
     deduplicationService.addPotentialDuplicate(potentialDuplicate);
@@ -158,8 +158,8 @@ class DeduplicationServiceMergeIntegrationTest extends PostgresIntegrationTestBa
     manager.update(enrollment2);
     original.getEnrollments().add(enrollment1);
     duplicate.getEnrollments().add(enrollment2);
-    trackedEntityService.updateTrackedEntity(original);
-    trackedEntityService.updateTrackedEntity(duplicate);
+    manager.update(original);
+    manager.update(duplicate);
     PotentialDuplicate potentialDuplicate =
         new PotentialDuplicate(original.getUid(), duplicate.getUid());
     deduplicationService.addPotentialDuplicate(potentialDuplicate);

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateRemoveTrackedEntityTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateRemoveTrackedEntityTest.java
@@ -169,10 +169,10 @@ class PotentialDuplicateRemoveTrackedEntityTest extends PostgresIntegrationTestB
     duplicate.getEnrollments().add(enrollment2);
     control1.getEnrollments().add(enrollment3);
     control2.getEnrollments().add(enrollment4);
-    trackedEntityService.updateTrackedEntity(original);
-    trackedEntityService.updateTrackedEntity(duplicate);
-    trackedEntityService.updateTrackedEntity(control1);
-    trackedEntityService.updateTrackedEntity(control2);
+    manager.update(original);
+    manager.update(duplicate);
+    manager.update(control1);
+    manager.update(control2);
     assertNotNull(trackedEntityService.getTrackedEntity(original.getUid()));
     assertNotNull(trackedEntityService.getTrackedEntity(duplicate.getUid()));
     assertNotNull(trackedEntityService.getTrackedEntity(control1.getUid()));

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateStoreRelationshipTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/deduplication/PotentialDuplicateStoreRelationshipTest.java
@@ -151,8 +151,8 @@ class PotentialDuplicateStoreRelationshipTest extends PostgresIntegrationTestBas
     duplicate = trackedEntityService.getTrackedEntity(duplicate.getUid());
     List<String> relationships = Lists.newArrayList(uni3.getUid());
     potentialDuplicateStore.moveRelationships(original, duplicate, relationships);
-    trackedEntityService.updateTrackedEntity(original);
-    trackedEntityService.updateTrackedEntity(duplicate);
+    manager.update(original);
+    manager.update(duplicate);
     Relationship _uni1 = getRelationship(uni1.getUid());
     Relationship _uni2 = getRelationship(uni2.getUid());
     Relationship _uni3 = getRelationship(uni3.getUid());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/AnalyticsValidationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/AnalyticsValidationServiceTest.java
@@ -202,7 +202,7 @@ class AnalyticsValidationServiceTest extends PostgresIntegrationTestBase {
     trackedEntityAttributeValue.setValue("123");
     entityAttributeValueService.addTrackedEntityAttributeValue(trackedEntityAttributeValue);
     trackedEntity.setTrackedEntityAttributeValues(Sets.newHashSet(trackedEntityAttributeValue));
-    trackedEntityService.updateTrackedEntity(trackedEntity);
+    manager.update(trackedEntity);
     Program program =
         createProgram(
             'A', null, Sets.newHashSet(entityAttribute), Sets.newHashSet(orgUnitA, orgUnitA), null);


### PR DESCRIPTION
## Big picture

Tracker has multiple services for each entity like tracked entity, enrollment, event and relationship. One is in dhis-api and one in dhis-service-tracker. Our goal is to provide one API (service) per entity that is part of the tracker domain/team.

Trackers architecture splits read/write into exporter services and an importer. So if you want to get data you use an exporter. If you want to insert, update or delete you have to go through the importer. Only then can we ensure integrity of tracker data.

Another goal is that code that provides tracker functionality and is thus owned by the tracker team lives in ideally one maven module (We can settle on a name later on maybe `dhis-service-tracker` or `dhis-tracker`).

This is a **big** task that we are going to implement in many small steps.

## This PR

- Removes `updateTrackedEntity(TrackedEntity)` from `TrackedEntityService`. Uses `manager.get` instead. Either because it's used in places where we can't use the importer yet or because it's used in places that will be removed in coming PRs.