### PR TITLE
fix: Change rule-engine snapshot version to release version 3.0.0

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -81,7 +81,7 @@
     <!-- *Dependencies* -->
 
     <!-- DHIS2 Rule Engine -->
-    <dhis2-rule-engine.version>3.0.0-20240411.110520-16</dhis2-rule-engine.version>
+    <dhis2-rule-engine.version>3.0.0</dhis2-rule-engine.version>
     <kotlinx-datetime.version>0.6.0</kotlinx-datetime.version>
 
     <!-- HISP Quick and Staxwax -->


### PR DESCRIPTION
It looks like the new rule-engine workflows might have some gaps in terms of properly handling the snapshot versions vs release versions and the availability of the same in maven. The timestamped snapshot version was missing in sonatype snapshot repo and v41 builds were failing. 

Maybe sonatype cleans up snapshot dependencies when the corresponding release version is published? Or maybe it cleansup after a while anyway? There could be some sort of cleanup configuration done in the rule-engine repository.

Assuming all our dhis2  releases (major/minor/patch) should ideally use only release versions of rule-engine and not snapshot versions. The workflow/releases for rule-engine and corresponding linking in dhis2-core probably needs some looking into. Will follow this up with Enrico once he is back from holidays.

This PR simply changes the snapshot version of rule-engine (which no more exists in sonatype) to a release version (3.0.0)