### PR TITLE
fix: rebundle approval app

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java
@@ -48,6 +48,7 @@ public interface AppManager {
       Set.of(
           // Javascript apps
           "aggregate-data-entry",
+          "approval",
           "app-management",
           "cache-cleaner",
           "capture",


### PR DESCRIPTION
Previously, it was mistakenly marked as a struts app and understandably removed: [commit](https://github.com/dhis2/dhis2-core/commit/bf75a859efc44c158827b6870dd92e71785e55ae#diff-51f2d46ebede0a2c8d46f862af94d08c1255a79d1eab1eaeff60571f3b23635e)

Local server to verify the fix:
![Screenshot 2024-08-21 at 2 34 47 PM](https://github.com/user-attachments/assets/a8c829e3-5f14-4c07-9126-b82a044dec68)
