### PR TITLE
chore: Return enrollments of event programs only [DHIS2-17712]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventProgramEnrollmentService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/EventProgramEnrollmentService.java
@@ -36,12 +36,15 @@ import java.util.List;
  */
 public interface EventProgramEnrollmentService {
 
-  /** Returns a list of enrollments in the given program. */
-  List<Enrollment> getEnrollments(Program program);
-
   /**
    * Returns the list of enrollments in the given program, only if the program is of type {@link
    * ProgramType#WITHOUT_REGISTRATION}
+   */
+  List<Enrollment> getEnrollments(Program program);
+
+  /**
+   * Returns the list of enrollments in the given program and status, only if the program is of type
+   * {@link ProgramType#WITHOUT_REGISTRATION}
    */
   List<Enrollment> getEnrollments(Program program, EnrollmentStatus enrollmentStatus);
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/copy/CopyService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/copy/CopyService.java
@@ -208,6 +208,11 @@ public class CopyService {
     return stageMappings;
   }
 
+  /**
+   * This method copies enrollments of event programs only, as these kinds of enrollments act as
+   * placeholders and are considered metadata. It won't copy enrollments of tracker programs because
+   * those are actual data.
+   */
   private void copyEnrollments(Program original, Program copy) {
     List<Enrollment> enrollments =
         copyList(copy, eventProgramEnrollmentService.getEnrollments(original), Enrollment.copyOf);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventProgramEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultEventProgramEnrollmentService.java
@@ -38,9 +38,6 @@ public class DefaultEventProgramEnrollmentService implements EventProgramEnrollm
   private final EventProgramEnrollmentStore eventProgramEnrollmentStore;
 
   @Override
-  // TODO(tracker) The CopyService is currently copying enrollments from tracker programs. We need
-  // to discuss if that's correct. Seems to make more sense to copy enrollments from event programs
-  // only.
   public List<Enrollment> getEnrollments(Program program) {
     return eventProgramEnrollmentStore.get(program);
   }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventProgramEnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateEventProgramEnrollmentStore.java
@@ -49,8 +49,11 @@ public class HibernateEventProgramEnrollmentStore implements EventProgramEnrollm
     try (Session session = entityManager.unwrap(Session.class)) {
 
       return session
-          .createQuery("from Enrollment e where e.program.uid = :programUid", Enrollment.class)
+          .createQuery(
+              "from Enrollment e where e.program.uid = :programUid and e.program.programType = :programType",
+              Enrollment.class)
           .setParameter("programUid", program.getUid())
+          .setParameter("programType", ProgramType.WITHOUT_REGISTRATION)
           .list();
     }
   }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventProgramEnrollmentServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/EventProgramEnrollmentServiceTest.java
@@ -91,15 +91,6 @@ class EventProgramEnrollmentServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  void testGetEnrollmentsByProgram() {
-    List<Enrollment> enrollments = eventProgramEnrollmentService.getEnrollments(programA);
-    assertContainsOnly(List.of(enrollmentA, enrollmentC), enrollments);
-
-    enrollments = eventProgramEnrollmentService.getEnrollments(programB);
-    assertContainsOnly(List.of(enrollmentB), enrollments);
-  }
-
-  @Test
   void shouldReturnEnrollmentsWhenGettingEnrollmentsOfAnEventProgram() {
     assertContainsOnly(
         List.of(eventProgramEnrollment),
@@ -107,7 +98,22 @@ class EventProgramEnrollmentServiceTest extends PostgresIntegrationTestBase {
   }
 
   @Test
-  void shouldReturnNoEnrollmentsWhenGettingEnrollmentsOfATrackerProgram() {
+  void shouldNotReturnEnrollmentsWhenGettingEnrollmentsOfATrackerProgram() {
+    assertEquals(enrollmentA, manager.get(Enrollment.class, enrollmentA.getUid()));
+    assertEquals(enrollmentB, manager.get(Enrollment.class, enrollmentB.getUid()));
+    assertIsEmpty(eventProgramEnrollmentService.getEnrollments(programA));
+    assertIsEmpty(eventProgramEnrollmentService.getEnrollments(programB));
+  }
+
+  @Test
+  void shouldReturnEnrollmentsWhenGettingEnrollmentsOfAnEventProgramByStatus() {
+    assertContainsOnly(
+        List.of(eventProgramEnrollment),
+        eventProgramEnrollmentService.getEnrollments(eventProgram, ACTIVE));
+  }
+
+  @Test
+  void shouldReturnNoEnrollmentsWhenGettingEnrollmentsOfATrackerProgramByStatus() {
     assertEquals(enrollmentA, manager.get(Enrollment.class, enrollmentA.getUid()));
     assertIsEmpty(eventProgramEnrollmentService.getEnrollments(programA, ACTIVE));
   }

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerIntegrationTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/ProgramControllerIntegrationTest.java
@@ -28,24 +28,17 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.test.web.WebClientUtils.assertStatus;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.hisp.dhis.association.jdbc.JdbcOrgUnitAssociationsStore;
 import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.jsontree.JsonList;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.test.web.HttpStatus;
 import org.hisp.dhis.test.web.WebClient;
 import org.hisp.dhis.test.webapi.PostgresControllerIntegrationTestBase;
-import org.hisp.dhis.test.webapi.json.domain.JsonWebMessage;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.webapi.controller.tracker.JsonEnrollment;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,8 +59,6 @@ class ProgramControllerIntegrationTest extends PostgresControllerIntegrationTest
 
   public static final String PROGRAM_UID = "PrZMWi7rBga";
 
-  public static final String ORG_UNIT_UID = "Orgunit1000";
-
   @BeforeEach
   public void testSetup() throws JsonProcessingException {
     DataElement dataElement1 = createDataElement('a');
@@ -86,68 +77,6 @@ class ProgramControllerIntegrationTest extends PostgresControllerIntegrationTest
         .content(HttpStatus.CREATED);
 
     POST("/metadata", WebClient.Body("program/create_program.json")).content(HttpStatus.OK);
-  }
-
-  @Test
-  void testCopyProgramEnrollments() {
-    OrganisationUnit orgUnit = orgUnitService.getOrganisationUnit(ORG_UNIT_UID);
-    User user = createAndAddUser(true, "user", Set.of(orgUnit), Set.of(orgUnit));
-    injectSecurityContextUser(user);
-
-    assertStatus(
-        HttpStatus.CREATED,
-        POST(
-            "/trackedEntityTypes",
-            "{'description': 'add TET for Enrollment test','id':'TEType10000','name':'Tracked Entity Type 1'}"));
-
-    assertStatus(
-        HttpStatus.CREATED,
-        POST(
-            "/trackedEntityAttributes/",
-            "{'name':'attrA', 'id':'TEAttr10000','shortName':'attrA', 'valueType':'TEXT', 'aggregationType':'NONE'}"));
-
-    POST(
-            "/tracker?async=false",
-            """
-{
-  "trackedEntities": [
-    {
-      "trackedEntityType": "TEType10000",
-      "orgUnit": "%s",
-      "enrollments": [
-        {
-          "program": "PrZMWi7rBga",
-          "orgUnit": "%s",
-          "status": "ACTIVE",
-          "enrolledAt": "2023-06-16",
-          "occurredAt': "2023-06-16"
-        }
-      ]
-    }
-  ]
-}
-"""
-                .formatted(ORG_UNIT_UID, ORG_UNIT_UID))
-        .content(HttpStatus.OK);
-
-    POST("/programs/%s/copy".formatted(PROGRAM_UID))
-        .content(HttpStatus.CREATED)
-        .as(JsonWebMessage.class);
-
-    JsonWebMessage enrollmentsForOrgUnit =
-        GET("/tracker/enrollments?orgUnit=%s".formatted(ORG_UNIT_UID))
-            .content(HttpStatus.OK)
-            .as(JsonWebMessage.class);
-
-    JsonList<JsonEnrollment> enrollments =
-        enrollmentsForOrgUnit.getList("enrollments", JsonEnrollment.class);
-    Set<JsonEnrollment> originalProgramEnrollments =
-        enrollments.stream()
-            .filter(enrollment -> enrollment.getProgram().equals(PROGRAM_UID))
-            .collect(Collectors.toSet());
-
-    assertEquals(2, enrollments.size());
-    assertEquals(1, originalProgramEnrollments.size());
   }
 
   @Test


### PR DESCRIPTION
The `CopyService` should only replicate metadata when copying a program, never the actual data. 
This means it should copy enrollments in event programs, where the enrollment serves as a placeholder, but should not copy enrollments in tracker programs, as these are considered data.