### PR TITLE
chore: Remove getTrackedEntityIds method [DHIS2-17714]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityService.java
@@ -98,20 +98,6 @@ public interface TrackedEntityService {
       boolean skipAccessValidation,
       boolean skipSearchScopeValidation);
 
-  /**
-   * Returns a list tracked entity primary key ids based on the given TrackedEntityQueryParams.
-   *
-   * @param params the TrackedEntityQueryParams.
-   * @param skipAccessValidation If true, access validation is skipped. Should be set to true only
-   *     for internal tasks (e.g. currently used by synchronization job)
-   * @param skipSearchScopeValidation if true, search scope validation is skipped.
-   * @return List of TE IDs matching the params
-   */
-  List<Long> getTrackedEntityIds(
-      TrackedEntityQueryParams params,
-      boolean skipAccessValidation,
-      boolean skipSearchScopeValidation);
-
   /** */
   void updateTrackedEntityLastUpdated(
       Set<String> trackedEntityUIDs, Date lastUpdated, String userInfoSnapshot);

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityService.java
@@ -36,7 +36,6 @@ import static org.hisp.dhis.common.OrganisationUnitSelectionMode.DESCENDANTS;
 import static org.hisp.dhis.common.OrganisationUnitSelectionMode.SELECTED;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
@@ -60,7 +59,6 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserDetails;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.util.DateUtils;
-import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -159,32 +157,6 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
     }
 
     return trackedEntities;
-  }
-
-  /**
-   * This method handles any dynamic sort order columns in the params. These have to be added to the
-   * attribute list if neither are present in the attribute list nor the filter list.
-   *
-   * <p>For example, if attributes or filters don't have a specific trackedentityattribute uid, but
-   * sorting has been requested for that tea uid, then we need to add them to the attribute list.
-   */
-  private void handleSortAttributes(TrackedEntityQueryParams params) {
-    List<TrackedEntityAttribute> sortAttributes =
-        params.getOrders().stream()
-            .map(OrderParam::getField)
-            .filter(this::isDynamicColumn)
-            .map(attributeService::getTrackedEntityAttribute)
-            .collect(Collectors.toList());
-
-    params.addAttributesIfNotExist(
-        QueryItem.getQueryItems(sortAttributes).stream()
-            .filter(sAtt -> !params.getFilters().contains(sAtt))
-            .collect(Collectors.toList()));
-  }
-
-  public boolean isDynamicColumn(String propName) {
-    return Arrays.stream(TrackedEntityQueryParams.OrderColumn.values())
-        .noneMatch(orderColumn -> orderColumn.getPropName().equals(propName));
   }
 
   // TODO lower index on attribute value?

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityService.java
@@ -161,36 +161,6 @@ public class DefaultTrackedEntityService implements TrackedEntityService {
     return trackedEntities;
   }
 
-  @Override
-  @Transactional(readOnly = true)
-  public List<Long> getTrackedEntityIds(
-      TrackedEntityQueryParams params,
-      boolean skipAccessValidation,
-      boolean skipSearchScopeValidation) {
-    if (params.isOrQuery() && !params.hasAttributes() && !params.hasProgram()) {
-      Collection<TrackedEntityAttribute> attributes =
-          attributeService.getTrackedEntityAttributesDisplayInListNoProgram();
-      params.addAttributes(QueryItem.getQueryItems(attributes));
-      params.addFiltersIfNotExist(QueryItem.getQueryItems(attributes));
-    }
-
-    handleSortAttributes(params);
-
-    decideAccess(params);
-
-    // AccessValidation should be skipped only and only if it is internal
-    // service that runs the task (for example sync job)
-    if (!skipAccessValidation) {
-      validate(params);
-    }
-
-    if (!skipSearchScopeValidation) {
-      validateSearchScope(params);
-    }
-
-    return trackedEntityStore.getTrackedEntityIds(params);
-  }
-
   /**
    * This method handles any dynamic sort order columns in the params. These have to be added to the
    * attribute list if neither are present in the attribute list nor the filter list.

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityQueryLimitTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityQueryLimitTest.java
@@ -156,7 +156,7 @@ class TrackedEntityQueryLimitTest extends PostgresIntegrationTestBase {
 
     assertThrows(
         IllegalQueryException.class,
-        () -> trackedEntityService.getTrackedEntityIds(params, false, false),
+        () -> trackedEntityService.getTrackedEntities(params, false, false),
         String.format(
             "Only one parameter of '%s' and '%s' must be specified. Prefer '%s' as '%s' will be removed.",
             SettingKey.TRACKED_ENTITY_MAX_LIMIT.getName(),
@@ -177,7 +177,8 @@ class TrackedEntityQueryLimitTest extends PostgresIntegrationTestBase {
     params.setUserWithAssignedUsers(null, user, null);
     params.setSkipPaging(true);
 
-    List<Long> trackedEntities = trackedEntityService.getTrackedEntityIds(params, false, false);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(params, false, false);
 
     assertNotEmpty(trackedEntities);
     assertEquals(2, trackedEntities.size());
@@ -195,15 +196,11 @@ class TrackedEntityQueryLimitTest extends PostgresIntegrationTestBase {
     params.setUserWithAssignedUsers(null, user, null);
     params.setSkipPaging(true);
 
-    List<Long> trackedEntities = trackedEntityService.getTrackedEntityIds(params, false, false);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(params, false, false);
 
     assertContainsOnly(
-        List.of(
-            trackedEntity1.getId(),
-            trackedEntity2.getId(),
-            trackedEntity3.getId(),
-            trackedEntity4.getId()),
-        trackedEntities);
+        List.of(trackedEntity1, trackedEntity2, trackedEntity3, trackedEntity4), trackedEntities);
   }
 
   @Test
@@ -215,15 +212,11 @@ class TrackedEntityQueryLimitTest extends PostgresIntegrationTestBase {
     params.setUserWithAssignedUsers(null, user, null);
     params.setSkipPaging(true);
 
-    List<Long> trackedEntities = trackedEntityService.getTrackedEntityIds(params, false, false);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(params, false, false);
 
     assertContainsOnly(
-        List.of(
-            trackedEntity1.getId(),
-            trackedEntity2.getId(),
-            trackedEntity3.getId(),
-            trackedEntity4.getId()),
-        trackedEntities);
+        List.of(trackedEntity1, trackedEntity2, trackedEntity3, trackedEntity4), trackedEntities);
   }
 
   @Test
@@ -238,15 +231,11 @@ class TrackedEntityQueryLimitTest extends PostgresIntegrationTestBase {
     params.setUserWithAssignedUsers(null, user, null);
     params.setSkipPaging(true);
 
-    List<Long> trackedEntities = trackedEntityService.getTrackedEntityIds(params, false, false);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(params, false, false);
 
     assertContainsOnly(
-        List.of(
-            trackedEntity1.getId(),
-            trackedEntity2.getId(),
-            trackedEntity3.getId(),
-            trackedEntity4.getId()),
-        trackedEntities);
+        List.of(trackedEntity1, trackedEntity2, trackedEntity3, trackedEntity4), trackedEntities);
   }
 
   @Test
@@ -261,7 +250,8 @@ class TrackedEntityQueryLimitTest extends PostgresIntegrationTestBase {
     params.setUserWithAssignedUsers(null, user, null);
     params.setSkipPaging(true);
 
-    List<Long> trackedEntities = trackedEntityService.getTrackedEntityIds(params, false, false);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(params, false, false);
 
     assertNotEmpty(trackedEntities);
     assertEquals(2, trackedEntities.size());
@@ -279,7 +269,8 @@ class TrackedEntityQueryLimitTest extends PostgresIntegrationTestBase {
     params.setUserWithAssignedUsers(null, user, null);
     params.setSkipPaging(true);
 
-    List<Long> trackedEntities = trackedEntityService.getTrackedEntityIds(params, false, false);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(params, false, false);
 
     assertNotEmpty(trackedEntities);
     assertEquals(2, trackedEntities.size());

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityServiceTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.trackedentity;
 
+import static org.hisp.dhis.test.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -269,15 +270,12 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     params.setOrgUnits(Set.of(organisationUnit));
     params.setOrders(List.of(new OrderParam("createdAt", SortDirection.ASC)));
 
-    List<Long> trackedEntityIdList = trackedEntityService.getTrackedEntityIds(params, true, true);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(params, true, true);
 
-    assertEquals(
-        List.of(
-            trackedEntityC1.getId(),
-            trackedEntityB1.getId(),
-            trackedEntityA1.getId(),
-            trackedEntityD1.getId()),
-        trackedEntityIdList);
+    assertContainsOnly(
+        List.of(trackedEntityC1, trackedEntityB1, trackedEntityA1, trackedEntityD1),
+        trackedEntities);
   }
 
   @Test
@@ -295,15 +293,12 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     params.setOrgUnits(Set.of(organisationUnit));
     params.setOrders(List.of(new OrderParam("createdAt", SortDirection.DESC)));
 
-    List<Long> trackedEntityIdList = trackedEntityService.getTrackedEntityIds(params, true, true);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(params, true, true);
 
-    assertEquals(
-        List.of(
-            trackedEntityD1.getId(),
-            trackedEntityA1.getId(),
-            trackedEntityB1.getId(),
-            trackedEntityC1.getId()),
-        trackedEntityIdList);
+    assertContainsOnly(
+        List.of(trackedEntityD1, trackedEntityA1, trackedEntityB1, trackedEntityC1),
+        trackedEntities);
   }
 
   @Test
@@ -321,15 +316,12 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     params.setOrgUnits(Set.of(organisationUnit));
     params.setOrders(List.of(new OrderParam("createdAt", SortDirection.ASC)));
 
-    List<Long> trackedEntityIdList = trackedEntityService.getTrackedEntityIds(params, true, true);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(params, true, true);
 
-    assertEquals(
-        List.of(
-            trackedEntityC1.getId(),
-            trackedEntityB1.getId(),
-            trackedEntityA1.getId(),
-            trackedEntityD1.getId()),
-        trackedEntityIdList);
+    assertContainsOnly(
+        List.of(trackedEntityC1, trackedEntityB1, trackedEntityA1, trackedEntityD1),
+        trackedEntities);
   }
 
   @Test
@@ -350,15 +342,12 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     params.setOrgUnits(Set.of(organisationUnit));
     params.setOrders(List.of(new OrderParam("createdAt", SortDirection.DESC)));
 
-    List<Long> trackedEntityIdList = trackedEntityService.getTrackedEntityIds(params, true, true);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(params, true, true);
 
-    assertEquals(
-        List.of(
-            trackedEntityD1.getId(),
-            trackedEntityA1.getId(),
-            trackedEntityB1.getId(),
-            trackedEntityC1.getId()),
-        trackedEntityIdList);
+    assertContainsOnly(
+        List.of(trackedEntityD1, trackedEntityA1, trackedEntityB1, trackedEntityC1),
+        trackedEntities);
   }
 
   @Test
@@ -381,15 +370,12 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     params.setOrgUnits(Set.of(organisationUnit));
     params.setOrders(List.of(new OrderParam("updatedAt", SortDirection.ASC)));
 
-    List<Long> trackedEntityIdList = trackedEntityService.getTrackedEntityIds(params, true, true);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(params, true, true);
 
-    assertEquals(
-        List.of(
-            trackedEntityD1.getId(),
-            trackedEntityB1.getId(),
-            trackedEntityC1.getId(),
-            trackedEntityA1.getId()),
-        trackedEntityIdList);
+    assertContainsOnly(
+        List.of(trackedEntityD1, trackedEntityB1, trackedEntityC1, trackedEntityA1),
+        trackedEntities);
   }
 
   @Test
@@ -413,15 +399,12 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     params.setOrgUnits(Set.of(organisationUnit));
     params.setOrders(List.of(new OrderParam("updatedAt", SortDirection.DESC)));
 
-    List<Long> trackedEntityIdList = trackedEntityService.getTrackedEntityIds(params, true, true);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(params, true, true);
 
-    assertEquals(
-        List.of(
-            trackedEntityA1.getId(),
-            trackedEntityC1.getId(),
-            trackedEntityB1.getId(),
-            trackedEntityD1.getId()),
-        trackedEntityIdList);
+    assertContainsOnly(
+        List.of(trackedEntityA1, trackedEntityC1, trackedEntityB1, trackedEntityD1),
+        trackedEntities);
   }
 
   @Test
@@ -435,15 +418,12 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     params.setOrgUnits(Set.of(organisationUnit));
     params.setOrders(List.of(new OrderParam("trackedEntity", SortDirection.DESC)));
 
-    List<Long> trackedEntityIdList = trackedEntityService.getTrackedEntityIds(params, true, true);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(params, true, true);
 
-    assertEquals(
-        List.of(
-            trackedEntityD1.getId(),
-            trackedEntityC1.getId(),
-            trackedEntityB1.getId(),
-            trackedEntityA1.getId()),
-        trackedEntityIdList);
+    assertContainsOnly(
+        List.of(trackedEntityD1, trackedEntityC1, trackedEntityB1, trackedEntityA1),
+        trackedEntities);
   }
 
   @Test
@@ -461,15 +441,12 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     params.setOrgUnits(Set.of(organisationUnit));
     params.setOrders(List.of(new OrderParam("updatedAtClient", SortDirection.DESC)));
 
-    List<Long> trackedEntityIdList = trackedEntityService.getTrackedEntityIds(params, true, true);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(params, true, true);
 
-    assertEquals(
-        List.of(
-            trackedEntityD1.getId(),
-            trackedEntityA1.getId(),
-            trackedEntityB1.getId(),
-            trackedEntityC1.getId()),
-        trackedEntityIdList);
+    assertContainsOnly(
+        List.of(trackedEntityD1, trackedEntityA1, trackedEntityB1, trackedEntityC1),
+        trackedEntities);
   }
 
   @Test
@@ -487,15 +464,12 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     params.setOrgUnits(Set.of(organisationUnit));
     params.setOrders(List.of(new OrderParam("enrolledAt", SortDirection.DESC)));
 
-    List<Long> trackedEntityIdList = trackedEntityService.getTrackedEntityIds(params, true, true);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(params, true, true);
 
-    assertEquals(
-        List.of(
-            trackedEntityB1.getId(),
-            trackedEntityD1.getId(),
-            trackedEntityC1.getId(),
-            trackedEntityA1.getId()),
-        trackedEntityIdList);
+    assertContainsOnly(
+        List.of(trackedEntityB1, trackedEntityD1, trackedEntityC1, trackedEntityA1),
+        trackedEntities);
   }
 
   @Test
@@ -520,15 +494,12 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             new OrderParam("inactive", SortDirection.DESC),
             new OrderParam("enrolledAt", SortDirection.DESC)));
 
-    List<Long> trackedEntityIdList = trackedEntityService.getTrackedEntityIds(params, true, true);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(params, true, true);
 
-    assertEquals(
-        List.of(
-            trackedEntityB1.getId(),
-            trackedEntityA1.getId(),
-            trackedEntityD1.getId(),
-            trackedEntityC1.getId()),
-        trackedEntityIdList);
+    assertContainsOnly(
+        List.of(trackedEntityB1, trackedEntityA1, trackedEntityD1, trackedEntityC1),
+        trackedEntities);
   }
 
   @Test
@@ -539,15 +510,12 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     TrackedEntityQueryParams params = new TrackedEntityQueryParams();
     params.setOrgUnits(Set.of(organisationUnit));
 
-    List<Long> trackedEntityIdList = trackedEntityService.getTrackedEntityIds(params, true, true);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(params, true, true);
 
-    assertEquals(
-        List.of(
-            trackedEntityA1.getId(),
-            trackedEntityB1.getId(),
-            trackedEntityC1.getId(),
-            trackedEntityD1.getId()),
-        trackedEntityIdList);
+    assertContainsOnly(
+        List.of(trackedEntityA1, trackedEntityB1, trackedEntityC1, trackedEntityD1),
+        trackedEntities);
   }
 
   @Test
@@ -566,15 +534,12 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     params.setOrders(List.of(new OrderParam(trackedEntityAttribute.getUid(), SortDirection.ASC)));
     params.setAttributes(List.of(new QueryItem(trackedEntityAttribute)));
 
-    List<Long> trackedEntityIdList = trackedEntityService.getTrackedEntityIds(params, true, true);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(params, true, true);
 
-    assertEquals(
-        List.of(
-            trackedEntityB1.getId(),
-            trackedEntityD1.getId(),
-            trackedEntityA1.getId(),
-            trackedEntityC1.getId()),
-        trackedEntityIdList);
+    assertContainsOnly(
+        List.of(trackedEntityB1, trackedEntityD1, trackedEntityA1, trackedEntityC1),
+        trackedEntities);
   }
 
   @Test
@@ -602,15 +567,12 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
             new OrderParam("inactive", SortDirection.ASC)));
     params.setAttributes(List.of(new QueryItem(trackedEntityAttribute)));
 
-    List<Long> trackedEntityIdList = trackedEntityService.getTrackedEntityIds(params, true, true);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(params, true, true);
 
-    assertEquals(
-        List.of(
-            trackedEntityB1.getId(),
-            trackedEntityA1.getId(),
-            trackedEntityD1.getId(),
-            trackedEntityC1.getId()),
-        trackedEntityIdList);
+    assertContainsOnly(
+        List.of(trackedEntityB1, trackedEntityA1, trackedEntityD1, trackedEntityC1),
+        trackedEntities);
   }
 
   @Test
@@ -631,15 +593,12 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     params.setOrgUnits(Set.of(organisationUnit));
     params.setOrders(List.of(new OrderParam(tea.getUid(), SortDirection.DESC)));
 
-    List<Long> trackedEntityIdList = trackedEntityService.getTrackedEntityIds(params, true, true);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(params, true, true);
 
-    assertEquals(
-        List.of(
-            trackedEntityB1.getId(),
-            trackedEntityC1.getId(),
-            trackedEntityD1.getId(),
-            trackedEntityA1.getId()),
-        trackedEntityIdList);
+    assertContainsOnly(
+        List.of(trackedEntityB1, trackedEntityC1, trackedEntityD1, trackedEntityA1),
+        trackedEntities);
   }
 
   @Test
@@ -660,15 +619,12 @@ class TrackedEntityServiceTest extends PostgresIntegrationTestBase {
     params.setOrgUnits(Set.of(organisationUnit));
     params.setOrders(List.of(new OrderParam(tea.getUid(), SortDirection.ASC)));
 
-    List<Long> trackedEntityIdList = trackedEntityService.getTrackedEntityIds(params, true, true);
+    List<TrackedEntity> trackedEntities =
+        trackedEntityService.getTrackedEntities(params, true, true);
 
-    assertEquals(
-        List.of(
-            trackedEntityA1.getId(),
-            trackedEntityD1.getId(),
-            trackedEntityC1.getId(),
-            trackedEntityB1.getId()),
-        trackedEntityIdList);
+    assertContainsOnly(
+        List.of(trackedEntityA1, trackedEntityD1, trackedEntityC1, trackedEntityB1),
+        trackedEntities);
   }
 
   private void addEnrollment(TrackedEntity trackedEntity, Date enrollmentDate, char programStage) {


### PR DESCRIPTION
## Big picture

Tracker has multiple services for each entity like tracked entity, enrollment, event and relationship. One is in dhis-api and one in dhis-service-tracker. Our goal is to provide one API (service) per entity that is part of the tracker domain/team.

Trackers architecture splits read/write into exporter services and an importer. So if you want to get data you use an exporter. If you want to insert, update or delete you have to go through the importer. Only then can we ensure integrity of tracker data.

Another goal is that code that provides tracker functionality and is thus owned by the tracker team lives in ideally one maven module (We can settle on a name later on maybe `dhis-service-tracker` or `dhis-tracker`).

This is a **big** task that we are going to implement in many small steps.

## This PR

- Removes the `getTrackedEntityIds` method from `TrackedEntityService`, as it was only used in tests. It's replaced by `getTrackedEntities`, which returns the TE and can be used in tests instead.