### PR TITLE
feat: mobileApplicationNotification [DHIS2-17630]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
@@ -67,6 +67,7 @@ public enum SettingKey {
   APPLICATION_TITLE("applicationTitle", "DHIS 2", String.class, false, true),
   APPLICATION_INTRO("keyApplicationIntro", true),
   APPLICATION_NOTIFICATION("keyApplicationNotification", true),
+  MOBILE_APPLICATION_NOTIFICATION("keyMobileApplicationNotification", false),
   APPLICATION_FOOTER("keyApplicationFooter", true),
   APPLICATION_RIGHT_FOOTER("keyApplicationRightFooter", true),
   FLAG("keyFlag", "dhis2", String.class),

--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/security/login_mobile.vm
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/dhis-web-commons/security/login_mobile.vm
@@ -45,6 +45,12 @@
 <div class="header-box" align="center"><a href="account.action">Create an account</a></div>
 #end
 
+#if ( $keyMobileApplicationNotification )
+<div id="mobileNotificationArea">
+	$!{keyMobileApplicationNotification}
+</div>
+#end
+
 </form>
 </div>
 </div>

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/interceptor/SystemSettingInterceptor.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/interceptor/SystemSettingInterceptor.java
@@ -54,6 +54,7 @@ public class SystemSettingInterceptor implements Interceptor {
           SettingKey.APPLICATION_TITLE,
           SettingKey.APPLICATION_INTRO,
           SettingKey.APPLICATION_NOTIFICATION,
+          SettingKey.MOBILE_APPLICATION_NOTIFICATION,
           SettingKey.APPLICATION_FOOTER,
           SettingKey.APPLICATION_RIGHT_FOOTER,
           SettingKey.FLAG,


### PR DESCRIPTION
See [DHIS2-17630](https://dhis2.atlassian.net/browse/DHIS2-17630).

This is a hook needed by PEPFAR (and conceivably others) to put custom HTML/JavaScript into the v40 mobile login page. They've moved their v40 implementation to a single sign-on system and they use system setting `keyApplicationNotification` to redirect non-mobile users to the sign-on system. The problem is that the login page for mobile users can't also redirect mobile users to the sign-on system, so mobile users effectively cannot log in. This feature/fix allows PEPFAR (or anyone else) to supply custom HTML/JavaScript for the mobile login page.

Note that this is only needed for v40, since v41 and following use a login app.

[DHIS2-17630]: https://dhis2.atlassian.net/browse/DHIS2-17630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ