### PR TITLE
fix: The coordinate fields are not backward compatible with some front end applications[2.42-DHIS2-17842]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -487,6 +487,10 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
     return coordinateFields.stream().distinct().collect(Collectors.toList());
   }
 
+  // -------------------------------------------------------------------------
+  // Supportive methods
+  // -------------------------------------------------------------------------
+
   // TODO!!! remove when all fe apps stop using old names of the coordinate fields
   /**
    * Temporary only, should not be in 2.42 release!!! Retrieves an old name of the coordinate field.
@@ -509,10 +513,6 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
 
     return coordinateField;
   }
-
-  // -------------------------------------------------------------------------
-  // Supportive methods
-  // -------------------------------------------------------------------------
 
   private QueryItem getQueryItem(
       String dimension, String filter, Program program, EventOutputType type) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -435,6 +435,24 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
       boolean defaultCoordinateFallback) {
     List<String> coordinateFields = new ArrayList<>();
 
+    //TODO!!! remove when all fe apps stop using old names of coordinate fields
+    if("pigeometry".equalsIgnoreCase(coordinateField))
+    {
+      coordinateField = "engeometry";
+    }
+
+    //TODO!!! remove when all fe apps stop using old names of coordinate fields
+    if("psigeometry".equalsIgnoreCase(coordinateField))
+    {
+      coordinateField = "evgeometry";
+    }
+
+    //TODO!!! remove when all fe apps stop using old names of coordinate fields
+    if("teigeometry".equalsIgnoreCase(coordinateField))
+    {
+      coordinateField = "tegeometry";
+    }
+
     if (coordinateField == null) {
       coordinateFields.add(StringUtils.EMPTY);
     } else if (COL_NAME_GEOMETRY_LIST.contains(coordinateField)) {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -435,23 +435,9 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
       boolean defaultCoordinateFallback) {
     List<String> coordinateFields = new ArrayList<>();
 
-    //TODO!!! remove when all fe apps stop using old names of coordinate fields
-    if("pigeometry".equalsIgnoreCase(coordinateField))
-    {
-      coordinateField = "engeometry";
-    }
-
-    //TODO!!! remove when all fe apps stop using old names of coordinate fields
-    if("psigeometry".equalsIgnoreCase(coordinateField))
-    {
-      coordinateField = "evgeometry";
-    }
-
-    //TODO!!! remove when all fe apps stop using old names of coordinate fields
-    if("teigeometry".equalsIgnoreCase(coordinateField))
-    {
-      coordinateField = "tegeometry";
-    }
+    // TODO!!! remove when all fe apps stop using old names of coordinate fields
+    coordinateField = mapCoordinateField(coordinateField);
+    fallbackCoordinateField = mapCoordinateField(fallbackCoordinateField);
 
     if (coordinateField == null) {
       coordinateFields.add(StringUtils.EMPTY);
@@ -499,6 +485,29 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
             program, fallbackCoordinateField, defaultCoordinateFallback));
 
     return coordinateFields.stream().distinct().collect(Collectors.toList());
+  }
+
+  // TODO!!! remove when all fe apps stop using old names of the coordinate fields
+  /**
+   * Temporary only, should not be in 2.42 release!!! Retrieves an old name of the coordinate field.
+   *
+   * @param coordinateField a name of the coordinate field
+   * @return old name of the coordinate field.
+   */
+  private String mapCoordinateField(String coordinateField) {
+    if ("pigeometry".equalsIgnoreCase(coordinateField)) {
+      coordinateField = COL_NAME_ENROLLMENT_GEOMETRY;
+    }
+
+    if ("psigeometry".equalsIgnoreCase(coordinateField)) {
+      coordinateField = COL_NAME_EVENT_GEOMETRY;
+    }
+
+    if ("teigeometry".equalsIgnoreCase(coordinateField)) {
+      coordinateField = COL_NAME_TRACKED_ENTITY_GEOMETRY;
+    }
+
+    return coordinateField;
   }
 
   // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -496,15 +496,15 @@ public class DefaultEventDataQueryService implements EventDataQueryService {
    */
   private String mapCoordinateField(String coordinateField) {
     if ("pigeometry".equalsIgnoreCase(coordinateField)) {
-      coordinateField = COL_NAME_ENROLLMENT_GEOMETRY;
+      return COL_NAME_ENROLLMENT_GEOMETRY;
     }
 
     if ("psigeometry".equalsIgnoreCase(coordinateField)) {
-      coordinateField = COL_NAME_EVENT_GEOMETRY;
+      return COL_NAME_EVENT_GEOMETRY;
     }
 
     if ("teigeometry".equalsIgnoreCase(coordinateField)) {
-      coordinateField = COL_NAME_TRACKED_ENTITY_GEOMETRY;
+      return COL_NAME_TRACKED_ENTITY_GEOMETRY;
     }
 
     return coordinateField;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventDataQueryServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventDataQueryServiceTest.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.analytics.event.data;
 
+import static org.hisp.dhis.analytics.event.data.DefaultEventCoordinateService.COL_NAME_ENROLLMENT_GEOMETRY;
+import static org.hisp.dhis.analytics.event.data.DefaultEventCoordinateService.COL_NAME_EVENT_GEOMETRY;
+import static org.hisp.dhis.analytics.event.data.DefaultEventCoordinateService.COL_NAME_TRACKED_ENTITY_GEOMETRY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -508,6 +511,41 @@ class EventDataQueryServiceTest extends PostgresIntegrationTestBase {
     assertEquals(
         List.of("evgeometry"),
         dataQueryService.getCoordinateFields(prA.getUid(), null, "evgeometry", false));
+    assertEquals(
+        List.of(deC.getUid()),
+        dataQueryService.getCoordinateFields(prA.getUid(), deC.getUid(), null, false));
+  }
+
+  @Test
+  void testGetBackwardCompatibleCoordinateField() {
+    final String OLD_COL_NAME_EVENT_GEOMETRY = "psigeometry";
+    final String OLD_COL_NAME_ENROLLMENT_GEOMETRY = "pigeometry";
+    final String OLD_COL_NAME_TRACKED_ENTITY_GEOMETRY = "teigeometry";
+
+    assertEquals(
+        List.of(COL_NAME_EVENT_GEOMETRY),
+        dataQueryService.getCoordinateFields(
+            prA.getUid(), OLD_COL_NAME_EVENT_GEOMETRY, null, false));
+    assertEquals(
+        List.of(COL_NAME_ENROLLMENT_GEOMETRY),
+        dataQueryService.getCoordinateFields(
+            prA.getUid(), OLD_COL_NAME_ENROLLMENT_GEOMETRY, null, false));
+    assertEquals(
+        List.of(COL_NAME_TRACKED_ENTITY_GEOMETRY),
+        dataQueryService.getCoordinateFields(
+            prA.getUid(), OLD_COL_NAME_TRACKED_ENTITY_GEOMETRY, null, false));
+    assertEquals(
+        List.of(COL_NAME_EVENT_GEOMETRY),
+        dataQueryService.getCoordinateFields(
+            prA.getUid(), null, OLD_COL_NAME_EVENT_GEOMETRY, false));
+    assertEquals(
+        List.of(COL_NAME_ENROLLMENT_GEOMETRY),
+        dataQueryService.getCoordinateFields(
+            prA.getUid(), null, OLD_COL_NAME_ENROLLMENT_GEOMETRY, false));
+    assertEquals(
+        List.of(COL_NAME_TRACKED_ENTITY_GEOMETRY),
+        dataQueryService.getCoordinateFields(
+            prA.getUid(), null, OLD_COL_NAME_TRACKED_ENTITY_GEOMETRY, false));
     assertEquals(
         List.of(deC.getUid()),
         dataQueryService.getCoordinateFields(prA.getUid(), deC.getUid(), null, false));


### PR DESCRIPTION
The names of the geometry columns have been updated. This change is not backward compatible, and some front-end applications are still using the old column names.