### PR TITLE
fix: broken OpenID value update with linked accounts

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/user/hibernate/User.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/user/hibernate/User.hbm.xml
@@ -121,7 +121,7 @@
 
     <property name="externalAuth" column="externalauth" />
 
-    <property name="openId" column="openid" unique="true" type="text" />
+    <property name="openId" column="openid" type="text" />
 
     <property name="ldapId" column="ldapid" unique="true" type="text" />
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
@@ -108,9 +108,9 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook<User> {
     }
 
     User existingUserWithMatchingOpenID = userService.getUserByOpenId(user.getOpenId());
-    boolean linkedIsAccountsDisabled =
+    boolean linkedAccountsDisabled =
         dhisConfig.isDisabled(ConfigurationKey.LINKED_ACCOUNTS_ENABLED);
-    if (linkedIsAccountsDisabled
+    if (linkedAccountsDisabled
         && (existingUserWithMatchingOpenID != null
             && !existingUserWithMatchingOpenID.getUid().equals(user.getUid()))) {
       addReports.accept(

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
@@ -38,6 +38,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.adapter.BaseIdentifiableObject_;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
@@ -107,8 +108,11 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook<User> {
     }
 
     User existingUserWithMatchingOpenID = userService.getUserByOpenId(user.getOpenId());
-    if (existingUserWithMatchingOpenID != null
-        && !existingUserWithMatchingOpenID.getUid().equals(user.getUid())) {
+    boolean linkedIsAccountsDisabled =
+        dhisConfig.isDisabled(ConfigurationKey.LINKED_ACCOUNTS_ENABLED);
+    if (linkedIsAccountsDisabled
+        && (existingUserWithMatchingOpenID != null
+            && !existingUserWithMatchingOpenID.getUid().equals(user.getUid()))) {
       addReports.accept(
           new ErrorReport(User.class, ErrorCode.E4054, "OIDC mapping value", user.getOpenId())
               .setErrorProperty(USERNAME));

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
@@ -202,6 +202,9 @@ class AccountControllerTest extends PostgresControllerIntegrationTestBase {
 
   @Test
   void testGetLinkedAccounts() {
+    createUserWithAuth("usera");
+    createUserWithAuth("userb");
+
     String openId = "email@provider.com";
     List<User> allUsers = userService.getAllUsers();
     for (User user : allUsers) {
@@ -211,7 +214,7 @@ class AccountControllerTest extends PostgresControllerIntegrationTestBase {
 
     JsonMixed response = GET("/account/linkedAccounts").content(HttpStatus.OK);
     JsonList<JsonObject> users = response.getList("users", JsonObject.class);
-    assertEquals(1, users.size());
+    assertEquals(3, users.size());
   }
 
   private static void assertMessage(String key, String value, String message, JsonMixed response) {

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -102,7 +102,6 @@ class UserControllerTest extends H2ControllerIntegrationTestBase {
 
   @BeforeEach
   void setUp() {
-
     // TODO(DHIS2-17768 platform) intentional? you are creating 2 users with username `peter` and
     // `Peter` and
     // assigning it to field peter

--- a/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-test-web-api/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller;
 
 import static java.util.Collections.emptySet;
+import static org.hisp.dhis.external.conf.ConfigurationKey.LINKED_ACCOUNTS_ENABLED;
 import static org.hisp.dhis.test.web.HttpStatus.Series.SUCCESSFUL;
 import static org.hisp.dhis.test.web.WebClient.Accept;
 import static org.hisp.dhis.test.web.WebClient.Body;
@@ -47,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
@@ -92,12 +94,15 @@ class UserControllerTest extends H2ControllerIntegrationTestBase {
 
   @Autowired private SessionRegistry sessionRegistry;
 
-  private User peter;
-
   @Autowired ObjectMapper objectMapper;
+
+  @Autowired private DhisConfigurationProvider config;
+
+  private User peter;
 
   @BeforeEach
   void setUp() {
+
     // TODO(DHIS2-17768 platform) intentional? you are creating 2 users with username `peter` and
     // `Peter` and
     // assigning it to field peter
@@ -188,8 +193,7 @@ class UserControllerTest extends H2ControllerIntegrationTestBase {
   }
 
   @Test
-  @DisplayName(
-      "Make sure an update after first setting OpenID works, has special handling logic in UserObjectBundleHook.")
+  @DisplayName("Check updates after setting an OpenID value works")
   void testSetOpenIdThenUpdate() {
     assertStatus(
         HttpStatus.OK,
@@ -207,6 +211,60 @@ class UserControllerTest extends H2ControllerIntegrationTestBase {
             "/users/{id}",
             peter.getUid() + "?importReportMode=ERRORS",
             Body("[{'op': 'add', 'path': '/openId', 'value': 'mapping value'}]")));
+  }
+
+  @Test
+  @DisplayName(
+      "Check you can set same OpenID value on multiple accounts when linked accounts are enabled")
+  void testSetOpenIdThenUpdateWithLinkedAccountsEnabled() {
+    config.getProperties().put(LINKED_ACCOUNTS_ENABLED.getKey(), "on");
+
+    User wendy = createUserWithAuth("wendy");
+
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/users/{id}",
+            peter.getUid() + "?importReportMode=ERRORS",
+            Body("[{'op': 'add', 'path': '/openId', 'value': 'peter@mail.org'}]")));
+
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/users/{id}",
+            wendy.getUid() + "?importReportMode=ERRORS",
+            Body("[{'op': 'add', 'path': '/openId', 'value': 'peter@mail.org'}]")));
+  }
+
+  @Test
+  @DisplayName(
+      "Check you can't set same OpenID value on multiple accounts when linked accounts are disabled")
+  void testSetOpenIdThenUpdateWithLinkedAccountsDisabled() {
+    config.getProperties().put(LINKED_ACCOUNTS_ENABLED.getKey(), "off");
+
+    User wendy = createUserWithAuth("wendy");
+
+    assertStatus(
+        HttpStatus.OK,
+        PATCH(
+            "/users/{id}",
+            peter.getUid() + "?importReportMode=ERRORS",
+            Body("[{'op': 'add', 'path': '/openId', 'value': 'peter@mail.org'}]")));
+
+    JsonImportSummary response =
+        PATCH(
+                "/users/{id}",
+                wendy.getUid() + "?importReportMode=ERRORS",
+                Body("[{'op': 'add', 'path': '/openId', 'value': 'peter@mail.org'}]"))
+            .content(HttpStatus.CONFLICT)
+            .get("response")
+            .as(JsonImportSummary.class);
+
+    assertEquals(
+        "Property `OIDC mapping value` already exists, was given `peter@mail.org`.",
+        response
+            .find(JsonErrorReport.class, error -> error.getErrorCode() == ErrorCode.E4054)
+            .getMessage());
   }
 
   /**


### PR DESCRIPTION
# Summary
Fixes broken OpenID value update with linked accounts. 
Linked accounts works by having multiple accounts set with the same OpenID mapping value, effectively making multiple DHIS2 accounts/users sharing one external managed identity.

# Automatic tests
UserControllerTest.testSetOpenIdThenUpdate()
UserControllerTest.testSetOpenIdThenUpdateWithLinkedAccountsEnabled()
UserControllerTest.testSetOpenIdThenUpdateWithLinkedAccountsDisabled()

# Manual test
1. Enable linked accounts in the dhis.conf. Property is: `linked_accounts.enabled`
2. Create two accounts, set both account's OpenID property to the same value.
3. Observe on second user that you get no error response when saving/updating the user.