### PR TITLE
fix: Delete legend set with ref in data set [DHIS2-6011]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/DataSetDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/DataSetDeletionHandler.java
@@ -105,11 +105,12 @@ public class DataSetDeletionHandler extends IdObjectDeletionHandler<DataSet> {
   }
 
   private void deleteLegendSet(LegendSet legendSet) {
-    for (DataSet dataSet : idObjectManager.getAllNoAcl(DataSet.class)) {
-      for (LegendSet ls : dataSet.getLegendSets()) {
-        if (legendSet.equals(ls)) {
-          dataSet.getLegendSets().remove(ls);
-          idObjectManager.updateNoAcl(dataSet);
+    for (DataSet ds : idObjectManager.getAllNoAcl(DataSet.class)) {
+      Iterator<LegendSet> lsIterator = ds.getLegendSets().iterator();
+      while (lsIterator.hasNext()) {
+        if (legendSet.equals(lsIterator.next())) {
+          lsIterator.remove();
+          idObjectManager.updateNoAcl(ds);
         }
       }
     }

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/legendset/LegendSetTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/legendset/LegendSetTest.java
@@ -1,0 +1,85 @@
+package org.hisp.dhis.legendset;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItem;
+
+import org.hisp.dhis.ApiTest;
+import org.hisp.dhis.test.e2e.actions.RestApiActions;
+import org.hisp.dhis.test.e2e.actions.metadata.MetadataActions;
+import org.hisp.dhis.test.e2e.dto.ApiResponse;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class LegendSetTest extends ApiTest {
+
+  private MetadataActions metadataActions;
+  private RestApiActions legendSetActions;
+  private RestApiActions dataSetActions;
+
+  @BeforeAll
+  public void init() {
+    //
+    metadataActions = new MetadataActions();
+    legendSetActions = new RestApiActions("legendSets");
+    dataSetActions = new RestApiActions("dataSets");
+  }
+
+  @Test
+  @DisplayName("Deleting a legend set which is referenced by a data set is successful")
+  void deleteLegendSetTest() {
+    metadataActions.importMetadata(dataSetWithLegendSet()).validateStatus(200);
+
+    // confirm data set has legend set
+    dataSetActions
+        .get("DsUid000001")
+        .validate()
+        .body("legendSets", hasItem(allOf(hasEntry("id", "LegSetUid01"))));
+
+    // delete legend set
+    ApiResponse response = legendSetActions.delete("LegSetUid01");
+    response.validate().body("httpStatus", equalTo("OK")).body("httpStatusCode", equalTo(200));
+
+    // confirm data set no longer has legend set
+    dataSetActions.get("DsUid000001").validate().body("legendSets", empty());
+  }
+
+  private String dataSetWithLegendSet() {
+    return """
+      {
+        "dataSets": [
+          {
+            "name": "ds 1",
+            "id": "DsUid000001",
+            "shortName": "ds 1",
+            "periodType": "Monthly",
+            "legendSets": [
+              {
+                "id": "LegSetUid01"
+              }
+            ]
+          }
+        ],
+        "legendSets": [
+          {
+            "name": "Test legend11",
+            "legends": [
+              {
+                "name": "45 - 60",
+                "startValue": 45.0,
+                "endValue": 60.0,
+                "displayName": "45 - 60",
+                "id": "LegUid00001"
+              }
+            ],
+            "displayName": "Test legend",
+            "id": "LegSetUid01"
+            }
+        ]
+      }
+      """;
+  }
+}

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/legendset/LegendSetTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/legendset/LegendSetTest.java
@@ -22,7 +22,6 @@ class LegendSetTest extends ApiTest {
 
   @BeforeAll
   public void init() {
-    //
     metadataActions = new MetadataActions();
     legendSetActions = new RestApiActions("legendSets");
     dataSetActions = new RestApiActions("dataSets");

--- a/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/legendset/LegendSetTest.java
+++ b/dhis-2/dhis-test-e2e/src/test/java/org/hisp/dhis/legendset/LegendSetTest.java
@@ -1,3 +1,30 @@
+/*
+ * Copyright (c) 2004-2024, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.legendset;
 
 import static org.hamcrest.Matchers.allOf;


### PR DESCRIPTION
# Issue
Deleting a `LegendSet`, which is referenced in a `DataSet`, fails and a `ConcurrentModificationException` is thrown internally. `409` response returned (sample below).
Endpoint: `DELETE` `/api/legendSet/{uid}`

# Cause
The implementation used to remove a `LegendSet` from a `DataSet` in `DataSetDeletionHandler` was using an enhanced for loop (iterator) and then trying to update the collection inside the loop.

# Fix
Use an iterator to iterate over the items and use the iterator to remove the item from the collection.

# Testing
## Automated
Added e2e test

# Sample error response when deleting legend set
```json
{
    "httpStatus": "Conflict",
    "httpStatusCode": 409,
    "status": "WARNING",
    "message": "One or more errors occurred, please see full details in import report.",
    "response": {
        "responseType": "ObjectReport",
        "klass": "org.hisp.dhis.legend.LegendSet",
        "uid": "k1JHPfXsJND",
        "errorReports": [
            {
                "message": "Object could not be deleted: handler 'org.hisp.dhis.dataset.DataSetDeletionHandler$$Lambda$1061/0x00007f73a0ec9580@9f79663' threw an exception while removing related objects: null",
                "args": [],
                "mainKlass": "org.hisp.dhis.legend.LegendSet",
                "errorCode": "E4030",
                "errorProperties": []
            }
        ]
    }
}
```